### PR TITLE
fix(ci): reproducible installs via dev-kit-managed skills + locked convergence

### DIFF
--- a/.agents/skills/effect-ts/SKILL.md
+++ b/.agents/skills/effect-ts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: effect-ts
-description: Use this skill whenever working in a repository that uses Effect, even if the current task is in a new file or the user does not explicitly ask for Effect help. Apply it to Effect patterns, services, layers, schemas, streams, runtimes, typed errors, observability, testing, HTTP, SQL, command-line scripts, project automation, and supporting tooling.
+description: Use this skill whenever working in a repository that uses Effect, even if the current task is in a new file or the user does not explicitly ask for Effect help. Apply it to Effect patterns, services, layers, schemas, streams, runtimes, typed errors, DateTime, Effect Atom, observability, testing, HTTP, SQL, command-line scripts, project automation, and supporting tooling.
 ---
 
 # Effect Expert
@@ -106,6 +106,19 @@ When the task touches one of these areas, consult the matching guide before impl
 - `./references/guide-schedule.md` for retries, repeats, backoff, polling, cron, and schedule composition
 - `./references/guide-schema.md` for schema-first application modeling,
   service contracts, transformations, unions, recursion, and branded types
+- `./references/guide-datetime.md` for current time, parsing, UTC and zoned
+  values, time zones, DST-safe arithmetic, formatting, Date interoperability,
+  and deterministic `TestClock` tests
+- `./references/guide-atom-data-fetching.md` for the core Effect Atom HTTP
+  data-fetching workflow, React hook choice, and action-lifetime ownership rules
+- `./references/atom-cache-lifecycle.md` for Effect Atom registry scope,
+  runtime memoization, families, TTL, SWR, polling, and aggregation resets
+- `./references/atom-http-and-invalidation.md` for `AtomHttpApi.Service`,
+  queries, mutations, reactivity keys, and invalidation
+- `./references/atom-tanstack-start.md` only for TanStack Start provider
+  placement, SSR isolation, hydration, and focus guidance
+- `./references/atom-testing.md` when adding or diagnosing deterministic Effect
+  Atom lifecycle tests
 - `./references/guide-sql.md` for Effect SQL usage, transactions, resolvers, schema-aware SQL, and migrations
 - `./references/guide-testing.md` for `@effect/vitest`, deterministic testing,
   honest test Layers, property tests, and protocol round trips
@@ -208,6 +221,15 @@ Install additional `@effect/*` packages only when the user task actually needs t
 - If a type is hard to express, simplify the design or introduce a properly typed helper instead of using unsafe TypeScript.
 - For layers, do not hide them inside `namespace` blocks. Prefer either `static` members on the service class or plain exported layer constants.
 
+### Date and Time
+
+- Prefer Effect `DateTime` over vanilla JavaScript `Date` for application
+  logic. Keep `Date` as an interoperability type at external boundaries.
+- Use `DateTime.now` inside Effect programs so current time remains driven by
+  the `Clock` service and deterministic under `TestClock`.
+- Preserve the distinction between instants, zoned wall-clock values, and
+  date-only domain values.
+
 ### Code Quality
 
 - Write type-safe code that leverages Effect's type system.
@@ -233,6 +255,12 @@ rely on installed declarations and version-matched canonical Effect source.
 - `./references/guide-retries.md`
 - `./references/guide-schedule.md`
 - `./references/guide-schema.md`
+- `./references/guide-datetime.md`
+- `./references/guide-atom-data-fetching.md`
+- `./references/atom-cache-lifecycle.md`
+- `./references/atom-http-and-invalidation.md`
+- `./references/atom-tanstack-start.md`
+- `./references/atom-testing.md`
 - `./references/guide-sql.md`
 - `./references/guide-testing.md`
 - `./references/guide-cli.md`

--- a/.agents/skills/effect-ts/UPSTREAM.md
+++ b/.agents/skills/effect-ts/UPSTREAM.md
@@ -16,14 +16,12 @@ They have been modified to:
 
 ## Local Authoring Checkout
 
-This repository may keep an ignored, version-matched Effect checkout for
-validating source paths and beta-sensitive APIs:
+This repository keeps an ignored, version-matched Effect checkout for
+validating source paths and beta-sensitive APIs. `vp i` runs the equivalent
+dev-kit setup automatically; it can also be invoked directly:
 
 ```bash
-git clone --depth 1 \
-  --branch 'effect@4.0.0-beta.102' \
-  https://github.com/Effect-TS/effect.git \
-  .repos/effect
+./bin/dev-kit.mjs effect sync
 ```
 
 Update the checkout, package dependencies, review baseline, feature index, and

--- a/.agents/skills/effect-ts/agents/openai.yaml
+++ b/.agents/skills/effect-ts/agents/openai.yaml
@@ -1,5 +1,4 @@
 interface:
   display_name: "Effect Expert"
   short_description: "Apply current Effect v4 patterns and tooling"
-  default_prompt: "Use $effect-ts to apply the relevant Effect architecture, schema, service, error, testing, HTTP, SQL, observability, or CLI guidance."
-
+  default_prompt: "Use $effect-ts to apply the relevant Effect architecture, DateTime, Atom, schema, service, error, testing, HTTP, SQL, observability, or CLI guidance."

--- a/.agents/skills/effect-ts/references/atom-cache-lifecycle.md
+++ b/.agents/skills/effect-ts/references/atom-cache-lifecycle.md
@@ -1,0 +1,78 @@
+# Effect Atom cache lifecycle
+
+## Registry and runtime scope
+
+`RegistryProvider` creates one `AtomRegistry` on its first render. Its options do not rebuild that registry later. Provider unmount schedules disposal after a short grace period, so a quick React remount can reuse the same registry; moving or keying the provider still changes the cache boundary.
+
+Place one provider around the client application subtree that should share data. Nested or route-local providers create separate caches.
+
+### React mounts and registry disposal
+
+`useAtomValue` keeps an atom active through its value subscription. `useAtomSet` and `useAtomRefresh` mount an atom through a React effect, while `useAtom` combines one value subscription with a setter. Use the combined hook when one component reads and writes the same atom; composing `useAtomValue` and `useAtomSet` adds a second mount and obscures which lifetime owns the work.
+
+Unmount releases only that hook's subscription or mount. The registry removes a node only after it has no remaining consumers and its idle TTL permits removal. Node disposal runs registered finalizers, including cancellation of interruptible Effect work. Therefore component unmount, registry eviction, and `Atom.Interrupt` are distinct events; do not use an unconditional interrupt write as a substitute for releasing a React mount.
+
+An atom runtime and a registry solve different problems:
+
+- the registry stores atom nodes, values, subscriptions, idle timers, and finalizers;
+- `Atom.context({ memoMap })` creates runtimes that share `Layer` construction through one `Layer.MemoMap`;
+- the module-level `Atom.runtime` uses Effect's module-level default memo map.
+
+Create one client runtime factory when several API/services must share layers:
+
+```ts
+import { Layer } from "effect";
+import { Atom } from "effect/unstable/reactivity";
+
+export const appAtomRuntime = Atom.context({
+  memoMap: Layer.makeMemoMapUnsafe(),
+});
+```
+
+Pass `appAtomRuntime` to each `AtomHttpApi.Service`. Do not create a memo map per query or component. On an SSR server, do not put request-specific authentication or services into a process-global memo map; use a request-scoped atom environment or keep the atom data path client-only.
+
+## Stable identity and families
+
+Export fixed queries directly. Use `Atom.family` when a parameter selects the resource:
+
+```ts
+export const projectAtom = Atom.family((projectId: string) =>
+  ApiClient.query("projects", "get", {
+    params: { projectId },
+    timeToLive: "5 minutes",
+    reactivityKeys: { projects: [projectId] },
+  }).pipe(Atom.swr({ staleTime: "30 seconds", revalidateOnMount: true })),
+);
+```
+
+The family must receive a stable key. Prefer a primitive ID. If the key is an object, give it deliberate Effect `Equal`/`Hash` semantics or reuse the same object; repeated object literals can produce distinct family entries.
+
+## Three independent clocks
+
+| Control                                         | Clock starts                      | What happens                                                                                         | What it does not mean                                 |
+| ----------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Registry/default idle TTL or query `timeToLive` | When an atom becomes unused       | The registry keeps the cached node until idle eviction                                               | The value is fresh during that period                 |
+| `Atom.swr({ staleTime })`                       | From the latest success timestamp | A stale value can revalidate automatically on mount or focus while the prior success remains visible | The node survives an unmount long enough to be reused |
+| `Atom.withRefresh(interval)`                    | While the wrapper is mounted      | A timer force-refreshes the source and is canceled on disposal                                       | Fresh requests are skipped                            |
+
+Set retention long enough for the navigation/remount reuse window. `staleTime` cannot rescue a source that idle eviction already removed. A common policy is a longer `timeToLive`, a shorter `staleTime`, and polling only on screens that truly need it.
+
+Manual `registry.refresh`, `useAtomRefresh`, invalidation, and `Atom.withRefresh` are forceful. They do not consult SWR freshness. Polling stops when the polling wrapper's lifetime is disposed because its finalizer clears the timer; applying `keepAlive` to that wrapper intentionally keeps polling alive.
+
+## The `AsyncResult.all` route reset
+
+`AsyncResult.all` returns the first non-success input. Therefore a route aggregate is only as reusable as its least-stable input:
+
+```ts
+const routeDataAtom = Atom.make((get) =>
+  AsyncResult.all({
+    project: get(projectAtom("p-1")),
+    // Bad if created during render or rebuilt for every route visit:
+    preferences: get(makePreferencesAtom()),
+  }),
+);
+```
+
+If `preferences` is a fresh or evicted atom, it starts at `Initial`; the aggregate also looks initial even though `project` is cached. Fix the input's ownership and retention. Define a singleton/family atom outside render and give it a deliberate idle TTL. Memoizing only the `AsyncResult.all` call does not repair an unstable input atom.
+
+`AsyncResult.all` also constructs a new success container. Keep aggregation inside a derived atom so the registry controls recomputation instead of rebuilding the container ad hoc in render.

--- a/.agents/skills/effect-ts/references/atom-http-and-invalidation.md
+++ b/.agents/skills/effect-ts/references/atom-http-and-invalidation.md
@@ -1,0 +1,97 @@
+# Effect Atom HTTP queries and invalidation
+
+## Build one API service
+
+`AtomHttpApi.Service` generates a typed client, a runtime, query atoms, and mutation functions. Pass the shared runtime factory so API services share the intended `Layer.MemoMap`:
+
+```ts
+import { FetchHttpClient } from "effect/unstable/http";
+import { AtomHttpApi } from "effect/unstable/reactivity";
+import { appAtomRuntime } from "./atom-runtime";
+import { Api } from "./api";
+
+export const ApiClient = AtomHttpApi.Service()("ApiClient", {
+  api: Api,
+  httpClient: FetchHttpClient.layer,
+  baseUrl: "/api",
+  runtime: appAtomRuntime,
+});
+```
+
+Compile examples against the installed Effect version; the reactivity and HTTP APIs are unstable.
+
+## Queries
+
+`query(group, endpoint, request)` returns an `Atom<AsyncResult<...>>`. The service internally memoizes request keys with a family. A public `Atom.family` remains useful for expressing domain ownership with a simple, stable parameter and applying one cache policy.
+
+Query options have separate roles:
+
+- `timeToLive`: finite values apply idle TTL; infinity keeps the query alive;
+- `reactivityKeys`: register the query for refresh after matching invalidation;
+- `serializationKey`: make decoded-only results serializable for hydration; it is not the runtime cache key;
+- `responseMode`: changes the response and error shape.
+
+Never place secrets in `serializationKey`, URL state, hydration payloads, or client-visible layers.
+
+## Mutations and action ownership
+
+Create mutation atoms once, then invoke them from the component or workflow that owns the action:
+
+```ts
+export const updateProject = ApiClient.mutation("projects", "update");
+
+// In the initiating component:
+const mutate = useAtomSet(updateProject, { mode: "promise" });
+await mutate({
+  params: { projectId },
+  payload: patch,
+  reactivityKeys: { projects: [projectId] },
+});
+```
+
+The mutation's `reactivityKeys` are invalidated only after the request succeeds. Failed mutations do not invalidate. Keep navigation, toasts, dialog closure, and optimistic UI at the action owner; keep shared server-state refresh in reactivity keys.
+
+If the component also renders the mutation result, use `useAtom(updateProject)` instead of pairing `useAtomValue` with `useAtomSet`. A module-scoped mutation atom is shared registry state, so an unconditional cleanup write of `Atom.Interrupt` can cancel work owned by another consumer and publishes an interrupted failure.
+
+Keep a multi-step mutation sequence in an owner that lives for the whole sequence. When navigation can unmount the initiating route after one request succeeds, a component-owned sequential fan-out can leave a partially completed operation. Use one stable workflow atom or service when client ownership is sufficient; use one server-side command or durable workflow when completion must survive browser navigation or disconnects.
+
+## Use one key vocabulary
+
+Array keys represent independent keys. Record keys support hierarchical broad-plus-entity invalidation:
+
+```ts
+const listKeys = { projects: [] };
+const detailKeys = { projects: [projectId] };
+
+ApiClient.query("projects", "list", { reactivityKeys: listKeys });
+ApiClient.query("projects", "get", { params: { projectId }, reactivityKeys: detailKeys });
+
+// This mutation invalidates the broad namespace and this entity key.
+await mutate({ params: { projectId }, payload: patch, reactivityKeys: detailKeys });
+```
+
+Record semantics register the property name and each `property:id` combination. Consequently, `{ projects: [projectId] }` is hierarchical: it invalidates both the broad `projects` namespace and the specific `projects:projectId` key. Every record-form project query also subscribed to that broad namespace can refresh. Use this when an entity write may affect lists or aggregates.
+
+For exact entity-only invalidation, use namespaced primitive array keys consistently instead:
+
+```ts
+const projectKey = (id: string) => `project:${id}`;
+
+const detailKeys = [projectKey(projectId)];
+const collectionKeys = ["projects"];
+
+ApiClient.query("projects", "get", { params: { projectId }, reactivityKeys: detailKeys });
+await mutate({ params: { projectId }, payload: patch, reactivityKeys: detailKeys });
+```
+
+Use `collectionKeys` for the collection query and for mutations that can change membership or ordering.
+
+Standardize key constructors in one module when several endpoints share them; mismatched strings fail silently.
+
+Choose invalidation breadth from the server write:
+
+- invalidate an exact array-form entity key when only one detail changed;
+- invalidate the collection key, or use hierarchical record keys, when list membership, ordering, totals, or filters can change;
+- invalidate multiple record properties when a write affects related aggregates.
+
+Do not both invalidate and manually refresh the same query unless two requests are intentional.

