### PR TITLE
feat: support per-incarnation Cloudflare agent bindings

### DIFF
--- a/.changeset/beta107-runtime-fixes.md
+++ b/.changeset/beta107-runtime-fixes.md
@@ -1,0 +1,19 @@
+---
+"effect-agent": patch
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+"@effect-agent/capabilities": patch
+"@effect-agent/sandbox": patch
+"@effect-agent/sandbox-local": patch
+"@effect-agent/session": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-node": patch
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/testing": patch
+---
+
+Align every public package with Effect 4.0.0-beta.107. Also expose per-incarnation Cloudflare
+Binding capture with live Durable Object context and derived identities, and prevent incomplete
+application Tool batches from a failed or aborted Run from poisoning prompts for later Runs.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -100,7 +100,9 @@ configuration, the single multiplexed `DurableAlarmService` with the idempotent
 committed alarm), the alarm/RPC wake scheduler, the Durable Object RPC port transport,
 `CloudflareDurableRuntime.layer`, `makeConversationObjectClass` (local-only constructor gates
 and the typed admission-limits gate before `submit`), and the Worker-side
-`CloudflareConversationClient`. It is a Layer-assembly library, not an application entrypoint.
+`CloudflareConversationClient`. `CloudflareBindingSource` may capture registered worker Bindings
+from `CloudflareBindingSourceContext` once per Object incarnation, after identity derivation. It
+is a Layer-assembly library, not an application entrypoint.
 
 ### `@effect-agent/testing`
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -247,6 +247,13 @@ Cloudflare platform APIs are wrapped as Effect services and supplied through Lay
 Conversation runtime requires storage, scheduling/alarm, clock, attachment, and observability
 services rather than importing bindings in the engine.
 
+`CloudflareDurableRuntimeOptions.bindings` accepts a resolved array, a closed Effect, or a
+per-incarnation callback. The callback runs after the Object's Conversation and producer
+identities are derived and receives the live `DurableObjectState`, raw Worker environment,
+`conversationId`, and `producerId`. This is the host boundary for capturing environment-backed
+resources such as Worker service bindings; database clients and other request-scoped resources
+remain outside the cached Durable Object runtime.
+
 Durable Object storage is the only correctness-critical store for that Conversation. In-memory
 object state is a cache because objects may stop unexpectedly. Alarm work is idempotent because
 alarms execute at least once.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -232,6 +232,12 @@ unknown unless a registered reconciliation policy can prove one of:
 Otherwise the run enters `Unknown` and requires operator or application resolution.
 The engine must not manufacture an error result and continue.
 
+A committed assistant response that declares application Tool Calls remains visible to recovery
+of its owning Run even before every call settles. If that Run instead terminates failed or
+aborted without completing the batch, a later Run MUST NOT replay the orphan assistant Tool
+declaration or partial Tool results from that incomplete batch as model history. Instruction and
+user messages committed before the declaration remain visible.
+
 ## 11. Durable steps
 
 A durable step is a named, versioned unit with a stable `StepId`, Effect Schema

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -97,15 +97,34 @@ export interface CloudflareDurableRuntimeOptions {
   readonly toolReconciler?: Layer.Layer<ToolReconciler> | undefined;
   /**
    * Registered worker Bindings resolved at durable claim time (S2, spec/subagents.md §11):
-   * build each with `DurableWorkerBinding.make(binding, digests)`. An Effect form is accepted
-   * because the capture is effectful; it runs once per incarnation during Layer construction.
-   * Defaults to the empty registration (every resolved claim fails closed).
+   * build each with `DurableWorkerBinding.make(binding, digests)`. An Effect or callback form is
+   * accepted because capture can be effectful. The callback receives the live Object context and
+   * derived identities and is evaluated once per incarnation during Layer construction. Defaults
+   * to the empty registration (every resolved claim fails closed).
    */
-  readonly bindings?:
-    | ReadonlyArray<ResolvedBinding>
-    | Effect.Effect<ReadonlyArray<ResolvedBinding>>
-    | undefined;
+  readonly bindings?: CloudflareBindingSource | undefined;
 }
