### PR TITLE
feat: pr-review example — a GitHub Action PR reviewer

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,36 @@
+# Agentic pull-request review via the examples/pr-review leaf workspace.
+# The job runs only when the ANTHROPIC_API_KEY secret is configured (the
+# secrets context is unavailable in `if:` conditions, so presence is carried
+# through a job-level env var). Reviews always post as COMMENT events.
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: "true"
+      VITE_GIT_HOOKS: "0"
+      HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    steps:
+      - if: env.HAS_ANTHROPIC_KEY == 'true'
+        uses: actions/checkout@v4
+
+      - if: env.HAS_ANTHROPIC_KEY == 'true'
+        uses: ./examples/pr-review
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,5 +1,5 @@
 # Agentic pull-request review via the examples/pr-review leaf workspace.
-# The job runs only when the ANTHROPIC_API_KEY secret is configured (the
+# The job runs only when the OPENAI_API_KEY secret is configured (the
 # secrets context is unavailable in `if:` conditions, so presence is carried
 # through a job-level env var). Reviews always post as COMMENT events.
 name: PR Review
@@ -24,13 +24,13 @@ jobs:
     env:
       CI: "true"
       VITE_GIT_HOOKS: "0"
-      HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+      HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
     steps:
-      - if: env.HAS_ANTHROPIC_KEY == 'true'
+      - if: env.HAS_OPENAI_KEY == 'true'
         uses: actions/checkout@v4
 
-      - if: env.HAS_ANTHROPIC_KEY == 'true'
+      - if: env.HAS_OPENAI_KEY == 'true'
         uses: ./examples/pr-review
         with:
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.worktrees
 coverage
 .vite
 docs/.vitepress/cache

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
-        "@effect/ai-anthropic": "catalog:",
+        "@effect/ai-openai": "catalog:",
         "@effect/platform-node": "catalog:",
         "effect": "catalog:",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,24 @@
         "vite-plus": "catalog:",
       },
     },
+    "examples/pr-review": {
+      "name": "@effect-agent/example-pr-review",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect-agent/capabilities": "workspace:*",
+        "@effect-agent/core": "workspace:*",
+        "@effect-agent/engine": "workspace:*",
+        "@effect/ai-anthropic": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "@types/node": "catalog:",
+        "typescript": "catalog:",
+        "vite-plus": "catalog:",
+      },
+    },
     "examples/providers": {
       "name": "@effect-agent/example-providers",
       "version": "0.0.0",
@@ -518,6 +536,8 @@
     "@effect-agent/engine": ["@effect-agent/engine@workspace:packages/engine"],
 
     "@effect-agent/example-demo": ["@effect-agent/example-demo@workspace:examples/demo"],
+
+    "@effect-agent/example-pr-review": ["@effect-agent/example-pr-review@workspace:examples/pr-review"],
 
     "@effect-agent/example-providers": ["@effect-agent/example-providers@workspace:examples/providers"],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -68,7 +68,9 @@ packages/
   testing/              Scripted model, fixtures, and conformance test kit
 examples/
   demo/             Leaf TanStack Start browser bench
+  pr-review/        Leaf GitHub pull-request reviewer (CLI + composite Action)
   providers/        Leaf OpenAI/Anthropic Model-binding compile proof
+  repo-ops/         Leaf repo-ops evidence auditor (P7 internal agent)
 ```
 
 Shared compiler options live in root `tsconfig.base.json`; they do not need a workspace package.

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -117,6 +117,34 @@ direct peer provider for the Vite+ toolchain. VitePress intentionally resolves t
 implementation as its nested dependency; the repository therefore does not use a global `vite`
 override. The documentation build is part of the root `build` and `ready` gates.
 
+## Releasing to npm
+
+Versioning uses changesets (`bun run changeset`, `bun run changeset:version`);
+publishing uses `bun run release:publish`, NOT `changeset publish`. In a
+non-pnpm repository changesets shells out to `npm publish`, which ships
+`workspace:*` and `catalog:` protocol ranges verbatim; `bun publish` resolves
+both at publish time. The release script also swaps each manifest's
+source-first export map (a private-development convention, see below) for the
+built `dist` entries during the publish, restores it afterwards, and skips
+versions already on the registry, so a partial publish can be re-run.
+
+The release sequence from an authenticated npm session (`bunx npm login`, an
+owner of the `@effect-agent` scope):
+
+1. `bun run changeset` — describe the change (one exists for 0.0.1);
+2. `bun run changeset:version && bun install` — cut versions and changelogs;
+3. `bun run ready`;
+4. `bun run release:publish -- --dry-run`, then without `--dry-run`
+   (append `--otp <code>` when npm 2FA asks);
+5. `bun x changeset tag && git push --follow-tags`.
+
+`@effect-agent/platform-cloudflare` and `@effect-agent/storage-cloudflare`
+remain `private` in the 0.0.1 release: their Durable Object class factories
+return classes with private fields, which TypeScript declaration emit rejects
+(TS4094), so `vp pack` produces no `.d.mts` for them. Publishing them
+requires annotating the factories' public return types (and scoping
+declaration builds to `src/`) first.
+
 ## Post-install setup
 
 `scripts/postinstall.ts` performs three deterministic steps:

--- a/examples/pr-review/.env.example
+++ b/examples/pr-review/.env.example
@@ -1,0 +1,8 @@
+# Live model runs (CLI and the opt-in live test profile).
+ANTHROPIC_API_KEY=
+
+# Posting reviews and reading private repositories.
+GITHUB_TOKEN=
+
+# Opt the live test profile in ("1" is the only enabling value).
+EFFECT_AGENT_LIVE=

--- a/examples/pr-review/.env.example
+++ b/examples/pr-review/.env.example
@@ -1,5 +1,5 @@
 # Live model runs (CLI and the opt-in live test profile).
-ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
 
 # Posting reviews and reading private repositories.
 GITHUB_TOKEN=

--- a/examples/pr-review/FRICTION.md
+++ b/examples/pr-review/FRICTION.md
@@ -26,10 +26,9 @@ path, recorded for the API-simplification backlog (same convention as
    text" constructor usable by leaf examples.
 
 4. **Live-gate helper is fixture-coupled.** `phase7LiveProfileEnabled` pins
-   `OPENAI_API_KEY`, so an Anthropic example re-implements the same
-   two-line gate with a different credential name. A parameterized
-   `liveProfileEnabled(credentialEnv)` in `@effect-agent/testing` would keep
-   one convention.
+   `OPENAI_API_KEY`, so this example still re-implements the same two-line
+   gate. A parameterized `liveProfileEnabled(credentialEnv)` in
+   `@effect-agent/testing` would keep one convention.
 
 5. **No shared repo-relative path validator.** The fail-closed path
    normalization demanded by SEC-007 is hand-copied from repo-ops (third

--- a/examples/pr-review/FRICTION.md
+++ b/examples/pr-review/FRICTION.md
@@ -1,0 +1,40 @@
+# Authoring friction observed while building `example-pr-review`
+
+Real observations from building this example against the public framework
+path, recorded for the API-simplification backlog (same convention as
+`examples/repo-ops/FRICTION.md`).
+
+1. **Typing a reusable run helper requires engine internals.** A function
+   that accepts "any binding of this definition" cannot be written against
+   `Agent.Any` — `AgentRuntime.run` wants the full nine-parameter
+   `RuntimeBinding<...>`, so `executeReview` re-states Input/Output/Toolkit
+   plus four inference-only type parameters. A public
+   `Agent.BindingOf<typeof Definition>` alias would remove the boilerplate.
+
+2. **`AgentResult.output` is typed as decoded but carries the encoded JSON.**
+   `run` validates the terminal text against the output schema but returns
+   the parsed JSON value, so a class-schema consumer must re-decode
+   (`Schema.decodeUnknownEffect(CodeReview)(result.output)`) to get a real
+   instance. Either returning the decoded value or typing the field as the
+   Encoded side would make the contract self-evident.
+
+3. **Scripted-model boilerplate is copied between examples again.** The
+   prompt-keyed scripted `LanguageModel` (call counter outside the Layer,
+   `toolTurn`/`finalParts` stream-part helpers) is now hand-rolled in
+   repo-ops, the demo, and here. `@effect-agent/testing` exports Travel
+   Planner fixtures but no generic "script these tool calls, then this final
+   text" constructor usable by leaf examples.
+
+4. **Live-gate helper is fixture-coupled.** `phase7LiveProfileEnabled` pins
+   `OPENAI_API_KEY`, so an Anthropic example re-implements the same
+   two-line gate with a different credential name. A parameterized
+   `liveProfileEnabled(credentialEnv)` in `@effect-agent/testing` would keep
+   one convention.
+
+5. **No shared repo-relative path validator.** The fail-closed path
+   normalization demanded by SEC-007 is hand-copied from repo-ops (third
+   copy in the repository, as its FRICTION.md predicted).
+
+6. **`Layer.succeed(Service)(value)` vs `Layer.succeed(Service, value)`**
+   both typecheck, and examples mix the two; a lint-level convention would
+   help newcomers copying from mixed sources.

--- a/examples/pr-review/README.md
+++ b/examples/pr-review/README.md
@@ -30,22 +30,22 @@ back as a pull-request review. It runs as a GitHub Action via
 
 ## Profiles
 
-| Profile                       | Model                        | Gate                                              |
-| ----------------------------- | ---------------------------- | ------------------------------------------------- |
-| Offline (every ordinary gate) | prompt-aware scripted model  | none — no network, no credentials                 |
-| Live (opt-in)                 | `claude-sonnet-5` by default | `EFFECT_AGENT_LIVE=1` **and** `ANTHROPIC_API_KEY` |
+| Profile                       | Model                       | Gate                                           |
+| ----------------------------- | --------------------------- | ---------------------------------------------- |
+| Offline (every ordinary gate) | prompt-aware scripted model | none — no network, no credentials              |
+| Live (opt-in)                 | `gpt-5.6-sol` by default    | `EFFECT_AGENT_LIVE=1` **and** `OPENAI_API_KEY` |
 
-Run the live smoke: `EFFECT_AGENT_LIVE=1 ANTHROPIC_API_KEY=... bun run test`.
+Run the live smoke: `EFFECT_AGENT_LIVE=1 OPENAI_API_KEY=... bun run test`.
 
 ## CLI
 
 ```sh
 bun src/cli.ts --repo owner/name --pr 123            # dry run: prints the plan
 bun src/cli.ts --repo owner/name --pr 123 --post     # posts the review
-bun src/cli.ts --model claude-opus-4-8 --post        # inside Actions: target from event payload
+bun src/cli.ts --model gpt-5.6-terra --post          # inside Actions: target from event payload
 ```
 
-Environment: `ANTHROPIC_API_KEY` (required for the model),
+Environment: `OPENAI_API_KEY` (required for the model),
 `GITHUB_TOKEN` (required to post; optional for public-repository reads),
 `GITHUB_REPOSITORY` / `GITHUB_EVENT_PATH` / `GITHUB_API_URL` (provided by
 GitHub Actions).
@@ -60,11 +60,11 @@ steps:
   - uses: actions/checkout@v4
   - uses: ./examples/pr-review
     with:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      openai-api-key: ${{ secrets.OPENAI_API_KEY }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-The repository workflow skips silently when the `ANTHROPIC_API_KEY` secret is
+The repository workflow skips silently when the `OPENAI_API_KEY` secret is
 absent, so forks and credential-less clones stay green.
 
 ## Honest limits

--- a/examples/pr-review/README.md
+++ b/examples/pr-review/README.md
@@ -1,0 +1,78 @@
+# Example: pull-request reviewer
+
+A PR-review bot built on the public framework path: one bounded, read-only
+Agent reviews a GitHub pull request and the host posts the validated result
+back as a pull-request review. It runs as a GitHub Action via
+[`action.yml`](action.yml) and the repository workflow
+`.github/workflows/pr-review.yml`.
+
+## Shape
+
+- **Definition** (`src/review-agent.ts`): `Agent.define("pr-reviewer")` with a
+  `ReviewMission` input, a structured `CodeReview` output, and three
+  `readonly` Effect AI Tools — `list_changed_files`, `read_file_diff`
+  (R-numbered annotated hunks), and `read_file` (head-version slices). Every
+  bound is finite (`AgentPolicy`), and run-level `UsageBudgetLimits` add cost
+  and token ceilings.
+- **Ports** (`src/source.ts`, `src/github.ts`): tools observe the pull
+  request only through `PullRequestSource`; publication happens only through
+  `ReviewPublisher`. GitHub REST adapters provide both for real runs; an
+  in-memory fixture source and a collecting publisher serve tests and dry
+  runs.
+- **Fail-closed publication** (`src/render.ts`): model output is untrusted
+  input. Every finding anchor is re-validated against the parsed unified
+  diff; findings that fail validation are demoted into the review body
+  instead of trusted. Suggestions publish as GitHub ```suggestion blocks.
+- **No agent-loop mutation**: the reviewer cannot post anything. The host
+  posts one review after the run settles — so a failed or truncated run
+  publishes nothing, and the bot defaults to `COMMENT` events
+  (`--apply-verdict` opts into APPROVE/REQUEST_CHANGES).
+
+## Profiles
+
+| Profile                       | Model                        | Gate                                              |
+| ----------------------------- | ---------------------------- | ------------------------------------------------- |
+| Offline (every ordinary gate) | prompt-aware scripted model  | none — no network, no credentials                 |
+| Live (opt-in)                 | `claude-sonnet-5` by default | `EFFECT_AGENT_LIVE=1` **and** `ANTHROPIC_API_KEY` |
+
+Run the live smoke: `EFFECT_AGENT_LIVE=1 ANTHROPIC_API_KEY=... bun run test`.
+
+## CLI
+
+```sh
+bun src/cli.ts --repo owner/name --pr 123            # dry run: prints the plan
+bun src/cli.ts --repo owner/name --pr 123 --post     # posts the review
+bun src/cli.ts --model claude-opus-4-8 --post        # inside Actions: target from event payload
+```
+
+Environment: `ANTHROPIC_API_KEY` (required for the model),
+`GITHUB_TOKEN` (required to post; optional for public-repository reads),
+`GITHUB_REPOSITORY` / `GITHUB_EVENT_PATH` / `GITHUB_API_URL` (provided by
+GitHub Actions).
+
+## GitHub Action
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+steps:
+  - uses: actions/checkout@v4
+  - uses: ./examples/pr-review
+    with:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The repository workflow skips silently when the `ANTHROPIC_API_KEY` secret is
+absent, so forks and credential-less clones stay green.
+
+## Honest limits
+
+- Ephemeral deployment class `E`: one `AgentRuntime.run` per invocation, no
+  durability claim, no exactly-once anything (the one external mutation is a
+  single review POST after the run).
+- The reviewer reads only files in the changeset — head versions, not the
+  full tree.
+- Pull requests beyond 300 changed files or 200k-character files are refused
+  typed, never silently truncated.

--- a/examples/pr-review/action.yml
+++ b/examples/pr-review/action.yml
@@ -3,16 +3,16 @@ description: >-
   Review the current pull request with the effect-agent pr-review example and
   post the validated result as a pull-request review.
 inputs:
-  anthropic-api-key:
-    description: "Anthropic API key for the review model."
+  openai-api-key:
+    description: "OpenAI API key for the review model."
     required: true
   github-token:
     description: "Token with pull-requests: write on this repository."
     required: true
   model:
-    description: "Anthropic model id."
+    description: "OpenAI model id."
     required: false
-    default: "claude-sonnet-5"
+    default: "gpt-5.6-sol"
   post:
     description: "Post the review ('true') or only print the plan ('false')."
     required: false
@@ -35,7 +35,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: >-
         bun src/cli.ts

--- a/examples/pr-review/action.yml
+++ b/examples/pr-review/action.yml
@@ -1,0 +1,44 @@
+name: "Effect Agent PR Review"
+description: >-
+  Review the current pull request with the effect-agent pr-review example and
+  post the validated result as a pull-request review.
+inputs:
+  anthropic-api-key:
+    description: "Anthropic API key for the review model."
+    required: true
+  github-token:
+    description: "Token with pull-requests: write on this repository."
+    required: true
+  model:
+    description: "Anthropic model id."
+    required: false
+    default: "claude-sonnet-5"
+  post:
+    description: "Post the review ('true') or only print the plan ('false')."
+    required: false
+    default: "true"
+  apply-verdict:
+    description: "Map the model verdict onto APPROVE/REQUEST_CHANGES instead of always COMMENT."
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.14
+    - name: Install workspace dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}/../..
+      run: bun install --frozen-lockfile
+    - name: Run the reviewer
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: >-
+        bun src/cli.ts
+        --model "${{ inputs.model }}"
+        ${{ inputs.post == 'true' && '--post' || '' }}
+        ${{ inputs.apply-verdict == 'true' && '--apply-verdict' || '' }}