--- a/.agents/skills/effect-ts/references/atom-tanstack-start.md
+++ b/.agents/skills/effect-ts/references/atom-tanstack-start.md
@@ -1,0 +1,69 @@
+# Effect Atom TanStack Start integration
+
+TanStack Start code is isomorphic by default, including route loaders. Treat every module used by a route as server-capable unless an explicit boundary says otherwise.
+
+## Choose an SSR strategy
+
+Use one of these models deliberately:
+
+### Client-only atom data
+
+- Put one `RegistryProvider` in the app/root component so client navigations share a registry.
+- Render atom consumers that touch browser-only APIs inside `ClientOnly` from `@tanstack/react-router`.
+- Accept that the fallback is the server-rendered state and fetching begins on the client.
+- Keep the client runtime and API service as module singletons.
+
+```tsx
+import { RegistryProvider } from "@effect/atom-react";
+import { ClientOnly } from "@tanstack/react-router";
+
+export function AppShell() {
+  return (
+    <RegistryProvider defaultIdleTTL={30_000}>
+      <ClientOnly fallback={<DashboardSkeleton />}>
+        <Dashboard />
+      </ClientOnly>
+    </RegistryProvider>
+  );
+}
+```
+
+### SSR plus hydration
+
+- Create the registry and any request-specific runtime/layers per request; never share user/auth state through a process-global registry or memo map.
+- Give decoded query atoms deterministic `serializationKey` values.
+- Mount/run the required serializable atoms on the server, dehydrate only the intended values, and pass them through the document safely.
+- Create the client registry once, then hydrate matching atom identities before descendants consume them. Use `HydrationBoundary` where the installed React adapter supports it.
+- Verify that server and client construct the same API service, family arguments, and serialization keys.
+
+Prefer framework loaders/server functions when they already own SSR data. Do not build a second atom SSR cache merely to mirror loader data; seed atoms from the loader or keep atom fetching client-only.
+
+## Focus is browser-only
+
+`Atom.windowFocusSignal` reads `window` and `document.visibilityState` when mounted. Do not mount it during SSR. Put focus-enabled consumers behind `ClientOnly`, or inject a no-op server signal and the browser signal on the client.
+
+```ts
+const project = projectAtom(projectId).pipe(
+  Atom.swr({
+    staleTime: "30 seconds",
+    revalidateOnFocus: true,
+    focusSignal: Atom.windowFocusSignal,
+  }),
+);
+```
+
+`revalidateOnFocus: true` respects `staleTime`; `"always"` forces a request on every focus signal.
+
+## In-memory limits
+
+Effect Atom's registry cache is in memory and scoped to that registry:
+
+- a new tab, hard reload, server process, or newly created provider starts another cache;
+- idle TTL evicts only unused atoms and is not a maximum-entry or byte-size bound;
+- `keepAlive` and infinite TTL can grow memory with unbounded family keys;
+- browser memory is not durable or shared across users/devices;
+- hydration transfers a snapshot, not a persistent distributed cache.
+
+For large or unbounded parameter spaces, use finite TTLs and avoid `keepAlive`. Put durable/shared caching at the HTTP, server, CDN, or database layer.
+
+Primary TanStack references: [execution model](https://tanstack.com/start/latest/docs/framework/react/guide/execution-model) and [`ClientOnly`](https://tanstack.com/router/latest/docs/api/router/clientOnlyComponent).

--- a/.agents/skills/effect-ts/references/atom-testing.md
+++ b/.agents/skills/effect-ts/references/atom-testing.md
@@ -1,0 +1,67 @@
+# Deterministic Effect Atom lifecycle testing
+
+Test cache policy below React first with `AtomRegistry.make()`. Add a React integration test only for provider placement, hook behavior, a browser-only SSR boundary, or hydration.
+
+Use fake timers, a request counter, controllable Effects, and explicit mounts:
+
+```ts
+const registry = AtomRegistry.make({ defaultIdleTTL: 1_000 });
+const unmount = registry.mount(queryAtom);
+const first = registry.get(queryAtom);
+
+// Advance the Effect scheduler/microtasks as required by the installed version.
+// Assert with AsyncResult predicates and request counts.
+
+unmount();
+```
+
+Avoid wall-clock sleeps. Flush Effect work with the repository's established `Effect.yieldNow`/test-clock pattern and advance the test runner's fake timers.
+
+Prefer the installed test APIs over invented helpers or matchers. The upstream Effect tests use `assert(AsyncResult.isSuccess(result))`, `Effect.runPromise(Effect.yieldNow)`, `vitest.advanceTimersByTimeAsync(...)`, and the cleanup returned by `registry.mount(atom)`.
+
+## Required scenarios
+
+### Remount reuse
+
+1. Mount and resolve the query; assert request count `1`.
+2. Unmount, advance less than idle TTL, remount the same atom identity.
+3. Assert the cached success is immediately available and no request occurs while still fresh.
+
+### Stale refresh
+
+1. Resolve once through an SWR wrapper.
+2. Advance past `staleTime` but not idle TTL.
+3. Remount or emit the injected focus signal.
+4. Assert the previous success stays available with `waiting: true`, then a second success arrives and request count becomes `2`.
+5. Also prove a fresh mount/focus does not request.
+
+### TTL eviction
+
+1. Resolve and unmount.
+2. Advance to just before TTL; assert reuse.
+3. Advance to/after TTL and flush disposal; remount.
+4. Assert `Initial`/waiting behavior and a new request.
+
+### Polling cleanup
+
+1. Mount the `Atom.withRefresh` wrapper and resolve once.
+2. Advance one interval; assert one forced refresh.
+3. Unmount and advance several intervals.
+4. Assert the counter does not change. This catches leaked timers or accidental `keepAlive`.
+
+### Mutation invalidation
+
+1. Mount list and detail queries with explicit keys.
+2. Run a successful mutation with matching keys; assert only the intended queries refresh.
+3. Run a failed mutation; assert no invalidation.
+4. Assert cleanup removes invalidation handlers after query disposal.
+
+### React Strict Mode and action ownership
+
+Use a React integration test when hook cleanup or action ownership is part of the behavior. Render the owner inside `StrictMode` and assert the development setup-cleanup replay does not write `Atom.Interrupt` or publish an interrupted failure before an explicit cancellation. When an action spans multiple requests, unmount during the sequence and prove the chosen policy: either the stable owner completes every step, or an explicit cancellation interrupts it intentionally. If the atom is shared, also prove unmounting one consumer does not cancel work still owned by another.
+
+### Aggregate stability
+
+Mount a route atom that uses `AsyncResult.all`, resolve every input, unmount, and remount inside the retention window. Assert the aggregate never returns to `Initial`. Then let one input expire and prove the aggregate reset is caused by that input, not the retained queries.
+
+For runtime/layer tests, seed `runtime.layer` through `RegistryProvider initialValues` with a deterministic test layer. This replaces network services without changing the production atom graph.

--- a/.agents/skills/effect-ts/references/audit-services.md
+++ b/.agents/skills/effect-ts/references/audit-services.md
@@ -44,17 +44,17 @@ Enumerate source and test files, then find:
 
 Record one row per discovered service or candidate:
 
-| Field | Question |
-| --- | --- |
-| Owner | Which module owns the capability's meaning? |
-| Contract | Where are its interface and tag? |
-| Construction | Does construction yield every runtime dependency? |
-| Production | Who owns the concrete implementation and Layer choice? |
-| Tests | Does it have an intentional and honest substitute strategy? |
-| Consumers | Are capabilities yielded or drilled as values? |
-| Requirements | Do requirements remain visible to the composition root? |
-| Type boundary | Who owns decoding, narrowing, and error translation? |
-| Verdict | Keep, deepen, relocate, merge, remove, or create? |
+| Field         | Question                                                    |
+| ------------- | ----------------------------------------------------------- |
+| Owner         | Which module owns the capability's meaning?                 |
+| Contract      | Where are its interface and tag?                            |
+| Construction  | Does construction yield every runtime dependency?           |
+| Production    | Who owns the concrete implementation and Layer choice?      |
+| Tests         | Does it have an intentional and honest substitute strategy? |
+| Consumers     | Are capabilities yielded or drilled as values?              |
+| Requirements  | Do requirements remain visible to the composition root?     |
+| Type boundary | Who owns decoding, narrowing, and error translation?        |
+| Verdict       | Keep, deepen, relocate, merge, remove, or create?           |
 
 Build a companion type-safety inventory using
 [`guide-type-safety-and-boundaries.md`](guide-type-safety-and-boundaries.md).

--- a/.agents/skills/effect-ts/references/guide-atom-data-fetching.md
+++ b/.agents/skills/effect-ts/references/guide-atom-data-fetching.md
@@ -1,0 +1,44 @@
+# Effect Atom Data Fetching
+
+Model server data as stable atoms owned outside React renders. Give the application one intentional registry boundary and one compatible runtime factory; then choose cache retention, freshness, polling, and invalidation independently.
+
+## Workflow
+
+1. Inspect the installed `effect` and `@effect/atom-react` versions and their source before copying signatures. These APIs live under `effect/unstable/reactivity` and may move.
+2. Locate every `RegistryProvider`, runtime factory, query atom, mutation atom, and route-level `AsyncResult.all`. Draw the ownership boundary before changing behavior.
+3. Keep one `RegistryProvider` for the intended client application lifetime. Define the shared runtime factory, API service, query families, and mutation atoms at module scope rather than in components.
+4. Choose each lifecycle control for its actual job:
+   - idle `timeToLive`: retain an unused registry value before disposal;
+   - `Atom.swr({ staleTime })`: decide when mount/focus revalidation is needed;
+   - `Atom.withRefresh`: force periodic refresh while mounted.
+5. Give queries stable identities and matching reactivity keys. Let successful mutations invalidate those keys rather than manually coordinating every consumer.
+6. Keep browser-only signals behind an SSR-safe boundary. Decide explicitly whether initial data is client-only or hydrated from a request-scoped server registry.
+7. Verify lifecycle behavior with fake time and request counters, not sleeps.
+
+## Ownership rules
+
+- Treat a query as shared read state: export one atom or `Atom.family` and let components subscribe.
+- Treat an action as an event owned by the initiating UI or workflow: export the mutation atom, invoke it with `useAtomSet`, and observe its result only where useful.
+- Never allocate a query atom in render. For parameterized queries, use a stable scalar or Effect `Hash`/`Equal` value as the family argument.
+- Ensure every input to a route-level `AsyncResult.all` has stable atom identity and compatible retention. One newly allocated or immediately evicted input returns to `Initial` and makes the whole aggregate appear reset even when the other inputs remain cached.
+- Do not describe manual refresh or polling as freshness caching. Refresh is forceful; `staleTime` only gates SWR's automatic mount/focus decisions.
+
+## React hooks and action lifetime
+
+Choose the hook that expresses the component's ownership:
+
+- `useAtomValue(atom)` subscribes for rendering without returning a setter;
+- `useAtomSet(atom)` mounts a writable atom and returns a setter without rendering from its value;
+- `useAtom(atom)` subscribes and returns a setter when the same component both renders and writes the atom.
+
+Do not pair `useAtomValue(atom)` with `useAtomSet(atom)` for the same atom in one component. The split form creates both a value subscription and a separate mount. Use `useAtom(atom)` instead. Calling an `Atom.family` directly with a stable primitive during render already returns the stable family member; a surrounding `useMemo` is not needed merely to preserve atom identity.
+
+The React hooks release their subscriptions and mounts when their component lifetime ends. Registry node removal then follows the atom's idle TTL and remaining consumers, and node disposal runs the atom lifetime finalizers. Do not confuse hook cleanup, idle retention, and operation cancellation: another consumer or a nonzero TTL can intentionally keep the node and its work alive after one component unmounts.
+
+Do not add a cleanup-only effect such as `useEffect(() => () => set(Atom.Interrupt), [set])` merely to mirror component unmount. `Atom.Interrupt` is a write that publishes an interrupted `AsyncResult.Failure`, not a passive release function. The cleanup also runs on dependency changes and during React Strict Mode's development effect replay, and it can interrupt work still owned by another consumer. Use `Atom.Interrupt` for an explicit user cancellation or a deliberately scoped cancellation policy, and test that ownership under Strict Mode.
+
+Decide whether an action must survive its initiating component before choosing its owner. A sequential client fan-out can partially complete if route unmount disposes its owner after earlier mutations succeed but before later ones start. If the whole sequence must be durable, move it to a stable workflow owner or one server-side command instead of relying on a route component's hook lifetime.
+
+## Completion check
+
+Confirm one registry boundary, stable atom identity, deliberate TTL/staleness/polling values, matching query and mutation keys, an intentional React hook and action lifetime, SSR-safe browser access, and tests for every lifecycle behavior changed.

--- a/.agents/skills/effect-ts/references/guide-cli.md
+++ b/.agents/skills/effect-ts/references/guide-cli.md
@@ -99,7 +99,8 @@ Run the narrowest meaningful checks:
 
 - Confirm that every TypeScript entrypoint named by `package.json` belongs to
   one checked TypeScript project.
-- `bun run check:scripts` for root scripts.
+- The repository's root `check` or typecheck script when the entrypoint belongs
+  to the root project.
 - Package-level `bun run check` when the script lives under an app/package and is included in that TS config.
 - The command's `--help` path.
 - A dry-run or harmless invalid-input path that loads the entrypoint and

--- a/.agents/skills/effect-ts/references/guide-datetime.md
+++ b/.agents/skills/effect-ts/references/guide-datetime.md
@@ -1,0 +1,72 @@
+# Effect DateTime
+
+Prefer Effect `DateTime` over vanilla JavaScript `Date` for application logic. Keep `Date` as an interoperability type at external boundaries, not the domain model.
+
+## Workflow
+
+1. Inspect the installed `effect` version and `DateTime` source before relying on exact signatures. DateTime APIs are version-sensitive.
+2. Identify whether each value represents an absolute instant, a wall-clock time in a named zone, or only a calendar date. Do not silently collapse these meanings.
+3. Decode external strings, numbers, and `Date` objects at the boundary. Use `Schema.DateTimeUtc`, `Schema.DateTimeUtcFromString`, `Schema.DateTimeUtcFromMillis`, `Schema.DateTimeUtcFromDate`, or `Schema.DateTimeZoned` as appropriate.
+4. Keep domain values as `DateTime.Utc` by default. Use `DateTime.Zoned` when calendar operations or presentation must retain an IANA time zone.
+5. Use `DateTime.now` inside Effect programs so the current time comes from the `Clock` service. Reserve `DateTime.nowUnsafe()` and `Date.now()` for explicit synchronous host boundaries.
+6. Perform comparisons, arithmetic, rounding, and formatting with `DateTime` operations, then convert to `Date` or epoch milliseconds only when an external API requires them.
+7. Test time-dependent behavior with `it.effect` and `TestClock`; advance virtual time instead of sleeping or consulting the live clock.
+
+## Construction and boundaries
+
+- Prefer safe decoding for untrusted input. `DateTime.make` and zoned constructors return `Option`; Schema decoders produce structured parse failures.
+- Use `DateTime.makeUnsafe` only for literals and values already validated by the program. Do not turn user input into defects.
+- Prefer explicit ISO 8601 strings with offsets at wire boundaries. Avoid implementation-dependent or locale-formatted date strings.
+- Do not invent a midnight instant for a genuinely date-only value such as a birthday. Preserve a validated `YYYY-MM-DD` or a domain-specific year/month/day structure until an actual time and zone are chosen.
+- Use `DateTime.makeZonedFromString` or `Schema.DateTimeZoned` when a serialized value must preserve its zone.
+- Use `DateTime.toDateUtc`, `DateTime.toEpochMillis`, and `DateTime.fromDateUnsafe` only at interop boundaries.
+
+```ts
+import { DateTime, Effect, Schema } from "effect";
+
+const Timestamp = Schema.DateTimeUtcFromString;
+
+const expiresAt = DateTime.makeUnsafe("2030-01-01T00:00:00Z");
+
+const isExpired = Effect.gen(function* () {
+  const now = yield* DateTime.now;
+  return DateTime.isLessThanOrEqualTo(expiresAt, now);
+});
+```
+
+## Instants, zones, and arithmetic
+
+- Treat `DateTime.Utc` as an instant without retained zone information. Treat `DateTime.Zoned` as the same kind of instant plus a zone used for wall-clock parts, formatting, and zone-aware transformations.
+- Use `DateTime.setZone` or `setZoneNamed` to view the same instant in another zone. When constructing from local wall-clock parts, use `makeZoned` with `adjustForTimeZone: true` and choose a deliberate `disambiguation` policy for DST gaps and repeated times.
+- Use `DateTime.addDuration` and `subtractDuration` for elapsed time. Use `DateTime.add` and `subtract` for calendar arithmetic such as days, months, and years; these operations account for a zoned value's calendar rules.
+- Use `DateTime.startOf`, `endOf`, or `nearest` rather than hand-editing fields. State `weekStartsOn` when week boundaries are domain-sensitive.
+- Use `DateTime.Order`, `Equivalence`, `min`, `max`, `between`, and comparison helpers rather than comparing formatted strings or mutable `Date` objects.
+- Use `formatIso` for UTC interchange, `formatIsoZoned` when preserving a zone, and `format` / `formatIntl` for presentation. Do not persist locale-formatted output.
+
+## Current time and tests
+
+Code that asks what time it is must remain clock-driven:
+
+```ts
+import { assert, it } from "@effect/vitest";
+import { DateTime, Duration, Effect } from "effect";
+import { TestClock } from "effect/testing";
+
+it.effect("expires after an hour", () =>
+  Effect.gen(function* () {
+    yield* TestClock.setTime(DateTime.toEpochMillis(DateTime.makeUnsafe("2030-01-01T00:00:00Z")));
+    const startedAt = yield* DateTime.now;
+
+    yield* TestClock.adjust("1 hour");
+    const now = yield* DateTime.now;
+
+    assert.strictEqual(Duration.toMillis(DateTime.distance(startedAt, now)), 60 * 60 * 1000);
+  }),
+);
+```
+
+`@effect/vitest` supplies `TestClock` to `it.effect`. Fork work that sleeps, times out, retries, or follows a schedule before advancing the clock. Use `it.live` only when a test intentionally needs real time.
+
+## Completion check
+
+Confirm that domain code uses `DateTime`, untrusted inputs are decoded, UTC versus zoned intent is explicit, DST behavior is deliberate, elapsed and calendar arithmetic are not confused, serialization is stable, and time-dependent tests use `TestClock` without wall-clock sleeps.

--- a/.agents/skills/effect-ts/references/guide-effect.md
+++ b/.agents/skills/effect-ts/references/guide-effect.md
@@ -47,11 +47,11 @@ The dominant usage pattern is:
 For reusable effectful operations, prefer `Effect.fn`.
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  return { id: userId, name: "Ada" };
+});
 ```
 
 Use `Effect.fn` when:
@@ -73,12 +73,12 @@ Repo examples:
 Use `Effect.gen` for orchestration and sequential workflows, especially when there are multiple `yield*` steps.
 
 ```ts
