### PR TITLE
feat: effect-agent umbrella package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,15 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "danieljvdm/effect-agent" }],
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "danieljvdm/effect-agent"
+    }
+  ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    ["effect-agent", "@effect-agent/core", "@effect-agent/engine", "@effect-agent/capabilities"]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/effect-agent-umbrella.md
+++ b/.changeset/effect-agent-umbrella.md
@@ -1,0 +1,21 @@
+---
+"effect-agent": patch
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+"@effect-agent/capabilities": patch
+"@effect-agent/sandbox": patch
+"@effect-agent/sandbox-local": patch
+"@effect-agent/session": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-node": patch
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/testing": patch
+---
+
+Introduce the `effect-agent` umbrella package: the framework's complete pure
+surface — schema-first authoring (core), the bounded interpreter (engine),
+and operational capabilities — as one dependency-clean root package,
+mirroring how `effect` fronts the `@effect/*` satellites. Platform adapters
+remain scoped. The umbrella is version-fixed to its three constituents.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and a browser test bench under `examples/demo`.
 - Working package scope: `@effect-agent/*`
 - Repository shape: **Vite+ monorepo** with framework packages in `packages/*`, leaf consumer
   benches in `examples/*`, and no `apps/`
-- Current packages: `core`, `engine`, `capabilities`, `sandbox`, `sandbox-local`, `session`,
+- Current packages: `effect-agent` (umbrella over the pure surface), `core`, `engine`, `capabilities`, `sandbox`, `sandbox-local`, `session`,
   `storage-memory`, `storage-sqlite`, `storage-cloudflare`, `platform-node`,
   `platform-cloudflare`, and `testing`
 - Current implementation milestone: **the roadmap table is complete** — Phase 7 internal