--- a/examples/pr-review/package.json
+++ b/examples/pr-review/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@effect-agent/example-pr-review",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vp pack",
+    "check": "tsc --noEmit -p tsconfig.json",
+    "test": "vp test --passWithNoTests",
+    "review": "bun src/cli.ts"
+  },
+  "dependencies": {
+    "@effect-agent/capabilities": "workspace:*",
+    "@effect-agent/core": "workspace:*",
+    "@effect-agent/engine": "workspace:*",
+    "@effect/ai-anthropic": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/pr-review/package.json
+++ b/examples/pr-review/package.json
@@ -13,7 +13,7 @@
     "@effect-agent/capabilities": "workspace:*",
     "@effect-agent/core": "workspace:*",
     "@effect-agent/engine": "workspace:*",
-    "@effect/ai-anthropic": "catalog:",
+    "@effect/ai-openai": "catalog:",
     "@effect/platform-node": "catalog:",
     "effect": "catalog:"
   },

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -1,0 +1,168 @@
+import { AnthropicClient } from "@effect/ai-anthropic";
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Config, Console, Effect, FileSystem, Layer, Option, Schema } from "effect";
+import { Command as CliCommand, Flag } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+
+import { IdGenerator } from "@effect-agent/core";
+
+import {
+  GitHubReviewTarget,
+  gitHubPullRequestSourceLayer,
+  gitHubReviewPublisherLayer,
+} from "./github.ts";
+import { DEFAULT_REVIEW_MODEL, makeAnthropicReviewer } from "./profiles.ts";
+import { ReviewPublicationPlan } from "./render.ts";
+import { ReviewToolkitLayer } from "./review-agent.ts";
+import { executeReview } from "./run-review.ts";
+
+// ---------------------------------------------------------------------------
+// The GitHub Action entrypoint: resolve which pull request to review (flags
+// first, then the Actions event payload), run one bounded ephemeral review,
+// and either print the validated publication plan (default: dry run) or post
+// it as a pull-request review (--post).
+// ---------------------------------------------------------------------------
+
+/** The pull request could not be resolved from flags or the environment. */
+class ReviewCliError extends Schema.TaggedErrorClass<ReviewCliError>()("ReviewCliError", {
+  reason: Schema.String,
+}) {
+  override get message() {
+    return this.reason;
+  }
+}
+
+/** The slice of a GitHub Actions event payload this CLI understands. */
+const GitHubEventWire = Schema.Struct({
+  pull_request: Schema.optionalKey(Schema.Struct({ number: Schema.Int })),
+  repository: Schema.optionalKey(Schema.Struct({ full_name: Schema.String })),
+});
+const decodeEvent = Schema.decodeUnknownEffect(Schema.fromJsonString(GitHubEventWire));
+
+const repoFlag = Flag.string("repo").pipe(
+  Flag.optional,
+  Flag.withDescription("Repository as owner/name; defaults to GITHUB_REPOSITORY."),
+);
+const prFlag = Flag.integer("pr").pipe(
+  Flag.optional,
+  Flag.withDescription("Pull request number; defaults to the GITHUB_EVENT_PATH payload."),
+);
+const modelFlag = Flag.string("model").pipe(
+  Flag.withDefault(DEFAULT_REVIEW_MODEL),
+  Flag.withDescription(`Anthropic model id (default ${DEFAULT_REVIEW_MODEL}).`),
+);
+const postFlag = Flag.boolean("post").pipe(
+  Flag.withDescription("Post the review to GitHub; without it the plan prints to stdout."),
+);
+const applyVerdictFlag = Flag.boolean("apply-verdict").pipe(
+  Flag.withDescription(
+    "Map the model verdict onto APPROVE/REQUEST_CHANGES instead of always COMMENT.",
+  ),
+);
+
+const resolveTarget = Effect.fn("resolveTarget")(function* (flags: {
+  readonly repo: Option.Option<string>;
+  readonly pr: Option.Option<number>;
+}) {
+  let repository = Option.getOrElse(flags.repo, () => "");
+  if (repository === "") {
+    repository = yield* Config.string("GITHUB_REPOSITORY").pipe(Config.withDefault(""));
+  }
+  let number = Option.getOrUndefined(flags.pr);
+  if (number === undefined || repository === "") {
+    const eventPath = yield* Config.string("GITHUB_EVENT_PATH").pipe(Config.withDefault(""));
+    if (eventPath !== "") {
+      const fs = yield* FileSystem.FileSystem;
+      const raw = yield* fs
+        .readFileString(eventPath)
+        .pipe(
+          Effect.mapError((error) =>
+            ReviewCliError.make({ reason: `Cannot read event payload: ${error.message}` }),
+          ),
+        );
+      const event = yield* decodeEvent(raw).pipe(
+        Effect.mapError((error) =>
+          ReviewCliError.make({ reason: `Cannot decode event payload: ${error.message}` }),
+        ),
+      );
+      number ??= event.pull_request?.number;
+      if (repository === "") repository = event.repository?.full_name ?? "";
+    }
+  }
+  if (repository === "" || number === undefined) {
+    return yield* ReviewCliError.make({
+      reason:
+        "No pull request to review: pass --repo owner/name and --pr <number>, or run inside a GitHub Actions pull_request event.",
+    });
+  }
+  return { repository, number };
+});
+
+const command = CliCommand.make(
+  "pr-review",
+  {
+    repo: repoFlag,
+    pr: prFlag,
+    model: modelFlag,
+    post: postFlag,
+    applyVerdict: applyVerdictFlag,
+  },
+  (flags) =>
+    Effect.gen(function* () {
+      const { repository, number } = yield* resolveTarget(flags);
+      const apiUrl = yield* Config.string("GITHUB_API_URL").pipe(
+        Config.withDefault("https://api.github.com"),
+      );
+      const token = yield* Config.option(Config.redacted("GITHUB_TOKEN"));
+
+      const targetLayer = GitHubReviewTarget.layer({ apiUrl, repository, number, token });
+      const githubDeps = Layer.merge(targetLayer, FetchHttpClient.layer);
+      const sourceLayer = gitHubPullRequestSourceLayer.pipe(Layer.provide(githubDeps));
+      const publisherLayer = gitHubReviewPublisherLayer.pipe(Layer.provide(githubDeps));
+      const anthropicLayer = AnthropicClient.layerConfig({
+        apiKey: Config.redacted("ANTHROPIC_API_KEY"),
+      }).pipe(Layer.provide(FetchHttpClient.layer));
+
+      yield* Console.log(
+        `Reviewing ${repository}#${number} with ${flags.model} (${flags.post ? "posting" : "dry run"})...`,
+      );
+
+      const outcome = yield* executeReview(makeAnthropicReviewer(flags.model), {
+        post: flags.post,
+        applyVerdict: flags.applyVerdict,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ReviewToolkitLayer.pipe(Layer.provideMerge(sourceLayer)),
+            publisherLayer,
+            anthropicLayer,
+            IdGenerator.layer,
+          ),
+        ),
+        Effect.scoped,
+      );
+
+      yield* Console.log(
+        `Review finished in ${outcome.turns} turn(s): verdict ${outcome.review.verdict}, ` +
+          `${outcome.plan.comments.length} inline comment(s), ${outcome.plan.demoted.length} demoted finding(s).`,
+      );
+      if (outcome.published !== undefined) {
+        yield* Console.log(`Posted ${outcome.published.event} review: ${outcome.published.url}`);
+      } else {
+        const encodedPlan = yield* Schema.encodeEffect(ReviewPublicationPlan)(outcome.plan);
+        yield* Console.log(JSON.stringify(encodedPlan, null, 2));
+      }
+    }),
+).pipe(
+  CliCommand.withDescription(
+    "Review one GitHub pull request with an effect-agent reviewer and post the validated result as a pull-request review.",
+  ),
+);
+
+const program = CliCommand.run(command, { version: "0.0.0" }).pipe(
+  Effect.tapError((error) => Console.error(String(error))),
+  Effect.scoped,
+  Effect.provide(NodeServices.layer),
+);
+
+NodeRuntime.runMain(program, { disableErrorReporting: true });

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -1,4 +1,4 @@
-import { AnthropicClient } from "@effect/ai-anthropic";
+import { OpenAiClient } from "@effect/ai-openai";
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Config, Console, Effect, FileSystem, Layer, Option, Schema } from "effect";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
@@ -11,7 +11,7 @@ import {
   gitHubPullRequestSourceLayer,
   gitHubReviewPublisherLayer,
 } from "./github.ts";
-import { DEFAULT_REVIEW_MODEL, makeAnthropicReviewer } from "./profiles.ts";
+import { DEFAULT_REVIEW_MODEL, makeOpenAiReviewer } from "./profiles.ts";
 import { ReviewPublicationPlan } from "./render.ts";
 import { ReviewToolkitLayer } from "./review-agent.ts";
 import { executeReview } from "./run-review.ts";