-const program = Effect.gen(function*() {
-  const config = yield* Config
-  const repo = yield* UserRepo
-  const user = yield* repo.getById("u_123")
-  return { config, user }
-})
+const program = Effect.gen(function* () {
+  const config = yield* Config;
+  const repo = yield* UserRepo;
+  const user = yield* repo.getById("u_123");
+  return { config, user };
+});
 ```
 
 Use `Effect.gen` when:
@@ -103,15 +103,15 @@ Use this rule:
 Good split:
 
 ```ts
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  const repo = yield* UserRepo
-  return yield* repo.getById(userId)
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  const repo = yield* UserRepo;
+  return yield* repo.getById(userId);
+});
 
-const program = Effect.gen(function*() {
-  const user = yield* loadUser("u_123")
-  yield* Effect.logInfo("loaded user", user)
-})
+const program = Effect.gen(function* () {
+  const user = yield* loadUser("u_123");
+  yield* Effect.logInfo("loaded user", user);
+});
 ```
 
 ## `Effect.fnUntraced` Is An Escape Hatch
@@ -127,17 +127,17 @@ Use it only when:
 If the only goal is to avoid an explicit named span, prefer:
 
 ```ts
-const normalizeUser = Effect.fn(function*(input: string) {
-  return input.trim().toLowerCase()
-})
+const normalizeUser = Effect.fn(function* (input: string) {
+  return input.trim().toLowerCase();
+});
 ```
 
 Instead of:
 
 ```ts
-const normalizeUser = Effect.fnUntraced(function*(input: string) {
-  return input.trim().toLowerCase()
-})
+const normalizeUser = Effect.fnUntraced(function* (input: string) {
+  return input.trim().toLowerCase();
+});
 ```
 
 ## Constructor Functions
@@ -149,7 +149,7 @@ The repo uses constructor functions very deliberately.
 Use for pure successful values.
 
 ```ts
-const ok = Effect.succeed(42)
+const ok = Effect.succeed(42);
 ```
 
 ### `Effect.fail`
@@ -157,7 +157,7 @@ const ok = Effect.succeed(42)
 Use for expected typed failures.
 
 ```ts
-const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }))
+const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }));
 ```
 
 ### `Effect.sync`
@@ -165,7 +165,7 @@ const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }))
 Use for synchronous side effects or pure synchronous construction that should live inside `Effect`.
 
 ```ts
-const buildConfig = Effect.sync(() => ({ retries: 3 }))
+const buildConfig = Effect.sync(() => ({ retries: 3 }));
 ```
 
 ### `Effect.try`
@@ -173,17 +173,17 @@ const buildConfig = Effect.sync(() => ({ retries: 3 }))
 Use for synchronous code that may throw.
 
 ```ts
-import { Effect, Schema } from "effect"
+import { Effect, Schema } from "effect";
 
 class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
-  cause: Schema.Defect()
+  cause: Schema.Defect(),
 }) {}
 
 const parseJson = (input: string) =>
   Effect.try({
     try: () => JSON.parse(input),
-    catch: (cause) => ParseError.make({ cause })
-  })
+    catch: (cause) => ParseError.make({ cause }),
+  });
 ```
 
 ### `Effect.tryPromise`
@@ -194,17 +194,17 @@ opaque cause when it is diagnostically useful. Compose Effect-native APIs
 directly instead of converting them through Promise.
 
 ```ts
-import { Effect, Schema } from "effect"
+import { Effect, Schema } from "effect";
 
 class FetchError extends Schema.TaggedErrorClass<FetchError>()("FetchError", {
-  cause: Schema.Defect()
+  cause: Schema.Defect(),
 }) {}
 
 const fetchText = (url: string) =>
   Effect.tryPromise({
     try: () => fetch(url).then((response) => response.text()),
-    catch: (cause) => FetchError.make({ cause })
-  })
+    catch: (cause) => FetchError.make({ cause }),
+  });
 ```
 
 Preferred rule:
@@ -224,9 +224,7 @@ The repo uses `map`, `flatMap`, and `tap` constantly for small local transformat
 Use to transform successful values.
 
 ```ts
-const userName = loadUser("u_123").pipe(
-  Effect.map((user) => user.name)
-)
+const userName = loadUser("u_123").pipe(Effect.map((user) => user.name));
 ```
 
 ### `Effect.flatMap`
@@ -234,9 +232,7 @@ const userName = loadUser("u_123").pipe(
 Use when the next step returns another `Effect`.
 
 ```ts
-const result = loadUser("u_123").pipe(
-  Effect.flatMap((user) => saveAudit(user.id))
-)
+const result = loadUser("u_123").pipe(Effect.flatMap((user) => saveAudit(user.id)));
 ```
 
 ### `Effect.tap`
@@ -245,8 +241,8 @@ Use for side effects that should preserve the main value.
 
 ```ts
 const result = loadUser("u_123").pipe(
-  Effect.tap((user) => Effect.logDebug("loaded user", { userId: user.id }))
-)
+  Effect.tap((user) => Effect.logDebug("loaded user", { userId: user.id })),
+);
 ```
 
 Preferred rule:
@@ -264,27 +260,23 @@ Repo style is:
 ### Access services in implementations
 
 ```ts
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  const repo = yield* UserRepo
-  return yield* repo.getById(userId)
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  const repo = yield* UserRepo;
+  return yield* repo.getById(userId);
+});
 ```
 
 or:
 
 ```ts
 const loadUser = (userId: string) =>
-  Effect.service(UserRepo).pipe(
-    Effect.flatMap((repo) => repo.getById(userId))
-  )
+  Effect.service(UserRepo).pipe(Effect.flatMap((repo) => repo.getById(userId)));
 ```
 
 ### Provide at the edge
 
 ```ts
-const program = loadUser("u_123").pipe(
-  Effect.provide(AppLayer)
-)
+const program = loadUser("u_123").pipe(Effect.provide(AppLayer));
 ```
 
 Use `provideService` and `provideServiceEffect` for targeted overrides, especially in tests or framework boundaries.
@@ -309,9 +301,7 @@ Common repo patterns:
 Use for targeted typed recovery.
 
 ```ts
-const safe = loadUser("u_123").pipe(
-  Effect.catchTag("UserNotFound", () => Effect.succeed(null))
-)
+const safe = loadUser("u_123").pipe(Effect.catchTag("UserNotFound", () => Effect.succeed(null)));
 ```
 
 ### `Effect.match`
@@ -322,9 +312,9 @@ Use when the caller wants a value either way.
 const result = loadUser("u_123").pipe(
   Effect.match({
     onFailure: () => null,
-    onSuccess: (user) => user
-  })
-)
+    onSuccess: (user) => user,
+  }),
+);
 ```
 
 For deeper guidance, see `./references/guide-error-handling.md`.
@@ -338,10 +328,7 @@ One of the strongest repo patterns is explicit resource ownership.
 Use for resources that must be cleaned up.
 
 ```ts
-const connection = Effect.acquireRelease(
-  openConnection,
-  (conn) => closeConnection(conn)
-)
+const connection = Effect.acquireRelease(openConnection, (conn) => closeConnection(conn));
 ```
 
 ### `Effect.scoped`
@@ -350,11 +337,11 @@ Use when a workflow consumes scoped resources and should tie cleanup to scope li
 
 ```ts
 const program = Effect.scoped(
-  Effect.gen(function*() {
-    const conn = yield* connection
-    return yield* conn.query("select 1")
-  })
-)
+  Effect.gen(function* () {
+    const conn = yield* connection;
+    return yield* conn.query("select 1");
+  }),
+);
 ```
 
 Repo examples:

--- a/.agents/skills/effect-ts/references/guide-error-handling.md
+++ b/.agents/skills/effect-ts/references/guide-error-handling.md
@@ -59,34 +59,34 @@ Repo references:
 Example:
 
 ```ts
-import { Effect, Schema } from "effect"
+import { Effect, Schema } from "effect";
 
-class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()(
-  "InvalidPayload",
-  {
-    field: Schema.String,
-    reason: Schema.String
-  }
-) {}
+class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()("InvalidPayload", {
+  field: Schema.String,
+  reason: Schema.String,
+}) {}
 
 const validate = Effect.fail(
   InvalidPayload.make({
     field: "email",
-    reason: "missing"
-  })
-)
+    reason: "missing",
+  }),
+);
 ```
 
 Expected application and service failures belong in the typed error channel.
 In generators, use an explicit control-flow exit when failing:
 
 ```ts
-return yield* Effect.fail(
-  InvalidPayload.make({
-    field: "email",
-    reason: "missing"
-  })
-)
+return (
+  yield *
+  Effect.fail(
+    InvalidPayload.make({
+      field: "email",
+      reason: "missing",
+    }),
+  )
+);
 ```
 
 Use this when:
@@ -128,18 +128,17 @@ Repo reference:
 Example:
 
 ```ts
-import { Data, Effect } from "effect"
+import { Data, Effect } from "effect";
 
 class UserNotFound extends Data.TaggedError("UserNotFound")<{
-  readonly userId: string
+  readonly userId: string;
 }> {}
 
-const loadUser = (userId: string) =>
-  Effect.fail(new UserNotFound({ userId }))
+const loadUser = (userId: string) => Effect.fail(new UserNotFound({ userId }));
 
-const program = Effect.gen(function*() {
-  yield* loadUser("u_123")
-})
+const program = Effect.gen(function* () {
+  yield* loadUser("u_123");
+});
 ```
 
 ## When To Prefer `Data.TaggedError` vs `Schema.TaggedErrorClass`
@@ -173,14 +172,14 @@ Repo references:
 Example:
 
 ```ts
-import { Effect, Schema } from "effect"
+import { Effect, Schema } from "effect";
 
 const UserPayload = Schema.Struct({
   id: Schema.String,
-  email: Schema.String
-})
+  email: Schema.String,
+});
 
-const decodeUser = Schema.decodeUnknownEffect(UserPayload)
+const decodeUser = Schema.decodeUnknownEffect(UserPayload);
 ```
 
 This gives you:
@@ -195,23 +194,23 @@ For application code, it is often better to convert `SchemaError` into a domain 
 Example:
 
 ```ts
-import { Data, Effect, Schema } from "effect"
+import { Data, Effect, Schema } from "effect";
 
 class InvalidRequestBody extends Data.TaggedError("InvalidRequestBody")<{
-  readonly message: string
+  readonly message: string;
 }> {}
 
 const UserPayload = Schema.Struct({
   id: Schema.String,
-  email: Schema.String
-})
+  email: Schema.String,
+});
 
 const decodeUser = (input: unknown) =>
   Schema.decodeUnknownEffect(UserPayload)(input).pipe(
     Effect.catchTag("SchemaError", (error) =>
-      Effect.fail(new InvalidRequestBody({ message: error.message }))
-    )
-  )
+      Effect.fail(new InvalidRequestBody({ message: error.message })),
+    ),
+  );
 ```
 
 Why:
@@ -262,38 +261,32 @@ Prefer using:
 Example:
 
 ```ts
-import { Effect, Schema } from "effect"
+import { Effect, Schema } from "effect";
 
-class TodoStorageError extends Schema.TaggedErrorClass<TodoStorageError>()(
-  "TodoStorageError",
-  {
-    operation: Schema.String,
-    cause: Schema.Defect()
-  }
-) {}
+class TodoStorageError extends Schema.TaggedErrorClass<TodoStorageError>()("TodoStorageError", {
+  operation: Schema.String,
+  cause: Schema.Defect(),
+}) {}
 
 const makeStorageError = (operation: string) => (cause: unknown) =>
   TodoStorageError.make({
     operation,
-    cause
-  })
+    cause,
+  });
 
 const loadTodo = (id: number) =>
   Effect.try({
     try: () => someLibraryCall(id),
-    catch: makeStorageError("loadTodo")
-  })
+    catch: makeStorageError("loadTodo"),
+  });
 ```
 
 When stack preservation matters in the encoded schema, prefer:
 
 ```ts
-class WorkerFailure extends Schema.TaggedErrorClass<WorkerFailure>()(
-  "WorkerFailure",
-  {
-    cause: Schema.Defect({ includeStack: true })
-  }
-) {}
+class WorkerFailure extends Schema.TaggedErrorClass<WorkerFailure>()("WorkerFailure", {
+  cause: Schema.Defect({ includeStack: true }),
+}) {}
 ```
 
 ### Why This Is Preferred
@@ -332,8 +325,8 @@ Bad:
 const loadTodo = (id: number) =>
   Effect.try({
     try: () => someLibraryCall(id),
-    catch: (cause) => cause as Error
-  })
+    catch: (cause) => cause as Error,
+  });
 ```
 
 Why this is bad:
@@ -373,10 +366,8 @@ Example:
 
 ```ts
 const recovered = program.pipe(
-  Effect.catchTag("UserNotFound", (error) =>
-    Effect.succeed({ id: error.userId, guest: true })
-  )
-)
+  Effect.catchTag("UserNotFound", (error) => Effect.succeed({ id: error.userId, guest: true })),
+);
 ```
 
 ### Handle several tagged errors with `Effect.catchTags`
@@ -387,9 +378,9 @@ Use `catchTags` when multiple domain errors should be handled together.
 const recovered = program.pipe(
   Effect.catchTags({
     UserNotFound: () => Effect.succeed(null),
-    InvalidPayload: (error) => Effect.succeed({ error: error.reason })
-  })
-)
+    InvalidPayload: (error) => Effect.succeed({ error: error.reason }),
+  }),
+);
 ```
 
 ### Handle predicate-based subsets with `Effect.catchIf`