+
+/** Per-incarnation host values available while registered worker Bindings are captured. */
+export interface CloudflareBindingSourceContext {
+  readonly ctx: DurableObjectState;
+  readonly env: unknown;
+  readonly conversationId: ConversationId;
+  readonly producerId: ProducerId;
+}
+
+/**
+ * Registered worker Bindings, or a closed Effect/callback that captures them once for each
+ * Durable Object incarnation. Callback Effects cannot require services or fail typed.
+ */
+export type CloudflareBindingSource =
+  | ReadonlyArray<ResolvedBinding>
+  | Effect.Effect<ReadonlyArray<ResolvedBinding>, never, never>
+  | ((
+      context: CloudflareBindingSourceContext,
+    ) =>
+      | ReadonlyArray<ResolvedBinding>
+      | Effect.Effect<ReadonlyArray<ResolvedBinding>, never, never>);
 
 /** Every construction failure of the assembled Cloudflare durable runtime stack. */
 export type CloudflareDurableRuntimeInitializationError =
@@ -208,13 +227,19 @@ const conversationIdFromState = (
       );
 
 const resolveBindings = (
-  bindings: CloudflareDurableRuntimeOptions["bindings"],
+  source: CloudflareDurableRuntimeOptions["bindings"],
+  context: CloudflareBindingSourceContext,
 ): Effect.Effect<ReadonlyArray<ResolvedBinding>> =>
-  bindings === undefined
+  source === undefined
     ? Effect.succeed([])
-    : Effect.isEffect(bindings)
-      ? bindings
-      : Effect.succeed(bindings);
+    : Effect.isEffect(source)
+      ? source
+      : typeof source === "function"
+        ? Effect.suspend(() => {
+            const bindings = source(context);
+            return Effect.isEffect(bindings) ? bindings : Effect.succeed(bindings);
+          })
+        : Effect.succeed(source);
 
 /**
  * The DC Layer assembly (deployment §12: a Layer-assembly library, not an app entrypoint;
@@ -243,7 +268,7 @@ export class CloudflareDurableRuntime {
   > {
     return Layer.unwrap(
       Effect.gen(function* () {
-        const { ctx } = yield* DurableObjectContext;
+        const { ctx, env } = yield* DurableObjectContext;
         const config = yield* configFromOptions(options);
         const conversationId = yield* conversationIdFromState(ctx);
         const producerId = yield* decodeProducerId(
@@ -317,7 +342,10 @@ export class CloudflareDurableRuntime {
             : Layer.succeed(DurableRuntimeFailpoint)({ hit: options.runtimeFailpoint(ctx) });
         const reconcilerLayer = options.toolReconciler ?? ToolReconciler.uncertain;
         const bindingResolverLayer = Layer.effect(AgentBindingResolver)(
-          Effect.map(resolveBindings(options.bindings), AgentBindingResolver.fromBindings),
+          Effect.map(
+            resolveBindings(options.bindings, { ctx, env, conversationId, producerId }),
+            (bindings) => AgentBindingResolver.fromBindings(bindings),
+          ),
         );
 
         const base = Layer.mergeAll(

--- a/packages/platform-cloudflare/test/binding-source.test.ts
+++ b/packages/platform-cloudflare/test/binding-source.test.ts
@@ -1,0 +1,46 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PRODUCER_PREFIX } from "./fixtures.ts";
+
+const dynamicStub = (conversation: string) =>
+  env.DYNAMIC_BINDINGS.get(env.DYNAMIC_BINDINGS.idFromName(conversation));
+const arrayStub = (conversation: string) =>
+  env.ARRAY_BINDINGS.get(env.ARRAY_BINDINGS.idFromName(conversation));
+const effectStub = (conversation: string) =>
+  env.EFFECT_BINDINGS.get(env.EFFECT_BINDINGS.idFromName(conversation));
+
+describe("Cloudflare Binding sources", () => {
+  it("evaluates the callback once with each incarnation's live host context and identities", async () => {
+    const firstConversation = `binding-source-first-${crypto.randomUUID()}`;
+    const secondConversation = `binding-source-second-${crypto.randomUUID()}`;
+    const first = dynamicStub(firstConversation);
+    const second = dynamicStub(secondConversation);
+
+    const firstProbe = await first.bindingSourceProbe();
+    expect(await first.bindingSourceProbe()).toEqual(firstProbe);
+    expect(firstProbe).toMatchObject({
+      evaluationCount: 1,
+      conversationId: firstConversation,
+      producerId: `${PRODUCER_PREFIX}:${firstConversation}`,
+      rawEnvHasNamespace: true,
+      stateMatches: true,
+    });
+
+    const secondProbe = await second.bindingSourceProbe();
+    expect(secondProbe).toMatchObject({
+      evaluationCount: 1,
+      conversationId: secondConversation,
+      producerId: `${PRODUCER_PREFIX}:${secondConversation}`,
+      rawEnvHasNamespace: true,
+      stateMatches: true,
+    });
+    expect(secondProbe.incarnation).not.toBe(firstProbe.incarnation);
+  });
+
+  it("keeps the legacy array and Effect source forms", async () => {
+    const conversation = `binding-source-legacy-${crypto.randomUUID()}`;
+    expect(await arrayStub(conversation).bindingSourceKind()).toBe("array");
+    expect(await effectStub(conversation).bindingSourceKind()).toBe("effect");
+  });
+});

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -17,6 +17,9 @@ import {
 } from "../src/index.ts";
 import { decodeConversationId, supplierCountsFor, supplierValuesFor } from "./fixtures.ts";
 import type {
+  ArrayBindingsConversationObject,
+  DynamicBindingsConversationObject,
+  EffectBindingsConversationObject,
   LimitedConversationObject,
   SubagentConversationObject,
   TestConversationObject,
@@ -30,6 +33,9 @@ declare global {
       LIMITED: DurableObjectNamespace<LimitedConversationObject>;
       TINYDB: DurableObjectNamespace<TinyDatabaseConversationObject>;
       SUBAGENTS: DurableObjectNamespace<SubagentConversationObject>;
+      DYNAMIC_BINDINGS: DurableObjectNamespace<DynamicBindingsConversationObject>;
+      ARRAY_BINDINGS: DurableObjectNamespace<ArrayBindingsConversationObject>;
+      EFFECT_BINDINGS: DurableObjectNamespace<EffectBindingsConversationObject>;
     }
   }
 }
@@ -41,7 +47,14 @@ declare global {
  * abort — the DC twin of the Node crash harness's helpers.
  */
 