--- a/bun.lock
+++ b/bun.lock
@@ -76,12 +76,10 @@
       "name": "@effect-agent/example-pr-review",
       "version": "0.0.0",
       "dependencies": {
-        "@effect-agent/capabilities": "workspace:*",
-        "@effect-agent/core": "workspace:*",
-        "@effect-agent/engine": "workspace:*",
         "@effect/ai-openai": "catalog:",
         "@effect/platform-node": "catalog:",
         "effect": "catalog:",
+        "effect-agent": "workspace:*",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
@@ -149,6 +147,20 @@
       "name": "@effect-agent/core",
       "version": "0.0.1-beta.3",
       "dependencies": {
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "typescript": "catalog:",
+        "vite-plus": "catalog:",
+      },
+    },
+    "packages/effect-agent": {
+      "name": "effect-agent",
+      "version": "0.0.1-beta.3",
+      "dependencies": {
+        "@effect-agent/capabilities": "workspace:*",
+        "@effect-agent/core": "workspace:*",
+        "@effect-agent/engine": "workspace:*",
         "effect": "catalog:",
       },
       "devDependencies": {
@@ -1566,6 +1578,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
+
+    "effect-agent": ["effect-agent@workspace:packages/effect-agent"],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.398", "", {}, "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ=="],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -53,6 +53,7 @@ Only packages required by the active roadmap phase exist:
 
 ```text
 packages/
+  effect-agent/         Umbrella: the pure authoring/interpreter/capabilities surface as one package
   core/                 Domain and Agent authoring package
   engine/               Ephemeral Agent interpreter
   capabilities/         Operational policy and capability adapters

--- a/examples/pr-review/package.json
+++ b/examples/pr-review/package.json
@@ -10,12 +10,10 @@
     "review": "bun src/cli.ts"
   },
   "dependencies": {
-    "@effect-agent/capabilities": "workspace:*",
-    "@effect-agent/core": "workspace:*",
-    "@effect-agent/engine": "workspace:*",
     "@effect/ai-openai": "catalog:",
     "@effect/platform-node": "catalog:",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "effect-agent": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -1,8 +1,7 @@
-import { BudgetExceeded } from "@effect-agent/capabilities";
-import { IdGenerator } from "@effect-agent/core";
 import { OpenAiClient } from "@effect/ai-openai";
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Config, Console, Effect, FileSystem, Layer, Option, Schema } from "effect";
+import { BudgetExceeded, IdGenerator } from "effect-agent";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
 import { FetchHttpClient } from "effect/unstable/http";
 

--- a/examples/pr-review/src/github.ts
+++ b/examples/pr-review/src/github.ts
@@ -1,8 +1,9 @@
-import { Context, Effect, Layer, Option, Redacted, Ref, Schema } from "effect";
+import type { Redacted } from "effect";
+import { Context, Effect, Layer, Option, Ref, Schema } from "effect";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import { ChangedFile } from "./diff.ts";
-import { ReviewPublicationPlan } from "./render.ts";
+import type { ReviewPublicationPlan } from "./render.ts";
 import {
   MAX_CHANGED_FILES,
   MAX_FILE_CHARS,

--- a/examples/pr-review/src/profiles.ts
+++ b/examples/pr-review/src/profiles.ts
@@ -1,6 +1,6 @@
-import { Agent } from "@effect-agent/core";
 import { OpenAiLanguageModel } from "@effect/ai-openai";
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
+import { Agent } from "effect-agent";
 import { LanguageModel, Model, type Response } from "effect/unstable/ai";
 
 import { CodeReview, PullRequestReviewer } from "./review-agent.ts";

--- a/examples/pr-review/src/render.ts
+++ b/examples/pr-review/src/render.ts
@@ -1,7 +1,9 @@
 import { Schema } from "effect";
 
-import { ChangedFile, commentableLines } from "./diff.ts";
-import { CodeReview, ReviewFinding } from "./review-agent.ts";
+import type { ChangedFile } from "./diff.ts";
+import { commentableLines } from "./diff.ts";
+import type { CodeReview } from "./review-agent.ts";
+import { ReviewFinding } from "./review-agent.ts";
 
 // ---------------------------------------------------------------------------
 // Publication planning: pure, deterministic, and fail-closed. Model output is

--- a/examples/pr-review/src/review-agent.ts
+++ b/examples/pr-review/src/review-agent.ts
@@ -1,6 +1,5 @@
-import { Agent, AgentPolicy } from "@effect-agent/core";
-import { ToolExecutionClass } from "@effect-agent/engine";
 import { Effect, Schema } from "effect";
+import { Agent, AgentPolicy, ToolExecutionClass } from "effect-agent";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import { annotatePatch, ChangedFileStatus, ChangedPath } from "./diff.ts";

--- a/examples/pr-review/src/run-review.ts
+++ b/examples/pr-review/src/run-review.ts
@@ -1,6 +1,11 @@
-import { makeUsageBudget, toRunBudgetHook, UsageBudgetLimits } from "@effect-agent/capabilities";
-import { AgentRuntime, type RuntimeBinding } from "@effect-agent/engine";
 import { Effect, Schema } from "effect";
+import {
+  makeUsageBudget,
+  toRunBudgetHook,
+  UsageBudgetLimits,
+  AgentRuntime,
+  type RuntimeBinding,
+} from "effect-agent";
 import { type Toolkit } from "effect/unstable/ai";
 
 import { PublishedReview, ReviewPublisher } from "./github.ts";

--- a/examples/pr-review/test/pr-review.test.ts
+++ b/examples/pr-review/test/pr-review.test.ts
@@ -1,7 +1,7 @@
-import { Agent, IdGenerator } from "@effect-agent/core";
 import { OpenAiClient } from "@effect/ai-openai";
 import { describe, expect, it } from "@effect/vitest";
 import { Config, Effect, Exit, Layer, Ref, Schema } from "effect";
+import { Agent, IdGenerator } from "effect-agent";
 import { Tool } from "effect/unstable/ai";
 import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 import { FetchHttpClient } from "effect/unstable/http";

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "effect-agent",
+  "name": "effect-agent-monorepo",
   "version": "0.0.0",
   "private": true,
   "workspaces": [

--- a/packages/effect-agent/LICENSE
+++ b/packages/effect-agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Daniel van der Merwe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/effect-agent/package.json
+++ b/packages/effect-agent/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "effect-agent",
+  "version": "0.0.1-beta.3",
+  "description": "Effect-native autonomous agents: the complete pure authoring and running surface of the Effect Agent framework in one package — schema-first definitions, the bounded interpreter, and operational capabilities.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-agent.git",
+    "directory": "packages/effect-agent"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "check": "tsc --noEmit -p tsconfig.json",
+    "test": "vp test --passWithNoTests"
+  },
+  "dependencies": {
+    "@effect-agent/capabilities": "workspace:*",
+    "@effect-agent/core": "workspace:*",
+    "@effect-agent/engine": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/packages/effect-agent/src/index.ts
+++ b/packages/effect-agent/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * The Effect Agent umbrella: the framework's complete pure surface — schema-
+ * first Agent authoring (`@effect-agent/core`), the bounded ephemeral
+ * interpreter (`@effect-agent/engine`), and operational capabilities
+ * (`@effect-agent/capabilities`) — as one dependency-clean package, mirroring
+ * how `effect` fronts the `@effect/*` satellites.
+ *
+ * Platform adapters stay scoped where their dependencies live:
+ * `@effect-agent/platform-node`, the storage adapters,
+ * `@effect-agent/sandbox-local`, `@effect-agent/platform-cloudflare`, and the
+ * `@effect-agent/testing` dev kit.
+ */
+export * from "@effect-agent/capabilities";
+export * from "@effect-agent/core";
+export * from "@effect-agent/engine";
+
+// Explicit re-exports resolve the star-export ambiguities so these names
+// stay present on the umbrella: `capabilities` re-exports the two core-owned
+// delegation-naming helpers, and both `engine` (type only) and `capabilities`
+// (Schema value + type) declare RunSchedulingOverride — the Schema form wins.
+export { delegationToolPrefix, isDelegationToolName } from "@effect-agent/core";
+export { CommandDrainPolicy, RunSchedulingOverride } from "@effect-agent/capabilities";

--- a/packages/effect-agent/tsconfig.json
+++ b/packages/effect-agent/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -22,6 +22,7 @@ const repositoryRoot = "../..";
 const packageNames = [
   "capabilities",
   "core",
+  "effect-agent",
   "engine",
   "platform-cloudflare",
   "platform-node",
@@ -49,6 +50,7 @@ const effectTestPackageNames = [
 const productionPackageNames = [
   "capabilities",
   "core",
+  "effect-agent",
   "engine",
   "platform-cloudflare",
   "platform-node",
@@ -272,8 +274,8 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       );
       // The pr-review GitHub Action bot is the fourth leaf example workspace.
       expect(prReview.name).toBe("@effect-agent/example-pr-review");
-      expect(prReview.dependencies?.["@effect-agent/core"]).toBe("workspace:*");
-      expect(prReview.dependencies?.["@effect-agent/engine"]).toBe("workspace:*");
+      // The example consumes the framework through the umbrella package.
+      expect(prReview.dependencies?.["effect-agent"]).toBe("workspace:*");
       expect(prReview.dependencies?.effect).toBe("catalog:");
       expect(prReview.dependencies?.["@effect/ai-openai"]).toBe("catalog:");
       expect(prReviewDependencies).not.toContain("wrangler");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,53 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/core" },
-    { "path": "./packages/engine" },
-    { "path": "./packages/capabilities" },
-    { "path": "./packages/sandbox" },
-    { "path": "./packages/sandbox-local" },
-    { "path": "./packages/session" },
-    { "path": "./packages/storage-memory" },
-    { "path": "./packages/storage-sqlite" },
-    { "path": "./packages/storage-cloudflare" },
-    { "path": "./packages/platform-cloudflare" },
-    { "path": "./packages/testing" },
-    { "path": "./examples/demo" },
-    { "path": "./examples/pr-review" },
-    { "path": "./examples/providers" },
-    { "path": "./examples/repo-ops" }
+    {
+      "path": "./packages/effect-agent"
+    },
+    {
+      "path": "./packages/core"
+    },
+    {
+      "path": "./packages/engine"
+    },
+    {
+      "path": "./packages/capabilities"
+    },
+    {
+      "path": "./packages/sandbox"
+    },
+    {
+      "path": "./packages/sandbox-local"
+    },
+    {
+      "path": "./packages/session"
+    },
+    {
+      "path": "./packages/storage-memory"
+    },
+    {
+      "path": "./packages/storage-sqlite"
+    },
+    {
+      "path": "./packages/storage-cloudflare"
+    },
+    {
+      "path": "./packages/platform-cloudflare"
+    },
+    {
+      "path": "./packages/testing"
+    },
+    {
+      "path": "./examples/demo"
+    },
+    {
+      "path": "./examples/pr-review"
+    },
+    {
+      "path": "./examples/providers"
+    },
+    {
+      "path": "./examples/repo-ops"
+    }
   ]
 }


### PR DESCRIPTION
The Effect-shaped layout: **root `effect-agent`** = the complete pure surface (core + engine + capabilities, ~180 exports, flat, ambiguities resolved explicitly) — `import { Agent, AgentPolicy, AgentRuntime, Subagent, makeUsageBudget } from "effect-agent"`. Scoped packages remain for everything carrying platform deps, exactly like `@effect/*`.

- npm name is unclaimed (verified); root workspace manifest renamed `effect-agent-monorepo` to free it.
- Version-fixed to core/engine/capabilities via changesets `fixed` group; baseline `0.0.1-beta.3`, rides the pending changeset to `beta.4`.
- `examples/pr-review` dogfoods it — three-package imports collapsed to one.
- Conformance inventory, root tsconfig references, README/TOOLCHAIN updated. Full `ready` green.

**Post-merge sequence**:
1. The bot opens the Version Packages (beta) PR (this branch carries the changeset for all 13).
2. One last OTP: `bun run release:publish -- --otp <code>` publishes `effect-agent@0.0.1-beta.3` alone (new names can't OIDC their first publish) → register its trusted publisher (same four values, workflow `release.yml`).
3. Merge the Version PR → the full 13-package `beta.4` ships via OIDC — the pipeline-validation release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)