@@ -404,9 +395,9 @@ Use `match` when you want to fully fold the typed error channel into a success v
 const outcome = program.pipe(
   Effect.match({
     onFailure: (error) => ({ ok: false as const, error }),
-    onSuccess: (value) => ({ ok: true as const, value })
-  })
-)
+    onSuccess: (value) => ({ ok: true as const, value }),
+  }),
+);
 ```
 
 ## Handling Defects
@@ -439,17 +430,17 @@ Use defects for:
 Use `sandbox` to expose `Cause<E>` in the error channel.
 
 ```ts
-import { Cause, Effect } from "effect"
+import { Cause, Effect } from "effect";
 
 const diagnosed = program.pipe(
   Effect.sandbox,
   Effect.catchCause((cause) => {
     if (Cause.hasDies(cause)) {
-      return Effect.succeed("defect")
+      return Effect.succeed("defect");
     }
-    return Effect.failCause(cause)
-  })
-)
+    return Effect.failCause(cause);
+  }),
+);
 ```
 
 Use `matchCause` or `matchCauseEffect` when you need to distinguish:
@@ -503,11 +494,11 @@ Interrupts signal that the fiber should stop. They should not usually be transla
 If interrupted work needs special cleanup, use `onInterrupt`.
 
 ```ts
-import { Console, Effect } from "effect"
+import { Console, Effect } from "effect";
 
 const program = longRunningTask.pipe(
-  Effect.onInterrupt(() => Console.log("cleaning up after interrupt"))
-)
+  Effect.onInterrupt(() => Console.log("cleaning up after interrupt")),
+);
 ```
 
 ### Use `Cause` inspection when interrupts must be distinguished

--- a/.agents/skills/effect-ts/references/guide-layers.md
+++ b/.agents/skills/effect-ts/references/guide-layers.md
@@ -83,18 +83,18 @@ There are two good definition styles:
 Example:
 
 ```ts
-import { Context, Effect, Schema } from "effect"
+import { Context, Effect, Schema } from "effect";
 
-class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
-  "UserRepoError",
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()("UserRepoError", {
+  message: Schema.String,
+}) {}
+
+class UserRepo extends Context.Service<
+  UserRepo,
   {
-    message: Schema.String
+    readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserRepoError>;
   }
-) {}
-
-class UserRepo extends Context.Service<UserRepo, {
-  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserRepoError>
-}>()("UserRepo") {}
+>()("UserRepo") {}
 ```
 
 Why this style is preferred:
@@ -123,23 +123,18 @@ Repo reference:
 When the implementation shape is clearer than the interface declaration, prefer using the `make` argument so the service shape is inferred from the implementation.
 
 ```ts
-import { Context, Effect, Schema } from "effect"
+import { Context, Effect, Schema } from "effect";
 
-class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
-  "UserRepoError",
-  {
-    message: Schema.String
-  }
-) {}
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()("UserRepoError", {
+  message: Schema.String,
+}) {}
 
 class UserRepo extends Context.Service<UserRepo>()("UserRepo", {
   make: Effect.succeed({
-    getById: Effect.fn("UserRepo.getById")(function*(id: string) {
-      return yield* Effect.fail(
-        UserRepoError.make({ message: `User ${id} not found` })
-      )
-    })
-  })
+    getById: Effect.fn("UserRepo.getById")(function* (id: string) {
+      return yield* Effect.fail(UserRepoError.make({ message: `User ${id} not found` }));
+    }),
+  }),
 }) {}
 ```
 
@@ -162,24 +157,24 @@ Prefer the explicit generic shape when:
 ## Service Example
 
 ```ts
-import { Context, Effect, Schema } from "effect"
+import { Context, Effect, Schema } from "effect";
 
-class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
-  "UserNotFound",
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", {
+  userId: Schema.String,
+}) {}
+
+class UserRepo extends Context.Service<
+  UserRepo,
   {
-    userId: Schema.String
+    readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserNotFound>;
   }
-) {}
-
-class UserRepo extends Context.Service<UserRepo, {
-  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserNotFound>
-}>()("UserRepo") {}
+>()("UserRepo") {}
 
 const loadUser = (userId: string) =>
-  Effect.gen(function*() {
-    const repo = yield* UserRepo
-    return yield* repo.getById(userId)
-  })
+  Effect.gen(function* () {
+    const repo = yield* UserRepo;
+    return yield* repo.getById(userId);
+  });
 ```
 
 Key points:
@@ -213,18 +208,16 @@ Use a full service instead when:
 Common patterns:
 
 ```ts
-const program = Effect.gen(function*() {
-  const repo = yield* UserRepo
-  return yield* repo.getById("u_123")
-})
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo;
+  return yield* repo.getById("u_123");
+});
 ```
 
 or:
 
 ```ts
-const program = Effect.service(UserRepo).pipe(
-  Effect.flatMap((repo) => repo.getById("u_123"))
-)
+const program = Effect.service(UserRepo).pipe(Effect.flatMap((repo) => repo.getById("u_123")));
 ```
 
 Best practice:
@@ -239,10 +232,10 @@ Prefer keeping service access inside the business operation that needs it rather
 Avoid this pattern:
 
 ```ts
-export const createTodo = Effect.fn(function*(title: string) {
-  const todos = yield* TodoService
-  return yield* todos.create(title)
-})
+export const createTodo = Effect.fn(function* (title: string) {
+  const todos = yield* TodoService;
+  return yield* todos.create(title);
+});
 ```
 
 Why this is usually a bad pattern:
@@ -261,14 +254,14 @@ Prefer one of these patterns instead:
 Good:
 
 ```ts
-export const completeTodo = Effect.fn("completeTodo")(function*(id: number) {
-  const todos = yield* TodoService
-  const todo = yield* todos.getById(id)
+export const completeTodo = Effect.fn("completeTodo")(function* (id: number) {
+  const todos = yield* TodoService;
+  const todo = yield* todos.getById(id);
   if (todo.completed) {
-    return todo
+    return todo;
   }
-  return yield* todos.setCompleted(id, true)
-})
+  return yield* todos.setCompleted(id, true);
+});
 ```
 
 This is good because:
@@ -315,8 +308,8 @@ Use for pure, already-constructed implementations.
 
 ```ts
 const UserRepoTest = Layer.succeed(UserRepo)({
-  getById: (id) => Effect.succeed({ id, name: "Test User" })
-})
+  getById: (id) => Effect.succeed({ id, name: "Test User" }),
+});
 ```
 
 Use this when:
@@ -330,23 +323,26 @@ Use this when:
 Use when constructing a service requires effects, other services, or scoped resource acquisition.
 
 ```ts
-class Config extends Context.Service<Config, {
-  readonly apiBaseUrl: string
-}>()("Config") {}
+class Config extends Context.Service<
+  Config,
+  {
+    readonly apiBaseUrl: string;
+  }
+>()("Config") {}
 
 const UserRepoLayer = Layer.effect(UserRepo)(
-  Effect.gen(function*() {
-    const config = yield* Config
+  Effect.gen(function* () {
+    const config = yield* Config;
 
     return {
       getById: (id) =>
         Effect.succeed({
           id,
-          name: `Fetched from ${config.apiBaseUrl}`
-        })
-    }
-  })
-)
+          name: `Fetched from ${config.apiBaseUrl}`,
+        }),
+    };
+  }),
+);
 ```
 
 Use this when:
@@ -395,42 +391,51 @@ These operators do different things. Do not treat them as interchangeable.
 ### Example Services
 
 ```ts
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer } from "effect";
 
-class Config extends Context.Service<Config, {
-  readonly apiBaseUrl: string
-}>()("Config") {}
+class Config extends Context.Service<
+  Config,
+  {
+    readonly apiBaseUrl: string;
+  }
+>()("Config") {}
 
-class Logger extends Context.Service<Logger, {
-  readonly log: (message: string) => Effect.Effect<void>
-}>()("Logger") {}
+class Logger extends Context.Service<
+  Logger,
+  {
+    readonly log: (message: string) => Effect.Effect<void>;
+  }
+>()("Logger") {}
 
-class UserRepo extends Context.Service<UserRepo, {
-  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
-}>()("UserRepo") {}
+class UserRepo extends Context.Service<
+  UserRepo,
+  {
+    readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>;
+  }
+>()("UserRepo") {}
 
 const ConfigLayer = Layer.succeed(Config)({
-  apiBaseUrl: "https://api.example.com"
-})
+  apiBaseUrl: "https://api.example.com",
+});
 
 const LoggerLayer = Layer.succeed(Logger)({
-  log: (message) => Effect.sync(() => console.log(message))
-})
+  log: (message) => Effect.sync(() => console.log(message)),
+});
 
 const UserRepoLayer = Layer.effect(UserRepo)(
-  Effect.gen(function*() {
-    const config = yield* Config
-    const logger = yield* Logger
+  Effect.gen(function* () {
+    const config = yield* Config;
+    const logger = yield* Logger;
 
     return {
       getById: (id) =>
-        Effect.gen(function*() {
-          yield* logger.log(`loading ${id} from ${config.apiBaseUrl}`)
-          return { id, name: "Ada" }
-        })
-    }
-  })
-)
+        Effect.gen(function* () {
+          yield* logger.log(`loading ${id} from ${config.apiBaseUrl}`);
+          return { id, name: "Ada" };
+        }),
+    };
+  }),
+);
 ```
 
 ### `Layer.mergeAll`
@@ -438,10 +443,7 @@ const UserRepoLayer = Layer.effect(UserRepo)(
 Use `Layer.mergeAll` to combine outputs of independent layers.
 
 ```ts
-const Dependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer
-)
+const Dependencies = Layer.mergeAll(ConfigLayer, LoggerLayer);
 ```
 
 Use this when:
@@ -464,10 +466,7 @@ Important:
 Correct pattern:
 
 ```ts
-const Dependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer
-)
+const Dependencies = Layer.mergeAll(ConfigLayer, LoggerLayer);
 ```
 
 ### `Layer.provide`
@@ -475,12 +474,9 @@ const Dependencies = Layer.mergeAll(
 Use `Layer.provide` to satisfy a target layer's dependencies with another layer, while keeping only the target layer's outputs.
 
 ```ts
-const Dependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer
-)
+const Dependencies = Layer.mergeAll(ConfigLayer, LoggerLayer);
 
-const UserRepoLayerReady = Layer.provide(UserRepoLayer, Dependencies)
+const UserRepoLayerReady = Layer.provide(UserRepoLayer, Dependencies);
 ```
 
 Interpretation:
@@ -495,12 +491,10 @@ This is the operator to use when you want to hide construction dependencies behi
 Example program:
 
 ```ts
-const program = Effect.gen(function*() {
-  const repo = yield* UserRepo
-  return yield* repo.getById("u_123")
-}).pipe(
-  Effect.provide(UserRepoLayerReady)
-)
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo;
+  return yield* repo.getById("u_123");
+}).pipe(Effect.provide(UserRepoLayerReady));
 ```
 
 ### `Layer.provideMerge`
@@ -508,12 +502,9 @@ const program = Effect.gen(function*() {
 Use `provideMerge` when you want to satisfy dependencies and retain both the dependency outputs and the target outputs.
 
 ```ts
-const Dependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer
-)
+const Dependencies = Layer.mergeAll(ConfigLayer, LoggerLayer);
 
-const AppLayer = Layer.provideMerge(UserRepoLayer, Dependencies)
+const AppLayer = Layer.provideMerge(UserRepoLayer, Dependencies);
 ```
 
 Interpretation:
@@ -526,16 +517,14 @@ This is useful for assembling larger application layers incrementally, especiall
 Example program:
 
 ```ts
-const program = Effect.gen(function*() {
-  const repo = yield* UserRepo
-  const logger = yield* Logger
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo;
+  const logger = yield* Logger;
 
-  const user = yield* repo.getById("u_123")
-  yield* logger.log(user.name)
-  return user
-}).pipe(
-  Effect.provide(AppLayer)
-)
+  const user = yield* repo.getById("u_123");
+  yield* logger.log(user.name);
+  return user;
+}).pipe(Effect.provide(AppLayer));
 ```
 
 Preferred rule:
@@ -566,29 +555,18 @@ Preferred style:
 Good pattern:
 
 ```ts
-const UserDependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer
-)
+const UserDependencies = Layer.mergeAll(ConfigLayer, LoggerLayer);
 
-const UserLayer = Layer.provide(UserRepoLayer, UserDependencies)
+const UserLayer = Layer.provide(UserRepoLayer, UserDependencies);
 
-const BillingDependencies = Layer.mergeAll(
-  ConfigLayer,
-  LoggerLayer,
-  DatabaseLayer
-)
+const BillingDependencies = Layer.mergeAll(ConfigLayer, LoggerLayer, DatabaseLayer);
 
-const BillingLayer = Layer.provide(BillingServiceLayer, BillingDependencies)
+const BillingLayer = Layer.provide(BillingServiceLayer, BillingDependencies);
 
-const AppLayer = Layer.mergeAll(
-  UserLayer,
-  BillingLayer,
-  HttpLayer
-).pipe(
+const AppLayer = Layer.mergeAll(UserLayer, BillingLayer, HttpLayer).pipe(
   Layer.provide(Telemetry),
-  Layer.provide(NodeSdk)
-)
+  Layer.provide(NodeSdk),
+);
 ```
 
 Why this style is preferred:
@@ -605,10 +583,10 @@ const AppLayer = Layer.provide(
   Layer.mergeAll(
     Layer.provide(UserRepoLayer, Layer.mergeAll(ConfigLayer, LoggerLayer)),
     Layer.provide(BillingServiceLayer, Layer.mergeAll(ConfigLayer, LoggerLayer, DatabaseLayer)),
-    HttpLayer
+    HttpLayer,
   ),
-  Telemetry
-).pipe(Layer.provide(NodeSdk))
+  Telemetry,
+).pipe(Layer.provide(NodeSdk));
 ```
 
 That style is harder to read because:
@@ -626,9 +604,9 @@ Example:
 ```ts
 const UserRepoLayerFromConfig = Layer.flatMap(ConfigLayer, (config) =>
   Layer.succeed(UserRepo)({
-    getById: (id) => Effect.succeed({ id, name: config.apiBaseUrl })
-  })
-)
+    getById: (id) => Effect.succeed({ id, name: config.apiBaseUrl }),
+  }),
+);
 ```
 
 This is more specialized than `merge` or `provide`.
@@ -661,12 +639,10 @@ Bad pattern:
 
 ```ts
 const loadUser = (userId: string) =>
-  Effect.gen(function*() {
-    const repo = yield* UserRepo
-    return yield* repo.getById(userId)
-  }).pipe(
-    Effect.provide(UserRepoLayer)
-  )
+  Effect.gen(function* () {
+    const repo = yield* UserRepo;
+    return yield* repo.getById(userId);
+  }).pipe(Effect.provide(UserRepoLayer));
 ```
 
 Why this is an anti-pattern:
@@ -681,14 +657,12 @@ Preferred pattern:
 
 ```ts
 const loadUser = (userId: string) =>
-  Effect.gen(function*() {
-    const repo = yield* UserRepo
-    return yield* repo.getById(userId)
-  })
+  Effect.gen(function* () {
+    const repo = yield* UserRepo;
+    return yield* repo.getById(userId);
+  });
 
-const program = loadUser("u_123").pipe(
-  Effect.provide(AppLayer)
-)
+const program = loadUser("u_123").pipe(Effect.provide(AppLayer));
 ```
 
 Rule of thumb:
@@ -712,10 +686,9 @@ Typical examples:
 Preferred pattern:
 
 ```ts
-const runtime = ManagedRuntime.make(AppLayer)
+const runtime = ManagedRuntime.make(AppLayer);
 
-const handleRequest = (id: string) =>
-  runtime.runPromise(loadUser(id))
+const handleRequest = (id: string) => runtime.runPromise(loadUser(id));
 ```
 
 Why:
@@ -734,9 +707,7 @@ Repo reference:
 Use `Effect.provide` to satisfy an effect's dependencies with a layer or context.
 
 ```ts
-const program = loadUser("u_123").pipe(
-  Effect.provide(UserRepoLayerReady)
-)
+const program = loadUser("u_123").pipe(Effect.provide(UserRepoLayerReady));
 ```
 
 This is the main boundary provisioning operator.
@@ -748,9 +719,9 @@ Use `provideService` for a single ad hoc implementation.
 ```ts
 const program = loadUser("u_123").pipe(
   Effect.provideService(UserRepo, {
-    getById: (id) => Effect.succeed({ id, name: "Inline User" })
-  })
-)
+    getById: (id) => Effect.succeed({ id, name: "Inline User" }),
+  }),
+);
 ```
 
 Good use cases:
@@ -812,11 +783,11 @@ Good:
 
 ```ts
 const sendWelcomeEmail = (userId: string) =>
-  Effect.gen(function*() {
-    const repo = yield* UserRepo
-    const user = yield* repo.getById(userId)
-    return user
-  })
+  Effect.gen(function* () {
+    const repo = yield* UserRepo;
+    const user = yield* repo.getById(userId);
+    return user;
+  });
 ```
 
 Avoid constructing `UserRepo` inside `sendWelcomeEmail`.
@@ -880,7 +851,7 @@ dependencies or configuration:
 ```ts
 // Avoid: requirements disappear from the Layer input channel.
 const makeUserRepoLayer = (config: Config, client: HttpClient) =>
-  Layer.effect(UserRepo)(makeUserRepo(config, client))
+  Layer.effect(UserRepo)(makeUserRepo(config, client));
 ```
 
 Model configuration, clients, databases, clocks, platform bindings, and
@@ -890,17 +861,14 @@ outer composition boundary:
 
 ```ts
 const UserRepoLayer = Layer.effect(UserRepo)(
-  Effect.gen(function*() {
-    const config = yield* Config
-    const client = yield* HttpClient
-    return UserRepo.of(makeUserRepo(config, client))
-  })
-)
+  Effect.gen(function* () {
+    const config = yield* Config;
+    const client = yield* HttpClient;
+    return UserRepo.of(makeUserRepo(config, client));
+  }),
+);
 
-const AppLayer = UserRepoLayer.pipe(
-  Layer.provide(ConfigLayer),
-  Layer.provide(HttpClientLayer)
-)
+const AppLayer = UserRepoLayer.pipe(Layer.provide(ConfigLayer), Layer.provide(HttpClientLayer));
 ```
 
 Arguments are acceptable only when they are intrinsic definitions that create
@@ -944,56 +912,60 @@ This keeps test wiring explicit and close to production composition style.
 ## Pattern: service definition plus live layer
 
 ```ts
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer } from "effect";
 
-class Config extends Context.Service<Config, {
-  readonly apiBaseUrl: string
-}>()("Config") {}
+class Config extends Context.Service<
+  Config,
+  {
+    readonly apiBaseUrl: string;
+  }
+>()("Config") {}
 
-class UserRepo extends Context.Service<UserRepo, {
-  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
-}>()("UserRepo") {}
+class UserRepo extends Context.Service<
+  UserRepo,
+  {
+    readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>;
+  }
+>()("UserRepo") {}
 
 const ConfigLayer = Layer.succeed(Config)({
-  apiBaseUrl: "https://api.example.com"
-})
+  apiBaseUrl: "https://api.example.com",
+});
 
 const UserRepoLayer = Layer.effect(UserRepo)(
-  Effect.gen(function*() {
-    const config = yield* Config
+  Effect.gen(function* () {
+    const config = yield* Config;
 
     return {
       getById: (id) =>
         Effect.succeed({
           id,
-          name: `Loaded via ${config.apiBaseUrl}`
-        })
-    }
-  })
-)
+          name: `Loaded via ${config.apiBaseUrl}`,
+        }),
+    };
+  }),
+);
 
-const Dependencies = Layer.mergeAll(ConfigLayer)
+const Dependencies = Layer.mergeAll(ConfigLayer);
 
-const AppLayer = Layer.provide(UserRepoLayer, Dependencies)
+const AppLayer = Layer.provide(UserRepoLayer, Dependencies);
 ```
 
 ## Pattern: provide at the top level
 
 ```ts
-const program = Effect.gen(function*() {
-  const repo = yield* UserRepo
-  return yield* repo.getById("u_123")
-}).pipe(
-  Effect.provide(AppLayer)
-)
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo;
+  return yield* repo.getById("u_123");
+}).pipe(Effect.provide(AppLayer));
 ```
 
 ## Pattern: single-service override in tests
 
 ```ts
 const TestRepo = Layer.succeed(UserRepo)({
-  getById: (id) => Effect.succeed({ id, name: "Test" })
-})
+  getById: (id) => Effect.succeed({ id, name: "Test" }),
+});
 ```
 
 ## Anti-Patterns

--- a/.agents/skills/effect-ts/references/guide-observability.md
+++ b/.agents/skills/effect-ts/references/guide-observability.md
@@ -45,22 +45,22 @@ Use `Effect.fn` as the default constructor for business-logic functions that ret
 Prefer this:
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  return { id: userId, name: "Ada" };
+});
 ```
 
 Over this:
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
 const loadUser = (userId: string) =>
-  Effect.gen(function*() {
-    return { id: userId, name: "Ada" }
-  })
+  Effect.gen(function* () {
+    return { id: userId, name: "Ada" };
+  });
 ```
 
 The second version works, but it throws away useful observability structure that `Effect.fn` gives you automatically.
@@ -72,17 +72,17 @@ For business-logic definitions, prefer `Effect.fn` over writing raw `Effect.gen`
 Prefer this:
 
 ```ts
-const refreshCache = Effect.fn("refreshCache")(function*() {
-  yield* Effect.logInfo("refreshing cache")
-})
+const refreshCache = Effect.fn("refreshCache")(function* () {
+  yield* Effect.logInfo("refreshing cache");
+});
 ```
 
 Over this:
 
 ```ts
-const refreshCache = Effect.gen(function*() {
-  yield* Effect.logInfo("refreshing cache")
-})
+const refreshCache = Effect.gen(function* () {
+  yield* Effect.logInfo("refreshing cache");
+});
 ```
 
 Why:
@@ -118,11 +118,11 @@ It is the preferred default because it adds:
 Example:
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const createUser = Effect.fn("createUser")(function*(name: string) {
-  return { id: "u_123", name }
-})
+const createUser = Effect.fn("createUser")(function* (name: string) {
+  return { id: "u_123", name };
+});
 ```
 
 Use this for:
@@ -145,17 +145,17 @@ If you do not want an explicit named span, prefer `Effect.fn` without a span nam
 Prefer this:
 
 ```ts
-const normalizeUser = Effect.fn(function*(input: string) {
-  return input.trim().toLowerCase()
-})
+const normalizeUser = Effect.fn(function* (input: string) {
+  return input.trim().toLowerCase();
+});
 ```
 
 Over this:
 
 ```ts
-const normalizeUser = Effect.fnUntraced(function*(input: string) {
-  return input.trim().toLowerCase()
-})
+const normalizeUser = Effect.fnUntraced(function* (input: string) {
+  return input.trim().toLowerCase();
+});
 ```
 
 Typical cases:
@@ -177,18 +177,18 @@ Preferred rule:
 Good:
 
 ```ts
-const parseCommand = Effect.fn("parseCommand")(function*(input: string) {
-  return input.trim()
-})
+const parseCommand = Effect.fn("parseCommand")(function* (input: string) {
+  return input.trim();
+});
 
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  return { id: userId, name: "Ada" };
+});
 
-const sendWelcomeEmail = Effect.fn("sendWelcomeEmail")(function*(userId: string) {
-  const user = yield* loadUser(userId)
-  return user.email
-})
+const sendWelcomeEmail = Effect.fn("sendWelcomeEmail")(function* (userId: string) {
+  const user = yield* loadUser(userId);
+  return user.email;
+});
 ```
 
 Why this is good:
@@ -223,17 +223,13 @@ Use `withSpan` when you need an explicit span around an effect that is not alrea
 Example:
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const syncUser = Effect.fn("syncUser")(function*(userId: string) {
-  const profile = yield* fetchProfile(userId).pipe(
-    Effect.withSpan("fetchProfile")
-  )
+const syncUser = Effect.fn("syncUser")(function* (userId: string) {
+  const profile = yield* fetchProfile(userId).pipe(Effect.withSpan("fetchProfile"));
 
-  return yield* persistProfile(profile).pipe(
-    Effect.withSpan("persistProfile")
-  )
-})
+  return yield* persistProfile(profile).pipe(Effect.withSpan("persistProfile"));
+});
 ```
 
 Use this when:
@@ -263,12 +259,12 @@ Use `annotateCurrentSpan` to attach important structured fields to the current s
 Example:
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  yield* Effect.annotateCurrentSpan({ userId })
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId });
+  return { id: userId, name: "Ada" };
+});
 ```
 
 Good span annotations:
@@ -301,10 +297,10 @@ These integrate with the current Effect execution context.
 Example:
 
 ```ts
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  yield* Effect.logDebug("loading user", { userId })
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  yield* Effect.logDebug("loading user", { userId });
+  return { id: userId, name: "Ada" };
+});
 ```
 
 ### `Effect.withLogSpan`
@@ -314,9 +310,7 @@ Use `withLogSpan` when you want log messages to carry a local logical span label
 Example:
 
 ```ts
-const program = Effect.logInfo("starting sync").pipe(
-  Effect.withLogSpan("user-sync")
-)
+const program = Effect.logInfo("starting sync").pipe(Effect.withLogSpan("user-sync"));
 ```
 
 This is useful for:
@@ -348,19 +342,19 @@ site.
 
 ```ts
 const runCheckout = (request: CheckoutRequest) =>
-  Effect.gen(function*() {
-    yield* Effect.logInfo("loading checkout state")
-    yield* validateCart(request.cart)
-    yield* Effect.logInfo("submitting payment")
-    yield* submitPayment(request.payment)
+  Effect.gen(function* () {
+    yield* Effect.logInfo("loading checkout state");
+    yield* validateCart(request.cart);
+    yield* Effect.logInfo("submitting payment");
+    yield* submitPayment(request.payment);
   }).pipe(
     Effect.annotateLogs({
       operation: "checkout",
       requestId: request.id,
-      cartId: request.cart.id
+      cartId: request.cart.id,
     }),
-    Effect.withLogSpan("checkout")
-  )
+    Effect.withLogSpan("checkout"),
+  );
 ```
 
 Add narrower annotations only when metadata belongs to a nested item, attempt,
@@ -388,18 +382,13 @@ Repo reference:
 Example:
 
 ```ts
-import { Effect, Metric } from "effect"
+import { Effect, Metric } from "effect";
 
-const requests = Metric.counter("user_load_requests").pipe(
-  Metric.withConstantInput(1)
-)
+const requests = Metric.counter("user_load_requests").pipe(Metric.withConstantInput(1));
 
-const loadUser = Effect.fn("loadUser")(
-  function*(userId: string) {
-    return { id: userId, name: "Ada" }
-  },
-  Effect.track(requests)
-)
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  return { id: userId, name: "Ada" };
+}, Effect.track(requests));
 ```
 
 ### Prefer boundary metrics over micro-metrics
@@ -432,14 +421,10 @@ Repo references:
 Preferred composition style:
 
 ```ts
-const AppLayer = Layer.mergeAll(
-  UserLayer,
-  BillingLayer,
-  HttpLayer
-).pipe(
+const AppLayer = Layer.mergeAll(UserLayer, BillingLayer, HttpLayer).pipe(
   Layer.provide(Telemetry),
-  Layer.provide(NodeSdk)
-)
+  Layer.provide(NodeSdk),
+);
 ```
 
 Why:
@@ -628,19 +613,14 @@ Example shape:
 const TelemetryLayer = NodeSdk.layer(() => ({
   resource: {
     serviceName: "todo-service",
-    serviceVersion: "1.0.0"
+    serviceVersion: "1.0.0",
   },
   spanProcessor: mySpanProcessor,
   metricReader: myMetricReader,
-  logRecordProcessor: myLogProcessor
-}))
+  logRecordProcessor: myLogProcessor,
+}));
 
-const AppLayer = Layer.mergeAll(
-  DomainLayer,
-  HttpLayer
-).pipe(
-  Layer.provide(TelemetryLayer)
-)
+const AppLayer = Layer.mergeAll(DomainLayer, HttpLayer).pipe(Layer.provide(TelemetryLayer));
 ```
 
 This keeps:
@@ -666,9 +646,9 @@ Bad:
 
 ```ts
 const loadUser = (userId: string) =>
-  Effect.gen(function*() {
-    return { id: userId, name: "Ada" }
-  })
+  Effect.gen(function* () {
+    return { id: userId, name: "Ada" };
+  });
 ```
 
 Why this is bad:
@@ -680,9 +660,9 @@ Why this is bad:
 Preferred:
 
 ```ts
-const loadUser = Effect.fn("loadUser")(function*(userId: string) {
-  return { id: userId, name: "Ada" }
-})
+const loadUser = Effect.fn("loadUser")(function* (userId: string) {
+  return { id: userId, name: "Ada" };
+});
 ```
 
 ### Anti-Pattern: using `Effect.fnUntraced` by default
@@ -729,36 +709,31 @@ Preferred order:
 ### Pattern: observable business operation
 
 ```ts
-import { Effect } from "effect"
+import { Effect } from "effect";
 
-const fetchUser = Effect.fn("fetchUser")(function*(userId: string) {
-  yield* Effect.annotateCurrentSpan({ userId })
-  yield* Effect.logDebug("fetching user", { userId })
-  return { id: userId, name: "Ada" }
-})
+const fetchUser = Effect.fn("fetchUser")(function* (userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId });
+  yield* Effect.logDebug("fetching user", { userId });
+  return { id: userId, name: "Ada" };
+});
 ```
 
 ### Pattern: orchestration with nested spans
 
 ```ts
-const syncUser = Effect.fn("syncUser")(function*(userId: string) {
-  const profile = yield* fetchRemoteProfile(userId).pipe(
-    Effect.withSpan("fetchRemoteProfile")
-  )
+const syncUser = Effect.fn("syncUser")(function* (userId: string) {
+  const profile = yield* fetchRemoteProfile(userId).pipe(Effect.withSpan("fetchRemoteProfile"));
 
-  return yield* persistProfile(profile).pipe(
-    Effect.withSpan("persistProfile")
-  )
-})
+  return yield* persistProfile(profile).pipe(Effect.withSpan("persistProfile"));
+});
 ```
 
 ### Pattern: framework boundary with runtime
 
 ```ts
-const runtime = ManagedRuntime.make(AppLayer)
+const runtime = ManagedRuntime.make(AppLayer);
 
-const handleRequest = (userId: string) =>
-  runtime.runPromise(fetchUser(userId))
+const handleRequest = (userId: string) => runtime.runPromise(fetchUser(userId));
 ```
 
 ## Good Repo Examples To Study

--- a/.agents/skills/effect-ts/references/guide-retries.md
+++ b/.agents/skills/effect-ts/references/guide-retries.md
@@ -70,9 +70,7 @@ This is explicitly covered in the module tests.
 Use this for the simplest bounded retry case.
 
 ```ts
-const retried = effect.pipe(
-  Effect.retry({ times: 3 })
-)
+const retried = effect.pipe(Effect.retry({ times: 3 }));
 ```
 
 Use this when:
@@ -93,9 +91,7 @@ The module tests show:
 Example:
 
 ```ts
-const retried = effect.pipe(
-  Effect.retry({ until: (error) => error._tag === "Done" })
-)
+const retried = effect.pipe(Effect.retry({ until: (error) => error._tag === "Done" }));
 ```
 
 ### `{ while: predicate }`
@@ -107,9 +103,7 @@ The tests also show pure and effectful `while` variants.
 Example:
 
 ```ts
-const retried = effect.pipe(
-  Effect.retry({ while: (error) => error._tag === "Retryable" })
-)
+const retried = effect.pipe(Effect.retry({ while: (error) => error._tag === "Retryable" }));
 ```
 
 ## Retry With Schedule
@@ -117,9 +111,7 @@ const retried = effect.pipe(
 Use a `Schedule` whenever timing matters.
 
 ```ts
-const retried = effect.pipe(
-  Effect.retry(Schedule.recurs(3))
-)
+const retried = effect.pipe(Effect.retry(Schedule.recurs(3)));
 ```
 
 Or with the richer object form:
@@ -128,9 +120,9 @@ Or with the richer object form:
 const retried = effect.pipe(
   Effect.retry({
     schedule: Schedule.recurs(3),
-    while: (error) => error._tag === "Retryable"
-  })
-)
+    while: (error) => error._tag === "Retryable",
+  }),
+);
 ```
 
 This is a very important repo pattern because it lets you combine:
@@ -178,13 +170,13 @@ The canonical source repeatedly uses these patterns:
 ### Fixed retry count
 
 ```ts
-Schedule.recurs(3)
+Schedule.recurs(3);
 ```
 
 ### Exponential backoff
 
 ```ts
-Schedule.exponential("500 millis", 1.5)
+Schedule.exponential("500 millis", 1.5);
 ```
 
 ### Exponential plus steady fallback spacing
@@ -193,7 +185,7 @@ Schedule.exponential("500 millis", 1.5)
 Schedule.exponential("500 millis", 1.5).pipe(
   Schedule.upTo({ times: 4 }),
   Schedule.andThen(Schedule.spaced("5 seconds")),
-)
+);
 ```
 
 This appears in production modules such as RPC and workflow code.
@@ -203,10 +195,8 @@ This appears in production modules such as RPC and workflow code.
 ```ts
 Schedule.forever.pipe(
   Schedule.setInputType<RetryableError>(),
-  Schedule.addDelay(({ input: error }) =>
-    Effect.succeed(error.retryAfter ?? "1 second")
-  ),
-)
+  Schedule.addDelay(({ input: error }) => Effect.succeed(error.retryAfter ?? "1 second")),
+);
 ```
 
 The OTLP exporter uses this shape to derive delays from actual HTTP failure details such as rate limits.
@@ -227,11 +217,11 @@ effect.pipe(
   Effect.retry(policy),
   Effect.catch((cause) => {
     if (!Cause.hasInterrupts(cause)) {
-      return Effect.failCause(cause)
+      return Effect.failCause(cause);
     }
-    return Effect.die("interrupted and retries exhausted")
-  })
-)
+    return Effect.die("interrupted and retries exhausted");
+  }),
+);
 ```
 
 Use this when:
@@ -298,17 +288,17 @@ const Plan = ExecutionPlan.make(
   {
     provide: FastLayer,
     attempts: 2,
-    schedule: Schedule.spaced("3 seconds")
+    schedule: Schedule.spaced("3 seconds"),
   },
   {
     provide: SafeLayer,
     attempts: 3,
-    schedule: Schedule.spaced("1 second")
+    schedule: Schedule.spaced("1 second"),
   },
   {
-    provide: FinalFallbackLayer
-  }
-)
+    provide: FinalFallbackLayer,
+  },
+);
 ```
 
 ### Step Semantics
@@ -358,7 +348,7 @@ one whose requirements are satisfied from the current context.
 Use this when the plan should be frozen with the current environment before being applied later.
 
 ```ts
-const capturedPlan = yield* Plan.captureRequirements
+const capturedPlan = yield * Plan.captureRequirements;
 ```
 
 ## `ExecutionPlan.merge`
@@ -385,9 +375,7 @@ Use `ExecutionPlan` when:
 ### Pattern: simple bounded retry
 
 ```ts
-const retried = effect.pipe(
-  Effect.retry({ times: 3 })
-)
+const retried = effect.pipe(Effect.retry({ times: 3 }));
 ```
 
 ### Pattern: retryable-error backoff
@@ -396,14 +384,14 @@ const retried = effect.pipe(
 const retryPolicy = Schedule.exponential("500 millis", 1.5).pipe(
   Schedule.upTo({ times: 4 }),
   Schedule.andThen(Schedule.spaced("5 seconds")),
-)
+);
 
 const retried = effect.pipe(
   Effect.retry({
     schedule: retryPolicy,
-    while: (error) => error._tag === "Retryable"
-  })
-)
+    while: (error) => error._tag === "Retryable",
+  }),
+);
 ```
 
 ### Pattern: fallback across providers
@@ -413,17 +401,17 @@ const Plan = ExecutionPlan.make(
   {
     provide: PrimaryLayer,
     attempts: 2,
-    schedule: Schedule.spaced("1 second")
+    schedule: Schedule.spaced("1 second"),
   },
   {
     provide: SecondaryLayer,
     attempts: 3,
-    schedule: Schedule.exponential(500, 1.5)
+    schedule: Schedule.exponential(500, 1.5),
   },
   {
-    provide: FinalFallbackLayer
-  }
-)
+    provide: FinalFallbackLayer,
+  },
+);
 ```
 
 ## Anti-Patterns

--- a/.agents/skills/effect-ts/references/guide-schedule.md
+++ b/.agents/skills/effect-ts/references/guide-schedule.md
@@ -49,9 +49,9 @@ attempt limits, and backoff in the schedule.
 Use the operator that matches the control flow:
 
 ```ts
-const retried = Effect.retry(loadRemote, retryPolicy)
-const repeated = Effect.repeat(refreshCache, refreshPolicy)
-const scheduled = Effect.schedule(runJob, nightly)
+const retried = Effect.retry(loadRemote, retryPolicy);
+const repeated = Effect.repeat(refreshCache, refreshPolicy);
+const scheduled = Effect.schedule(runJob, nightly);
 ```
 
 - `retry` steps the schedule when the effect fails; the schedule input is the
@@ -69,7 +69,7 @@ before the schedule is stepped, so `recurs(3)` permits one initial attempt and
 up to three retries.
 
 ```ts
-const retryThreeTimes = Schedule.recurs(3)
+const retryThreeTimes = Schedule.recurs(3);
 ```
 
 ### `Schedule.forever`
@@ -78,7 +78,7 @@ const retryThreeTimes = Schedule.recurs(3)
 combinators unless a tight loop is intentional.
 
 ```ts
-const unbounded = Schedule.forever
+const unbounded = Schedule.forever;
 ```
 
 ### `Schedule.spaced`
@@ -86,7 +86,7 @@ const unbounded = Schedule.forever
 Use `spaced` when each delay starts after the preceding action completes.
 
 ```ts
-const pollEverySecond = Schedule.spaced("1 second")
+const pollEverySecond = Schedule.spaced("1 second");
 ```
 
 ### `Schedule.fixed`
@@ -95,7 +95,7 @@ Use `fixed` for a regular cadence that accounts for the time spent running the
 action. This differs from naïve spacing when the action itself is slow.
 
 ```ts
-const everyMinute = Schedule.fixed("1 minute")
+const everyMinute = Schedule.fixed("1 minute");
 ```
 
 ### `Schedule.windowed`
@@ -103,7 +103,7 @@ const everyMinute = Schedule.fixed("1 minute")
 Use `windowed` to align work to the nearest interval boundary.
 
 ```ts
-const flushOnTenSecondWindows = Schedule.windowed("10 seconds")
+const flushOnTenSecondWindows = Schedule.windowed("10 seconds");
 ```
 
 ### `Schedule.duration`
@@ -111,7 +111,7 @@ const flushOnTenSecondWindows = Schedule.windowed("10 seconds")
 `duration` recurs once after the given delay, then completes.
 
 ```ts
-const onceAfterOneSecond = Schedule.duration("1 second")
+const onceAfterOneSecond = Schedule.duration("1 second");
 ```
 
 ### `Schedule.during`
@@ -119,7 +119,7 @@ const onceAfterOneSecond = Schedule.duration("1 second")
 `during` recurs only within an elapsed-time window.
 
 ```ts
-const forThirtySeconds = Schedule.during("30 seconds")
+const forThirtySeconds = Schedule.during("30 seconds");
 ```
 
 ### `Schedule.cron`
@@ -129,7 +129,7 @@ with `CronParseError`, so keep that failure visible where the expression is not
 a trusted constant.
 
 ```ts
-const nightly = Schedule.cron("0 0 * * *")
+const nightly = Schedule.cron("0 0 * * *");
 ```
 
 ## Backoff
@@ -139,7 +139,7 @@ const nightly = Schedule.cron("0 0 * * *")
 Use exponential backoff for transient external failures.
 
 ```ts
-const backoff = Schedule.exponential("100 millis", 2)
+const backoff = Schedule.exponential("100 millis", 2);
 ```
 
 Bound the policy explicitly:
@@ -148,7 +148,7 @@ Bound the policy explicitly:
 const boundedBackoff = Schedule.exponential("100 millis").pipe(
   Schedule.upTo({ duration: "30 seconds", times: 6 }),
   Schedule.jittered,
-)
+);
 ```
 
 ### `Schedule.fibonacci`
@@ -156,9 +156,7 @@ const boundedBackoff = Schedule.exponential("100 millis").pipe(
 Use Fibonacci backoff when growth should be gentler than exponential.
 
 ```ts
-const fibonacciBackoff = Schedule.fibonacci("100 millis").pipe(
-  Schedule.upTo({ times: 6 }),
-)
+const fibonacciBackoff = Schedule.fibonacci("100 millis").pipe(Schedule.upTo({ times: 6 }));
 ```
 
 ### `Schedule.jittered`
@@ -167,9 +165,7 @@ Use jitter for distributed clients, workers, or polling loops that might
 otherwise synchronize their retries.
 
 ```ts
-const jittered = Schedule.exponential("200 millis").pipe(
-  Schedule.jittered,
-)
+const jittered = Schedule.exponential("200 millis").pipe(Schedule.jittered);
 ```
 
 ## Bounding Policies
@@ -184,7 +180,7 @@ const bounded = Schedule.spaced("1 second").pipe(
     duration: "20 seconds",
     times: 5,
   }),
-)
+);
 ```
 
 Prefer `upTo` over rebuilding count and elapsed-time checks with mutable state.
@@ -198,10 +194,8 @@ Use `andThen` when one policy should complete before another begins.
 ```ts
 const quickThenSlow = Schedule.exponential("100 millis").pipe(
   Schedule.upTo({ times: 3 }),
-  Schedule.andThen(
-    Schedule.spaced("5 seconds").pipe(Schedule.upTo({ times: 5 })),
-  ),
-)
+  Schedule.andThen(Schedule.spaced("5 seconds").pipe(Schedule.upTo({ times: 5 }))),
+);
 ```
 
 This is the v4 replacement for older examples that used `Schedule.either` to
@@ -221,10 +215,7 @@ largest delay. Use it to enforce several stop conditions while retaining the
 slowest applicable cadence.
 
 ```ts
-const countedBackoff = Schedule.max([
-  Schedule.exponential("100 millis"),
-  Schedule.recurs(5),
-])
+const countedBackoff = Schedule.max([Schedule.exponential("100 millis"), Schedule.recurs(5)]);
 ```
 
 ### `Schedule.min`
@@ -234,10 +225,7 @@ smallest available delay. Use it only when that "any policy may continue"
 behavior is intended.
 
 ```ts
-const fastestAvailable = Schedule.min([
-  Schedule.spaced("1 second"),
-  Schedule.spaced("5 seconds"),
-])
+const fastestAvailable = Schedule.min([Schedule.spaced("1 second"), Schedule.spaced("5 seconds")]);
 ```
 
 Do not treat `max` and `min` as ordinary numeric delay combinators without
@@ -252,9 +240,9 @@ Use `modifyDelay` to replace the computed delay from schedule metadata.
 ```ts
 const cappedDelay = Schedule.exponential("100 millis").pipe(
   Schedule.modifyDelay(({ duration }) =>
-    Effect.succeed(Duration.min(duration, Duration.seconds(5)))
+    Effect.succeed(Duration.min(duration, Duration.seconds(5))),
   ),
-)
+);
 ```
 
 ### `Schedule.addDelay`
@@ -266,11 +254,9 @@ For retries, inspect the typed error through `metadata.input`.
 const serverAware = Schedule.spaced("1 second").pipe(
   Schedule.setInputType<RateLimitedError>(),
   Schedule.addDelay(({ input: error }) =>
-    error._tag === "RateLimited"
-      ? Effect.succeed(error.retryAfter)
-      : Effect.succeed(Duration.zero)
+    error._tag === "RateLimited" ? Effect.succeed(error.retryAfter) : Effect.succeed(Duration.zero),
   ),
-)
+);
 ```
 
 ### `Schedule.map`
@@ -299,9 +285,9 @@ const observed = Schedule.exponential("100 millis").pipe(
         delay: String(duration),
         errorTag: input._tag,
       }),
-    )
+    ),
   ),
-)
+);
 ```
 
 ## Advanced Construction And Inspection

--- a/.agents/skills/effect-ts/references/guide-schema.md
+++ b/.agents/skills/effect-ts/references/guide-schema.md
@@ -57,16 +57,14 @@ Make Schema the source of truth for application data. Export the schema value
 and derive its decoded TypeScript type from `.Type` under the same name.
 
 ```ts
-export const ArtifactId = Schema.NonEmptyString.pipe(
-  Schema.brand("@acme/ArtifactId")
-)
-export type ArtifactId = typeof ArtifactId.Type
+export const ArtifactId = Schema.NonEmptyString.pipe(Schema.brand("@acme/ArtifactId"));
+export type ArtifactId = typeof ArtifactId.Type;
 
 export const GenerateInput = Schema.Struct({
   artifactId: ArtifactId,
-  prompt: Schema.String
-})
-export type GenerateInput = typeof GenerateInput.Type
+  prompt: Schema.String,
+});
+export type GenerateInput = typeof GenerateInput.Type;
 ```
 
 Use schema classes for named reusable models when their validated construction,
@@ -127,14 +125,14 @@ Bad pattern:
 const Todo = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
-  completed: Schema.Boolean
-})
+  completed: Schema.Boolean,
+});
 
 const TodoSql = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
-  completed: Schema.BooleanFromBit
-})
+  completed: Schema.BooleanFromBit,
+});
 ```
 
 This is usually a sign that transformations are not being used properly.
@@ -165,23 +163,23 @@ When a schema represents a named domain model, reusable payload, or long-lived A
 Prefer:
 
 ```ts
-import { Schema } from "effect"
+import { Schema } from "effect";
 
 export class User extends Schema.Class<User>("User")({
   id: Schema.String,
-  name: Schema.String
+  name: Schema.String,
 }) {}
 ```
 
 Over:
 
 ```ts
-import { Schema } from "effect"
+import { Schema } from "effect";
 
 export const User = Schema.Struct({
   id: Schema.String,
-  name: Schema.String
-})
+  name: Schema.String,
+});
 ```
 
 Why `Class` variants are usually better:
@@ -248,8 +246,8 @@ Example:
 const Todo = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
-  completed: Schema.Boolean
-})
+  completed: Schema.Boolean,
+});
 ```
 
 ## `Class`, `TaggedClass`, and `TaggedErrorClass`