-export type TestNamespace = "CONVERSATIONS" | "LIMITED" | "TINYDB" | "SUBAGENTS";
+export type TestNamespace =
+  | "CONVERSATIONS"
+  | "LIMITED"
+  | "TINYDB"
+  | "SUBAGENTS"
+  | "DYNAMIC_BINDINGS"
+  | "ARRAY_BINDINGS"
+  | "EFFECT_BINDINGS";
 
 /** A FRESH stub for the named Conversation (never cache stubs across aborts). */
 export const stubFor = (conversation: string, namespace: TestNamespace = "CONVERSATIONS") => {

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -1,3 +1,5 @@
+import { Effect } from "effect";
+
 import { makeConversationObjectClass, type ConversationObjectOptions } from "../src/index.ts";
 import {
   CONVERSATIONS_BINDING,
@@ -37,6 +39,36 @@ const baseOptions: ConversationObjectOptions = {
   runtimeFailpoint: runtimeEvictionFailpoint,
 };
 
+interface BindingSourceProbe {
+  readonly evaluationCount: number;
+  readonly incarnation: number;
+  readonly conversationId: string;
+  readonly producerId: string;
+  readonly rawEnvHasNamespace: boolean;
+}
+
+let nextBindingSourceIncarnation = 0;
+const bindingSourceProbes = new WeakMap<DurableObjectState, BindingSourceProbe>();
+
+const dynamicBindings: NonNullable<ConversationObjectOptions["bindings"]> = ({
+  ctx,
+  env,
+  conversationId,
+  producerId,
+}) =>
+  Effect.sync(() => {
+    const previous = bindingSourceProbes.get(ctx);
+    const probe = {
+      evaluationCount: (previous?.evaluationCount ?? 0) + 1,
+      incarnation: previous?.incarnation ?? ++nextBindingSourceIncarnation,
+      conversationId,
+      producerId,
+      rawEnvHasNamespace: typeof env === "object" && env !== null && "DYNAMIC_BINDINGS" in env,
+    };
+    bindingSourceProbes.set(ctx, probe);
+    return [];
+  });
+
 /** The eviction/alarm/chaos suites' Conversation Object. */
 export class TestConversationObject extends makeConversationObjectClass(baseOptions) {}
 
@@ -54,6 +86,41 @@ export class TinyDatabaseConversationObject extends makeConversationObjectClass(
   namespaceBinding: "TINYDB",
   maxDatabaseBytes: 1,
 }) {}
+
+/** Callback-form Binding capture probe. */
+export class DynamicBindingsConversationObject extends makeConversationObjectClass({
+  ...baseOptions,
+  namespaceBinding: "DYNAMIC_BINDINGS",
+  bindings: dynamicBindings,
+}) {
+  async bindingSourceProbe(): Promise<BindingSourceProbe & { readonly stateMatches: boolean }> {
+    const probe = bindingSourceProbes.get(this.ctx);
+    if (probe === undefined) throw new Error("Binding source was not evaluated");
+    return { ...probe, stateMatches: bindingSourceProbes.has(this.ctx) };
+  }
+}
+
+/** Legacy array-form Binding capture probe. */
+export class ArrayBindingsConversationObject extends makeConversationObjectClass({
+  ...baseOptions,
+  namespaceBinding: "ARRAY_BINDINGS",
+  bindings: [],
+}) {
+  async bindingSourceKind(): Promise<string> {
+    return "array";
+  }
+}
+
+/** Legacy Effect-form Binding capture probe. */
+export class EffectBindingsConversationObject extends makeConversationObjectClass({
+  ...baseOptions,
+  namespaceBinding: "EFFECT_BINDINGS",
+  bindings: Effect.succeed([]),
+}) {
+  async bindingSourceKind(): Promise<string> {
+    return "effect";
+  }
+}
 
 /**
  * The WP4 cross-Object subagent matrix's Conversation Object: parent and child Conversations

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -38,6 +38,18 @@ export default defineConfig({
                 LIMITED: { className: "LimitedConversationObject", useSQLite: true },
                 TINYDB: { className: "TinyDatabaseConversationObject", useSQLite: true },
                 SUBAGENTS: { className: "SubagentConversationObject", useSQLite: true },
+                DYNAMIC_BINDINGS: {
+                  className: "DynamicBindingsConversationObject",
+                  useSQLite: true,
+                },
+                ARRAY_BINDINGS: {
+                  className: "ArrayBindingsConversationObject",
+                  useSQLite: true,
+                },
+                EFFECT_BINDINGS: {
+                  className: "EffectBindingsConversationObject",
+                  useSQLite: true,
+                },
               },
             },
           }),

--- a/packages/session/src/run-journal.ts
+++ b/packages/session/src/run-journal.ts
@@ -294,9 +294,9 @@ const toolMessageFromSettled = Effect.fn("RunJournal.toolMessageFromSettled")(
  *   first `ModelResponseRecorded`. The projection consumes it only for Run correlation.
  */
 export interface RunJournalProjection {
-  /** Full canonical model-visible prompt across every committed Turn of every Run. */
+  /** Canonical projection for the requested Run; may end at its resumable Tool declaration. */
   readonly prompt: Prompt.Prompt;
-  /** Canonical prompt excluding the projected Run's records: the resuming Attempt's history. */
+  /** Valid prior-Run history excluding the projected Run's records and orphan Tool batches. */
   readonly historyBefore: Prompt.Prompt;
   /** Number of canonical Turns already committed for the projected Run. */
   readonly committedTurns: number;
@@ -309,6 +309,26 @@ interface FoldState {
   readonly pendingToolsForRun: boolean;
   readonly committedTurns: number;
 }
+
+const decodeToolCallId = Schema.decodeSync(ToolCallId);
+
+const declaredApplicationToolCallIds = (prompt: Prompt.Prompt): ReadonlyArray<string> => {
+  const ids: Array<string> = [];
+  for (const message of prompt.content) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.content) {
+      if (part.type === "tool-call" && !part.providerExecuted) ids.push(part.id);
+    }
+  }
+  return ids;
+};
+
+const withoutApplicationToolCallMessages = (prompt: Prompt.Prompt): ReadonlyArray<Prompt.Message> =>
+  prompt.content.filter(
+    (message) =>
+      message.role !== "assistant" ||
+      !message.content.some((part) => part.type === "tool-call" && !part.providerExecuted),
+  );
 
 /**
  * Phase 5 audit tags that are prompt-transparent: they carry durability evidence (preparation,
@@ -338,16 +358,23 @@ const PROMPT_TRANSPARENT_TAGS: ReadonlySet<string> = new Set([
 
 /**
  * Pure projection: rebuild one Run's resume state from canonical records (DUR-015). Canonical
- * order is authoritative; the fold appends each `ModelResponseRecorded`'s messages and flushes
- * each contiguous group of `ToolCallSettled` records into one Tool message, exactly mirroring the
- * per-Turn commit shape produced by `turnCanonicalBatch` (no-tool Turns) and by the
+ * order is authoritative; the fold projects each complete `ModelResponseRecorded` Turn and the
+ * owning Run's resumable incomplete Tool Turn, while excluding incomplete Tool batches from prior
+ * Runs. It flushes each contiguous group of valid `ToolCallSettled` records into one Tool message,
+ * exactly mirroring the per-Turn commit shape produced by `turnCanonicalBatch` (no-tool Turns) and
+ * by the
  * `turnResponseBatch`/`turnResultsBatch` split (tool-declaring Turns). The Phase 5 audit tags
  * are skipped transparently, so split-batch commits replay to the same prompt as P4 single-batch
  * commits.
+ *
+ * An incomplete application Tool turn remains visible while projecting its owning Run so active
+ * recovery can resume the declared batch. It is not a valid model-visible Turn boundary for a
+ * later Run: the orphan assistant Tool declaration and any partial Tool results from that Turn
+ * are excluded, while preceding instruction/user messages in the response record remain history.
  */
