### PR TITLE
fix(release): shell-safe changesets action commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,17 +56,15 @@ jobs:
         with:
           title: "chore: version packages (beta)"
           commit: "chore: version packages (beta)"
-          version: bun run changeset:version && bun install
+          # The changesets action does not shell-interpret its command
+          # strings ('&&' arrives as a literal argument), so both commands
+          # live in package.json scripts, which bun runs through a shell.
+          version: bun run ci:version
           # Branch protection already requires the full `ready` gate on the
           # exact merged tree, so the publish path re-verifies only what it
-          # consumes: the built artifacts. Re-running the whole test suite
-          # here would only add a second chance for slow-runner flakes to
-          # block a release the merge gate already validated.
-          publish: >-
-            bun run build &&
-            bun run release:publish -- --ci &&
-            bun x changeset tag &&
-            git push --follow-tags
+          # consumes (the build), then publishes, tags, and pushes tags —
+          # all inside one package.json script for real shell chaining.
+          publish: bun run ci:publish
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "changeset:version": "bun x changeset version",
     "changeset:publish": "bun x changeset publish",
     "release:publish": "bun scripts/release-publish.ts",
+    "ci:version": "bun x changeset version && bun install",
+    "ci:publish": "bun run build && bun scripts/release-publish.ts --ci && bun x changeset tag && git push --follow-tags",
     "requirements:coverage": "bun scripts/requirements-coverage.ts",
     "reset:development-storage": "bun scripts/reset-development-storage.ts",
     "formal:check": "bun scripts/formal-check.ts",


### PR DESCRIPTION
The version path's first live run exposed that the changesets action passes its command strings to the executable verbatim — `&&` became a literal argument, so `changeset version` errored and earlier multi-step publish chains had silently run only their first command. Both flows move into package.json scripts (`ci:version`, `ci:publish`) for real shell chaining. Also enabled the repo setting allowing Actions to open the Version Packages PR (the second failure in the same run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)