@@ -261,7 +259,7 @@ Use for named reusable schema-backed models.
 ```ts
 class Product extends Schema.Class<Product>("Product")({
   id: Schema.String,
-  price: Schema.Number
+  price: Schema.Number,
 }) {}
 ```
 
@@ -275,8 +273,8 @@ Prefer:
 const todo = Todo.make({
   id: 1,
   title: "write docs",
-  completed: false
-})
+  completed: false,
+});
 ```
 
 Over:
@@ -285,8 +283,8 @@ Over:
 const todo = new Todo({
   id: 1,
   title: "write docs",
-  completed: false
-})
+  completed: false,
+});
 ```
 
 Why:
@@ -308,12 +306,12 @@ Use for members of tagged unions.
 
 ```ts
 class Circle extends Schema.TaggedClass<Circle>()("Circle", {
-  radius: Schema.Number
+  radius: Schema.Number,
 }) {}
 
 class Rectangle extends Schema.TaggedClass<Rectangle>()("Rectangle", {
   width: Schema.Number,
-  height: Schema.Number
+  height: Schema.Number,
 }) {}
 ```
 
@@ -323,7 +321,7 @@ Use for schema-backed typed errors.
 
 ```ts
 class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  id: Schema.String
+  id: Schema.String,
 }) {}
 ```
 
@@ -342,8 +340,8 @@ Prefer:
 
 ```ts
 const Query = Schema.Struct({
-  search: Schema.optionalKey(Schema.String)
-})
+  search: Schema.optionalKey(Schema.String),
+});
 ```
 
 Use `optional` when the value itself should be `A | undefined`, not just an omitted field.
@@ -353,24 +351,21 @@ Use `optional` when the value itself should be `A | undefined`, not just an omit
 Use `Schema.Union([...])` for ordinary unions.
 
 ```ts
-const Id = Schema.Union([
-  Schema.String,
-  Schema.Number
-])
+const Id = Schema.Union([Schema.String, Schema.Number]);
 ```
 
 Prefer tagged unions for domain variants.
 
 ```ts
 class Created extends Schema.TaggedClass<Created>()("Created", {
-  id: Schema.String
+  id: Schema.String,
 }) {}
 
 class Deleted extends Schema.TaggedClass<Deleted>()("Deleted", {
-  id: Schema.String
+  id: Schema.String,
 }) {}
 
-const TodoEvent = Schema.Union([Created, Deleted])
+const TodoEvent = Schema.Union([Created, Deleted]);
 ```
 
 Why:
@@ -384,14 +379,14 @@ Use `Schema.suspend` for recursive schemas.
 
 ```ts
 type Tree = {
-  readonly name: string
-  readonly children: ReadonlyArray<Tree>
-}
+  readonly name: string;
+  readonly children: ReadonlyArray<Tree>;
+};
 
 const Tree: Schema.Schema<Tree> = Schema.Struct({
   name: Schema.String,
-  children: Schema.Array(Schema.suspend((): Schema.Schema<Tree> => Tree))
-})
+  children: Schema.Array(Schema.suspend((): Schema.Schema<Tree> => Tree)),
+});
 ```
 
 Use it whenever a schema refers to itself, directly or indirectly.
@@ -416,9 +411,9 @@ Use `decodeTo` when you want one schema to decode into another schema's type.
 const TrimmedString = Schema.String.pipe(
   Schema.decodeTo(Schema.String, {
     decode: (value) => value.trim(),
-    encode: (value) => value
-  })
-)
+    encode: (value) => value,
+  }),
+);
 ```
 
 The canonical docs explicitly note that `decodeTo` is curried and should be used with `pipe`.
@@ -432,19 +427,19 @@ Use `encodeTo` when the reverse direction reads more clearly.
 Use `transformOrFail` when the transformation itself is effectful or may fail.
 
 ```ts
-import * as Effect from "effect/Effect"
-import * as Schema from "effect/Schema"
-import * as SchemaTransformation from "effect/SchemaTransformation"
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as SchemaTransformation from "effect/SchemaTransformation";
 
 const VerifiedString = Schema.String.pipe(
   Schema.decodeTo(
     Schema.String,
     SchemaTransformation.transformOrFail({
       decode: (value) => Effect.succeed(value.trim()),
-      encode: (value) => Effect.succeed(value)
-    })
-  )
-)
+      encode: (value) => Effect.succeed(value),
+    }),
+  ),
+);
 ```
 
 Use this when:
@@ -460,13 +455,13 @@ Very often, the right answer is not a second object schema but a transformed fie
 Example shape:
 
 ```ts
-const Completed = Schema.BooleanFromBit
+const Completed = Schema.BooleanFromBit;
 
 const Todo = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
-  completed: Completed
-})
+  completed: Completed,
+});
 ```
 
 In this pattern:
@@ -519,9 +514,7 @@ Use opaque or branded schemas when a value should stay distinct from its structu
 Use `brand` for refined nominal distinctions.
 
 ```ts
-const UserId = Schema.String.pipe(
-  Schema.brand("UserId")
-)
+const UserId = Schema.String.pipe(Schema.brand("UserId"));
 ```
 
 This is useful for:
@@ -598,7 +591,7 @@ Preferred rule:
 Good pattern:
 
 ```ts
-const decodeUser = Schema.decodeUnknownEffect(User)
+const decodeUser = Schema.decodeUnknownEffect(User);
 ```
 
 ## Schema Metadata And Derived Tooling

--- a/.agents/skills/effect-ts/references/guide-sql.md
+++ b/.agents/skills/effect-ts/references/guide-sql.md
@@ -79,7 +79,7 @@ Prefer typed SQL queries instead of leaving row shapes implicit.
 The repo uses typed query literals like:
 
 ```ts
-const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM test`
+const rows = yield * sql<{ id: number; name: string }>`SELECT * FROM test`;
 ```
 
 This is the first level of typed SQL usage and is already better than untyped row access.
@@ -111,8 +111,8 @@ Why:
 Avoid this pattern:
 
 ```ts
-const row = yield* sql`SELECT id, title FROM todos WHERE id = ${id}`
-const todo = row[0] as TodoRow
+const row = yield * sql`SELECT id, title FROM todos WHERE id = ${id}`;
+const todo = row[0] as TodoRow;
 ```
 
 Prefer:
@@ -126,10 +126,10 @@ Example boundary decode:
 const TodoRow = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
-  completed: Schema.Boolean
-})
+  completed: Schema.Boolean,
+});
 
-const decodeTodoRows = Schema.decodeUnknownEffect(Schema.Array(TodoRow))
+const decodeTodoRows = Schema.decodeUnknownEffect(Schema.Array(TodoRow));
 ```
 
 Then keep the query and decoding together in one SQL-aware operation.
@@ -150,11 +150,11 @@ const resolver = SqlResolver.findById({
   Id: Schema.Number,
   Result: Schema.Struct({
     id: Schema.Number,
-    name: Schema.String
+    name: Schema.String,
   }),
   ResultId: (row) => row.id,
-  execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
-})
+  execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`,
+});
 ```
 
 This is a preferred pattern when:
@@ -201,17 +201,17 @@ Prefer a layer that provides `SqlClient`, and let domain services depend on that
 Good pattern:
 
 ```ts
-import * as Context from "effect/Context"
-import * as Effect from "effect/Effect"
-import * as SqlClient from "effect/unstable/sql/SqlClient"
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 class TodoRepo extends Context.Service<TodoRepo>()("TodoRepo", {
   make: Effect.succeed({
-    getById: Effect.fn("TodoRepo.getById")(function*(id: number) {
-      const sql = yield* SqlClient.SqlClient
-      return yield* sql`SELECT id, title, completed FROM todos WHERE id = ${id}`
-    })
-  })
+    getById: Effect.fn("TodoRepo.getById")(function* (id: number) {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`SELECT id, title, completed FROM todos WHERE id = ${id}`;
+    }),
+  }),
 }) {}
 ```
 
@@ -233,16 +233,16 @@ Repo reference:
 Prefer:
 
 ```ts
-const createAndAudit = Effect.fn("TodoRepo.createAndAudit")(function*(title: string) {
-  const sql = yield* SqlClient.SqlClient
+const createAndAudit = Effect.fn("TodoRepo.createAndAudit")(function* (title: string) {
+  const sql = yield* SqlClient.SqlClient;
 
   return yield* sql.withTransaction(
-    Effect.gen(function*() {
-      yield* sql`INSERT INTO todos ${sql.insert({ title, completed: false })}`
-      yield* sql`INSERT INTO audit_log ${sql.insert({ event: "todo_created" })}`
-    })
-  )
-})
+    Effect.gen(function* () {
+      yield* sql`INSERT INTO todos ${sql.insert({ title, completed: false })}`;
+      yield* sql`INSERT INTO audit_log ${sql.insert({ event: "todo_created" })}`;
+    }),
+  );
+});
 ```
 
 Avoid:
@@ -265,10 +265,10 @@ Avoid exposing one exported accessor function per SQL service method if it only 
 Bad:
 
 ```ts
-export const createTodo = Effect.fn(function*(title: string) {
-  const todos = yield* TodoRepo
-  return yield* todos.create(title)
-})
+export const createTodo = Effect.fn(function* (title: string) {
+  const todos = yield* TodoRepo;
+  return yield* todos.create(title);
+});
 ```
 
 Prefer:
@@ -352,25 +352,25 @@ The runtime-specific SQL migrator packages expose `fromRecord(...)` to define mi
 Example shape:
 
 ```ts
-import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
-import * as Effect from "effect/Effect"
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator";
+import * as Effect from "effect/Effect";
 
 const migrations = SqliteMigrator.fromRecord({
-  "1_create_todos": Effect.gen(function*() {
+  "1_create_todos": Effect.gen(function* () {
     yield* sql`
       CREATE TABLE todos (
         id INTEGER PRIMARY KEY NOT NULL,
         title TEXT NOT NULL,
         completed INTEGER NOT NULL DEFAULT 0
       )
-    `.withoutTransform
+    `.withoutTransform;
   }),
-  "2_add_todo_index": Effect.gen(function*() {
+  "2_add_todo_index": Effect.gen(function* () {
     yield* sql`
       CREATE INDEX todos_completed_idx ON todos (completed)
-    `.withoutTransform
-  })
-})
+    `.withoutTransform;
+  }),
+});
 ```
 
 This matches the model used by the canonical migrator implementation:
@@ -386,11 +386,11 @@ Use the runtime-specific `run(...)` helper when you want a startup effect that r
 Example shape:
 
 ```ts
-import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator";
 
 const runMigrations = SqliteMigrator.run({
-  loader: migrations
-})
+  loader: migrations,
+});
 ```
 
 This is a good fit when:
@@ -408,11 +408,11 @@ Use the runtime-specific `layer(...)` helper when migrations should run as part 
 Example shape:
 
 ```ts
-import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator";
 
 const MigrationLayer = SqliteMigrator.layer({
-  loader: migrations
-})
+  loader: migrations,
+});
 ```
 
 From the canonical packages, this is implemented as `Layer.effectDiscard(run(options))`.
@@ -428,16 +428,13 @@ That means:
 Preferred shape:
 
 ```ts
-const SqlLayer = SqliteClient.layer({ filename: "todos.sqlite" })
+const SqlLayer = SqliteClient.layer({ filename: "todos.sqlite" });
 
 const MigrationLayer = SqliteMigrator.layer({
-  loader: migrations
-})
+  loader: migrations,
+});
 
-const MigratedSqlLayer = Layer.merge(
-  SqlLayer,
-  MigrationLayer.pipe(Layer.provide(SqlLayer))
-)
+const MigratedSqlLayer = Layer.merge(SqlLayer, MigrationLayer.pipe(Layer.provide(SqlLayer)));
 ```
 
 This keeps the structure explicit:

--- a/.agents/skills/effect-ts/references/guide-testing.md
+++ b/.agents/skills/effect-ts/references/guide-testing.md
@@ -46,8 +46,8 @@ repository explicitly owns that workflow.
 Preferred imports for Effect tests:
 
 ```ts
-import { assert, describe, it, layer } from "@effect/vitest"
-import { Effect } from "effect"
+import { assert, describe, it, layer } from "@effect/vitest";
+import { Effect } from "effect";
 ```
 
 `@effect/vitest` re-exports Vitest, so it is the normal entrypoint for test APIs in an Effect codebase.
@@ -74,15 +74,15 @@ This comes directly from the internal implementation.
 Example:
 
 ```ts
-import { assert, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
 
 it.effect("loads a user", () =>
-  Effect.gen(function*() {
-    yield* Effect.void
-    assert.isTrue(true)
-  })
-)
+  Effect.gen(function* () {
+    yield* Effect.void;
+    assert.isTrue(true);
+  }),
+);
 ```
 
 Use `it.effect` when:
@@ -100,10 +100,10 @@ Example:
 
 ```ts
 it.live("uses live services", () =>
-  Effect.gen(function*() {
-    yield* Effect.void
-  })
-)
+  Effect.gen(function* () {
+    yield* Effect.void;
+  }),
+);
 ```
 
 Use `it.live` when:
@@ -123,11 +123,11 @@ Preferred pattern:
 
 ```ts
 it.effect("does something", () =>
-  Effect.gen(function*() {
-    const value = yield* someEffect
-    assert.strictEqual(value, 1)
-  })
-)
+  Effect.gen(function* () {
+    const value = yield* someEffect;
+    assert.strictEqual(value, 1);
+  }),
+);
 ```
 
 Prefer `Effect.gen` inside `it.effect` and `it.live` for readability.
@@ -147,9 +147,9 @@ The canonical source also uses `expect` in some tests, but for skill guidance pr
 Examples:
 
 ```ts
-assert.isTrue(value === 1)
-assert.strictEqual(a + b, b + a)
-assert.include(text, substring)
+assert.isTrue(value === 1);
+assert.strictEqual(a + b, b + a);
+assert.include(text, substring);
 ```
 
 ## Test Context
@@ -160,12 +160,12 @@ Example:
 
 ```ts
 it.effect("uses context", (ctx) =>
-  Effect.gen(function*() {
+  Effect.gen(function* () {
     ctx.onTestFailed(() => {
       // cleanup or diagnostics
-    })
-  })
-)
+    });
+  }),
+);
 ```
 
 Use this when you need:
@@ -201,12 +201,12 @@ Use `it.prop` for non-Effect property tests.
 Example:
 
 ```ts
-import { it } from "@effect/vitest"
-import { FastCheck } from "effect/testing"
+import { it } from "@effect/vitest";
+import { FastCheck } from "effect/testing";
 
-const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true });
 
-it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a)
+it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a);
 ```
 
 Important limitation from the internal implementation:
@@ -225,17 +225,17 @@ This is the more powerful property-testing mode for Effect code.
 Example:
 
 ```ts
-import { assert, it } from "@effect/vitest"
-import { Effect } from "effect"
-import { FastCheck } from "effect/testing"
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { FastCheck } from "effect/testing";
 
-const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true });
 
 it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>
-  Effect.gen(function*() {
-    assert.strictEqual(a + b, b + a)
-  })
-)
+  Effect.gen(function* () {
+    assert.strictEqual(a + b, b + a);
+  }),
+);
 ```
 
 Unlike top-level `it.prop`, `it.effect.prop` does support `Schema` inputs by converting them with `Schema.toArbitrary`.
@@ -260,23 +260,23 @@ This is one of the most important `@effect/vitest` features.
 Example:
 
 ```ts