-export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(function* (
+const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwner")(function* (
   records: ReadonlyArray<CanonicalRecordEnvelope>,
-  runId: RunId,
+  ownerRunId: RunId | undefined,
 ): Effect.fn.Return<RunJournalProjection, RunJournalError> {
   let state: FoldState = {
     all: [],
@@ -356,6 +383,36 @@ export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(funct
     pendingToolsForRun: false,
     committedTurns: 0,
   };
+
+  const settledToolCallRecordIds = new Set<string>();
+  for (const envelope of records) {
+    const payload = envelope.record.payload;
+    if (payload._tag !== "ToolCallSettled") continue;
+    settledToolCallRecordIds.add(envelope.record.recordId);
+  }
+
+  const decodedResponses = new Map<string, Prompt.Prompt>();
+  const incompleteToolTurns = new Set<string>();
+  const incompleteToolCalls = new Set<string>();
+  for (const envelope of records) {
+    const payload = envelope.record.payload;
+    if (payload._tag !== "ModelResponseRecorded") continue;
+    const messages = yield* decodePromptMessages(payload.messages);
+    decodedResponses.set(envelope.record.recordId, messages);
+    const declared = declaredApplicationToolCallIds(messages);
+    const declaredRecordIds: Array<RecordId> = [];
+    for (const id of declared) {
+      const toolCallId = yield* Effect.try({
+        try: () => decodeToolCallId(id),
+        catch: (cause) => journalError("Failed to decode a declared Tool Call ID", cause),
+      });
+      declaredRecordIds.push(toolCallSettledRecordId(payload.runId, payload.turn, toolCallId));
+    }
+    if (declaredRecordIds.some((recordId) => !settledToolCallRecordIds.has(recordId))) {
+      incompleteToolTurns.add(envelope.record.recordId);
+      for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
+    }
+  }
 
   const flushTools = Effect.fn("RunJournal.flushTools")(function* (
     current: FoldState,
@@ -375,24 +432,37 @@ export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(funct
     const payload = envelope.record.payload;
     if (PROMPT_TRANSPARENT_TAGS.has(payload._tag)) continue;
     if (payload._tag === "ToolCallSettled") {
-      if (state.pendingTools.length > 0 && state.pendingToolsForRun !== (payload.runId === runId)) {
+      if (payload.runId !== ownerRunId && incompleteToolCalls.has(envelope.record.recordId)) {
+        continue;
+      }
+      if (
+        state.pendingTools.length > 0 &&
+        state.pendingToolsForRun !== (payload.runId === ownerRunId)
+      ) {
         state = yield* flushTools(state);
       }
       state = {
         ...state,
         pendingTools: [...state.pendingTools, payload],
-        pendingToolsForRun: payload.runId === runId,
+        pendingToolsForRun: payload.runId === ownerRunId,
       };
       continue;
     }
     state = yield* flushTools(state);
     if (payload._tag !== "ModelResponseRecorded") continue;
-    const messages = yield* decodePromptMessages(payload.messages);
-    const forRun = payload.runId === runId;
+    const messages = decodedResponses.get(envelope.record.recordId);
+    if (messages === undefined) {
+      return yield* journalError("A canonical ModelResponseRecorded was not decoded");
+    }
+    const forRun = payload.runId === ownerRunId;
+    const visibleMessages =
+      !forRun && incompleteToolTurns.has(envelope.record.recordId)
+        ? withoutApplicationToolCallMessages(messages)
+        : messages.content;
     state = {
       ...state,
-      all: [...state.all, ...messages.content],
-      before: forRun ? state.before : [...state.before, ...messages.content],
+      all: [...state.all, ...visibleMessages],
+      before: forRun ? state.before : [...state.before, ...visibleMessages],
       committedTurns: forRun ? Math.max(state.committedTurns, payload.turn) : state.committedTurns,
     };
   }
@@ -405,17 +475,27 @@ export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(funct
   };
 });
 
-const NO_RUN = decodeRunId("run:none");
+/** Pure projection of one Run's durable recovery state from canonical records. */
+export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(
+  (
+    records: ReadonlyArray<CanonicalRecordEnvelope>,
+    runId: RunId,
+  ): Effect.Effect<RunJournalProjection, RunJournalError> =>
+    projectRunJournalForOwner(records, runId),
+);
 
 /**
- * Pure prompt reconstruction from canonical records: `UserInputRecorded` + `ModelResponseRecorded`
- * + `ToolCallSettled` → the deterministic model-visible Prompt (plan §Coordinator flow step 3).
+ * Pure valid-prompt projection from canonical records: `UserInputRecorded` +
+ * `ModelResponseRecorded` + complete `ToolCallSettled` batches → the deterministic model-visible
+ * Prompt (plan §Coordinator flow step 3).
  */
 export const promptFromCanonicalRecords = Effect.fn("RunJournal.promptFromCanonicalRecords")(
   (
     records: ReadonlyArray<CanonicalRecordEnvelope>,
   ): Effect.Effect<Prompt.Prompt, RunJournalError> =>
-    projectRunJournal(records, NO_RUN).pipe(Effect.map((projection) => projection.prompt)),
+    projectRunJournalForOwner(records, undefined).pipe(
+      Effect.map((projection) => projection.prompt),
+    ),
 );
 
 /** Everything one committed Turn contributes to its canonical batch. */
@@ -435,7 +515,6 @@ export interface TurnCommitInput {
   readonly createdAt: DateTime.Utc;
 }
 
-const decodeToolCallId = Schema.decodeSync(ToolCallId);
 const decodePersistedJson = Schema.decodeUnknownEffect(PersistedJson);
 const encodePrompt = Schema.encodeEffect(Prompt.Prompt);
 

--- a/packages/session/test/run-journal.test.ts
+++ b/packages/session/test/run-journal.test.ts
@@ -14,7 +14,9 @@ import {
   ObservationOffset,
   ProducerId,
   RecordEnvelope,
+  RunJournalError,
   modelResponseRecordId,
+  promptFromCanonicalRecords,
   projectRunJournal,
   runIdForSubmission,
   subagentJoinBatchId,
@@ -38,6 +40,7 @@ import {
 
 const SUBMISSION_ID = Schema.decodeSync(SubmissionId)("submission-journal");
 const RUN_ID = runIdForSubmission(SUBMISSION_ID);
+const LATER_RUN_ID = runIdForSubmission(Schema.decodeSync(SubmissionId)("submission-later"));
 const CALL_ONE = Schema.decodeSync(ToolCallId)("call-1");
 const CALL_TWO = Schema.decodeSync(ToolCallId)("call-2");
 const PRODUCER_ID = Schema.decodeSync(ProducerId)("producer-journal");
@@ -87,10 +90,10 @@ const toolTurnAppended: ReadonlyArray<Prompt.Message> = [
   }),
 ];
 
-const turnInput = (appended: ReadonlyArray<Prompt.Message>, turn = 1) => ({
-  runId: RUN_ID,
+const turnInput = (appended: ReadonlyArray<Prompt.Message>, turn = 1, runId = RUN_ID) => ({
+  runId,
   turn,
-  turnId: turnIdForRun(RUN_ID, turn),
+  turnId: turnIdForRun(runId, turn),
   appended,
   producerId: PRODUCER_ID,
   deploymentId: DEPLOYMENT_ID,
@@ -174,6 +177,217 @@ describe("run journal batch split (plan §2.1)", () => {
         expect(splitProjection.committedTurns).toBe(singleProjection.committedTurns);
         expect(splitProjection.prompt).toEqual(singleProjection.prompt);
         expect(splitProjection.historyBefore).toEqual(singleProjection.historyBefore);
+      }),
+    );
+
+    it.effect("does not replay an incomplete assistant Tool turn into a later Run", () =>
+      Effect.gen(function* () {
+        const failedResponse = yield* turnResponseBatch(turnInput(toolTurnAppended));
+        const records = envelopesOf([failedResponse]);
+
+        const recovering = yield* projectRunJournal(records, RUN_ID);
+        expect(
+          recovering.prompt.content.some(
+            (message) =>
+              message.role === "assistant" &&
+              message.content.some((part) => part.type === "tool-call" && part.id === CALL_ONE),
+          ),
+        ).toBe(true);
+
+        const later = yield* projectRunJournal(records, LATER_RUN_ID);
+        expect(later.prompt.content.map((message) => message.role)).toEqual(["system", "user"]);
+        expect(
+          later.prompt.content.some(
+            (message) =>
+              message.role === "assistant" &&
+              message.content.some((part) => part.type === "tool-call"),
+          ),
+        ).toBe(false);
+        expect(later.historyBefore).toEqual(later.prompt);
+      }),
+    );
+
+    it.effect("does not reserve the real run:none identity for canonical prompt projection", () =>
+      Effect.gen(function* () {
+        const runNone = runIdForSubmission(Schema.decodeSync(SubmissionId)("none"));
+        expect(runNone).toBe("run:none");
+        const response = yield* turnResponseBatch(turnInput(toolTurnAppended, 1, runNone));
+        const records = envelopesOf([response]);
+
+        const recovering = yield* projectRunJournal(records, runNone);
+        expect(recovering.prompt.content.map((message) => message.role)).toEqual([
+          "system",
+          "user",
+          "assistant",
+        ]);
+
+        const canonicalPrompt = yield* promptFromCanonicalRecords(records);
+        expect(canonicalPrompt.content.map((message) => message.role)).toEqual(["system", "user"]);
+      }),
+    );
+
+    it.effect("reports an invalid persisted Tool Call ID as a journal error", () =>
+      Effect.gen(function* () {
+        const malformedTurn: ReadonlyArray<Prompt.Message> = [
+          Prompt.makeMessage("assistant", {
+            content: [
+              Prompt.makePart("tool-call", {
+                id: "",
+                name: "book_flight",
+                params: { destination: "Kyoto" },
+                providerExecuted: false,
+              }),
+            ],
+          }),
+        ];
+        const response = yield* turnResponseBatch(turnInput(malformedTurn));
+
+        const error = yield* promptFromCanonicalRecords(envelopesOf([response])).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(RunJournalError);
+        expect(error.message).toBe("Failed to decode a declared Tool Call ID");
+      }),
+    );
+
+    it.effect(
+      "omits a partially settled application Tool batch from later Runs without classifying provider calls",
+      () =>
+        Effect.gen(function* () {
+          const response = yield* turnResponseBatch(turnInput(toolTurnAppended));
+          const results = yield* turnResultsBatch(turnInput(toolTurnAppended));
+          const firstSettled = results.records[0]!;
+          const partialRecords = [response.records[0]!, firstSettled].map((record, index) =>
+            envelopeAt(index + 1, record),
+          );
+
+          const recovering = yield* projectRunJournal(partialRecords, RUN_ID);
+          const recoveringAssistant = recovering.prompt.content.find(
+            (message) => message.role === "assistant",
+          );
+          expect(
+            recoveringAssistant?.role === "assistant"
+              ? recoveringAssistant.content
+                  .filter((part) => part.type === "tool-call")
+                  .map((part) => part.id)
+              : [],
+          ).toEqual([CALL_ONE, CALL_TWO]);
+          const recoveringTool = recovering.prompt.content.find(
+            (message) => message.role === "tool",
+          );
+          expect(
+            recoveringTool?.role === "tool"
+              ? recoveringTool.content
+                  .filter((part) => part.type === "tool-result")
+                  .map((part) => part.id)
+              : [],
+          ).toEqual([CALL_ONE]);
+
+          const later = yield* projectRunJournal(partialRecords, LATER_RUN_ID);
+          expect(later.prompt.content.map((message) => message.role)).toEqual(["system", "user"]);
+          expect(later.prompt.content.some((message) => message.role === "assistant")).toBe(false);
+          expect(later.prompt.content.some((message) => message.role === "tool")).toBe(false);
+
+          const providerTurn: ReadonlyArray<Prompt.Message> = [
+            Prompt.makeMessage("system", { content: "Answer as JSON." }),
+            Prompt.makeMessage("user", {
+              content: [Prompt.makePart("text", { text: '{"question":"search?"}' })],
+            }),
+            Prompt.makeMessage("assistant", {
+              content: [
+                Prompt.makePart("tool-call", {
+                  id: "provider-call",
+                  name: "web_search",
+                  params: { query: "Kyoto" },
+                  providerExecuted: true,
+                }),
+              ],
+            }),
+          ];
+          const providerResponse = yield* turnResponseBatch(turnInput(providerTurn));
+          const providerLater = yield* projectRunJournal(
+            envelopesOf([providerResponse]),
+            LATER_RUN_ID,
+          );
+          expect(providerLater.prompt.content.map((message) => message.role)).toEqual([
+            "system",
+            "user",
+            "assistant",
+          ]);
+        }),
+    );
+
+    it.effect("matches Tool settlements by Run, Turn, and call identity", () =>
+      Effect.gen(function* () {
+        const firstTurn: ReadonlyArray<Prompt.Message> = [
+          Prompt.makeMessage("system", { content: "Answer as JSON." }),
+          Prompt.makeMessage("user", {
+            content: [Prompt.makePart("text", { text: '{"question":"book twice?"}' })],
+          }),
+          Prompt.makeMessage("assistant", {
+            content: [
+              Prompt.makePart("tool-call", {
+                id: CALL_ONE,
+                name: "book_flight",
+                params: { destination: "Kyoto" },
+                providerExecuted: false,
+              }),
+            ],
+          }),
+          Prompt.makeMessage("tool", {
+            content: [
+              Prompt.makePart("tool-result", {
+                id: CALL_ONE,
+                name: "book_flight",
+                result: { bookingRef: "flight-42" },
+                isFailure: false,
+                providerExecuted: false,
+              }),
+            ],
+          }),
+        ];
+        const secondTurn: ReadonlyArray<Prompt.Message> = [
+          Prompt.makeMessage("assistant", {
+            content: [
+              Prompt.makePart("tool-call", {
+                id: CALL_ONE,
+                name: "book_flight",
+                params: { destination: "Osaka" },
+                providerExecuted: false,
+              }),
+            ],
+          }),
+        ];
+
+        const firstResponse = yield* turnResponseBatch(turnInput(firstTurn));
+        const firstResults = yield* turnResultsBatch(turnInput(firstTurn));
+        const secondResponse = yield* turnResponseBatch(turnInput(secondTurn, 2));
+        const records = envelopesOf([firstResponse, firstResults, secondResponse]);
+
+        const recovering = yield* projectRunJournal(records, RUN_ID);
+        expect(recovering.prompt.content.map((message) => message.role)).toEqual([
+          "system",
+          "user",
+          "assistant",
+          "tool",
+          "assistant",
+        ]);
+
+        const later = yield* projectRunJournal(records, LATER_RUN_ID);
+        expect(later.prompt.content.map((message) => message.role)).toEqual([
+          "system",
+          "user",
+          "assistant",
+          "tool",
+        ]);
+        expect(later.prompt.content.filter((message) => message.role === "assistant")).toHaveLength(
+          1,
+        );
+        expect(
+          later.prompt.content.flatMap((message) =>
+            message.role === "tool"
+              ? message.content.filter((part) => part.type === "tool-result").map((part) => part.id)
+              : [],
+          ),
+        ).toEqual([CALL_ONE]);
       }),
     );
 


### PR DESCRIPTION
## What changed

- Add a per-incarnation Cloudflare binding source that receives the live Durable Object state, Worker environment, and derived conversation/producer identities while preserving the existing array and Effect forms.
- Prevent a failed or aborted Run with an incomplete application-tool batch from poisoning later model prompts, while retaining the batch for recovery of its owning Run.
- Add a fresh changeset for all public packages so the already-landed Effect beta.107 upgrade is actually published.

## What went wrong

The Effect beta.107 upgrade reached main without a new changeset, so the release workflow published zero packages and npm beta.4 still targets Effect beta.102. Separately, the Cloudflare host could not construct bindings from live per-object context, and the generic journal projection could replay an orphan tool declaration into a later Run.

## Evidence

- Session journal regression: 11/11 passed; full session suite: 124/124 passed.
- Cloudflare binding-source workerd regression: 2/2 passed.
- Repository check passed.
- All 13 package builds passed, including Cloudflare declaration output.
- Full ready could not finish locally because the system Node 26.7 runtime rejects the repository crash-worker flag; CI runs on the pinned toolchain.