@@ -49,7 +49,7 @@ const prFlag = Flag.integer("pr").pipe(
 );
 const modelFlag = Flag.string("model").pipe(
   Flag.withDefault(DEFAULT_REVIEW_MODEL),
-  Flag.withDescription(`Anthropic model id (default ${DEFAULT_REVIEW_MODEL}).`),
+  Flag.withDescription(`OpenAI model id (default ${DEFAULT_REVIEW_MODEL}).`),
 );
 const postFlag = Flag.boolean("post").pipe(
   Flag.withDescription("Post the review to GitHub; without it the plan prints to stdout."),
@@ -119,15 +119,15 @@ const command = CliCommand.make(
       const githubDeps = Layer.merge(targetLayer, FetchHttpClient.layer);
       const sourceLayer = gitHubPullRequestSourceLayer.pipe(Layer.provide(githubDeps));
       const publisherLayer = gitHubReviewPublisherLayer.pipe(Layer.provide(githubDeps));
-      const anthropicLayer = AnthropicClient.layerConfig({
-        apiKey: Config.redacted("ANTHROPIC_API_KEY"),
+      const openAiLayer = OpenAiClient.layerConfig({
+        apiKey: Config.redacted("OPENAI_API_KEY"),
       }).pipe(Layer.provide(FetchHttpClient.layer));
 
       yield* Console.log(
         `Reviewing ${repository}#${number} with ${flags.model} (${flags.post ? "posting" : "dry run"})...`,
       );
 
-      const outcome = yield* executeReview(makeAnthropicReviewer(flags.model), {
+      const outcome = yield* executeReview(makeOpenAiReviewer(flags.model), {
         post: flags.post,
         applyVerdict: flags.applyVerdict,
       }).pipe(
@@ -135,7 +135,7 @@ const command = CliCommand.make(
           Layer.mergeAll(
             ReviewToolkitLayer.pipe(Layer.provideMerge(sourceLayer)),
             publisherLayer,
-            anthropicLayer,
+            openAiLayer,
             IdGenerator.layer,
           ),
         ),

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -1,11 +1,10 @@
+import { BudgetExceeded } from "@effect-agent/capabilities";
+import { IdGenerator } from "@effect-agent/core";
 import { OpenAiClient } from "@effect/ai-openai";
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Config, Console, Effect, FileSystem, Layer, Option, Schema } from "effect";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
 import { FetchHttpClient } from "effect/unstable/http";
-
-import { IdGenerator } from "@effect-agent/core";
-import { BudgetExceeded } from "@effect-agent/capabilities";
 
 import {
   GitHubReviewTarget,

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -5,6 +5,7 @@ import { Command as CliCommand, Flag } from "effect/unstable/cli";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { IdGenerator } from "@effect-agent/core";
+import { BudgetExceeded } from "@effect-agent/capabilities";
 
 import {
   GitHubReviewTarget,
@@ -160,7 +161,13 @@ const command = CliCommand.make(
 );
 
 const program = CliCommand.run(command, { version: "0.0.0" }).pipe(
-  Effect.tapError((error) => Console.error(String(error))),
+  Effect.tapError((error) =>
+    Console.error(
+      Schema.is(BudgetExceeded)(error)
+        ? `Budget exceeded: ${error.limit} observed ${error.observedValue}, limit ${error.limitValue}.`
+        : String(error),
+    ),
+  ),
   Effect.scoped,
   Effect.provide(NodeServices.layer),
 );

--- a/examples/pr-review/src/diff.ts
+++ b/examples/pr-review/src/diff.ts
@@ -1,0 +1,136 @@
+import { Schema } from "effect";
+
+// ---------------------------------------------------------------------------
+// Changed-file and unified-diff primitives shared by the tool surface, the
+// publication planner, and the GitHub adapter. The parser is deterministic
+// and bounded; it never throws on malformed hunks — unparseable patch text
+// simply yields no commentable lines, which fails findings closed.
+// ---------------------------------------------------------------------------
+
+/** A repository-relative file path as transported values carry it. */
+export const ChangedPath = Schema.NonEmptyString.check(Schema.isMaxLength(512));
+
+/** GitHub's changed-file status vocabulary, kept verbatim. */
+export const ChangedFileStatus = Schema.Literals([
+  "added",
+  "removed",
+  "modified",
+  "renamed",
+  "copied",
+  "changed",
+  "unchanged",
+]);
+
+/** One file changed by the pull request, with its optional textual patch. */
+export class ChangedFile extends Schema.Class<ChangedFile>(
+  "@effect-agent/example-pr-review/ChangedFile",
+)({
+  path: ChangedPath,
+  status: ChangedFileStatus,
+  additions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  deletions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  /** Present for renames/copies: the path the file previously had. */
+  previousPath: Schema.optionalKey(ChangedPath),
+  /** Unified-diff hunks; absent for binary or oversized files. */
+  patch: Schema.optionalKey(Schema.String),
+}) {}
+
+/** One parsed line of a unified diff, with both coordinate systems. */
+export interface PatchLine {
+  readonly kind: "context" | "add" | "del";
+  readonly oldLine: number | undefined;
+  readonly newLine: number | undefined;
+  readonly text: string;
+}
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * Parse unified-diff hunk text into coordinate-tagged lines. Lines outside a
+ * recognized hunk header are ignored rather than guessed at.
+ */
+export const parsePatch = (patch: string): ReadonlyArray<PatchLine> => {
+  const lines: Array<PatchLine> = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let inHunk = false;
+  for (const raw of patch.split("\n")) {
+    const header = HUNK_HEADER.exec(raw);
+    if (header !== null) {
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (raw.startsWith("+")) {
+      lines.push({ kind: "add", oldLine: undefined, newLine, text: raw.slice(1) });
+      newLine += 1;
+    } else if (raw.startsWith("-")) {
+      lines.push({ kind: "del", oldLine, newLine: undefined, text: raw.slice(1) });
+      oldLine += 1;
+    } else if (raw.startsWith(" ") || raw === "") {
+      lines.push({ kind: "context", oldLine, newLine, text: raw.slice(1) });
+      oldLine += 1;
+      newLine += 1;
+    } else if (raw.startsWith("\\")) {
+      // "\ No newline at end of file" — metadata, not a diff line.
+    } else {
+      // Unrecognized content ends the current hunk conservatively.
+      inHunk = false;
+    }
+  }
+  return lines;
+};
+
+/**
+ * The new-file line numbers a GitHub review comment may anchor to on the
+ * RIGHT side: every added or context line that appears in the diff.
+ */
+export const commentableLines = (patch: string): ReadonlySet<number> => {
+  const lines = new Set<number>();
+  for (const line of parsePatch(patch)) {
+    if (line.newLine !== undefined) lines.add(line.newLine);
+  }
+  return lines;
+};
+
+/**
+ * Render a patch with explicit RIGHT-side line numbers so the model can
+ * anchor findings without arithmetic. `R<n>` marks a line that exists in the
+ * new version of the file (`+` added, blank context); deleted lines keep a
+ * bare `-` marker and no number.
+ */
+export const annotatePatch = (patch: string): string => {
+  const output: Array<string> = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let inHunk = false;
+  for (const raw of patch.split("\n")) {
+    const header = HUNK_HEADER.exec(raw);
+    if (header !== null) {
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      inHunk = true;
+      output.push(raw);
+      continue;
+    }
+    if (!inHunk) continue;
+    if (raw.startsWith("+")) {
+      output.push(`R${newLine} + ${raw.slice(1)}`);
+      newLine += 1;
+    } else if (raw.startsWith("-")) {
+      output.push(`      - ${raw.slice(1)}`);
+      oldLine += 1;
+    } else if (raw.startsWith(" ") || raw === "") {
+      output.push(`R${newLine}   ${raw.slice(1)}`);
+      oldLine += 1;
+      newLine += 1;
+    } else if (raw.startsWith("\\")) {
+      output.push(`        ${raw}`);
+    } else {
+      inHunk = false;
+    }
+  }
+  return output.join("\n");
+};

--- a/examples/pr-review/src/github.ts
+++ b/examples/pr-review/src/github.ts
@@ -1,0 +1,357 @@
+import { Context, Effect, Layer, Option, Redacted, Ref, Schema } from "effect";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { ChangedFile } from "./diff.ts";
+import {
+  MAX_CHANGED_FILES,
+  MAX_FILE_CHARS,
+  normalizeRepoRelativePath,
+  PullRequestMetadata,
+  PullRequestSource,
+  PullRequestSourceFailure,
+  ReviewInputViolation,
+} from "./source.ts";
+import { ReviewPublicationPlan } from "./render.ts";
+
+// ---------------------------------------------------------------------------
+// GitHub REST adapters for the PullRequestSource port and the ReviewPublisher.
+// Wire payloads are decoded through minimal Schemas — never asserted — and
+// every upstream fault becomes the typed PullRequestSourceFailure /
+// GitHubApiFailure instead of an untyped defect.
+// ---------------------------------------------------------------------------
+
+/** Which pull request to review and how to reach the API. */
+export class GitHubReviewTarget extends Context.Service<
+  GitHubReviewTarget,
+  {
+    /** API root, e.g. `https://api.github.com` (no trailing slash). */
+    readonly apiUrl: string;
+    /** `owner/name`. */
+    readonly repository: string;
+    readonly number: number;
+    /** Absent token means unauthenticated reads (public repositories only). */
+    readonly token: Option.Option<Redacted.Redacted<string>>;
+  }
+>()("@effect-agent/example-pr-review/GitHubReviewTarget") {
+  static layer(config: {
+    readonly apiUrl: string;
+    readonly repository: string;
+    readonly number: number;
+    readonly token: Option.Option<Redacted.Redacted<string>>;
+  }): Layer.Layer<GitHubReviewTarget> {
+    return Layer.succeed(this, GitHubReviewTarget.of(config));
+  }
+}
+
+/** A GitHub API call failed: transport, status, or payload decode. */
+export class GitHubApiFailure extends Schema.TaggedErrorClass<GitHubApiFailure>()(
+  "GitHubApiFailure",
+  {
+    operation: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message() {
+    return `GitHub API operation '${this.operation}' failed: ${this.reason}`;
+  }
+}
+
+// --- Wire schemas (decode-only, minimal fields) ------------------------------
+
+const GitHubPullRequestWire = Schema.Struct({
+  number: Schema.Int,
+  title: Schema.String,
+  body: Schema.NullOr(Schema.String),
+  base: Schema.Struct({ ref: Schema.String }),
+  head: Schema.Struct({ ref: Schema.String, sha: Schema.String }),
+});
+
+const GitHubFileWire = Schema.Struct({
+  filename: Schema.String,
+  status: Schema.String,
+  additions: Schema.Int,
+  deletions: Schema.Int,
+  patch: Schema.optionalKey(Schema.String),
+  previous_filename: Schema.optionalKey(Schema.String),
+});
+
+const GitHubFilesPageWire = Schema.Array(GitHubFileWire);
+
+const GitHubReviewWire = Schema.Struct({
+  id: Schema.Int,
+  html_url: Schema.String,
+});
+
+/** The publication receipt callers report back to the operator. */
+export class PublishedReview extends Schema.Class<PublishedReview>(
+  "@effect-agent/example-pr-review/PublishedReview",
+)({
+  reviewId: Schema.Int,
+  url: Schema.String,
+  event: Schema.String,
+  inlineComments: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+}) {}
+
+/** Posts one planned review; the ONLY mutating operation in this example. */
+export class ReviewPublisher extends Context.Service<
+  ReviewPublisher,
+  {
+    readonly publish: (
+      plan: ReviewPublicationPlan,
+    ) => Effect.Effect<PublishedReview, GitHubApiFailure>;
+  }
+>()("@effect-agent/example-pr-review/ReviewPublisher") {}
+
+// --- Shared request plumbing -------------------------------------------------
+
+const FILE_STATUSES = new Set([
+  "added",
+  "removed",
+  "modified",
+  "renamed",
+  "copied",
+  "changed",
+  "unchanged",
+]);
+
+const withCommonHeaders = (
+  request: HttpClientRequest.HttpClientRequest,
+  token: Option.Option<Redacted.Redacted<string>>,
+): HttpClientRequest.HttpClientRequest => {
+  const base = request.pipe(
+    HttpClientRequest.setHeaders({
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "effect-agent-example-pr-review",
+    }),
+  );
+  return Option.isSome(token) ? base.pipe(HttpClientRequest.bearerToken(token.value)) : base;
+};
+
+const failWith =
+  (operation: string) =>
+  (error: { readonly _tag: string; readonly message?: string }): PullRequestSourceFailure =>
+    PullRequestSourceFailure.make({
+      operation,
+      reason: `${error._tag}: ${error.message ?? "request failed"}`.slice(0, 2_048),
+    });
+
+const decodeJsonBody = <S extends Schema.Top>(schema: S, operation: string) => {
+  const decode = Schema.decodeUnknownEffect(schema);
+  return (
+    response: HttpClientResponse.HttpClientResponse,
+  ): Effect.Effect<S["Type"], PullRequestSourceFailure, S["DecodingServices"]> =>
+    response.json.pipe(
+      Effect.mapError(failWith(operation)),
+      Effect.flatMap((body) => decode(body).pipe(Effect.mapError(failWith(operation)))),
+    );
+};
+
+const executeOk = (
+  operation: string,
+  request: HttpClientRequest.HttpClientRequest,
+): Effect.Effect<
+  HttpClientResponse.HttpClientResponse,
+  PullRequestSourceFailure,
+  HttpClient.HttpClient
+> =>
+  HttpClient.execute(request).pipe(
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
+    Effect.mapError(failWith(operation)),
+  );
+
+const toChangedFile = (wire: typeof GitHubFileWire.Type): ChangedFile =>
+  ChangedFile.make({
+    path: wire.filename,
+    status: FILE_STATUSES.has(wire.status) ? (wire.status as ChangedFile["status"]) : "changed",
+    additions: wire.additions,
+    deletions: wire.deletions,
+    ...(wire.previous_filename !== undefined ? { previousPath: wire.previous_filename } : {}),
+    ...(wire.patch !== undefined ? { patch: wire.patch } : {}),
+  });
+
+// --- Live PullRequestSource --------------------------------------------------
+
+/**
+ * GitHub-backed PullRequestSource. Metadata and the changeset are fetched
+ * once per Layer build and cached: the pull request is reviewed as one
+ * consistent snapshot even if the branch moves mid-run.
+ */
+export const gitHubPullRequestSourceLayer: Layer.Layer<
+  PullRequestSource,
+  never,
+  GitHubReviewTarget | HttpClient.HttpClient
+> = Layer.effect(PullRequestSource)(
+  Effect.gen(function* () {
+    const target = yield* GitHubReviewTarget;
+    const client = yield* HttpClient.HttpClient;
+    const prefix = `${target.apiUrl}/repos/${target.repository}/pulls/${target.number}`;
+
+    const fetchMetadata = executeOk(
+      "getPullRequest",
+      withCommonHeaders(
+        HttpClientRequest.get(prefix).pipe(HttpClientRequest.acceptJson),
+        target.token,
+      ),
+    ).pipe(
+      Effect.flatMap(decodeJsonBody(GitHubPullRequestWire, "getPullRequest")),
+      Effect.map((wire) =>
+        PullRequestMetadata.make({
+          repository: target.repository,
+          number: wire.number,
+          title: wire.title.slice(0, 400),
+          body: (wire.body ?? "").slice(0, 20_000),
+          baseRef: wire.base.ref,
+          headRef: wire.head.ref,
+          headSha: wire.head.sha,
+        }),
+      ),
+    );
+
+    const fetchFiles = Effect.gen(function* () {
+      const perPage = 100;
+      const all: Array<ChangedFile> = [];
+      for (let page = 1; page <= MAX_CHANGED_FILES / perPage; page += 1) {
+        const response = yield* executeOk(
+          "listChangedFiles",
+          withCommonHeaders(
+            HttpClientRequest.get(`${prefix}/files`).pipe(
+              HttpClientRequest.acceptJson,
+              HttpClientRequest.setUrlParams({
+                per_page: String(perPage),
+                page: String(page),
+              }),
+            ),
+            target.token,
+          ),
+        );
+        const wires = yield* decodeJsonBody(GitHubFilesPageWire, "listChangedFiles")(response);
+        all.push(...wires.map(toChangedFile));
+        if (wires.length < perPage) break;
+      }
+      return all as ReadonlyArray<ChangedFile>;
+    });
+
+    const metadata = yield* Effect.cached(
+      fetchMetadata.pipe(Effect.provideService(HttpClient.HttpClient, client)),
+    );
+    const changedFiles = yield* Effect.cached(
+      fetchFiles.pipe(Effect.provideService(HttpClient.HttpClient, client)),
+    );
+
+    const readFile = (path: string) =>
+      Effect.gen(function* () {
+        const relative = yield* normalizeRepoRelativePath(path);
+        const files = yield* changedFiles;
+        if (!files.some((file) => file.path === relative)) {
+          return yield* ReviewInputViolation.make({
+            input: relative,
+            reason: "Path is not part of this pull request's changeset.",
+          });
+        }
+        const head = yield* metadata;
+        const encodedPath = relative.split("/").map(encodeURIComponent).join("/");
+        const response = yield* executeOk(
+          "readFile",
+          withCommonHeaders(
+            HttpClientRequest.get(
+              `${target.apiUrl}/repos/${target.repository}/contents/${encodedPath}`,
+            ).pipe(
+              HttpClientRequest.accept("application/vnd.github.raw+json"),
+              HttpClientRequest.setUrlParams({ ref: head.headSha }),
+            ),
+            target.token,
+          ),
+        ).pipe(Effect.provideService(HttpClient.HttpClient, client));
+        const text = yield* response.text.pipe(Effect.mapError(failWith("readFile")));
+        if (text.length > MAX_FILE_CHARS) {
+          return yield* ReviewInputViolation.make({
+            input: relative,
+            reason: `File is larger than the ${MAX_FILE_CHARS}-character read bound.`,
+          });
+        }
+        return text;
+      });
+
+    return PullRequestSource.of({ metadata, changedFiles, readFile });
+  }),
+);
+
+// --- Live ReviewPublisher ------------------------------------------------------
+
+/** GitHub-backed publisher: one POST to the pull-request reviews endpoint. */
+export const gitHubReviewPublisherLayer: Layer.Layer<
+  ReviewPublisher,
+  never,
+  GitHubReviewTarget | HttpClient.HttpClient
+> = Layer.effect(ReviewPublisher)(
+  Effect.gen(function* () {
+    const target = yield* GitHubReviewTarget;
+    const client = yield* HttpClient.HttpClient;
+    return ReviewPublisher.of({
+      publish: (plan) =>
+        Effect.gen(function* () {
+          const payload = {
+            event: plan.event,
+            body: plan.body,
+            comments: plan.comments.map((comment) => ({
+              path: comment.path,
+              line: comment.line,
+              side: "RIGHT",
+              ...(comment.startLine !== undefined
+                ? { start_line: comment.startLine, start_side: "RIGHT" }
+                : {}),
+              body: comment.body,
+            })),
+          };
+          const request = withCommonHeaders(
+            HttpClientRequest.post(
+              `${target.apiUrl}/repos/${target.repository}/pulls/${target.number}/reviews`,
+            ).pipe(HttpClientRequest.acceptJson, HttpClientRequest.bodyJsonUnsafe(payload)),
+            target.token,
+          );
+          const wire = yield* HttpClient.execute(request).pipe(
+            Effect.flatMap(HttpClientResponse.filterStatusOk),
+            Effect.flatMap((response) =>
+              response.json.pipe(Effect.flatMap(Schema.decodeUnknownEffect(GitHubReviewWire))),
+            ),
+            Effect.mapError((error) =>
+              GitHubApiFailure.make({
+                operation: "createReview",
+                reason: `${error._tag}: ${error.message ?? "request failed"}`.slice(0, 2_048),
+              }),
+            ),
+            Effect.provideService(HttpClient.HttpClient, client),
+          );
+          return PublishedReview.make({
+            reviewId: wire.id,
+            url: wire.html_url,
+            event: plan.event,
+            inlineComments: plan.comments.length,
+          });
+        }),
+    });
+  }),
+);
+
+// --- Collecting ReviewPublisher (tests and dry-run assertions) ----------------
+
+/** In-memory publisher: records every plan and mints a deterministic receipt. */
+export const collectingReviewPublisherLayer = (
+  published: Ref.Ref<ReadonlyArray<ReviewPublicationPlan>>,
+): Layer.Layer<ReviewPublisher> =>
+  Layer.succeed(ReviewPublisher)(
+    ReviewPublisher.of({
+      publish: (plan) =>
+        Ref.update(published, (plans) => [...plans, plan]).pipe(
+          Effect.flatMap(() => Ref.get(published)),
+          Effect.map((plans) =>
+            PublishedReview.make({
+              reviewId: plans.length,
+              url: `memory://review/${plans.length}`,
+              event: plan.event,
+              inlineComments: plan.comments.length,
+            }),
+          ),
+        ),
+    }),
+  );

--- a/examples/pr-review/src/github.ts
+++ b/examples/pr-review/src/github.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Layer, Option, Redacted, Ref, Schema } from "effect";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import { ChangedFile } from "./diff.ts";
+import { ReviewPublicationPlan } from "./render.ts";
 import {
   MAX_CHANGED_FILES,
   MAX_FILE_CHARS,
@@ -11,7 +12,6 @@ import {
   PullRequestSourceFailure,
   ReviewInputViolation,
 } from "./source.ts";
-import { ReviewPublicationPlan } from "./render.ts";
 
 // ---------------------------------------------------------------------------
 // GitHub REST adapters for the PullRequestSource port and the ReviewPublisher.

--- a/examples/pr-review/src/index.ts
+++ b/examples/pr-review/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./diff.ts";
+export * from "./github.ts";
+export * from "./profiles.ts";
+export * from "./render.ts";
+export * from "./review-agent.ts";
+export * from "./run-review.ts";
+export * from "./source.ts";

--- a/examples/pr-review/src/profiles.ts
+++ b/examples/pr-review/src/profiles.ts
@@ -1,0 +1,157 @@
+import { AnthropicLanguageModel } from "@effect/ai-anthropic";
+import { Effect, Layer, Ref, Schema, Stream } from "effect";
+import { LanguageModel, Model, type Response } from "effect/unstable/ai";
+
+import { Agent } from "@effect-agent/core";
+
+import { CodeReview, PullRequestReviewer } from "./review-agent.ts";
+
+// ---------------------------------------------------------------------------
+// The reviewer's two profiles, mirroring the repo-ops shape: a deterministic
+// offline profile (prompt-aware scripted model over a fixture pull request)
+// that runs on every ordinary gate, and an opt-in live profile (real
+// Anthropic model) behind an explicit environment gate.
+// ---------------------------------------------------------------------------
+
+/** The reviewer's committed capability claim, schema-first like every profile. */
+export class PullRequestReviewerProfile extends Schema.Class<PullRequestReviewerProfile>(
+  "@effect-agent/example-pr-review/PullRequestReviewerProfile",
+)({
+  /** Ephemeral runtime: one bounded AgentRuntime.run per CI invocation. */
+  deploymentClass: Schema.Literal("E"),
+  /** Every model-callable tool is a read of the pull request; none mutate. */
+  readOnlyToolSurface: Schema.Literal(true),
+  /** The review is posted by the host AFTER the run settles, never by a tool. */
+  publicationOutsideAgentLoop: Schema.Literal(true),
+  /** Finding anchors are validated against the parsed diff before posting. */
+  anchorsValidatedBeforePublication: Schema.Literal(true),
+  /** The live profile is env-gated out of every ordinary test gate. */
+  liveProfileOptIn: Schema.Literal(true),
+  /** Never claimed at any phase (DUR-003). */
+  exactlyOnceExternalEffects: Schema.Literal(false),
+}) {}
+
+export const pullRequestReviewerProfile = PullRequestReviewerProfile.make({
+  deploymentClass: "E",
+  readOnlyToolSurface: true,
+  publicationOutsideAgentLoop: true,
+  anchorsValidatedBeforePublication: true,
+  liveProfileOptIn: true,
+  exactlyOnceExternalEffects: false,
+});
+
+// ---------------------------------------------------------------------------
+// Live profile.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_REVIEW_MODEL = "claude-sonnet-5";
+
+export const LIVE_GATE_ENV = "EFFECT_AGENT_LIVE";
+export const LIVE_CREDENTIAL_ENV = "ANTHROPIC_API_KEY";
+
+/** `EFFECT_AGENT_LIVE=1` plus a credential is the only enabling combination. */
+export const liveReviewProfileEnabled = (env: Record<string, string | undefined>): boolean =>
+  env[LIVE_GATE_ENV] === "1" && (env[LIVE_CREDENTIAL_ENV] ?? "") !== "";
+
+/**
+ * Live binding factory: one definition, caller-selected model. The Anthropic
+ * client Layer (with its redacted ANTHROPIC_API_KEY) is supplied by the
+ * application, never by the definition (D-027).
+ */
+export const makeAnthropicReviewer = (model?: string | undefined) =>
+  Agent.withModel(
+    PullRequestReviewer,
+    AnthropicLanguageModel.model(model ?? DEFAULT_REVIEW_MODEL, { max_tokens: 8_000 }),
+  );
+
+// ---------------------------------------------------------------------------
+// Deterministic offline profile: a prompt-aware scripted model that walks the
+// real tool surface — list, diff, read — then returns the fixture review as
+// its terminal JSON. Decisions key on committed history in the prompt, never
+// on call order, so replays stay honest.
+// ---------------------------------------------------------------------------
+
+export const OFFLINE_LIST_CALL_ID = "list-1";
+export const OFFLINE_DIFF_CALL_ID = "diff-1";
+export const OFFLINE_READ_CALL_ID = "read-1";
+
+const scriptedUsage = { inputTokens: { total: 64 }, outputTokens: { total: 48 } };
+
+const toolTurn = (
+  ...calls: ReadonlyArray<Response.StreamPartEncoded>
+): ReadonlyArray<Response.StreamPartEncoded> => [
+  ...calls,
+  { type: "finish", reason: "tool-calls", usage: scriptedUsage },
+];
+
+const finalParts = (text: string): ReadonlyArray<Response.StreamPartEncoded> => [
+  { type: "text-start", id: "code-review" },
+  { type: "text-delta", id: "code-review", delta: text },
+  { type: "text-end", id: "code-review" },
+  { type: "finish", reason: "stop", usage: scriptedUsage },
+];
+
+/**
+ * Build the offline scripted reviewer model. Turn 1 lists the changeset,
+ * Turn 2 reads one file diff, Turn 3 reads head context, Turn 4 returns the
+ * scripted review JSON.
+ */
+export const makeOfflineReviewerModel = (script: {
+  readonly diffPath: string;
+  readonly readPath: string;
+  readonly review: CodeReview;
+}) =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make(0);
+    const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+    const decide = (promptJson: string): ReadonlyArray<Response.StreamPartEncoded> => {
+      if (promptJson.includes(OFFLINE_READ_CALL_ID)) {
+        return finalParts(JSON.stringify(Schema.encodeSync(CodeReview)(script.review)));
+      }
+      if (promptJson.includes(OFFLINE_DIFF_CALL_ID)) {
+        return toolTurn({
+          type: "tool-call",
+          id: OFFLINE_READ_CALL_ID,
+          name: "read_file",
+          params: { path: script.readPath },
+          providerExecuted: false,
+        });
+      }
+      if (promptJson.includes(OFFLINE_LIST_CALL_ID)) {
+        return toolTurn({
+          type: "tool-call",
+          id: OFFLINE_DIFF_CALL_ID,
+          name: "read_file_diff",
+          params: { path: script.diffPath },
+          providerExecuted: false,
+        });
+      }
+      return toolTurn({
+        type: "tool-call",
+        id: OFFLINE_LIST_CALL_ID,
+        name: "list_changed_files",
+        params: {},
+        providerExecuted: false,
+      });
+    };
+    const model = Model.make(
+      "scripted",
+      "pr-review-offline",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        LanguageModel.make({
+          generateText: () => Effect.succeed([]),
+          streamText: (request) =>
+            Stream.unwrap(
+              Effect.gen(function* () {
+                yield* Ref.update(calls, (value) => value + 1);
+                const promptJson = JSON.stringify(request.prompt);
+                yield* Ref.update(prompts, (previous) => [...previous, promptJson]);
+                return Stream.fromIterable(decide(promptJson));
+              }),
+            ),
+        }),
+      ),
+    );
+    return { model, calls: Ref.get(calls), prompts: Ref.get(prompts) };
+  });

--- a/examples/pr-review/src/profiles.ts
+++ b/examples/pr-review/src/profiles.ts
@@ -1,8 +1,7 @@
+import { Agent } from "@effect-agent/core";
 import { OpenAiLanguageModel } from "@effect/ai-openai";
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
 import { LanguageModel, Model, type Response } from "effect/unstable/ai";
-
-import { Agent } from "@effect-agent/core";
 
 import { CodeReview, PullRequestReviewer } from "./review-agent.ts";
 

--- a/examples/pr-review/src/profiles.ts
+++ b/examples/pr-review/src/profiles.ts
@@ -1,4 +1,4 @@
-import { AnthropicLanguageModel } from "@effect/ai-anthropic";
+import { OpenAiLanguageModel } from "@effect/ai-openai";
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
 import { LanguageModel, Model, type Response } from "effect/unstable/ai";
 
@@ -10,7 +10,7 @@ import { CodeReview, PullRequestReviewer } from "./review-agent.ts";
 // The reviewer's two profiles, mirroring the repo-ops shape: a deterministic
 // offline profile (prompt-aware scripted model over a fixture pull request)
 // that runs on every ordinary gate, and an opt-in live profile (real
-// Anthropic model) behind an explicit environment gate.
+// OpenAI model) behind an explicit environment gate.
 // ---------------------------------------------------------------------------
 
 /** The reviewer's committed capability claim, schema-first like every profile. */
@@ -44,24 +44,28 @@ export const pullRequestReviewerProfile = PullRequestReviewerProfile.make({
 // Live profile.
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_REVIEW_MODEL = "claude-sonnet-5";
+export const DEFAULT_REVIEW_MODEL = "gpt-5.6-sol";
 
 export const LIVE_GATE_ENV = "EFFECT_AGENT_LIVE";
-export const LIVE_CREDENTIAL_ENV = "ANTHROPIC_API_KEY";
+export const LIVE_CREDENTIAL_ENV = "OPENAI_API_KEY";
 
 /** `EFFECT_AGENT_LIVE=1` plus a credential is the only enabling combination. */
 export const liveReviewProfileEnabled = (env: Record<string, string | undefined>): boolean =>
   env[LIVE_GATE_ENV] === "1" && (env[LIVE_CREDENTIAL_ENV] ?? "") !== "";
 
 /**
- * Live binding factory: one definition, caller-selected model. The Anthropic
- * client Layer (with its redacted ANTHROPIC_API_KEY) is supplied by the
+ * Live binding factory: one definition, caller-selected model. The OpenAI
+ * client Layer (with its redacted OPENAI_API_KEY) is supplied by the
  * application, never by the definition (D-027).
  */
-export const makeAnthropicReviewer = (model?: string | undefined) =>
+export const makeOpenAiReviewer = (model?: string) =>
   Agent.withModel(
     PullRequestReviewer,
-    AnthropicLanguageModel.model(model ?? DEFAULT_REVIEW_MODEL, { max_tokens: 8_000 }),
+    OpenAiLanguageModel.model(model ?? DEFAULT_REVIEW_MODEL, {
+      max_output_tokens: 8_000,
+      store: false,
+      strictJsonSchema: true,
+    }),
   );
 
 // ---------------------------------------------------------------------------
@@ -130,7 +134,7 @@ export const makeOfflineReviewerModel = (script: {
         type: "tool-call",
         id: OFFLINE_LIST_CALL_ID,
         name: "list_changed_files",
-        params: {},
+        params: { scope: "all" },
         providerExecuted: false,
       });
     };

--- a/examples/pr-review/src/render.ts
+++ b/examples/pr-review/src/render.ts
@@ -1,0 +1,137 @@
+import { Schema } from "effect";
+
+import { ChangedFile, commentableLines } from "./diff.ts";
+import { CodeReview, ReviewFinding } from "./review-agent.ts";
+
+// ---------------------------------------------------------------------------
+// Publication planning: pure, deterministic, and fail-closed. Model output is
+// untrusted input, so every finding anchor is validated against the parsed
+// diff before it may become an inline comment; findings that fail validation
+// are demoted into the review body instead of being dropped or trusted.
+// ---------------------------------------------------------------------------
+
+export const ReviewEvent = Schema.Literals(["COMMENT", "APPROVE", "REQUEST_CHANGES"]);
+export type ReviewEvent = typeof ReviewEvent.Type;
+
+/** One inline comment exactly as the GitHub review API accepts it. */
+export class ReviewCommentDraft extends Schema.Class<ReviewCommentDraft>(
+  "@effect-agent/example-pr-review/ReviewCommentDraft",
+)({
+  path: Schema.NonEmptyString,
+  /** The last (or only) commented line, RIGHT side of the diff. */
+  line: Schema.Int.check(Schema.isGreaterThan(0)),
+  /** Present only for multi-line comments; strictly less than `line`. */
+  startLine: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+  body: Schema.NonEmptyString,
+}) {}
+
+/** The complete, validated review ready for one GitHub reviews API call. */
+export class ReviewPublicationPlan extends Schema.Class<ReviewPublicationPlan>(
+  "@effect-agent/example-pr-review/ReviewPublicationPlan",
+)({
+  event: ReviewEvent,
+  body: Schema.String.check(Schema.isMaxLength(60_000)),
+  comments: Schema.Array(ReviewCommentDraft),
+  /** Findings whose anchors failed diff validation; folded into `body`. */
+  demoted: Schema.Array(ReviewFinding),
+}) {}
+
+const severityLabel: Record<ReviewFinding["severity"], string> = {
+  blocking: "🛑 blocking",
+  important: "⚠️ important",
+  nit: "💅 nit",
+};
+
+/** A fence long enough that the suggestion content can never close it early. */
+const suggestionFence = (suggestion: string): string => {
+  let fence = "```";
+  while (suggestion.includes(fence)) fence = `${fence}\``;
+  return fence;
+};
+
+const renderCommentBody = (finding: ReviewFinding): string => {
+  const parts = [`**[${severityLabel[finding.severity]}] ${finding.title}**`, "", finding.body];
+  if (finding.suggestion !== undefined) {
+    const fence = suggestionFence(finding.suggestion);
+    parts.push("", `${fence}suggestion`, finding.suggestion, fence);
+  }
+  return parts.join("\n");
+};
+
+const renderDemoted = (finding: ReviewFinding): string => {
+  const location = `\`${finding.path}:${finding.startLine}${
+    finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""
+  }\``;
+  return [
+    `- ${location} **[${severityLabel[finding.severity]}] ${finding.title}** — ${finding.body}`,
+  ].join("\n");
+};
+
+/**
+ * Why one finding cannot become an inline comment, or undefined when it can.
+ * Exported so tests can pin each rule individually.
+ */
+export const anchorViolation = (
+  finding: ReviewFinding,
+  files: ReadonlyArray<ChangedFile>,
+): string | undefined => {
+  const file = files.find((candidate) => candidate.path === finding.path);
+  if (file === undefined) return "path is not part of the changeset";
+  if (file.patch === undefined) return "file has no textual diff";
+  if (finding.endLine < finding.startLine) return "endLine precedes startLine";
+  if (finding.endLine - finding.startLine + 1 > 100) return "range is implausibly large";
+  const anchors = commentableLines(file.patch);
+  for (let line = finding.startLine; line <= finding.endLine; line += 1) {
+    if (!anchors.has(line)) return `line ${line} is not part of the diff`;
+  }
+  return undefined;
+};
+
+/**
+ * Turn one validated review into the exact GitHub publication payload.
+ * `applyVerdict: false` (the safe default) always posts a COMMENT review;
+ * `true` maps the model's verdict onto APPROVE / REQUEST_CHANGES.
+ */
+export const planPublication = (
+  review: CodeReview,
+  files: ReadonlyArray<ChangedFile>,
+  options: { readonly applyVerdict: boolean },
+): ReviewPublicationPlan => {
+  const comments: Array<ReviewCommentDraft> = [];
+  const demoted: Array<ReviewFinding> = [];
+  for (const finding of review.findings) {
+    if (anchorViolation(finding, files) === undefined) {
+      comments.push(
+        ReviewCommentDraft.make({
+          path: finding.path,
+          line: finding.endLine,
+          ...(finding.endLine > finding.startLine ? { startLine: finding.startLine } : {}),
+          body: renderCommentBody(finding),
+        }),
+      );
+    } else {
+      demoted.push(finding);
+    }
+  }
+
+  const bodyParts = [review.summary];
+  if (demoted.length > 0) {
+    bodyParts.push("", "### Findings without a valid diff anchor", ...demoted.map(renderDemoted));
+  }
+  bodyParts.push("", "_Automated review by the effect-agent pr-review example._");
+
+  const event: ReviewEvent = options.applyVerdict
+    ? review.verdict === "approve"
+      ? "APPROVE"
+      : review.verdict === "request-changes"
+        ? "REQUEST_CHANGES"
+        : "COMMENT"
+    : "COMMENT";
+
+  return ReviewPublicationPlan.make({
+    event,
+    body: bodyParts.join("\n").slice(0, 60_000),
+    comments,
+    demoted,
+  });
+};

--- a/examples/pr-review/src/review-agent.ts
+++ b/examples/pr-review/src/review-agent.ts
@@ -1,8 +1,7 @@
-import { Effect, Schema } from "effect";
-import { Tool, Toolkit } from "effect/unstable/ai";
-
 import { Agent, AgentPolicy } from "@effect-agent/core";
 import { ToolExecutionClass } from "@effect-agent/engine";
+import { Effect, Schema } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
 
 import { annotatePatch, ChangedFileStatus, ChangedPath } from "./diff.ts";
 import {

--- a/examples/pr-review/src/review-agent.ts
+++ b/examples/pr-review/src/review-agent.ts
@@ -1,0 +1,282 @@
+import { Effect, Schema } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import { Agent, AgentPolicy } from "@effect-agent/core";
+import { ToolExecutionClass } from "@effect-agent/engine";
+
+import { annotatePatch, ChangedFileStatus, ChangedPath } from "./diff.ts";
+import {
+  normalizeRepoRelativePath,
+  PullRequestSource,
+  PullRequestSourceFailure,
+  ReviewInputViolation,
+} from "./source.ts";
+
+// ---------------------------------------------------------------------------
+// The pull-request reviewer: a bounded, read-only agent. Every tool observes
+// the pull request through the PullRequestSource port; nothing the model can
+// call mutates anything. Publishing the review happens OUTSIDE the agent
+// loop, after the finding anchors have been validated against the real diff
+// (model output is untrusted input, AGENTS.md rule 11).
+// ---------------------------------------------------------------------------
+
+const MAX_FINDINGS = 20;
+
+/** Annotated patches larger than this are truncated with an explicit marker. */
+const MAX_PATCH_CHARS = 60_000;
+
+/** One `read_file` slice never exceeds this many lines. */
+const MAX_SLICE_LINES = 1_000;
+const DEFAULT_SLICE_LINES = 400;
+
+// ---------------------------------------------------------------------------
+// Tool surface.
+// ---------------------------------------------------------------------------
+
+export class ChangedFileSummary extends Schema.Class<ChangedFileSummary>(
+  "@effect-agent/example-pr-review/ChangedFileSummary",
+)({
+  path: ChangedPath,
+  status: ChangedFileStatus,
+  additions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  deletions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  hasTextualDiff: Schema.Boolean,
+}) {}
+
+export class ChangedFilesView extends Schema.Class<ChangedFilesView>(
+  "@effect-agent/example-pr-review/ChangedFilesView",
+)({
+  totalFiles: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  files: Schema.Array(ChangedFileSummary).check(Schema.isMaxLength(300)),
+}) {}
+
+export const ListChangedFiles = Tool.make("list_changed_files", {
+  description:
+    "List every file changed by this pull request with its status, line counts, and whether a textual diff is available.",
+  parameters: Schema.Struct({}),
+  success: ChangedFilesView,
+  failure: PullRequestSourceFailure,
+  failureMode: "error",
+  dependencies: [PullRequestSource],
+}).annotate(ToolExecutionClass, "readonly");
+
+export class FileDiffQuery extends Schema.Class<FileDiffQuery>(
+  "@effect-agent/example-pr-review/FileDiffQuery",
+)({
+  path: ChangedPath,
+}) {}
+
+export class FileDiffView extends Schema.Class<FileDiffView>(
+  "@effect-agent/example-pr-review/FileDiffView",
+)({
+  path: ChangedPath,
+  status: ChangedFileStatus,
+  /**
+   * The unified diff with explicit RIGHT-side line numbers: `R<n>` marks a
+   * line present in the new file version (only those may anchor findings);
+   * `-` marks removed lines. Empty when no textual diff exists.
+   */
+  annotatedPatch: Schema.String,
+  truncated: Schema.Boolean,
+}) {}
+
+export const ReadFileDiff = Tool.make("read_file_diff", {
+  description:
+    "Read the annotated unified diff of one changed file. Lines marked R<number> exist in the new version and are the only valid finding anchors.",
+  parameters: FileDiffQuery,
+  success: FileDiffView,
+  failure: Schema.Union([PullRequestSourceFailure, ReviewInputViolation]),
+  failureMode: "error",
+  dependencies: [PullRequestSource],
+}).annotate(ToolExecutionClass, "readonly");
+
+export class FileSliceQuery extends Schema.Class<FileSliceQuery>(
+  "@effect-agent/example-pr-review/FileSliceQuery",
+)({
+  path: ChangedPath,
+  /** 1-based first line to read; defaults to 1. */
+  startLine: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+  /** Number of lines to read; defaults to 400, capped at 1000. */
+  maxLines: Schema.optionalKey(
+    Schema.Int.check(Schema.isGreaterThan(0)).check(Schema.isLessThanOrEqualTo(MAX_SLICE_LINES)),
+  ),
+}) {}
+
+export class FileSlice extends Schema.Class<FileSlice>("@effect-agent/example-pr-review/FileSlice")(
+  {
+    path: ChangedPath,
+    startLine: Schema.Int.check(Schema.isGreaterThan(0)),
+    endLine: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    totalLines: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    /** Slice content with each line prefixed by its 1-based line number. */
+    content: Schema.String,
+  },
+) {}
+
+export const ReadFile = Tool.make("read_file", {
+  description:
+    "Read a numbered slice of the NEW (head) version of one changed file, for context around the diff. Only files in the changeset are readable.",
+  parameters: FileSliceQuery,
+  success: FileSlice,
+  failure: Schema.Union([PullRequestSourceFailure, ReviewInputViolation]),
+  failureMode: "error",
+  dependencies: [PullRequestSource],
+}).annotate(ToolExecutionClass, "readonly");
+
+export const ReviewToolkit = Toolkit.make(ListChangedFiles, ReadFileDiff, ReadFile);
+
+export const ReviewToolkitLayer = ReviewToolkit.toLayer({
+  list_changed_files: () =>
+    Effect.gen(function* () {
+      const source = yield* PullRequestSource;
+      const files = yield* source.changedFiles;
+      return ChangedFilesView.make({
+        totalFiles: files.length,
+        files: files.map((file) =>
+          ChangedFileSummary.make({
+            path: file.path,
+            status: file.status,
+            additions: file.additions,
+            deletions: file.deletions,
+            hasTextualDiff: file.patch !== undefined,
+          }),
+        ),
+      });
+    }),
+  read_file_diff: (query) =>
+    Effect.gen(function* () {
+      const source = yield* PullRequestSource;
+      const relative = yield* normalizeRepoRelativePath(query.path);
+      const files = yield* source.changedFiles;
+      const file = files.find((candidate) => candidate.path === relative);
+      if (file === undefined) {
+        return yield* ReviewInputViolation.make({
+          input: relative,
+          reason: "Path is not part of this pull request's changeset.",
+        });
+      }
+      const annotated = file.patch === undefined ? "" : annotatePatch(file.patch);
+      const truncated = annotated.length > MAX_PATCH_CHARS;
+      return FileDiffView.make({
+        path: file.path,
+        status: file.status,
+        annotatedPatch: truncated
+          ? `${annotated.slice(0, MAX_PATCH_CHARS)}\n[diff truncated]`
+          : annotated,
+        truncated,
+      });
+    }),
+  read_file: (query) =>
+    Effect.gen(function* () {
+      const source = yield* PullRequestSource;
+      const relative = yield* normalizeRepoRelativePath(query.path);
+      const content = yield* source.readFile(relative);
+      const lines = content.split("\n");
+      const startLine = query.startLine ?? 1;
+      const maxLines = query.maxLines ?? DEFAULT_SLICE_LINES;
+      if (startLine > lines.length) {
+        return yield* ReviewInputViolation.make({
+          input: `${relative}:${startLine}`,
+          reason: `startLine is beyond the end of the file (${lines.length} lines).`,
+        });
+      }
+      const slice = lines.slice(startLine - 1, startLine - 1 + maxLines);
+      const endLine = startLine + slice.length - 1;
+      return FileSlice.make({
+        path: relative,
+        startLine,
+        endLine,
+        totalLines: lines.length,
+        content: slice
+          .map((text, index) => `${String(startLine + index).padStart(5)}  ${text}`)
+          .join("\n"),
+      });
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// Mission input and review output contracts.
+// ---------------------------------------------------------------------------
+
+export class ReviewMission extends Schema.Class<ReviewMission>(
+  "@effect-agent/example-pr-review/ReviewMission",
+)({
+  repository: Schema.NonEmptyString.check(Schema.isMaxLength(200)),
+  number: Schema.Int.check(Schema.isGreaterThan(0)),
+  title: Schema.String.check(Schema.isMaxLength(400)),
+  body: Schema.String.check(Schema.isMaxLength(20_000)),
+  baseRef: Schema.NonEmptyString.check(Schema.isMaxLength(300)),
+  headRef: Schema.NonEmptyString.check(Schema.isMaxLength(300)),
+  changedFileCount: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+}) {}
+
+export const FindingSeverity = Schema.Literals(["blocking", "important", "nit"]);
+export type FindingSeverity = typeof FindingSeverity.Type;
+
+export class ReviewFinding extends Schema.Class<ReviewFinding>(
+  "@effect-agent/example-pr-review/ReviewFinding",
+)({
+  path: ChangedPath,
+  /** 1-based line numbers in the NEW file version; must appear in the diff. */
+  startLine: Schema.Int.check(Schema.isGreaterThan(0)),
+  endLine: Schema.Int.check(Schema.isGreaterThan(0)),
+  severity: FindingSeverity,
+  title: Schema.NonEmptyString.check(Schema.isMaxLength(120)),
+  body: Schema.NonEmptyString.check(Schema.isMaxLength(2_000)),
+  /** Replacement for exactly lines startLine..endLine; omit when unsure. */
+  suggestion: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(2_000))),
+}) {}
+
+export const ReviewVerdict = Schema.Literals(["approve", "comment", "request-changes"]);
+export type ReviewVerdict = typeof ReviewVerdict.Type;
+
+export class CodeReview extends Schema.Class<CodeReview>(
+  "@effect-agent/example-pr-review/CodeReview",
+)({
+  summary: Schema.NonEmptyString.check(Schema.isMaxLength(4_000)),
+  verdict: ReviewVerdict,
+  findings: Schema.Array(ReviewFinding).check(Schema.isMaxLength(MAX_FINDINGS)),
+}) {}
+
+// ---------------------------------------------------------------------------
+// Instructions. Live models diverge wherever the contract is implicit, so the
+// exact JSON shape, the anchor rule, and the suggestion rule are all spelled
+// out with types (the lesson recorded by commit 7d7890e).
+// ---------------------------------------------------------------------------
+
+export const reviewInstructions = (mission: ReviewMission): string =>
+  [
+    `You are a senior code reviewer for pull request #${mission.number} ("${mission.title}") in ${mission.repository}, merging ${mission.headRef} into ${mission.baseRef}. It changes ${mission.changedFileCount} file(s).`,
+    mission.body.length > 0
+      ? `Author description:\n${mission.body}`
+      : "The author provided no description.",
+    "Work in this order:",
+    "1. Call list_changed_files once to see the changeset.",
+    "2. Call read_file_diff for every file you review. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
+    "3. Call read_file when you need surrounding context the diff does not show. Only changed files are readable.",
+    "4. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
+    '5. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}]}.',
+    `Report at most ${MAX_FINDINGS} findings; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
+    'Use verdict "request-changes" only when at least one finding is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.',
+  ].join("\n");
+
+// ---------------------------------------------------------------------------
+// Agent Definition: model-agnostic; bindings live in profiles.ts (D-027).
+// ---------------------------------------------------------------------------
+
+export const PullRequestReviewer = Agent.define("pr-reviewer", {
+  input: ReviewMission,
+  output: CodeReview,
+  instructions: reviewInstructions,
+  toolkit: ReviewToolkit,
+  policy: AgentPolicy.make({
+    maxTurns: 12,
+    maxToolCalls: 24,
+    maxDuration: "8 minutes",
+    toolConcurrency: 2,
+    tokenBudget: 300_000,
+  }),
+  description:
+    "Review one pull request read-only: list the changeset, read annotated diffs and head-file context, and return a structured, line-anchored code review.",
+  metadata: { deploymentClass: "E", surface: "read-only" },
+});

--- a/examples/pr-review/src/review-agent.ts
+++ b/examples/pr-review/src/review-agent.ts
@@ -50,10 +50,17 @@ export class ChangedFilesView extends Schema.Class<ChangedFilesView>(
   files: Schema.Array(ChangedFileSummary).check(Schema.isMaxLength(300)),
 }) {}
 
+export class ListChangedFilesQuery extends Schema.Class<ListChangedFilesQuery>(
+  "@effect-agent/example-pr-review/ListChangedFilesQuery",
+)({
+  /** Explicit constant keeps the zero-choice operation compatible with strict provider schemas. */
+  scope: Schema.Literal("all"),
+}) {}
+
 export const ListChangedFiles = Tool.make("list_changed_files", {
   description:
     "List every file changed by this pull request with its status, line counts, and whether a textual diff is available.",
-  parameters: Schema.Struct({}),
+  parameters: ListChangedFilesQuery,
   success: ChangedFilesView,
   failure: PullRequestSourceFailure,
   failureMode: "error",

--- a/examples/pr-review/src/run-review.ts
+++ b/examples/pr-review/src/run-review.ts
@@ -1,0 +1,98 @@
+import { Effect, Schema } from "effect";
+import { type Toolkit } from "effect/unstable/ai";
+
+import { AgentRuntime, type RuntimeBinding } from "@effect-agent/engine";
+import { makeUsageBudget, toRunBudgetHook, UsageBudgetLimits } from "@effect-agent/capabilities";
+
+import { PublishedReview, ReviewPublisher } from "./github.ts";
+import { planPublication, ReviewPublicationPlan } from "./render.ts";
+import { CodeReview, ReviewMission, type ReviewToolkit } from "./review-agent.ts";
+import { PullRequestSource } from "./source.ts";
+
+// ---------------------------------------------------------------------------
+// One review run, end to end: read the pull request, run the bounded agent,
+// validate the review against the real diff, then (optionally) publish.
+// Publication happens strictly AFTER the agent loop so no model turn can
+// observe or influence the mutation, and a failed run publishes nothing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run-level usage bounds on top of the definition's AgentPolicy. Real diffs
+ * are token-heavy, so the input budget is research-sized with cost as the
+ * safety net (mirroring the live travel-chat profile).
+ */
+export const reviewBudgetLimits = UsageBudgetLimits.make({
+  maxInputTokens: 400_000,
+  maxOutputTokens: 16_000,
+  maxToolCalls: 24,
+  maxCostMicrousd: 2_000_000,
+  maxDurationMillis: 480_000,
+});
+
+/** Everything one review run produced, publication receipt included. */
+export class ReviewRunOutcome extends Schema.Class<ReviewRunOutcome>(
+  "@effect-agent/example-pr-review/ReviewRunOutcome",
+)({
+  review: CodeReview,
+  plan: ReviewPublicationPlan,
+  published: Schema.optionalKey(PublishedReview),
+  turns: Schema.Int.check(Schema.isGreaterThan(0)),
+}) {}
+
+export interface ExecuteReviewOptions {
+  /** Post the review to GitHub; `false` stops after planning (dry run). */
+  readonly post: boolean;
+  /** Map the model's verdict onto APPROVE/REQUEST_CHANGES instead of COMMENT. */
+  readonly applyVerdict: boolean;
+}
+
+/**
+ * Execute one review with any explicit Agent Binding for the reviewer
+ * definition. The binding stays a parameter (D-027): tests pass a scripted
+ * model, the CLI passes a live Anthropic binding, and the model Layer's
+ * requirements stay visible in this Effect's `R`.
+ */
+export const executeReview = <Instructions, Provider, ModelProvides, ModelRequires>(
+  binding: RuntimeBinding<
+    typeof ReviewMission,
+    typeof CodeReview,
+    Instructions,
+    Toolkit.Tools<typeof ReviewToolkit>,
+    Provider,
+    ModelProvides,
+    ModelRequires
+  >,
+  options: ExecuteReviewOptions,
+) =>
+  Effect.gen(function* () {
+    const source = yield* PullRequestSource;
+    const metadata = yield* source.metadata;
+    const files = yield* source.changedFiles;
+    const mission = ReviewMission.make({
+      repository: metadata.repository,
+      number: metadata.number,
+      title: metadata.title,
+      body: metadata.body,
+      baseRef: metadata.baseRef,
+      headRef: metadata.headRef,
+      changedFileCount: files.length,
+    });
+
+    const budget = yield* makeUsageBudget(reviewBudgetLimits);
+    const result = yield* AgentRuntime.run(binding, mission, {
+      budget: toRunBudgetHook(budget),
+      estimateCostMicrousd: () => Effect.succeed(500),
+    });
+
+    // The engine validated the terminal JSON against the output schema; this
+    // decode recovers the typed value on this side of the generic boundary.
+    const review = yield* Schema.decodeUnknownEffect(CodeReview)(result.output);
+    const plan = planPublication(review, files, { applyVerdict: options.applyVerdict });
+
+    if (!options.post) {
+      return ReviewRunOutcome.make({ review, plan, turns: result.turns });
+    }
+    const publisher = yield* ReviewPublisher;
+    const published = yield* publisher.publish(plan);
+    return ReviewRunOutcome.make({ review, plan, published, turns: result.turns });
+  });

--- a/examples/pr-review/src/run-review.ts
+++ b/examples/pr-review/src/run-review.ts
@@ -1,8 +1,7 @@
+import { makeUsageBudget, toRunBudgetHook, UsageBudgetLimits } from "@effect-agent/capabilities";
+import { AgentRuntime, type RuntimeBinding } from "@effect-agent/engine";
 import { Effect, Schema } from "effect";
 import { type Toolkit } from "effect/unstable/ai";
-
-import { AgentRuntime, type RuntimeBinding } from "@effect-agent/engine";
-import { makeUsageBudget, toRunBudgetHook, UsageBudgetLimits } from "@effect-agent/capabilities";
 
 import { PublishedReview, ReviewPublisher } from "./github.ts";
 import { planPublication, ReviewPublicationPlan } from "./render.ts";

--- a/examples/pr-review/src/run-review.ts
+++ b/examples/pr-review/src/run-review.ts
@@ -49,7 +49,7 @@ export interface ExecuteReviewOptions {
 /**
  * Execute one review with any explicit Agent Binding for the reviewer
  * definition. The binding stays a parameter (D-027): tests pass a scripted
- * model, the CLI passes a live Anthropic binding, and the model Layer's
+ * model, the CLI passes a live OpenAI binding, and the model Layer's
  * requirements stay visible in this Effect's `R`.
  */
 export const executeReview = <Instructions, Provider, ModelProvides, ModelRequires>(

--- a/examples/pr-review/src/source.ts
+++ b/examples/pr-review/src/source.ts
@@ -1,0 +1,157 @@
+import { Context, Effect, Layer, Schema } from "effect";
+
+import { ChangedFile } from "./diff.ts";
+
+// ---------------------------------------------------------------------------
+// The pull-request source port: everything the review tools may observe about
+// one pull request. The live adapter speaks the GitHub REST API; the fixture
+// adapter serves an in-memory pull request so ordinary gates and dry runs
+// need no network or credential.
+// ---------------------------------------------------------------------------
+
+/** Reading a file head version larger than this is refused, never truncated silently. */
+export const MAX_FILE_CHARS = 200_000;
+
+/** The changeset surface is bounded; larger pull requests fail typed. */
+export const MAX_CHANGED_FILES = 300;
+
+/** Pull-request identity and framing shown to the agent as its mission. */
+export class PullRequestMetadata extends Schema.Class<PullRequestMetadata>(
+  "@effect-agent/example-pr-review/PullRequestMetadata",
+)({
+  /** `owner/name`, exactly as GitHub renders it. */
+  repository: Schema.NonEmptyString.check(Schema.isMaxLength(200)),
+  number: Schema.Int.check(Schema.isGreaterThan(0)),
+  title: Schema.String.check(Schema.isMaxLength(400)),
+  /** Author-provided description; empty when the author left none. */
+  body: Schema.String.check(Schema.isMaxLength(20_000)),
+  baseRef: Schema.NonEmptyString.check(Schema.isMaxLength(300)),
+  headRef: Schema.NonEmptyString.check(Schema.isMaxLength(300)),
+  headSha: Schema.NonEmptyString.check(Schema.isMaxLength(64)),
+}) {}
+
+/** The upstream source failed: API error, network fault, or malformed payload. */
+export class PullRequestSourceFailure extends Schema.TaggedErrorClass<PullRequestSourceFailure>()(
+  "PullRequestSourceFailure",
+  {
+    operation: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message() {
+    return `Pull-request source operation '${this.operation}' failed: ${this.reason}`;
+  }
+}
+
+/** A model-supplied path or range was invalid; always fail-closed (SEC-007). */
+export class ReviewInputViolation extends Schema.TaggedErrorClass<ReviewInputViolation>()(
+  "ReviewInputViolation",
+  {
+    input: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message() {
+    return `Rejected review input '${this.input}': ${this.reason}`;
+  }
+}
+
+const BACKSLASH = String.fromCharCode(92);
+
+/**
+ * Normalize and validate one model-supplied repository-relative path.
+ * Absolute paths, drive letters, backslashes, empty segments, `.` and `..`
+ * segments are all violations — never silently fixed. The changeset list is
+ * the real allowlist; this check is defense in depth for URL construction.
+ */
+export const normalizeRepoRelativePath = (
+  path: string,
+): Effect.Effect<string, ReviewInputViolation> => {
+  const fail = (reason: string) => Effect.fail(ReviewInputViolation.make({ input: path, reason }));
+  if (path.length === 0 || path.length > 512) {
+    return fail("Path length is out of bounds.");
+  }
+  if (path.includes(BACKSLASH)) {
+    return fail("Path contains a forbidden backslash.");
+  }
+  if (path.startsWith("/") || /^[A-Za-z]:/.test(path)) {
+    return fail("Path must be repository-relative, not absolute.");
+  }
+  const segments = path.split("/");
+  for (const segment of segments) {
+    if (segment === "" || segment === "." || segment === "..") {
+      return fail("Path segments must not be empty, '.', or '..'.");
+    }
+  }
+  return Effect.succeed(segments.join("/"));
+};
+
+/** Read-only view of one pull request; the only repository access tools get. */
+export class PullRequestSource extends Context.Service<
+  PullRequestSource,
+  {
+    readonly metadata: Effect.Effect<PullRequestMetadata, PullRequestSourceFailure>;
+    readonly changedFiles: Effect.Effect<ReadonlyArray<ChangedFile>, PullRequestSourceFailure>;
+    /**
+     * The head-version content of one CHANGED file. Paths outside the
+     * changeset are violations: the reviewer reads the change, not the tree.
+     */
+    readonly readFile: (
+      path: string,
+    ) => Effect.Effect<string, PullRequestSourceFailure | ReviewInputViolation>;
+  }
+>()("@effect-agent/example-pr-review/PullRequestSource") {}
+
+/** One fixture file: its changeset entry plus optional head content. */
+export class FixtureFile extends Schema.Class<FixtureFile>(
+  "@effect-agent/example-pr-review/FixtureFile",
+)({
+  file: ChangedFile,
+  headContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(MAX_FILE_CHARS))),
+}) {}
+
+/** A complete in-memory pull request for tests, dry runs, and live smokes. */
+export class FixturePullRequest extends Schema.Class<FixturePullRequest>(
+  "@effect-agent/example-pr-review/FixturePullRequest",
+)({
+  metadata: PullRequestMetadata,
+  files: Schema.Array(FixtureFile).check(Schema.isMaxLength(MAX_CHANGED_FILES)),
+}) {}
+
+const requireChanged = (
+  fixture: FixturePullRequest,
+  path: string,
+): Effect.Effect<FixtureFile, ReviewInputViolation> => {
+  const entry = fixture.files.find((candidate) => candidate.file.path === path);
+  return entry === undefined
+    ? Effect.fail(
+        ReviewInputViolation.make({
+          input: path,
+          reason: "Path is not part of this pull request's changeset.",
+        }),
+      )
+    : Effect.succeed(entry);
+};
+
+/** Deterministic `PullRequestSource` over one fixture pull request. */
+export const fixturePullRequestSourceLayer = (
+  fixture: FixturePullRequest,
+): Layer.Layer<PullRequestSource> =>
+  Layer.succeed(PullRequestSource)(
+    PullRequestSource.of({
+      metadata: Effect.succeed(fixture.metadata),
+      changedFiles: Effect.succeed(fixture.files.map((entry) => entry.file)),
+      readFile: (path) =>
+        Effect.gen(function* () {
+          const relative = yield* normalizeRepoRelativePath(path);
+          const entry = yield* requireChanged(fixture, relative);
+          if (entry.headContent === undefined) {
+            return yield* ReviewInputViolation.make({
+              input: relative,
+              reason: "No head content is available for this file.",
+            });
+          }
+          return entry.headContent;
+        }),
+    }),
+  );

--- a/examples/pr-review/test/pr-review.test.ts
+++ b/examples/pr-review/test/pr-review.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Config, Effect, Exit, Layer, Ref, Schema } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { AnthropicClient } from "@effect/ai-anthropic";
+
+import { Agent, IdGenerator } from "@effect-agent/core";
+
+import {
+  anchorViolation,
+  annotatePatch,
+  ChangedFile,
+  CodeReview,
+  collectingReviewPublisherLayer,
+  commentableLines,
+  executeReview,
+  FixtureFile,
+  FixturePullRequest,
+  fixturePullRequestSourceLayer,
+  liveReviewProfileEnabled,
+  makeAnthropicReviewer,
+  makeOfflineReviewerModel,
+  normalizeRepoRelativePath,
+  parsePatch,
+  planPublication,
+  PullRequestMetadata,
+  PullRequestReviewer,
+  PullRequestReviewerProfile,
+  pullRequestReviewerProfile,
+  ReviewFinding,
+  ReviewPublicationPlan,
+  ReviewToolkitLayer,
+} from "../src/index.ts";
+
+// ---------------------------------------------------------------------------
+// Deterministic fixture pull request: one reviewable TypeScript change with a
+// real patch, plus one binary file without a textual diff.
+// ---------------------------------------------------------------------------
+
+const HELLO_PATCH = [
+  "@@ -1,3 +1,4 @@",
+  " const one = 1;",
+  "-const two = 3;",
+  "+const two = 2;",
+  "+const three = 3;",
+  " export const sum = one + two;",
+].join("\n");
+
+const HELLO_HEAD = [
+  "const one = 1;",
+  "const two = 2;",
+  "const three = 3;",
+  "export const sum = one + two;",
+].join("\n");
+
+const fixture = FixturePullRequest.make({
+  metadata: PullRequestMetadata.make({
+    repository: "acme/widgets",
+    number: 7,
+    title: "Fix the sum constant",
+    body: "Replaces the wrong literal and introduces `three`.",
+    baseRef: "main",
+    headRef: "fix/sum",
+    headSha: "0123456789abcdef0123456789abcdef01234567",
+  }),
+  files: [
+    FixtureFile.make({
+      file: ChangedFile.make({
+        path: "src/hello.ts",
+        status: "modified",
+        additions: 2,
+        deletions: 1,
+        patch: HELLO_PATCH,
+      }),
+      headContent: HELLO_HEAD,
+    }),
+    FixtureFile.make({
+      file: ChangedFile.make({
+        path: "assets/logo.png",
+        status: "added",
+        additions: 0,
+        deletions: 0,
+      }),
+    }),
+  ],
+});
+
+/** The review the offline script returns: one valid anchor, two invalid. */
+const scriptedReview = CodeReview.make({
+  summary: "The constant fix is correct; two notes could not be anchored.",
+  verdict: "comment",
+  findings: [
+    ReviewFinding.make({
+      path: "src/hello.ts",
+      startLine: 3,
+      endLine: 3,
+      severity: "nit",
+      title: "Name the magic number",
+      body: "The literal duplicates the meaning of `three`.",
+      suggestion: "const three = 3; // named constant",
+    }),
+    ReviewFinding.make({
+      path: "src/hello.ts",
+      startLine: 99,
+      endLine: 99,
+      severity: "important",
+      title: "Ghost anchor",
+      body: "This line does not exist in the diff.",
+    }),
+    ReviewFinding.make({
+      path: "assets/logo.png",
+      startLine: 1,
+      endLine: 1,
+      severity: "nit",
+      title: "Binary note",
+      body: "Binary files carry no textual diff.",
+    }),
+  ],
+});
+
+const requiresNothing = <A, E>(effect: Effect.Effect<A, E, never>): Effect.Effect<A, E, never> =>
+  effect;
+
+// ---------------------------------------------------------------------------
+// Profile claim.
+// ---------------------------------------------------------------------------
+
+describe("pr-review profile", () => {
+  it("pins the profile claim and its schema round-trip", () => {
+    const decoded = Schema.decodeUnknownSync(PullRequestReviewerProfile)(
+      Schema.encodeSync(PullRequestReviewerProfile)(pullRequestReviewerProfile),
+    );
+    expect(decoded).toEqual(pullRequestReviewerProfile);
+    expect(pullRequestReviewerProfile).toEqual({
+      deploymentClass: "E",
+      readOnlyToolSurface: true,
+      publicationOutsideAgentLoop: true,
+      anchorsValidatedBeforePublication: true,
+      liveProfileOptIn: true,
+      exactlyOnceExternalEffects: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Diff parsing and annotation.
+// ---------------------------------------------------------------------------
+
+describe("unified diff primitives", () => {
+  it("parses hunk coordinates for both file versions", () => {
+    const lines = parsePatch(HELLO_PATCH);
+    expect(lines).toEqual([
+      { kind: "context", oldLine: 1, newLine: 1, text: "const one = 1;" },
+      { kind: "del", oldLine: 2, newLine: undefined, text: "const two = 3;" },
+      { kind: "add", oldLine: undefined, newLine: 2, text: "const two = 2;" },
+      { kind: "add", oldLine: undefined, newLine: 3, text: "const three = 3;" },
+      { kind: "context", oldLine: 3, newLine: 4, text: "export const sum = one + two;" },
+    ]);
+  });
+
+  it("collects exactly the RIGHT-side commentable lines", () => {
+    expect([...commentableLines(HELLO_PATCH)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    expect(commentableLines("not a diff").size).toBe(0);
+  });
+
+  it("annotates every new-file line with its R-number", () => {
+    expect(annotatePatch(HELLO_PATCH)).toEqual(
+      [
+        "@@ -1,3 +1,4 @@",
+        "R1   const one = 1;",
+        "      - const two = 3;",
+        "R2 + const two = 2;",
+        "R3 + const three = 3;",
+        "R4   export const sum = one + two;",
+      ].join("\n"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed path validation (SEC-007).
+// ---------------------------------------------------------------------------
+
+describe("path validation", () => {
+  it.effect("normalizes model-supplied paths fail-closed", () =>
+    Effect.gen(function* () {
+      expect(yield* normalizeRepoRelativePath("src/hello.ts")).toBe("src/hello.ts");
+      for (const hostile of [
+        "/etc/passwd",
+        "../outside.ts",
+        "src/../../outside.ts",
+        "src//gap.ts",
+        "C:evil.ts",
+        "src/./here.ts",
+        "",
+      ]) {
+        const exit = yield* Effect.exit(normalizeRepoRelativePath(hostile));
+        expect(Exit.isFailure(exit)).toBe(true);
+      }
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Anchor validation and publication planning.
+// ---------------------------------------------------------------------------
+
+describe("publication planning", () => {
+  const files = fixture.files.map((entry) => entry.file);
+  const validFinding = scriptedReview.findings[0] as ReviewFinding;
+
+  it("accepts anchors on diff lines and rejects everything else", () => {
+    expect(anchorViolation(validFinding, files)).toBeUndefined();
+    expect(
+      anchorViolation(ReviewFinding.make({ ...validFinding, startLine: 99, endLine: 99 }), files),
+    ).toContain("not part of the diff");
+    expect(
+      anchorViolation(ReviewFinding.make({ ...validFinding, path: "assets/logo.png" }), files),
+    ).toContain("no textual diff");
+    expect(
+      anchorViolation(ReviewFinding.make({ ...validFinding, path: "not/changed.ts" }), files),
+    ).toContain("not part of the changeset");
+    expect(
+      anchorViolation(ReviewFinding.make({ ...validFinding, startLine: 3, endLine: 2 }), files),
+    ).toContain("precedes");
+  });
+
+  it("plans inline comments for valid anchors and demotes the rest", () => {
+    const plan = planPublication(scriptedReview, files, { applyVerdict: false });
+    expect(plan.event).toBe("COMMENT");
+    expect(plan.comments).toHaveLength(1);
+    expect(plan.comments[0]?.path).toBe("src/hello.ts");
+    expect(plan.comments[0]?.line).toBe(3);
+    expect(plan.comments[0]?.startLine).toBeUndefined();
+    expect(plan.comments[0]?.body).toContain("```suggestion");
+    expect(plan.comments[0]?.body).toContain("const three = 3; // named constant");
+    expect(plan.demoted).toHaveLength(2);
+    expect(plan.body).toContain("Findings without a valid diff anchor");
+    expect(plan.body).toContain("`src/hello.ts:99`");
+    expect(plan.body).toContain("`assets/logo.png:1`");
+  });
+
+  it("maps the verdict onto the review event only when asked to", () => {
+    const blocking = CodeReview.make({
+      summary: "Blocked.",
+      verdict: "request-changes",
+      findings: [],
+    });
+    expect(planPublication(blocking, files, { applyVerdict: false }).event).toBe("COMMENT");
+    expect(planPublication(blocking, files, { applyVerdict: true }).event).toBe("REQUEST_CHANGES");
+    const approving = CodeReview.make({ summary: "Fine.", verdict: "approve", findings: [] });
+    expect(planPublication(approving, files, { applyVerdict: true }).event).toBe("APPROVE");
+  });
+
+  it("extends the suggestion fence past any backticks in the replacement", () => {
+    const tricky = CodeReview.make({
+      summary: "Fence test.",
+      verdict: "comment",
+      findings: [
+        ReviewFinding.make({
+          ...validFinding,
+          suggestion: 'const fence = "```";',
+        }),
+      ],
+    });
+    const body = planPublication(tricky, files, { applyVerdict: false }).comments[0]?.body ?? "";
+    expect(body).toContain("````suggestion");
+  });
+
+  it("comments a multi-line range with start_line strictly below line", () => {
+    const ranged = CodeReview.make({
+      summary: "Range test.",
+      verdict: "comment",
+      findings: [ReviewFinding.make({ ...validFinding, startLine: 2, endLine: 3 })],
+    });
+    const comment = planPublication(ranged, files, { applyVerdict: false }).comments[0];
+    expect(comment?.startLine).toBe(2);
+    expect(comment?.line).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offline end-to-end: scripted model over the real toolkit, source port, and
+// publication path — the exact wiring the CLI uses, minus GitHub and the
+// live model.
+// ---------------------------------------------------------------------------
+
+describe("offline review run", () => {
+  it.effect("reviews the fixture pull request end-to-end and publishes the validated plan", () =>
+    Effect.gen(function* () {
+      const scripted = yield* makeOfflineReviewerModel({
+        diffPath: "src/hello.ts",
+        readPath: "src/hello.ts",
+        review: scriptedReview,
+      });
+      const binding = Agent.withModel(PullRequestReviewer, scripted.model);
+      const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
+
+      const program = executeReview(binding, { post: true, applyVerdict: false }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
+            collectingReviewPublisherLayer(published),
+            IdGenerator.layer,
+          ),
+        ),
+        Effect.scoped,
+      );
+      const outcome = yield* requiresNothing(program);
+
+      // The terminal JSON decoded into the scripted review exactly.
+      expect(outcome.review).toEqual(scriptedReview);
+      // list -> diff -> read -> final: four model turns, four prompts.
+      expect(outcome.turns).toBe(4);
+      expect(yield* scripted.calls).toBe(4);
+
+      // The instructions carried the mission framing into the first prompt.
+      const prompts = yield* scripted.prompts;
+      expect(prompts[0]).toContain("pull request #7");
+      expect(prompts[0]).toContain("acme/widgets");
+
+      // Anchor validation split the findings exactly as planned.
+      expect(outcome.plan.comments).toHaveLength(1);
+      expect(outcome.plan.demoted).toHaveLength(2);
+
+      // Publication went through the collecting publisher exactly once.
+      const plans = yield* Ref.get(published);
+      expect(plans).toHaveLength(1);
+      expect(plans[0]?.event).toBe("COMMENT");
+      expect(outcome.published?.url).toBe("memory://review/1");
+      expect(outcome.published?.inlineComments).toBe(1);
+
+      // The dry-run print path encodes cleanly.
+      const encoded = yield* Schema.encodeEffect(ReviewPublicationPlan)(outcome.plan);
+      expect(typeof encoded.body).toBe("string");
+    }),
+  );
+
+  it.effect("publishes nothing on a dry run", () =>
+    Effect.gen(function* () {
+      const scripted = yield* makeOfflineReviewerModel({
+        diffPath: "src/hello.ts",
+        readPath: "src/hello.ts",
+        review: scriptedReview,
+      });
+      const binding = Agent.withModel(PullRequestReviewer, scripted.model);
+      const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
+      const outcome = yield* executeReview(binding, { post: false, applyVerdict: false }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
+            collectingReviewPublisherLayer(published),
+            IdGenerator.layer,
+          ),
+        ),
+        Effect.scoped,
+      );
+      expect(outcome.published).toBeUndefined();
+      expect(yield* Ref.get(published)).toHaveLength(0);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Opt-in live profile: the SAME definition bound to a real Anthropic model
+// over the fixture pull request, behind the explicit environment gate.
+// Ordinary gates make zero network calls and need zero credentials.
+// ---------------------------------------------------------------------------
+
+const liveEnabled = liveReviewProfileEnabled(process.env);
+
+const AnthropicClientLayer = AnthropicClient.layerConfig({
+  apiKey: Config.redacted("ANTHROPIC_API_KEY"),
+}).pipe(Layer.provide(FetchHttpClient.layer));
+
+describe.skipIf(!liveEnabled)("pr-review live profile (opt-in)", () => {
+  it.live(
+    "reviews the fixture pull request with a live Anthropic model",
+    () =>
+      Effect.gen(function* () {
+        const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
+        const outcome = yield* executeReview(makeAnthropicReviewer(), {
+          post: false,
+          applyVerdict: false,
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
+              collectingReviewPublisherLayer(published),
+              AnthropicClientLayer,
+              IdGenerator.layer,
+            ),
+          ),
+          Effect.scoped,
+        );
+        // The output contract held against a real model; anchors that survived
+        // validation must reference the only diff in the fixture.
+        expect(outcome.review.summary.length).toBeGreaterThan(0);
+        for (const comment of outcome.plan.comments) {
+          expect(comment.path).toBe("src/hello.ts");
+          expect([1, 2, 3, 4]).toContain(comment.line);
+        }
+        expect(yield* Ref.get(published)).toHaveLength(0);
+      }),
+    300_000,
+  );
+});

--- a/examples/pr-review/test/pr-review.test.ts
+++ b/examples/pr-review/test/pr-review.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Config, Effect, Exit, Layer, Ref, Schema } from "effect";
+import { Tool } from "effect/unstable/ai";
+import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 import { FetchHttpClient } from "effect/unstable/http";
-import { AnthropicClient } from "@effect/ai-anthropic";
+import { OpenAiClient } from "@effect/ai-openai";
 
 import { Agent, IdGenerator } from "@effect-agent/core";
 
@@ -17,7 +19,8 @@ import {
   FixturePullRequest,
   fixturePullRequestSourceLayer,
   liveReviewProfileEnabled,
-  makeAnthropicReviewer,
+  ListChangedFiles,
+  makeOpenAiReviewer,
   makeOfflineReviewerModel,
   normalizeRepoRelativePath,
   parsePatch,
@@ -25,11 +28,23 @@ import {
   PullRequestMetadata,
   PullRequestReviewer,
   PullRequestReviewerProfile,
+  ReadFile,
+  ReadFileDiff,
   pullRequestReviewerProfile,
   ReviewFinding,
   ReviewPublicationPlan,
   ReviewToolkitLayer,
 } from "../src/index.ts";
+
+describe("OpenAI tool schema compatibility", () => {
+  it("encodes every reviewer tool as a strict OpenAI object schema", () => {
+    for (const tool of [ListChangedFiles, ReadFileDiff, ReadFile]) {
+      const jsonSchema = Tool.getJsonSchema(tool, { transformer: toCodecOpenAI });
+      expect(jsonSchema.type).toBe("object");
+      expect(jsonSchema.anyOf).toBeUndefined();
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Deterministic fixture pull request: one reviewable TypeScript change with a
@@ -361,24 +376,24 @@ describe("offline review run", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Opt-in live profile: the SAME definition bound to a real Anthropic model
+// Opt-in live profile: the SAME definition bound to a real OpenAI model
 // over the fixture pull request, behind the explicit environment gate.
 // Ordinary gates make zero network calls and need zero credentials.
 // ---------------------------------------------------------------------------
 
 const liveEnabled = liveReviewProfileEnabled(process.env);
 
-const AnthropicClientLayer = AnthropicClient.layerConfig({
-  apiKey: Config.redacted("ANTHROPIC_API_KEY"),
+const OpenAiClientLayer = OpenAiClient.layerConfig({
+  apiKey: Config.redacted("OPENAI_API_KEY"),
 }).pipe(Layer.provide(FetchHttpClient.layer));
 
 describe.skipIf(!liveEnabled)("pr-review live profile (opt-in)", () => {
   it.live(
-    "reviews the fixture pull request with a live Anthropic model",
+    "reviews the fixture pull request with a live OpenAI model",
     () =>
       Effect.gen(function* () {
         const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
-        const outcome = yield* executeReview(makeAnthropicReviewer(), {
+        const outcome = yield* executeReview(makeOpenAiReviewer(), {
           post: false,
           applyVerdict: false,
         }).pipe(
@@ -386,7 +401,7 @@ describe.skipIf(!liveEnabled)("pr-review live profile (opt-in)", () => {
             Layer.mergeAll(
               ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
               collectingReviewPublisherLayer(published),
-              AnthropicClientLayer,
+              OpenAiClientLayer,
               IdGenerator.layer,
             ),
           ),

--- a/examples/pr-review/test/pr-review.test.ts
+++ b/examples/pr-review/test/pr-review.test.ts
@@ -1,11 +1,10 @@
+import { Agent, IdGenerator } from "@effect-agent/core";
+import { OpenAiClient } from "@effect/ai-openai";
 import { describe, expect, it } from "@effect/vitest";
 import { Config, Effect, Exit, Layer, Ref, Schema } from "effect";
 import { Tool } from "effect/unstable/ai";
 import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 import { FetchHttpClient } from "effect/unstable/http";
-import { OpenAiClient } from "@effect/ai-openai";
-
-import { Agent, IdGenerator } from "@effect-agent/core";
 
 import {
   anchorViolation,

--- a/examples/pr-review/tsconfig.json
+++ b/examples/pr-review/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "changeset": "bun x changeset",
     "changeset:version": "bun x changeset version",
     "changeset:publish": "bun x changeset publish",
+    "release:publish": "tsx scripts/release-publish.ts",
     "requirements:coverage": "tsx scripts/requirements-coverage.ts",
     "reset:development-storage": "tsx scripts/reset-development-storage.ts",
     "formal:check": "tsx scripts/formal-check.ts",

--- a/packages/capabilities/CHANGELOG.md
+++ b/packages/capabilities/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @effect-agent/capabilities
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/engine@0.0.1

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/capabilities",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Operational capabilities for Effect Agent: approvals, budgets, context management, command queues, MCP, structural redaction, and subagents.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/capabilities"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @effect-agent/core
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/core",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Schema-first Agent authoring for Effect Agent: immutable definitions, explicit model bindings, policies, and core domain values.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/core"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @effect-agent/engine
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/engine",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "The Effect Agent ephemeral interpreter: a bounded agent loop over Effect AI with typed run events, budgets, and deterministic tool scheduling.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/engine"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/platform-cloudflare/CHANGELOG.md
+++ b/packages/platform-cloudflare/CHANGELOG.md
@@ -1,0 +1,16 @@
+# @effect-agent/platform-cloudflare
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/session@0.0.1
+  - @effect-agent/storage-cloudflare@0.0.1

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,10 +1,24 @@
 {
   "name": "@effect-agent/platform-cloudflare",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
+  "description": "Class DC layer assembly for Effect Agent: SQLite-backed Conversation Durable Objects with alarm-driven recovery.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/platform-cloudflare"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/platform-node/CHANGELOG.md
+++ b/packages/platform-node/CHANGELOG.md
@@ -1,0 +1,16 @@
+# @effect-agent/platform-node
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/session@0.0.1
+  - @effect-agent/storage-sqlite@0.0.1

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/platform-node",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Class DN layer assembly for Effect Agent: the durable Node/SQLite runtime host, wake scheduler, and ownership drain.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/platform-node"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/sandbox-local/CHANGELOG.md
+++ b/packages/sandbox-local/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @effect-agent/sandbox-local
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/sandbox@0.0.1

--- a/packages/sandbox-local/package.json
+++ b/packages/sandbox-local/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/sandbox-local",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Node-local child-process Sandbox adapter for Effect Agent; honestly labeled unisolated development tooling, not a security boundary.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/sandbox-local"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @effect-agent/sandbox
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/sandbox",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Platform-neutral sandbox contracts for Effect Agent: schema-first requests, events, errors, and the streaming Sandbox service.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/sandbox"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/session/CHANGELOG.md
+++ b/packages/session/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @effect-agent/session
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/engine@0.0.1

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/session",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Canonical Conversation records, reducers, store ports, recovery classifier, and the durable agent runtime coordinator for Effect Agent.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/session"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/storage-cloudflare/CHANGELOG.md
+++ b/packages/storage-cloudflare/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @effect-agent/storage-cloudflare
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/session@0.0.1

--- a/packages/storage-cloudflare/package.json
+++ b/packages/storage-cloudflare/package.json
@@ -1,10 +1,24 @@
 {
   "name": "@effect-agent/storage-cloudflare",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
+  "description": "Durable Object SQLite storage adapters and the routed port protocol for Effect Agent on Cloudflare.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/storage-cloudflare"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/storage-memory/CHANGELOG.md
+++ b/packages/storage-memory/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @effect-agent/storage-memory
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/session@0.0.1

--- a/packages/storage-memory/package.json
+++ b/packages/storage-memory/package.json
@@ -1,11 +1,24 @@
 {
   "name": "@effect-agent/storage-memory",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "In-memory Conversation store and submission ledger reference adapters for Effect Agent tests and conformance suites.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/storage-memory"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
     "./testing": "./src/testing.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/storage-memory/vite.config.ts
+++ b/packages/storage-memory/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite-plus";
+
+// This package ships two public entries: the storage adapters at "." and the
+// deterministic test helpers at "./testing". `vp pack` builds only the default
+// entry without this config, which would leave the "./testing" subpath broken
+// in the published artifact.
+export default defineConfig({
+  pack: {
+    entry: ["src/index.ts", "src/testing.ts"],
+    dts: true,
+    sourcemap: true,
+  },
+});

--- a/packages/storage-sqlite/CHANGELOG.md
+++ b/packages/storage-sqlite/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @effect-agent/storage-sqlite
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/session@0.0.1

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/storage-sqlite",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Node SQLite Conversation store and submission ledger adapters for the Effect Agent durable runtime.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/storage-sqlite"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,0 +1,20 @@
+# @effect-agent/testing
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial 0.0.1 release of the Effect Agent framework packages for live
+  integration testing: the schema-first authoring core, the ephemeral
+  interpreter, operational capabilities, sandbox contracts and the local
+  adapter, canonical session records with the durable coordinator, the
+  memory/SQLite/Cloudflare storage adapters, the Node and Cloudflare platform
+  assemblies, and the deterministic testing kit.
+- Updated dependencies []:
+  - @effect-agent/core@0.0.1
+  - @effect-agent/engine@0.0.1
+  - @effect-agent/capabilities@0.0.1
+  - @effect-agent/session@0.0.1
+  - @effect-agent/storage-memory@0.0.1
+  - @effect-agent/storage-sqlite@0.0.1
+  - @effect-agent/platform-node@0.0.1

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@effect-agent/testing",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "description": "Scripted models, deterministic fixtures, and adapter conformance kits for testing Effect Agent applications.",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/testing"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -33,7 +33,7 @@ const packageNames = [
   "storage-sqlite",
   "testing",
 ] as const;
-const exampleNames = ["demo", "providers", "repo-ops"] as const;
+const exampleNames = ["demo", "pr-review", "providers", "repo-ops"] as const;
 const effectTestPackageNames = [
   "capabilities",
   "engine",
@@ -228,9 +228,11 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       const demo = yield* readManifest(`${repositoryRoot}/examples/demo/package.json`);
       const providers = yield* readManifest(`${repositoryRoot}/examples/providers/package.json`);
       const repoOps = yield* readManifest(`${repositoryRoot}/examples/repo-ops/package.json`);
+      const prReview = yield* readManifest(`${repositoryRoot}/examples/pr-review/package.json`);
       const demoDependencies = manifestDependencies(demo);
       const providerDependencies = manifestDependencies(providers);
       const repoOpsDependencies = manifestDependencies(repoOps);
+      const prReviewDependencies = manifestDependencies(prReview);
 
       expect(demo.name).toBe("@effect-agent/example-demo");
       expect(demo.dependencies?.["@effect-agent/core"]).toBe("workspace:*");
@@ -268,6 +270,16 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(repoOpsDependencies.some((dependency) => dependency.startsWith("@cloudflare/"))).toBe(
         false,
       );
+      // The pr-review GitHub Action bot is the fourth leaf example workspace.
+      expect(prReview.name).toBe("@effect-agent/example-pr-review");
+      expect(prReview.dependencies?.["@effect-agent/core"]).toBe("workspace:*");
+      expect(prReview.dependencies?.["@effect-agent/engine"]).toBe("workspace:*");
+      expect(prReview.dependencies?.effect).toBe("catalog:");
+      expect(prReview.dependencies?.["@effect/ai-anthropic"]).toBe("catalog:");
+      expect(prReviewDependencies).not.toContain("wrangler");
+      expect(prReviewDependencies.some((dependency) => dependency.startsWith("@cloudflare/"))).toBe(
+        false,
+      );
 
       for (const packageName of packageNames) {
         const manifest = yield* readManifest(
@@ -276,6 +288,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         expect(manifestDependencies(manifest)).not.toContain(demo.name);
         expect(manifestDependencies(manifest)).not.toContain(providers.name);
         expect(manifestDependencies(manifest)).not.toContain(repoOps.name);
+        expect(manifestDependencies(manifest)).not.toContain(prReview.name);
         for (const adapter of providerAdapterDependencies) {
           expect(manifestDependencies(manifest)).not.toContain(adapter);
         }

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -275,7 +275,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(prReview.dependencies?.["@effect-agent/core"]).toBe("workspace:*");
       expect(prReview.dependencies?.["@effect-agent/engine"]).toBe("workspace:*");
       expect(prReview.dependencies?.effect).toBe("catalog:");
-      expect(prReview.dependencies?.["@effect/ai-anthropic"]).toBe("catalog:");
+      expect(prReview.dependencies?.["@effect/ai-openai"]).toBe("catalog:");
       expect(prReviewDependencies).not.toContain("wrangler");
       expect(prReviewDependencies.some((dependency) => dependency.startsWith("@cloudflare/"))).toBe(
         false,

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -1,0 +1,220 @@
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Console, Effect, FileSystem, Schema, Stream } from "effect";
+import { Command as CliCommand, Flag } from "effect/unstable/cli";
+import { ChildProcess } from "effect/unstable/process";
+
+// ---------------------------------------------------------------------------
+// Publish the public `@effect-agent/*` workspaces to npm with `bun publish`.
+//
+// Why not `changeset publish`: changesets shells out to `npm publish` in a
+// non-pnpm repository, and npm ships `workspace:*` and `catalog:` protocol
+// ranges verbatim — broken manifests. `bun publish` resolves both protocols
+// at publish time (verified against Bun 1.3.14).
+//
+// The repository keeps package export maps pointing at TypeScript source for
+// development (TOOLCHAIN.md); published artifacts must point at `dist`. This
+// script therefore rewrites each manifest's exports to the built `dist`
+// entries for the duration of one `bun publish`, then restores the original
+// bytes exactly — on success, failure, or interrupt.
+//
+// Flow: `bun run build` (dist artifacts) → `bun x changeset version` (cut the
+// versions) → `bun run release:publish -- --otp <code>` → `bun x changeset
+// tag` and push tags. Idempotent: versions already on the registry are
+// skipped, so a partial publish can simply be re-run.
+// ---------------------------------------------------------------------------
+
+const REGISTRY = "https://registry.npmjs.org";
+
+class ReleaseError extends Schema.TaggedErrorClass<ReleaseError>()("ReleaseError", {
+  package: Schema.String,
+  reason: Schema.String,
+}) {
+  override get message() {
+    return `${this.package}: ${this.reason}`;
+  }
+}
+
+class CommandError extends Schema.TaggedErrorClass<CommandError>()("CommandError", {
+  command: Schema.String,
+  exitCode: Schema.Int,
+  output: Schema.String,
+}) {
+  override get message() {
+    return this.output.length > 0
+      ? `${this.command} exited with code ${this.exitCode}: ${this.output}`
+      : `${this.command} exited with code ${this.exitCode}`;
+  }
+}
+
+const PublishManifest = Schema.Struct({
+  name: Schema.String,
+  version: Schema.String,
+  private: Schema.optionalKey(Schema.Boolean),
+  exports: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+});
+
+const decodeManifest = Schema.decodeUnknownEffect(Schema.fromJsonString(PublishManifest));
+
+const runCommand = Effect.fn("runCommand")(function* (
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+) {
+  const formatted = [command, ...args].join(" ");
+  const child = yield* ChildProcess.make(command, args, { cwd, stderr: "pipe", stdout: "pipe" });
+  const [output, exitCode] = yield* Effect.all([
+    Stream.mkString(Stream.decodeText(child.all)),
+    child.exitCode,
+  ]);
+  const trimmed = output.trim();
+  if (exitCode !== 0) {
+    return yield* CommandError.make({ command: formatted, exitCode, output: trimmed });
+  }
+  return trimmed;
+});
+
+/** True when `name@version` already exists on the public registry. */
+const alreadyPublished = Effect.fn("alreadyPublished")(function* (name: string, version: string) {
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(`${REGISTRY}/${name.replace("/", "%2f")}/${version}`),
+    catch: (cause) =>
+      ReleaseError.make({
+        package: name,
+        reason: `Registry lookup failed: ${String(cause)}`,
+      }),
+  });
+  if (response.status === 200) return true;
+  if (response.status === 404) return false;
+  return yield* ReleaseError.make({
+    package: name,
+    reason: `Unexpected registry status ${response.status} for version lookup.`,
+  });
+});
+
+/**
+ * Map one source export path to its built dist entry, mirroring the `vp pack`
+ * (tsdown) output naming: `./src/<entry>.ts` → `./dist/<entry>.mjs` with
+ * `./dist/<entry>.d.mts` types.
+ */
+const distExport = (sourcePath: string): { types: string; default: string } | undefined => {
+  const match = /^\.\/src\/([A-Za-z0-9_-]+)\.ts$/.exec(sourcePath);
+  if (match === null) return undefined;
+  return { types: `./dist/${match[1]}.d.mts`, default: `./dist/${match[1]}.mjs` };
+};
+
+const publishOne = Effect.fn("publishOne")(function* (options: {
+  readonly directory: string;
+  readonly dryRun: boolean;
+  readonly otp: string | undefined;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const manifestPath = `${options.directory}/package.json`;
+  const originalBytes = yield* fs.readFileString(manifestPath);
+  const manifest = yield* decodeManifest(originalBytes);
+
+  if (manifest.private === true) {
+    yield* Console.log(`- ${manifest.name}: private, skipped`);
+    return "skipped" as const;
+  }
+  if (yield* alreadyPublished(manifest.name, manifest.version)) {
+    yield* Console.log(`- ${manifest.name}@${manifest.version}: already on the registry, skipped`);
+    return "skipped" as const;
+  }
+
+  // Rewrite every source export to its dist entry, fail-closed on both an
+  // unrecognized export shape and a missing built artifact.
+  const parsed: unknown = JSON.parse(originalBytes);
+  const mutable = parsed as { exports?: Record<string, unknown> };
+  const exportsMap = manifest.exports ?? {};
+  const rewritten: Record<string, { types: string; default: string }> = {};
+  for (const [key, sourcePath] of Object.entries(exportsMap)) {
+    const dist = distExport(sourcePath);
+    if (dist === undefined) {
+      return yield* ReleaseError.make({
+        package: manifest.name,
+        reason: `Export '${key}' ('${sourcePath}') is not a recognized ./src/<entry>.ts path.`,
+      });
+    }
+    for (const artifact of [dist.types, dist.default]) {
+      if (!(yield* fs.exists(`${options.directory}/${artifact.slice(2)}`))) {
+        return yield* ReleaseError.make({
+          package: manifest.name,
+          reason: `Built artifact '${artifact}' is missing; run the build first.`,
+        });
+      }
+    }
+    rewritten[key] = dist;
+  }
+  mutable.exports = rewritten;
+
+  // Dry runs validate the packed artifact without registry credentials;
+  // real publishes require an authenticated npm session (`bunx npm login`).
+  const args = options.dryRun
+    ? ["pm", "pack", "--dry-run"]
+    : [
+        "publish",
+        "--access",
+        "public",
+        ...(options.otp !== undefined ? ["--otp", options.otp] : []),
+      ];
+
+  // The manifest swap is scoped: acquireRelease restores the original bytes
+  // even when the publish fails or the fiber is interrupted.
+  yield* Effect.acquireRelease(
+    fs.writeFileString(manifestPath, JSON.stringify(parsed, null, 2)),
+    () => fs.writeFileString(manifestPath, originalBytes).pipe(Effect.orDie),
+  );
+  yield* runCommand(options.directory, "bun", args);
+  yield* Console.log(
+    `- ${manifest.name}@${manifest.version}: ${options.dryRun ? "dry-run ok" : "published"}`,
+  );
+  return "published" as const;
+});
+
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+  Flag.withDescription("Pack and validate everything without uploading to the registry."),
+);
+const otpFlag = Flag.string("otp").pipe(
+  Flag.optional,
+  Flag.withDescription("npm one-time password forwarded to every bun publish."),
+);
+
+const command = CliCommand.make(
+  "release-publish",
+  { dryRun: dryRunFlag, otp: otpFlag },
+  ({ dryRun, otp }) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directories = (yield* fs.readDirectory("packages"))
+        .filter((entry) => !entry.startsWith("."))
+        .sort()
+        .map((entry) => `packages/${entry}`);
+      yield* Console.log(
+        `Publishing ${directories.length} workspaces to ${REGISTRY}${dryRun ? " (dry run)" : ""}...`,
+      );
+      let published = 0;
+      for (const directory of directories) {
+        const outcome = yield* Effect.scoped(
+          publishOne({ directory, dryRun, otp: otp._tag === "Some" ? otp.value : undefined }),
+        );
+        if (outcome === "published") published += 1;
+      }
+      yield* Console.log(
+        dryRun
+          ? `Dry run complete: ${published} package(s) would publish.`
+          : `Published ${published} package(s). Now run: bun x changeset tag && git push --follow-tags`,
+      );
+    }),
+).pipe(
+  CliCommand.withDescription(
+    "Publish public @effect-agent/* workspaces with bun publish (resolves workspace:/catalog: protocols) using dist export maps.",
+  ),
+);
+
+const program = CliCommand.run(command, { version: "1.0.0" }).pipe(
+  Effect.tapError((error) => Console.error(String(error))),
+  Effect.scoped,
+  Effect.provide(NodeServices.layer),
+);
+
+NodeRuntime.runMain(program, { disableErrorReporting: true });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     { "path": "./packages/platform-cloudflare" },
     { "path": "./packages/testing" },
     { "path": "./examples/demo" },
-    { "path": "./examples/providers" }
+    { "path": "./examples/pr-review" },
+    { "path": "./examples/providers" },
+    { "path": "./examples/repo-ops" }
   ]
 }


### PR DESCRIPTION
## What

Adds `examples/pr-review`, the fourth leaf example workspace: a PR-review bot built entirely on the public framework path, runnable as a GitHub Action.

- **Definition**: `Agent.define("pr-reviewer")` — `ReviewMission` in, structured `CodeReview` out, three `readonly` Effect AI tools (`list_changed_files`, `read_file_diff` with R-numbered annotated hunks, `read_file` head slices). Finite `AgentPolicy` plus run-level `UsageBudgetLimits` (cost-capped).
- **Fail-closed publication**: model output is untrusted — every finding anchor is re-validated against the parsed unified diff; invalid anchors demote into the review body. Valid ones become inline comments with ` ```suggestion ` blocks. Publication happens strictly after the run settles, via one review POST (COMMENT by default; `--apply-verdict` opts into verdict mapping).
- **CLI** (`effect/unstable/cli`): dry-run default, `--post`, `--model` (default `gpt-5.6-sol`), Actions event-payload target resolution, exit 1 on failure.
- **Action wiring**: composite `examples/pr-review/action.yml` + `.github/workflows/pr-review.yml`, silently skipped while the `OPENAI_API_KEY` secret is absent.
- **Profiles**: prompt-keyed scripted model drives the real toolkit on every ordinary gate (no network, no credentials); live OpenAI profile is `EFFECT_AGENT_LIVE=1`-gated.

## Repo housekeeping folded in

- Toolchain conformance inventory + root tsconfig references updated (including the previously missing `repo-ops` reference); TOOLCHAIN.md workspace listing.
- `.worktrees/` gitignored (repo-wide format checks were walking secondary checkouts).
- New `FRICTION.md` records six authoring friction points for the API-simplification backlog.

## Evidence

- `bun run ready` green on this branch rebased onto `main` (post release-tooling), including the 12 new example tests; live smoke gate-skips.
- The reviewer was exercised for real from the kommunikasie integration worktree: a linked local checkout dry-ran PR #255 (four turns, validated COMMENT plan, nothing posted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)