-import { describe, it, layer } from "@effect/vitest"
-import { Context, Effect, Layer } from "effect"
+import { describe, it, layer } from "@effect/vitest";
+import { Context, Effect, Layer } from "effect";
 
 class Foo extends Context.Service<Foo, string>()("Foo") {
-  static readonly layer = Layer.succeed(Foo)("foo")
+  static readonly layer = Layer.succeed(Foo)("foo");
 }
 
 describe("foo", () => {
   layer(Foo.layer)((it) => {
     it.effect("gets foo", () =>
-      Effect.gen(function*() {
-        const foo = yield* Foo
-        return foo
-      })
-    )
-  })
-})
+      Effect.gen(function* () {
+        const foo = yield* Foo;
+        return foo;
+      }),
+    );
+  });
+});
 ```
 
 What it does internally:
@@ -314,14 +314,12 @@ If multiple tests use the same layer, do not write tests like this:
 
 ```ts
 it.effect("creates and lists todos", () =>
-  Effect.gen(function*() {
-    const service = yield* TodoService
-    yield* service.create("write tests")
-    yield* service.create("ship feature")
-  }).pipe(
-    Effect.provide(TodoService.inMemoryLayer)
-  )
-)
+  Effect.gen(function* () {
+    const service = yield* TodoService;
+    yield* service.create("write tests");
+    yield* service.create("ship feature");
+  }).pipe(Effect.provide(TodoService.inMemoryLayer)),
+);
 ```
 
 Why this is the wrong pattern:
@@ -338,23 +336,23 @@ Prefer:
 describe("TodoService", () => {
   layer(TodoService.inMemoryLayer)((it) => {
     it.effect("creates and lists todos", () =>
-      Effect.gen(function*() {
-        const service = yield* TodoService
-        yield* service.create("write tests")
-        yield* service.create("ship feature")
-      })
-    )
+      Effect.gen(function* () {
+        const service = yield* TodoService;
+        yield* service.create("write tests");
+        yield* service.create("ship feature");
+      }),
+    );
 
     it.effect("updates completion and deletes todos", () =>
-      Effect.gen(function*() {
-        const service = yield* TodoService
-        const todo = yield* service.create("close issue")
-        yield* service.setCompleted(todo.id, true)
-        yield* service.remove(todo.id)
-      })
-    )
-  })
-})
+      Effect.gen(function* () {
+        const service = yield* TodoService;
+        const todo = yield* service.create("close issue");
+        yield* service.setCompleted(todo.id, true);
+        yield* service.remove(todo.id);
+      }),
+    );
+  });
+});
 ```
 
 Rule:
@@ -381,14 +379,14 @@ Example:
 layer(Foo.layer)((it) => {
   it.layer(Bar.layer)("nested", (it) => {
     it.effect("gets both", () =>
-      Effect.gen(function*() {
-        const foo = yield* Foo
-        const bar = yield* Bar
-        return [foo, bar]
-      })
-    )
-  })
-})
+      Effect.gen(function* () {
+        const foo = yield* Foo;
+        const bar = yield* Bar;
+        return [foo, bar];
+      }),
+    );
+  });
+});
 ```
 
 Important behavior from the implementation:
@@ -476,11 +474,11 @@ It is not needed for ordinary test structure.
 
 ```ts
 it.effect("does work", () =>
-  Effect.gen(function*() {
-    const value = yield* Effect.succeed(1)
-    assert.strictEqual(value, 1)
-  })
-)
+  Effect.gen(function* () {
+    const value = yield* Effect.succeed(1);
+    assert.strictEqual(value, 1);
+  }),
+);
 ```
 
 ### Pattern: shared layer for a test group
@@ -488,33 +486,33 @@ it.effect("does work", () =>
 ```ts
 layer(AppLayer)("app", (it) => {
   it.effect("uses app services", () =>
-    Effect.gen(function*() {
-      yield* Effect.void
-    })
-  )
-})
+    Effect.gen(function* () {
+      yield* Effect.void;
+    }),
+  );
+});
 ```
 
 ### Pattern: property test with Effect
 
 ```ts
 it.effect.prop("law", [FastCheck.integer()], ([n]) =>
-  Effect.gen(function*() {
-    assert.strictEqual(n + 0, n)
-  })
-)
+  Effect.gen(function* () {
+    assert.strictEqual(n + 0, n);
+  }),
+);
 ```
 
 ### Pattern: use `TestClock`
 
 ```ts
 it.effect("uses TestClock", () =>
-  Effect.gen(function*() {
-    const fiber = yield* Effect.forkChild(Effect.sleep("1 second"))
-    yield* TestClock.adjust("1 second")
-    yield* Fiber.join(fiber)
-  })
-)
+  Effect.gen(function* () {
+    const fiber = yield* Effect.forkChild(Effect.sleep("1 second"));
+    yield* TestClock.adjust("1 second");
+    yield* Fiber.join(fiber);
+  }),
+);
 ```
 
 ## Anti-Patterns

--- a/.agents/skills/effect-ts/references/guide-type-safety-and-boundaries.md
+++ b/.agents/skills/effect-ts/references/guide-type-safety-and-boundaries.md
@@ -49,13 +49,13 @@ domain policy.
 
 Choose the Schema adapter that matches the caller's control flow:
 
-| Intent | Adapter |
-| --- | --- |
-| Boolean type guard | `Schema.is(Model)` |
-| Optional tolerant decode | `Schema.decodeUnknownOption(Model)` |
-| Typed Effect failure | `Schema.decodeUnknownEffect(Model)` |
-| JSON string decode | `Schema.fromJsonString(Model)` |
-| Any JSON-compatible value | `Schema.Json` |
+| Intent                    | Adapter                             |
+| ------------------------- | ----------------------------------- |
+| Boolean type guard        | `Schema.is(Model)`                  |
+| Optional tolerant decode  | `Schema.decodeUnknownOption(Model)` |
+| Typed Effect failure      | `Schema.decodeUnknownEffect(Model)` |
+| JSON string decode        | `Schema.fromJsonString(Model)`      |
+| Any JSON-compatible value | `Schema.Json`                       |
 
 Define small schemas for provider responses, SDK payloads, persisted data, and
 other structured external values. Decode once in the adapter and return the

--- a/.agents/skills/effect-ts/references/version-and-source.md
+++ b/.agents/skills/effect-ts/references/version-and-source.md
@@ -84,4 +84,3 @@ Before completing version-sensitive work:
 - every installed Effect v4 package resolves to the same beta
 - no source path is assumed solely because it appears in this skill
 - current-main guidance is not presented as installed-version behavior
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - run: bun install --frozen-lockfile
+      # One frozen, script-suppressed install, then locked Dev Kit
+      # convergence (tsgo patch, managed outputs) before any check runs.
+      - run: bun install --frozen-lockfile --ignore-scripts
+
+      - run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
       - run: bun run ready

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,9 @@ jobs:
           node-version: 24
       - run: npm install -g npm@latest
 
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
+
+      - run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
       - name: Version or publish
         uses: changesets/action@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ packages.
   independently in a package.
 - After changing an Effect-family version, run `bun install`, `bun run sync:effect`, and
   `bun run ready`.
-- After changing `agent-skills.jsonc` or its dependency, run `bun run sync:agent-skills` and commit
-  the generated `.agents/skills` copies and `.claude/skills` symlinks.
+- After changing `dev-kit.jsonc` or its dependency, run `bunx dev-kit apply` and commit the
+  regenerated `.agents/skills` copies, `.claude/skills` symlinks, and `dev-kit.lock.json`.
 - Contributor agent skills are repository tooling. They are not runtime Skill definitions and
   must not be imported by `@effect-agent/*`.
 - Before handoff, run `bun run ready`.

--- a/agent-skills.jsonc
+++ b/agent-skills.jsonc
@@ -1,9 +1,0 @@
-{
-  "$schema": "./node_modules/@danieljvdm/agent-skills/schema/agent-skills.schema.json",
-  "include": ["effect"],
-  "targets": {
-    "agents": { "enabled": true, "mode": "copy" },
-    "claude": { "enabled": true, "mode": "symlink" },
-    "opencode": { "enabled": false, "mode": "symlink" },
-  },
-}

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@changesets/changelog-github": "0.7.0",
         "@changesets/cli": "2.31.0",
-        "@danieljvdm/agent-skills": "github:danieljvdm/agent-skills#e1cdbe5dbad7576617052285d0cad43091432e0f",
         "@danieljvdm/dev-kit": "0.11.3",
         "@effect-agent/core": "workspace:*",
         "@effect-agent/platform-node": "workspace:*",
@@ -511,8 +510,6 @@
     "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260813.1", "", {}, "sha512-RQNfm7xD10hNHEQZFxQPmyGMJ9+aDGPcdFZ0x1LtmjRoLFcgZkGvfaqJAbOMQBAUFSESO3bYJS4p9mOLv28Ihg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
-
-    "@danieljvdm/agent-skills": ["@danieljvdm/agent-skills@github:danieljvdm/agent-skills#e1cdbe5", { "dependencies": { "@effect/platform-node": "4.0.0-beta.102", "effect": "4.0.0-beta.102", "jsonc-parser": "3.3.1", "tsx": "4.22.4" }, "bin": { "agent-skills": "./bin/agent-skills.mjs" } }, "danieljvdm-agent-skills-e1cdbe5", "sha512-Drf23NK0l8wHJKwDBAM/+zdZ+lX7yjwiHt4hXFUWkcTe5Zn0aE71JMTpg/CQ8A4k3tF0+GG1U7zzv1ed0BgE1A=="],
 
     "@danieljvdm/dev-kit": ["@danieljvdm/dev-kit@0.11.3", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.102", "@stylistic/eslint-plugin": "5.10.0", "effect": "4.0.0-beta.102", "jsonc-parser": "3.3.1", "semver": "7.8.5" }, "peerDependencies": { "oxfmt": ">=0.60.0 <0.61.0", "oxlint": ">=1.75.0 <2.0.0", "vite-plus": ">=0.2.6 <0.3.0" }, "optionalPeers": ["oxfmt", "oxlint", "vite-plus"], "bin": { "dev-kit": "bin/dev-kit.mjs" } }, "sha512-x+Us/B3MKDBdPRFUcozqhF007eV1XNLc0g5TqcXvrXzRq/GvFgoztrFdv8g6BGnipMKjnqK3bkHHzLy3gqHhDA=="],
 

--- a/dev-kit.jsonc
+++ b/dev-kit.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/@danieljvdm/dev-kit/schema/dev-kit.schema.json",
-  "include": ["dev-kit", "testing", "cloudflare"],
+  "include": ["dev-kit", "effect-ts", "testing", "cloudflare"],
   "setup": {
     "agentInstructions": { "enabled": true },
     "claudeInstructions": { "enabled": true },

--- a/dev-kit.lock.json
+++ b/dev-kit.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "toolVersion": "0.11.3",
-  "manifestDigest": "sha256:5ab8ba32bb2a178f5e532826b10d338b8a11a360810880e64b0d92ac63c78add",
+  "manifestDigest": "sha256:0b9dc205e81f64ea7ae62b68772aa258f4d167915289b614f594910b4f9a9243",
   "setup": {
     "effectSource": {
       "packageName": "effect",
@@ -41,6 +41,15 @@
       "digest": "sha256:934e6a086784b8cc9cc19c85587ba60481f57613fb8b85e4aea6b5556da72e0f"
     },
     {
+      "resourceId": "skill:effect-ts@agents",
+      "path": ".agents/skills/effect-ts",
+      "skill": "effect-ts",
+      "target": "agents",
+      "mode": "copy",
+      "kind": "directory",
+      "digest": "sha256:50786d8d351fa32953de526bc12ac67fee34fecfebff5dccde4f9fe0c3354ba3"
+    },
+    {
       "resourceId": "skill:testing@agents",
       "path": ".agents/skills/testing",
       "skill": "testing",
@@ -71,6 +80,15 @@
       "mode": "symlink",
       "kind": "symlink",
       "digest": "sha256:b59ba0874ef06cb4c651bb9b3012b014c9063648577f3f3181894e8ca3086d8f"
+    },
+    {
+      "resourceId": "skill:effect-ts@claude",
+      "path": ".claude/skills/effect-ts",
+      "skill": "effect-ts",
+      "target": "claude",
+      "mode": "symlink",
+      "kind": "symlink",
+      "digest": "sha256:057d09728194631224706ae6afbf877107388501832bf0f3e2c6516c7d55f242"
     },
     {
       "resourceId": "skill:testing@claude",

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -106,8 +106,6 @@ Run commands from the repository root:
 | `bun run ready`                               | Run check, test, and build; this is the local and CI handoff gate              |
 | `bun run format:write`                        | Apply repository formatting                                                    |
 | `bun run sync:effect`                         | Align the local Effect source checkout with the catalog pin                    |
-| `bun run sync:agent-skills`                   | Refresh checked-in contributor skills                                          |
-| `bun run sync:agent-skills:dry`               | Preview contributor skill changes                                              |
 
 Vite+ owns shared configuration in `vite.config.ts`. Package-specific scripts remain in each
 package manifest so Vite+ can order and cache them from the actual workspace dependency graph.
@@ -213,15 +211,12 @@ To upgrade Effect:
 
 ## Contributor agent skills
 
-[`@danieljvdm/agent-skills`](https://github.com/danieljvdm/agent-skills) is a root development
-dependency. `agent-skills.jsonc` opts into its `effect` family:
-
-- `effect-ts`
-
-The sync command copies these into `.agents/skills` and creates `.claude/skills` symlinks to the
-copies. Both the copies and symlinks are committed so a fresh checkout gives agents the same
-instructions before dependency installation. Re-run the sync command after changing the manifest
-or updating the dependency.
+Contributor skills are managed by [`@danieljvdm/dev-kit`](https://github.com/danieljvdm/dev-kit)
+from `dev-kit.jsonc` (currently the `dev-kit`, `effect-ts`, `testing`, and `cloudflare`
+selections). `dev-kit apply` runs on postinstall and converges the committed copies in
+`.agents/skills` plus the `.claude/skills` symlinks; `dev-kit.lock.json` records the exact
+resolution, and CI verifies it with `dev-kit apply --locked` after a script-suppressed frozen
+install. Use the `dev-kit` skill before changing managed outputs.
 
 These are contributor instructions. They are not the runtime Skill abstraction described in the
 product specification and must not be imported by a framework package.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   "type": "module",
   "scripts": {
     "postinstall": "dev-kit apply",
-    "sync:agent-skills": "agent-skills sync",
-    "sync:agent-skills:dry": "agent-skills sync --dry-run",
     "sync:effect": "dev-kit effect sync",
     "patch:tsgo": "dev-kit tsgo patch",
     "changeset": "bun x changeset",
@@ -35,7 +33,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.0",
-    "@danieljvdm/agent-skills": "github:danieljvdm/agent-skills#e1cdbe5dbad7576617052285d0cad43091432e0f",
     "@danieljvdm/dev-kit": "0.11.3",
     "@effect-agent/core": "workspace:*",
     "@effect-agent/platform-node": "workspace:*",


### PR DESCRIPTION
CI has been red on every run since the release-tooling merge. Root cause: `@danieljvdm/agent-skills` pinned as a `github:` tarball — GitHub regenerates API tarballs non-reproducibly, so `bun install --frozen-lockfile` fails its integrity check on every CI machine.

**Fix**: the `effect-ts` skill now comes from dev-kit's own catalog (`dev-kit.jsonc` gains `effect-ts`; dev-kit also brings its `effect-cli`/`effect-patterns` companions). `@danieljvdm/agent-skills` is removed entirely — dependency, `agent-skills.jsonc`, sync scripts, and docs (TOOLCHAIN/AGENTS updated to the dev-kit flow).

**Workflow discipline** (per the dev-kit skill): both `ci.yml` and `release.yml` now do one frozen **script-suppressed** install followed by locked convergence (`bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked`), so managed outputs are verified against the committed lock before any check or publish runs.

This PR's own CI run is the validation — it should be the first green check on this repo today. Branch protection requiring the `ready` check lands the moment this is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)