### PR TITLE
feat(observability): add native tool telemetry

### DIFF
--- a/.changeset/native-tool-observability.md
+++ b/.changeset/native-tool-observability.md
@@ -1,0 +1,19 @@
+---
+"effect-agent": patch
+"@effect-agent/engine": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Export privacy-safe canonical Tool spans and bounded terminal logs from the engine, including
+value-level failures and delayed terminal event/trace commit, while isolating complete span-
+lifecycle defects through Effect's error reporter.
+Add an explicit host-provided Cloudflare observability Layer at the Worker
+factory boundary, with background flushes after native RPC, wake, and alarm spans through
+`ctx.waitUntil`, plus a typed exporter error that retains the host cause without delaying delivery.
+Coalesce background export requests per
+Conversation Object into capped two-attempt cycles with at most one queued cycle, preserve typed
+export Causes until the final always-fulfilled `waitUntil` bridge, and keep synchronous background
+registration failure synchronously observable without invoking an unowned exporter or replacing
+native delivery.
+Automatic Cloudflare diagnostics expose only bounded framework classifications; retained exporter,
+defect, interrupt, and platform Causes never enter framework logs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Verify locked Dev Kit setup
         run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
+      - name: Patch Effect TypeScript-Go
+        run: bun run patch:tsgo
+
       # Restored after the install because a reinstall can recreate
       # node_modules, which would drop a cache restored earlier.
       - name: Restore Vite Task cache
@@ -93,6 +96,9 @@ jobs:
       - name: Verify locked Dev Kit setup
         run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
+      - name: Patch Effect TypeScript-Go
+        run: bun run patch:tsgo
+
       - name: Restore Vite Task cache
         id: task-cache
         uses: actions/cache/restore@v4
@@ -131,6 +137,9 @@ jobs:
 
       - name: Verify locked Dev Kit setup
         run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
+
+      - name: Patch Effect TypeScript-Go
+        run: bun run patch:tsgo
 
       - name: Restore Vite Task cache
         id: task-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Verify locked Dev Kit setup
         run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
+      - name: Patch Effect TypeScript-Go
+        run: bun run patch:tsgo
+
       - name: Version or publish
         uses: changesets/action@v1
         with:

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -32740,9 +32740,8 @@ var makeIsolatedToolTracer = (delegate) => {
     const guardedPrimitive = {
       ["~effect/Effect/evaluate"]: evaluate2
     };
-    let delegated;
     try {
-      delegated = delegateContext(guardedPrimitive, fiber3);
+      delegateContext(guardedPrimitive, fiber3);
     } catch (defect) {
       const observed2 = currentEvaluation();
       switch (observed2._tag) {
@@ -32761,7 +32760,7 @@ var makeIsolatedToolTracer = (delegate) => {
       case "Failed":
         throw observed.error;
       case "Succeeded":
-        return delegated;
+        return observed.value;
       case "Pending":
         return evaluate2(fiber3);
     }
@@ -33083,6 +33082,7 @@ var preflightApproval = (context3, turnId, prepared, options) => exports_Stream.
     }
   });
 })));
+var ProviderResponsePartId = exports_Schema.String.check(exports_Schema.isMaxLength(128), exports_Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/));
 var ProviderToolCallId = ToolCallId.check(exports_Schema.isMaxLength(128), exports_Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/));
 var isTelemetryToolCallId = exports_Schema.is(ProviderToolCallId);
 var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWaiting) => {
@@ -33565,6 +33565,23 @@ var stageProviderResultPayload = (trace2, payload) => exports_Effect.gen(functio
   trace2.providerResultPayloads.push(normalized);
   trace2.providerStagedPayloadBytes += snapshot2.bytes;
 });
+var ProviderToolResultSnapshot = exports_Schema.Struct({
+  result: exports_Schema.Json,
+  metadata: exports_Schema.Record(exports_Schema.String, exports_Schema.Json)
+});
+var snapshotProviderToolResultPart = exports_Effect.fnUntraced(function* (trace2, part) {
+  const snapshot2 = boundedJsonSnapshot({ result: part.encodedResult, metadata: part.metadata }, MAX_STAGED_PROVIDER_BYTES - trace2.providerStagedPayloadBytes);
+  if (snapshot2 === undefined) {
+    return yield* ModelProtocolError.make({
+      message: `Model response exceeded the ${MAX_STAGED_PROVIDER_BYTES}-byte staged provider event limit`
+    });
+  }
+  const normalized = yield* exports_Schema.decodeUnknownEffect(ProviderToolResultSnapshot)(snapshot2.value).pipe(exports_Effect.mapError(() => ModelProtocolError.make({
+    message: "Provider Tool result could not be normalized as JSON"
+  })));
+  trace2.providerStagedPayloadBytes += snapshot2.bytes;
+  return normalized;
+});
 var stampProviderResultEvent = (context3, turnId, payload) => exports_Effect.map(eventBase(context3), (base2) => {
   switch (payload._tag) {
     case "ToolProgress":
@@ -33614,6 +33631,43 @@ var decodeToolCallId = exports_Effect.fn("AgentRuntime.decodeToolCallId")((id2) 
 var decodeProviderToolCallId = exports_Effect.fn("AgentRuntime.decodeProviderToolCallId")((id2) => exports_Schema.decodeEffect(ProviderToolCallId)(id2).pipe(exports_Effect.mapError(() => ModelProtocolError.make({
   message: "Model supplied an invalid Tool Call ID; expected 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens"
 }))));
+var decodeProviderResponsePartId = exports_Effect.fn("AgentRuntime.decodeProviderResponsePartId")((id2) => exports_Schema.decodeEffect(ProviderResponsePartId)(id2).pipe(exports_Effect.mapError(() => ModelProtocolError.make({
+  message: "Model supplied an invalid response part ID; expected 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens"
+}))));
+var validateProviderPartIdentifiers = exports_Effect.fnUntraced(function* (part) {
+  switch (part.type) {
+    case "text-start":
+    case "text-delta":
+    case "text-end":
+    case "reasoning-start":
+    case "reasoning-delta":
+    case "reasoning-end":
+    case "source":
+      yield* decodeProviderResponsePartId(part.id);
+      return;
+    case "response-metadata":
+      if (part.id !== undefined)
+        yield* decodeProviderResponsePartId(part.id);
+      return;
+    case "tool-params-start":
+    case "tool-params-delta":
+    case "tool-params-end":
+    case "tool-call":
+    case "tool-result":
+      yield* decodeProviderToolCallId(part.id);
+      return;
+    case "tool-approval-request":
+      yield* decodeProviderResponsePartId(part.approvalId);
+      yield* decodeProviderToolCallId(part.toolCallId);
+      return;
+    case "error":
+    case "file":
+    case "finish":
+    case "reasoning":
+    case "text":
+      return;
+  }
+});
 var decodeEventJson = exports_Effect.fn("AgentRuntime.decodeEventJson")((value4, label) => exports_Schema.decodeUnknownEffect(exports_Schema.Json)(value4).pipe(exports_Effect.mapError((cause) => ModelProtocolError.make({
   message: `${label} is not JSON: ${cause.message}`
 }))));
@@ -33658,10 +33712,9 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
       message: "Model response emitted content after its finish part"
     });
   }
-  if (part.type === "tool-params-start" || part.type === "tool-params-delta" || part.type === "tool-params-end" || part.type === "tool-call" || part.type === "tool-result") {
-    yield* decodeProviderToolCallId(part.id);
-  }
-  trace2.parts.push(part);
+  yield* validateProviderPartIdentifiers(part);
+  if (part.type !== "tool-call" && part.type !== "tool-result")
+    trace2.parts.push(part);
   switch (part.type) {
     case "text-start": {
       yield* startPart(trace2.textParts, part.id, "text");
@@ -33758,13 +33811,13 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
       const tool = tools[part.name];
       const encodedParameters = yield* encodeToolCallParameters(tool, part.name, part.params);
       const parameters = yield* decodeEventJson(encodedParameters, "Tool parameters");
-      trace2.parts[trace2.parts.length - 1] = exports_Response.makePart("tool-call", {
+      trace2.parts.push(exports_Response.makePart("tool-call", {
         id: part.id,
         name: part.name,
         params: parameters,
         providerExecuted: part.providerExecuted,
         metadata: part.metadata
-      });
+      }));
       trace2.toolCalls.set(part.id, {
         name: part.name,
         providerExecuted: part.providerExecuted
@@ -33811,7 +33864,8 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
         });
       }
       const toolCallId = yield* decodeToolCallId(part.id);
-      const result4 = yield* decodeEventJson(part.encodedResult, "Tool result");
+      const normalized = yield* snapshotProviderToolResultPart(trace2, part);
+      const result4 = normalized.result;
       if (part.preliminary === true) {
         yield* stageProviderResultPayload(trace2, {
           _tag: "ToolProgress",
@@ -33820,6 +33874,16 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
           result: result4,
           providerExecuted: true
         });
+        trace2.parts.push(exports_Response.toolResultPart({
+          id: part.id,
+          name: part.name,
+          isFailure: part.isFailure,
+          result: result4,
+          encodedResult: result4,
+          providerExecuted: true,
+          preliminary: true,
+          metadata: normalized.metadata
+        }));
         return [];
       }
       if (trace2.finalToolResultIds.has(part.id)) {
@@ -33827,25 +33891,35 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
           message: `Tool Call ${part.id} produced more than one terminal result`
         });
       }
-      trace2.finalToolResultIds.add(part.id);
       if (part.isFailure) {
         yield* stageProviderResultPayload(trace2, {
           _tag: "ToolCallFailed",
           toolCallId,
           toolName: part.name,
-          errorTag: errorTag(part.result),
-          message: errorMessage(part.result),
+          errorTag: errorTag(result4),
+          message: errorMessage(result4),
           providerExecuted: true
         });
-        return [];
+      } else {
+        yield* stageProviderResultPayload(trace2, {
+          _tag: "ToolCallSucceeded",
+          toolCallId,
+          toolName: part.name,
+          result: result4,
+          providerExecuted: true
+        });
       }
-      yield* stageProviderResultPayload(trace2, {
-        _tag: "ToolCallSucceeded",
-        toolCallId,
-        toolName: part.name,
+      trace2.finalToolResultIds.add(part.id);
+      trace2.parts.push(exports_Response.toolResultPart({
+        id: part.id,
+        name: part.name,
+        isFailure: part.isFailure,
         result: result4,
-        providerExecuted: true
-      });
+        encodedResult: result4,
+        providerExecuted: true,
+        preliminary: false,
+        metadata: normalized.metadata
+      }));
       return [];
     }
     case "finish": {
@@ -37532,6 +37606,44 @@ var layer14 = (delegation, childBinding, options) => {
   return toolkit.toLayer(build2);
 };
 var SubagentRuntime = { layer: layer14 };
+// packages/pr-review/src/internal/effort.ts
+var EFFORT_ALIASES = {
+  low: 0,
+  medium: 0.25,
+  high: 0.5,
+  xhigh: 0.75,
+  max: 1
+};
+var aliasPosition = EFFORT_ALIASES;
+
+class InvalidEffortInput extends exports_Schema.TaggedError()("InvalidEffortInput", {
+  input: exports_Schema.String
+}) {
+  get message() {
+    return `Invalid effort '${this.input}': expected one of ` + `${Object.keys(EFFORT_ALIASES).join(", ")} or a number between 0 and 1.`;
+  }
+}
+var isEffortPosition = (value4) => Number.isFinite(value4) && value4 >= 0 && value4 <= 1;
+var parseEffortPosition = (raw) => {
+  const normalized = raw.trim().toLowerCase();
+  const named = aliasPosition[normalized];
+  if (named !== undefined)
+    return named;
+  if (normalized === "")
+    return;
+  const numeric = Number(normalized);
+  return isEffortPosition(numeric) ? numeric : undefined;
+};
+var resolveEffortRung = (position, rungs) => {
+  const clamped = Math.min(1, Math.max(0, position));
+  let selected = rungs[0];
+  for (const rung of rungs) {
+    if (EFFORT_ALIASES[rung] <= clamped)
+      selected = rung;
+  }
+  return selected;
+};
+
 // packages/pr-review/src/internal/diff.ts
 var ChangedPath = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512));
 var ChangedFileStatus = exports_Schema.Literals([
@@ -37690,6 +37802,7 @@ class PullRequestSource extends exports_Context.Service()("@effect-agent/pr-revi
 
 // packages/pr-review/src/internal/review-agent.ts
 var MAX_FINDINGS = 20;
+var MAX_CONCERNS = 10;
 var MAX_PATCH_CHARS = 60000;
 var MAX_SLICE_LINES = 1000;
 var DEFAULT_SLICE_LINES = 400;
@@ -37860,10 +37973,18 @@ class ReviewFinding extends exports_Schema.Class("@effect-agent/pr-review/Review
 }
 var ReviewVerdict = exports_Schema.Literals(["approve", "comment", "request-changes"]);
 
+class ReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/ReviewConcern")({
+  severity: FindingSeverity,
+  title: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(120)),
+  body: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2000))
+}) {
+}
+
 class CodeReview extends exports_Schema.Class("@effect-agent/pr-review/CodeReview")({
   summary: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(4000)),
   verdict: ReviewVerdict,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_FINDINGS))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_FINDINGS)),
+  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CONCERNS)))
 }) {
 }
 var resolveGuidance = (guidance, mission) => {
@@ -37886,9 +38007,13 @@ ${mission.body}` : "The author provided no description.",
     "2. Call read_file_diff for every file you review. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
     "3. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap honestly in your summary when it matters.",
     "4. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
-    '5. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}]}.',
-    `Report at most ${maxFindings} findings; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
-    'Use verdict "request-changes" only when at least one finding is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.'
+    "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
+    "Go shallow only when the diff has no behavioral surface at all: doc typos, formatting, lockfile or generated-code regeneration, a mechanical rename. Line count is not the signal — a one-line change to auth, money, SQL, a comparison operator, or a config default is not trivial.",
+    "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
+    '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor; report none when none exist.',
+    '6. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>}.',
+    `Report at most ${maxFindings} findings and at most ${MAX_CONCERNS} concerns; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
+    'Use verdict "request-changes" only when at least one finding or concern is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.'
   ].join(`
 `);
 };
@@ -38000,6 +38125,7 @@ var rankAndDedupeFindings = (findings) => {
 
 // packages/pr-review/src/internal/fan-out.ts
 var MAX_CHILD_FINDINGS = 8;
+var MAX_CHILD_CONCERNS = 3;
 var FileReviewToolkit = exports_Toolkit.make(ReadFileDiff, ReadFile);
 var FileReviewToolkitLayer = FileReviewToolkit.toLayer({
   read_file_diff: readFileDiffHandler,
@@ -38016,7 +38142,8 @@ class FileReviewBrief extends exports_Schema.Class("@effect-agent/pr-review/File
 
 class FileReviewReport extends exports_Schema.Class("@effect-agent/pr-review/FileReviewReport")({
   unitId: ReviewUnitId,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS)),
+  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CHILD_CONCERNS)))
 }) {
 }
 var staticGuidanceLines = (guidance) => {
@@ -38032,8 +38159,10 @@ var makeFileReviewerInstructions = (options = {}) => (brief) => [
   "1. Call read_file_diff for every file in your unit. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
   "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
   "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
-  `4. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"unitId": ${JSON.stringify(brief.unitId)}, "findings": [{"path": <string, a file in your unit>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}]}.`,
-  `Report at most ${MAX_CHILD_FINDINGS} findings; prefer the most important ones. An empty findings array is a valid report. Never report on files outside your unit. Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.`
+  "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
+  "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
+  `4. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"unitId": ${JSON.stringify(brief.unitId)}, "findings": [{"path": <string, a file in your unit>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for concerns about YOUR unit's files with no valid line anchor (a missing cleanup, a coverage gap the diff implies, sequencing the diff leaves open) — never duplicate a finding here>}.`,
+  `Report at most ${MAX_CHILD_FINDINGS} findings and at most ${MAX_CHILD_CONCERNS} concerns; prefer the most important ones. An empty findings array is a valid report. Never report on files outside your unit. Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.`
 ].join(`
 `);
 var fileReviewerInstructions = makeFileReviewerInstructions();
@@ -38053,7 +38182,8 @@ class FileReviewRequest extends exports_Schema.Class("@effect-agent/pr-review/Fi
 
 class FileReviewUnitResult extends exports_Schema.Class("@effect-agent/pr-review/FileReviewUnitResult")({
   unitId: ReviewUnitId,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS)),
+  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CHILD_CONCERNS)))
 }) {
 }
 
@@ -38113,19 +38243,25 @@ var FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
   })
 });
 var FanOutReviewToolkit = exports_Toolkit.make(ListReviewUnits, DelegateFileReview);
-var fanOutReviewInstructions = (mission) => [
-  `You coordinate the review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}, merging ${mission.headRef} into ${mission.baseRef}. It changes ${mission.changedFileCount} file(s).`,
-  mission.body.length > 0 ? `Author description:
+var makeFanOutReviewInstructions = (options = {}) => (mission) => {
+  const maxFindings = clampMaxFindings(options.maxFindings);
+  return [
+    `You coordinate the review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}, merging ${mission.headRef} into ${mission.baseRef}. It changes ${mission.changedFileCount} file(s).`,
+    mission.body.length > 0 ? `Author description:
 ${mission.body}` : "The author provided no description.",
-  "Work in this order:",
-  "1. Call list_review_units once to get the planned review units.",
-  "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
-  `3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
-  "4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most 20 findings.",
-  '5. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}]}. Copy findings verbatim from the delegation results; never invent or edit anchors.',
-  'Use verdict "request-changes" only when at least one finding is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.'
-].join(`
+    ...staticGuidanceLines(options.guidance),
+    "Work in this order:",
+    "1. Call list_review_units once to get the planned review units.",
+    "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
+    `3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
+    `4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
+    `5. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
+    '6. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>}. Copy findings and concerns verbatim from the delegation results; never invent or edit anchors.',
+    'Use verdict "request-changes" only when at least one finding or concern is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.'
+  ].join(`
 `);
+};
+var fanOutReviewInstructions = makeFanOutReviewInstructions();
 var defaultFanOutPolicy = AgentPolicy.make({
   maxTurns: 6,
   maxToolCalls: 1 + MAX_REVIEW_UNITS,
@@ -38143,10 +38279,10 @@ var makeFileReviewerDefinition = (options = {}) => Agent.define("pr-file-reviewe
   description: "Review one bounded unit of a pull request's changeset read-only and return line-anchored findings for exactly those files.",
   metadata: { deploymentClass: "E", surface: "read-only" }
 });
-var makeFanOutReviewerDefinition = () => Agent.define("pr-fanout-reviewer", {
+var makeFanOutReviewerDefinition = (options = {}) => Agent.define("pr-fanout-reviewer", {
   input: ReviewMission,
   output: CodeReview,
-  instructions: fanOutReviewInstructions,
+  instructions: makeFanOutReviewInstructions(options),
   toolkit: FanOutReviewToolkit,
   policy: defaultFanOutPolicy,
   description: "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
@@ -38165,15 +38301,16 @@ var makeFileReviewDelegation = (child) => Subagent.define("delegate_file_review"
   })),
   projectResult: (report2) => exports_Effect.succeed(FileReviewUnitResult.make({
     unitId: report2.unitId,
-    findings: report2.findings
+    findings: report2.findings,
+    ...report2.concerns !== undefined ? { concerns: report2.concerns } : {}
   })),
   policy: fileReviewPolicy
 });
 var makeFanOutReviewSuite = (options = {}) => {
-  const child = makeFileReviewerDefinition(options);
+  const child = makeFileReviewerDefinition({ guidance: options.guidance });
   return {
     child,
-    parent: makeFanOutReviewerDefinition(),
+    parent: makeFanOutReviewerDefinition(options),
     delegation: makeFileReviewDelegation(child)
   };
 };
@@ -40279,10 +40416,20 @@ class ReviewPublicationPlan extends exports_Schema.Class("@effect-agent/pr-revie
   commitSha: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(64))
 }) {
 }
+var severityEmoji = {
+  blocking: "\uD83D\uDED1",
+  important: "⚠️",
+  nit: "\uD83D\uDC85"
+};
+var severityRank2 = {
+  blocking: 0,
+  important: 1,
+  nit: 2
+};
 var severityLabel = {
-  blocking: "\uD83D\uDED1 blocking",
-  important: "⚠️ important",
-  nit: "\uD83D\uDC85 nit"
+  blocking: `${severityEmoji.blocking} blocking`,
+  important: `${severityEmoji.important} important`,
+  nit: `${severityEmoji.nit} nit`
 };
 var suggestionFence = (suggestion) => {
   let fence = "```";
@@ -40299,13 +40446,50 @@ var renderCommentBody = (finding) => {
   return parts2.join(`
 `);
 };
-var renderDemoted = (finding) => {
+var renderDemoted = (finding, reason) => {
   const location2 = `\`${finding.path}:${finding.startLine}${finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}\``;
-  return [
-    `- ${location2} **[${severityLabel[finding.severity]}] ${finding.title}** — ${finding.body}`
-  ].join(`
-`);
+  return `- ${location2} **[${severityLabel[finding.severity]}] ${finding.title}** — ${finding.body} _(demoted: ${reason})_`;
 };
+var countNoun = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
+var severityCounts = (review) => {
+  const severities = [
+    ...review.findings.map((finding) => finding.severity),
+    ...(review.concerns ?? []).map((concern) => concern.severity)
+  ];
+  return {
+    blocking: severities.filter((severity2) => severity2 === "blocking").length,
+    important: severities.filter((severity2) => severity2 === "important").length,
+    total: severities.length
+  };
+};
+var renderVerdictCallout = (review) => {
+  const counts = severityCounts(review);
+  if (counts.blocking > 0) {
+    return `> [!CAUTION]
+> ${countNoun(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+  }
+  if (counts.important > 0) {
+    return `> [!IMPORTANT]
+> ${countNoun(counts.important, "important finding")} to address before merging.`;
+  }
+  if (counts.total > 0) {
+    return "> ℹ️ Minor suggestions only — mergeable as-is.";
+  }
+  return review.verdict === "approve" ? "> ✅ No issues found." : "> ℹ️ No findings — see the summary.";
+};
+var renderConcern = (concern) => [`### ${severityEmoji[concern.severity]} ${concern.title}`, "", concern.body].join(`
+`);
+var commentSafe = (value4) => value4.replaceAll("--", "- -");
+var renderReviewMetadata = (options3) => [
+  "<!-- effect-agent-pr-review metadata",
+  `reviewed-head: ${commentSafe(options3.headSha)}`,
+  ...options3.baseRef !== undefined && options3.headRef !== undefined ? [`base-ref: ${commentSafe(options3.baseRef)}`, `head-ref: ${commentSafe(options3.headRef)}`] : [],
+  `files-visible: ${options3.filesVisible} of ${options3.totalChangedFiles}`,
+  "Findings were written against the head commit above; if commits have landed",
+  "since, treat file and line callouts as potentially stale and re-diff first.",
+  "-->"
+].join(`
+`);
 var anchorViolation = (finding, files) => {
   const file2 = files.find((candidate) => candidate.path === finding.path);
   if (file2 === undefined)
@@ -40327,7 +40511,8 @@ var planPublication = (review, files, options3) => {
   const comments = [];
   const demoted = [];
   for (const finding of review.findings) {
-    if (anchorViolation(finding, files) === undefined) {
+    const violation = anchorViolation(finding, files);
+    if (violation === undefined) {
       comments.push(ReviewCommentDraft.make({
         path: finding.path,
         line: finding.endLine,
@@ -40335,27 +40520,73 @@ var planPublication = (review, files, options3) => {
         body: renderCommentBody(finding)
       }));
     } else {
-      demoted.push(finding);
+      demoted.push({ finding, reason: violation });
     }
   }
-  const bodyParts = [review.summary];
-  if (files.length < options3.totalChangedFiles) {
-    bodyParts.push("", `⚠️ Reviewed ${files.length} of ${options3.totalChangedFiles} changed files — the changeset exceeded the reviewer's file bound.`);
+  const sortedConcerns = [...review.concerns ?? []].sort((a, b) => severityRank2[a.severity] - severityRank2[b.severity]);
+  const sortedDemoted = [...demoted].sort((a, b) => severityRank2[a.finding.severity] - severityRank2[b.finding.severity]);
+  const footerParts = ["Automated review by @effect-agent/pr-review"];
+  if (options3.modelLabel !== undefined)
+    footerParts.push(options3.modelLabel);
+  if (options3.usage !== undefined && options3.usageScope !== undefined) {
+    const scope3 = options3.usageScope === "coordinator" ? " (coordinator)" : "";
+    footerParts.push(`${options3.usage.inputTokens} in / ${options3.usage.outputTokens} out tokens${scope3}`);
   }
-  if (demoted.length > 0) {
-    bodyParts.push("", "### Findings without a valid diff anchor", ...demoted.map(renderDemoted));
+  if (options3.runUrl !== undefined)
+    footerParts.push(`[run](${options3.runUrl})`);
+  footerParts.push(`reviewed at ${options3.headSha.slice(0, 7)}`);
+  const footer = `_${footerParts.join(" · ")}._`;
+  const renderHead = (concernsKept2, demotedKept2, omitted2) => {
+    const parts2 = [renderVerdictCallout(review), "", review.summary];
+    for (const concern of sortedConcerns.slice(0, concernsKept2)) {
+      parts2.push("", renderConcern(concern));
+    }
+    if (files.length < options3.totalChangedFiles) {
+      parts2.push("", `⚠️ Reviewed ${files.length} of ${options3.totalChangedFiles} changed files — the changeset exceeded the reviewer's file bound.`);
+    }
+    if (demotedKept2 > 0) {
+      parts2.push("", "### Findings without a valid diff anchor", ...sortedDemoted.slice(0, demotedKept2).map(({ finding, reason }) => renderDemoted(finding, reason)));
+    }
+    if (omitted2 > 0) {
+      parts2.push("", `⚠️ ${countNoun(omitted2, "review item")} omitted — the body exceeded GitHub's review size cap.`);
+    }
+    parts2.push("", footer);
+    return parts2.join(`
+`);
+  };
+  const counts = severityCounts(review);
+  const event = !options3.applyVerdict ? "COMMENT" : counts.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.important === 0 ? "APPROVE" : "COMMENT";
+  const tail = [
+    renderReviewMetadata({
+      headSha: options3.headSha,
+      baseRef: options3.baseRef,
+      headRef: options3.headRef,
+      filesVisible: files.length,
+      totalChangedFiles: options3.totalChangedFiles
+    }),
+    ...options3.fingerprint === undefined ? [] : [renderFingerprintMarker(options3.fingerprint)]
+  ].join(`
+`);
+  const headBudget = 60000 - tail.length - 1;
+  let concernsKept = sortedConcerns.length;
+  let demotedKept = sortedDemoted.length;
+  let omitted = 0;
+  let head3 = renderHead(concernsKept, demotedKept, omitted);
+  while (head3.length > headBudget && (demotedKept > 0 || concernsKept > 0)) {
+    if (demotedKept > 0)
+      demotedKept -= 1;
+    else
+      concernsKept -= 1;
+    omitted += 1;
+    head3 = renderHead(concernsKept, demotedKept, omitted);
   }
-  bodyParts.push("", `_Automated review by @effect-agent/pr-review · reviewed at ${options3.headSha.slice(0, 7)}._`);
-  const event = options3.applyVerdict ? review.verdict === "approve" ? "APPROVE" : review.verdict === "request-changes" ? "REQUEST_CHANGES" : "COMMENT" : "COMMENT";
-  const body = options3.fingerprint === undefined ? bodyParts.join(`
-`).slice(0, 60000) : `${bodyParts.join(`
-`).slice(0, 60000 - FINGERPRINT_MARKER_LENGTH - 1)}
-${renderFingerprintMarker(options3.fingerprint)}`;
+  const body = `${head3.slice(0, headBudget)}
+${tail}`;
   return ReviewPublicationPlan.make({
     event,
     body,
     comments,
-    demoted,
+    demoted: demoted.map(({ finding }) => finding),
     commitSha: options3.headSha
   });
 };
@@ -40380,7 +40611,9 @@ class ReviewRunOutcome extends exports_Schema.Class("@effect-agent/pr-review/Rev
   review: CodeReview,
   plan: ReviewPublicationPlan,
   published: exports_Schema.optionalKey(PublishedReview),
-  turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0))
+  turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0)),
+  usage: exports_Schema.optionalKey(UsageTotals),
+  usageScope: exports_Schema.optionalKey(exports_Schema.Literals(["run", "coordinator"]))
 }) {
 }
 var buildReviewMission = (metadata, files) => ReviewMission.make({
@@ -40395,7 +40628,8 @@ var buildReviewMission = (metadata, files) => ReviewMission.make({
 var enforceFindingsBound = (review, maxFindings) => review.findings.length <= maxFindings ? review : CodeReview.make({
   summary: review.summary,
   verdict: review.verdict,
-  findings: rankAndDedupeFindings(review.findings).slice(0, maxFindings)
+  findings: rankAndDedupeFindings(review.findings).slice(0, maxFindings),
+  ...review.concerns !== undefined ? { concerns: review.concerns } : {}
 });
 var executeReview = (binding, options3) => exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
@@ -40410,18 +40644,33 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
   });
   const decoded = yield* exports_Schema.decodeUnknownEffect(CodeReview)(result4.output);
   const review = enforceFindingsBound(decoded, clampMaxFindings(options3.maxFindings));
+  const usage = yield* budget2.snapshot;
   const plan = planPublication(review, files, {
     applyVerdict: options3.applyVerdict,
     headSha: metadata.headSha,
     totalChangedFiles: metadata.totalChangedFiles,
+    baseRef: metadata.baseRef,
+    headRef: metadata.headRef,
+    modelLabel: options3.modelLabel,
+    runUrl: options3.runUrl,
+    usage,
+    usageScope: options3.usageScope,
     fingerprint
   });
+  const scope3 = options3.usageScope === undefined ? {} : { usageScope: options3.usageScope };
   if (!options3.post) {
-    return ReviewRunOutcome.make({ review, plan, turns: result4.turns });
+    return ReviewRunOutcome.make({ review, plan, turns: result4.turns, usage, ...scope3 });
   }
   const publisher = yield* ReviewPublisher;
   const published = yield* publisher.publish(plan);
-  return ReviewRunOutcome.make({ review, plan, published, turns: result4.turns });
+  return ReviewRunOutcome.make({
+    review,
+    plan,
+    published,
+    turns: result4.turns,
+    usage,
+    ...scope3
+  });
 });
 
 // packages/pr-review/src/internal/factory.ts
@@ -40457,13 +40706,20 @@ var make57 = (options3) => {
     metadata: { deploymentClass: "E", surface: "read-only" }
   });
   const binding = Object.freeze({ definition, model: options3.model });
-  const signature = (mission) => `${definition.instructions(mission)}\x00applyVerdict=${String(options3.applyVerdict ?? false)}`;
+  const signature = (mission) => [
+    definition.instructions(mission),
+    `applyVerdict=${String(options3.applyVerdict ?? false)}`,
+    ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
+  ].join("\x00");
   const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
     post: runOptions.post ?? false,
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? reviewBudgetLimits,
     maxFindings: clampMaxFindings(options3.maxFindings),
-    signature
+    signature,
+    modelLabel: options3.modelLabel,
+    runUrl: runOptions.runUrl,
+    usageScope: "run"
   }).pipe(exports_Effect.provide(exports_Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
   return {
     definition,
@@ -40473,15 +40729,18 @@ var make57 = (options3) => {
   };
 };
 var makeFanOut = (options3) => {
-  const suite = makeFanOutReviewSuite({ guidance: options3.guidance });
+  const suite = makeFanOutReviewSuite({
+    guidance: options3.guidance,
+    maxFindings: options3.maxFindings
+  });
   const binding = Object.freeze({ definition: suite.parent, model: options3.model });
   const childBinding = Object.freeze({ definition: suite.child, model: options3.model });
   const guidanceLines = options3.guidance === undefined ? [] : typeof options3.guidance === "string" ? [options3.guidance] : options3.guidance;
   const signature = (mission) => [
-    fanOutReviewInstructions(mission),
+    suite.parent.instructions(mission),
     `childGuidance=${JSON.stringify(guidanceLines)}`,
-    `maxFindings=${String(clampMaxFindings(options3.maxFindings))}`,
-    `applyVerdict=${String(options3.applyVerdict ?? false)}`
+    `applyVerdict=${String(options3.applyVerdict ?? false)}`,
+    ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
   ].join(" ");
   const delegationLayer = fanOutHandlersLayerFor(suite.delegation)(childBinding).pipe(exports_Layer.provide(exports_Layer.mergeAll(FileReviewToolkitLayer, SubagentReservationsMemoryLive, IdGenerator.layer)));
   const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
@@ -40489,7 +40748,10 @@ var makeFanOut = (options3) => {
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? fanOutReviewBudgetLimits,
     maxFindings: clampMaxFindings(options3.maxFindings),
-    signature
+    signature,
+    modelLabel: options3.modelLabel,
+    runUrl: runOptions.runUrl,
+    usageScope: "coordinator"
   }).pipe(exports_Effect.provide(exports_Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
   return {
     definition: suite.parent,
@@ -51172,14 +51434,24 @@ var PROVIDER_CREDENTIAL_ENV = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY"
 };
-var makeOpenAiReviewModel = (model3) => exports_OpenAiLanguageModel.model(model3 ?? DEFAULT_MODEL.openai, {
+var PROVIDER_EFFORT_RUNGS = {
+  openai: ["low", "medium", "high", "xhigh"],
+  anthropic: ["low", "medium", "high"]
+};
+var makeOpenAiReviewModel = (model3, effort) => exports_OpenAiLanguageModel.model(model3 ?? DEFAULT_MODEL.openai, {
   max_output_tokens: 8000,
   store: false,
-  strictJsonSchema: true
+  strictJsonSchema: true,
+  ...effort === undefined ? {} : { reasoning: { effort: resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS.openai) } }
 });
-var makeAnthropicReviewModel = (model3) => exports_AnthropicLanguageModel.model(model3 ?? DEFAULT_MODEL.anthropic, {
-  max_tokens: 8000
+var makeAnthropicReviewModel = (model3, effort) => exports_AnthropicLanguageModel.model(model3 ?? DEFAULT_MODEL.anthropic, {
+  max_tokens: 8000,
+  ...effort === undefined ? {} : { output_config: { effort: resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS.anthropic) } }
 });
+var describeReviewModel = (provider, model3, effort) => {
+  const base2 = `${provider}/${model3 ?? DEFAULT_MODEL[provider]}`;
+  return effort === undefined ? base2 : `${base2} (effort ${resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS[provider])})`;
+};
 var openAiClientLayer = exports_OpenAiClient.layerConfig({
   apiKey: exports_Config.redacted(PROVIDER_CREDENTIAL_ENV.openai)
 }).pipe(exports_Layer.provide(exports_FetchHttpClient.layer));
@@ -51198,9 +51470,29 @@ class ReviewGateFailed extends exports_Schema.TaggedError()("ReviewGateFailed", 
     return `Review verdict '${this.verdict}' fails the configured '${this.failOn}' gate.`;
   }
 }
+
+class InvalidMaxDurationInput extends exports_Schema.TaggedError()("InvalidMaxDurationInput", {
+  minutes: exports_Schema.Int
+}) {
+  get message() {
+    return `Invalid max-duration-minutes '${this.minutes}': expected a positive number of minutes.`;
+  }
+}
 var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () {
   const provider = yield* exports_Config.literals(["openai", "anthropic"], "PR_REVIEW_PROVIDER").pipe(exports_Config.withDefault(DEFAULT_PROVIDER));
   const model3 = yield* exports_Config.option(exports_Config.nonEmptyString("PR_REVIEW_MODEL"));
+  const effortRaw = yield* exports_Config.option(exports_Config.nonEmptyString("PR_REVIEW_EFFORT"));
+  let effort;
+  if (exports_Option.isSome(effortRaw)) {
+    effort = parseEffortPosition(effortRaw.value);
+    if (effort === undefined) {
+      return yield* InvalidEffortInput.make({ input: effortRaw.value });
+    }
+  }
+  const maxDurationMinutes = exports_Option.getOrUndefined(yield* exports_Config.option(exports_Config.int("PR_REVIEW_MAX_DURATION_MINUTES")));
+  if (maxDurationMinutes !== undefined && maxDurationMinutes <= 0) {
+    return yield* InvalidMaxDurationInput.make({ minutes: maxDurationMinutes });
+  }
   const post3 = yield* exports_Config.boolean("PR_REVIEW_POST").pipe(exports_Config.withDefault(true));
   const applyVerdict = yield* exports_Config.boolean("PR_REVIEW_APPLY_VERDICT").pipe(exports_Config.withDefault(false));
   const fanOut = yield* exports_Config.boolean("PR_REVIEW_FAN_OUT").pipe(exports_Config.withDefault(false));
@@ -51213,6 +51505,7 @@ var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () 
   return {
     provider,
     model: exports_Option.getOrUndefined(model3),
+    effort,
     post: post3,
     applyVerdict,
     fanOut,
@@ -51220,6 +51513,7 @@ var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () 
     guidanceFile: exports_Option.getOrUndefined(guidanceFile),
     ignore: ignoreRaw.split(",").map((pattern) => pattern.trim()).filter((pattern) => pattern.length > 0),
     maxFindings: exports_Option.getOrUndefined(maxFindings),
+    maxDurationMinutes,
     failOn,
     skipUnchanged
   };
@@ -51272,12 +51566,36 @@ var writeActionOutputs = exports_Effect.fn("writeActionOutputs")(function* (entr
     flag: "a"
   });
 });
+var writeStepSummary = exports_Effect.fn("writeStepSummary")(function* (lines) {
+  const summaryPath = yield* exports_Config.string("GITHUB_STEP_SUMMARY").pipe(exports_Config.withDefault(""));
+  if (summaryPath === "")
+    return;
+  const fs = yield* exports_FileSystem.FileSystem;
+  yield* fs.writeFileString(summaryPath, `${lines.join(`
+`)}
+`, { flag: "a" });
+});
 var outcomeOutputs = (outcome) => [
   ["skipped", "false"],
   ["verdict", outcome.review.verdict],
   ["inline-comments", String(outcome.plan.comments.length)],
   ["demoted-findings", String(outcome.plan.demoted.length)],
+  ["concerns", String(outcome.review.concerns?.length ?? 0)],
+  ...outcome.usage === undefined ? [] : [
+    ["input-tokens", String(outcome.usage.inputTokens)],
+    ["output-tokens", String(outcome.usage.outputTokens)]
+  ],
   ["review-url", outcome.published?.url ?? ""]
+];
+var outcomeSummary = (outcome, modelLabel) => [
+  "### Pull-request review",
+  `- Verdict: **${outcome.review.verdict}**`,
+  `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
+  ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
+  ...outcome.usage === undefined ? [] : [
+    `- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out${outcome.usageScope === "coordinator" ? " (coordinator)" : ""}`
+  ],
+  ...outcome.published === undefined ? ["- Dry run: nothing posted"] : [`- Posted: ${outcome.published.url}`]
 ];
 var skip = (reason) => exports_Effect.gen(function* () {
   yield* exports_Console.log(`Skipping review: ${reason}`);
@@ -51285,7 +51603,16 @@ var skip = (reason) => exports_Effect.gen(function* () {
     ["skipped", "true"],
     ["skip-reason", reason]
   ]);
+  yield* writeStepSummary(["### Pull-request review skipped", `- Reason: ${reason}`]);
   return { _tag: "Skipped", reason };
+});
+var resolveRunUrl = exports_Effect.fn("resolveRunUrl")(function* () {
+  const runId = yield* exports_Config.string("GITHUB_RUN_ID").pipe(exports_Config.withDefault(""));
+  const repository = yield* exports_Config.string("GITHUB_REPOSITORY").pipe(exports_Config.withDefault(""));
+  if (runId === "" || repository === "")
+    return;
+  const server = yield* exports_Config.string("GITHUB_SERVER_URL").pipe(exports_Config.withDefault("https://github.com"));
+  return `${server}/${repository}/actions/runs/${runId}`;
 });
 var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* () {
   const event = yield* readGitHubEvent();
@@ -51310,6 +51637,10 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           ["skip-reason", "changeset unchanged since the last review"],
           ["fingerprint", current]
         ]);
+        yield* writeStepSummary([
+          "### Pull-request review skipped",
+          "- Reason: changeset unchanged since the last review"
+        ]);
         return {
           _tag: "Skipped",
           reason: "changeset unchanged since the last review"
@@ -51317,12 +51648,14 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       }
     }
     yield* exports_Console.log(`Reviewing ${target.repository}#${target.number} (${options3.post === false ? "dry run" : "posting"})...`);
-    const outcome = yield* reviewer.run({ post: options3.post ?? true });
+    const runUrl = yield* resolveRunUrl();
+    const outcome = yield* reviewer.run({ post: options3.post ?? true, runUrl });
     yield* exports_Console.log(`Review finished in ${outcome.turns} turn(s): verdict ${outcome.review.verdict}, ` + `${outcome.plan.comments.length} inline comment(s), ${outcome.plan.demoted.length} demoted finding(s).`);
     if (outcome.published !== undefined) {
       yield* exports_Console.log(`Posted ${outcome.published.event} review: ${outcome.published.url}`);
     }
     yield* writeActionOutputs(outcomeOutputs(outcome));
+    yield* writeStepSummary(outcomeSummary(outcome, options3.modelLabel));
     if (options3.failOn === "request-changes" && outcome.review.verdict === "request-changes") {
       return yield* ReviewGateFailed.make({
         verdict: outcome.review.verdict,
@@ -51335,23 +51668,32 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
 var reviewActionProgram = exports_Effect.gen(function* () {
   const inputs = yield* resolveActionInputs();
   const guidance = yield* resolveGuidance2(inputs);
+  const modelLabel = describeReviewModel(inputs.provider, inputs.model, inputs.effort);
+  const defaults = inputs.fanOut ? fanOutReviewBudgetLimits : reviewBudgetLimits;
+  const budget2 = inputs.maxDurationMinutes === undefined ? defaults : UsageBudgetLimits.make({
+    ...defaults,
+    maxDurationMillis: inputs.maxDurationMinutes * 60000
+  });
   const shared = {
     guidance,
     ignore: inputs.ignore,
     maxFindings: inputs.maxFindings,
-    applyVerdict: inputs.applyVerdict
+    applyVerdict: inputs.applyVerdict,
+    modelLabel,
+    budget: budget2
   };
   const harness = {
     post: inputs.post,
     failOn: inputs.failOn,
-    skipUnchanged: inputs.skipUnchanged
+    skipUnchanged: inputs.skipUnchanged,
+    modelLabel
   };
   if (inputs.provider === "anthropic") {
-    const model4 = makeAnthropicReviewModel(inputs.model);
+    const model4 = makeAnthropicReviewModel(inputs.model, inputs.effort);
     const reviewer2 = inputs.fanOut ? PrReview.makeFanOut({ ...shared, model: model4 }) : PrReview.make({ ...shared, model: model4 });
     return yield* runReviewAction(reviewer2, harness).pipe(exports_Effect.provide(anthropicClientLayer));
   }
-  const model3 = makeOpenAiReviewModel(inputs.model);
+  const model3 = makeOpenAiReviewModel(inputs.model, inputs.effort);
   const reviewer = inputs.fanOut ? PrReview.makeFanOut({ ...shared, model: model3 }) : PrReview.make({ ...shared, model: model3 });
   return yield* runReviewAction(reviewer, harness).pipe(exports_Effect.provide(openAiClientLayer));
 });
@@ -51361,6 +51703,8 @@ var main = () => exports_NodeRuntime.runMain(reviewActionProgram.pipe(exports_Ef
 var INPUT_TO_ENV = [
   ["INPUT_PROVIDER", "PR_REVIEW_PROVIDER"],
   ["INPUT_MODEL", "PR_REVIEW_MODEL"],
+  ["INPUT_EFFORT", "PR_REVIEW_EFFORT"],
+  ["INPUT_MAX-DURATION-MINUTES", "PR_REVIEW_MAX_DURATION_MINUTES"],
   ["INPUT_POST", "PR_REVIEW_POST"],
   ["INPUT_APPLY-VERDICT", "PR_REVIEW_APPLY_VERDICT"],
   ["INPUT_FAN-OUT", "PR_REVIEW_FAN_OUT"],

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -3056,6 +3056,19 @@ var PreventSchedulerYield = /* @__PURE__ */ Reference("effect/Scheduler/PreventS
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/Tracer.js
+var exports_Tracer = {};
+__export(exports_Tracer, {
+  make: () => make7,
+  externalSpan: () => externalSpan,
+  TracerKey: () => TracerKey,
+  Tracer: () => Tracer,
+  ParentSpanKey: () => ParentSpanKey,
+  ParentSpan: () => ParentSpan,
+  NativeSpan: () => NativeSpan,
+  MinimumTraceLevel: () => MinimumTraceLevel,
+  DisablePropagation: () => DisablePropagation,
+  CurrentTraceLevel: () => CurrentTraceLevel
+});
 var ParentSpanKey = "effect/Tracer/ParentSpan";
 
 class ParentSpan extends (/* @__PURE__ */ Service()(ParentSpanKey, {
@@ -3063,6 +3076,13 @@ class ParentSpan extends (/* @__PURE__ */ Service()(ParentSpanKey, {
 })) {
 }
 var make7 = (options) => options;
+var externalSpan = (options) => ({
+  _tag: "ExternalSpan",
+  spanId: options.spanId,
+  traceId: options.traceId,
+  sampled: options.sampled ?? true,
+  annotations: options.annotations ?? empty()
+});
 var DisablePropagation = /* @__PURE__ */ Reference("effect/Tracer/DisablePropagation", {
   defaultValue: constFalse
 });
@@ -28560,6 +28580,80 @@ var withTime = /* @__PURE__ */ dual((args2) => isEffect(args2[0]), (self, label)
 }), () => self, () => sync(() => {
   console.timeEnd(label);
 }))));
+// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/ErrorReporter.js
+var exports_ErrorReporter = {};
+__export(exports_ErrorReporter, {
+  severity: () => severity,
+  report: () => report,
+  make: () => make42,
+  layer: () => layer13,
+  isIgnored: () => isIgnored,
+  ignore: () => ignore5,
+  getSeverity: () => getSeverity,
+  getAttributes: () => getAttributes,
+  attributes: () => attributes,
+  TypeId: () => TypeId41,
+  CurrentErrorReporters: () => CurrentErrorReporters2
+});
+var TypeId41 = "~effect/ErrorReporter";
+var make42 = (report) => {
+  const reported = new WeakSet;
+  return {
+    [TypeId41]: TypeId41,
+    report(options) {
+      if (reported.has(options.cause))
+        return;
+      reported.add(options.cause);
+      for (let i = 0;i < options.cause.reasons.length; i++) {
+        const reason = options.cause.reasons[i];
+        if (reason._tag === "Interrupt")
+          continue;
+        const original = reason._tag === "Fail" ? reason.error : reason.defect;
+        const isObject2 = typeof original === "object" && original !== null;
+        if (isObject2) {
+          if (reported.has(original))
+            continue;
+          reported.add(original);
+        }
+        if (isIgnored(original))
+          continue;
+        const pretty2 = causePrettyError(original, reason.annotations);
+        report({
+          ...options,
+          error: pretty2,
+          severity: isObject2 ? getSeverity(original) : "Info",
+          attributes: isObject2 ? getAttributes(original) : emptyAttributes
+        });
+      }
+    }
+  };
+};
+var CurrentErrorReporters2 = CurrentErrorReporters;
+var layer13 = (reporters, options) => effect(CurrentErrorReporters2, withFiber2(fnUntraced2(function* (fiber3) {
+  const currentReporters = new Set(options?.mergeWithExisting === true ? fiber3.getRef(CurrentErrorReporters) : []);
+  for (const reporter of reporters) {
+    currentReporters.add(isEffect2(reporter) ? yield* reporter : reporter);
+  }
+  return currentReporters;
+})));
+var report = (cause) => withFiber2((fiber3) => {
+  reportCauseUnsafe(fiber3, cause);
+  return void_4;
+});
+var ignore5 = "~effect/ErrorReporter/ignore";
+var isIgnored = (u) => typeof u === "object" && u !== null && (ignore5 in u) && u[ignore5] === true;
+var severity = "~effect/ErrorReporter/severity";
+var getSeverity = (error2) => {
+  if (severity in error2 && values2.includes(error2[severity])) {
+    return error2[severity];
+  }
+  return "Info";
+};
+var attributes = "~effect/ErrorReporter/attributes";
+var getAttributes = (error2) => {
+  return attributes in error2 ? error2[attributes] : emptyAttributes;
+};
+var emptyAttributes = {};
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/Ref.js
 var exports_Ref = {};
 __export(exports_Ref, {
@@ -28572,16 +28666,16 @@ __export(exports_Ref, {
   modifySome: () => modifySome,
   modify: () => modify4,
   makeUnsafe: () => makeUnsafe9,
-  make: () => make42,
+  make: () => make43,
   getUnsafe: () => getUnsafe5,
   getAndUpdateSome: () => getAndUpdateSome,
   getAndUpdate: () => getAndUpdate,
   getAndSet: () => getAndSet,
   get: () => get9
 });
-var TypeId41 = "~effect/Ref";
+var TypeId42 = "~effect/Ref";
 var RefProto = {
-  [TypeId41]: {
+  [TypeId42]: {
     _A: identity
   },
   ...PipeInspectableProto,
@@ -28597,7 +28691,7 @@ var makeUnsafe9 = (value4) => {
   self.ref = make11(value4);
   return self;
 };
-var make42 = (value4) => sync3(() => makeUnsafe9(value4));
+var make43 = (value4) => sync3(() => makeUnsafe9(value4));
 var get9 = (self) => sync3(() => self.ref.current);
 var set4 = /* @__PURE__ */ dual(2, (self, value4) => sync3(() => set(self.ref, value4)));
 var getAndSet = /* @__PURE__ */ dual(2, (self, value4) => sync3(() => {
@@ -29544,119 +29638,36 @@ var makeUsageBudget = (limits) => makeUsageBudgetRoot(UsageBudgetNodeConfig.make
   id: "standalone-run",
   limits
 }));
-// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/LanguageModel.js
-var exports_LanguageModel = {};
-__export(exports_LanguageModel, {
-  streamText: () => streamText,
-  make: () => make48,
-  getObjectName: () => getObjectName,
-  generateText: () => generateText,
-  generateObject: () => generateObject,
-  defaultCodecTransformer: () => defaultCodecTransformer2,
-  LanguageModel: () => LanguageModel,
-  GenerateTextResponse: () => GenerateTextResponse,
-  GenerateObjectResponse: () => GenerateObjectResponse
-});
-
-// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/FiberSet.js
-var TypeId42 = "~effect/FiberSet";
-var isFiberSet = (u) => hasProperty(u, TypeId42);
-var Proto8 = {
-  [TypeId42]: TypeId42,
-  [Symbol.iterator]() {
-    if (this.state._tag === "Closed") {
-      return empty2();
-    }
-    return this.state.backing[Symbol.iterator]();
-  },
-  ...PipeInspectableProto,
-  toJSON() {
-    return {
-      _id: "FiberSet",
-      state: this.state
-    };
-  }
-};
-var makeUnsafe10 = (backing, deferred) => {
-  const self = Object.create(Proto8);
-  self.state = {
-    _tag: "Open",
-    backing
-  };
-  self.deferred = deferred;
-  return self;
-};
-var make43 = () => acquireRelease2(sync3(() => makeUnsafe10(new Set, makeUnsafe2())), (set5) => suspend3(() => {
-  const state = set5.state;
-  if (state._tag === "Closed")
-    return void_4;
-  set5.state = {
-    _tag: "Closed"
-  };
-  const fibers = state.backing;
-  return interruptAll(fibers).pipe(into(set5.deferred));
-}));
-var internalFiberId = -1;
-var isInternalInterruption = /* @__PURE__ */ toPredicate(/* @__PURE__ */ compose(filterInterruptors, /* @__PURE__ */ has2(internalFiberId)));
-var addUnsafe = /* @__PURE__ */ dual((args2) => isFiberSet(args2[0]), (self, fiber3, options) => {
-  if (self.state._tag === "Closed") {
-    fiber3.interruptUnsafe(internalFiberId);
-    return;
-  } else if (self.state.backing.has(fiber3)) {
-    return;
-  }
-  self.state.backing.add(fiber3);
-  fiber3.addObserver((exit3) => {
-    if (self.state._tag === "Closed") {
-      return;
-    }
-    self.state.backing.delete(fiber3);
-    if (isFailure4(exit3) && (options?.propagateInterruption === true ? !isInternalInterruption(exit3.cause) : !hasInterruptsOnly2(exit3.cause))) {
-      doneUnsafe(self.deferred, exit3);
-    }
-  });
-});
-var constInterruptedFiber = /* @__PURE__ */ function() {
-  let fiber3 = undefined;
-  return () => {
-    if (fiber3 === undefined) {
-      fiber3 = runFork2(interrupt4);
-    }
-    return fiber3;
-  };
-}();
-var run3 = function() {
-  const self = arguments[0];
-  if (!isEffect2(arguments[1])) {
-    const options = arguments[1];
-    return (effect2) => runImpl(self, effect2, options);
-  }
-  return runImpl(self, arguments[1], arguments[2]);
-};
-var runImpl = (self, effect2, options) => withFiber2((parent) => {
-  if (self.state._tag === "Closed") {
-    return sync3(constInterruptedFiber);
-  }
-  const fiber3 = runForkWith2(parent.context)(effect2);
-  addUnsafe(self, fiber3, options);
-  return succeed6(fiber3);
-});
-var runtime = (self) => () => map8(context2(), (services2) => {
-  const runFork3 = runForkWith2(services2);
-  return (effect2, options) => {
-    if (self.state._tag === "Closed") {
-      return constInterruptedFiber();
-    }
-    const fiber3 = runFork3(effect2, options);
-    addUnsafe(self, fiber3, options);
-    return fiber3;
-  };
-});
-var join4 = (self) => _await(self.deferred);
-var awaitEmpty = (self) => whileLoop2({
-  while: () => self.state._tag === "Open" && self.state.backing.size > 0,
-  body: () => await_(headUnsafe(self)),
-  step: constVoid
+// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/AiError.js
+var exports_AiError = {};
+__export(exports_AiError, {
+  reasonFromHttpStatus: () => reasonFromHttpStatus,
+  make: () => make44,
+  isAiErrorReason: () => isAiErrorReason,
+  isAiError: () => isAiError,
+  UsageInfo: () => UsageInfo,
+  UnsupportedSchemaError: () => UnsupportedSchemaError,
+  UnknownError: () => UnknownError3,
+  ToolkitRequiredError: () => ToolkitRequiredError,
+  ToolResultEncodingError: () => ToolResultEncodingError,
+  ToolParameterValidationError: () => ToolParameterValidationError,
+  ToolNotFoundError: () => ToolNotFoundError,
+  ToolConfigurationError: () => ToolConfigurationError,
+  StructuredOutputError: () => StructuredOutputError,
+  RateLimitError: () => RateLimitError,
+  QuotaExhaustedError: () => QuotaExhaustedError,
+  ProviderMetadata: () => ProviderMetadata2,
+  NetworkError: () => NetworkError,
+  InvalidUserInputError: () => InvalidUserInputError,
+  InvalidToolResultError: () => InvalidToolResultError,
+  InvalidRequestError: () => InvalidRequestError,
+  InvalidOutputError: () => InvalidOutputError,
+  InternalProviderError: () => InternalProviderError,
+  HttpContext: () => HttpContext,
+  ContentPolicyError: () => ContentPolicyError,
+  AuthenticationError: () => AuthenticationError,
+  AiErrorReason: () => AiErrorReason,
+  AiError: () => AiError
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/Response.js
@@ -30354,6 +30365,7 @@ class AiError extends (/* @__PURE__ */ Error4("effect/ai/AiError/AiError")({
     return `${this.module}.${this.method}: ${this.reason.message}`;
   }
 }
+var isAiError = (u) => hasProperty(u, TypeId43);
 var isAiErrorReason = (u) => hasProperty(u, ReasonTypeId2);
 var make44 = (params) => new AiError(params);
 var reasonFromHttpStatus = (params) => {
@@ -30397,6 +30409,120 @@ var reasonFromHttpStatus = (params) => {
       return new UnknownError3(common);
   }
 };
+// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/LanguageModel.js
+var exports_LanguageModel = {};
+__export(exports_LanguageModel, {
+  streamText: () => streamText,
+  make: () => make49,
+  getObjectName: () => getObjectName,
+  generateText: () => generateText,
+  generateObject: () => generateObject,
+  defaultCodecTransformer: () => defaultCodecTransformer2,
+  LanguageModel: () => LanguageModel,
+  GenerateTextResponse: () => GenerateTextResponse,
+  GenerateObjectResponse: () => GenerateObjectResponse
+});
+
+// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/FiberSet.js
+var TypeId44 = "~effect/FiberSet";
+var isFiberSet = (u) => hasProperty(u, TypeId44);
+var Proto8 = {
+  [TypeId44]: TypeId44,
+  [Symbol.iterator]() {
+    if (this.state._tag === "Closed") {
+      return empty2();
+    }
+    return this.state.backing[Symbol.iterator]();
+  },
+  ...PipeInspectableProto,
+  toJSON() {
+    return {
+      _id: "FiberSet",
+      state: this.state
+    };
+  }
+};
+var makeUnsafe10 = (backing, deferred) => {
+  const self = Object.create(Proto8);
+  self.state = {
+    _tag: "Open",
+    backing
+  };
+  self.deferred = deferred;
+  return self;
+};
+var make45 = () => acquireRelease2(sync3(() => makeUnsafe10(new Set, makeUnsafe2())), (set5) => suspend3(() => {
+  const state = set5.state;
+  if (state._tag === "Closed")
+    return void_4;
+  set5.state = {
+    _tag: "Closed"
+  };
+  const fibers = state.backing;
+  return interruptAll(fibers).pipe(into(set5.deferred));
+}));
+var internalFiberId = -1;
+var isInternalInterruption = /* @__PURE__ */ toPredicate(/* @__PURE__ */ compose(filterInterruptors, /* @__PURE__ */ has2(internalFiberId)));
+var addUnsafe = /* @__PURE__ */ dual((args2) => isFiberSet(args2[0]), (self, fiber3, options) => {
+  if (self.state._tag === "Closed") {
+    fiber3.interruptUnsafe(internalFiberId);
+    return;
+  } else if (self.state.backing.has(fiber3)) {
+    return;
+  }
+  self.state.backing.add(fiber3);
+  fiber3.addObserver((exit3) => {
+    if (self.state._tag === "Closed") {
+      return;
+    }
+    self.state.backing.delete(fiber3);
+    if (isFailure4(exit3) && (options?.propagateInterruption === true ? !isInternalInterruption(exit3.cause) : !hasInterruptsOnly2(exit3.cause))) {
+      doneUnsafe(self.deferred, exit3);
+    }
+  });
+});
+var constInterruptedFiber = /* @__PURE__ */ function() {
+  let fiber3 = undefined;
+  return () => {
+    if (fiber3 === undefined) {
+      fiber3 = runFork2(interrupt4);
+    }
+    return fiber3;
+  };
+}();
+var run3 = function() {
+  const self = arguments[0];
+  if (!isEffect2(arguments[1])) {
+    const options = arguments[1];
+    return (effect2) => runImpl(self, effect2, options);
+  }
+  return runImpl(self, arguments[1], arguments[2]);
+};
+var runImpl = (self, effect2, options) => withFiber2((parent) => {
+  if (self.state._tag === "Closed") {
+    return sync3(constInterruptedFiber);
+  }
+  const fiber3 = runForkWith2(parent.context)(effect2);
+  addUnsafe(self, fiber3, options);
+  return succeed6(fiber3);
+});
+var runtime = (self) => () => map8(context2(), (services2) => {
+  const runFork3 = runForkWith2(services2);
+  return (effect2, options) => {
+    if (self.state._tag === "Closed") {
+      return constInterruptedFiber();
+    }
+    const fiber3 = runFork3(effect2, options);
+    addUnsafe(self, fiber3, options);
+    return fiber3;
+  };
+});
+var join4 = (self) => _await(self.deferred);
+var awaitEmpty = (self) => whileLoop2({
+  while: () => self.state._tag === "Open" && self.state.backing.size > 0,
+  body: () => await_(headUnsafe(self)),
+  step: constVoid
+});
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/Random.js
 var Random3 = Random;
@@ -30469,7 +30595,7 @@ __export(exports_Prompt, {
   prependSystem: () => prependSystem,
   makePart: () => makePart2,
   makeMessage: () => makeMessage,
-  make: () => make45,
+  make: () => make46,
   isPrompt: () => isPrompt,
   isPart: () => isPart2,
   isMessage: () => isMessage,
@@ -30640,8 +30766,8 @@ var ToolMessage = /* @__PURE__ */ Struct({
 });
 var toolMessage = (params) => makeMessage("tool", params);
 var Message = /* @__PURE__ */ Union2([SystemMessage, UserMessage, AssistantMessage, ToolMessage]);
-var TypeId44 = "~effect/unstable/ai/Prompt";
-var isPrompt = (u) => hasProperty(u, TypeId44);
+var TypeId45 = "~effect/unstable/ai/Prompt";
+var isPrompt = (u) => hasProperty(u, TypeId45);
 var $Prompt = /* @__PURE__ */ declare((u) => isPrompt(u), {
   identifier: "Prompt"
 });
@@ -30664,7 +30790,7 @@ var Prompt = /* @__PURE__ */ Struct({
   })
 })));
 var Proto9 = {
-  [TypeId44]: TypeId44,
+  [TypeId45]: TypeId45,
   pipe() {
     return pipeArguments(this, arguments);
   }
@@ -30674,7 +30800,7 @@ var makePrompt = (content) => Object.assign(Object.create(Proto9), {
 });
 var decodeMessagesSync = /* @__PURE__ */ decodeSync2(/* @__PURE__ */ ArraySchema(Message));
 var empty12 = /* @__PURE__ */ makePrompt([]);
-var make45 = (input) => {
+var make46 = (input) => {
   if (typeof input === "string") {
     const part = makePart2("text", {
       text: input
@@ -30822,7 +30948,7 @@ var fromResponseParts = (parts2) => {
   return makePrompt(messages);
 };
 var concat3 = /* @__PURE__ */ dual(2, (self, input) => {
-  const other = make45(input);
+  const other = make46(input);
   if (self.content.length === 0) {
     return other;
   }
@@ -30880,7 +31006,7 @@ var appendSystem = /* @__PURE__ */ dual(2, (self, content) => {
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/ResponseIdTracker.js
 class ResponseIdTracker extends (/* @__PURE__ */ Service()("effect/ai/ResponseIdTracker")) {
 }
-var make46 = /* @__PURE__ */ sync3(() => {
+var make47 = /* @__PURE__ */ sync3(() => {
   const sentParts = new Map;
   const none3 = () => {
     sentParts.clear();
@@ -30937,8 +31063,8 @@ var make46 = /* @__PURE__ */ sync3(() => {
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/Telemetry.js
-var addSpanAttributes = (keyPrefix, transformKey) => (span2, attributes) => {
-  for (const [key, value4] of Object.entries(attributes)) {
+var addSpanAttributes = (keyPrefix, transformKey) => (span2, attributes2) => {
+  for (const [key, value4] of Object.entries(attributes2)) {
     if (isNotNullish(value4)) {
       span2.attribute(`${keyPrefix}.${transformKey(key)}`, value4);
     }
@@ -30973,10 +31099,10 @@ class CurrentSpanTransformer extends (/* @__PURE__ */ Service()("effect/ai/Telem
 var exports_Toolkit = {};
 __export(exports_Toolkit, {
   merge: () => merge5,
-  make: () => make47,
+  make: () => make48,
   empty: () => empty13
 });
-var TypeId45 = "~effect/ai/Toolkit";
+var TypeId46 = "~effect/ai/Toolkit";
 var Proto10 = {
   .../* @__PURE__ */ Prototype2({
     label: "Toolkit",
@@ -31091,7 +31217,7 @@ var Proto10 = {
       };
     })
   }),
-  [TypeId45]: TypeId45,
+  [TypeId46]: TypeId46,
   of: identity,
   toHandlers(build2) {
     return gen3({
@@ -31134,7 +31260,7 @@ var resolveInput = (...tools) => {
   return output;
 };
 var empty13 = /* @__PURE__ */ makeProto2({});
-var make47 = (...tools) => makeProto2(resolveInput(...tools));
+var make48 = (...tools) => makeProto2(resolveInput(...tools));
 var merge5 = (...toolkits) => {
   const tools = {};
   for (const toolkit of toolkits) {
@@ -31214,7 +31340,7 @@ class GenerateObjectResponse extends GenerateTextResponse {
     this.value = value4;
   }
 }
-var make48 = /* @__PURE__ */ fnUntraced2(function* (params) {
+var make49 = /* @__PURE__ */ fnUntraced2(function* (params) {
   const codecTransformer = params.codecTransformer ?? defaultCodecTransformer2;
   const parentSpanTransformer = yield* serviceOption2(CurrentSpanTransformer);
   const getSpanTransformer = serviceOption2(CurrentSpanTransformer).pipe(map8(orElse(() => parentSpanTransformer)));
@@ -31227,7 +31353,7 @@ var make48 = /* @__PURE__ */ fnUntraced2(function* (params) {
   }, fnUntraced2(function* (span2) {
     const spanTransformer = yield* getSpanTransformer;
     const providerOptions = {
-      prompt: make45(options.prompt),
+      prompt: make46(options.prompt),
       tools: [],
       toolChoice: "none",
       responseFormat: {
@@ -31258,7 +31384,7 @@ var make48 = /* @__PURE__ */ fnUntraced2(function* (params) {
     }, fnUntraced2(function* (span2) {
       const spanTransformer = yield* getSpanTransformer;
       const providerOptions = {
-        prompt: make45(options.prompt),
+        prompt: make46(options.prompt),
         tools: [],
         toolChoice: "none",
         responseFormat: {
@@ -31302,7 +31428,7 @@ var make48 = /* @__PURE__ */ fnUntraced2(function* (params) {
       }
     });
     const providerOptions = {
-      prompt: make45(options.prompt),
+      prompt: make46(options.prompt),
       tools: [],
       toolChoice: "none",
       responseFormat: {
@@ -31630,7 +31756,7 @@ var make48 = /* @__PURE__ */ fnUntraced2(function* (params) {
     if (preResolvedStreamParts.length > 0) {
       yield* offerAll(queue, preResolvedStreamParts);
     }
-    const toolCallFibers = yield* make43();
+    const toolCallFibers = yield* make45();
     const toolCallSemaphore = concurrency === "unbounded" ? undefined : yield* make15(concurrency);
     const handleToolCall = fnUntraced2(function* (part) {
       const tool = toolkit.tools[part.name];
@@ -31969,7 +32095,7 @@ var exports_Tool = {};
 __export(exports_Tool, {
   unsafeSecureJsonParse: () => unsafeSecureJsonParse,
   providerDefined: () => providerDefined,
-  make: () => make49,
+  make: () => make50,
   isUserDefined: () => isUserDefined,
   isProviderDefined: () => isProviderDefined,
   isEmptyParamsRecord: () => isEmptyParamsRecord,
@@ -31979,7 +32105,7 @@ __export(exports_Tool, {
   getJsonSchema: () => getJsonSchema,
   getDescription: () => getDescription,
   dynamic: () => dynamic,
-  TypeId: () => TypeId46,
+  TypeId: () => TypeId47,
   Title: () => Title,
   Strict: () => Strict,
   Readonly: () => Readonly,
@@ -31992,15 +32118,15 @@ __export(exports_Tool, {
   DynamicTypeId: () => DynamicTypeId,
   Destructive: () => Destructive
 });
-var TypeId46 = "~effect/ai/Tool";
+var TypeId47 = "~effect/ai/Tool";
 var ProviderDefinedTypeId = "~effect/ai/Tool/ProviderDefined";
 var DynamicTypeId = "~effect/ai/Tool/Dynamic";
-var isUserDefined = (u) => hasProperty(u, TypeId46) && !isProviderDefined(u) && !isDynamic(u);
+var isUserDefined = (u) => hasProperty(u, TypeId47) && !isProviderDefined(u) && !isDynamic(u);
 var isProviderDefined = (u) => hasProperty(u, ProviderDefinedTypeId);
 var isDynamic = (u) => hasProperty(u, DynamicTypeId);
 var clone = (self, overrides) => Object.assign(Object.create(Object.getPrototypeOf(self)), self, overrides);
 var Proto11 = {
-  [TypeId46]: {
+  [TypeId47]: {
     _Requirements: identity
   },
   pipe() {
@@ -32062,7 +32188,7 @@ var dynamicProto = (options) => {
   self.id = `effect/ai/Tool/${options.name}`;
   return self;
 };
-var make49 = (name, options) => {
+var make50 = (name, options) => {
   const successSchema = options?.success ?? Void2;
   const failureSchema = options?.failure ?? Never2;
   return userDefinedProto({
@@ -32236,6 +32362,466 @@ var EmptyParams = /* @__PURE__ */ Record(String6, Never2);
 function isEmptyParamsRecord(indexSignature) {
   return indexSignature.parameter === string2 && isNever2(indexSignature.type);
 }
+// packages/engine/src/provider-result-staging-internal.ts
+var MAX_JSON_DEPTH = 128;
+var FailedSnapshot = Symbol("@effect-agent/engine/FailedProviderResultSnapshot");
+var boundedJsonSnapshot = (root, maxBytes, maxDepth = MAX_JSON_DEPTH) => {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0 || !Number.isSafeInteger(maxDepth) || maxDepth < 0) {
+    return;
+  }
+  let total = 0;
+  const ancestors = new WeakSet;
+  const add5 = (bytes) => {
+    if (bytes > maxBytes - total)
+      return false;
+    total += bytes;
+    return true;
+  };
+  const addString = (value4) => {
+    if (!add5(2))
+      return false;
+    for (let index2 = 0;index2 < value4.length; index2 += 1) {
+      const code = value4.charCodeAt(index2);
+      if (code === 34 || code === 92) {
+        if (!add5(2))
+          return false;
+      } else if (code <= 31) {
+        if (!add5(code >= 8 && code <= 13 && code !== 11 ? 2 : 6))
+          return false;
+      } else if (code <= 127) {
+        if (!add5(1))
+          return false;
+      } else if (code <= 2047) {
+        if (!add5(2))
+          return false;
+      } else if (code >= 55296 && code <= 56319) {
+        const low = value4.charCodeAt(index2 + 1);
+        if (low >= 56320 && low <= 57343) {
+          if (!add5(4))
+            return false;
+          index2 += 1;
+        } else if (!add5(6)) {
+          return false;
+        }
+      } else if (code >= 56320 && code <= 57343) {
+        if (!add5(6))
+          return false;
+      } else if (!add5(3)) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const visit = (value4, depth) => {
+    if (depth > maxDepth)
+      return FailedSnapshot;
+    if (value4 === null)
+      return add5(4) ? null : FailedSnapshot;
+    switch (typeof value4) {
+      case "string":
+        return addString(value4) ? value4 : FailedSnapshot;
+      case "boolean":
+        return add5(value4 ? 4 : 5) ? value4 : FailedSnapshot;
+      case "number": {
+        if (!Number.isFinite(value4))
+          return add5(4) ? null : FailedSnapshot;
+        const encoded = JSON.stringify(value4);
+        return encoded !== undefined && add5(encoded.length) ? value4 : FailedSnapshot;
+      }
+      case "object": {
+        if (ancestors.has(value4))
+          return FailedSnapshot;
+        const isArray2 = Array.isArray(value4);
+        const prototype = Object.getPrototypeOf(value4);
+        if (prototype !== (isArray2 ? Array.prototype : Object.prototype) && prototype !== null) {
+          return FailedSnapshot;
+        }
+        if (Object.getOwnPropertyDescriptor(value4, "toJSON") !== undefined || prototype !== null && Object.getOwnPropertyDescriptor(prototype, "toJSON") !== undefined) {
+          return FailedSnapshot;
+        }
+        ancestors.add(value4);
+        try {
+          if (isArray2) {
+            const lengthDescriptor = Object.getOwnPropertyDescriptor(value4, "length");
+            if (lengthDescriptor === undefined || !("value" in lengthDescriptor) || typeof lengthDescriptor.value !== "number" || !Number.isSafeInteger(lengthDescriptor.value) || lengthDescriptor.value < 0) {
+              return FailedSnapshot;
+            }
+            if (!add5(1))
+              return FailedSnapshot;
+            const snapshot3 = [];
+            for (let index2 = 0;index2 < lengthDescriptor.value; index2 += 1) {
+              if (index2 > 0 && !add5(1))
+                return FailedSnapshot;
+              const descriptor = Object.getOwnPropertyDescriptor(value4, index2);
+              if (descriptor === undefined) {
+                if (!add5(4))
+                  return FailedSnapshot;
+                snapshot3.push(null);
+                continue;
+              }
+              if (!("value" in descriptor))
+                return FailedSnapshot;
+              const item = visit(descriptor.value, depth + 1);
+              if (item === FailedSnapshot)
+                return FailedSnapshot;
+              snapshot3.push(item);
+            }
+            if (!add5(1))
+              return FailedSnapshot;
+            Object.setPrototypeOf(snapshot3, null);
+            return Object.freeze(snapshot3);
+          }
+          if (!add5(1))
+            return FailedSnapshot;
+          const entries3 = [];
+          let first = true;
+          for (const key in value4) {
+            const descriptor = Object.getOwnPropertyDescriptor(value4, key);
+            if (descriptor === undefined || !descriptor.enumerable)
+              continue;
+            if (!("value" in descriptor))
+              return FailedSnapshot;
+            if (!first && !add5(1))
+              return FailedSnapshot;
+            first = false;
+            if (!addString(key) || !add5(1))
+              return FailedSnapshot;
+            const item = visit(descriptor.value, depth + 1);
+            if (item === FailedSnapshot)
+              return FailedSnapshot;
+            entries3.push([key, item]);
+          }
+          if (!add5(1))
+            return FailedSnapshot;
+          const snapshot2 = Object.fromEntries(entries3);
+          Object.setPrototypeOf(snapshot2, null);
+          return Object.freeze(snapshot2);
+        } finally {
+          ancestors.delete(value4);
+        }
+      }
+      case "bigint":
+      case "function":
+      case "symbol":
+      case "undefined":
+        return FailedSnapshot;
+    }
+    return FailedSnapshot;
+  };
+  try {
+    const value4 = visit(root, 0);
+    return value4 === FailedSnapshot ? undefined : { value: value4, bytes: total };
+  } catch {
+    return;
+  }
+};
+
+// packages/engine/src/tool-telemetry-internal.ts
+class ToolSpanFailure extends exports_AiError.AiError.extend("@effect-agent/engine/ToolSpanFailure")({}) {
+  name = "ToolCallFailed";
+  static marker() {
+    return ToolSpanFailure.make({
+      module: "effect-agent",
+      method: "execute_tool",
+      reason: exports_AiError.UnknownError.make({
+        description: "Tool execution reached a failed terminal state"
+      })
+    });
+  }
+}
+var TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE = "@effect-agent/engine/ToolSpanFailureMarker";
+var terminalOutcomeTokens = new WeakMap;
+var annotateToolSpanTerminalOutcome = (outcome, failureMarker) => {
+  const token = {};
+  terminalOutcomeTokens.set(token, { outcome, failureMarker });
+  return exports_Effect.annotateCurrentSpan({
+    "effect_agent.tool.outcome": outcome,
+    [TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE]: token
+  });
+};
+var emitThenAfter = (event, after) => exports_Stream.unwrap(exports_Effect.sync(() => {
+  let firstPull = true;
+  let afterPhase = "unarmed";
+  const runAfter = exports_Effect.suspend(() => {
+    if (afterPhase !== "pending")
+      return exports_Effect.void;
+    afterPhase = "running";
+    return after.pipe(exports_Effect.onExit(() => exports_Effect.sync(() => {
+      afterPhase = "completed";
+    })));
+  });
+  const pull = exports_Effect.suspend(() => {
+    if (firstPull) {
+      return exports_Effect.map(event, (value4) => {
+        firstPull = false;
+        afterPhase = "pending";
+        return [value4];
+      });
+    }
+    return exports_Effect.andThen(runAfter, exports_Cause.done());
+  });
+  return exports_Stream.fromPull(exports_Effect.succeed(pull)).pipe(exports_Stream.ensuring(exports_Effect.exit(exports_Effect.interruptible(runAfter)).pipe(exports_Effect.flatMap((exit3) => {
+    if (exports_Exit.isSuccess(exit3))
+      return exports_Effect.void;
+    return reportDerivativeCause(exit3.cause);
+  }))));
+}));
+var stripToolSpanFailures = (cause, marker) => {
+  const found = cause.reasons.some((reason) => exports_Cause.isFailReason(reason) && reason.error === marker);
+  if (!found) {
+    return { found: false, residual: cause };
+  }
+  const reasons = cause.reasons.filter((reason) => {
+    if (exports_Cause.isFailReason(reason) && reason.error === marker) {
+      return false;
+    }
+    return true;
+  });
+  return { found: true, residual: exports_Cause.fromReasons(reasons) };
+};
+var restoreToolSpanFailureCause = (cause, marker, original) => {
+  const { found, residual } = stripToolSpanFailures(cause, marker);
+  return {
+    found,
+    restored: original === undefined ? residual : exports_Cause.combine(original, residual)
+  };
+};
+var reportDerivativeCause = (cause) => {
+  const reportableReasons = [];
+  const interruptionReasons = [];
+  for (const reason of cause.reasons) {
+    if (exports_Cause.isInterruptReason(reason))
+      interruptionReasons.push(reason);
+    else
+      reportableReasons.push(reason);
+  }
+  const reportExit = reportableReasons.length === 0 ? exports_Effect.succeed(exports_Exit.succeed(undefined)) : exports_Effect.exit(exports_ErrorReporter.report(exports_Cause.fromReasons(reportableReasons)));
+  return exports_Effect.flatMap(reportExit, (exit3) => {
+    if (exports_Exit.isFailure(exit3)) {
+      for (const reason of exit3.cause.reasons) {
+        if (exports_Cause.isInterruptReason(reason))
+          interruptionReasons.push(reason);
+      }
+    }
+    return interruptionReasons.length === 0 ? exports_Effect.void : exports_Effect.failCause(exports_Cause.fromReasons(interruptionReasons));
+  });
+};
+var isolateToolTerminalTelemetry = (telemetry) => telemetry.pipe(exports_Effect.catchCause(reportDerivativeCause));
+var MAX_REPORTED_SPAN_LIFECYCLE_DEFECTS = 16;
+
+class ToolSpanLifecycleFailure extends Error {
+  name = "ToolSpanLifecycleFailure";
+  constructor() {
+    super("Tool span lifecycle failed");
+  }
+}
+
+class IsolatedToolSpan {
+  _tag = "Span";
+  name;
+  spanId;
+  traceId;
+  parent;
+  annotations;
+  attributes = new Map;
+  links;
+  sampled;
+  kind;
+  status;
+  #delegate;
+  #recordDefect;
+  #terminalOutcome;
+  #terminalFailure;
+  constructor(delegate, options, recordDefect) {
+    this.#delegate = delegate;
+    this.#recordDefect = recordDefect;
+    this.name = options.name;
+    this.spanId = delegate.spanId;
+    this.traceId = delegate.traceId;
+    this.parent = options.parent;
+    this.annotations = options.annotations;
+    this.links = [...options.links];
+    this.sampled = delegate.sampled;
+    this.kind = options.kind;
+    this.status = { _tag: "Started", startTime: options.startTime };
+  }
+  end(endTime, exit3) {
+    if (this.status._tag === "Ended")
+      return;
+    const exportedExit = this.#terminalOutcome === "failure" ? exports_Exit.fail(this.#terminalFailure ?? new ToolSpanLifecycleFailure) : this.#terminalOutcome === "success" ? exports_Exit.succeed(undefined) : exit3;
+    this.status = {
+      _tag: "Ended",
+      startTime: this.status.startTime,
+      endTime,
+      exit: exportedExit
+    };
+    if (this.#terminalOutcome !== undefined) {
+      this.attributes.set("effect_agent.tool.outcome", this.#terminalOutcome);
+      try {
+        this.#delegate.attribute("effect_agent.tool.outcome", this.#terminalOutcome);
+      } catch (defect) {
+        this.#recordDefect(defect);
+      }
+    }
+    try {
+      this.#delegate.end(endTime, exportedExit);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+  attribute(key, value4) {
+    if (key === TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE) {
+      if (typeof value4 === "object" && value4 !== null) {
+        const terminal = terminalOutcomeTokens.get(value4);
+        if (terminal !== undefined) {
+          this.#terminalOutcome = terminal.outcome;
+          this.#terminalFailure = terminal.failureMarker;
+        }
+      }
+      return;
+    }
+    this.attributes.set(key, value4);
+    try {
+      this.#delegate.attribute(key, value4);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+  event(name, startTime, attributes2) {
+    try {
+      this.#delegate.event(name, startTime, attributes2);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+  addLinks(links) {
+    this.links.push(...links);
+    try {
+      this.#delegate.addLinks(links);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+}
+var makeIsolatedToolTracer = (delegate) => {
+  const defects = [];
+  const recordDefect = (defect) => {
+    if (defects.length < MAX_REPORTED_SPAN_LIFECYCLE_DEFECTS)
+      defects.push(defect);
+  };
+  let delegateContext;
+  try {
+    delegateContext = delegate.context?.bind(delegate);
+  } catch (defect) {
+    recordDefect(defect);
+    delegateContext = undefined;
+  }
+  const context3 = delegateContext === undefined ? undefined : (primitive, fiber3) => {
+    let evaluation = { _tag: "Pending" };
+    const currentEvaluation = () => evaluation;
+    const evaluate2 = (currentFiber) => {
+      switch (evaluation._tag) {
+        case "Succeeded":
+          return evaluation.value;
+        case "Failed":
+          throw evaluation.error;
+        case "Pending": {
+          try {
+            const value4 = primitive["~effect/Effect/evaluate"](currentFiber);
+            evaluation = { _tag: "Succeeded", value: value4 };
+            return value4;
+          } catch (error2) {
+            evaluation = { _tag: "Failed", error: error2 };
+            throw error2;
+          }
+        }
+      }
+    };
+    const guardedPrimitive = {
+      ["~effect/Effect/evaluate"]: evaluate2
+    };
+    let delegated;
+    try {
+      delegated = delegateContext(guardedPrimitive, fiber3);
+    } catch (defect) {
+      const observed2 = currentEvaluation();
+      switch (observed2._tag) {
+        case "Failed":
+          throw observed2.error;
+        case "Succeeded":
+          recordDefect(defect);
+          return observed2.value;
+        case "Pending":
+          recordDefect(defect);
+          return evaluate2(fiber3);
+      }
+    }
+    const observed = currentEvaluation();
+    switch (observed._tag) {
+      case "Failed":
+        throw observed.error;
+      case "Succeeded":
+        return delegated;
+      case "Pending":
+        return evaluate2(fiber3);
+    }
+  };
+  const tracer3 = exports_Tracer.make({
+    context: context3,
+    span(options) {
+      let delegateSpan;
+      try {
+        delegateSpan = delegate.span(options);
+      } catch (defect) {
+        recordDefect(defect);
+        return new exports_Tracer.NativeSpan(options);
+      }
+      try {
+        return new IsolatedToolSpan(delegateSpan, options, recordDefect);
+      } catch (defect) {
+        recordDefect(defect);
+        try {
+          delegateSpan.end(options.startTime, exports_Exit.fail(new ToolSpanLifecycleFailure));
+        } catch (closeDefect) {
+          recordDefect(closeDefect);
+        }
+        return new exports_Tracer.NativeSpan(options);
+      }
+    }
+  });
+  const reportLifecycleDefects = exports_Effect.suspend(() => {
+    const pending = defects.splice(0);
+    return exports_Effect.forEach(pending, (defect) => isolateToolTerminalTelemetry(exports_ErrorReporter.report(exports_Cause.die(defect))), { discard: true });
+  });
+  return { tracer: tracer3, reportLifecycleDefects };
+};
+
+class ToolSpanTelemetry extends exports_Context.Service()("@effect-agent/engine/ToolSpanTelemetry") {
+  static layer = exports_Layer.effect(ToolSpanTelemetry, exports_Effect.map(exports_Tracer.Tracer, (delegate) => ToolSpanTelemetry.of({
+    isolateToolkitHandle: (effect2) => exports_Effect.currentSpan.pipe(exports_Effect.option, exports_Effect.flatMap((parentOption) => {
+      if (exports_Option.isNone(parentOption))
+        return effect2;
+      const parent = parentOption.value;
+      const local = new exports_Tracer.NativeSpan({
+        name: "AgentRuntime.toolkit.handle",
+        parent: exports_Option.some(parent),
+        annotations: exports_Context.add(exports_Context.empty(), exports_Tracer.DisablePropagation, true),
+        links: [],
+        startTime: 0n,
+        kind: "internal",
+        sampled: parent.sampled
+      });
+      return effect2.pipe(exports_Effect.withParentSpan(local), exports_Effect.onExit((exit3) => exports_Effect.sync(() => {
+        local.end(0n, exit3);
+      })));
+    })),
+    isolateSpanLifecycle: (stream) => exports_Stream.unwrap(exports_Effect.sync(() => {
+      const isolated = makeIsolatedToolTracer(delegate);
+      return stream.pipe(exports_Stream.provideService(exports_Tracer.Tracer, isolated.tracer), exports_Stream.ensuring(isolated.reportLifecycleDefects));
+    }))
+  })));
+}
+
 // packages/engine/src/durable-step.ts
 var ToolExecutionClass = exports_Context.Reference("@effect-agent/engine/ToolExecutionClass", { defaultValue: () => "uncertain" });
 var getToolExecutionClass = (tool) => exports_Context.get(tool.annotations, ToolExecutionClass);
@@ -32288,6 +32874,8 @@ var modelCounter = exports_Metric.counter("effect_agent_model_calls_total", {
 var toolCounter = exports_Metric.counter("effect_agent_tool_calls_total", {
   description: "Agent tool handlers started; no content or high-cardinality identifiers are recorded."
 });
+var MAX_STAGED_PROVIDER_EVENTS = 256;
+var MAX_STAGED_PROVIDER_BYTES = 1024 * 1024;
 var withSemaphorePermit = (semaphore, stream) => exports_Stream.scoped(exports_Stream.fromEffect(exports_Effect.acquireRelease(semaphore.take(1), (permits) => semaphore.release(permits).pipe(exports_Effect.asVoid))).pipe(exports_Stream.flatMap(() => stream)));
 var hasTool = (tools, name) => Object.hasOwn(tools, name);
 var startPart = (parts2, id2, description) => {
@@ -32495,16 +33083,47 @@ var preflightApproval = (context3, turnId, prepared, options) => exports_Stream.
     }
   });
 })));
+var ProviderToolCallId = ToolCallId.check(exports_Schema.isMaxLength(128), exports_Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/));
+var isTelemetryToolCallId = exports_Schema.is(ProviderToolCallId);
 var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWaiting) => {
   const call = prepared.call;
+  const telemetryToolCallId = isTelemetryToolCallId(call.id) ? call.id : undefined;
+  const executionClass = getToolExecutionClass(prepared.tool);
+  const toolSpanFailure = ToolSpanFailure.marker();
   let terminal = false;
+  let terminalResultCommitted = false;
+  let terminalOutcome;
+  let terminalResult;
+  let propagatedFailure;
+  const terminalTelemetry = (outcome) => annotateToolSpanTerminalOutcome(outcome, outcome === "failure" ? toolSpanFailure : undefined).pipe(exports_Effect.andThen((outcome === "success" ? exports_Effect.logInfo("agent tool execution completed") : exports_Effect.logWarning("agent tool execution failed")).pipe(exports_Effect.annotateLogs({
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": call.name,
+    "gen_ai.tool.type": "function",
+    ...telemetryToolCallId === undefined ? {} : {
+      "gen_ai.tool.call.id": telemetryToolCallId,
+      toolCallId: telemetryToolCallId
+    },
+    "gen_ai.agent.name": context3.agentId,
+    "gen_ai.conversation.id": context3.conversationId,
+    "effect_agent.tool.execution_class": executionClass,
+    "effect_agent.tool.outcome": outcome,
+    agentId: context3.agentId,
+    conversationId: context3.conversationId,
+    runId: context3.runId,
+    turnId,
+    toolName: call.name,
+    toolExecutionClass: executionClass,
+    toolOutcome: outcome
+  }))));
+  const isolatedTerminalTelemetry = (outcome) => isolateToolTerminalTelemetry(terminalTelemetry(outcome));
+  const terminalEventThenTelemetry = (event, outcome, failSpan) => emitThenAfter(event, isolatedTerminalTelemetry(outcome).pipe(exports_Effect.andThen(failSpan ? exports_Effect.fail(toolSpanFailure) : exports_Effect.void)));
   const started = exports_Stream.fromEffect(exports_Effect.gen(function* () {
     const toolCallId = yield* decodeToolCallId(call.id);
     yield* exports_Effect.logDebug("agent tool handler started").pipe(exports_Effect.annotateLogs({
       agentId: context3.agentId,
       runId: context3.runId,
       turnId,
-      toolCallId,
+      ...telemetryToolCallId === undefined ? {} : { toolCallId: telemetryToolCallId },
       toolName: call.name
     }));
     yield* exports_Metric.update(toolCounter, 1);
@@ -32515,7 +33134,7 @@ var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWa
       toolName: call.name
     });
   }).pipe(exports_Effect.withLogSpan("AgentRuntime.tool")));
-  const results = exports_Stream.unwrap(toolkit.handle(prepared.name, prepared.nativeHandlerParams, call.id).pipe(exports_Effect.withSpan("AgentRuntime.toolkit.handle"))).pipe(exports_Stream.mapEffect((result4) => exports_Effect.gen(function* () {
+  const results = exports_Stream.unwrap(exports_Effect.flatMap(ToolSpanTelemetry, ({ isolateToolkitHandle }) => isolateToolkitHandle(toolkit.handle(prepared.name, prepared.nativeHandlerParams, call.id)))).pipe(exports_Stream.mapEffect((result4) => exports_Effect.gen(function* () {
     if (terminal || trace2.finalToolResultIds.has(call.id)) {
       return yield* ModelProtocolError.make({
         message: `Tool Call ${call.id} produced more than one terminal result`
@@ -32523,7 +33142,7 @@ var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWa
     }
     const toolCallId = yield* decodeToolCallId(call.id);
     if (result4.preliminary) {
-      return ToolProgress.make({
+      const event = ToolProgress.make({
         ...yield* eventBase(context3),
         turnId,
         toolCallId,
@@ -32531,17 +33150,27 @@ var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWa
         result: yield* decodeEventJson(result4.encodedResult, "Tool result"),
         providerExecuted: false
       });
+      return event;
     }
     terminal = true;
-    trace2.finalToolResultIds.add(call.id);
-    trace2.applicationToolResults[prepared.declarationIndex] = {
-      id: call.id,
-      name: call.name,
+    terminalOutcome = result4.isFailure ? "failure" : "success";
+    terminalResult = {
       encodedResult: result4.encodedResult,
-      isFailure: result4.isFailure
+      isFailure: result4.isFailure,
+      result: result4.result
     };
-    if (result4.isFailure) {
-      return ToolCallFailed.make({
+    return;
+  })), exports_Stream.filter((event) => event !== undefined));
+  const commitTerminalResult = exports_Effect.suspend(() => {
+    if (!terminal || terminalOutcome === undefined || terminalResult === undefined) {
+      return exports_Effect.fail(ModelProtocolError.make({
+        message: `Tool Call ${call.id} completed without a terminal result`
+      }));
+    }
+    const result4 = terminalResult;
+    return exports_Effect.gen(function* () {
+      const toolCallId = yield* decodeToolCallId(call.id);
+      const event = result4.isFailure ? ToolCallFailed.make({
         ...yield* eventBase(context3),
         turnId,
         toolCallId,
@@ -32549,45 +33178,86 @@ var executePreparedToolCall = (context3, turnId, toolkit, prepared, trace2, onWa
         errorTag: errorTag(result4.result),
         message: errorMessage(result4.result),
         providerExecuted: false
+      }) : ToolCallSucceeded.make({
+        ...yield* eventBase(context3),
+        turnId,
+        toolCallId,
+        toolName: call.name,
+        result: yield* decodeEventJson(result4.encodedResult, "Tool result"),
+        providerExecuted: false
       });
-    }
-    return ToolCallSucceeded.make({
-      ...yield* eventBase(context3),
-      turnId,
-      toolCallId,
-      toolName: call.name,
-      result: yield* decodeEventJson(result4.encodedResult, "Tool result"),
-      providerExecuted: false
+      trace2.finalToolResultIds.add(call.id);
+      trace2.applicationToolResults[prepared.declarationIndex] = {
+        id: call.id,
+        name: call.name,
+        encodedResult: result4.encodedResult,
+        isFailure: result4.isFailure
+      };
+      terminalResultCommitted = true;
+      return event;
     });
-  })));
-  const requireTerminal = exports_Stream.fromEffect(exports_Effect.suspend(() => terminal ? exports_Effect.void : exports_Effect.fail(ModelProtocolError.make({
-    message: `Tool Call ${call.id} completed without a terminal result`
-  })))).pipe(exports_Stream.drain);
-  return started.pipe(exports_Stream.concat(results), exports_Stream.concat(requireTerminal), exports_Stream.catchCause((cause) => {
-    const waiting = waitingFromCause(cause);
+  });
+  const finalizeTerminalResult = exports_Stream.unwrap(exports_Effect.sync(() => terminalEventThenTelemetry(commitTerminalResult, terminalOutcome ?? "failure", terminalOutcome === "failure")));
+  const failTerminalResult = (cause) => {
+    terminal = true;
+    terminalOutcome = "failure";
+    terminalResult = undefined;
+    propagatedFailure = cause;
+    return terminalEventThenTelemetry(makeToolFailedEvent(context3, turnId, call, exports_Cause.squash(cause)).pipe(exports_Effect.tap(() => exports_Effect.sync(() => {
+      trace2.finalToolResultIds.add(call.id);
+      terminalResultCommitted = true;
+    }))), "failure", true);
+  };
+  const measured = started.pipe(exports_Stream.concat(results), exports_Stream.concat(finalizeTerminalResult), exports_Stream.catchCause((cause) => {
+    const { found: hasToolSpanFailure, residual: toolCause } = stripToolSpanFailures(cause, toolSpanFailure);
+    if (hasToolSpanFailure) {
+      return exports_Stream.failCause(cause);
+    }
+    if (terminalResultCommitted) {
+      return exports_Stream.failCause(toolCause);
+    }
+    if (toolCause.reasons.length > 0 && toolCause.reasons.every(exports_Cause.isInterruptReason)) {
+      return exports_Stream.failCause(toolCause);
+    }
+    const waiting = waitingFromCause(toolCause);
     if (waiting !== undefined) {
       if (terminal || trace2.finalToolResultIds.has(call.id)) {
-        return exports_Stream.fail(ModelProtocolError.make({
+        return failTerminalResult(exports_Cause.fail(ModelProtocolError.make({
           message: `Tool Call ${call.id} raised the waiting signal after its terminal result`
-        }));
+        })));
       }
       onWaiting(waiting);
       return exports_Stream.empty;
     }
     if (terminal) {
-      return exports_Stream.failCause(cause);
+      return failTerminalResult(toolCause);
     }
-    terminal = true;
-    trace2.finalToolResultIds.add(call.id);
-    return exports_Stream.fromEffect(makeToolFailedEvent(context3, turnId, call, exports_Cause.squash(cause))).pipe(exports_Stream.concat(exports_Stream.failCause(cause)));
-  }), exports_Stream.withSpan("AgentRuntime.tool", {
+    return failTerminalResult(toolCause);
+  }), exports_Stream.withSpan(`execute_tool ${call.name}`, {
+    kind: "internal",
     attributes: {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": call.name,
+      "gen_ai.tool.type": "function",
+      ...telemetryToolCallId === undefined ? {} : {
+        "gen_ai.tool.call.id": telemetryToolCallId,
+        toolCallId: telemetryToolCallId
+      },
+      "gen_ai.agent.name": context3.agentId,
+      "gen_ai.conversation.id": context3.conversationId,
+      "effect_agent.tool.execution_class": executionClass,
       agentId: context3.agentId,
+      conversationId: context3.conversationId,
       runId: context3.runId,
       turnId,
-      toolCallId: call.id,
       toolName: call.name
     }
+  }));
+  return exports_Stream.unwrap(exports_Effect.map(ToolSpanTelemetry, ({ isolateSpanLifecycle }) => isolateSpanLifecycle(measured))).pipe(exports_Stream.catchCause((cause) => {
+    const { found, restored } = restoreToolSpanFailureCause(cause, toolSpanFailure, propagatedFailure);
+    if (!found)
+      return exports_Stream.failCause(restored);
+    return restored.reasons.length === 0 ? exports_Stream.empty : exports_Stream.failCause(restored);
   }));
 };
 var executeToolBatch = (context3, turnId, toolkit, calls, trace2, concurrency, options, brokerAccounting, settledCallIds) => exports_Stream.unwrap(exports_Effect.gen(function* () {
@@ -32861,6 +33531,50 @@ var eventBase = exports_Effect.fnUntraced(function* (context3) {
     timestamp
   };
 });
+var snapshotStagedProviderEvent = (trace2, payload) => exports_Effect.suspend(() => {
+  const stagedEventCount = trace2.providerResultPayloads.length + (trace2.turnCompletion === undefined ? 0 : 1);
+  if (stagedEventCount >= MAX_STAGED_PROVIDER_EVENTS) {
+    return exports_Effect.fail(ModelProtocolError.make({
+      message: `Model response exceeded the ${MAX_STAGED_PROVIDER_EVENTS}-event staged provider event limit`
+    }));
+  }
+  const snapshot2 = boundedJsonSnapshot(payload, MAX_STAGED_PROVIDER_BYTES - trace2.providerStagedPayloadBytes);
+  if (snapshot2 === undefined) {
+    return exports_Effect.fail(ModelProtocolError.make({
+      message: `Model response exceeded the ${MAX_STAGED_PROVIDER_BYTES}-byte staged provider event limit`
+    }));
+  }
+  return exports_Effect.succeed(snapshot2);
+});
+var stageProviderResultPayload = (trace2, payload) => exports_Effect.gen(function* () {
+  const snapshot2 = yield* snapshotStagedProviderEvent(trace2, payload);
+  const snapshotObject = snapshot2.value;
+  if (snapshotObject === null || typeof snapshotObject !== "object" || Array.isArray(snapshotObject) || Object.getPrototypeOf(snapshotObject) !== null) {
+    return yield* ModelProtocolError.make({
+      message: "Provider Tool result could not be normalized as JSON"
+    });
+  }
+  const resultDescriptor = Object.getOwnPropertyDescriptor(snapshotObject, "result");
+  const normalizedResult = resultDescriptor !== undefined && "value" in resultDescriptor ? exports_Schema.decodeUnknownOption(exports_Schema.Json)(resultDescriptor.value) : exports_Option.none();
+  if (payload._tag !== "ToolCallFailed" && exports_Option.isNone(normalizedResult)) {
+    return yield* ModelProtocolError.make({
+      message: "Provider Tool result could not be normalized as JSON"
+    });
+  }
+  const normalized = payload._tag === "ToolCallFailed" ? Object.freeze({ ...payload }) : Object.freeze({ ...payload, result: exports_Option.getOrThrow(normalizedResult) });
+  trace2.providerResultPayloads.push(normalized);
+  trace2.providerStagedPayloadBytes += snapshot2.bytes;
+});
+var stampProviderResultEvent = (context3, turnId, payload) => exports_Effect.map(eventBase(context3), (base2) => {
+  switch (payload._tag) {
+    case "ToolProgress":
+      return ToolProgress.make({ ...base2, turnId, ...payload });
+    case "ToolCallSucceeded":
+      return ToolCallSucceeded.make({ ...base2, turnId, ...payload });
+    case "ToolCallFailed":
+      return ToolCallFailed.make({ ...base2, turnId, ...payload });
+  }
+});
 var decodeInput = exports_Effect.fn("AgentRuntime.decodeInput")((agent2, input) => exports_Schema.decodeUnknownEffect(agent2.definition.input)(input).pipe(exports_Effect.mapError((cause) => AgentInputError.make({
   message: cause.message
 }))));
@@ -32896,6 +33610,9 @@ var makeInitialPrompt = exports_Effect.fn("AgentRuntime.makeInitialPrompt")((ins
 }));
 var decodeToolCallId = exports_Effect.fn("AgentRuntime.decodeToolCallId")((id2) => exports_Schema.decodeEffect(ToolCallId)(id2).pipe(exports_Effect.mapError((cause) => ModelProtocolError.make({
   message: `Invalid Tool Call ID: ${cause.message}`
+}))));
+var decodeProviderToolCallId = exports_Effect.fn("AgentRuntime.decodeProviderToolCallId")((id2) => exports_Schema.decodeEffect(ProviderToolCallId)(id2).pipe(exports_Effect.mapError(() => ModelProtocolError.make({
+  message: "Model supplied an invalid Tool Call ID; expected 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens"
 }))));
 var decodeEventJson = exports_Effect.fn("AgentRuntime.decodeEventJson")((value4, label) => exports_Schema.decodeUnknownEffect(exports_Schema.Json)(value4).pipe(exports_Effect.mapError((cause) => ModelProtocolError.make({
   message: `${label} is not JSON: ${cause.message}`
@@ -32940,6 +33657,9 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
     return yield* ModelProtocolError.make({
       message: "Model response emitted content after its finish part"
     });
+  }
+  if (part.type === "tool-params-start" || part.type === "tool-params-delta" || part.type === "tool-params-end" || part.type === "tool-call" || part.type === "tool-result") {
+    yield* decodeProviderToolCallId(part.id);
   }
   trace2.parts.push(part);
   switch (part.type) {
@@ -33093,16 +33813,14 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
       const toolCallId = yield* decodeToolCallId(part.id);
       const result4 = yield* decodeEventJson(part.encodedResult, "Tool result");
       if (part.preliminary === true) {
-        return [
-          ToolProgress.make({
-            ...yield* eventBase(context3),
-            turnId,
-            toolCallId,
-            toolName: part.name,
-            result: result4,
-            providerExecuted: part.providerExecuted
-          })
-        ];
+        yield* stageProviderResultPayload(trace2, {
+          _tag: "ToolProgress",
+          toolCallId,
+          toolName: part.name,
+          result: result4,
+          providerExecuted: true
+        });
+        return [];
       }
       if (trace2.finalToolResultIds.has(part.id)) {
         return yield* ModelProtocolError.make({
@@ -33111,28 +33829,24 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
       }
       trace2.finalToolResultIds.add(part.id);
       if (part.isFailure) {
-        return [
-          ToolCallFailed.make({
-            ...yield* eventBase(context3),
-            turnId,
-            toolCallId,
-            toolName: part.name,
-            errorTag: errorTag(part.result),
-            message: errorMessage(part.result),
-            providerExecuted: part.providerExecuted
-          })
-        ];
-      }
-      return [
-        ToolCallSucceeded.make({
-          ...yield* eventBase(context3),
-          turnId,
+        yield* stageProviderResultPayload(trace2, {
+          _tag: "ToolCallFailed",
           toolCallId,
           toolName: part.name,
-          result: result4,
-          providerExecuted: part.providerExecuted
-        })
-      ];
+          errorTag: errorTag(part.result),
+          message: errorMessage(part.result),
+          providerExecuted: true
+        });
+        return [];
+      }
+      yield* stageProviderResultPayload(trace2, {
+        _tag: "ToolCallSucceeded",
+        toolCallId,
+        toolName: part.name,
+        result: result4,
+        providerExecuted: true
+      });
+      return [];
     }
     case "finish": {
       const openPart = firstOpenPart(trace2);
@@ -33144,6 +33858,16 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
       trace2.finished = true;
       trace2.finishReason = part.reason;
       trace2.usage = part.usage;
+      if (Array.from(trace2.toolCalls.values()).some(({ providerExecuted }) => providerExecuted)) {
+        const turnCompletion = { finishReason: part.reason };
+        const snapshot2 = yield* snapshotStagedProviderEvent(trace2, {
+          _tag: "TurnCompleted",
+          ...turnCompletion
+        });
+        trace2.turnCompletion = turnCompletion;
+        trace2.providerStagedPayloadBytes += snapshot2.bytes;
+        return [];
+      }
       return [
         TurnCompleted.make({
           ...yield* eventBase(context3),
@@ -33158,7 +33882,12 @@ var eventsForPart = exports_Effect.fnUntraced(function* (context3, turnId, turn,
         message: `Model response failed: ${errorMessage(part.error)}`
       });
     }
-    default: {
+    case "file":
+    case "reasoning":
+    case "response-metadata":
+    case "source":
+    case "text":
+    case "tool-approval-request": {
       return [];
     }
   }
@@ -33191,6 +33920,9 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     toolParameterParts: new Map,
     toolCalls: new Map,
     finalToolResultIds: new Set,
+    providerResultPayloads: [],
+    providerStagedPayloadBytes: 0,
+    turnCompletion: undefined,
     applicationToolCalls: [],
     applicationCallDescriptors: [],
     applicationToolResults: [],
@@ -33229,19 +33961,16 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
       turnId
     }
   }));
-  const continuation = exports_Stream.unwrap(exports_Effect.gen(function* () {
+  const continuation = exports_Stream.unwrap(exports_Effect.sync(() => {
     if (!trace2.finished) {
       return failRunEventStream(ModelProtocolError.make({
         message: "Model response ended without a finish part"
       }));
     }
-    yield* consumeUsage(agent2, context3, trace2, options);
-    const toolCalls = priorToolCalls + trace2.toolCalls.size;
-    if (toolCalls + context3.programmaticToolCalls > agent2.definition.policy.maxToolCalls) {
-      return failRunEventStream(AgentPolicyError.make({
-        limit: "tool-calls",
-        message: `Agent exceeded its ${agent2.definition.policy.maxToolCalls} Tool Call limit`
-      }));
+    const hasProviderCalls = Array.from(trace2.toolCalls.values()).some(({ providerExecuted }) => providerExecuted);
+    const turnCompletion = trace2.turnCompletion;
+    if (hasProviderCalls && turnCompletion === undefined) {
+      return failRunEventStream(ModelProtocolError.make({ message: "Model response omitted staged Turn completion" }));
     }
     const providerOnly = trace2.toolCalls.size > 0 && Array.from(trace2.toolCalls.values()).every(({ providerExecuted }) => providerExecuted);
     const missingProviderResult = Array.from(trace2.toolCalls.entries()).find(([id2, call]) => call.providerExecuted && !trace2.finalToolResultIds.has(id2));
@@ -33250,6 +33979,20 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         message: `Provider-executed Tool Call ${missingProviderResult[0]} completed without a terminal result`
       }));
     }
+    const toolCalls = priorToolCalls + trace2.toolCalls.size;
+    if (toolCalls + context3.programmaticToolCalls > agent2.definition.policy.maxToolCalls) {
+      return failRunEventStream(AgentPolicyError.make({
+        limit: "tool-calls",
+        message: `Agent exceeded its ${agent2.definition.policy.maxToolCalls} Tool Call limit`
+      }));
+    }
+    const stagedResponse = exports_Stream.fromIterable(trace2.providerResultPayloads).pipe(exports_Stream.mapEffect((payload) => stampProviderResultEvent(context3, turnId, payload)), exports_Stream.concat(turnCompletion === undefined ? exports_Stream.empty : exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => TurnCompleted.make({
+      ...base2,
+      turnId,
+      turn,
+      finishReason: turnCompletion.finishReason
+    })))));
+    const afterValidatedResponse = (next2) => stagedResponse.pipe(exports_Stream.concat(exports_Stream.unwrap(exports_Effect.andThen(consumeUsage(agent2, context3, trace2, options), next2))));
     const historyWithResponse = (...additions) => exports_Prompt.fromMessages([
       ...prompt.content,
       ...promptFromTurnParts(trace2).content,
@@ -33277,16 +34020,15 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         return makeTurn(agent2, context3, nextPrompt, turn + 1, toolCalls, options);
       }
       const output = yield* decodeFinalOutput(agent2, trace2.text.join(""));
-      const completed = RunCompleted.make({
-        ...yield* eventBase(context3),
+      return exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
+        ...base2,
         output,
         turns: turn,
         finishReason: "model-stop"
-      });
-      return exports_Stream.succeed(completed);
+      })));
     });
     if (providerOnly && trace2.finishReason === "stop") {
-      return yield* settleOrFollowUp(historyWithResponse());
+      return afterValidatedResponse(settleOrFollowUp(historyWithResponse()));
     }
     if (trace2.toolCalls.size > 0) {
       if (trace2.finishReason !== "tool-calls") {
@@ -33301,31 +34043,35 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         }));
       }
       if (trace2.applicationToolCalls.length === 0) {
-        yield* applyRepeatedFailurePolicy(context3, trace2, agent2.definition.policy.repeatedFailureLimit);
-        return yield* continueTurn(historyWithResponse());
+        return afterValidatedResponse(exports_Effect.gen(function* () {
+          yield* applyRepeatedFailurePolicy(context3, trace2, agent2.definition.policy.repeatedFailureLimit);
+          return yield* continueTurn(historyWithResponse());
+        }));
       }
-      const toolkit = yield* agent2.definition.toolkit;
-      const concurrency = yield* schedulingConcurrency(agent2.definition.policy.toolConcurrency, options.scheduling);
-      if (options.durability !== undefined) {
-        yield* options.durability.commitResponse({
-          turn,
-          turnId,
-          responseMessages: promptFromTurnParts(trace2),
-          calls: trace2.applicationCallDescriptors
-        });
-      }
-      const toolResults = guardBudgetStream(executeToolBatch(context3, turnId, toolkit, trace2.applicationToolCalls, trace2, concurrency, options, {
-        maxToolCalls: agent2.definition.policy.maxToolCalls,
-        declaredToolCalls: toolCalls
-      }), options.budget);
-      return toolResults.pipe(exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, prompt, turn, toolCalls, options)));
+      return afterValidatedResponse(exports_Effect.gen(function* () {
+        const toolkit = yield* agent2.definition.toolkit;
+        const concurrency = yield* schedulingConcurrency(agent2.definition.policy.toolConcurrency, options.scheduling);
+        if (options.durability !== undefined) {
+          yield* options.durability.commitResponse({
+            turn,
+            turnId,
+            responseMessages: promptFromTurnParts(trace2),
+            calls: trace2.applicationCallDescriptors
+          });
+        }
+        const toolResults = guardBudgetStream(executeToolBatch(context3, turnId, toolkit, trace2.applicationToolCalls, trace2, concurrency, options, {
+          maxToolCalls: agent2.definition.policy.maxToolCalls,
+          declaredToolCalls: toolCalls
+        }), options.budget);
+        return toolResults.pipe(exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, prompt, turn, toolCalls, options)));
+      }));
     }
     if (trace2.finishReason !== "stop") {
       return failRunEventStream(ModelProtocolError.make({
         message: `Model stopped without a final answer (${trace2.finishReason})`
       }));
     }
-    return yield* settleOrFollowUp(historyWithResponse());
+    return afterValidatedResponse(settleOrFollowUp(historyWithResponse()));
   }));
   return started.pipe(exports_Stream.concat(response), exports_Stream.concat(continuation));
 }));
@@ -33385,6 +34131,9 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
     toolParameterParts: new Map,
     toolCalls: new Map,
     finalToolResultIds: new Set,
+    providerResultPayloads: [],
+    providerStagedPayloadBytes: 0,
+    turnCompletion: undefined,
     applicationToolCalls: [],
     applicationCallDescriptors: [],
     applicationToolResults: [],
@@ -33583,7 +34332,7 @@ var stream = (agent2, input, options = {}) => {
     }), exports_Stream.provide(engineToolServices));
   }));
   const finalized = options.input?.end === undefined ? interpreted : interpreted.pipe(exports_Stream.ensuring(options.input.end()));
-  return finalized.pipe(exports_Stream.provide(agent2.model, { local: true }));
+  return finalized.pipe(exports_Stream.provide(agent2.model, { local: true }), exports_Stream.provide(ToolSpanTelemetry.layer));
 };
 var reduceRunEvents = (agent2, events2) => exports_Effect.gen(function* () {
   const reduction = yield* exports_Stream.runFold(events2, () => ({}), (state, event) => event._tag === "RunCompleted" ? { completed: event } : state);
@@ -34981,9 +35730,9 @@ function Stream2(success, error2) {
 }
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/rpc/Rpc.js
-var TypeId47 = "~effect/rpc/Rpc";
+var TypeId48 = "~effect/rpc/Rpc";
 var Proto12 = {
-  [TypeId47]: TypeId47,
+  [TypeId48]: TypeId48,
   pipe() {
     return pipeArguments(this, arguments);
   },
@@ -35072,7 +35821,7 @@ var makeProto3 = (options) => {
   Rpc.key = `effect/rpc/Rpc/${options._tag}`;
   return Rpc;
 };
-var make50 = (tag2, options) => {
+var make51 = (tag2, options) => {
   const successSchema = options?.success ?? Void2;
   const errorSchema = options?.error ?? Never2;
   const defectSchema = options?.defect ?? Defect();
@@ -35247,7 +35996,7 @@ class InitializeResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct(
 }))) {
 }
 
-class Initialize extends (/* @__PURE__ */ make50("initialize", {
+class Initialize extends (/* @__PURE__ */ make51("initialize", {
   success: InitializeResult,
   error: McpError,
   payload: {
@@ -35258,7 +36007,7 @@ class Initialize extends (/* @__PURE__ */ make50("initialize", {
   }
 })) {
 }
-class CancelledNotification extends (/* @__PURE__ */ make50("notifications/cancelled", {
+class CancelledNotification extends (/* @__PURE__ */ make51("notifications/cancelled", {
   payload: {
     ...NotificationMeta.fields,
     requestId: RequestId,
@@ -35267,7 +36016,7 @@ class CancelledNotification extends (/* @__PURE__ */ make50("notifications/cance
 })) {
 }
 
-class ProgressNotification extends (/* @__PURE__ */ make50("notifications/progress", {
+class ProgressNotification extends (/* @__PURE__ */ make51("notifications/progress", {
   payload: {
     ...NotificationMeta.fields,
     progressToken: ProgressToken,
@@ -35336,7 +36085,7 @@ class ReadResourceResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struc
 }))) {
 }
 
-class ReadResource extends (/* @__PURE__ */ make50("resources/read", {
+class ReadResource extends (/* @__PURE__ */ make51("resources/read", {
   success: ReadResourceResult,
   error: McpError,
   payload: {
@@ -35345,7 +36094,7 @@ class ReadResource extends (/* @__PURE__ */ make50("resources/read", {
   }
 })) {
 }
-class Subscribe extends (/* @__PURE__ */ make50("resources/subscribe", {
+class Subscribe extends (/* @__PURE__ */ make51("resources/subscribe", {
   success: /* @__PURE__ */ Struct({}),
   error: McpError,
   payload: {
@@ -35355,7 +36104,7 @@ class Subscribe extends (/* @__PURE__ */ make50("resources/subscribe", {
 })) {
 }
 
-class Unsubscribe extends (/* @__PURE__ */ make50("resources/unsubscribe", {
+class Unsubscribe extends (/* @__PURE__ */ make51("resources/unsubscribe", {
   success: /* @__PURE__ */ Struct({}),
   error: McpError,
   payload: {
@@ -35365,7 +36114,7 @@ class Unsubscribe extends (/* @__PURE__ */ make50("resources/unsubscribe", {
 })) {
 }
 
-class ResourceUpdatedNotification extends (/* @__PURE__ */ make50("notifications/resources/updated", {
+class ResourceUpdatedNotification extends (/* @__PURE__ */ make51("notifications/resources/updated", {
   payload: {
     ...NotificationMeta.fields,
     uri: String6
@@ -35444,7 +36193,7 @@ class GetPromptResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/GetP
 })) {
 }
 
-class GetPrompt extends (/* @__PURE__ */ make50("prompts/get", {
+class GetPrompt extends (/* @__PURE__ */ make51("prompts/get", {
   success: GetPromptResult,
   error: McpError,
   payload: {
@@ -35488,7 +36237,7 @@ class CallToolResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/CallT
 })) {
 }
 
-class CallTool extends (/* @__PURE__ */ make50("tools/call", {
+class CallTool extends (/* @__PURE__ */ make51("tools/call", {
   success: CallToolResult,
   error: McpError,
   payload: {
@@ -35500,7 +36249,7 @@ class CallTool extends (/* @__PURE__ */ make50("tools/call", {
 }
 var LoggingLevel = /* @__PURE__ */ Literals(["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"]);
 
-class SetLevel extends (/* @__PURE__ */ make50("logging/setLevel", {
+class SetLevel extends (/* @__PURE__ */ make51("logging/setLevel", {
   payload: {
     ...RequestMeta.fields,
     level: LoggingLevel
@@ -35510,7 +36259,7 @@ class SetLevel extends (/* @__PURE__ */ make50("logging/setLevel", {
 })) {
 }
 
-class LoggingMessageNotification extends (/* @__PURE__ */ make50("notifications/message", {
+class LoggingMessageNotification extends (/* @__PURE__ */ make51("notifications/message", {
   payload: /* @__PURE__ */ Struct({
     ...NotificationMeta.fields,
     level: LoggingLevel,
@@ -35555,7 +36304,7 @@ class CreateMessageResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 })) {
 }
 
-class CreateMessage extends (/* @__PURE__ */ make50("sampling/createMessage", {
+class CreateMessage extends (/* @__PURE__ */ make51("sampling/createMessage", {
   success: CreateMessageResult,
   error: McpError,
   payload: {
@@ -35584,7 +36333,7 @@ class ElicitDeclineResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 }
 var ElicitResult = /* @__PURE__ */ Union2([ElicitAcceptResult, ElicitDeclineResult]);
 
-class Elicit extends (/* @__PURE__ */ make50("elicitation/create", {
+class Elicit extends (/* @__PURE__ */ make51("elicitation/create", {
   success: ElicitResult,
   error: McpError,
   payload: {
@@ -36484,7 +37233,7 @@ var settleReservation = (reservations, reservationId, startedAt) => exports_Effe
   }
   yield* reservations.release(reservationId);
 }).pipe(exports_Effect.orDie);
-var layer13 = (delegation, childBinding, options) => {
+var layer14 = (delegation, childBinding, options) => {
   const caps = options.parentCaps ?? delegationCapsFromPolicy(delegation.policy);
   const allocation = delegationAllocationFromPolicy(delegation.policy);
   const toolkit = exports_Toolkit.make(delegation.tool);
@@ -36782,45 +37531,7 @@ var layer13 = (delegation, childBinding, options) => {
   });
   return toolkit.toLayer(build2);
 };
-var SubagentRuntime = { layer: layer13 };
-// packages/pr-review/src/internal/effort.ts
-var EFFORT_ALIASES = {
-  low: 0,
-  medium: 0.25,
-  high: 0.5,
-  xhigh: 0.75,
-  max: 1
-};
-var aliasPosition = EFFORT_ALIASES;
-
-class InvalidEffortInput extends exports_Schema.TaggedError()("InvalidEffortInput", {
-  input: exports_Schema.String
-}) {
-  get message() {
-    return `Invalid effort '${this.input}': expected one of ` + `${Object.keys(EFFORT_ALIASES).join(", ")} or a number between 0 and 1.`;
-  }
-}
-var isEffortPosition = (value4) => Number.isFinite(value4) && value4 >= 0 && value4 <= 1;
-var parseEffortPosition = (raw) => {
-  const normalized = raw.trim().toLowerCase();
-  const named = aliasPosition[normalized];
-  if (named !== undefined)
-    return named;
-  if (normalized === "")
-    return;
-  const numeric = Number(normalized);
-  return isEffortPosition(numeric) ? numeric : undefined;
-};
-var resolveEffortRung = (position, rungs) => {
-  const clamped = Math.min(1, Math.max(0, position));
-  let selected = rungs[0];
-  for (const rung of rungs) {
-    if (EFFORT_ALIASES[rung] <= clamped)
-      selected = rung;
-  }
-  return selected;
-};
-
+var SubagentRuntime = { layer: layer14 };
 // packages/pr-review/src/internal/diff.ts
 var ChangedPath = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512));
 var ChangedFileStatus = exports_Schema.Literals([
@@ -36979,7 +37690,6 @@ class PullRequestSource extends exports_Context.Service()("@effect-agent/pr-revi
 
 // packages/pr-review/src/internal/review-agent.ts
 var MAX_FINDINGS = 20;
-var MAX_CONCERNS = 10;
 var MAX_PATCH_CHARS = 60000;
 var MAX_SLICE_LINES = 1000;
 var DEFAULT_SLICE_LINES = 400;
@@ -37150,18 +37860,10 @@ class ReviewFinding extends exports_Schema.Class("@effect-agent/pr-review/Review
 }
 var ReviewVerdict = exports_Schema.Literals(["approve", "comment", "request-changes"]);
 
-class ReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/ReviewConcern")({
-  severity: FindingSeverity,
-  title: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(120)),
-  body: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2000))
-}) {
-}
-
 class CodeReview extends exports_Schema.Class("@effect-agent/pr-review/CodeReview")({
   summary: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(4000)),
   verdict: ReviewVerdict,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_FINDINGS)),
-  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CONCERNS)))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_FINDINGS))
 }) {
 }
 var resolveGuidance = (guidance, mission) => {
@@ -37184,13 +37886,9 @@ ${mission.body}` : "The author provided no description.",
     "2. Call read_file_diff for every file you review. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
     "3. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap honestly in your summary when it matters.",
     "4. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
-    "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
-    "Go shallow only when the diff has no behavioral surface at all: doc typos, formatting, lockfile or generated-code regeneration, a mechanical rename. Line count is not the signal — a one-line change to auth, money, SQL, a comparison operator, or a config default is not trivial.",
-    "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
-    '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor; report none when none exist.',
-    '6. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>}.',
-    `Report at most ${maxFindings} findings and at most ${MAX_CONCERNS} concerns; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
-    'Use verdict "request-changes" only when at least one finding or concern is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.'
+    '5. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}]}.',
+    `Report at most ${maxFindings} findings; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
+    'Use verdict "request-changes" only when at least one finding is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.'
   ].join(`
 `);
 };
@@ -37302,7 +38000,6 @@ var rankAndDedupeFindings = (findings) => {
 
 // packages/pr-review/src/internal/fan-out.ts
 var MAX_CHILD_FINDINGS = 8;
-var MAX_CHILD_CONCERNS = 3;
 var FileReviewToolkit = exports_Toolkit.make(ReadFileDiff, ReadFile);
 var FileReviewToolkitLayer = FileReviewToolkit.toLayer({
   read_file_diff: readFileDiffHandler,
@@ -37319,8 +38016,7 @@ class FileReviewBrief extends exports_Schema.Class("@effect-agent/pr-review/File
 
 class FileReviewReport extends exports_Schema.Class("@effect-agent/pr-review/FileReviewReport")({
   unitId: ReviewUnitId,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS)),
-  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CHILD_CONCERNS)))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS))
 }) {
 }
 var staticGuidanceLines = (guidance) => {
@@ -37336,10 +38032,8 @@ var makeFileReviewerInstructions = (options = {}) => (brief) => [
   "1. Call read_file_diff for every file in your unit. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
   "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
   "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
-  "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
-  "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
-  `4. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"unitId": ${JSON.stringify(brief.unitId)}, "findings": [{"path": <string, a file in your unit>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for concerns about YOUR unit's files with no valid line anchor (a missing cleanup, a coverage gap the diff implies, sequencing the diff leaves open) — never duplicate a finding here>}.`,
-  `Report at most ${MAX_CHILD_FINDINGS} findings and at most ${MAX_CHILD_CONCERNS} concerns; prefer the most important ones. An empty findings array is a valid report. Never report on files outside your unit. Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.`
+  `4. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"unitId": ${JSON.stringify(brief.unitId)}, "findings": [{"path": <string, a file in your unit>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}]}.`,
+  `Report at most ${MAX_CHILD_FINDINGS} findings; prefer the most important ones. An empty findings array is a valid report. Never report on files outside your unit. Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.`
 ].join(`
 `);
 var fileReviewerInstructions = makeFileReviewerInstructions();
@@ -37359,8 +38053,7 @@ class FileReviewRequest extends exports_Schema.Class("@effect-agent/pr-review/Fi
 
 class FileReviewUnitResult extends exports_Schema.Class("@effect-agent/pr-review/FileReviewUnitResult")({
   unitId: ReviewUnitId,
-  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS)),
-  concerns: exports_Schema.optionalKey(exports_Schema.Array(ReviewConcern).check(exports_Schema.isMaxLength(MAX_CHILD_CONCERNS)))
+  findings: exports_Schema.Array(ReviewFinding).check(exports_Schema.isMaxLength(MAX_CHILD_FINDINGS))
 }) {
 }
 
@@ -37420,25 +38113,19 @@ var FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
   })
 });
 var FanOutReviewToolkit = exports_Toolkit.make(ListReviewUnits, DelegateFileReview);
-var makeFanOutReviewInstructions = (options = {}) => (mission) => {
-  const maxFindings = clampMaxFindings(options.maxFindings);
-  return [
-    `You coordinate the review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}, merging ${mission.headRef} into ${mission.baseRef}. It changes ${mission.changedFileCount} file(s).`,
-    mission.body.length > 0 ? `Author description:
+var fanOutReviewInstructions = (mission) => [
+  `You coordinate the review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}, merging ${mission.headRef} into ${mission.baseRef}. It changes ${mission.changedFileCount} file(s).`,
+  mission.body.length > 0 ? `Author description:
 ${mission.body}` : "The author provided no description.",
-    ...staticGuidanceLines(options.guidance),
-    "Work in this order:",
-    "1. Call list_review_units once to get the planned review units.",
-    "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
-    `3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
-    `4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
-    `5. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
-    '6. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>}. Copy findings and concerns verbatim from the delegation results; never invent or edit anchors.',
-    'Use verdict "request-changes" only when at least one finding or concern is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.'
-  ].join(`
+  "Work in this order:",
+  "1. Call list_review_units once to get the planned review units.",
+  "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
+  `3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
+  "4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most 20 findings.",
+  '5. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}]}. Copy findings verbatim from the delegation results; never invent or edit anchors.',
+  'Use verdict "request-changes" only when at least one finding is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.'
+].join(`
 `);
-};
-var fanOutReviewInstructions = makeFanOutReviewInstructions();
 var defaultFanOutPolicy = AgentPolicy.make({
   maxTurns: 6,
   maxToolCalls: 1 + MAX_REVIEW_UNITS,
@@ -37456,10 +38143,10 @@ var makeFileReviewerDefinition = (options = {}) => Agent.define("pr-file-reviewe
   description: "Review one bounded unit of a pull request's changeset read-only and return line-anchored findings for exactly those files.",
   metadata: { deploymentClass: "E", surface: "read-only" }
 });
-var makeFanOutReviewerDefinition = (options = {}) => Agent.define("pr-fanout-reviewer", {
+var makeFanOutReviewerDefinition = () => Agent.define("pr-fanout-reviewer", {
   input: ReviewMission,
   output: CodeReview,
-  instructions: makeFanOutReviewInstructions(options),
+  instructions: fanOutReviewInstructions,
   toolkit: FanOutReviewToolkit,
   policy: defaultFanOutPolicy,
   description: "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
@@ -37476,18 +38163,17 @@ var makeFileReviewDelegation = (child) => Subagent.define("delegate_file_review"
     paths: request3.paths,
     focus: "defects-first: correctness, security, concurrency, resources, error handling"
   })),
-  projectResult: (report) => exports_Effect.succeed(FileReviewUnitResult.make({
-    unitId: report.unitId,
-    findings: report.findings,
-    ...report.concerns !== undefined ? { concerns: report.concerns } : {}
+  projectResult: (report2) => exports_Effect.succeed(FileReviewUnitResult.make({
+    unitId: report2.unitId,
+    findings: report2.findings
   })),
   policy: fileReviewPolicy
 });
 var makeFanOutReviewSuite = (options = {}) => {
-  const child = makeFileReviewerDefinition({ guidance: options.guidance });
+  const child = makeFileReviewerDefinition(options);
   return {
     child,
-    parent: makeFanOutReviewerDefinition(options),
+    parent: makeFanOutReviewerDefinition(),
     delegation: makeFileReviewDelegation(child)
   };
 };
@@ -37558,16 +38244,16 @@ var ignoringPullRequestSourceLayer = (patterns) => exports_Layer.effect(PullRequ
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/FetchHttpClient.js
 var exports_FetchHttpClient = {};
 __export(exports_FetchHttpClient, {
-  layer: () => layer14,
+  layer: () => layer15,
   RequestInit: () => RequestInit,
   Fetch: () => Fetch
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/Headers.js
-var TypeId48 = /* @__PURE__ */ Symbol.for("~effect/http/Headers");
+var TypeId49 = /* @__PURE__ */ Symbol.for("~effect/http/Headers");
 var Proto13 = /* @__PURE__ */ Object.defineProperties(/* @__PURE__ */ Object.create(null), {
-  [TypeId48]: {
-    value: TypeId48
+  [TypeId49]: {
+    value: TypeId49
   },
   [symbolRedactable]: {
     value(context4) {
@@ -37596,7 +38282,7 @@ var Proto13 = /* @__PURE__ */ Object.defineProperties(/* @__PURE__ */ Object.cre
     value: BaseProto[NodeInspectSymbol]
   }
 });
-var make51 = (input) => Object.assign(Object.create(Proto13), input);
+var make52 = (input) => Object.assign(Object.create(Proto13), input);
 var Equivalence6 = /* @__PURE__ */ makeEquivalence4(/* @__PURE__ */ strictEqual());
 var empty14 = /* @__PURE__ */ Object.create(Proto13);
 var fromInput2 = (input) => {
@@ -37621,21 +38307,21 @@ var fromInput2 = (input) => {
 };
 var fromRecordUnsafe = (input) => Object.setPrototypeOf(input, Proto13);
 var set5 = /* @__PURE__ */ dual(3, (self, key, value4) => {
-  const out = make51(self);
+  const out = make52(self);
   out[key.toLowerCase()] = value4;
   return out;
 });
-var setAll = /* @__PURE__ */ dual(2, (self, headers) => make51({
+var setAll = /* @__PURE__ */ dual(2, (self, headers) => make52({
   ...self,
   ...fromInput2(headers)
 }));
 var merge6 = /* @__PURE__ */ dual(2, (self, headers) => {
-  const out = make51(self);
+  const out = make52(self);
   Object.assign(out, headers);
   return out;
 });
 var remove7 = /* @__PURE__ */ dual(2, (self, key) => {
-  const out = make51(self);
+  const out = make52(self);
   delete out[key.toLowerCase()];
   return out;
 });
@@ -37692,7 +38378,7 @@ __export(exports_HttpClient, {
   mapRequestEffect: () => mapRequestEffect,
   mapRequest: () => mapRequest,
   makeWith: () => makeWith2,
-  make: () => make55,
+  make: () => make56,
   layerMergedContext: () => layerMergedContext,
   isHttpClient: () => isHttpClient,
   head: () => head2,
@@ -37715,10 +38401,10 @@ __export(exports_HttpClient, {
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/Cookies.js
-var TypeId49 = "~effect/http/Cookies";
+var TypeId50 = "~effect/http/Cookies";
 var CookieTypeId = "~effect/http/Cookies/Cookie";
 var Proto14 = {
-  [TypeId49]: TypeId49,
+  [TypeId50]: TypeId50,
   ...BaseProto,
   toJSON() {
     return {
@@ -37904,11 +38590,11 @@ var tryDecodeURIComponent = (str) => {
 };
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/UrlParams.js
-var TypeId50 = "~effect/http/UrlParams";
-var isUrlParams = (u) => hasProperty(u, TypeId50);
+var TypeId51 = "~effect/http/UrlParams";
+var isUrlParams = (u) => hasProperty(u, TypeId51);
 var Proto15 = {
   ...PipeInspectableProto,
-  [TypeId50]: TypeId50,
+  [TypeId51]: TypeId51,
   [Symbol.iterator]() {
     return this.params[Symbol.iterator]();
   },
@@ -37925,7 +38611,7 @@ var Proto15 = {
     return array(this.params.flat());
   }
 };
-var make52 = (params) => {
+var make53 = (params) => {
   const self = Object.create(Proto15);
   self.params = params;
   return self;
@@ -37944,7 +38630,7 @@ var fromInput3 = (input) => {
       out.push(parsed[i]);
     }
   }
-  return make52(out);
+  return make53(out);
 };
 var fromInputNested = (input) => {
   const entries3 = typeof input[Symbol.iterator] === "function" ? fromIterable2(input) : Object.entries(input);
@@ -37982,13 +38668,13 @@ var UrlParamsSchema = /* @__PURE__ */ declare(isUrlParams, {
   expected: "UrlParams",
   toEquivalence: () => Equivalence7,
   toCodec: () => link3()(ArraySchema(Tuple2([String6, String6])), transform2({
-    decode: make52,
+    decode: make53,
     encode: (self) => self.params
   }))
 });
-var empty15 = /* @__PURE__ */ make52([]);
-var set7 = /* @__PURE__ */ dual(3, (self, key, value4) => make52(append(filter3(self.params, ([k]) => k !== key), [key, String(value4)])));
-var transform3 = /* @__PURE__ */ dual(2, (self, f) => make52(f(self.params)));
+var empty15 = /* @__PURE__ */ make53([]);
+var set7 = /* @__PURE__ */ dual(3, (self, key, value4) => make53(append(filter3(self.params, ([k]) => k !== key), [key, String(value4)])));
+var transform3 = /* @__PURE__ */ dual(2, (self, f) => make53(f(self.params)));
 var setAll2 = /* @__PURE__ */ dual(2, (self, input) => {
   const out = fromInput3(input);
   const params = out.params;
@@ -38003,7 +38689,7 @@ var setAll2 = /* @__PURE__ */ dual(2, (self, input) => {
   }
   return out;
 });
-var append3 = /* @__PURE__ */ dual(3, (self, key, value4) => make52(append(self.params, [key, String(value4)])));
+var append3 = /* @__PURE__ */ dual(3, (self, key, value4) => make53(append(self.params, [key, String(value4)])));
 var appendAll3 = /* @__PURE__ */ dual(2, (self, input) => transform3(self, appendAll(fromInput3(input).params)));
 var toString = (input) => new URLSearchParams(fromInput3(input).params).toString();
 var toRecord = (self) => {
@@ -38029,7 +38715,7 @@ var schemaRecord = /* @__PURE__ */ UrlParamsSchema.pipe(/* @__PURE__ */ decodeTo
 })));
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpBody.js
-var TypeId51 = "~effect/http/HttpBody";
+var TypeId52 = "~effect/http/HttpBody";
 var HttpBodyErrorTypeId = "~effect/http/HttpBody/HttpBodyError";
 
 class HttpBodyError extends (/* @__PURE__ */ TaggedError2("HttpBodyError")) {
@@ -38037,9 +38723,9 @@ class HttpBodyError extends (/* @__PURE__ */ TaggedError2("HttpBodyError")) {
 }
 
 class Proto16 {
-  [TypeId51];
+  [TypeId52];
   constructor() {
-    this[TypeId51] = TypeId51;
+    this[TypeId52] = TypeId52;
   }
   [NodeInspectSymbol]() {
     return this.toJSON();
@@ -38202,8 +38888,8 @@ var fileContentLength = (size9, options) => {
 var file = (path, options) => flatMap5(FileSystem, (fs) => map8(fs.stat(path), (info2) => stream2(fs.stream(path, options), options?.contentType, fileContentLength(info2.size, options))));
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpClientError.js
-var TypeId52 = "~effect/http/HttpClientError";
-var isHttpClientError = (u) => hasProperty(u, TypeId52);
+var TypeId53 = "~effect/http/HttpClientError";
+var isHttpClientError = (u) => hasProperty(u, TypeId53);
 
 class HttpClientError extends (/* @__PURE__ */ TaggedError2("HttpClientError")) {
   constructor(props) {
@@ -38216,7 +38902,7 @@ class HttpClientError extends (/* @__PURE__ */ TaggedError2("HttpClientError")) 
       super(props);
     }
   }
-  [TypeId52] = TypeId52;
+  [TypeId53] = TypeId53;
   get request() {
     return this.reason.request;
   }
@@ -38304,7 +38990,7 @@ __export(exports_HttpClientRequest, {
   options: () => options,
   modify: () => modify5,
   makeWith: () => makeWith,
-  make: () => make54,
+  make: () => make55,
   isHttpClientRequest: () => isHttpClientRequest,
   head: () => head,
   get: () => get10,
@@ -38345,7 +39031,7 @@ var updateHeaders = (headers, body) => {
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/Url.js
 class UrlError extends (/* @__PURE__ */ TaggedError2("UrlError")) {
 }
-var make53 = (url2, params, hash2) => try_({
+var make54 = (url2, params, hash2) => try_({
   try: () => {
     const urlInstance = new URL(url2, baseUrl());
     for (let i = 0;i < params.params.length; i++) {
@@ -38371,10 +39057,10 @@ var baseUrl = () => {
 };
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpClientRequest.js
-var TypeId53 = "~effect/http/HttpClientRequest";
-var isHttpClientRequest = (u) => hasProperty(u, TypeId53);
+var TypeId54 = "~effect/http/HttpClientRequest";
+var isHttpClientRequest = (u) => hasProperty(u, TypeId54);
 var Proto17 = {
-  [TypeId53]: TypeId53,
+  [TypeId54]: TypeId54,
   ...BaseProto,
   toJSON() {
     return {
@@ -38402,19 +39088,19 @@ function makeWith(method, url2, urlParams2, hash2, headers, body) {
   return self;
 }
 var empty17 = /* @__PURE__ */ makeWith("GET", "", empty15, /* @__PURE__ */ none2(), empty14, empty16);
-var make54 = (method) => (url2, options) => modify5(empty17, {
+var make55 = (method) => (url2, options) => modify5(empty17, {
   method,
   url: url2,
   ...options ?? undefined
 });
-var get10 = /* @__PURE__ */ make54("GET");
-var post = /* @__PURE__ */ make54("POST");
-var patch = /* @__PURE__ */ make54("PATCH");
-var put = /* @__PURE__ */ make54("PUT");
-var del = /* @__PURE__ */ make54("DELETE");
-var head = /* @__PURE__ */ make54("HEAD");
-var options = /* @__PURE__ */ make54("OPTIONS");
-var trace2 = /* @__PURE__ */ make54("TRACE");
+var get10 = /* @__PURE__ */ make55("GET");
+var post = /* @__PURE__ */ make55("POST");
+var patch = /* @__PURE__ */ make55("PATCH");
+var put = /* @__PURE__ */ make55("PUT");
+var del = /* @__PURE__ */ make55("DELETE");
+var head = /* @__PURE__ */ make55("HEAD");
+var options = /* @__PURE__ */ make55("OPTIONS");
+var trace2 = /* @__PURE__ */ make55("TRACE");
 var modify5 = /* @__PURE__ */ dual(2, (self, options2) => {
   let result4 = self;
   if (options2.method) {
@@ -38504,7 +39190,7 @@ var bodyFormDataRecord = /* @__PURE__ */ dual(2, (self, entries3) => setBody(sel
 var bodyStream = /* @__PURE__ */ dual((args2) => isHttpClientRequest(args2[0]), (self, body, options2) => setBody(self, stream2(body, options2?.contentType, options2?.contentLength)));
 var bodyFile = /* @__PURE__ */ dual((args2) => isHttpClientRequest(args2[0]), (self, path, options2) => map8(file(path, options2), (body) => setBody(self, body)));
 function toUrl(self) {
-  const r = make53(self.url, self.urlParams, getOrUndefined(self.hash));
+  const r = make54(self.url, self.urlParams, getOrUndefined(self.hash));
   if (isSuccess2(r)) {
     return some2(r.success);
   }
@@ -38536,7 +39222,7 @@ var parseContentLength = (contentLength) => {
   return Number.isNaN(parsed) ? undefined : parsed;
 };
 var toWebResult = (self, options2) => {
-  const url2 = make53(self.url, self.urlParams, getOrUndefined(self.hash));
+  const url2 = make54(self.url, self.urlParams, getOrUndefined(self.hash));
   if (isFailure2(url2)) {
     return fail2(url2.failure);
   }
@@ -38600,11 +39286,11 @@ __export(exports_HttpClientResponse, {
   fromWeb: () => fromWeb2,
   filterStatusOk: () => filterStatusOk,
   filterStatus: () => filterStatus,
-  TypeId: () => TypeId55
+  TypeId: () => TypeId56
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpIncomingMessage.js
-var TypeId54 = "~effect/http/HttpIncomingMessage";
+var TypeId55 = "~effect/http/HttpIncomingMessage";
 var schemaBodyJson2 = (schema3, options2) => {
   const decode2 = decodeEffect2(toCodecJson(schema3));
   return (self) => flatMap5(self.json, (u) => decode2(u, options2));
@@ -38641,7 +39327,7 @@ var inspect = (self, that) => {
 };
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpClientResponse.js
-var TypeId55 = "~effect/http/HttpClientResponse";
+var TypeId56 = "~effect/http/HttpClientResponse";
 var fromWeb2 = (request3, source) => new WebHttpClientResponse(request3, source);
 var schemaJson = (schema3, options2) => {
   const decode2 = decodeEffect2(toCodecJson(schema3).annotate({
@@ -38694,16 +39380,16 @@ var filterStatusOk = (self) => self.status >= 200 && self.status < 300 ? succeed
 }));
 
 class WebHttpClientResponse extends Class2 {
-  [TypeId54];
   [TypeId55];
+  [TypeId56];
   request;
   source;
   constructor(request3, source) {
     super();
     this.request = request3;
     this.source = source;
-    this[TypeId54] = TypeId54;
     this[TypeId55] = TypeId55;
+    this[TypeId56] = TypeId56;
   }
   toJSON() {
     return inspect(this, {
@@ -38819,8 +39505,8 @@ var toHeaders = (span2) => fromRecordUnsafe({
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/http/HttpClient.js
-var TypeId56 = "~effect/http/HttpClient";
-var isHttpClient = (u) => hasProperty(u, TypeId56);
+var TypeId57 = "~effect/http/HttpClient";
+var isHttpClient = (u) => hasProperty(u, TypeId57);
 var HttpClient = /* @__PURE__ */ Service("effect/HttpClient");
 var accessor = (method) => (...args2) => flatMap5(HttpClient, (client) => client[method](...args2));
 var execute = /* @__PURE__ */ accessor("execute");
@@ -38850,7 +39536,7 @@ var makeWith2 = (postprocess, preprocess) => {
   return self;
 };
 var Proto18 = {
-  [TypeId56]: TypeId56,
+  [TypeId57]: TypeId57,
   pipe() {
     return pipeArguments(this, arguments);
   },
@@ -38861,13 +39547,13 @@ var Proto18 = {
     };
   },
   .../* @__PURE__ */ Object.fromEntries(/* @__PURE__ */ allShort.map(([fullMethod, method]) => [method, function(url2, options3) {
-    return this.execute(make54(fullMethod)(url2, options3));
+    return this.execute(make55(fullMethod)(url2, options3));
   }]))
 };
-var make55 = (f) => makeWith2((effect2) => flatMap5(effect2, (request3) => withFiber2((fiber3) => {
+var make56 = (f) => makeWith2((effect2) => flatMap5(effect2, (request3) => withFiber2((fiber3) => {
   const scopedController = scopedRequests.get(request3);
   const controller = scopedController ?? new AbortController;
-  const urlResult = make53(request3.url, request3.urlParams, getOrUndefined(request3.hash));
+  const urlResult = make54(request3.url, request3.urlParams, getOrUndefined(request3.hash));
   if (isFailure2(urlResult)) {
     return fail6(new HttpClientError({
       reason: new InvalidUrlError({
@@ -39253,8 +39939,8 @@ class InterruptibleResponse {
     this.original = original;
     this.controller = controller;
   }
+  [TypeId56] = TypeId56;
   [TypeId55] = TypeId55;
-  [TypeId54] = TypeId54;
   applyInterrupt(effect2) {
     return suspend3(() => {
       responseRegistry.unregister(this.original);
@@ -39323,7 +40009,7 @@ var Fetch = /* @__PURE__ */ Reference("effect/http/FetchHttpClient/Fetch", {
 
 class RequestInit extends (/* @__PURE__ */ Service()("effect/http/FetchHttpClient/RequestInit")) {
 }
-var fetch = /* @__PURE__ */ make55((request3, url2, signal, fiber3) => {
+var fetch = /* @__PURE__ */ make56((request3, url2, signal, fiber3) => {
   const fetch2 = fiber3.getRef(Fetch);
   const options3 = fiber3.context.mapUnsafe.get(RequestInit.key) ?? {};
   let headers = options3.headers ? merge6(fromInput2(options3.headers), request3.headers) : request3.headers;
@@ -39357,7 +40043,7 @@ var fetch = /* @__PURE__ */ make55((request3, url2, signal, fiber3) => {
   }
   return send(undefined);
 });
-var layer14 = /* @__PURE__ */ layerMergedContext(/* @__PURE__ */ succeed6(fetch));
+var layer15 = /* @__PURE__ */ layerMergedContext(/* @__PURE__ */ succeed6(fetch));
 // packages/pr-review/src/internal/github.ts
 class GitHubReviewTarget extends exports_Context.Service()("@effect-agent/pr-review/GitHubReviewTarget") {
   static layer(config) {
@@ -39593,20 +40279,10 @@ class ReviewPublicationPlan extends exports_Schema.Class("@effect-agent/pr-revie
   commitSha: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(64))
 }) {
 }
-var severityEmoji = {
-  blocking: "\uD83D\uDED1",
-  important: "⚠️",
-  nit: "\uD83D\uDC85"
-};
-var severityRank2 = {
-  blocking: 0,
-  important: 1,
-  nit: 2
-};
 var severityLabel = {
-  blocking: `${severityEmoji.blocking} blocking`,
-  important: `${severityEmoji.important} important`,
-  nit: `${severityEmoji.nit} nit`
+  blocking: "\uD83D\uDED1 blocking",
+  important: "⚠️ important",
+  nit: "\uD83D\uDC85 nit"
 };
 var suggestionFence = (suggestion) => {
   let fence = "```";
@@ -39623,50 +40299,13 @@ var renderCommentBody = (finding) => {
   return parts2.join(`
 `);
 };
-var renderDemoted = (finding, reason) => {
+var renderDemoted = (finding) => {
   const location2 = `\`${finding.path}:${finding.startLine}${finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}\``;
-  return `- ${location2} **[${severityLabel[finding.severity]}] ${finding.title}** — ${finding.body} _(demoted: ${reason})_`;
-};
-var countNoun = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
-var severityCounts = (review) => {
-  const severities = [
-    ...review.findings.map((finding) => finding.severity),
-    ...(review.concerns ?? []).map((concern) => concern.severity)
-  ];
-  return {
-    blocking: severities.filter((severity) => severity === "blocking").length,
-    important: severities.filter((severity) => severity === "important").length,
-    total: severities.length
-  };
-};
-var renderVerdictCallout = (review) => {
-  const counts = severityCounts(review);
-  if (counts.blocking > 0) {
-    return `> [!CAUTION]
-> ${countNoun(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
-  }
-  if (counts.important > 0) {
-    return `> [!IMPORTANT]
-> ${countNoun(counts.important, "important finding")} to address before merging.`;
-  }
-  if (counts.total > 0) {
-    return "> ℹ️ Minor suggestions only — mergeable as-is.";
-  }
-  return review.verdict === "approve" ? "> ✅ No issues found." : "> ℹ️ No findings — see the summary.";
-};
-var renderConcern = (concern) => [`### ${severityEmoji[concern.severity]} ${concern.title}`, "", concern.body].join(`
+  return [
+    `- ${location2} **[${severityLabel[finding.severity]}] ${finding.title}** — ${finding.body}`
+  ].join(`
 `);
-var commentSafe = (value4) => value4.replaceAll("--", "- -");
-var renderReviewMetadata = (options3) => [
-  "<!-- effect-agent-pr-review metadata",
-  `reviewed-head: ${commentSafe(options3.headSha)}`,
-  ...options3.baseRef !== undefined && options3.headRef !== undefined ? [`base-ref: ${commentSafe(options3.baseRef)}`, `head-ref: ${commentSafe(options3.headRef)}`] : [],
-  `files-visible: ${options3.filesVisible} of ${options3.totalChangedFiles}`,
-  "Findings were written against the head commit above; if commits have landed",
-  "since, treat file and line callouts as potentially stale and re-diff first.",
-  "-->"
-].join(`
-`);
+};
 var anchorViolation = (finding, files) => {
   const file2 = files.find((candidate) => candidate.path === finding.path);
   if (file2 === undefined)
@@ -39688,8 +40327,7 @@ var planPublication = (review, files, options3) => {
   const comments = [];
   const demoted = [];
   for (const finding of review.findings) {
-    const violation = anchorViolation(finding, files);
-    if (violation === undefined) {
+    if (anchorViolation(finding, files) === undefined) {
       comments.push(ReviewCommentDraft.make({
         path: finding.path,
         line: finding.endLine,
@@ -39697,73 +40335,27 @@ var planPublication = (review, files, options3) => {
         body: renderCommentBody(finding)
       }));
     } else {
-      demoted.push({ finding, reason: violation });
+      demoted.push(finding);
     }
   }
-  const sortedConcerns = [...review.concerns ?? []].sort((a, b) => severityRank2[a.severity] - severityRank2[b.severity]);
-  const sortedDemoted = [...demoted].sort((a, b) => severityRank2[a.finding.severity] - severityRank2[b.finding.severity]);
-  const footerParts = ["Automated review by @effect-agent/pr-review"];
-  if (options3.modelLabel !== undefined)
-    footerParts.push(options3.modelLabel);
-  if (options3.usage !== undefined && options3.usageScope !== undefined) {
-    const scope3 = options3.usageScope === "coordinator" ? " (coordinator)" : "";
-    footerParts.push(`${options3.usage.inputTokens} in / ${options3.usage.outputTokens} out tokens${scope3}`);
+  const bodyParts = [review.summary];
+  if (files.length < options3.totalChangedFiles) {
+    bodyParts.push("", `⚠️ Reviewed ${files.length} of ${options3.totalChangedFiles} changed files — the changeset exceeded the reviewer's file bound.`);
   }
-  if (options3.runUrl !== undefined)
-    footerParts.push(`[run](${options3.runUrl})`);
-  footerParts.push(`reviewed at ${options3.headSha.slice(0, 7)}`);
-  const footer = `_${footerParts.join(" · ")}._`;
-  const renderHead = (concernsKept2, demotedKept2, omitted2) => {
-    const parts2 = [renderVerdictCallout(review), "", review.summary];
-    for (const concern of sortedConcerns.slice(0, concernsKept2)) {
-      parts2.push("", renderConcern(concern));
-    }
-    if (files.length < options3.totalChangedFiles) {
-      parts2.push("", `⚠️ Reviewed ${files.length} of ${options3.totalChangedFiles} changed files — the changeset exceeded the reviewer's file bound.`);
-    }
-    if (demotedKept2 > 0) {
-      parts2.push("", "### Findings without a valid diff anchor", ...sortedDemoted.slice(0, demotedKept2).map(({ finding, reason }) => renderDemoted(finding, reason)));
-    }
-    if (omitted2 > 0) {
-      parts2.push("", `⚠️ ${countNoun(omitted2, "review item")} omitted — the body exceeded GitHub's review size cap.`);
-    }
-    parts2.push("", footer);
-    return parts2.join(`
-`);
-  };
-  const counts = severityCounts(review);
-  const event = !options3.applyVerdict ? "COMMENT" : counts.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.important === 0 ? "APPROVE" : "COMMENT";
-  const tail = [
-    renderReviewMetadata({
-      headSha: options3.headSha,
-      baseRef: options3.baseRef,
-      headRef: options3.headRef,
-      filesVisible: files.length,
-      totalChangedFiles: options3.totalChangedFiles
-    }),
-    ...options3.fingerprint === undefined ? [] : [renderFingerprintMarker(options3.fingerprint)]
-  ].join(`
-`);
-  const headBudget = 60000 - tail.length - 1;
-  let concernsKept = sortedConcerns.length;
-  let demotedKept = sortedDemoted.length;
-  let omitted = 0;
-  let head3 = renderHead(concernsKept, demotedKept, omitted);
-  while (head3.length > headBudget && (demotedKept > 0 || concernsKept > 0)) {
-    if (demotedKept > 0)
-      demotedKept -= 1;
-    else
-      concernsKept -= 1;
-    omitted += 1;
-    head3 = renderHead(concernsKept, demotedKept, omitted);
+  if (demoted.length > 0) {
+    bodyParts.push("", "### Findings without a valid diff anchor", ...demoted.map(renderDemoted));
   }
-  const body = `${head3.slice(0, headBudget)}
-${tail}`;
+  bodyParts.push("", `_Automated review by @effect-agent/pr-review · reviewed at ${options3.headSha.slice(0, 7)}._`);
+  const event = options3.applyVerdict ? review.verdict === "approve" ? "APPROVE" : review.verdict === "request-changes" ? "REQUEST_CHANGES" : "COMMENT" : "COMMENT";
+  const body = options3.fingerprint === undefined ? bodyParts.join(`
+`).slice(0, 60000) : `${bodyParts.join(`
+`).slice(0, 60000 - FINGERPRINT_MARKER_LENGTH - 1)}
+${renderFingerprintMarker(options3.fingerprint)}`;
   return ReviewPublicationPlan.make({
     event,
     body,
     comments,
-    demoted: demoted.map(({ finding }) => finding),
+    demoted,
     commitSha: options3.headSha
   });
 };
@@ -39788,9 +40380,7 @@ class ReviewRunOutcome extends exports_Schema.Class("@effect-agent/pr-review/Rev
   review: CodeReview,
   plan: ReviewPublicationPlan,
   published: exports_Schema.optionalKey(PublishedReview),
-  turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0)),
-  usage: exports_Schema.optionalKey(UsageTotals),
-  usageScope: exports_Schema.optionalKey(exports_Schema.Literals(["run", "coordinator"]))
+  turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0))
 }) {
 }
 var buildReviewMission = (metadata, files) => ReviewMission.make({
@@ -39805,8 +40395,7 @@ var buildReviewMission = (metadata, files) => ReviewMission.make({
 var enforceFindingsBound = (review, maxFindings) => review.findings.length <= maxFindings ? review : CodeReview.make({
   summary: review.summary,
   verdict: review.verdict,
-  findings: rankAndDedupeFindings(review.findings).slice(0, maxFindings),
-  ...review.concerns !== undefined ? { concerns: review.concerns } : {}
+  findings: rankAndDedupeFindings(review.findings).slice(0, maxFindings)
 });
 var executeReview = (binding, options3) => exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
@@ -39821,33 +40410,18 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
   });
   const decoded = yield* exports_Schema.decodeUnknownEffect(CodeReview)(result4.output);
   const review = enforceFindingsBound(decoded, clampMaxFindings(options3.maxFindings));
-  const usage = yield* budget2.snapshot;
   const plan = planPublication(review, files, {
     applyVerdict: options3.applyVerdict,
     headSha: metadata.headSha,
     totalChangedFiles: metadata.totalChangedFiles,
-    baseRef: metadata.baseRef,
-    headRef: metadata.headRef,
-    modelLabel: options3.modelLabel,
-    runUrl: options3.runUrl,
-    usage,
-    usageScope: options3.usageScope,
     fingerprint
   });
-  const scope3 = options3.usageScope === undefined ? {} : { usageScope: options3.usageScope };
   if (!options3.post) {
-    return ReviewRunOutcome.make({ review, plan, turns: result4.turns, usage, ...scope3 });
+    return ReviewRunOutcome.make({ review, plan, turns: result4.turns });
   }
   const publisher = yield* ReviewPublisher;
   const published = yield* publisher.publish(plan);
-  return ReviewRunOutcome.make({
-    review,
-    plan,
-    published,
-    turns: result4.turns,
-    usage,
-    ...scope3
-  });
+  return ReviewRunOutcome.make({ review, plan, published, turns: result4.turns });
 });
 
 // packages/pr-review/src/internal/factory.ts
@@ -39860,14 +40434,14 @@ var requireReadonly = (tools) => {
     }
   }
 };
-var provideIgnore = (effect2, ignore5) => ignore5 !== undefined && ignore5.length > 0 ? effect2.pipe(exports_Effect.provide(ignoringPullRequestSourceLayer(ignore5))) : effect2;
-var makeFingerprint = (signature, ignore5) => provideIgnore(exports_Effect.gen(function* () {
+var provideIgnore = (effect2, ignore6) => ignore6 !== undefined && ignore6.length > 0 ? effect2.pipe(exports_Effect.provide(ignoringPullRequestSourceLayer(ignore6))) : effect2;
+var makeFingerprint = (signature, ignore6) => provideIgnore(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
   const metadata = yield* source.metadata;
   const files = yield* source.changedFiles;
   return yield* computeChangesetFingerprint(files, signature(buildReviewMission(metadata, files)));
-}), ignore5);
-var make56 = (options3) => {
+}), ignore6);
+var make57 = (options3) => {
   const extraTools = options3.extraTools ?? EMPTY_TOOLS;
   requireReadonly(extraTools);
   const definition = Agent.define("pr-reviewer", {
@@ -39883,20 +40457,13 @@ var make56 = (options3) => {
     metadata: { deploymentClass: "E", surface: "read-only" }
   });
   const binding = Object.freeze({ definition, model: options3.model });
-  const signature = (mission) => [
-    definition.instructions(mission),
-    `applyVerdict=${String(options3.applyVerdict ?? false)}`,
-    ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
-  ].join("\x00");
+  const signature = (mission) => `${definition.instructions(mission)}\x00applyVerdict=${String(options3.applyVerdict ?? false)}`;
   const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
     post: runOptions.post ?? false,
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? reviewBudgetLimits,
     maxFindings: clampMaxFindings(options3.maxFindings),
-    signature,
-    modelLabel: options3.modelLabel,
-    runUrl: runOptions.runUrl,
-    usageScope: "run"
+    signature
   }).pipe(exports_Effect.provide(exports_Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
   return {
     definition,
@@ -39906,18 +40473,15 @@ var make56 = (options3) => {
   };
 };
 var makeFanOut = (options3) => {
-  const suite = makeFanOutReviewSuite({
-    guidance: options3.guidance,
-    maxFindings: options3.maxFindings
-  });
+  const suite = makeFanOutReviewSuite({ guidance: options3.guidance });
   const binding = Object.freeze({ definition: suite.parent, model: options3.model });
   const childBinding = Object.freeze({ definition: suite.child, model: options3.model });
   const guidanceLines = options3.guidance === undefined ? [] : typeof options3.guidance === "string" ? [options3.guidance] : options3.guidance;
   const signature = (mission) => [
-    suite.parent.instructions(mission),
+    fanOutReviewInstructions(mission),
     `childGuidance=${JSON.stringify(guidanceLines)}`,
-    `applyVerdict=${String(options3.applyVerdict ?? false)}`,
-    ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
+    `maxFindings=${String(clampMaxFindings(options3.maxFindings))}`,
+    `applyVerdict=${String(options3.applyVerdict ?? false)}`
   ].join(" ");
   const delegationLayer = fanOutHandlersLayerFor(suite.delegation)(childBinding).pipe(exports_Layer.provide(exports_Layer.mergeAll(FileReviewToolkitLayer, SubagentReservationsMemoryLive, IdGenerator.layer)));
   const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
@@ -39925,10 +40489,7 @@ var makeFanOut = (options3) => {
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? fanOutReviewBudgetLimits,
     maxFindings: clampMaxFindings(options3.maxFindings),
-    signature,
-    modelLabel: options3.modelLabel,
-    runUrl: runOptions.runUrl,
-    usageScope: "coordinator"
+    signature
   }).pipe(exports_Effect.provide(exports_Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
   return {
     definition: suite.parent,
@@ -39938,7 +40499,7 @@ var makeFanOut = (options3) => {
     fingerprint: makeFingerprint(signature, options3.ignore)
   };
 };
-var PrReview = { make: make56, makeFanOut };
+var PrReview = { make: make57, makeFanOut };
 
 // packages/pr-review/src/internal/github-env.ts
 class ReviewTargetUnresolved extends exports_Schema.TaggedError()("ReviewTargetUnresolved", {
@@ -40002,9 +40563,9 @@ var gitHubReviewLayers = (target) => exports_Layer.unwrap(exports_Effect.gen(fun
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-beta.107+572e5a9a9ccc3c07/node_modules/@effect/ai-anthropic/dist/AnthropicClient.js
 var exports_AnthropicClient = {};
 __export(exports_AnthropicClient, {
-  make: () => make58,
+  make: () => make59,
   layerConfig: () => layerConfig,
-  layer: () => layer15,
+  layer: () => layer16,
   AnthropicClient: () => AnthropicClient
 });
 
@@ -43802,7 +44363,7 @@ var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet200 = BetaGetSkillVersio
 var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet4XX = BetaErrorResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete200 = BetaDeleteSkillVersionResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete4XX = BetaErrorResponse;
-var make57 = (httpClient, options3 = {}) => {
+var make58 = (httpClient, options3 = {}) => {
   const unexpectedStatus = (response) => flatMap5(orElseSucceed2(response.json, () => "Unexpected status code"), (description) => fail6(new HttpClientError({
     reason: new StatusCodeError({
       request: response.request,
@@ -44591,11 +45152,11 @@ var RedactedAnthropicHeaders = {
   AnthropicApiKey: "x-api-key"
 };
 var withRedactedHeaders = /* @__PURE__ */ updateService3(CurrentRedactedNames, /* @__PURE__ */ appendAll(/* @__PURE__ */ Object.values(RedactedAnthropicHeaders)));
-var make58 = /* @__PURE__ */ fnUntraced2(function* (options3) {
+var make59 = /* @__PURE__ */ fnUntraced2(function* (options3) {
   const baseClient = yield* HttpClient;
   const apiVersion = options3.apiVersion ?? "2023-06-01";
   const httpClient = baseClient.pipe(mapRequest((request3) => request3.pipe(prependUrl(options3.apiUrl ?? "https://api.anthropic.com"), isNotUndefined(options3.apiKey) ? setHeader(RedactedAnthropicHeaders.AnthropicApiKey, value3(options3.apiKey)) : identity, setHeader("anthropic-version", apiVersion), acceptJson)), isNotUndefined(options3.transformClient) ? options3.transformClient : identity);
-  const client = make57(httpClient, {
+  const client = make58(httpClient, {
     transformClient: fnUntraced2(function* (client2) {
       const config = yield* AnthropicConfig.getOrUndefined;
       if (isNotUndefined(config?.transformClient)) {
@@ -44649,12 +45210,12 @@ var make58 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createMessageStream
   });
 }, withRedactedHeaders);
-var layer15 = (options3) => effect(AnthropicClient, make58(options3));
+var layer16 = (options3) => effect(AnthropicClient, make59(options3));
 var layerConfig = (options3) => effect(AnthropicClient, gen3(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
   const apiVersion = isNotUndefined(options3?.apiVersion) ? yield* options3.apiVersion : undefined;
-  return yield* make58({
+  return yield* make59({
     apiKey,
     apiUrl,
     apiVersion,
@@ -44666,8 +45227,8 @@ var exports_AnthropicLanguageModel = {};
 __export(exports_AnthropicLanguageModel, {
   withConfigOverride: () => withConfigOverride,
   model: () => model,
-  make: () => make60,
-  layer: () => layer16,
+  make: () => make61,
+  layer: () => layer17,
   Config: () => Config
 });
 
@@ -45306,7 +45867,7 @@ var supportedKeywords2 = /* @__PURE__ */ new Set(["$ref", "type", "title", "desc
 var formats2 = /* @__PURE__ */ new Set(["date-time", "time", "date", "duration", "email", "hostname", "uri", "ipv4", "ipv6", "uuid"]);
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/ai/Model.js
-var TypeId57 = "~effect/ai/Model";
+var TypeId58 = "~effect/ai/Model";
 
 class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ProviderName")) {
 }
@@ -45314,7 +45875,7 @@ class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/
 class ModelName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ModelName")) {
 }
 var Proto19 = {
-  [TypeId57]: TypeId57,
+  [TypeId58]: TypeId58,
   ["~effect/Layer"]: {
     _ROut: identity,
     _E: identity,
@@ -45332,9 +45893,9 @@ var Proto19 = {
     };
   }
 };
-var make59 = (provider, modelName, layer16) => Object.assign(Object.create(Proto19), {
+var make60 = (provider, modelName, layer17) => Object.assign(Object.create(Proto19), {
   provider
-}, merge2(layer16, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
+}, merge2(layer17, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
 
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-beta.107+572e5a9a9ccc3c07/node_modules/@effect/ai-anthropic/dist/AnthropicTelemetry.js
 var addAnthropicRequestAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.request", camelToSnake);
@@ -45376,11 +45937,11 @@ var formatIssue = /* @__PURE__ */ makeFormatterDefault();
 
 class Config extends (/* @__PURE__ */ Service()("@effect/ai-anthropic/AnthropicLanguageModel/Config")) {
 }
-var model = (model2, config) => make59("anthropic", model2, layer16({
+var model = (model2, config) => make60("anthropic", model2, layer17({
   model: model2,
   config
 }));
-var make60 = /* @__PURE__ */ fnUntraced2(function* ({
+var make61 = /* @__PURE__ */ fnUntraced2(function* ({
   model: model2,
   config: providerConfig
 }) {
@@ -45459,7 +46020,7 @@ var make60 = /* @__PURE__ */ fnUntraced2(function* ({
       payload
     };
   });
-  return yield* make48({
+  return yield* make49({
     codecTransformer: toCodecAnthropic,
     generateText: fnUntraced2(function* (options3) {
       const config = yield* makeConfig;
@@ -45501,7 +46062,7 @@ var make60 = /* @__PURE__ */ fnUntraced2(function* ({
     })))
   });
 });
-var layer16 = (options3) => effect(LanguageModel, make60(options3));
+var layer17 = (options3) => effect(LanguageModel, make61(options3));
 var withConfigOverride = /* @__PURE__ */ dual(2, (self, overrides) => flatMap5(serviceOption2(Config), (config) => provideService2(self, Config, {
   ...config._tag === "Some" ? config.value : {},
   ...overrides
@@ -47302,19 +47863,19 @@ var transformToolCallParams = /* @__PURE__ */ fnUntraced2(function* (tools, tool
 var exports_OpenAiClient = {};
 __export(exports_OpenAiClient, {
   withWebSocketMode: () => withWebSocketMode,
-  make: () => make62,
+  make: () => make63,
   layerWebSocketMode: () => layerWebSocketMode,
   layerConfig: () => layerConfig2,
-  layer: () => layer17,
+  layer: () => layer18,
   OpenAiSocket: () => OpenAiSocket,
   OpenAiClient: () => OpenAiClient
 });
 
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/unstable/socket/Socket.js
-var TypeId58 = "~effect/socket/Socket";
+var TypeId59 = "~effect/socket/Socket";
 var Socket = /* @__PURE__ */ Service("effect/socket/Socket");
-var make61 = (options3) => Socket.of({
-  [TypeId58]: TypeId58,
+var make62 = (options3) => Socket.of({
+  [TypeId59]: TypeId59,
   runRaw: options3.runRaw,
   run: options3.run ?? ((handler, opts) => options3.runRaw((data) => typeof data === "string" ? handler(encoder3.encode(data)) : data instanceof Uint8Array ? handler(data) : handler(new Uint8Array(data)), opts)),
   runString: options3.runString ?? (options3.run ? (handler, opts) => options3.run((data) => handler(decoder2.decode(data)), opts) : (handler, opts) => options3.runRaw((data) => typeof data === "string" ? handler(data) : data instanceof Uint8Array ? handler(decoder2.decode(data)) : handler(decoder2.decode(new Uint8Array(data))), opts)),
@@ -47405,7 +47966,7 @@ var fromWebSocket = (acquire, options3) => withFiber2((fiber3) => {
   const acquireContext = fiber3.context;
   const closeCodeIsError = options3?.closeCodeIsError ?? defaultCloseCodeIsError;
   const runRaw = (handler, opts) => scopedWith2(fnUntraced2(function* (scope3) {
-    const fiberSet = yield* make43().pipe(provide(scope3));
+    const fiberSet = yield* make45().pipe(provide(scope3));
     const ws = yield* provide(acquire, scope3);
     const run5 = yield* provideService2(runtime(fiberSet)(), WebSocket, ws);
     let open3 = false;
@@ -47503,7 +48064,7 @@ var fromWebSocket = (acquire, options3) => withFiber2((fiber3) => {
     }
   }));
   const writer = succeed6(write2);
-  return succeed6(make61({
+  return succeed6(make62({
     runRaw,
     writer
   }));
@@ -48152,7 +48713,7 @@ var RedactedOpenAiHeaders = {
   OpenAiProject: "OpenAI-Project"
 };
 var withRedactedHeaders2 = /* @__PURE__ */ updateService3(CurrentRedactedNames, /* @__PURE__ */ appendAll(/* @__PURE__ */ Object.values(RedactedOpenAiHeaders)));
-var make62 = /* @__PURE__ */ fnUntraced2(function* (options3) {
+var make63 = /* @__PURE__ */ fnUntraced2(function* (options3) {
   const baseClient = yield* HttpClient;
   const apiUrl = options3.apiUrl ?? "https://api.openai.com/v1";
   const httpClient = baseClient.pipe(mapRequest(flow(prependUrl(apiUrl), options3.apiKey ? bearerToken(value3(options3.apiKey)) : identity, options3.organizationId ? setHeader(RedactedOpenAiHeaders.OpenAiOrganization, value3(options3.organizationId)) : identity, options3.projectId ? setHeader(RedactedOpenAiHeaders.OpenAiProject, value3(options3.projectId)) : identity, acceptJson)), filterStatusOk2, options3.transformClient ? options3.transformClient : identity);
@@ -48198,13 +48759,13 @@ var make62 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createEmbedding
   });
 }, withRedactedHeaders2);
-var layer17 = (options3) => effect(OpenAiClient, make62(options3));
+var layer18 = (options3) => effect(OpenAiClient, make63(options3));
 var layerConfig2 = (options3) => effect(OpenAiClient, gen3(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
   const organizationId = isNotUndefined(options3?.organizationId) ? yield* options3.organizationId : undefined;
   const projectId = isNotUndefined(options3?.projectId) ? yield* options3.projectId : undefined;
-  return yield* make62({
+  return yield* make63({
     apiKey,
     apiUrl,
     organizationId,
@@ -48217,7 +48778,7 @@ class OpenAiSocket extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiC
 }
 var makeSocket = /* @__PURE__ */ gen3(function* () {
   const client = yield* OpenAiClient;
-  const tracker = yield* make46;
+  const tracker = yield* make47;
   const socketScope = yield* scope2;
   const makeRequest = flatMap5(OpenAiConfig.getOrUndefined, (config) => {
     const httpClient = isNotUndefined(config?.transformClient) ? config.transformClient(client.client) : client.client;
@@ -48364,8 +48925,8 @@ var exports_OpenAiLanguageModel = {};
 __export(exports_OpenAiLanguageModel, {
   withConfigOverride: () => withConfigOverride2,
   model: () => model2,
-  make: () => make63,
-  layer: () => layer18,
+  make: () => make64,
+  layer: () => layer19,
   Config: () => Config2
 });
 
@@ -48415,11 +48976,11 @@ var SharedModelIds = ModelIdsShared.members[1];
 
 class Config2 extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiLanguageModel/Config")) {
 }
-var model2 = (model3, config) => make59("openai", model3, layer18({
+var model2 = (model3, config) => make60("openai", model3, layer19({
   model: model3,
   config
 }));
-var make63 = /* @__PURE__ */ fnUntraced2(function* ({
+var make64 = /* @__PURE__ */ fnUntraced2(function* ({
   model: model3,
   config: providerConfig
 }) {
@@ -48480,7 +49041,7 @@ var make63 = /* @__PURE__ */ fnUntraced2(function* ({
       request3.previous_response_id = options3.previousResponseId;
     return request3;
   });
-  return yield* make48({
+  return yield* make49({
     codecTransformer: toCodecOpenAI,
     generateText: fnUntraced2(function* (options3) {
       const config = yield* makeConfig;
@@ -48523,7 +49084,7 @@ var make63 = /* @__PURE__ */ fnUntraced2(function* ({
     })))
   });
 });
-var layer18 = (options3) => effect(LanguageModel, make63(options3));
+var layer19 = (options3) => effect(LanguageModel, make64(options3));
 var withConfigOverride2 = /* @__PURE__ */ dual(2, (self, overrides) => flatMap5(serviceOption2(Config2), (config) => provideService2(self, Config2, {
   ...config._tag === "Some" ? config.value : {},
   ...overrides
@@ -50611,24 +51172,14 @@ var PROVIDER_CREDENTIAL_ENV = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY"
 };
-var PROVIDER_EFFORT_RUNGS = {
-  openai: ["low", "medium", "high", "xhigh"],
-  anthropic: ["low", "medium", "high"]
-};
-var makeOpenAiReviewModel = (model3, effort) => exports_OpenAiLanguageModel.model(model3 ?? DEFAULT_MODEL.openai, {
+var makeOpenAiReviewModel = (model3) => exports_OpenAiLanguageModel.model(model3 ?? DEFAULT_MODEL.openai, {
   max_output_tokens: 8000,
   store: false,
-  strictJsonSchema: true,
-  ...effort === undefined ? {} : { reasoning: { effort: resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS.openai) } }
+  strictJsonSchema: true
 });
-var makeAnthropicReviewModel = (model3, effort) => exports_AnthropicLanguageModel.model(model3 ?? DEFAULT_MODEL.anthropic, {
-  max_tokens: 8000,
-  ...effort === undefined ? {} : { output_config: { effort: resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS.anthropic) } }
+var makeAnthropicReviewModel = (model3) => exports_AnthropicLanguageModel.model(model3 ?? DEFAULT_MODEL.anthropic, {
+  max_tokens: 8000
 });
-var describeReviewModel = (provider, model3, effort) => {
-  const base2 = `${provider}/${model3 ?? DEFAULT_MODEL[provider]}`;
-  return effort === undefined ? base2 : `${base2} (effort ${resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS[provider])})`;
-};
 var openAiClientLayer = exports_OpenAiClient.layerConfig({
   apiKey: exports_Config.redacted(PROVIDER_CREDENTIAL_ENV.openai)
 }).pipe(exports_Layer.provide(exports_FetchHttpClient.layer));
@@ -50647,29 +51198,9 @@ class ReviewGateFailed extends exports_Schema.TaggedError()("ReviewGateFailed", 
     return `Review verdict '${this.verdict}' fails the configured '${this.failOn}' gate.`;
   }
 }
-
-class InvalidMaxDurationInput extends exports_Schema.TaggedError()("InvalidMaxDurationInput", {
-  minutes: exports_Schema.Int
-}) {
-  get message() {
-    return `Invalid max-duration-minutes '${this.minutes}': expected a positive number of minutes.`;
-  }
-}
 var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () {
   const provider = yield* exports_Config.literals(["openai", "anthropic"], "PR_REVIEW_PROVIDER").pipe(exports_Config.withDefault(DEFAULT_PROVIDER));
   const model3 = yield* exports_Config.option(exports_Config.nonEmptyString("PR_REVIEW_MODEL"));
-  const effortRaw = yield* exports_Config.option(exports_Config.nonEmptyString("PR_REVIEW_EFFORT"));
-  let effort;
-  if (exports_Option.isSome(effortRaw)) {
-    effort = parseEffortPosition(effortRaw.value);
-    if (effort === undefined) {
-      return yield* InvalidEffortInput.make({ input: effortRaw.value });
-    }
-  }
-  const maxDurationMinutes = exports_Option.getOrUndefined(yield* exports_Config.option(exports_Config.int("PR_REVIEW_MAX_DURATION_MINUTES")));
-  if (maxDurationMinutes !== undefined && maxDurationMinutes <= 0) {
-    return yield* InvalidMaxDurationInput.make({ minutes: maxDurationMinutes });
-  }
   const post3 = yield* exports_Config.boolean("PR_REVIEW_POST").pipe(exports_Config.withDefault(true));
   const applyVerdict = yield* exports_Config.boolean("PR_REVIEW_APPLY_VERDICT").pipe(exports_Config.withDefault(false));
   const fanOut = yield* exports_Config.boolean("PR_REVIEW_FAN_OUT").pipe(exports_Config.withDefault(false));
@@ -50682,7 +51213,6 @@ var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () 
   return {
     provider,
     model: exports_Option.getOrUndefined(model3),
-    effort,
     post: post3,
     applyVerdict,
     fanOut,
@@ -50690,7 +51220,6 @@ var resolveActionInputs = exports_Effect.fn("resolveActionInputs")(function* () 
     guidanceFile: exports_Option.getOrUndefined(guidanceFile),
     ignore: ignoreRaw.split(",").map((pattern) => pattern.trim()).filter((pattern) => pattern.length > 0),
     maxFindings: exports_Option.getOrUndefined(maxFindings),
-    maxDurationMinutes,
     failOn,
     skipUnchanged
   };
@@ -50743,36 +51272,12 @@ var writeActionOutputs = exports_Effect.fn("writeActionOutputs")(function* (entr
     flag: "a"
   });
 });
-var writeStepSummary = exports_Effect.fn("writeStepSummary")(function* (lines) {
-  const summaryPath = yield* exports_Config.string("GITHUB_STEP_SUMMARY").pipe(exports_Config.withDefault(""));
-  if (summaryPath === "")
-    return;
-  const fs = yield* exports_FileSystem.FileSystem;
-  yield* fs.writeFileString(summaryPath, `${lines.join(`
-`)}
-`, { flag: "a" });
-});
 var outcomeOutputs = (outcome) => [
   ["skipped", "false"],
   ["verdict", outcome.review.verdict],
   ["inline-comments", String(outcome.plan.comments.length)],
   ["demoted-findings", String(outcome.plan.demoted.length)],
-  ["concerns", String(outcome.review.concerns?.length ?? 0)],
-  ...outcome.usage === undefined ? [] : [
-    ["input-tokens", String(outcome.usage.inputTokens)],
-    ["output-tokens", String(outcome.usage.outputTokens)]
-  ],
   ["review-url", outcome.published?.url ?? ""]
-];
-var outcomeSummary = (outcome, modelLabel) => [
-  "### Pull-request review",
-  `- Verdict: **${outcome.review.verdict}**`,
-  `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
-  ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
-  ...outcome.usage === undefined ? [] : [
-    `- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out${outcome.usageScope === "coordinator" ? " (coordinator)" : ""}`
-  ],
-  ...outcome.published === undefined ? ["- Dry run: nothing posted"] : [`- Posted: ${outcome.published.url}`]
 ];
 var skip = (reason) => exports_Effect.gen(function* () {
   yield* exports_Console.log(`Skipping review: ${reason}`);
@@ -50780,16 +51285,7 @@ var skip = (reason) => exports_Effect.gen(function* () {
     ["skipped", "true"],
     ["skip-reason", reason]
   ]);
-  yield* writeStepSummary(["### Pull-request review skipped", `- Reason: ${reason}`]);
   return { _tag: "Skipped", reason };
-});
-var resolveRunUrl = exports_Effect.fn("resolveRunUrl")(function* () {
-  const runId = yield* exports_Config.string("GITHUB_RUN_ID").pipe(exports_Config.withDefault(""));
-  const repository = yield* exports_Config.string("GITHUB_REPOSITORY").pipe(exports_Config.withDefault(""));
-  if (runId === "" || repository === "")
-    return;
-  const server = yield* exports_Config.string("GITHUB_SERVER_URL").pipe(exports_Config.withDefault("https://github.com"));
-  return `${server}/${repository}/actions/runs/${runId}`;
 });
 var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* () {
   const event = yield* readGitHubEvent();
@@ -50814,10 +51310,6 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           ["skip-reason", "changeset unchanged since the last review"],
           ["fingerprint", current]
         ]);
-        yield* writeStepSummary([
-          "### Pull-request review skipped",
-          "- Reason: changeset unchanged since the last review"
-        ]);
         return {
           _tag: "Skipped",
           reason: "changeset unchanged since the last review"
@@ -50825,14 +51317,12 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       }
     }
     yield* exports_Console.log(`Reviewing ${target.repository}#${target.number} (${options3.post === false ? "dry run" : "posting"})...`);
-    const runUrl = yield* resolveRunUrl();
-    const outcome = yield* reviewer.run({ post: options3.post ?? true, runUrl });
+    const outcome = yield* reviewer.run({ post: options3.post ?? true });
     yield* exports_Console.log(`Review finished in ${outcome.turns} turn(s): verdict ${outcome.review.verdict}, ` + `${outcome.plan.comments.length} inline comment(s), ${outcome.plan.demoted.length} demoted finding(s).`);
     if (outcome.published !== undefined) {
       yield* exports_Console.log(`Posted ${outcome.published.event} review: ${outcome.published.url}`);
     }
     yield* writeActionOutputs(outcomeOutputs(outcome));
-    yield* writeStepSummary(outcomeSummary(outcome, options3.modelLabel));
     if (options3.failOn === "request-changes" && outcome.review.verdict === "request-changes") {
       return yield* ReviewGateFailed.make({
         verdict: outcome.review.verdict,
@@ -50845,32 +51335,23 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
 var reviewActionProgram = exports_Effect.gen(function* () {
   const inputs = yield* resolveActionInputs();
   const guidance = yield* resolveGuidance2(inputs);
-  const modelLabel = describeReviewModel(inputs.provider, inputs.model, inputs.effort);
-  const defaults = inputs.fanOut ? fanOutReviewBudgetLimits : reviewBudgetLimits;
-  const budget2 = inputs.maxDurationMinutes === undefined ? defaults : UsageBudgetLimits.make({
-    ...defaults,
-    maxDurationMillis: inputs.maxDurationMinutes * 60000
-  });
   const shared = {
     guidance,
     ignore: inputs.ignore,
     maxFindings: inputs.maxFindings,
-    applyVerdict: inputs.applyVerdict,
-    modelLabel,
-    budget: budget2
+    applyVerdict: inputs.applyVerdict
   };
   const harness = {
     post: inputs.post,
     failOn: inputs.failOn,
-    skipUnchanged: inputs.skipUnchanged,
-    modelLabel
+    skipUnchanged: inputs.skipUnchanged
   };
   if (inputs.provider === "anthropic") {
-    const model4 = makeAnthropicReviewModel(inputs.model, inputs.effort);
+    const model4 = makeAnthropicReviewModel(inputs.model);
     const reviewer2 = inputs.fanOut ? PrReview.makeFanOut({ ...shared, model: model4 }) : PrReview.make({ ...shared, model: model4 });
     return yield* runReviewAction(reviewer2, harness).pipe(exports_Effect.provide(anthropicClientLayer));
   }
-  const model3 = makeOpenAiReviewModel(inputs.model, inputs.effort);
+  const model3 = makeOpenAiReviewModel(inputs.model);
   const reviewer = inputs.fanOut ? PrReview.makeFanOut({ ...shared, model: model3 }) : PrReview.make({ ...shared, model: model3 });
   return yield* runReviewAction(reviewer, harness).pipe(exports_Effect.provide(openAiClientLayer));
 });
@@ -50880,8 +51361,6 @@ var main = () => exports_NodeRuntime.runMain(reviewActionProgram.pipe(exports_Ef
 var INPUT_TO_ENV = [
   ["INPUT_PROVIDER", "PR_REVIEW_PROVIDER"],
   ["INPUT_MODEL", "PR_REVIEW_MODEL"],
-  ["INPUT_EFFORT", "PR_REVIEW_EFFORT"],
-  ["INPUT_MAX-DURATION-MINUTES", "PR_REVIEW_MAX_DURATION_MINUTES"],
   ["INPUT_POST", "PR_REVIEW_POST"],
   ["INPUT_APPLY-VERDICT", "PR_REVIEW_APPLY_VERDICT"],
   ["INPUT_FAN-OUT", "PR_REVIEW_FAN_OUT"],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
           { text: "Agent definitions", link: "/guide/agents" },
           { text: "Tools & Layers", link: "/guide/tools" },
           { text: "Run & stream", link: "/guide/run-agents" },
+          { text: "Observability", link: "/guide/observability" },
           { text: "Conversations", link: "/guide/conversations" },
           { text: "Deterministic testing", link: "/guide/testing" },
         ],

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -495,3 +495,44 @@ This is the first package created outside a numbered roadmap phase; D-025's phas
 otherwise unchanged.
 
 Record: [ADR-0016](adr/0016-pr-review-package.md)
+
+### D-036 — Native Tool observability and Cloudflare exporter lifecycle
+
+**Status:** Accepted (owner-directed, 2026-08-14)
+
+**Decision:** Make the engine's logical application-handler lifecycle the canonical content-free
+OpenTelemetry `execute_tool` span, deriving terminal status from the actual Tool result so
+value-level failures export as failed spans. The complete in-memory handler-attempt lifecycle set
+is success, failure, interruption, and nonterminal waiting. Success, failure, and interruption end
+that attempt; waiting may remain unresolved indefinitely. Denial and provider execution remain
+call-level classifications only. Emit one bounded terminal log for success/failure attempts and
+none for interruption. Logs carry identity, execution class, and outcome fields; never include Tool
+parameters/results, prompts, commands, source code, conversation content, or failure messages by
+default. Recovery may start another attempt and makes no exactly-once telemetry claim.
+Report terminal Logger/Tracer defects through Effect's owned `ErrorReporter` boundary, isolating a
+defective reporter so observability never changes Tool settlement. Early-close cleanup reports
+typed failures and defects rather than silently discarding them; the canonical span restores its
+bounded outcome attribute from authenticated private terminal state before export.
+
+Let Cloudflare hosts provide an outer Effect observability Layer plus a vendor-neutral flush
+service at the Worker factory boundary. The runtime Layer requires that capability explicitly;
+the host Layer may consume Object context and fail acquisition typed, while the factory alone
+chooses the no-op default when no Layer is passed. After every native RPC, port, wake, and alarm
+span closes, reserve background export for `ctx.waitUntil`; native delivery never awaits it.
+Apply a schema-validated cooperative timeout to interruptible exporters without claiming a hard
+bound for uninterruptible work. Coalesce
+deliveries per Object incarnation into shared pending/trailing/queued batch tickets before
+`waitUntil`; each batch waits for its reserved deliveries to settle and only its first owner
+registers the shared background Promise. Cap cycles at one first plus at most one trailing attempt,
+with one queued cycle while trailing runs, without concurrent exporters, per-delivery background
+registrations, or a waiter queue. Preserve typed failures, defects, and interruption until the final
+always-fulfilled `waitUntil` bridge, but automatically log only bounded framework-owned failure
+classifications. Export failure, defect, or timeout never replaces the original success/failure or
+alarm retry signal. A synchronous `waitUntil` registration failure logs only its bounded
+classification, does not invoke the unowned exporter continuation, and likewise returns the exact
+delivery Promise. Export adapters retain foreign causes in the typed
+`CloudflareTelemetryExportError` for explicit host-controlled diagnostics; foreign causes, defects,
+fiber IDs, and platform Causes never enter automatic logs. Keep the `ManagedRuntime` cached for the
+Object incarnation and change no canonical or wire schema.
+
+Record: [ADR-0018](adr/0018-native-tool-observability.md)

--- a/docs/PHASE-6-EVIDENCE.md
+++ b/docs/PHASE-6-EVIDENCE.md
@@ -119,7 +119,7 @@ outside the repository); CI runs them through the ordinary `bun run test` gate.
     facets, `BrowserCrypto.layer`, per-Object producer identity
     (`{prefix}:{conversationId}`), and `AgentBindingResolver`
     (`packages/platform-cloudflare/src/layers.ts`);
-  - `makeConversationObjectClass(options)` — the class applications export from their Worker:
+  - `makeConversationObjectClass(options, telemetry?)` — the class applications export from their Worker:
     a **local-only** constructor gate (`blockConcurrencyWhile`: migration + exact-version
     check, config decode, defensive ensure-alarm; never a recovery pass, so two Objects can
     never deadlock in constructor gates), entry points (`submitEncoded`,

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -189,9 +189,11 @@ transform-mode workers).
 2. `vp config` installs the repository's `.vite-hooks/pre-commit` hook.
 3. `effect-tsgo patch` patches the managed TypeScript compiler.
 
-CI skips the source checkout because production checks use installed packages, not reference
-source. Local development keeps the checkout because implementation agents often need to verify
-current Effect v4 and Effect AI behavior.
+CI installs with lifecycle scripts suppressed, verifies the locked Dev Kit outputs, and then runs
+`bun run patch:tsgo` explicitly in every job that checks, tests, or builds TypeScript. This preserves
+the postinstall compiler invariant without cloning the Effect source checkout. Local development
+keeps the checkout because implementation agents often need to verify current Effect v4 and Effect
+AI behavior.
 
 Known workaround: the `preferTypedSchemaDecoder` language-service rule is set to `"off"` in
 `tsconfig.base.json` because `@effect/tsgo` `0.33.0` nil-panics in that rule

--- a/docs/adr/0018-native-tool-observability.md
+++ b/docs/adr/0018-native-tool-observability.md
@@ -99,9 +99,10 @@ remain failed/interrupted until the final always-fulfilled `waitUntil` Promise b
 exporter causes, arbitrary defects, and fiber IDs are never passed to the automatic Logger; the
 typed export error retains its cause for explicit host-controlled inspection. Timeout, exporter
 failure, or synchronous `waitUntil` registration failure never changes the original result or alarm
-rejection. Registration failure is logged synchronously with its exact platform Cause and the
-`wait_until_registration` classification before the exact delivery Promise is returned, and the
-unowned exporter continuation is not invoked.
+rejection. Registration failure is logged synchronously with only the bounded
+`wait_until_registration` classification before the exact delivery Promise is returned; its
+arbitrary platform Cause is not sent to the configured Logger, and the unowned exporter
+continuation is not invoked.
 Native rejection spans are sanitized before the original Cause is restored. The runtime remains
 cached for the Object incarnation; it is not disposed per delivery. Hosts configure one
 native-delivery flush owner and do not duplicate this path with effect-cf or another native

--- a/docs/adr/0018-native-tool-observability.md
+++ b/docs/adr/0018-native-tool-observability.md
@@ -1,0 +1,151 @@
+# ADR-0018: Native Tool observability and Cloudflare exporter lifecycle
+
+- Status: Accepted
+- Date: 2026-08-14
+- Decision owners: Project owner
+- Related decisions: D-001, D-019, D-032, D-033, D-036
+- Builds on: [ADR-0001](0001-effect-native-core.md),
+  [ADR-0014](0014-cloudflare-conversation-objects.md),
+  [ADR-0015](0015-hardening-shape.md)
+
+## Context
+
+A downstream `0.0.1-beta.5` Cloudflare deployment could observe successful repository Tools in
+canonical events but could not search for them in exported logs or spans. Its emergency bridge
+wrapped an application loopback RPC executor with content-free `execute_tool` telemetry and
+manually flushed exporters after native RPC delivery. That restored visibility, but duplicated
+canonical Tool names, execution classes, outcomes, and platform lifecycle outside the framework.
+
+The engine already had a logical span around the full application-handler lifecycle. Ordinary
+span failure inference was insufficient because Effect AI can represent a Tool failure as a
+terminal value. The Cloudflare package also built a private cached `ManagedRuntime` without a
+host observability Layer or a native-delivery export boundary.
+
+## Decision
+
+The existing engine handler lifecycle is the canonical OpenTelemetry Tool span. It is named
+`execute_tool {toolName}`, follows GenAI `execute_tool` attributes, retains framework correlation,
+and records the declared execution class plus a bounded success/failure outcome. Because the
+framework already owns the Conversation ID, the span/log records it as `gen_ai.conversation.id`
+and backward-compatible `conversationId`; it never derives identity from content. When an
+in-memory handler attempt's complete lifecycle set is success, failure, interruption, and
+nonterminal waiting. Success, failure, and interruption terminate that in-memory attempt; waiting
+may remain unresolved indefinitely. Denied and provider-executed calls remain solely call-level
+classifications and create no application-handler attempt. Success/failure attempts emit one
+outcome after the handler stream settles, while interrupted attempts emit no terminal outcome log.
+Value-level returned failures are failure, and any post-terminal error or
+duplicate result overrides an apparent success to failure. At-least-once recovery can start another
+attempt with its own telemetry. Framework terminal logs contain only bounded identity/outcome
+fields. No Tool input, output, prompt,
+conversation content, command, source, or failure message is exported.
+Provider/model Tool Call IDs are untrusted and must contain 1–128 ASCII characters matching
+`[A-Za-z0-9][A-Za-z0-9._:-]*`. The engine validates before Turn correlation, canonical event
+emission, or application handler scheduling; rejection is a typed protocol failure. Span/log
+correlation therefore contains only the already-validated identifier.
+The terminal Tool Run event and in-memory trace result are not committed until the handler stream
+settles. A stream that fails after a provisional terminal value commits one `ToolCallFailed`, never
+the provisional success, before preserving the original Cause for the batch. Terminal state is
+committed and emitted before derivative telemetry, so telemetry interruption cannot make completed
+Tool work eligible for replay. An internal emission boundary returns the singleton terminal event
+on the first pull, then gives telemetry to the next pull or structured stream finalization on early
+downstream closure. A synchronous phase gate permits one attempt and does not retry an in-flight
+interrupted action. Once the terminal outcome annotation exists, it determines the canonical span
+status even if downstream cancellation or telemetry interruption determines the channel Exit. The
+status source is module-private identity-authenticated state rather than the publicly mutable
+attribute map.
+Span-facing failures use one fresh bounded marker object per handler attempt and recognize only that
+exact identity; a handler cannot forge the control path by returning the same error class. The
+original Cause is restored unchanged outside the measured boundary. Effect AI's parameter
+annotations land on a manually constructed,
+non-exported local span whose parent is the canonical span. Its `Tracer.DisablePropagation`
+annotation makes explicit host-owned handler spans filter past it and attach to the canonical span,
+while no duplicate framework handler span or raw handler Cause is exported by framework-owned
+instrumentation. Logger/Tracer defects during canonical span creation,
+annotation, logging, or closure are reported through Effect's owned `ErrorReporter` boundary
+without changing the Tool event or exit. Creation falls back to a non-exported local span; closure
+cannot rerun a completed handler; a defective reporter is isolated too. External interruption of
+terminal telemetry or the reporter remains interruption instead of being recovered.
+The engine composition boundary derives an internal `ToolSpanTelemetry` capability from the host's
+ambient Tracer. Individual Tool execution consumes that capability and never selects, decorates, or
+locally provides a Tracer implementation. Reusable stream executions allocate independent local
+isolation/defect state, and absence of a current span is not converted into a defect.
+Provider-executed calls remain outside that handler capability. Their progress/terminal events and
+`TurnCompleted` are staged until the complete model response validates all call/result
+correlations, so a malformed duplicate or post-finish part cannot append a provisional Tool
+success.
+
+`@effect-agent/platform-cloudflare` exposes a host-owned `CloudflareRuntimeTelemetry` service.
+`CloudflareDurableRuntime.layer` requires it explicitly, and the Worker passes its provider as the
+second `makeConversationObjectClass` argument rather than hiding it in runtime options. The host
+Layer may require the Durable Object context or namespace and fail acquisition typed. It is
+provided outside the complete Object application Layer so its Effect Logger/Tracer/Metric
+configuration and any additional Layer outputs are present in the cached runtime. Every native
+RPC, port call, wake, and alarm
+attempt closes an owner-delivery span, then requests host export through `ctx.waitUntil`. Native
+delivery never awaits export.
+`telemetryFlushTimeout` is a cooperative budget for interruptible exporters, not a hard bound on
+code that masks interruption; Cloudflare owns that remaining background lifetime. The service
+exposes the concrete typed `CloudflareTelemetryExportError`, retaining a foreign exporter cause for
+host diagnostics. Before calling `waitUntil`, a per-incarnation coordinator synchronously reserves
+each delivery into a shared pending, trailing, or queued batch. A batch waits for all deliveries
+reserved into it to settle before exporting, and only its first owner registers the shared
+always-fulfilled background Promise. Cycles remain capped at a first attempt plus one trailing
+attempt, with one queued cycle while trailing runs. This prevents concurrent attempts, per-delivery
+background registrations, and unbounded exporter waiters under a stalled export. Each batch also
+retains at most 64 delivery settlements; excess arrivals are lossy-coalesced into its requested
+export and produce one bounded `reservation_limit` diagnostic for that batch. Expected failures, defects, and
+interruption log only a bounded framework-owned failure classification and remain failed/interrupted
+until the final always-fulfilled `waitUntil` Promise bridge. Foreign exporter causes, arbitrary
+defects, fiber IDs, and caught platform Causes are never passed to the automatic Logger; the typed
+export error retains its cause for explicit host-controlled inspection. Timeout, exporter failure,
+or synchronous `waitUntil` registration failure never changes the original result or alarm
+rejection; registration failure is logged synchronously as `wait_until_registration` before the
+exact delivery Promise is returned, and the unowned exporter continuation is not invoked.
+Native rejection spans are sanitized before the original Cause is restored. The runtime remains
+cached for the Object incarnation; it is not disposed per delivery. Hosts configure one
+native-delivery flush owner and do not duplicate this path with effect-cf or another native
+boundary.
+
+Telemetry remains derivative. No Run Event, canonical record, wire schema, persistence mutation, or
+replay decision changes.
+
+## Rejected alternatives
+
+- **Application executor wrappers:** they cannot reliably own engine Tool identity or terminal
+  value classification and force every downstream application to duplicate framework semantics.
+- **A Sentry- or OTLP-specific platform API:** exporter choice belongs to the host. A one-method
+  flush service is enough for Effect OTLP and vendor adapters.
+- **Payload capture by default:** arguments/results are sensitive and unbounded. The framework
+  ships no implicit capture switch.
+- **Disposing `ManagedRuntime` after each event:** it would tear down storage, PubSub, and exporter
+  scopes that must survive across Object inputs, and Cloudflare exposes no reliable final
+  shutdown callback.
+- **Awaiting a bounded flush in the native delivery Promise:** interruption-masking exporter code
+  defeats the apparent hard bound and can delay RPC completion or suppress an alarm retry signal.
+  `ctx.waitUntil` preserves span-before-flush ordering without making exporter completion part of
+  native delivery.
+- **A semaphore or per-delivery background Promise around each flush:** it bounds exporter
+  concurrency but leaves an unbounded waiter/registration queue under a stalled exporter. Shared
+  pending/trailing/queued batch tickets bound both dimensions.
+
+## Consequences
+
+Downstream applications can remove canonical Tool wrappers and native-RPC flush duplication.
+Operators get searchable Tool identity and bounded outcomes without tenant content. Export no
+longer adds latency to native Cloudflare delivery; a background flush can still be cancelled by
+Object eviction, as expected. In the DC assembly tested with `@effect-agent/storage-cloudflare`,
+durability belongs to canonical state, not observability.
+
+## Validation
+
+- `packages/engine/test/agent-runtime.test.ts` — success, returned failure, thrown typed failure,
+  post-terminal failed-event/trace deferral, span create/close/context defects, single primitive
+  evaluation, composed marker/residual Causes, host-owned handler-span parenting, status,
+  attributes, logging, and all-exported-span content/Cause exclusion.
+- `packages/platform-cloudflare/test/telemetry.test.ts` — every public native edge, span-before-
+  background-flush ordering, non-blocking RPC/alarm exits, concurrent delivery, typed exporter
+  failure, and content-free attributes/events/links.
+- `packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts` — virtual-time proof
+  of the cooperative timeout, uninterruptible-exporter behavior, same-turn/active/trailing/final-
+  settlement coordinator cases, bounded shared waitUntil registration count/identity, bounded
+  Cause-free diagnostics, delayed-start causal completion, and original-plus-residual restoration.

--- a/docs/adr/0018-native-tool-observability.md
+++ b/docs/adr/0018-native-tool-observability.md
@@ -38,8 +38,8 @@ duplicate result overrides an apparent success to failure. At-least-once recover
 attempt with its own telemetry. Framework terminal logs contain only bounded identity/outcome
 fields. No Tool input, output, prompt,
 conversation content, command, source, or failure message is exported.
-Provider/model Tool Call IDs are untrusted and must contain 1–128 ASCII characters matching
-`[A-Za-z0-9][A-Za-z0-9._:-]*`. The engine validates before Turn correlation, canonical event
+Provider/model Tool Call IDs are untrusted and their entire value must match
+`[A-Za-z0-9][A-Za-z0-9._:-]{0,127}`. The engine validates before Turn correlation, canonical event
 emission, or application handler scheduling; rejection is a typed protocol failure. Span/log
 correlation therefore contains only the already-validated identifier.
 The terminal Tool Run event and in-memory trace result are not committed until the handler stream
@@ -75,7 +75,7 @@ correlations, so a malformed duplicate or post-finish part cannot append a provi
 success.
 
 `@effect-agent/platform-cloudflare` exposes a host-owned `CloudflareRuntimeTelemetry` service.
-`CloudflareDurableRuntime.layer` requires it explicitly, and the Worker passes its provider as the
+the `makeConversationObjectClass` native-entrypoint runtime requires it explicitly, and the Worker passes its provider as the
 second `makeConversationObjectClass` argument rather than hiding it in runtime options. The host
 Layer may require the Durable Object context or namespace and fail acquisition typed. It is
 provided outside the complete Object application Layer so its Effect Logger/Tracer/Metric
@@ -93,14 +93,15 @@ always-fulfilled background Promise. Cycles remain capped at a first attempt plu
 attempt, with one queued cycle while trailing runs. This prevents concurrent attempts, per-delivery
 background registrations, and unbounded exporter waiters under a stalled export. Each batch also
 retains at most 64 delivery settlements; excess arrivals are lossy-coalesced into its requested
-export and produce one bounded `reservation_limit` diagnostic for that batch. Expected failures, defects, and
-interruption log only a bounded framework-owned failure classification and remain failed/interrupted
-until the final always-fulfilled `waitUntil` Promise bridge. Foreign exporter causes, arbitrary
-defects, fiber IDs, and caught platform Causes are never passed to the automatic Logger; the typed
-export error retains its cause for explicit host-controlled inspection. Timeout, exporter failure,
-or synchronous `waitUntil` registration failure never changes the original result or alarm
-rejection; registration failure is logged synchronously as `wait_until_registration` before the
-exact delivery Promise is returned, and the unowned exporter continuation is not invoked.
+export and produce one bounded `reservation_limit` diagnostic for that batch. Expected exporter
+failures, defects, and interruption log only a bounded framework-owned failure classification and
+remain failed/interrupted until the final always-fulfilled `waitUntil` Promise bridge. Foreign
+exporter causes, arbitrary defects, and fiber IDs are never passed to the automatic Logger; the
+typed export error retains its cause for explicit host-controlled inspection. Timeout, exporter
+failure, or synchronous `waitUntil` registration failure never changes the original result or alarm
+rejection. Registration failure is logged synchronously with its exact platform Cause and the
+`wait_until_registration` classification before the exact delivery Promise is returned, and the
+unowned exporter continuation is not invoked.
 Native rejection spans are sanitized before the original Cause is restored. The runtime remains
 cached for the Object incarnation; it is not disposed per delivery. Hosts configure one
 native-delivery flush owner and do not duplicate this path with effect-cf or another native

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ The records below reflect explicit owner decisions.
 | [ADR-0009](0009-leaf-example-workspaces.md)                    | Keep runnable consumer benches in leaf example workspaces                                                                                                                  |
 | [ADR-0016](0016-pr-review-package.md)                          | Package the pull-request reviewer with a prebuilt GitHub Action (owner-directed, 2026-08-14)                                                                               |
 | [ADR-0017](0017-code-mode-executor-and-broker.md)              | Code Mode: `CodeExecutor` port in sandbox, engine-owned native Tool broker, one native Tool over an explicit allowlist (owner-directed, 2026-08-14; ephemeral slices only) |
+| [ADR-0018](0018-native-tool-observability.md)                  | Own native Tool telemetry and Cloudflare export lifecycle                                                                                                                  |
 
 ## Accepted by default
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,0 +1,202 @@
+# Observability
+
+Effect Agent emits logical measurements and leaves exporter selection to the host. Tool
+instrumentation belongs to `@effect-agent/engine`; exporter lifecycle at Cloudflare native
+delivery boundaries belongs to `@effect-agent/platform-cloudflare`. Neither package depends on
+Sentry or another telemetry vendor.
+
+## Tool execution
+
+Each in-memory application-handler attempt creates one canonical internal OpenTelemetry span:
+
+```text
+execute_tool <tool-name>
+```
+
+The span covers `ToolCallStarted` through settlement of the handler result stream. The complete
+application-handler attempt lifecycle set is success, failure, interruption, and nonterminal
+waiting. Success, failure, and interruption terminate that in-memory attempt; waiting may remain
+unresolved indefinitely. Denied and provider-executed calls are call-level classifications only
+and never create an application-handler attempt. Success/failure attempts emit one bounded outcome only after that
+stream settles: a Tool failure returned as a value (`failureMode: "return"`) closes the span with a
+failed status just like a failure in the Effect error channel, while an error or duplicate result
+after an apparent terminal success overrides the span/log outcome to failure. Interrupted attempts
+emit no terminal outcome log. Recovery is
+at-least-once and can create another attempt—and therefore another span—without changing the
+canonical event stream.
+The terminal Run event and Turn trace result remain provisional until the handler stream settles;
+a failure after a provisional terminal value therefore commits one `ToolCallFailed`, never
+`ToolCallSucceeded`, before its original Cause propagates.
+Exporter-visible failure detail is one fresh bounded framework marker object per handler attempt.
+Only that exact identity is recognized, so an independently constructed same-class handler failure
+is ordinary Tool failure. The original typed error, defect, or interruption is restored unchanged
+after the span closes.
+Effect AI's Toolkit implementation annotations land on a manually constructed, non-exported local
+span whose parent is the canonical Tool span. The local span carries
+`Tracer.DisablePropagation=true`, so explicit host-owned spans created by the Tool handler filter
+past it and export as children of `execute_tool`; tracing remains enabled for application code.
+There is no exported `AgentRuntime.toolkit.handle` span, and Toolkit parameters cannot contaminate
+the canonical span.
+
+| Attribute                           | Meaning                                              |
+| ----------------------------------- | ---------------------------------------------------- |
+| `gen_ai.operation.name`             | Always `execute_tool`                                |
+| `gen_ai.tool.name`                  | Effect AI Tool name                                  |
+| `gen_ai.tool.type`                  | Always `function`                                    |
+| `gen_ai.tool.call.id`               | Validated provider/runtime Tool Call correlation     |
+| `gen_ai.agent.name`                 | Agent Definition ID                                  |
+| `gen_ai.conversation.id`            | Framework-owned conversation/session correlation     |
+| `effect_agent.tool.execution_class` | `readonly`, `idempotent`, or fail-closed `uncertain` |
+| `effect_agent.tool.outcome`         | Bounded terminal `success` or `failure`              |
+| `agentId`, `conversationId`         | Backward-compatible Agent/conversation correlation   |
+| `runId`, `turnId`                   | Framework Run/Turn correlation                       |
+| `toolCallId`, `toolName`            | Backward-compatible validated/name correlation       |
+
+Provider/model Tool Call IDs are untrusted input. The engine accepts only 1–128 ASCII characters
+matching `[A-Za-z0-9][A-Za-z0-9._:-]*` and validates before Turn correlation, canonical event
+emission, or handler scheduling. An invalid ID fails the Run with a typed `ModelProtocolError` and
+never invokes the Tool. The semantic and compatibility telemetry fields therefore contain the same
+already-validated identifier used by the framework.
+
+This follows OpenTelemetry's
+[`gen_ai.conversation.id` guidance](https://github.com/open-telemetry/semantic-conventions-genai/blob/30182acd5ed78ab5f619041eaec5e95a4eb83a48/docs/registry/attributes/gen-ai.md):
+use a readily available conversation identifier and never synthesize one from trace IDs, hashes,
+or request content.
+
+Successful attempts emit one info log (`agent tool execution completed`); failed attempts emit one
+warning (`agent tool execution failed`). Both carry the same bounded identity, execution-class,
+and outcome fields. The existing start log remains debug-only. Provider-executed Tools have no
+application handler and therefore do not produce this span or these logs.
+If a handler stream fails after producing a provisional terminal value, the engine emits one
+`ToolCallFailed`, never `ToolCallSucceeded`, before preserving the original handler Cause for the
+batch failure.
+If a host Logger or Tracer defects while creating, annotating, or closing the canonical span or
+emitting its terminal log, the engine reports that telemetry Cause through Effect's
+`ErrorReporter` boundary and preserves the Tool event and exit. Span creation falls back to a
+non-exported local span; span-close failure never reruns a handler that already completed.
+A defective reporter is isolated as well: observability cannot make a completed side effect appear
+eligible for recovery. The terminal Run event and Turn trace result are committed and emitted
+before terminal telemetry runs. External interruption is never recovered by this derivative
+boundary, but it therefore cannot erase completed Tool state; only non-interrupt telemetry Causes
+are reported and suppressed. Internally, an emission boundary returns the singleton terminal event
+from its first pull, then starts telemetry from the next pull or structured stream finalization if
+the owner closes after that event. A synchronous phase gate gives the action one owner and never
+retries an in-flight interrupted attempt. Once the terminal outcome annotation exists, it remains
+authoritative for canonical span status over downstream cancellation or telemetry interruption.
+The authority is module-private identity state, not the mutable public outcome attribute.
+`AgentRuntime.stream` builds this isolation policy once at its composition boundary as an internal
+`ToolSpanTelemetry` capability derived from the host's ambient Tracer. Tool execution consumes that
+capability; it does not select, decorate, or locally provide a Tracer implementation. Each
+execution of a reusable Tool stream gets its own local tracer-isolation/defect state, and a Toolkit
+effect invoked without a current span simply runs unchanged with its typed error channel intact.
+
+Tool parameters, results, prompts, source code, commands, conversation content, and failure
+messages are never attached to these spans or logs. There is no implicit content-capture mode.
+Applications that deliberately add content telemetry own its classification, redaction,
+authorization, and retention policy.
+
+## Cloudflare exporter lifecycle
+
+`makeConversationObjectClass` caches one `ManagedRuntime` per Durable Object incarnation. Supply
+the host telemetry Layer as its second argument:
+
+```ts
+import {
+  CloudflareRuntimeTelemetry,
+  makeConversationObjectClass,
+} from "@effect-agent/platform-cloudflare";
+import { Effect, Layer } from "effect";
+import { OtlpExporter } from "effect/unstable/observability";
+
+declare const HostObservability: Layer.Layer<OtlpExporter.Flusher>;
+
+const Telemetry = Layer.effect(
+  CloudflareRuntimeTelemetry,
+  Effect.map(OtlpExporter.Flusher, ({ flush }) => CloudflareRuntimeTelemetry.of({ flush })),
+).pipe(Layer.provideMerge(HostObservability));
+
+export class ConversationObject extends makeConversationObjectClass(
+  {
+    namespaceBinding: "CONVERSATIONS",
+    deploymentId: "production",
+    producerPrefix: "conversation",
+    telemetryFlushTimeout: 2_000,
+  },
+  Telemetry,
+) {}
+```
+
+`HostObservability` is where the application installs its Effect Logger, Tracer, Metric, and
+exporter layers. `OtlpExporter.Flusher` is one implementation; any vendor or custom exporter can
+provide the same content-free `CloudflareRuntimeTelemetry` service. The Layer may require
+`DurableObjectContext` or `ConversationObjectNamespace` to derive configuration from the Object
+environment, may provide additional services alongside the required telemetry capability, and a
+typed acquisition failure remains part of constructor-gate failure. Those additional outputs and
+defaulted Effect Logger/Tracer/Metric overrides remain present in the cached `ManagedRuntime`.
+Omitting
+the second argument installs `CloudflareRuntimeTelemetry.layerNoop` at this Worker composition
+edge. `CloudflareDurableRuntime.layer` itself requires the telemetry service explicitly; it does
+not choose or hide a provider in runtime options.
+
+`flush` has the typed error channel `CloudflareTelemetryExportError`. A custom adapter maps its
+foreign exporter failure with `CloudflareTelemetryExportError.make({ cause })`, retaining the
+original value for host diagnostics without placing it on entrypoint spans or changing delivery
+results.
+
+Every native encoded RPC, cross-Object port call, wake, and alarm attempt gets one owner-side server
+span. The native RPC/alarm Promise never awaits export. Before `ctx.waitUntil`, one per-incarnation
+coordinator synchronously reserves the delivery into a shared pending, trailing, or queued batch.
+Each batch retains at most 64 delivery settlement Promises, waits for those retained deliveries to
+settle, and only its first owner registers its shared always-fulfilled background Promise. Further
+arrivals are lossy-coalesced into the requested export without retaining their Promise and produce
+one bounded `reservation_limit` diagnostic per capped batch. Cycles remain capped at a first
+attempt plus one trailing attempt; deliveries arriving while that trailing attempt runs share one
+queued cycle. There is at most one active exporter, one coalesced trailing batch, and one queued
+cycle—never concurrent export attempts, per-delivery background registrations, or unbounded
+delivery retention. `telemetryFlushTimeout` is a cooperative budget:
+effect-agent interrupts an interruptible exporter when the budget expires, but does not claim a
+hard deadline for exporter code that masks interruption. Cloudflare owns that remaining background
+lifetime and may cancel it when the Object is evicted.
+
+Expected exporter failure, timeout, defect, interruption, and `waitUntil` registration diagnostics
+contain only a framework-owned `effect_agent.cloudflare.telemetry.failure_kind` classification.
+Foreign exporter causes, arbitrary defects, fiber IDs, and caught platform causes are never passed
+to the configured Logger. `CloudflareTelemetryExportError.cause` remains available only when the
+host explicitly inspects the typed failure at its own diagnostic boundary. Failures stay rejected
+through the coordinator. Only the final always-fulfilled
+`waitUntil` Promise bridge isolates background telemetry failure from the original RPC result or
+alarm retry signal. Budget expiry logs a bounded warning and remains a typed `TimeoutError` through
+the same boundary. None of these diagnostics is attached to the already-closed native span. Native rejection spans likewise receive only a bounded failure
+marker before the original Cause is restored. The cached runtime is not disposed per event:
+Durable Objects have no guaranteed shutdown callback, and storage/runtime/exporter scopes must
+remain available for later events in the same incarnation.
+
+A synchronous `ctx.waitUntil` registration failure is also derivative: effect-agent emits only the
+bounded `wait_until_registration` classification, cancels that unowned batch ticket, then returns
+the already-running native delivery Promise unchanged rather than creating an uncertain RPC
+outcome. The caught platform Cause is not made available to the automatic Logger. The registration
+failure means Cloudflare has not accepted ownership of that background work, so the gated exporter is not invoked. The diagnostic uses the
+already-built runtime's synchronous Logger contract; logger defects are captured without starting a
+fiber. Even a broken diagnostic sink does not change the delivery result or alarm retry signal.
+
+There must be one native-delivery flush owner. If an effect-cf or host native-entry integration already
+flushes the same exporter, either disable that integration's delivery flush and provide it via
+`CloudflareRuntimeTelemetry`, or keep the existing owner and provide the Effect observability Layer
+merged with `CloudflareRuntimeTelemetry.layerNoop`. Do not install both delivery flush paths.
+
+## Migrating an application wrapper
+
+Applications upgrading from `@effect-agent/*` `0.0.1-beta.5` can remove loopback executor
+wrappers that duplicate `execute_tool` names, execution classes, or outcomes after upgrading the
+engine. Cloudflare applications can also remove per-RPC manual exporter flushes after choosing the
+single lifecycle owner described above. Keep application-specific scope fields on a parent span or
+as ambient log annotations if they are still useful.
+
+If an application adopted an earlier preview of this API, move `telemetry: Telemetry` out of
+`CloudflareDurableRuntimeOptions` and pass the same Layer as the second
+`makeConversationObjectClass(options, Telemetry)` argument. Acquisition requirements and typed
+errors then remain visible at the Worker composition boundary.
+
+Verify the migration by searching for `gen_ai.operation.name=execute_tool`, checking both bounded
+outcomes, and forcing one failed alarm delivery. The downstream emergency bridge that motivated
+this API is [Kommunikasie PR #353](https://github.com/reve-ai/kommunikasie/pull/353).

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -52,8 +52,8 @@ the canonical span.
 | `runId`, `turnId`                   | Framework Run/Turn correlation                       |
 | `toolCallId`, `toolName`            | Backward-compatible validated/name correlation       |
 
-Provider/model Tool Call IDs are untrusted input. The engine accepts only 1–128 ASCII characters
-matching `[A-Za-z0-9][A-Za-z0-9._:-]*` and validates before Turn correlation, canonical event
+Provider/model Tool Call IDs are untrusted input. The engine accepts only values whose entire string
+matches `[A-Za-z0-9][A-Za-z0-9._:-]{0,127}` and validates before Turn correlation, canonical event
 emission, or handler scheduling. An invalid ID fails the Run with a typed `ModelProtocolError` and
 never invokes the Tool. The semantic and compatibility telemetry fields therefore contain the same
 already-validated identifier used by the framework.
@@ -133,10 +133,10 @@ provide the same content-free `CloudflareRuntimeTelemetry` service. The Layer ma
 environment, may provide additional services alongside the required telemetry capability, and a
 typed acquisition failure remains part of constructor-gate failure. Those additional outputs and
 defaulted Effect Logger/Tracer/Metric overrides remain present in the cached `ManagedRuntime`.
-Omitting
-the second argument installs `CloudflareRuntimeTelemetry.layerNoop` at this Worker composition
-edge. `CloudflareDurableRuntime.layer` itself requires the telemetry service explicitly; it does
-not choose or hide a provider in runtime options.
+Omitting the second argument installs `CloudflareRuntimeTelemetry.layerNoop` at this Worker
+composition edge. `CloudflareDurableRuntime.layer` owns only durable runtime services; native
+entrypoint instrumentation consumes telemetry in `makeConversationObjectClass`, which preserves
+the host Layer's telemetry and additional outputs without choosing or hiding a provider.
 
 `flush` has the typed error channel `CloudflareTelemetryExportError`. A custom adapter maps its
 foreign exporter failure with `CloudflareTelemetryExportError.make({ cause })`, retaining the
@@ -158,11 +158,11 @@ effect-agent interrupts an interruptible exporter when the budget expires, but d
 hard deadline for exporter code that masks interruption. Cloudflare owns that remaining background
 lifetime and may cancel it when the Object is evicted.
 
-Expected exporter failure, timeout, defect, interruption, and `waitUntil` registration diagnostics
-contain only a framework-owned `effect_agent.cloudflare.telemetry.failure_kind` classification.
-Foreign exporter causes, arbitrary defects, fiber IDs, and caught platform causes are never passed
-to the configured Logger. `CloudflareTelemetryExportError.cause` remains available only when the
-host explicitly inspects the typed failure at its own diagnostic boundary. Failures stay rejected
+Expected exporter failure, timeout, defect, and interruption diagnostics contain only a
+framework-owned `effect_agent.cloudflare.telemetry.failure_kind` classification. Foreign exporter
+causes, arbitrary defects, and fiber IDs are never passed to the configured Logger.
+`CloudflareTelemetryExportError.cause` remains available only when the host explicitly inspects the
+typed failure at its own diagnostic boundary. Failures stay rejected
 through the coordinator. Only the final always-fulfilled
 `waitUntil` Promise bridge isolates background telemetry failure from the original RPC result or
 alarm retry signal. Budget expiry logs a bounded warning and remains a typed `TimeoutError` through
@@ -171,11 +171,11 @@ marker before the original Cause is restored. The cached runtime is not disposed
 Durable Objects have no guaranteed shutdown callback, and storage/runtime/exporter scopes must
 remain available for later events in the same incarnation.
 
-A synchronous `ctx.waitUntil` registration failure is also derivative: effect-agent emits only the
-bounded `wait_until_registration` classification, cancels that unowned batch ticket, then returns
-the already-running native delivery Promise unchanged rather than creating an uncertain RPC
-outcome. The caught platform Cause is not made available to the automatic Logger. The registration
-failure means Cloudflare has not accepted ownership of that background work, so the gated exporter is not invoked. The diagnostic uses the
+A synchronous `ctx.waitUntil` registration failure is also derivative: effect-agent emits the
+bounded `wait_until_registration` classification with the exact platform Cause as a structured
+Logger Cause, cancels that unowned batch ticket, then returns the already-running native delivery
+Promise unchanged rather than creating an uncertain RPC outcome. The registration failure means
+Cloudflare has not accepted ownership of that background work, so the gated exporter is not invoked. The diagnostic uses the
 already-built runtime's synchronous Logger contract; logger defects are captured without starting a
 fiber. Even a broken diagnostic sink does not change the delivery result or alarm retry signal.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -171,13 +171,14 @@ marker before the original Cause is restored. The cached runtime is not disposed
 Durable Objects have no guaranteed shutdown callback, and storage/runtime/exporter scopes must
 remain available for later events in the same incarnation.
 
-A synchronous `ctx.waitUntil` registration failure is also derivative: effect-agent emits the
-bounded `wait_until_registration` classification with the exact platform Cause as a structured
-Logger Cause, cancels that unowned batch ticket, then returns the already-running native delivery
-Promise unchanged rather than creating an uncertain RPC outcome. The registration failure means
-Cloudflare has not accepted ownership of that background work, so the gated exporter is not invoked. The diagnostic uses the
-already-built runtime's synchronous Logger contract; logger defects are captured without starting a
-fiber. Even a broken diagnostic sink does not change the delivery result or alarm retry signal.
+A synchronous `ctx.waitUntil` registration failure is also derivative: effect-agent emits only the
+bounded `wait_until_registration` classification, cancels that unowned batch ticket, then returns
+the already-running native delivery Promise unchanged rather than creating an uncertain RPC
+outcome. The arbitrary platform Cause is not sent to the configured Logger. The registration
+failure means Cloudflare has not accepted ownership of that background work, so the gated exporter
+is not invoked. The diagnostic uses the already-built runtime's synchronous Logger contract; logger
+defects are captured without starting a fiber. Even a broken diagnostic sink does not change the
+delivery result or alarm retry signal.
 
 There must be one native-delivery flush owner. If an effect-cf or host native-entry integration already
 flushes the same exporter, either disable that integration's delivery flush and provide it via

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -111,7 +111,14 @@ committed alarm), the alarm/RPC wake scheduler, the Durable Object RPC port tran
 and the typed admission-limits gate before `submit`), and the Worker-side
 `CloudflareConversationClient`. `CloudflareBindingSource` may capture registered worker Bindings
 from `CloudflareBindingSourceContext` once per Object incarnation, after identity derivation. It
-is a Layer-assembly library, not an application entrypoint.
+also exposes `CloudflareRuntimeTelemetry`: hosts install vendor-neutral Effect observability in the
+cached Object runtime and provide a flush Effect. Every native RPC, wake, and alarm reserves a
+post-settlement export batch; only the first owner registers that batch's shared Promise with
+`ctx.waitUntil`. Native delivery does not await export; the configured timeout is
+a cooperative budget for interruptible exporters, while Cloudflare owns the background lifetime.
+`CloudflareTelemetryExportError` retains a custom exporter's foreign failure in the typed channel
+while the native boundary prevents it from masking delivery. It is a Layer-assembly library, not
+an application entrypoint.
 
 ### `@effect-agent/pr-review`
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -128,6 +128,19 @@ Configuration families include:
 - retention;
 - feature flags and compatibility gates.
 
+`CloudflareDurableRuntime.layer` explicitly requires `CloudflareRuntimeTelemetry`. A Worker supplies
+the host Layer as the second `makeConversationObjectClass(options, telemetry)` argument; that outer
+Layer may install Effect Logger, Tracer, Metric, and exporter services, require
+`DurableObjectContext` or `ConversationObjectNamespace`, and fail acquisition typed. The factory
+is generic over any additional services that merged host Layer provides and retains those outputs
+in the cached runtime. Its existing first explicit generic remains the telemetry acquisition error;
+additional output inference is appended for source compatibility. The factory selects
+`CloudflareRuntimeTelemetry.layerNoop` only when that second argument is omitted. The
+framework selects no vendor and runtime options do not hide a provider. `flush` fails with
+`CloudflareTelemetryExportError`, which retains a foreign exporter cause for host diagnostics.
+`telemetryFlushTimeout` is schema-validated and positive; it is a cooperative background budget
+for interruptible exporters, not a hard deadline for code that masks interruption.
+
 Secrets are resolved through a secret provider and wrapped as redacted values.
 Startup diagnostics may list missing secret names but never values.
 
@@ -254,6 +267,44 @@ identities are derived and receives the live `DurableObjectState`, raw Worker en
 resources such as Worker service bindings; database clients and other request-scoped resources
 remain outside the cached Durable Object runtime.
 
+Every native Conversation Object RPC, cross-Object port call, wake, and alarm attempt is measured
+at the owner delivery boundary. The entry span closes before the host-provided telemetry flush
+runs. The native RPC/alarm Promise never awaits export. Before `ctx.waitUntil`, a per-incarnation
+coordinator synchronously reserves each delivery into a shared batch. Same-turn deliveries share
+the pending first batch; deliveries received during its export share one trailing batch; deliveries
+received while trailing runs share one separate queued cycle. A batch retains at most 64 delivery
+settlement Promises, waits for those retained deliveries to settle, and only its first owner
+registers the shared always-fulfilled background Promise. Further arrivals are lossy-coalesced into
+the requested export without retaining their Promise and produce one bounded `reservation_limit`
+diagnostic per capped batch. This preserves the first/trailing/queued cap while preventing
+concurrent exporters, per-delivery `waitUntil` registrations, and unbounded delivery retention. A typed failure, defect,
+or cooperative timeout never replaces the original delivery result. This ordering applies on
+success and failure, so a failed alarm remains rejected for workerd redelivery while export
+continues in the background. An exporter that masks interruption can outlive
+`telemetryFlushTimeout` until Cloudflare cancels the `waitUntil` work; it still cannot hold delivery
+open or create concurrent exporter attempts. A synchronous `waitUntil` registration failure logs
+only a framework-owned `wait_until_registration` classification through the already-built runtime's
+synchronous Logger contract, cancels the unowned batch without invoking its exporter, and returns the
+already-running delivery Promise unchanged; failure of that derivative diagnostic sink is isolated
+too. The caught platform Cause is never passed to the automatic Logger.
+
+Expected export failure, timeout, defect, and interruption logs carry only the bounded
+`effect_agent.cloudflare.telemetry.failure_kind` classification. Foreign exporter causes, arbitrary
+defects, fiber IDs, and platform Causes are not automatically logged. A
+`CloudflareTelemetryExportError` still retains its foreign cause for explicit host-controlled
+inspection. The coordinator preserves both failures from each capped two-attempt cycle. Only the
+final always-fulfilled `waitUntil` Promise bridge consumes that rejection so it cannot alter native
+delivery or become an unhandled background Promise. Cooperative budget expiry follows the same
+path as a logged typed `TimeoutError`.
+
+The host configures one native-delivery flush owner. When effect-cf or another native-entry adapter
+already owns the same exporter flush, either disable that path and provide the exporter through
+`CloudflareRuntimeTelemetry`, or retain it and merge host observability with
+`CloudflareRuntimeTelemetry.layerNoop`. Installing both would duplicate export attempts. The cached
+`ManagedRuntime` is not disposed per delivery. Cloudflare provides no guaranteed Object shutdown
+callback, so background delivery-triggered coalesced flushing—not graceful finalization—is the
+export reliability boundary.
+
 Durable Object storage is the only correctness-critical store for that Conversation. In-memory
 object state is a cache because objects may stop unexpectedly. Alarm work is idempotent because
 alarms execute at least once.
@@ -264,8 +315,9 @@ eviction (per-failpoint `ctx.abort()` with alarm-only convergence), alarm-retry 
 and throw-retry), runtime-restart (Miniflare dispose/reopen over persisted storage), and
 fault-injection (failpoints on every durable mutation plus routed-transport faults) scenarios
 are implemented and green ([Phase 6 evidence](../PHASE-6-EVIDENCE.md)). The tested harness is
-workerd/Miniflare; the hosted production service, its observability adapters, and live soak
-remain explicitly unclaimed — Phase 7 completed the roadmap without hosted-platform evidence
+workerd/Miniflare; the hosted production service and live soak remain explicitly unclaimed. The
+vendor-neutral observability Layer and native lifecycle are covered in workerd, but no hosted
+exporter certification is claimed — Phase 7 completed the roadmap without hosted-platform evidence
 ([Phase 7 evidence](../PHASE-7-EVIDENCE.md)), and hosted-service operation stays outside the
 roadmap's claims until open-source preparation revisits it.
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -128,9 +128,10 @@ Configuration families include:
 - retention;
 - feature flags and compatibility gates.
 
-`CloudflareDurableRuntime.layer` explicitly requires `CloudflareRuntimeTelemetry`. A Worker supplies
-the host Layer as the second `makeConversationObjectClass(options, telemetry)` argument; that outer
-Layer may install Effect Logger, Tracer, Metric, and exporter services, require
+Native entrypoint instrumentation in `makeConversationObjectClass` explicitly requires
+`CloudflareRuntimeTelemetry`; `CloudflareDurableRuntime.layer` itself owns only the durable runtime
+assembly. A Worker supplies the host Layer as the second
+`makeConversationObjectClass(options, telemetry)` argument; that outer Layer may install Effect Logger, Tracer, Metric, and exporter services, require
 `DurableObjectContext` or `ConversationObjectNamespace`, and fail acquisition typed. The factory
 is generic over any additional services that merged host Layer provides and retains those outputs
 in the cached runtime. Its existing first explicit generic remains the telemetry acquisition error;
@@ -283,10 +284,10 @@ success and failure, so a failed alarm remains rejected for workerd redelivery w
 continues in the background. An exporter that masks interruption can outlive
 `telemetryFlushTimeout` until Cloudflare cancels the `waitUntil` work; it still cannot hold delivery
 open or create concurrent exporter attempts. A synchronous `waitUntil` registration failure logs
-only a framework-owned `wait_until_registration` classification through the already-built runtime's
-synchronous Logger contract, cancels the unowned batch without invoking its exporter, and returns the
-already-running delivery Promise unchanged; failure of that derivative diagnostic sink is isolated
-too. The caught platform Cause is never passed to the automatic Logger.
+the framework-owned `wait_until_registration` classification and the exact platform Cause through
+the already-built runtime's synchronous Logger contract, cancels the unowned batch without invoking
+its exporter, and returns the already-running delivery Promise unchanged; failure of that derivative
+diagnostic sink is isolated too.
 
 Expected export failure, timeout, defect, and interruption logs carry only the bounded
 `effect_agent.cloudflare.telemetry.failure_kind` classification. Foreign exporter causes, arbitrary

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -284,10 +284,10 @@ success and failure, so a failed alarm remains rejected for workerd redelivery w
 continues in the background. An exporter that masks interruption can outlive
 `telemetryFlushTimeout` until Cloudflare cancels the `waitUntil` work; it still cannot hold delivery
 open or create concurrent exporter attempts. A synchronous `waitUntil` registration failure logs
-the framework-owned `wait_until_registration` classification and the exact platform Cause through
-the already-built runtime's synchronous Logger contract, cancels the unowned batch without invoking
-its exporter, and returns the already-running delivery Promise unchanged; failure of that derivative
-diagnostic sink is isolated too.
+only the framework-owned `wait_until_registration` classification through the already-built
+runtime's synchronous Logger contract. Its arbitrary platform Cause is not logged. The boundary
+cancels the unowned batch without invoking its exporter and returns the already-running delivery
+Promise unchanged; failure of that derivative diagnostic sink is isolated too.
 
 Expected export failure, timeout, defect, and interruption logs carry only the bounded
 `effect_agent.cloudflare.telemetry.failure_kind` classification. Foreign exporter causes, arbitrary

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -157,8 +157,9 @@ ID, Agent Definition ID, declared execution class, and framework Run/Turn correl
 in-memory handler attempt classified as success or failure, one terminal annotation/log is emitted
 only after the handler stream is known complete. The framework-owned Conversation ID is recorded
 as both `gen_ai.conversation.id` and backward-compatible `conversationId`; no conversation
-identifier is synthesized from content. Provider/model Tool Call IDs are accepted only when they
-contain 1–128 ASCII characters matching `[A-Za-z0-9][A-Za-z0-9._:-]*`. Validation occurs before a
+identifier is synthesized from content. Provider/model Tool Call IDs are accepted only when their
+entire string matches `[A-Za-z0-9][A-Za-z0-9._:-]{0,127}`. The same bounded full-string grammar
+applies to response-part lifecycle, source, response, and approval identifiers. Validation occurs before a
 model-supplied ID enters Turn correlation, a canonical Run event, or application handler
 scheduling; rejection is a typed `ModelProtocolError`. Consequently `gen_ai.tool.call.id` and the
 compatibility `toolCallId` carry only an already-validated identifier.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -122,15 +122,89 @@ The default is bounded parallel execution owned by the engine.
 
 ### Completion
 
-Every started call reaches exactly one in-memory terminal classification:
+When a declared Tool Call settles, its call-level terminal classification is:
 
 - success;
+- failure returned as a terminal Tool value;
 - typed failure in the Effect error channel;
 - infrastructure failure;
 - denied;
 - interrupted.
 
-The durable runtime adds unknown outcome.
+The DN and DC assemblies add unknown outcome. Approval suspension and unresolved Tool Calls are
+nonterminal and may remain unresolved indefinitely; the runtime does not replay an ordinary
+unresolved call merely to force settlement. Denial happens during preflight, before any application
+Handler starts. Provider-executed calls likewise have no application-handler attempt.
+
+An in-memory application-handler attempt therefore starts only for a native call that passed
+preflight. Its complete lifecycle classification set is:
+
+- success — terminal;
+- failure — terminal, including returned failures, typed or infrastructure Causes, and
+  post-terminal anomalies;
+- interruption — terminal for that in-memory attempt and preserved as interruption;
+- waiting — nonterminal and potentially indefinite.
+
+Only success and failure receive a bounded terminal telemetry outcome. Interruption produces no
+terminal outcome log. Denied and provider-executed calls remain solely call-level classifications:
+neither creates an application-handler attempt.
+
+### Observability
+
+The application-handler lifecycle owns one canonical internal span named
+`execute_tool {gen_ai.tool.name}`. It carries the stable GenAI operation, Tool name/type, Tool Call
+ID, Agent Definition ID, declared execution class, and framework Run/Turn correlation. For an
+in-memory handler attempt classified as success or failure, one terminal annotation/log is emitted
+only after the handler stream is known complete. The framework-owned Conversation ID is recorded
+as both `gen_ai.conversation.id` and backward-compatible `conversationId`; no conversation
+identifier is synthesized from content. Provider/model Tool Call IDs are accepted only when they
+contain 1–128 ASCII characters matching `[A-Za-z0-9][A-Za-z0-9._:-]*`. Validation occurs before a
+model-supplied ID enters Turn correlation, a canonical Run event, or application handler
+scheduling; rejection is a typed `ModelProtocolError`. Consequently `gen_ai.tool.call.id` and the
+compatibility `toolCallId` carry only an already-validated identifier.
+Recovery is at-least-once and may start another attempt with its own telemetry. A failure returned
+as a value closes the span failed even though it does not fail the public Effect; an error, waiting
+signal, or duplicate result after an apparent terminal result overrides the telemetry outcome to
+failure and preserves the original Cause/protocol error.
+The terminal Tool Run event and `applicationToolResults`/final-result trace commit occur only after
+the handler stream settles and before derivative terminal telemetry. A handler anomaly after a
+provisional terminal value commits one `ToolCallFailed`, never the provisional success or trace
+result, while preserving the original Cause. Telemetry interruption cannot erase completed Tool
+state. An internal emission boundary returns the singleton terminal event from the first pull,
+then gives derivative telemetry to either the next pull or structured stream finalization when
+downstream closes after that event. A synchronous phase gate allows one telemetry attempt and
+never retries an in-flight interrupted action. Once the terminal outcome annotation exists, it is
+authoritative for canonical span status even if downstream cancellation or telemetry interruption
+determines the enclosing channel Exit. That status is held in module-private identity-authenticated
+state; the public mutable `effect_agent.tool.outcome` attribute remains observation only and cannot
+control span closure. Immediately before delegate export, the wrapper restores that attribute from
+the authenticated private terminal state so the emitted classification cannot remain tampered.
+Waiting before any terminal result remains nonterminal and is not mislabeled as either outcome.
+Provider-executed Tools do not run an application handler and do not create this span.
+Failed spans see one fresh bounded framework marker object per handler attempt and recognize only
+that exact identity, so a same-class handler failure cannot enter the control path. The original
+handler Cause is restored outside the span without changing the public `E`. Effect AI's parameter annotations land on a manually
+constructed non-exported span parented by the canonical span. With
+`Tracer.DisablePropagation=true`, explicit host-owned handler spans filter past the local span and
+remain enabled as canonical-span children; no second framework handler span is exported and no
+Toolkit parameter can reach a framework-exported span.
+
+One bounded terminal log per success/failure in-memory handler attempt is emitted at info for
+success or warning for failure. Interrupted attempts emit neither. Tool parameters, results,
+prompts, source code, commands, conversation content, and
+failure messages are absent from the span and logs. High-cardinality correlation stays out of
+metric labels. Telemetry is a derivative signal: it never changes canonical events, scheduling,
+settlement, or replay. A Logger/Tracer defect anywhere in canonical span creation, annotation,
+terminal logging, or closure is forwarded to Effect's owned `ErrorReporter` boundary without
+changing the Tool event or exit. Creation falls back to a non-exported local span, closure cannot
+rerun a completed handler, and a defective reporter is isolated too. External interruption remains
+interruption; the derivative boundary reports every typed failure or defect it owns and suppresses
+those only after reporting.
+The Run composition boundary derives the internal Tool span-lifecycle capability from the host's
+ambient Tracer; Tool execution consumes that capability without selecting or providing a Tracer.
+Each reusable Tool stream materialization receives independent isolation state and defect
+reporting. If Toolkit handling runs without an ambient current span, it runs unchanged and keeps
+its typed error channel rather than manufacturing an untyped tracing precondition.
 
 ### Provider-executed Tools
 
@@ -140,6 +214,30 @@ events with that provenance, but no `ToolCallStarted` event. These calls still c
 and Turn budgets. When another Turn is required, provider results remain assistant content rather
 than becoming application Tool output messages. Their authorization, recovery, and source-trust
 limits belong to the explicit provider capability that enabled them.
+
+Provider progress/terminal events and `TurnCompleted` are staged until the complete streamed model
+Turn has validated every call/result correlation and rejected any post-finish content. A duplicate,
+mismatched, missing, or otherwise malformed terminal result therefore emits no append-only
+`ToolCallSucceeded` event from that response. Declarations may already be visible because they are
+the correlation inputs being validated; staged terminal facts become visible together only after
+the response is known complete. Staging retains payloads rather than pre-stamped Run events: the
+runtime assigns sequence and timestamp only when each validated event is actually emitted. Live
+text or reasoning deltas that were emitted while provider results remained provisional therefore
+precede those result events in the canonical stream, and the Run sequence remains monotonic in
+append order. The complete staged event suffix is emitted before usage accounting, official-history
+advancement, input draining, settlement/continuation, or response-persistence mutations begin.
+
+Because provider output is untrusted, one Turn may stage at most 256 provider events total across
+progress, terminal results, and Turn completion, and at most 1,048,576 UTF-8 bytes across all of
+their event payloads, with at most 128 nested JSON levels. The runtime normalizes each retained
+event once into an owned, frozen, plain-JSON snapshot while counting the exact bytes of that same
+snapshot only to the remaining budget; it never materializes the whole untrusted payload as a
+serialized string merely to reject it. Accessor-backed values, `toJSON` hooks, non-plain
+prototypes, reflection failures, cycles, and excessive nesting fail closed rather than being
+evaluated again at a later serialization boundary. Any bound or normalization failure is checked
+before retaining the next payload and fails the response with a typed
+`ModelProtocolError`; none of that response's staged progress, terminal, or Turn-completion events
+are emitted.
 
 A response containing only provider-executed calls may finish with `stop` and final text in the
 same Turn, because no application Handler remains unresolved. A response containing any

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -261,9 +261,9 @@ host's ambient Tracer; Tool execution does not replace the Tracer service locall
 Cloudflare exporter diagnostics export only bounded framework classifications. Retained foreign
 exporter causes, arbitrary defects, and fiber IDs are never passed to the configured Logger; raw
 exporter cause inspection is an explicit host decision at the typed error boundary. A synchronous
-`waitUntil` registration rejection is an irreducible platform lifecycle failure, so its exact Cause
-is passed structurally to the host Logger together with the bounded
-`wait_until_registration` classification; effect-agent adds no request or conversation content.
+`waitUntil` registration rejection is an irreducible platform lifecycle failure, but automatic
+diagnostics still emit only the bounded `wait_until_registration` classification. Its arbitrary
+foreign Cause is never passed to the configured Logger by default.
 
 Minimum operational alerts:
 

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -222,6 +222,47 @@ The OpenTelemetry surface includes:
 
 High-cardinality IDs belong in traces/logs, not unrestricted metric labels.
 
+Framework-owned Tool telemetry is content-free by default. It records bounded identity,
+execution class, and terminal outcome fields, but never Tool parameters/results, prompts, source
+code, commands, conversation content, or failure messages. Successful terminal Tool logs are
+info, failures are warning, and start logs remain debug-only. Any application-added content
+capture is an explicit host policy and must classify and structurally redact content before
+export. Failed framework spans expose a bounded failure marker to exporters and restore the
+original typed error, defect, or interruption only outside the measured boundary. Effect AI
+Toolkit annotations land on a manually constructed non-exported span whose
+`Tracer.DisablePropagation=true` parent chain leads to the canonical span. Parameters cannot
+escape through a second framework measurement or contaminate the canonical span, while explicit
+host-owned handler spans remain enabled and filter past the local span. Applications own the
+classification/redaction of telemetry they add deliberately.
+The application-handler attempt lifecycle is success, failure, interruption, or nonterminal
+waiting; denied and provider-executed calls are call-level only and create no handler attempt.
+Framework-owned `conversationId` is identity metadata rather than conversation content and is
+exported as `gen_ai.conversation.id` plus the compatibility field; instrumentation never derives a
+conversation identifier by hashing or inspecting content.
+Provider/model Tool Call IDs are untrusted. The engine accepts only 1–128 ASCII characters matching
+`[A-Za-z0-9][A-Za-z0-9._:-]*` and validates before the value enters Turn correlation, canonical Run
+events, or application handler scheduling. Rejection is a typed `ModelProtocolError` with no Tool
+invocation. Framework telemetry records the same already-validated identifier as
+`gen_ai.tool.call.id` and the compatibility `toolCallId`.
+Logger/Tracer defects across canonical span creation, annotation, terminal logging, and closure are
+reported through Effect's `ErrorReporter` boundary without changing Tool settlement. Creation uses
+a non-exported local fallback span and closure never reruns a completed handler. Reporter defects
+are isolated, so a broken telemetry sink cannot trigger recovery of a completed external side
+effect. The terminal Run event and Turn trace result commit before derivative terminal telemetry;
+external interruption of telemetry or its reporter is restored, never consumed, but cannot erase
+that completed state. Early-close finalization reports any derivative typed failure or defect
+through the same boundary before suppressing it. Canonical span closure restores the bounded public
+outcome attribute from module-private authenticated terminal state before host export.
+Each handler attempt owns one fresh bounded span-failure marker object, and the engine recognizes
+only that exact identity. An independently constructed same-class handler failure cannot be
+mistaken for framework control flow or swallowed.
+The isolation policy is an engine-owned capability built at the Run composition boundary from the
+host's ambient Tracer; Tool execution does not replace the Tracer service locally.
+Cloudflare automatic diagnostics export only bounded framework classifications. Retained foreign
+exporter causes, arbitrary defects, fiber IDs, and caught platform Causes are never passed to the
+configured Logger; raw exporter cause inspection is an explicit host decision at the typed error
+boundary.
+
 Minimum operational alerts:
 
 - accepted submission without timely settlement;

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -239,8 +239,8 @@ waiting; denied and provider-executed calls are call-level only and create no ha
 Framework-owned `conversationId` is identity metadata rather than conversation content and is
 exported as `gen_ai.conversation.id` plus the compatibility field; instrumentation never derives a
 conversation identifier by hashing or inspecting content.
-Provider/model Tool Call IDs are untrusted. The engine accepts only 1–128 ASCII characters matching
-`[A-Za-z0-9][A-Za-z0-9._:-]*` and validates before the value enters Turn correlation, canonical Run
+Provider/model Tool Call IDs are untrusted. The engine accepts only values whose entire string
+matches `[A-Za-z0-9][A-Za-z0-9._:-]{0,127}` and validates before the value enters Turn correlation, canonical Run
 events, or application handler scheduling. Rejection is a typed `ModelProtocolError` with no Tool
 invocation. Framework telemetry records the same already-validated identifier as
 `gen_ai.tool.call.id` and the compatibility `toolCallId`.
@@ -258,10 +258,12 @@ only that exact identity. An independently constructed same-class handler failur
 mistaken for framework control flow or swallowed.
 The isolation policy is an engine-owned capability built at the Run composition boundary from the
 host's ambient Tracer; Tool execution does not replace the Tracer service locally.
-Cloudflare automatic diagnostics export only bounded framework classifications. Retained foreign
-exporter causes, arbitrary defects, fiber IDs, and caught platform Causes are never passed to the
-configured Logger; raw exporter cause inspection is an explicit host decision at the typed error
-boundary.
+Cloudflare exporter diagnostics export only bounded framework classifications. Retained foreign
+exporter causes, arbitrary defects, and fiber IDs are never passed to the configured Logger; raw
+exporter cause inspection is an explicit host decision at the typed error boundary. A synchronous
+`waitUntil` registration rejection is an irreducible platform lifecycle failure, so its exact Cause
+is passed structurally to the host Logger together with the bounded
+`wait_until_registration` classification; effect-agent adds no request or conversation content.
 
 Minimum operational alerts:
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -73,6 +73,20 @@ import {
   type Toolkit,
 } from "effect/unstable/ai";
 
+import {
+  boundedJsonSnapshot,
+  type BoundedJsonSnapshot,
+} from "./provider-result-staging-internal.ts";
+import {
+  annotateToolSpanTerminalOutcome,
+  emitThenAfter,
+  isolateToolTerminalTelemetry,
+  restoreToolSpanFailureCause,
+  stripToolSpanFailures,
+  ToolSpanFailure,
+  ToolSpanTelemetry,
+} from "./tool-telemetry-internal.ts";
+
 /**
  * Structural shape of an Agent Binding accepted by the interpreter and by
  * `AgentSpawner.spawn`: a model-agnostic Definition paired with an explicit
@@ -203,8 +217,9 @@ export type AgentRuntimeFailure<
 /**
  * Services the engine itself provides locally to every Run: `AgentSpawner`
  * bound to the Run's immutable identity and delegation depth, `RunEventSink`
- * and `SubagentDurability` bound to the active Tool batch, and `DurableStep`
- * bound to the active Tool Call. They are excluded from the runtime's public
+ * and `SubagentDurability` bound to the active Tool batch, `DurableStep`
+ * bound to the active Tool Call, and `ToolSpanTelemetry` bound at the Run
+ * composition edge. They are excluded from the runtime's public
  * requirements and MUST NOT be satisfied from an application Layer.
  */
 export type EngineProvidedToolServices =
@@ -212,7 +227,8 @@ export type EngineProvidedToolServices =
   | RunEventSink
   | DurableStep
   | SubagentDurability
-  | ToolBroker;
+  | ToolBroker
+  | ToolSpanTelemetry;
 
 /**
  * Inferred agent services plus the runtime's identity-generation authority.
@@ -303,6 +319,12 @@ interface TurnTrace {
     }
   >;
   readonly finalToolResultIds: Set<string>;
+  /** Provider result payloads held until the complete model response validates. */
+  readonly providerResultPayloads: Array<ProviderResultEventPayload>;
+  /** Exact retained JSON bytes across every staged provider event, including Turn completion. */
+  providerStagedPayloadBytes: number;
+  /** Turn completion held with provider results so malformed trailing parts append neither. */
+  turnCompletion: { readonly finishReason: Response.FinishReason } | undefined;
   readonly applicationToolCalls: Array<Response.ToolCallPart<string, unknown>>;
   /** Durable-hook view of the application calls, in declaration order (encoded parameters). */
   readonly applicationCallDescriptors: Array<RunToolCallDescriptor>;
@@ -316,6 +338,35 @@ interface TurnTrace {
   finishReason: Response.FinishReason | undefined;
   usage: Response.Usage | undefined;
 }
+
+type ProviderResultEventPayload =
+  | {
+      readonly _tag: "ToolProgress";
+      readonly toolCallId: ToolCallId;
+      readonly toolName: string;
+      readonly result: Schema.Json;
+      readonly providerExecuted: true;
+    }
+  | {
+      readonly _tag: "ToolCallSucceeded";
+      readonly toolCallId: ToolCallId;
+      readonly toolName: string;
+      readonly result: Schema.Json;
+      readonly providerExecuted: true;
+    }
+  | {
+      readonly _tag: "ToolCallFailed";
+      readonly toolCallId: ToolCallId;
+      readonly toolName: string;
+      readonly errorTag: string;
+      readonly message: string;
+      readonly providerExecuted: true;
+    };
+
+// Provider output is untrusted. Holding terminal facts until whole-response validation is
+// fail-closed only while the additional staging allocation itself is deterministic and bounded.
+const MAX_STAGED_PROVIDER_EVENTS = 256;
+const MAX_STAGED_PROVIDER_BYTES = 1024 * 1024;
 
 type PartLifecycle = "open" | "closed";
 
@@ -718,6 +769,12 @@ const preflightApproval = <Tools extends Record<string, Tool.Any>, HookError, Ho
     ),
   );
 
+const ProviderToolCallId = ToolCallId.check(
+  Schema.isMaxLength(128),
+  Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
+);
+const isTelemetryToolCallId = Schema.is(ProviderToolCallId);
+
 const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
   context: RunContext,
   turnId: TurnId,
@@ -735,10 +792,89 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
 ): Stream.Stream<
   RunEvent,
   ModelProtocolError | AiError.AiError | Tool.HandlerError<ToolUnion<Tools>>,
-  Tool.HandlerServices<ToolUnion<Tools>>
+  ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
 > => {
+  type ToolExecutionError =
+    | ModelProtocolError
+    | AiError.AiError
+    | Tool.HandlerError<ToolUnion<Tools>>;
+
   const call = prepared.call;
+  const telemetryToolCallId = isTelemetryToolCallId(call.id) ? call.id : undefined;
+  const executionClass = getToolExecutionClass(prepared.tool);
+  const toolSpanFailure = ToolSpanFailure.marker();
   let terminal = false;
+  let terminalResultCommitted = false;
+  let terminalOutcome: "success" | "failure" | undefined;
+  let terminalResult:
+    | {
+        readonly encodedResult: unknown;
+        readonly isFailure: boolean;
+        readonly result: unknown;
+      }
+    | undefined;
+  let propagatedFailure: Cause.Cause<ToolExecutionError> | undefined;
+
+  const terminalTelemetry = (outcome: "success" | "failure") =>
+    annotateToolSpanTerminalOutcome(
+      outcome,
+      outcome === "failure" ? toolSpanFailure : undefined,
+    ).pipe(
+      Effect.andThen(
+        (outcome === "success"
+          ? Effect.logInfo("agent tool execution completed")
+          : Effect.logWarning("agent tool execution failed")
+        ).pipe(
+          Effect.annotateLogs({
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": call.name,
+            "gen_ai.tool.type": "function",
+            ...(telemetryToolCallId === undefined
+              ? {}
+              : {
+                  "gen_ai.tool.call.id": telemetryToolCallId,
+                  toolCallId: telemetryToolCallId,
+                }),
+            "gen_ai.agent.name": context.agentId,
+            "gen_ai.conversation.id": context.conversationId,
+            "effect_agent.tool.execution_class": executionClass,
+            "effect_agent.tool.outcome": outcome,
+            agentId: context.agentId,
+            conversationId: context.conversationId,
+            runId: context.runId,
+            turnId,
+            toolName: call.name,
+            toolExecutionClass: executionClass,
+            toolOutcome: outcome,
+          }),
+        ),
+      ),
+    );
+
+  const isolatedTerminalTelemetry = (outcome: "success" | "failure") =>
+    // Measurement is derivative: a broken Logger/Tracer must never change the Tool event or make
+    // an already-completed external side effect eligible for recovery. Non-interrupt Causes reach
+    // Effect's owned reporter boundary; external interruption remains interruption.
+    isolateToolTerminalTelemetry(terminalTelemetry(outcome));
+
+  /**
+   * Preserve an actual emission boundary between canonical state and derivative telemetry. The
+   * singleton event chunk reaches the downstream Run stream before telemetry can start. The next
+   * pull normally owns telemetry; structured finalization owns it when downstream closes after the
+   * event. Their shared phase gate permits one attempt, while a returned Tool failure still fails a
+   * normal second pull with the private span marker.
+   */
+  const terminalEventThenTelemetry = <EventError>(
+    event: Effect.Effect<RunEvent, EventError>,
+    outcome: "success" | "failure",
+    failSpan: boolean,
+  ): Stream.Stream<RunEvent, EventError | ToolSpanFailure> =>
+    emitThenAfter(
+      event,
+      isolatedTerminalTelemetry(outcome).pipe(
+        Effect.andThen(failSpan ? Effect.fail(toolSpanFailure) : Effect.void),
+      ),
+    );
 
   const started = Stream.fromEffect(
     Effect.gen(function* () {
@@ -748,7 +884,7 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
           agentId: context.agentId,
           runId: context.runId,
           turnId,
-          toolCallId,
+          ...(telemetryToolCallId === undefined ? {} : { toolCallId: telemetryToolCallId }),
           toolName: call.name,
         }),
       );
@@ -762,31 +898,82 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
     }).pipe(Effect.withLogSpan("AgentRuntime.tool")),
   );
 
-  const results = Stream.unwrap(
-    toolkit
-      .handle(prepared.name, prepared.nativeHandlerParams, call.id)
-      .pipe(Effect.withSpan("AgentRuntime.toolkit.handle")),
+  const results: Stream.Stream<
+    RunEvent,
+    ToolExecutionError,
+    ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
+  > = Stream.unwrap(
+    Effect.flatMap(ToolSpanTelemetry, ({ isolateToolkitHandle }) =>
+      isolateToolkitHandle(toolkit.handle(prepared.name, prepared.nativeHandlerParams, call.id)),
+    ),
   ).pipe(
-    Stream.mapEffect((result) =>
-      Effect.gen(function* () {
-        if (terminal || trace.finalToolResultIds.has(call.id)) {
-          return yield* ModelProtocolError.make({
-            message: `Tool Call ${call.id} produced more than one terminal result`,
-          });
-        }
-        const toolCallId = yield* decodeToolCallId(call.id);
-        if (result.preliminary) {
-          return ToolProgress.make({
-            ...(yield* eventBase(context)),
-            turnId,
-            toolCallId,
-            toolName: call.name,
-            result: yield* decodeEventJson(result.encodedResult, "Tool result"),
-            providerExecuted: false,
-          });
-        }
+    Stream.mapEffect(
+      (result): Effect.Effect<RunEvent | undefined, ModelProtocolError> =>
+        Effect.gen(function* () {
+          if (terminal || trace.finalToolResultIds.has(call.id)) {
+            return yield* ModelProtocolError.make({
+              message: `Tool Call ${call.id} produced more than one terminal result`,
+            });
+          }
+          const toolCallId = yield* decodeToolCallId(call.id);
+          if (result.preliminary) {
+            const event: RunEvent = ToolProgress.make({
+              ...(yield* eventBase(context)),
+              turnId,
+              toolCallId,
+              toolName: call.name,
+              result: yield* decodeEventJson(result.encodedResult, "Tool result"),
+              providerExecuted: false,
+            });
+            return event;
+          }
 
-        terminal = true;
+          terminal = true;
+          terminalOutcome = result.isFailure ? "failure" : "success";
+          terminalResult = {
+            encodedResult: result.encodedResult,
+            isFailure: result.isFailure,
+            result: result.result,
+          };
+          // A terminal Toolkit value is provisional until its handler stream closes. Emitting the
+          // append-only event or committing the Turn trace here would leave contradictory Run state
+          // if that stream later fails or produces another terminal value.
+          return undefined;
+        }),
+    ),
+    Stream.filter((event): event is RunEvent => event !== undefined),
+  );
+
+  const commitTerminalResult: Effect.Effect<RunEvent, ModelProtocolError> = Effect.suspend(
+    (): Effect.Effect<RunEvent, ModelProtocolError> => {
+      if (!terminal || terminalOutcome === undefined || terminalResult === undefined) {
+        return Effect.fail(
+          ModelProtocolError.make({
+            message: `Tool Call ${call.id} completed without a terminal result`,
+          }),
+        );
+      }
+      const result = terminalResult;
+      return Effect.gen(function* () {
+        const toolCallId = yield* decodeToolCallId(call.id);
+        const event: RunEvent = result.isFailure
+          ? ToolCallFailed.make({
+              ...(yield* eventBase(context)),
+              turnId,
+              toolCallId,
+              toolName: call.name,
+              errorTag: errorTag(result.result),
+              message: errorMessage(result.result),
+              providerExecuted: false,
+            })
+          : ToolCallSucceeded.make({
+              ...(yield* eventBase(context)),
+              turnId,
+              toolCallId,
+              toolName: call.name,
+              result: yield* decodeEventJson(result.encodedResult, "Tool result"),
+              providerExecuted: false,
+            });
         trace.finalToolResultIds.add(call.id);
         trace.applicationToolResults[prepared.declarationIndex] = {
           id: call.id,
@@ -794,54 +981,77 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
           encodedResult: result.encodedResult,
           isFailure: result.isFailure,
         };
-        if (result.isFailure) {
-          return ToolCallFailed.make({
-            ...(yield* eventBase(context)),
-            turnId,
-            toolCallId,
-            toolName: call.name,
-            errorTag: errorTag(result.result),
-            message: errorMessage(result.result),
-            providerExecuted: false,
-          });
-        }
-        return ToolCallSucceeded.make({
-          ...(yield* eventBase(context)),
-          turnId,
-          toolCallId,
-          toolName: call.name,
-          result: yield* decodeEventJson(result.encodedResult, "Tool result"),
-          providerExecuted: false,
-        });
-      }),
-    ),
+        terminalResultCommitted = true;
+        return event;
+      });
+    },
   );
 
-  const requireTerminal = Stream.fromEffect(
-    Effect.suspend(() =>
-      terminal
-        ? Effect.void
-        : Effect.fail(
-            ModelProtocolError.make({
-              message: `Tool Call ${call.id} completed without a terminal result`,
-            }),
-          ),
-    ),
-  ).pipe(Stream.drain);
+  const finalizeTerminalResult: Stream.Stream<RunEvent, ModelProtocolError | ToolSpanFailure> =
+    Stream.unwrap(
+      Effect.sync(() =>
+        terminalEventThenTelemetry(
+          commitTerminalResult,
+          terminalOutcome ?? "failure",
+          terminalOutcome === "failure",
+        ),
+      ),
+    );
 
-  return started.pipe(
+  const failTerminalResult = (
+    cause: Cause.Cause<ToolExecutionError>,
+  ): Stream.Stream<RunEvent, ModelProtocolError | ToolSpanFailure> => {
+    terminal = true;
+    terminalOutcome = "failure";
+    terminalResult = undefined;
+    propagatedFailure = cause;
+    return terminalEventThenTelemetry(
+      makeToolFailedEvent(context, turnId, call, Cause.squash(cause)).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            trace.finalToolResultIds.add(call.id);
+            terminalResultCommitted = true;
+          }),
+        ),
+      ),
+      "failure",
+      true,
+    );
+  };
+
+  const measured = started.pipe(
     Stream.concat(results),
-    Stream.concat(requireTerminal),
+    Stream.concat(finalizeTerminalResult),
     Stream.catchCause((cause) => {
-      const waiting = waitingFromCause(cause);
+      // A value-level failure already has its terminal event and bounded span-facing
+      // signal. Let only the outer recovery consume it.
+      const { found: hasToolSpanFailure, residual: toolCause } = stripToolSpanFailures(
+        cause,
+        toolSpanFailure,
+      );
+      if (hasToolSpanFailure) {
+        return Stream.failCause(cause);
+      }
+      if (terminalResultCommitted) {
+        return Stream.failCause(toolCause);
+      }
+      if (toolCause.reasons.length > 0 && toolCause.reasons.every(Cause.isInterruptReason)) {
+        // Interruption terminates only this in-memory handler attempt. It emits no append-only Tool
+        // terminal event and no success/failure terminal log; the canonical span observes and
+        // preserves the exact interruption Cause from its enclosing stream Exit.
+        return Stream.failCause(toolCause);
+      }
+      const waiting = waitingFromCause(toolCause);
       if (waiting !== undefined) {
         if (terminal || trace.finalToolResultIds.has(call.id)) {
           // A handler that produced a terminal result cannot also wait: the
           // anomaly fails loud and typed instead of suspending a settled call.
-          return Stream.fail(
-            ModelProtocolError.make({
-              message: `Tool Call ${call.id} raised the waiting signal after its terminal result`,
-            }),
+          return failTerminalResult(
+            Cause.fail(
+              ModelProtocolError.make({
+                message: `Tool Call ${call.id} raised the waiting signal after its terminal result`,
+              }),
+            ),
           );
         }
         // The waiting call stays open: no terminal result is recorded, no
@@ -852,22 +1062,47 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
         return Stream.empty;
       }
       if (terminal) {
-        return Stream.failCause(cause);
+        // The provisional value never became append-only state. Replace it with one failed
+        // terminal event, then preserve the handler Cause outside the span-facing marker.
+        return failTerminalResult(toolCause);
       }
-      terminal = true;
-      trace.finalToolResultIds.add(call.id);
-      return Stream.fromEffect(
-        makeToolFailedEvent(context, turnId, call, Cause.squash(cause)),
-      ).pipe(Stream.concat(Stream.failCause(cause)));
+      return failTerminalResult(toolCause);
     }),
-    Stream.withSpan("AgentRuntime.tool", {
+    Stream.withSpan(`execute_tool ${call.name}`, {
+      kind: "internal",
       attributes: {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": call.name,
+        "gen_ai.tool.type": "function",
+        ...(telemetryToolCallId === undefined
+          ? {}
+          : {
+              "gen_ai.tool.call.id": telemetryToolCallId,
+              toolCallId: telemetryToolCallId,
+            }),
+        "gen_ai.agent.name": context.agentId,
+        "gen_ai.conversation.id": context.conversationId,
+        "effect_agent.tool.execution_class": executionClass,
         agentId: context.agentId,
+        conversationId: context.conversationId,
         runId: context.runId,
         turnId,
-        toolCallId: call.id,
         toolName: call.name,
       },
+    }),
+  );
+
+  return Stream.unwrap(
+    Effect.map(ToolSpanTelemetry, ({ isolateSpanLifecycle }) => isolateSpanLifecycle(measured)),
+  ).pipe(
+    Stream.catchCause((cause) => {
+      const { found, restored } = restoreToolSpanFailureCause(
+        cause,
+        toolSpanFailure,
+        propagatedFailure,
+      );
+      if (!found) return Stream.failCause(restored);
+      return restored.reasons.length === 0 ? Stream.empty : Stream.failCause(restored);
     }),
   );
 };
@@ -913,7 +1148,7 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
   | AgentChildPending
   | AiError.AiError
   | Tool.HandlerError<ToolUnion<Tools>>,
-  HookRequirements | Tool.HandlerServices<ToolUnion<Tools>>
+  HookRequirements | ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
 > =>
   Stream.unwrap(
     Effect.gen(function* () {
@@ -1041,7 +1276,7 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
         Stream.Stream<
           RunEvent,
           ModelProtocolError | AiError.AiError | Tool.HandlerError<ToolUnion<Tools>>,
-          Tool.HandlerServices<ToolUnion<Tools>>
+          ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
         >
       >((stream, group) => {
         const next = Stream.mergeAll(
@@ -1101,7 +1336,7 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
       const settling: Stream.Stream<
         RunEvent,
         never,
-        Tool.HandlerServices<ToolUnion<Tools>>
+        ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
       > = handlers.pipe(
         Stream.provideService(RunEventSink, batchSink),
         Stream.provideService(SubagentDurability, batchSubagentDurability),
@@ -1421,6 +1656,85 @@ const eventBase = Effect.fnUntraced(function* (context: RunContext) {
   };
 });
 
+const snapshotStagedProviderEvent = (
+  trace: TurnTrace,
+  payload: unknown,
+): Effect.Effect<BoundedJsonSnapshot, ModelProtocolError> =>
+  Effect.suspend(() => {
+    const stagedEventCount =
+      trace.providerResultPayloads.length + (trace.turnCompletion === undefined ? 0 : 1);
+    if (stagedEventCount >= MAX_STAGED_PROVIDER_EVENTS) {
+      return Effect.fail(
+        ModelProtocolError.make({
+          message: `Model response exceeded the ${MAX_STAGED_PROVIDER_EVENTS}-event staged provider event limit`,
+        }),
+      );
+    }
+    const snapshot = boundedJsonSnapshot(
+      payload,
+      MAX_STAGED_PROVIDER_BYTES - trace.providerStagedPayloadBytes,
+    );
+    if (snapshot === undefined) {
+      return Effect.fail(
+        ModelProtocolError.make({
+          message: `Model response exceeded the ${MAX_STAGED_PROVIDER_BYTES}-byte staged provider event limit`,
+        }),
+      );
+    }
+    return Effect.succeed(snapshot);
+  });
+
+const stageProviderResultPayload = (
+  trace: TurnTrace,
+  payload: ProviderResultEventPayload,
+): Effect.Effect<void, ModelProtocolError> =>
+  Effect.gen(function* () {
+    const snapshot = yield* snapshotStagedProviderEvent(trace, payload);
+    const snapshotObject = snapshot.value;
+    if (
+      snapshotObject === null ||
+      typeof snapshotObject !== "object" ||
+      Array.isArray(snapshotObject) ||
+      Object.getPrototypeOf(snapshotObject) !== null
+    ) {
+      return yield* ModelProtocolError.make({
+        message: "Provider Tool result could not be normalized as JSON",
+      });
+    }
+    const resultDescriptor = Object.getOwnPropertyDescriptor(snapshotObject, "result");
+    const normalizedResult =
+      resultDescriptor !== undefined && "value" in resultDescriptor
+        ? Schema.decodeUnknownOption(Schema.Json)(resultDescriptor.value)
+        : Option.none<Schema.Json>();
+    if (payload._tag !== "ToolCallFailed" && Option.isNone(normalizedResult)) {
+      return yield* ModelProtocolError.make({
+        message: "Provider Tool result could not be normalized as JSON",
+      });
+    }
+    const normalized: ProviderResultEventPayload =
+      payload._tag === "ToolCallFailed"
+        ? Object.freeze({ ...payload })
+        : Object.freeze({ ...payload, result: Option.getOrThrow(normalizedResult) });
+    trace.providerResultPayloads.push(normalized);
+    trace.providerStagedPayloadBytes += snapshot.bytes;
+  });
+
+const stampProviderResultEvent = (
+  context: RunContext,
+  turnId: TurnId,
+  payload: ProviderResultEventPayload,
+): Effect.Effect<RunEvent> =>
+  Effect.map(eventBase(context), (base) => {
+    switch (payload._tag) {
+      case "ToolProgress":
+        return ToolProgress.make({ ...base, turnId, ...payload });
+      case "ToolCallSucceeded":
+        return ToolCallSucceeded.make({ ...base, turnId, ...payload });
+      case "ToolCallFailed":
+        return ToolCallFailed.make({ ...base, turnId, ...payload });
+    }
+  });
+
 const decodeInput = Effect.fn("AgentRuntime.decodeInput")(
   <AgentValue extends Agent.Any>(
     agent: AgentValue,
@@ -1513,6 +1827,17 @@ const decodeToolCallId = Effect.fn("AgentRuntime.decodeToolCallId")((id: string)
   ),
 );
 
+const decodeProviderToolCallId = Effect.fn("AgentRuntime.decodeProviderToolCallId")((id: string) =>
+  Schema.decodeEffect(ProviderToolCallId)(id).pipe(
+    Effect.mapError(() =>
+      ModelProtocolError.make({
+        message:
+          "Model supplied an invalid Tool Call ID; expected 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens",
+      }),
+    ),
+  ),
+);
+
 const decodeEventJson = Effect.fn("AgentRuntime.decodeEventJson")(
   (value: unknown, label: string): Effect.Effect<Schema.Json, ModelProtocolError> =>
     Schema.decodeUnknownEffect(Schema.Json)(value).pipe(
@@ -1594,6 +1919,17 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
     return yield* ModelProtocolError.make({
       message: "Model response emitted content after its finish part",
     });
+  }
+  if (
+    part.type === "tool-params-start" ||
+    part.type === "tool-params-delta" ||
+    part.type === "tool-params-end" ||
+    part.type === "tool-call" ||
+    part.type === "tool-result"
+  ) {
+    // Provider/model Tool Call IDs are untrusted correlation keys. Reject them before they enter
+    // the Turn trace maps, canonical event stream, or application handler scheduling boundary.
+    yield* decodeProviderToolCallId(part.id);
   }
   trace.parts.push(part);
   switch (part.type) {
@@ -1759,16 +2095,14 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
       const toolCallId = yield* decodeToolCallId(part.id);
       const result = yield* decodeEventJson(part.encodedResult, "Tool result");
       if (part.preliminary === true) {
-        return [
-          ToolProgress.make({
-            ...(yield* eventBase(context)),
-            turnId,
-            toolCallId,
-            toolName: part.name,
-            result,
-            providerExecuted: part.providerExecuted,
-          }),
-        ];
+        yield* stageProviderResultPayload(trace, {
+          _tag: "ToolProgress",
+          toolCallId,
+          toolName: part.name,
+          result,
+          providerExecuted: true,
+        });
+        return [];
       }
       if (trace.finalToolResultIds.has(part.id)) {
         return yield* ModelProtocolError.make({
@@ -1777,28 +2111,24 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
       }
       trace.finalToolResultIds.add(part.id);
       if (part.isFailure) {
-        return [
-          ToolCallFailed.make({
-            ...(yield* eventBase(context)),
-            turnId,
-            toolCallId,
-            toolName: part.name,
-            errorTag: errorTag(part.result),
-            message: errorMessage(part.result),
-            providerExecuted: part.providerExecuted,
-          }),
-        ];
-      }
-      return [
-        ToolCallSucceeded.make({
-          ...(yield* eventBase(context)),
-          turnId,
+        yield* stageProviderResultPayload(trace, {
+          _tag: "ToolCallFailed",
           toolCallId,
           toolName: part.name,
-          result,
-          providerExecuted: part.providerExecuted,
-        }),
-      ];
+          errorTag: errorTag(part.result),
+          message: errorMessage(part.result),
+          providerExecuted: true,
+        });
+        return [];
+      }
+      yield* stageProviderResultPayload(trace, {
+        _tag: "ToolCallSucceeded",
+        toolCallId,
+        toolName: part.name,
+        result,
+        providerExecuted: true,
+      });
+      return [];
     }
     case "finish": {
       const openPart = firstOpenPart(trace);
@@ -1810,6 +2140,16 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
       trace.finished = true;
       trace.finishReason = part.reason;
       trace.usage = part.usage;
+      if (Array.from(trace.toolCalls.values()).some(({ providerExecuted }) => providerExecuted)) {
+        const turnCompletion = { finishReason: part.reason };
+        const snapshot = yield* snapshotStagedProviderEvent(trace, {
+          _tag: "TurnCompleted",
+          ...turnCompletion,
+        });
+        trace.turnCompletion = turnCompletion;
+        trace.providerStagedPayloadBytes += snapshot.bytes;
+        return [];
+      }
       return [
         TurnCompleted.make({
           ...(yield* eventBase(context)),
@@ -1824,7 +2164,12 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
         message: `Model response failed: ${errorMessage(part.error)}`,
       });
     }
-    default: {
+    case "file":
+    case "reasoning":
+    case "response-metadata":
+    case "source":
+    case "text":
+    case "tool-approval-request": {
       return [];
     }
   }
@@ -1916,6 +2261,9 @@ const makeTurn = <
         toolParameterParts: new Map(),
         toolCalls: new Map(),
         finalToolResultIds: new Set(),
+        providerResultPayloads: [],
+        providerStagedPayloadBytes: 0,
+        turnCompletion: undefined,
         applicationToolCalls: [],
         applicationCallDescriptors: [],
         applicationToolResults: [],
@@ -1971,7 +2319,7 @@ const makeTurn = <
       );
 
       const continuation = Stream.unwrap(
-        Effect.gen(function* () {
+        Effect.sync(() => {
           if (!trace.finished) {
             return failRunEventStream(
               ModelProtocolError.make({
@@ -1979,14 +2327,13 @@ const makeTurn = <
               }),
             );
           }
-          yield* consumeUsage(agent, context, trace, options);
-          const toolCalls = priorToolCalls + trace.toolCalls.size;
-          if (toolCalls + context.programmaticToolCalls > agent.definition.policy.maxToolCalls) {
+          const hasProviderCalls = Array.from(trace.toolCalls.values()).some(
+            ({ providerExecuted }) => providerExecuted,
+          );
+          const turnCompletion = trace.turnCompletion;
+          if (hasProviderCalls && turnCompletion === undefined) {
             return failRunEventStream(
-              AgentPolicyError.make({
-                limit: "tool-calls",
-                message: `Agent exceeded its ${agent.definition.policy.maxToolCalls} Tool Call limit`,
-              }),
+              ModelProtocolError.make({ message: "Model response omitted staged Turn completion" }),
             );
           }
           const providerOnly =
@@ -2002,6 +2349,50 @@ const makeTurn = <
               }),
             );
           }
+          const toolCalls = priorToolCalls + trace.toolCalls.size;
+          if (toolCalls + context.programmaticToolCalls > agent.definition.policy.maxToolCalls) {
+            return failRunEventStream(
+              AgentPolicyError.make({
+                limit: "tool-calls",
+                message: `Agent exceeded its ${agent.definition.policy.maxToolCalls} Tool Call limit`,
+              }),
+            );
+          }
+
+          const stagedResponse = Stream.fromIterable(trace.providerResultPayloads).pipe(
+            Stream.mapEffect((payload) => stampProviderResultEvent(context, turnId, payload)),
+            Stream.concat(
+              turnCompletion === undefined
+                ? Stream.empty
+                : Stream.fromEffect(
+                    Effect.map(eventBase(context), (base) =>
+                      TurnCompleted.make({
+                        ...base,
+                        turnId,
+                        turn,
+                        finishReason: turnCompletion.finishReason,
+                      }),
+                    ),
+                  ),
+            ),
+          );
+          const afterValidatedResponse = <
+            EventError,
+            EventRequirements,
+            SetupError,
+            SetupRequirements,
+          >(
+            next: Effect.Effect<
+              Stream.Stream<RunEvent, EventError, EventRequirements>,
+              SetupError,
+              SetupRequirements
+            >,
+          ) =>
+            stagedResponse.pipe(
+              Stream.concat(
+                Stream.unwrap(Effect.andThen(consumeUsage(agent, context, trace, options), next)),
+              ),
+            );
 
           /** Official history advanced through this Turn's response, plus any Tool message. */
           const historyWithResponse = (...additions: ReadonlyArray<Prompt.Message>) =>
@@ -2056,17 +2447,20 @@ const makeTurn = <
                 return makeTurn(agent, context, nextPrompt, turn + 1, toolCalls, options);
               }
               const output = yield* decodeFinalOutput(agent, trace.text.join(""));
-              const completed = RunCompleted.make({
-                ...(yield* eventBase(context)),
-                output,
-                turns: turn,
-                finishReason: "model-stop",
-              });
-              return Stream.succeed<RunEvent>(completed);
+              return Stream.fromEffect(
+                Effect.map(eventBase(context), (base) =>
+                  RunCompleted.make({
+                    ...base,
+                    output,
+                    turns: turn,
+                    finishReason: "model-stop",
+                  }),
+                ),
+              );
             });
 
           if (providerOnly && trace.finishReason === "stop") {
-            return yield* settleOrFollowUp(historyWithResponse());
+            return afterValidatedResponse(settleOrFollowUp(historyWithResponse()));
           }
 
           if (trace.toolCalls.size > 0) {
@@ -2086,53 +2480,58 @@ const makeTurn = <
               );
             }
             if (trace.applicationToolCalls.length === 0) {
-              yield* applyRepeatedFailurePolicy(
-                context,
-                trace,
-                agent.definition.policy.repeatedFailureLimit,
+              return afterValidatedResponse(
+                Effect.gen(function* () {
+                  yield* applyRepeatedFailurePolicy(
+                    context,
+                    trace,
+                    agent.definition.policy.repeatedFailureLimit,
+                  );
+                  return yield* continueTurn(historyWithResponse());
+                }),
               );
-              return yield* continueTurn(historyWithResponse());
             }
-            const toolkit = yield* agent.definition.toolkit;
-            const concurrency = yield* schedulingConcurrency(
-              agent.definition.policy.toolConcurrency,
-              options.scheduling,
-            );
-            if (options.durability !== undefined) {
-              // Durable turn-commit seam: the response becomes canonical
-              // after the finish-part validations and before approval
-              // preflight or preparation, creating the provably-safe window
-              // of durability §15 ("after model item commit, before tool
-              // preparation" resumes the declared batch without model
-              // re-invocation). No-tool Turns never reach this branch and
-              // keep their late single-batch commit.
-              yield* options.durability.commitResponse({
-                turn,
-                turnId,
-                responseMessages: promptFromTurnParts(trace),
-                calls: trace.applicationCallDescriptors,
-              });
-            }
-            const toolResults = guardBudgetStream(
-              executeToolBatch(
-                context,
-                turnId,
-                toolkit,
-                trace.applicationToolCalls,
-                trace,
-                concurrency,
-                options,
-                {
-                  maxToolCalls: agent.definition.policy.maxToolCalls,
-                  declaredToolCalls: toolCalls,
-                },
-              ),
-              options.budget,
-            );
-            return toolResults.pipe(
-              Stream.concat(
-                toolBatchContinuation(agent, context, trace, prompt, turn, toolCalls, options),
-              ),
+            return afterValidatedResponse(
+              Effect.gen(function* () {
+                const toolkit = yield* agent.definition.toolkit;
+                const concurrency = yield* schedulingConcurrency(
+                  agent.definition.policy.toolConcurrency,
+                  options.scheduling,
+                );
+                if (options.durability !== undefined) {
+                  // Turn-response commit seam: staged canonical response events are emitted before
+                  // this persistence mutation, while approval preflight and preparation still run
+                  // afterward. This retains durability §15's provably-safe resume window without
+                  // allowing eager continuation work to overtake the append-only event stream.
+                  yield* options.durability.commitResponse({
+                    turn,
+                    turnId,
+                    responseMessages: promptFromTurnParts(trace),
+                    calls: trace.applicationCallDescriptors,
+                  });
+                }
+                const toolResults = guardBudgetStream(
+                  executeToolBatch(
+                    context,
+                    turnId,
+                    toolkit,
+                    trace.applicationToolCalls,
+                    trace,
+                    concurrency,
+                    options,
+                    {
+                      maxToolCalls: agent.definition.policy.maxToolCalls,
+                      declaredToolCalls: toolCalls,
+                    },
+                  ),
+                  options.budget,
+                );
+                return toolResults.pipe(
+                  Stream.concat(
+                    toolBatchContinuation(agent, context, trace, prompt, turn, toolCalls, options),
+                  ),
+                );
+              }),
             );
           }
 
@@ -2143,7 +2542,7 @@ const makeTurn = <
               }),
             );
           }
-          return yield* settleOrFollowUp(historyWithResponse());
+          return afterValidatedResponse(settleOrFollowUp(historyWithResponse()));
         }),
       );
 
@@ -2314,6 +2713,9 @@ const makeResumeTurn = <
         toolParameterParts: new Map(),
         toolCalls: new Map(),
         finalToolResultIds: new Set(),
+        providerResultPayloads: [],
+        providerStagedPayloadBytes: 0,
+        turnCompletion: undefined,
         applicationToolCalls: [],
         applicationCallDescriptors: [],
         applicationToolResults: [],
@@ -2671,7 +3073,12 @@ const stream = <
     options.input?.end === undefined
       ? interpreted
       : interpreted.pipe(Stream.ensuring(options.input.end()));
-  return finalized.pipe(Stream.provide(agent.model, { local: true }));
+  return finalized.pipe(
+    Stream.provide(agent.model, { local: true }),
+    // The engine composition boundary owns span-lifecycle isolation while preserving the host's
+    // ambient Tracer/Logger configuration. Individual Tool executions consume this capability.
+    Stream.provide(ToolSpanTelemetry.layer),
+  );
 };
 
 interface RunReduction {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -321,7 +321,7 @@ interface TurnTrace {
   readonly finalToolResultIds: Set<string>;
   /** Provider result payloads held until the complete model response validates. */
   readonly providerResultPayloads: Array<ProviderResultEventPayload>;
-  /** Exact retained JSON bytes across every staged provider event, including Turn completion. */
+  /** Exact retained JSON bytes across provider Tool results and staged provider events. */
   providerStagedPayloadBytes: number;
   /** Turn completion held with provider results so malformed trailing parts append neither. */
   turnCompletion: { readonly finishReason: Response.FinishReason } | undefined;
@@ -769,6 +769,10 @@ const preflightApproval = <Tools extends Record<string, Tool.Any>, HookError, Ho
     ),
   );
 
+const ProviderResponsePartId = Schema.String.check(
+  Schema.isMaxLength(128),
+  Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
+);
 const ProviderToolCallId = ToolCallId.check(
   Schema.isMaxLength(128),
   Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
@@ -1719,6 +1723,37 @@ const stageProviderResultPayload = (
     trace.providerStagedPayloadBytes += snapshot.bytes;
   });
 
+const ProviderToolResultSnapshot = Schema.Struct({
+  result: Schema.Json,
+  metadata: Schema.Record(Schema.String, Schema.Json),
+});
+
+const snapshotProviderToolResultPart = Effect.fnUntraced(function* (
+  trace: TurnTrace,
+  part: Response.ToolResultPart<string, unknown, unknown>,
+) {
+  const snapshot = boundedJsonSnapshot(
+    { result: part.encodedResult, metadata: part.metadata },
+    MAX_STAGED_PROVIDER_BYTES - trace.providerStagedPayloadBytes,
+  );
+  if (snapshot === undefined) {
+    return yield* ModelProtocolError.make({
+      message: `Model response exceeded the ${MAX_STAGED_PROVIDER_BYTES}-byte staged provider event limit`,
+    });
+  }
+  const normalized = yield* Schema.decodeUnknownEffect(ProviderToolResultSnapshot)(
+    snapshot.value,
+  ).pipe(
+    Effect.mapError(() =>
+      ModelProtocolError.make({
+        message: "Provider Tool result could not be normalized as JSON",
+      }),
+    ),
+  );
+  trace.providerStagedPayloadBytes += snapshot.bytes;
+  return normalized;
+});
+
 const stampProviderResultEvent = (
   context: RunContext,
   turnId: TurnId,
@@ -1838,6 +1873,52 @@ const decodeProviderToolCallId = Effect.fn("AgentRuntime.decodeProviderToolCallI
   ),
 );
 
+const decodeProviderResponsePartId = Effect.fn("AgentRuntime.decodeProviderResponsePartId")(
+  (id: string) =>
+    Schema.decodeEffect(ProviderResponsePartId)(id).pipe(
+      Effect.mapError(() =>
+        ModelProtocolError.make({
+          message:
+            "Model supplied an invalid response part ID; expected 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens",
+        }),
+      ),
+    ),
+);
+
+const validateProviderPartIdentifiers = Effect.fnUntraced(function* (part: Response.AnyPart) {
+  switch (part.type) {
+    case "text-start":
+    case "text-delta":
+    case "text-end":
+    case "reasoning-start":
+    case "reasoning-delta":
+    case "reasoning-end":
+    case "source":
+      yield* decodeProviderResponsePartId(part.id);
+      return;
+    case "response-metadata":
+      if (part.id !== undefined) yield* decodeProviderResponsePartId(part.id);
+      return;
+    case "tool-params-start":
+    case "tool-params-delta":
+    case "tool-params-end":
+    case "tool-call":
+    case "tool-result":
+      yield* decodeProviderToolCallId(part.id);
+      return;
+    case "tool-approval-request":
+      yield* decodeProviderResponsePartId(part.approvalId);
+      yield* decodeProviderToolCallId(part.toolCallId);
+      return;
+    case "error":
+    case "file":
+    case "finish":
+    case "reasoning":
+    case "text":
+      return;
+  }
+});
+
 const decodeEventJson = Effect.fn("AgentRuntime.decodeEventJson")(
   (value: unknown, label: string): Effect.Effect<Schema.Json, ModelProtocolError> =>
     Schema.decodeUnknownEffect(Schema.Json)(value).pipe(
@@ -1920,18 +2001,10 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
       message: "Model response emitted content after its finish part",
     });
   }
-  if (
-    part.type === "tool-params-start" ||
-    part.type === "tool-params-delta" ||
-    part.type === "tool-params-end" ||
-    part.type === "tool-call" ||
-    part.type === "tool-result"
-  ) {
-    // Provider/model Tool Call IDs are untrusted correlation keys. Reject them before they enter
-    // the Turn trace maps, canonical event stream, or application handler scheduling boundary.
-    yield* decodeProviderToolCallId(part.id);
-  }
-  trace.parts.push(part);
+  // Provider/model identifiers are untrusted correlation keys. Reject them before they enter
+  // the Turn trace, lifecycle maps, canonical event stream, diagnostics, or Tool scheduler.
+  yield* validateProviderPartIdentifiers(part);
+  if (part.type !== "tool-call" && part.type !== "tool-result") trace.parts.push(part);
   switch (part.type) {
     case "text-start": {
       yield* startPart(trace.textParts, part.id, "text");
@@ -2036,17 +2109,19 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
         part.params as Tool.Parameters<ToolUnion<Tools>>,
       );
       const parameters = yield* decodeEventJson(encodedParameters, "Tool parameters");
-      // Official history carries the wire form: rebuild the just-pushed trace
+      // Official history carries the wire form: rebuild the trace
       // part with the Schema-encoded parameters (the provider re-serializes
       // them on the next request regardless), while `applicationToolCalls`
       // below keeps the decoded part for the handler path — see TurnTrace.
-      trace.parts[trace.parts.length - 1] = Response.makePart("tool-call", {
-        id: part.id,
-        name: part.name,
-        params: parameters,
-        providerExecuted: part.providerExecuted,
-        metadata: part.metadata,
-      });
+      trace.parts.push(
+        Response.makePart("tool-call", {
+          id: part.id,
+          name: part.name,
+          params: parameters,
+          providerExecuted: part.providerExecuted,
+          metadata: part.metadata,
+        }),
+      );
       trace.toolCalls.set(part.id, {
         name: part.name,
         providerExecuted: part.providerExecuted,
@@ -2093,7 +2168,8 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
         });
       }
       const toolCallId = yield* decodeToolCallId(part.id);
-      const result = yield* decodeEventJson(part.encodedResult, "Tool result");
+      const normalized = yield* snapshotProviderToolResultPart(trace, part);
+      const result = normalized.result;
       if (part.preliminary === true) {
         yield* stageProviderResultPayload(trace, {
           _tag: "ToolProgress",
@@ -2102,6 +2178,18 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
           result,
           providerExecuted: true,
         });
+        trace.parts.push(
+          Response.toolResultPart({
+            id: part.id,
+            name: part.name,
+            isFailure: part.isFailure,
+            result,
+            encodedResult: result,
+            providerExecuted: true,
+            preliminary: true,
+            metadata: normalized.metadata,
+          }),
+        );
         return [];
       }
       if (trace.finalToolResultIds.has(part.id)) {
@@ -2109,25 +2197,37 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
           message: `Tool Call ${part.id} produced more than one terminal result`,
         });
       }
-      trace.finalToolResultIds.add(part.id);
       if (part.isFailure) {
         yield* stageProviderResultPayload(trace, {
           _tag: "ToolCallFailed",
           toolCallId,
           toolName: part.name,
-          errorTag: errorTag(part.result),
-          message: errorMessage(part.result),
+          errorTag: errorTag(result),
+          message: errorMessage(result),
           providerExecuted: true,
         });
-        return [];
+      } else {
+        yield* stageProviderResultPayload(trace, {
+          _tag: "ToolCallSucceeded",
+          toolCallId,
+          toolName: part.name,
+          result,
+          providerExecuted: true,
+        });
       }
-      yield* stageProviderResultPayload(trace, {
-        _tag: "ToolCallSucceeded",
-        toolCallId,
-        toolName: part.name,
-        result,
-        providerExecuted: true,
-      });
+      trace.finalToolResultIds.add(part.id);
+      trace.parts.push(
+        Response.toolResultPart({
+          id: part.id,
+          name: part.name,
+          isFailure: part.isFailure,
+          result,
+          encodedResult: result,
+          providerExecuted: true,
+          preliminary: false,
+          metadata: normalized.metadata,
+        }),
+      );
       return [];
     }
     case "finish": {

--- a/packages/engine/src/provider-result-staging-internal.ts
+++ b/packages/engine/src/provider-result-staging-internal.ts
@@ -1,0 +1,165 @@
+import type { Schema } from "effect";
+
+const MAX_JSON_DEPTH = 128;
+
+export interface BoundedJsonSnapshot {
+  readonly value: Schema.Json;
+  readonly bytes: number;
+}
+
+const FailedSnapshot = Symbol("@effect-agent/engine/FailedProviderResultSnapshot");
+
+/**
+ * @internal Normalize one untrusted JSON value into an owned, frozen snapshot while counting the
+ * exact UTF-8 bytes of that same snapshot. The traversal never invokes `toJSON` or accessors,
+ * rejects non-plain objects and excessive nesting, and stops as soon as the byte budget is spent.
+ */
+export const boundedJsonSnapshot = (
+  root: unknown,
+  maxBytes: number,
+  maxDepth = MAX_JSON_DEPTH,
+): BoundedJsonSnapshot | undefined => {
+  if (
+    !Number.isSafeInteger(maxBytes) ||
+    maxBytes < 0 ||
+    !Number.isSafeInteger(maxDepth) ||
+    maxDepth < 0
+  ) {
+    return undefined;
+  }
+  let total = 0;
+  const ancestors = new WeakSet<object>();
+  const add = (bytes: number): boolean => {
+    if (bytes > maxBytes - total) return false;
+    total += bytes;
+    return true;
+  };
+  const addString = (value: string): boolean => {
+    if (!add(2)) return false;
+    for (let index = 0; index < value.length; index += 1) {
+      const code = value.charCodeAt(index);
+      if (code === 0x22 || code === 0x5c) {
+        if (!add(2)) return false;
+      } else if (code <= 0x1f) {
+        // Backspace, tab, newline, form-feed, and carriage-return use two-byte escapes; all other
+        // control characters use a six-byte `\\u00xx` escape.
+        if (!add(code >= 0x08 && code <= 0x0d && code !== 0x0b ? 2 : 6)) return false;
+      } else if (code <= 0x7f) {
+        if (!add(1)) return false;
+      } else if (code <= 0x7ff) {
+        if (!add(2)) return false;
+      } else if (code >= 0xd800 && code <= 0xdbff) {
+        const low = value.charCodeAt(index + 1);
+        if (low >= 0xdc00 && low <= 0xdfff) {
+          if (!add(4)) return false;
+          index += 1;
+        } else if (!add(6)) {
+          return false;
+        }
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        if (!add(6)) return false;
+      } else if (!add(3)) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const visit = (value: unknown, depth: number): Schema.Json | typeof FailedSnapshot => {
+    if (depth > maxDepth) return FailedSnapshot;
+    if (value === null) return add(4) ? null : FailedSnapshot;
+    switch (typeof value) {
+      case "string":
+        return addString(value) ? value : FailedSnapshot;
+      case "boolean":
+        return add(value ? 4 : 5) ? value : FailedSnapshot;
+      case "number": {
+        // JSON's numeric representation is inherently bounded for one IEEE-754 value. Retain the
+        // wire-equivalent null for non-finite values so counting and later serialization agree.
+        if (!Number.isFinite(value)) return add(4) ? null : FailedSnapshot;
+        const encoded = JSON.stringify(value);
+        return encoded !== undefined && add(encoded.length) ? value : FailedSnapshot;
+      }
+      case "object": {
+        if (ancestors.has(value)) return FailedSnapshot;
+        const isArray = Array.isArray(value);
+        const prototype = Object.getPrototypeOf(value);
+        if (prototype !== (isArray ? Array.prototype : Object.prototype) && prototype !== null) {
+          return FailedSnapshot;
+        }
+        if (
+          Object.getOwnPropertyDescriptor(value, "toJSON") !== undefined ||
+          (prototype !== null && Object.getOwnPropertyDescriptor(prototype, "toJSON") !== undefined)
+        ) {
+          return FailedSnapshot;
+        }
+        ancestors.add(value);
+        try {
+          if (isArray) {
+            const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+            if (
+              lengthDescriptor === undefined ||
+              !("value" in lengthDescriptor) ||
+              typeof lengthDescriptor.value !== "number" ||
+              !Number.isSafeInteger(lengthDescriptor.value) ||
+              lengthDescriptor.value < 0
+            ) {
+              return FailedSnapshot;
+            }
+            if (!add(1)) return FailedSnapshot;
+            const snapshot: Array<Schema.Json> = [];
+            for (let index = 0; index < lengthDescriptor.value; index += 1) {
+              if (index > 0 && !add(1)) return FailedSnapshot;
+              const descriptor = Object.getOwnPropertyDescriptor(value, index);
+              if (descriptor === undefined) {
+                if (!add(4)) return FailedSnapshot;
+                snapshot.push(null);
+                continue;
+              }
+              if (!("value" in descriptor)) return FailedSnapshot;
+              const item = visit(descriptor.value, depth + 1);
+              if (item === FailedSnapshot) return FailedSnapshot;
+              snapshot.push(item);
+            }
+            if (!add(1)) return FailedSnapshot;
+            Object.setPrototypeOf(snapshot, null);
+            return Object.freeze(snapshot);
+          }
+          if (!add(1)) return FailedSnapshot;
+          const entries: Array<readonly [string, Schema.Json]> = [];
+          let first = true;
+          for (const key in value) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (descriptor === undefined || !descriptor.enumerable) continue;
+            if (!("value" in descriptor)) return FailedSnapshot;
+            if (!first && !add(1)) return FailedSnapshot;
+            first = false;
+            if (!addString(key) || !add(1)) return FailedSnapshot;
+            const item = visit(descriptor.value, depth + 1);
+            if (item === FailedSnapshot) return FailedSnapshot;
+            entries.push([key, item]);
+          }
+          if (!add(1)) return FailedSnapshot;
+          const snapshot: Record<string, Schema.Json> = Object.fromEntries(entries);
+          Object.setPrototypeOf(snapshot, null);
+          return Object.freeze(snapshot);
+        } finally {
+          ancestors.delete(value);
+        }
+      }
+      case "bigint":
+      case "function":
+      case "symbol":
+      case "undefined":
+        return FailedSnapshot;
+    }
+    return FailedSnapshot;
+  };
+
+  try {
+    const value = visit(root, 0);
+    return value === FailedSnapshot ? undefined : { value, bytes: total };
+  } catch {
+    // Revoked or adversarial proxies and reflection failures are protocol-invalid, never trusted.
+    return undefined;
+  }
+};

--- a/packages/engine/src/run-options.ts
+++ b/packages/engine/src/run-options.ts
@@ -161,9 +161,9 @@ export interface RunTurnResponseCommit {
  * Dependency-neutral durability seam implemented by a durable coordinator.
  *
  * Invocation ordering inside one Tool-declaring Turn is normative:
- * `commitResponse` fires after the finish part's continuation validations and
- * before approval preflight (making the response canonical before any Tool
- * work — the provably-safe resume window); `prepareToolCalls` fires after
+ * `commitResponse` fires after the finish part's continuation validations and staged canonical
+ * provider/Turn events have been emitted, but before approval preflight (making the response
+ * canonical before any Tool work — the provably-safe resume window); `prepareToolCalls` fires after
  * every approval resolved approved and before any handler acquires a
  * scheduler permit, with the non-`readonly` calls of the batch (it is skipped
  * entirely when no call needs preparation); `step` persists Durable Step
@@ -171,7 +171,7 @@ export interface RunTurnResponseCommit {
  * the ephemeral runtime always has.
  */
 export interface RunDurabilityHook<Error = never, Requirements = never> {
-  /** After the finish part's validations, before approval preflight. */
+  /** After validated staged response events are emitted, before approval preflight. */
   readonly commitResponse: (
     commit: RunTurnResponseCommit,
   ) => Effect.Effect<void, Error, Requirements>;

--- a/packages/engine/src/tool-telemetry-internal.ts
+++ b/packages/engine/src/tool-telemetry-internal.ts
@@ -361,9 +361,8 @@ export const makeIsolatedToolTracer = (delegate: Tracer.Tracer): IsolatedToolTra
             ["~effect/Effect/evaluate"]: evaluate,
           };
 
-          let delegated: X;
           try {
-            delegated = delegateContext(guardedPrimitive, fiber);
+            delegateContext(guardedPrimitive, fiber);
           } catch (defect) {
             const observed = currentEvaluation();
             switch (observed._tag) {
@@ -382,7 +381,7 @@ export const makeIsolatedToolTracer = (delegate: Tracer.Tracer): IsolatedToolTra
             case "Failed":
               throw observed.error;
             case "Succeeded":
-              return delegated;
+              return observed.value;
             case "Pending":
               return evaluate(fiber);
           }

--- a/packages/engine/src/tool-telemetry-internal.ts
+++ b/packages/engine/src/tool-telemetry-internal.ts
@@ -1,0 +1,496 @@
+import {
+  Cause,
+  Context,
+  Effect,
+  ErrorReporter,
+  Exit,
+  type Fiber,
+  Layer,
+  Option,
+  Stream,
+  Tracer,
+} from "effect";
+import { AiError } from "effect/unstable/ai";
+
+/**
+ * @internal Payload-free control signal used only to close the canonical Tool span with a failed
+ * Exit. It is removed immediately outside that span and never enters the public error channel.
+ */
+export class ToolSpanFailure extends AiError.AiError.extend<ToolSpanFailure>(
+  "@effect-agent/engine/ToolSpanFailure",
+)({}) {
+  override readonly name = "ToolCallFailed";
+
+  /** Schema-safe factory retaining the generated constructor required by Effect Schema. */
+  static marker(): ToolSpanFailure {
+    return ToolSpanFailure.make({
+      module: "effect-agent",
+      method: "execute_tool",
+      reason: AiError.UnknownError.make({
+        description: "Tool execution reached a failed terminal state",
+      }),
+    });
+  }
+}
+
+const TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE = "@effect-agent/engine/ToolSpanFailureMarker";
+const terminalOutcomeTokens = new WeakMap<
+  object,
+  {
+    readonly outcome: "success" | "failure";
+    readonly failureMarker: ToolSpanFailure | undefined;
+  }
+>();
+
+/** @internal Annotate one completed attempt and hand its existing marker to the isolated span. */
+export const annotateToolSpanTerminalOutcome = (
+  outcome: "success" | "failure",
+  failureMarker?: ToolSpanFailure,
+): Effect.Effect<void> => {
+  const token = {};
+  terminalOutcomeTokens.set(token, { outcome, failureMarker });
+  return Effect.annotateCurrentSpan({
+    "effect_agent.tool.outcome": outcome,
+    [TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE]: token,
+  });
+};
+
+/**
+ * @internal Emit one canonical value from the first pull, then run derivative work from either the
+ * next pull or structured stream finalization when the downstream owner stops after that value.
+ * The synchronous phase transition gives the action one owner across the pull/finalizer race, and
+ * a started action is never retried after interruption.
+ */
+export const emitThenAfter = <A, E, R, E2, R2>(
+  event: Effect.Effect<A, E, R>,
+  after: Effect.Effect<void, E2, R2>,
+): Stream.Stream<A, E | E2, R | R2> =>
+  Stream.unwrap(
+    Effect.sync(() => {
+      let firstPull = true;
+      let afterPhase: "unarmed" | "pending" | "running" | "completed" = "unarmed";
+      const runAfter = Effect.suspend((): Effect.Effect<void, E2, R2> => {
+        if (afterPhase !== "pending") return Effect.void;
+        afterPhase = "running";
+        return after.pipe(
+          Effect.onExit(() =>
+            Effect.sync(() => {
+              afterPhase = "completed";
+            }),
+          ),
+        );
+      });
+      const pull = Effect.suspend(
+        (): Effect.Effect<readonly [A], E | E2 | Cause.Done<void>, R | R2> => {
+          if (firstPull) {
+            return Effect.map(event, (value) => {
+              firstPull = false;
+              afterPhase = "pending";
+              return [value] as const;
+            });
+          }
+          return Effect.andThen(runAfter, Cause.done());
+        },
+      );
+      return Stream.fromPull(Effect.succeed(pull)).pipe(
+        Stream.ensuring(
+          // A typed `after` failure remains visible to an ordinary second pull. Cleanup only owns
+          // the otherwise-unobservable early-close path, so capture its Exit after the action has
+          // annotated the canonical span. `IsolatedToolSpan.end` derives a failed export status
+          // from that bounded outcome when cleanup consumes the private span marker. Only
+          // derivative failure/defect Reasons are suppressed; external interruption is restored.
+          Effect.exit(Effect.interruptible(runAfter)).pipe(
+            Effect.flatMap((exit) => {
+              if (Exit.isSuccess(exit)) return Effect.void;
+              return reportDerivativeCause(exit.cause);
+            }),
+          ),
+        ),
+      );
+    }),
+  );
+
+export const stripToolSpanFailures = <E>(
+  cause: Cause.Cause<E | ToolSpanFailure>,
+  marker: ToolSpanFailure,
+): { readonly found: boolean; readonly residual: Cause.Cause<E | ToolSpanFailure> } => {
+  const found = cause.reasons.some(
+    (reason) => Cause.isFailReason(reason) && reason.error === marker,
+  );
+  if (!found) {
+    // Effect v4 Cause is a flat collection of Reasons. Object-identity absence proves only that
+    // this invocation's marker is absent: another ToolSpanFailure may still be a genuine handler
+    // failure, so retain both the exact Cause object and its complete error union.
+    return { found: false, residual: cause };
+  }
+  const reasons = cause.reasons.filter((reason) => {
+    if (Cause.isFailReason(reason) && reason.error === marker) {
+      return false;
+    }
+    return true;
+  });
+  return { found: true, residual: Cause.fromReasons(reasons) };
+};
+
+/** @internal Remove only the private marker and restore the saved Cause plus every residual. */
+export const restoreToolSpanFailureCause = <E, Original>(
+  cause: Cause.Cause<E | ToolSpanFailure>,
+  marker: ToolSpanFailure,
+  original: Cause.Cause<Original> | undefined,
+): {
+  readonly found: boolean;
+  readonly restored: Cause.Cause<E | Original | ToolSpanFailure>;
+} => {
+  const { found, residual } = stripToolSpanFailures(cause, marker);
+  return {
+    found,
+    restored: original === undefined ? residual : Cause.combine(original, residual),
+  };
+};
+
+/**
+ * @internal Report derivative terminal-telemetry failures without consuming external
+ * interruption. Reporter defects are isolated, while interruption of either the measurement or
+ * reporter is restored as interruption instead of allowing Tool settlement to continue.
+ */
+const reportDerivativeCause = <E>(cause: Cause.Cause<E>): Effect.Effect<void> => {
+  const reportableReasons: Array<Cause.Reason<E>> = [];
+  const interruptionReasons: Array<Cause.Interrupt> = [];
+  for (const reason of cause.reasons) {
+    if (Cause.isInterruptReason(reason)) interruptionReasons.push(reason);
+    else reportableReasons.push(reason);
+  }
+
+  const reportExit =
+    reportableReasons.length === 0
+      ? Effect.succeed(Exit.succeed(undefined))
+      : Effect.exit(ErrorReporter.report(Cause.fromReasons(reportableReasons)));
+  return Effect.flatMap(reportExit, (exit) => {
+    if (Exit.isFailure(exit)) {
+      for (const reason of exit.cause.reasons) {
+        if (Cause.isInterruptReason(reason)) interruptionReasons.push(reason);
+      }
+    }
+    return interruptionReasons.length === 0
+      ? Effect.void
+      : Effect.failCause(Cause.fromReasons<never>(interruptionReasons));
+  });
+};
+
+export const isolateToolTerminalTelemetry = <R>(
+  telemetry: Effect.Effect<void, never, R>,
+): Effect.Effect<void, never, R> => telemetry.pipe(Effect.catchCause(reportDerivativeCause));
+
+const MAX_REPORTED_SPAN_LIFECYCLE_DEFECTS = 16;
+
+/** Content-free marker used only to close a delegate that cannot be wrapped safely. */
+class ToolSpanLifecycleFailure extends Error {
+  override readonly name = "ToolSpanLifecycleFailure";
+
+  constructor() {
+    super("Tool span lifecycle failed");
+  }
+}
+
+/**
+ * @internal Guard one host span so synchronous exporter defects cannot alter Tool execution.
+ * The wrapper retains the span contract for Effect while forwarding every measurement to the host.
+ */
+class IsolatedToolSpan implements Tracer.Span {
+  readonly _tag = "Span";
+  readonly name: string;
+  readonly spanId: string;
+  readonly traceId: string;
+  readonly parent: Tracer.Span["parent"];
+  readonly annotations: Tracer.Span["annotations"];
+  readonly attributes = new Map<string, unknown>();
+  readonly links: Array<Tracer.SpanLink>;
+  readonly sampled: boolean;
+  readonly kind: Tracer.SpanKind;
+  status: Tracer.SpanStatus;
+
+  readonly #delegate: Tracer.Span;
+  readonly #recordDefect: (defect: unknown) => void;
+  #terminalOutcome: "success" | "failure" | undefined;
+  #terminalFailure: ToolSpanFailure | undefined;
+
+  constructor(
+    delegate: Tracer.Span,
+    options: Parameters<Tracer.Tracer["span"]>[0],
+    recordDefect: (defect: unknown) => void,
+  ) {
+    this.#delegate = delegate;
+    this.#recordDefect = recordDefect;
+    this.name = options.name;
+    this.spanId = delegate.spanId;
+    this.traceId = delegate.traceId;
+    this.parent = options.parent;
+    this.annotations = options.annotations;
+    this.links = [...options.links];
+    // The host tracer owns the final sampling decision. Reading it here keeps that access inside
+    // the caller's existing creation try/fallback together with span allocation and identifiers.
+    this.sampled = delegate.sampled;
+    this.kind = options.kind;
+    this.status = { _tag: "Started", startTime: options.startTime };
+  }
+
+  end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    if (this.status._tag === "Ended") return;
+    // Early downstream closure can own terminal telemetry from a no-fail stream finalizer, where
+    // the private typed marker is intentionally captured because there is no consumer left to
+    // observe it. Once present, the bounded outcome annotation is authoritative for this completed
+    // attempt even if downstream cancellation or telemetry interruption determines the channel Exit.
+    const exportedExit =
+      this.#terminalOutcome === "failure"
+        ? Exit.fail(this.#terminalFailure ?? new ToolSpanLifecycleFailure())
+        : this.#terminalOutcome === "success"
+          ? Exit.succeed(undefined)
+          : exit;
+    this.status = {
+      _tag: "Ended",
+      startTime: this.status.startTime,
+      endTime,
+      exit: exportedExit,
+    };
+    if (this.#terminalOutcome !== undefined) {
+      // The public attribute map is intentionally mutable for ordinary instrumentation. Restore
+      // this framework-owned value from the authenticated private token at the export boundary so
+      // handler or telemetry code cannot forge the canonical terminal classification.
+      this.attributes.set("effect_agent.tool.outcome", this.#terminalOutcome);
+      try {
+        this.#delegate.attribute("effect_agent.tool.outcome", this.#terminalOutcome);
+      } catch (defect) {
+        this.#recordDefect(defect);
+      }
+    }
+    try {
+      this.#delegate.end(endTime, exportedExit);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+
+  attribute(key: string, value: unknown): void {
+    if (key === TOOL_SPAN_FAILURE_MARKER_ATTRIBUTE) {
+      if (typeof value === "object" && value !== null) {
+        const terminal = terminalOutcomeTokens.get(value);
+        if (terminal !== undefined) {
+          this.#terminalOutcome = terminal.outcome;
+          this.#terminalFailure = terminal.failureMarker;
+        }
+      }
+      return;
+    }
+    this.attributes.set(key, value);
+    try {
+      this.#delegate.attribute(key, value);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+
+  event(name: string, startTime: bigint, attributes?: Record<string, unknown>): void {
+    try {
+      this.#delegate.event(name, startTime, attributes);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+
+  addLinks(links: ReadonlyArray<Tracer.SpanLink>): void {
+    this.links.push(...links);
+    try {
+      this.#delegate.addLinks(links);
+    } catch (defect) {
+      this.#recordDefect(defect);
+    }
+  }
+}
+
+interface IsolatedToolTracer {
+  readonly tracer: Tracer.Tracer;
+  readonly reportLifecycleDefects: Effect.Effect<void>;
+}
+
+/**
+ * @internal Isolate the complete canonical span lifecycle. A creation defect receives a local,
+ * non-exported span so the handler still runs; delegate method/finalization defects are retained
+ * as bounded reporter diagnostics and never enter the handler stream Cause.
+ */
+export const makeIsolatedToolTracer = (delegate: Tracer.Tracer): IsolatedToolTracer => {
+  const defects: Array<unknown> = [];
+  const recordDefect = (defect: unknown): void => {
+    if (defects.length < MAX_REPORTED_SPAN_LIFECYCLE_DEFECTS) defects.push(defect);
+  };
+  let delegateContext: Tracer.Tracer["context"];
+  try {
+    delegateContext = delegate.context?.bind(delegate);
+  } catch (defect) {
+    recordDefect(defect);
+    delegateContext = undefined;
+  }
+  const context: Tracer.Tracer["context"] =
+    delegateContext === undefined
+      ? undefined
+      : <X>(primitive: Tracer.EffectPrimitive<X>, fiber: Fiber.Fiber<unknown, unknown>): X => {
+          type Evaluation =
+            | { readonly _tag: "Pending" }
+            | { readonly _tag: "Succeeded"; readonly value: X }
+            | { readonly _tag: "Failed"; readonly error: unknown };
+          let evaluation: Evaluation = { _tag: "Pending" };
+          const currentEvaluation = (): Evaluation => evaluation;
+          const evaluate = (currentFiber: Fiber.Fiber<unknown, unknown>): X => {
+            switch (evaluation._tag) {
+              case "Succeeded":
+                return evaluation.value;
+              case "Failed":
+                throw evaluation.error;
+              case "Pending": {
+                try {
+                  const value = primitive["~effect/Effect/evaluate"](currentFiber);
+                  evaluation = { _tag: "Succeeded", value };
+                  return value;
+                } catch (error) {
+                  evaluation = { _tag: "Failed", error };
+                  throw error;
+                }
+              }
+            }
+          };
+          const guardedPrimitive: Tracer.EffectPrimitive<X> = {
+            ["~effect/Effect/evaluate"]: evaluate,
+          };
+
+          let delegated: X;
+          try {
+            delegated = delegateContext(guardedPrimitive, fiber);
+          } catch (defect) {
+            const observed = currentEvaluation();
+            switch (observed._tag) {
+              case "Failed":
+                throw observed.error;
+              case "Succeeded":
+                recordDefect(defect);
+                return observed.value;
+              case "Pending":
+                recordDefect(defect);
+                return evaluate(fiber);
+            }
+          }
+          const observed = currentEvaluation();
+          switch (observed._tag) {
+            case "Failed":
+              throw observed.error;
+            case "Succeeded":
+              return delegated;
+            case "Pending":
+              return evaluate(fiber);
+          }
+        };
+  const tracer = Tracer.make({
+    context,
+    span(options) {
+      let delegateSpan: Tracer.Span;
+      try {
+        delegateSpan = delegate.span(options);
+      } catch (defect) {
+        recordDefect(defect);
+        // This native span is deliberately not handed to the host exporter. It only preserves
+        // Effect's current-span contract so Tool behavior continues without observable tracing.
+        return new Tracer.NativeSpan(options);
+      }
+      try {
+        return new IsolatedToolSpan(delegateSpan, options, recordDefect);
+      } catch (defect) {
+        recordDefect(defect);
+        try {
+          // Allocation succeeded, so best-effort close the host span without attaching the raw
+          // wrapper defect. The start time gives this abandoned measurement a bounded duration.
+          delegateSpan.end(options.startTime, Exit.fail(new ToolSpanLifecycleFailure()));
+        } catch (closeDefect) {
+          recordDefect(closeDefect);
+        }
+        return new Tracer.NativeSpan(options);
+      }
+    },
+  });
+  const reportLifecycleDefects = Effect.suspend(() => {
+    const pending = defects.splice(0);
+    return Effect.forEach(
+      pending,
+      (defect) => isolateToolTerminalTelemetry(ErrorReporter.report(Cause.die(defect))),
+      { discard: true },
+    );
+  });
+  return { tracer, reportLifecycleDefects };
+};
+
+export interface ToolSpanTelemetryService {
+  /** Measure one Tool handler attempt while isolating every host span-lifecycle defect. */
+  readonly isolateSpanLifecycle: <A, E, R>(
+    stream: Stream.Stream<A, E, R>,
+  ) => Stream.Stream<A, E, R>;
+  /** Keep Effect AI implementation annotations local while preserving host-owned handler spans. */
+  readonly isolateToolkitHandle: <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+}
+
+/**
+ * @internal Engine-owned span-lifecycle policy. The AgentRuntime composition boundary builds this
+ * capability from the host's ambient Tracer; Tool execution consumes it without selecting,
+ * decorating, or locally providing a Tracer implementation.
+ */
+export class ToolSpanTelemetry extends Context.Service<
+  ToolSpanTelemetry,
+  ToolSpanTelemetryService
+>()("@effect-agent/engine/ToolSpanTelemetry") {
+  static readonly layer: Layer.Layer<ToolSpanTelemetry> = Layer.effect(
+    ToolSpanTelemetry,
+    Effect.map(Tracer.Tracer, (delegate) =>
+      ToolSpanTelemetry.of({
+        isolateToolkitHandle: (effect) =>
+          Effect.currentSpan.pipe(
+            Effect.option,
+            Effect.flatMap((parentOption) => {
+              if (Option.isNone(parentOption)) return effect;
+              const parent = parentOption.value;
+              // Effect AI annotates its current span with decoded Tool parameters before forking
+              // the handler. Keep those annotations on a local span that is never handed to the
+              // host tracer. DisablePropagation makes explicit handler spans filter past this
+              // implementation parent and attach to the canonical execute_tool span instead.
+              const local = new Tracer.NativeSpan({
+                name: "AgentRuntime.toolkit.handle",
+                parent: Option.some(parent),
+                annotations: Context.add(Context.empty(), Tracer.DisablePropagation, true),
+                links: [],
+                startTime: 0n,
+                kind: "internal",
+                sampled: parent.sampled,
+              });
+              return effect.pipe(
+                Effect.withParentSpan(local),
+                Effect.onExit((exit) =>
+                  Effect.sync(() => {
+                    local.end(0n, exit);
+                  }),
+                ),
+              );
+            }),
+          ),
+        isolateSpanLifecycle: (stream) =>
+          Stream.unwrap(
+            Effect.sync(() => {
+              const isolated = makeIsolatedToolTracer(delegate);
+              return stream.pipe(
+                Stream.provideService(Tracer.Tracer, isolated.tracer),
+                // `Stream.ensuring` runs after the canonical span's own finalizer, so creation,
+                // annotation, and close defects are reported outside this execution's measurement.
+                Stream.ensuring(isolated.reportLifecycleDefects),
+              );
+            }),
+          ),
+      }),
+    ),
+  );
+}

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -21,13 +21,17 @@ import {
   DateTime,
   Deferred,
   Effect,
+  ErrorReporter,
   Exit,
   Fiber,
   Layer,
+  Logger,
   Option,
   Ref,
+  References,
   Schema,
   Stream,
+  Tracer,
 } from "effect";
 import { TestClock } from "effect/testing";
 import {
@@ -42,11 +46,23 @@ import {
 
 import {
   AgentRuntime,
+  ToolExecutionClass,
   withTerminalDefectEvent,
   type RunBudgetHook,
   type RunTurnResume,
   type RunUsageDelta,
 } from "../src/index.ts";
+import { boundedJsonSnapshot } from "../src/provider-result-staging-internal.ts";
+import {
+  annotateToolSpanTerminalOutcome,
+  emitThenAfter,
+  isolateToolTerminalTelemetry,
+  makeIsolatedToolTracer,
+  restoreToolSpanFailureCause,
+  stripToolSpanFailures,
+  ToolSpanTelemetry,
+  ToolSpanFailure,
+} from "../src/tool-telemetry-internal.ts";
 
 class ScheduledToolFailure extends Schema.TaggedError<ScheduledToolFailure>()(
   "ScheduledToolFailure",
@@ -56,6 +72,10 @@ class ScheduledToolFailure extends Schema.TaggedError<ScheduledToolFailure>()(
 class HookFailure extends Schema.TaggedError<HookFailure>()("HookFailure", {
   message: Schema.String,
 }) {}
+
+class TestCauseSource extends Context.Service<TestCauseSource, string>()(
+  "@effect-agent/engine/test/TestCauseSource",
+) {}
 
 class BudgetGuardFailure extends Schema.TaggedError<BudgetGuardFailure>()("BudgetGuardFailure", {
   message: Schema.String,
@@ -154,6 +174,88 @@ const errorMessageForTest = (error: unknown): string =>
   typeof error.message === "string"
     ? error.message
     : String(error);
+
+/** Traverse every OTLP-facing observation value, including Maps and non-enumerable Error fields. */
+const reachableTelemetryValues = (root: unknown): ReadonlyArray<unknown> => {
+  const values: Array<unknown> = [];
+  const visited = new WeakSet<object>();
+  const visit = (value: unknown): void => {
+    values.push(value);
+    if ((typeof value !== "object" && typeof value !== "function") || value === null) return;
+    if (visited.has(value)) return;
+    visited.add(value);
+    if (value instanceof Map) {
+      for (const [key, item] of value) {
+        visit(key);
+        visit(item);
+      }
+    } else if (value instanceof Set) {
+      for (const item of value) visit(item);
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      visit(key);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && "value" in descriptor) visit(descriptor.value);
+    }
+  };
+  visit(root);
+  return values;
+};
+
+/** Snapshot every field Effect's OTLP tracer exports, without retaining a successful Exit value. */
+const exportedSpanObservation = (span: Tracer.NativeSpan) => ({
+  name: span.name,
+  spanId: span.spanId,
+  traceId: span.traceId,
+  parentSpanId: Option.getOrUndefined(span.parent)?.spanId,
+  sampled: span.sampled,
+  kind: span.kind,
+  startTime: span.startTime,
+  status:
+    span.status._tag === "Started"
+      ? span.status
+      : {
+          _tag: span.status._tag,
+          startTime: span.status.startTime,
+          endTime: span.status.endTime,
+          failureCause: Exit.isFailure(span.status.exit) ? span.status.exit.cause : undefined,
+        },
+  attributes: Object.fromEntries(span.attributes),
+  events: span.events.map(([name, startTime, attributes]) => ({
+    name,
+    startTime,
+    attributes: { ...attributes },
+  })),
+  links: span.links.map(({ span: linkedSpan, attributes }) => ({
+    traceId: linkedSpan.traceId,
+    spanId: linkedSpan.spanId,
+    attributes: { ...attributes },
+  })),
+});
+
+/** Snapshot every input or context field Effect's pinned OTLP logger can export. */
+const exportedLogObservation = ({ cause, fiber, logLevel, message }: Logger.Options<unknown>) => ({
+  message,
+  level: logLevel,
+  cause,
+  annotations: { ...fiber.getRef(References.CurrentLogAnnotations) },
+  logSpans: fiber
+    .getRef(References.CurrentLogSpans)
+    .map(([label, startTime]) => ({ label, startTime })),
+  fiberId: fiber.id,
+  currentSpan:
+    fiber.currentSpan === undefined
+      ? undefined
+      : {
+          traceId: fiber.currentSpan.traceId,
+          spanId: fiber.currentSpan.spanId,
+        },
+});
+
+type ExportedLogObservation = ReturnType<typeof exportedLogObservation>;
+
+const renderedLogMessage = (message: unknown): string =>
+  Array.isArray(message) ? message.join(" ") : String(message);
 
 layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
   it.effect("preserves official prior history as the exact prefix of a new Run", () => {
@@ -412,6 +514,1634 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(providerResultStayedAssistant).toBe(true);
       expect(result.some((event) => event._tag === "ToolCallStarted")).toBe(false);
     });
+  });
+
+  it.effect("exports content-free canonical Tool spans and bounded terminal logs", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const logs: Array<ExportedLogObservation> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const logger = Logger.make<unknown, void>((options) => {
+      const observation = exportedLogObservation(options);
+      logs.push(observation);
+    });
+    const handlerSecret = "handler-result-must-not-be-exported";
+    const failureSecret = "failure-message-must-not-be-exported";
+    const failureToolCallId = "fail-observed-1";
+    const returnedFailure = ScheduledToolFailure.make({ message: failureSecret });
+    const Read = Tool.make("read", {
+      parameters: Schema.Struct({ path: Schema.String }),
+      success: Schema.String,
+    }).annotate(ToolExecutionClass, "readonly");
+    const Fail = Tool.make("fail", {
+      parameters: Schema.Struct({ command: Schema.String }),
+      success: Schema.String,
+      failure: ScheduledToolFailure,
+      failureMode: "return",
+    });
+    const tools = Toolkit.make(Read, Fail);
+    const model = Model.make(
+      "scripted",
+      "tool-observability",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        Effect.gen(function* () {
+          const turn = yield* Ref.make(0);
+          return yield* LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () =>
+              Stream.unwrap(
+                Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                  Effect.map((value) =>
+                    value === 0
+                      ? Stream.fromIterable<Response.StreamPartEncoded>([
+                          {
+                            type: "tool-call",
+                            id: "read-observed-1",
+                            name: "read",
+                            params: { path: "/private/source.ts" },
+                            providerExecuted: false,
+                          },
+                          {
+                            type: "tool-call",
+                            id: failureToolCallId,
+                            name: "fail",
+                            params: { command: "printenv SECRET" },
+                            providerExecuted: false,
+                          },
+                          { type: "finish", reason: "tool-calls", usage },
+                        ])
+                      : Stream.fromIterable(finalParts('{"answer":"observed"}')),
+                  ),
+                ),
+              ),
+          });
+        }),
+      ),
+    );
+    const definition = Agent.define("tool-observability", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Call both Tools.",
+      toolkit: tools,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 2,
+        maxDuration: "30 seconds",
+        toolConcurrency: 2,
+      }),
+    });
+    const toolLayer = tools.toLayer({
+      read: () => Effect.succeed(handlerSecret).pipe(Effect.withSpan("host.read")),
+      fail: () => Effect.fail(returnedFailure),
+    });
+
+    return Effect.gen(function* () {
+      const events = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "Which Tools ran?",
+      }).pipe(Stream.runCollect, Effect.provide(toolLayer));
+
+      expect(events.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(1);
+      expect(events.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(1);
+
+      const toolSpans = spans
+        .filter((span) => span.name.startsWith("execute_tool "))
+        .toSorted((left, right) => left.name.localeCompare(right.name));
+      expect(toolSpans).toHaveLength(2);
+      expect(toolSpans.map((span) => span.name)).toEqual([
+        "execute_tool fail",
+        "execute_tool read",
+      ]);
+      expect(spans.some((span) => span.name === "AgentRuntime.toolkit.handle")).toBe(false);
+      const hostOwnedSpan = spans.find((span) => span.name === "host.read");
+      expect(hostOwnedSpan?.status._tag).toBe("Ended");
+      expect(Object.fromEntries(hostOwnedSpan?.attributes ?? [])).toEqual({});
+      expect(hostOwnedSpan?.events).toEqual([]);
+      expect(hostOwnedSpan?.links).toEqual([]);
+      const hostParent = Option.getOrUndefined(hostOwnedSpan?.parent ?? Option.none());
+      expect(hostParent?._tag).toBe("Span");
+      if (hostParent?._tag !== "Span") {
+        throw new Error("Expected the host-owned handler span to have a canonical Tool parent");
+      }
+      expect(hostParent.name).toBe("execute_tool read");
+      expect(hostOwnedSpan?.traceId).toBe(hostParent.traceId);
+
+      const [failedSpan, succeededSpan] = toolSpans;
+      expect(failedSpan?.kind).toBe("internal");
+      const failedAttributes = Object.fromEntries(failedSpan?.attributes ?? []);
+      expect(failedAttributes).toMatchObject({
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "fail",
+        "gen_ai.tool.type": "function",
+        "gen_ai.agent.name": "tool-observability",
+        "gen_ai.conversation.id": "conversation-1",
+        "effect_agent.tool.execution_class": "uncertain",
+        "effect_agent.tool.outcome": "failure",
+        agentId: "tool-observability",
+        conversationId: "conversation-1",
+        runId: "run-1",
+        turnId: "turn-1",
+        toolCallId: failureToolCallId,
+        toolName: "fail",
+        "gen_ai.tool.call.id": failureToolCallId,
+      });
+      expect(Object.fromEntries(succeededSpan?.attributes ?? [])).toMatchObject({
+        "gen_ai.tool.name": "read",
+        "gen_ai.tool.call.id": "read-observed-1",
+        "effect_agent.tool.execution_class": "readonly",
+        "effect_agent.tool.outcome": "success",
+        toolCallId: "read-observed-1",
+      });
+      expect(failedSpan?.status._tag).toBe("Ended");
+      expect(succeededSpan?.status._tag).toBe("Ended");
+      if (failedSpan?.status._tag !== "Ended" || !Exit.isFailure(failedSpan.status.exit)) {
+        throw new Error("Expected the returned Tool failure span to end failed");
+      }
+      expect(Cause.pretty(failedSpan.status.exit.cause)).not.toContain(failureSecret);
+      if (succeededSpan?.status._tag !== "Ended") {
+        throw new Error("Expected the successful Tool span to end");
+      }
+      expect(Exit.isSuccess(succeededSpan.status.exit)).toBe(true);
+
+      const terminalLogs = logs.filter((entry) =>
+        ["agent tool execution completed", "agent tool execution failed"].includes(
+          renderedLogMessage(entry.message),
+        ),
+      );
+      expect(terminalLogs).toHaveLength(2);
+      expect(
+        terminalLogs
+          .map((entry) => ({
+            level: entry.level,
+            message: renderedLogMessage(entry.message),
+            outcome: entry.annotations.toolOutcome,
+            toolName: entry.annotations.toolName,
+          }))
+          .toSorted((left, right) => String(left.toolName).localeCompare(String(right.toolName))),
+      ).toEqual([
+        {
+          level: "Warn",
+          message: "agent tool execution failed",
+          outcome: "failure",
+          toolName: "fail",
+        },
+        {
+          level: "Info",
+          message: "agent tool execution completed",
+          outcome: "success",
+          toolName: "read",
+        },
+      ]);
+      expect(terminalLogs.map(({ annotations }) => annotations["gen_ai.operation.name"])).toEqual([
+        "execute_tool",
+        "execute_tool",
+      ]);
+      expect(terminalLogs.map(({ annotations }) => annotations["gen_ai.conversation.id"])).toEqual([
+        "conversation-1",
+        "conversation-1",
+      ]);
+      expect(terminalLogs.map(({ annotations }) => annotations.conversationId)).toEqual([
+        "conversation-1",
+        "conversation-1",
+      ]);
+      const failedLog = terminalLogs.find(({ annotations }) => annotations.toolName === "fail");
+      expect(failedLog?.annotations).toMatchObject({
+        "gen_ai.tool.call.id": failureToolCallId,
+        toolCallId: failureToolCallId,
+      });
+      const succeededLog = terminalLogs.find(({ annotations }) => annotations.toolName === "read");
+      expect(succeededLog?.annotations).toMatchObject({
+        "gen_ai.tool.call.id": "read-observed-1",
+        toolCallId: "read-observed-1",
+      });
+      const exportedValues = reachableTelemetryValues({
+        spans: spans.map(exportedSpanObservation),
+        logs,
+      });
+      expect(exportedValues).not.toContain(returnedFailure);
+      const exportedStrings = exportedValues
+        .filter((value) => typeof value === "string")
+        .join("\n");
+      expect(exportedStrings).not.toContain("/private/source.ts");
+      expect(exportedStrings).not.toContain("printenv SECRET");
+      expect(exportedStrings).not.toContain(handlerSecret);
+      expect(exportedStrings).not.toContain(failureSecret);
+    }).pipe(Effect.provideService(Tracer.Tracer, tracer), Effect.provide(Logger.layer([logger])));
+  });
+
+  it.effect("rejects invalid model Tool Call IDs before correlation or handler execution", () =>
+    Effect.gen(function* () {
+      const handlerCalls = yield* Ref.make(0);
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const invalidIdSecret = "invalid-tool-call-id-must-not-reach-a-handler";
+      const invalidId = `unsafe/${invalidIdSecret}/${"x".repeat(256)}`;
+      const Read = Tool.make("read_invalid_id", {
+        parameters: Schema.Struct({ path: Schema.String }),
+        success: Schema.String,
+      });
+      const tools = Toolkit.make(Read);
+      const definition = Agent.define("invalid-tool-call-id", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Call the Tool.",
+        toolkit: tools,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const model = modelFromParts([
+        {
+          type: "tool-call",
+          id: invalidId,
+          name: "read_invalid_id",
+          params: { path: "/private/source.ts" },
+          providerExecuted: false,
+        },
+        { type: "finish", reason: "tool-calls", usage },
+      ]);
+      const toolLayer = tools.toLayer({
+        read_invalid_id: () =>
+          Ref.update(handlerCalls, (calls) => calls + 1).pipe(Effect.as("unexpected")),
+      });
+
+      const exit = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "Which Tool ran?",
+      }).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(ModelProtocolError);
+      expect(failure.message).toContain("invalid Tool Call ID");
+      expect(failure.message).not.toContain(invalidIdSecret);
+      expect(yield* Ref.get(handlerCalls)).toBe(0);
+      expect(observed.some((event) => event._tag === "ToolCallDeclared")).toBe(false);
+      expect(observed.some((event) => event._tag === "ToolCallStarted")).toBe(false);
+      expect(observed.some((event) => event._tag === "ToolCallSucceeded")).toBe(false);
+      expect(observed.some((event) => event._tag === "ToolCallFailed")).toBe(false);
+    }),
+  );
+
+  it.effect("exports one failed Tool outcome when downstream stops at its terminal event", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const logs: Array<ExportedLogObservation> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const logger = Logger.make<unknown, void>((options) => {
+      logs.push(exportedLogObservation(options));
+    });
+    const failureSecret = "early-close-returned-failure-must-not-be-exported";
+    const returnedFailure = ScheduledToolFailure.make({ message: failureSecret });
+    const Fail = Tool.make("fail_early", {
+      parameters: Schema.Struct({ command: Schema.String }),
+      success: Schema.String,
+      failure: ScheduledToolFailure,
+      failureMode: "return",
+    });
+    const tools = Toolkit.make(Fail);
+    const model = modelFromParts([
+      {
+        type: "tool-call",
+        id: "fail-early-1",
+        name: "fail_early",
+        params: { command: "private command" },
+        providerExecuted: false,
+      },
+      { type: "finish", reason: "tool-calls", usage },
+    ]);
+    const definition = Agent.define("early-close-tool-observability", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Call the Tool.",
+      toolkit: tools,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const events = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "Fail once",
+      }).pipe(
+        Stream.takeUntil((event) => event._tag === "ToolCallFailed"),
+        Stream.runCollect,
+        Effect.provide(tools.toLayer({ fail_early: () => Effect.fail(returnedFailure) })),
+      );
+
+      expect(events.at(-1)).toMatchObject({
+        _tag: "ToolCallFailed",
+        toolCallId: "fail-early-1",
+        toolName: "fail_early",
+        providerExecuted: false,
+      });
+      const terminalLogs = logs.filter(
+        (entry) => renderedLogMessage(entry.message) === "agent tool execution failed",
+      );
+      expect(terminalLogs).toHaveLength(1);
+      expect(terminalLogs[0]?.annotations).toMatchObject({
+        "effect_agent.tool.outcome": "failure",
+        toolName: "fail_early",
+        toolOutcome: "failure",
+      });
+
+      const span = spans.find((candidate) => candidate.name === "execute_tool fail_early");
+      expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
+        "effect_agent.tool.outcome": "failure",
+      });
+      if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
+        throw new Error("Expected the early-closed returned Tool failure span to end failed");
+      }
+      const exportedValues = reachableTelemetryValues({
+        spans: [exportedSpanObservation(span)],
+        logs: terminalLogs,
+      });
+      expect(exportedValues).not.toContain(returnedFailure);
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        failureSecret,
+      );
+    }).pipe(Effect.provideService(Tracer.Tracer, tracer), Effect.provide(Logger.layer([logger])));
+  });
+
+  it.effect("runs deferred work once from an ordinary second pull", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const observed = yield* emitThenAfter(
+        Effect.succeed("terminal-event"),
+        Ref.update(attempts, (count) => count + 1),
+      ).pipe(Stream.runCollect);
+
+      expect([...observed]).toEqual(["terminal-event"]);
+      expect(yield* Ref.get(attempts)).toBe(1);
+    }),
+  );
+
+  it.effect("runs deferred work once when downstream closes after the first value", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const observed = yield* emitThenAfter(
+        Effect.succeed("terminal-event"),
+        Ref.update(attempts, (count) => count + 1),
+      ).pipe(Stream.take(1), Stream.runCollect);
+
+      expect([...observed]).toEqual(["terminal-event"]);
+      expect(yield* Ref.get(attempts)).toBe(1);
+    }),
+  );
+
+  it.effect("preserves exact interruption during an in-flight early-close finalizer", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const blocked = yield* Deferred.make<void>();
+      const interruptor = 7332;
+      const fiber = yield* emitThenAfter(
+        Effect.succeed("terminal-event"),
+        Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(blocked))),
+      ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
+
+      yield* Deferred.await(entered);
+      fiber.interruptUnsafe(interruptor);
+      const exit = yield* Fiber.await(fiber);
+
+      if (Exit.isSuccess(exit)) throw new Error("Expected early-close finalizer interruption");
+      expect(exit.cause.reasons).toHaveLength(1);
+      expect(exit.cause.reasons[0]?._tag).toBe("Interrupt");
+      if (exit.cause.reasons[0]?._tag !== "Interrupt") {
+        throw new Error("Expected exact early-close interruption Cause");
+      }
+      expect(exit.cause.reasons[0].fiberId).toBe(interruptor);
+    }),
+  );
+
+  it.effect("reports typed failures and defects owned by early-close finalization", () => {
+    const typedFailure = new Error("early-close-typed-derivative-failure");
+    const defect = new Error("early-close-derivative-defect");
+    const reports: Array<Cause.Cause<unknown>> = [];
+    const reporter = ErrorReporter.make(({ cause }) => {
+      reports.push(cause);
+    });
+
+    return Effect.gen(function* () {
+      const typedObserved = yield* emitThenAfter(
+        Effect.succeed("typed-event"),
+        Effect.fail(typedFailure),
+      ).pipe(Stream.take(1), Stream.runCollect);
+      const defectObserved = yield* emitThenAfter(
+        Effect.succeed("defect-event"),
+        Effect.die(defect),
+      ).pipe(Stream.take(1), Stream.runCollect);
+
+      expect([...typedObserved]).toEqual(["typed-event"]);
+      expect([...defectObserved]).toEqual(["defect-event"]);
+      expect(reports).toHaveLength(2);
+      expect(reports[0]?.reasons).toHaveLength(1);
+      expect(reports[0]?.reasons[0]?._tag).toBe("Fail");
+      if (reports[0]?.reasons[0]?._tag !== "Fail") {
+        throw new Error("Expected the early-close typed failure to reach ErrorReporter");
+      }
+      expect(reports[0].reasons[0].error).toBe(typedFailure);
+      expect(reports[1]?.reasons).toHaveLength(1);
+      expect(reports[1]?.reasons[0]?._tag).toBe("Die");
+      if (reports[1]?.reasons[0]?._tag !== "Die") {
+        throw new Error("Expected the early-close defect to reach ErrorReporter");
+      }
+      expect(reports[1].reasons[0].defect).toBe(defect);
+    }).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+  });
+
+  it.effect("does not arm deferred work when the event fails", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const eventFailure = new Error("terminal event was not committed");
+      const exit = yield* emitThenAfter(
+        Effect.fail(eventFailure),
+        Ref.update(attempts, (count) => count + 1),
+      ).pipe(Stream.runDrain, Effect.exit);
+
+      if (Exit.isSuccess(exit)) throw new Error("Expected the event Effect to fail");
+      expect(Cause.findErrorOption(exit.cause)).toEqual(Option.some(eventFailure));
+      expect(yield* Ref.get(attempts)).toBe(0);
+    }),
+  );
+
+  it.effect("does not arm deferred work when downstream takes zero values", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const observed = yield* emitThenAfter(
+        Effect.succeed("terminal-event"),
+        Ref.update(attempts, (count) => count + 1),
+      ).pipe(Stream.take(0), Stream.runCollect);
+
+      expect([...observed]).toEqual([]);
+      expect(yield* Ref.get(attempts)).toBe(0);
+    }),
+  );
+
+  it.effect("does not arm deferred work when an opened scope closes before its first pull", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const stream = emitThenAfter(
+        Effect.succeed("terminal-event"),
+        Ref.update(attempts, (count) => count + 1),
+      );
+
+      yield* Effect.scoped(Stream.toPull(stream).pipe(Effect.asVoid));
+      expect(yield* Ref.get(attempts)).toBe(0);
+    }),
+  );
+
+  it.effect("emits the event first and never retries an interrupted deferred action", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const observed: Array<string> = [];
+      const exit = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const telemetryEntered = yield* Deferred.make<void>();
+          const telemetryBlocked = yield* Deferred.make<void>();
+          const stream = emitThenAfter(
+            Effect.succeed("terminal-event"),
+            Ref.update(attempts, (count) => count + 1).pipe(
+              Effect.andThen(Deferred.succeed(telemetryEntered, undefined)),
+              Effect.andThen(Deferred.await(telemetryBlocked)),
+            ),
+          ).pipe(
+            Stream.tap((event) =>
+              Effect.sync(() => {
+                observed.push(event);
+              }),
+            ),
+          );
+          const pull = yield* Stream.toPull(stream);
+
+          expect(yield* pull).toEqual(["terminal-event"]);
+          expect(observed).toEqual(["terminal-event"]);
+
+          const secondPull = yield* Effect.forkChild(pull);
+          yield* Deferred.await(telemetryEntered);
+          yield* Fiber.interrupt(secondPull);
+          return yield* Fiber.await(secondPull);
+        }),
+      );
+
+      expect(observed).toEqual(["terminal-event"]);
+      if (Exit.isSuccess(exit)) throw new Error("Expected terminal telemetry interruption");
+      expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+      expect(yield* Ref.get(attempts)).toBe(1);
+    }),
+  );
+
+  it.effect("keeps committed terminal outcomes authoritative over telemetry interruption", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+
+    return Effect.gen(function* () {
+      const telemetry = yield* ToolSpanTelemetry;
+      const failureMarker = ToolSpanFailure.marker();
+      yield* Effect.forEach(
+        ["success", "failure"] as const,
+        (outcome) =>
+          Effect.gen(function* () {
+            const entered = yield* Deferred.make<void>();
+            const blocked = yield* Deferred.make<void>();
+            const pullExit = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const stream = emitThenAfter(
+                  Effect.succeed(`terminal-${outcome}`),
+                  annotateToolSpanTerminalOutcome(
+                    outcome,
+                    outcome === "failure" ? failureMarker : undefined,
+                  ).pipe(
+                    Effect.andThen(
+                      Effect.flatMap(Effect.currentSpan, (span) =>
+                        Effect.sync(() => {
+                          // Host/application code can mutate this public observation map. The
+                          // authenticated private terminal state must remain authoritative.
+                          span.attribute(
+                            "effect_agent.tool.outcome",
+                            outcome === "success" ? "failure" : "success",
+                          );
+                        }),
+                      ),
+                    ),
+                    Effect.andThen(Deferred.succeed(entered, undefined)),
+                    Effect.andThen(Deferred.await(blocked)),
+                  ),
+                ).pipe(
+                  Stream.withSpan(`execute_tool interrupted-${outcome}`),
+                  telemetry.isolateSpanLifecycle,
+                );
+                const pull = yield* Stream.toPull(stream);
+                expect(yield* pull).toEqual([`terminal-${outcome}`]);
+                const secondPull = yield* Effect.forkChild(pull);
+                yield* Deferred.await(entered);
+                yield* Fiber.interrupt(secondPull);
+                return yield* Fiber.await(secondPull);
+              }),
+            );
+            if (Exit.isSuccess(pullExit)) throw new Error("Expected telemetry interruption");
+            expect(Cause.hasInterrupts(pullExit.cause)).toBe(true);
+          }),
+        { discard: true },
+      );
+
+      for (const outcome of ["success", "failure"] as const) {
+        const span = spans.find(
+          (candidate) => candidate.name === `execute_tool interrupted-${outcome}`,
+        );
+        expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
+          "effect_agent.tool.outcome": outcome,
+        });
+        if (span?.status._tag !== "Ended") throw new Error("Expected the Tool span to end");
+        expect(Exit.isSuccess(span.status.exit)).toBe(outcome === "success");
+        if (outcome === "failure") {
+          if (Exit.isSuccess(span.status.exit)) throw new Error("Expected a failed Tool span");
+          expect(Cause.findErrorOption(span.status.exit.cause)).toEqual(Option.some(failureMarker));
+        }
+        expect(Object.fromEntries(span.attributes)).not.toHaveProperty(
+          "@effect-agent/engine/ToolSpanFailureMarker",
+        );
+      }
+    }).pipe(Effect.provide(ToolSpanTelemetry.layer), Effect.provideService(Tracer.Tracer, tracer));
+  });
+
+  it.effect("preserves the enclosing interruption when no terminal outcome exists", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+
+    return Effect.gen(function* () {
+      const telemetry = yield* ToolSpanTelemetry;
+      const entered = yield* Deferred.make<void>();
+      const blocked = yield* Deferred.make<void>();
+      const pullExit = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const stream = emitThenAfter(
+            Effect.succeed("nonterminal-event"),
+            Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(blocked))),
+          ).pipe(Stream.withSpan("execute_tool without-outcome"), telemetry.isolateSpanLifecycle);
+          const pull = yield* Stream.toPull(stream);
+          expect(yield* pull).toEqual(["nonterminal-event"]);
+          const secondPull = yield* Effect.forkChild(pull);
+          yield* Deferred.await(entered);
+          yield* Fiber.interrupt(secondPull);
+          return yield* Fiber.await(secondPull);
+        }),
+      );
+      if (Exit.isSuccess(pullExit)) throw new Error("Expected telemetry interruption");
+
+      const span = spans.find((candidate) => candidate.name === "execute_tool without-outcome");
+      if (span?.status._tag !== "Ended" || Exit.isSuccess(span.status.exit)) {
+        throw new Error("Expected the unannotated span to preserve interruption");
+      }
+      expect(Cause.hasInterrupts(span.status.exit.cause)).toBe(true);
+    }).pipe(Effect.provide(ToolSpanTelemetry.layer), Effect.provideService(Tracer.Tracer, tracer));
+  });
+
+  it.effect("runs Toolkit handling unchanged when no current span exists", () => {
+    const tracer = Tracer.make({
+      span: (options) => new Tracer.NativeSpan(options),
+    });
+    const expectedFailure = ScheduledToolFailure.make({ message: "typed-no-parent-span" });
+    let attempts = 0;
+
+    return Effect.gen(function* () {
+      const telemetry = yield* ToolSpanTelemetry;
+      const success = yield* telemetry.isolateToolkitHandle(
+        Effect.sync(() => {
+          attempts += 1;
+          return "handled-without-parent";
+        }),
+      );
+      const failureExit = yield* telemetry
+        .isolateToolkitHandle(
+          Effect.suspend(() => {
+            attempts += 1;
+            return Effect.fail(expectedFailure);
+          }),
+        )
+        .pipe(Effect.exit);
+
+      expect(success).toBe("handled-without-parent");
+      expect(failureFrom(failureExit)).toBe(expectedFailure);
+      expect(attempts).toBe(2);
+    }).pipe(Effect.provide(ToolSpanTelemetry.layer), Effect.provideService(Tracer.Tracer, tracer));
+  });
+
+  it.effect("allocates span isolation for each execution of a reusable Stream", () => {
+    let isolationAllocations = 0;
+    const delegateContext: NonNullable<Tracer.Tracer["context"]> = <X>(
+      primitive: Tracer.EffectPrimitive<X>,
+      fiber: Fiber.Fiber<unknown, unknown>,
+    ): X => primitive["~effect/Effect/evaluate"](fiber);
+    const instrumentedContext = new Proxy(delegateContext, {
+      get(target, property, receiver) {
+        if (property === "bind") {
+          return (thisArgument: unknown) => {
+            isolationAllocations += 1;
+            return target.bind(thisArgument);
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const delegate = Tracer.make({
+      span: (options) => new Tracer.NativeSpan(options),
+      context: instrumentedContext,
+    });
+
+    return Effect.gen(function* () {
+      const telemetry = yield* ToolSpanTelemetry;
+      const reusable = Stream.succeed("value").pipe(
+        Stream.withSpan("reusable-isolated-stream"),
+        telemetry.isolateSpanLifecycle,
+      );
+      const beforeExecutions = isolationAllocations;
+      const [left, right] = yield* Effect.all(
+        [Stream.runCollect(reusable), Stream.runCollect(reusable)],
+        { concurrency: "unbounded" },
+      );
+
+      expect([...left]).toEqual(["value"]);
+      expect([...right]).toEqual(["value"]);
+      expect(isolationAllocations - beforeExecutions).toBe(2);
+    }).pipe(
+      Effect.provide(ToolSpanTelemetry.layer),
+      Effect.provideService(Tracer.Tracer, delegate),
+    );
+  });
+
+  it.effect("drains a queued terminal event before a merged producer interruption", () =>
+    Effect.gen(function* () {
+      const observed: Array<string> = [];
+      const exit = yield* Stream.mergeAll(
+        [emitThenAfter(Effect.succeed("terminal-event"), Effect.interrupt)],
+        { concurrency: "unbounded" },
+      ).pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            observed.push(event);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.exit,
+      );
+
+      expect(observed).toEqual(["terminal-event"]);
+      if (Exit.isSuccess(exit)) throw new Error("Expected merged producer interruption");
+      expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+    }),
+  );
+
+  it.effect("preserves external interruption at the terminal telemetry boundary", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const blocked = yield* Deferred.make<void>();
+      const fiber = yield* isolateToolTerminalTelemetry(
+        Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(blocked))),
+      ).pipe(Effect.forkChild);
+
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) throw new Error("Expected terminal telemetry interruption");
+      expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+    }),
+  );
+
+  it.effect("preserves the host tracer's final sampling decision", () => {
+    const requestedSampling: Array<boolean> = [];
+    const delegate = Tracer.make({
+      span(options) {
+        requestedSampling.push(options.sampled);
+        return new Tracer.NativeSpan({ ...options, sampled: false });
+      },
+    });
+
+    return Effect.gen(function* () {
+      const telemetry = yield* ToolSpanTelemetry;
+      const observed = yield* Stream.fromEffect(
+        Effect.map(Effect.currentSpan, (span) => span.sampled),
+      )
+        .pipe(Stream.withSpan("sampling-decision"), telemetry.isolateSpanLifecycle)
+        .pipe(Stream.runCollect);
+
+      expect(requestedSampling).toEqual([true]);
+      expect([...observed]).toEqual([false]);
+    }).pipe(
+      Effect.provide(ToolSpanTelemetry.layer),
+      Effect.provideService(Tracer.Tracer, delegate),
+    );
+  });
+
+  it.effect("preserves the host tracer context receiver", () => {
+    const receiverToken = Symbol("host-tracer-receiver");
+    let contextCalls = 0;
+    class ReceiverAwareTracer implements Tracer.Tracer {
+      readonly receiver = receiverToken;
+
+      span(options: Parameters<Tracer.Tracer["span"]>[0]): Tracer.Span {
+        return new Tracer.NativeSpan(options);
+      }
+
+      context<X>(primitive: Tracer.EffectPrimitive<X>, fiber: Fiber.Fiber<unknown, unknown>): X {
+        if (this.receiver !== receiverToken) throw new Error("host tracer receiver was lost");
+        contextCalls += 1;
+        return primitive["~effect/Effect/evaluate"](fiber);
+      }
+    }
+    const delegate = new ReceiverAwareTracer();
+    const isolated = makeIsolatedToolTracer(delegate);
+    const primitive: Tracer.EffectPrimitive<string> = {
+      ["~effect/Effect/evaluate"]: () => "completed",
+    };
+
+    return Effect.withFiber((fiber) =>
+      Effect.sync(() => {
+        const context = isolated.tracer.context;
+        if (context === undefined) throw new Error("Expected the isolated tracer context");
+
+        expect(context(primitive, fiber)).toBe("completed");
+        expect(contextCalls).toBe(1);
+      }),
+    );
+  });
+
+  it.effect("isolates a defecting host tracer context getter", () => {
+    const contextDefect = new Error("host-tracer-context-getter-defect");
+    const reports: Array<Cause.Cause<unknown>> = [];
+    const delegate = Object.defineProperty(
+      Tracer.make({
+        span: (options) => new Tracer.NativeSpan(options),
+      }),
+      "context",
+      {
+        get: () => {
+          throw contextDefect;
+        },
+      },
+    );
+    const isolated = makeIsolatedToolTracer(delegate);
+    const reporter = ErrorReporter.make(({ cause }) => {
+      reports.push(cause);
+    });
+
+    return Effect.gen(function* () {
+      expect(isolated.tracer.context).toBeUndefined();
+      yield* isolated.reportLifecycleDefects;
+      expect(reports).toHaveLength(1);
+      expect(reports[0]?.reasons.filter(Cause.isDieReason).map(({ defect }) => defect)).toEqual([
+        contextDefect,
+      ]);
+    }).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+  });
+
+  it.effect("preserves interruption raised while reporting span lifecycle defects", () => {
+    const contextDefect = new Error("host-tracer-context-defect-before-reporter-interruption");
+    const interruptor = 7331;
+    const delegate = Object.defineProperty(
+      Tracer.make({
+        span: (options) => new Tracer.NativeSpan(options),
+      }),
+      "context",
+      {
+        get: () => {
+          throw contextDefect;
+        },
+      },
+    );
+    const isolated = makeIsolatedToolTracer(delegate);
+    const reporter = ErrorReporter.make(({ cause, fiber }) => {
+      expect(cause.reasons).toHaveLength(1);
+      expect(cause.reasons[0]?._tag).toBe("Die");
+      if (cause.reasons[0]?._tag !== "Die") throw new Error("Expected lifecycle defect");
+      expect(cause.reasons[0].defect).toBe(contextDefect);
+      fiber.interruptUnsafe(interruptor);
+    });
+
+    return Effect.gen(function* () {
+      const reportingFiber = yield* Effect.forkChild(isolated.reportLifecycleDefects);
+      const exit = yield* Fiber.await(reportingFiber);
+      if (Exit.isSuccess(exit)) throw new Error("Expected reporter interruption");
+      expect(exit.cause.reasons).toHaveLength(1);
+      expect(exit.cause.reasons[0]?._tag).toBe("Interrupt");
+      if (exit.cause.reasons[0]?._tag !== "Interrupt") {
+        throw new Error("Expected exact reporter interruption Cause");
+      }
+      expect(exit.cause.reasons[0].fiberId).toBe(interruptor);
+    }).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+  });
+
+  it.effect(
+    "evaluates the primitive once when host tracer context defects before evaluation",
+    () => {
+      const contextDefect = new Error("host-tracer-context-before-evaluation-defect");
+      const reports: Array<Cause.Cause<unknown>> = [];
+      let evaluations = 0;
+      const delegate = Tracer.make({
+        span: (options) => new Tracer.NativeSpan(options),
+        context: () => {
+          throw contextDefect;
+        },
+      });
+      const isolated = makeIsolatedToolTracer(delegate);
+      const reporter = ErrorReporter.make(({ cause }) => {
+        reports.push(cause);
+      });
+      const primitive: Tracer.EffectPrimitive<string> = {
+        ["~effect/Effect/evaluate"]: () => {
+          evaluations += 1;
+          return "completed";
+        },
+      };
+
+      return Effect.withFiber((fiber) =>
+        Effect.gen(function* () {
+          const context = isolated.tracer.context;
+          if (context === undefined) throw new Error("Expected the isolated tracer context");
+
+          expect(context(primitive, fiber)).toBe("completed");
+          expect(evaluations).toBe(1);
+          yield* isolated.reportLifecycleDefects;
+          expect(reports).toHaveLength(1);
+          expect(reports[0]?.reasons.filter(Cause.isDieReason).map(({ defect }) => defect)).toEqual(
+            [contextDefect],
+          );
+        }),
+      ).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+    },
+  );
+
+  it.effect(
+    "returns the recorded primitive value when host tracer context defects afterward",
+    () => {
+      const contextDefect = new Error("host-tracer-context-after-evaluation-defect");
+      const reports: Array<Cause.Cause<unknown>> = [];
+      let evaluations = 0;
+      const delegate = Tracer.make({
+        span: (options) => new Tracer.NativeSpan(options),
+        context: <X>(
+          primitive: Tracer.EffectPrimitive<X>,
+          fiber: Fiber.Fiber<unknown, unknown>,
+        ): X => {
+          primitive["~effect/Effect/evaluate"](fiber);
+          throw contextDefect;
+        },
+      });
+      const isolated = makeIsolatedToolTracer(delegate);
+      const reporter = ErrorReporter.make(({ cause }) => {
+        reports.push(cause);
+      });
+      const primitive: Tracer.EffectPrimitive<string> = {
+        ["~effect/Effect/evaluate"]: () => {
+          evaluations += 1;
+          return "completed";
+        },
+      };
+
+      return Effect.withFiber((fiber) =>
+        Effect.gen(function* () {
+          const context = isolated.tracer.context;
+          if (context === undefined) throw new Error("Expected the isolated tracer context");
+
+          expect(context(primitive, fiber)).toBe("completed");
+          expect(evaluations).toBe(1);
+          yield* isolated.reportLifecycleDefects;
+          expect(reports).toHaveLength(1);
+          expect(reports[0]?.reasons.filter(Cause.isDieReason).map(({ defect }) => defect)).toEqual(
+            [contextDefect],
+          );
+        }),
+      ).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+    },
+  );
+
+  it.effect("rethrows the original primitive error once when host tracer context wraps it", () => {
+    const primitiveError = new Error("primitive-evaluation-error");
+    const contextDefect = new Error("host-tracer-context-wrapper-defect");
+    const reports: Array<Cause.Cause<unknown>> = [];
+    let evaluations = 0;
+    const delegate = Tracer.make({
+      span: (options) => new Tracer.NativeSpan(options),
+      context: <X>(
+        primitive: Tracer.EffectPrimitive<X>,
+        fiber: Fiber.Fiber<unknown, unknown>,
+      ): X => {
+        try {
+          return primitive["~effect/Effect/evaluate"](fiber);
+        } catch {
+          throw contextDefect;
+        }
+      },
+    });
+    const isolated = makeIsolatedToolTracer(delegate);
+    const reporter = ErrorReporter.make(({ cause }) => {
+      reports.push(cause);
+    });
+    const primitive: Tracer.EffectPrimitive<string> = {
+      ["~effect/Effect/evaluate"]: () => {
+        evaluations += 1;
+        throw primitiveError;
+      },
+    };
+
+    return Effect.withFiber((fiber) =>
+      Effect.gen(function* () {
+        const context = isolated.tracer.context;
+        if (context === undefined) throw new Error("Expected the isolated tracer context");
+
+        let observed: unknown;
+        try {
+          context(primitive, fiber);
+        } catch (error) {
+          observed = error;
+        }
+        expect(observed).toBe(primitiveError);
+        expect(evaluations).toBe(1);
+        yield* isolated.reportLifecycleDefects;
+        expect(reports).toEqual([]);
+      }),
+    ).pipe(Effect.provide(ErrorReporter.layer([reporter])));
+  });
+
+  it.effect("keeps Tool success unchanged when terminal telemetry defects", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const logs: Array<ExportedLogObservation> = [];
+    const reports: Array<Cause.Cause<unknown>> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const telemetryDefect = new Error("terminal-logger-defect-must-not-reach-exported-span-or-log");
+    const reporterDefect = new Error("terminal-error-reporter-defect-must-be-isolated");
+    let defectiveReporterCalls = 0;
+    const logger = Logger.make<unknown, void>((options) => {
+      const rendered = renderedLogMessage(options.message);
+      logs.push(exportedLogObservation(options));
+      if (rendered === "agent tool execution completed") throw telemetryDefect;
+    });
+    const reporter = ErrorReporter.make(({ cause }) => {
+      reports.push(cause);
+      defectiveReporterCalls += 1;
+      throw reporterDefect;
+    });
+    let handlerAttempts = 0;
+
+    const Read = Tool.make("read_once", {
+      parameters: Schema.Struct({ path: Schema.String }),
+      success: Schema.String,
+    });
+    const tools = Toolkit.make(Read);
+    const model = Model.make(
+      "scripted",
+      "terminal-telemetry-defect",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        Effect.gen(function* () {
+          const turn = yield* Ref.make(0);
+          return yield* LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () =>
+              Stream.unwrap(
+                Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                  Effect.map((value) =>
+                    Stream.fromIterable<Response.StreamPartEncoded>(
+                      value === 0
+                        ? [
+                            {
+                              type: "tool-call",
+                              id: "read-once-1",
+                              name: "read_once",
+                              params: { path: "/private/tool-input" },
+                              providerExecuted: false,
+                            },
+                            { type: "finish", reason: "tool-calls", usage },
+                          ]
+                        : finalParts('{"answer":"done"}'),
+                    ),
+                  ),
+                ),
+              ),
+          });
+        }),
+      ),
+    );
+    const definition = Agent.define("terminal-telemetry-defect", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Read once, then answer.",
+      toolkit: tools,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const exit = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "Read the file",
+      }).pipe(
+        Stream.runCollect,
+        Effect.provide(
+          tools.toLayer({
+            read_once: () =>
+              Effect.sync(() => {
+                handlerAttempts += 1;
+                return "original-success";
+              }),
+          }),
+        ),
+        Effect.exit,
+      );
+
+      if (Exit.isFailure(exit)) throw new Error("Terminal telemetry changed Tool success");
+      expect(handlerAttempts).toBe(1);
+      expect(exit.value.filter((event) => event._tag === "ToolCallSucceeded")).toEqual([
+        expect.objectContaining({
+          toolCallId: "read-once-1",
+          toolName: "read_once",
+          result: "original-success",
+          providerExecuted: false,
+        }),
+      ]);
+      expect(exit.value.filter((event) => event._tag === "RunCompleted")).toHaveLength(1);
+
+      expect(reports).toHaveLength(1);
+      expect(defectiveReporterCalls).toBe(1);
+      expect(reports[0]?.reasons.filter(Cause.isDieReason).map(({ defect }) => defect)).toEqual([
+        telemetryDefect,
+      ]);
+
+      const span = spans.find((candidate) => candidate.name === "execute_tool read_once");
+      expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
+        "effect_agent.tool.outcome": "success",
+      });
+      if (span?.status._tag !== "Ended") throw new Error("Expected the Tool span to end");
+      expect(Exit.isSuccess(span.status.exit)).toBe(true);
+
+      const exportedValues = reachableTelemetryValues({
+        spans: spans.map(exportedSpanObservation),
+        logs,
+      });
+      expect(exportedValues).not.toContain(telemetryDefect);
+      expect(exportedValues).not.toContain(reporterDefect);
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        telemetryDefect.message,
+      );
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        reporterDefect.message,
+      );
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        "/private/tool-input",
+      );
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.effect(Tracer.Tracer, Effect.succeed(tracer)),
+          Logger.layer([logger]),
+          ErrorReporter.layer([reporter]),
+        ),
+      ),
+    );
+  });
+
+  it.effect(
+    "keeps completed Tool results when canonical span create, wrap, or close defects",
+    () => {
+      const spans: Array<Tracer.NativeSpan> = [];
+      const reports: Array<Cause.Cause<unknown>> = [];
+      const createDefect = new Error("canonical-span-create-defect");
+      const wrapDefect = new Error("canonical-span-wrap-defect");
+      const wrapCloseDefect = new Error("canonical-span-wrap-close-defect");
+      const closeDefect = new Error("canonical-span-close-defect");
+      class CloseDefectSpan extends Tracer.NativeSpan {
+        override end(): void {
+          throw closeDefect;
+        }
+      }
+      const tracer = Tracer.make({
+        span(options) {
+          if (options.name === "execute_tool create_safe") throw createDefect;
+          if (options.name === "execute_tool wrap_safe") {
+            const allocated = new Tracer.NativeSpan(options);
+            spans.push(allocated);
+            return new Proxy(allocated, {
+              get(target, property) {
+                if (property === "sampled") throw wrapDefect;
+                if (property === "end") {
+                  return (endTime: bigint, exit: Exit.Exit<unknown, unknown>): void => {
+                    target.end(endTime, exit);
+                    throw wrapCloseDefect;
+                  };
+                }
+                const value = Reflect.get(target, property, target);
+                return typeof value === "function" ? value.bind(target) : value;
+              },
+            });
+          }
+          const span =
+            options.name === "execute_tool close_safe"
+              ? new CloseDefectSpan(options)
+              : new Tracer.NativeSpan(options);
+          spans.push(span);
+          return span;
+        },
+      });
+      const reporter = ErrorReporter.make(({ cause }) => {
+        reports.push(cause);
+      });
+      const CreateSafe = Tool.make("create_safe", {
+        parameters: Schema.Struct({ value: Schema.String }),
+        success: Schema.String,
+      });
+      const WrapSafe = Tool.make("wrap_safe", {
+        parameters: Schema.Struct({ value: Schema.String }),
+        success: Schema.String,
+      });
+      const CloseSafe = Tool.make("close_safe", {
+        parameters: Schema.Struct({ value: Schema.String }),
+        success: Schema.String,
+      });
+      const tools = Toolkit.make(CreateSafe, WrapSafe, CloseSafe);
+      const model = Model.make(
+        "scripted",
+        "span-lifecycle-defects",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          Effect.gen(function* () {
+            const turn = yield* Ref.make(0);
+            return yield* LanguageModel.make({
+              generateText: () => Effect.succeed([]),
+              streamText: () =>
+                Stream.unwrap(
+                  Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                    Effect.map((value) =>
+                      Stream.fromIterable<Response.StreamPartEncoded>(
+                        value === 0
+                          ? [
+                              {
+                                type: "tool-call",
+                                id: "span-create-1",
+                                name: "create_safe",
+                                params: { value: "create" },
+                                providerExecuted: false,
+                              },
+                              {
+                                type: "tool-call",
+                                id: "span-wrap-1",
+                                name: "wrap_safe",
+                                params: { value: "wrap" },
+                                providerExecuted: false,
+                              },
+                              {
+                                type: "tool-call",
+                                id: "span-close-1",
+                                name: "close_safe",
+                                params: { value: "close" },
+                                providerExecuted: false,
+                              },
+                              { type: "finish", reason: "tool-calls", usage },
+                            ]
+                          : finalParts('{"answer":"done"}'),
+                      ),
+                    ),
+                  ),
+                ),
+            });
+          }),
+        ),
+      );
+      const definition = Agent.define("span-lifecycle-defects", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Call all three Tools, then answer.",
+        toolkit: tools,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 3,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      let createAttempts = 0;
+      let wrapAttempts = 0;
+      let closeAttempts = 0;
+
+      return Effect.gen(function* () {
+        const exit = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+          question: "exercise span lifecycle",
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(
+            tools.toLayer({
+              create_safe: () =>
+                Effect.sync(() => {
+                  createAttempts += 1;
+                  return "create-result";
+                }),
+              wrap_safe: () =>
+                Effect.sync(() => {
+                  wrapAttempts += 1;
+                  return "wrap-result";
+                }),
+              close_safe: () =>
+                Effect.sync(() => {
+                  closeAttempts += 1;
+                  return "close-result";
+                }),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        if (Exit.isFailure(exit)) throw new Error("Span lifecycle telemetry changed Tool success");
+        expect(createAttempts).toBe(1);
+        expect(wrapAttempts).toBe(1);
+        expect(closeAttempts).toBe(1);
+        expect(exit.value.filter((event) => event._tag === "ToolCallSucceeded")).toEqual([
+          expect.objectContaining({
+            toolCallId: "span-create-1",
+            toolName: "create_safe",
+            result: "create-result",
+          }),
+          expect.objectContaining({
+            toolCallId: "span-wrap-1",
+            toolName: "wrap_safe",
+            result: "wrap-result",
+          }),
+          expect.objectContaining({
+            toolCallId: "span-close-1",
+            toolName: "close_safe",
+            result: "close-result",
+          }),
+        ]);
+        expect(exit.value.filter((event) => event._tag === "RunCompleted")).toHaveLength(1);
+        expect(
+          reports.flatMap((cause) =>
+            cause.reasons.filter(Cause.isDieReason).map(({ defect }) => defect),
+          ),
+        ).toEqual([createDefect, wrapDefect, wrapCloseDefect, closeDefect]);
+        expect(spans.some((span) => span.name === "execute_tool create_safe")).toBe(false);
+        const wrapSpan = spans.find((span) => span.name === "execute_tool wrap_safe");
+        expect(wrapSpan?.status._tag).toBe("Ended");
+        if (wrapSpan?.status._tag !== "Ended" || !Exit.isFailure(wrapSpan.status.exit)) {
+          throw new Error("Expected the allocated wrapper-failure span to close failed");
+        }
+        expect(spans.find((span) => span.name === "execute_tool close_safe")?.status._tag).toBe(
+          "Started",
+        );
+
+        const exportedValues = reachableTelemetryValues(spans.map(exportedSpanObservation));
+        expect(exportedValues).not.toContain(createDefect);
+        expect(exportedValues).not.toContain(wrapDefect);
+        expect(exportedValues).not.toContain(wrapCloseDefect);
+        expect(exportedValues).not.toContain(closeDefect);
+        const exportedStrings = exportedValues
+          .filter((value) => typeof value === "string")
+          .join("\n");
+        expect(exportedStrings).not.toContain(createDefect.message);
+        expect(exportedStrings).not.toContain(wrapDefect.message);
+        expect(exportedStrings).not.toContain(wrapCloseDefect.message);
+        expect(exportedStrings).not.toContain(closeDefect.message);
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.effect(Tracer.Tracer, Effect.succeed(tracer)),
+            ErrorReporter.layer([reporter]),
+          ),
+        ),
+      );
+    },
+  );
+
+  it.effect("overrides apparent Tool success when the handler stream later fails", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const logs: Array<ExportedLogObservation> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const logger = Logger.make<unknown, void>((options) => {
+      logs.push(exportedLogObservation(options));
+    });
+    const postTerminalSecret = "post-terminal-handler-secret";
+    const postTerminalFailure = AiError.make({
+      module: "Toolkit",
+      method: "lookup.handle",
+      reason: AiError.UnknownError.make({ description: postTerminalSecret }),
+    });
+    const postTerminalInterruptor = 4242;
+    const Lookup = Tool.make("lookup", {
+      parameters: Schema.Struct({ query: Schema.String }),
+      success: Schema.String,
+    });
+    const tools = Toolkit.make(Lookup);
+    const anomalousRuntime = Effect.map(
+      tools,
+      (native) =>
+        ({
+          tools: native.tools,
+          handle: <Name extends keyof typeof tools.tools>(
+            name: Name,
+            parameters: Tool.Parameters<(typeof tools.tools)[Name]>,
+            toolCallId?: string,
+          ) =>
+            native.handle(name, parameters, toolCallId).pipe(
+              Effect.map((results) =>
+                results.pipe(
+                  // Defects and interruption have error channel `never`, so this adversarial
+                  // composed Cause works for every generic Tool without widening HandlerError.
+                  Stream.concat(
+                    Stream.failCause(
+                      Cause.combine(
+                        Cause.die(postTerminalFailure),
+                        Cause.interrupt(postTerminalInterruptor),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        }) satisfies Toolkit.WithHandler<typeof tools.tools>,
+    );
+    // Test-only Effect AI Toolkit seam: runtime execution consumes the Toolkit Effect and
+    // `tools`; handler Layer construction stays on the native `tools` value below.
+    const anomalousTools = Object.assign(anomalousRuntime, {
+      "~effect/ai/Toolkit": "~effect/ai/Toolkit" as const,
+      tools: tools.tools,
+    }) as Toolkit.Toolkit<typeof tools.tools>;
+    const model = modelFromParts([
+      {
+        type: "tool-call",
+        id: "post-terminal-1",
+        name: "lookup",
+        params: { query: "status" },
+        providerExecuted: false,
+      },
+      { type: "finish", reason: "tool-calls", usage },
+    ]);
+    const definition = Agent.define("post-terminal-tool-failure", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Look up the status.",
+      toolkit: anomalousTools,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+    });
+    const finalized = Ref.makeUnsafe(0);
+    const toolLayer = tools.toLayer({
+      lookup: () =>
+        Effect.succeed("apparently successful").pipe(
+          Effect.ensuring(Ref.update(finalized, (count) => count + 1)),
+        ),
+    });
+
+    return Effect.gen(function* () {
+      const observed = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const exit = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "status",
+      }).pipe(
+        Stream.tap((event) => Ref.update(observed, (events) => [...events, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) {
+        throw new Error("Expected the post-terminal Tool failure to escape as a defect");
+      }
+      expect(
+        exit.cause.reasons
+          .filter(Cause.isDieReason)
+          .map((reason) => reason.defect)
+          .includes(postTerminalFailure),
+      ).toBe(true);
+      expect(Cause.interruptors(exit.cause).has(postTerminalInterruptor)).toBe(true);
+      expect(exit.cause.reasons.filter(Cause.isFailReason)).toEqual([]);
+      expect(yield* Ref.get(finalized)).toBe(1);
+      const terminalEvents = (yield* Ref.get(observed)).filter(
+        (event) => event._tag === "ToolCallSucceeded" || event._tag === "ToolCallFailed",
+      );
+      expect(terminalEvents).toEqual([
+        expect.objectContaining({
+          _tag: "ToolCallFailed",
+          toolCallId: "post-terminal-1",
+          toolName: "lookup",
+          providerExecuted: false,
+        }),
+      ]);
+      expect(terminalEvents.some((event) => event._tag === "ToolCallSucceeded")).toBe(false);
+      const span = spans.find((candidate) => candidate.name === "execute_tool lookup");
+      expect(span).toBeDefined();
+      expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
+        "effect_agent.tool.outcome": "failure",
+      });
+      if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
+        throw new Error("Expected the post-terminal Tool span to end failed");
+      }
+      const exportedValues = reachableTelemetryValues({
+        spans: [exportedSpanObservation(span)],
+        logs,
+      });
+      expect(exportedValues).not.toContain(postTerminalFailure);
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        postTerminalSecret,
+      );
+
+      const terminalLogs = logs.filter((entry) =>
+        ["agent tool execution completed", "agent tool execution failed"].includes(
+          renderedLogMessage(entry.message),
+        ),
+      );
+      expect(
+        terminalLogs.map((entry) => ({
+          message: renderedLogMessage(entry.message),
+          outcome: entry.annotations.toolOutcome,
+        })),
+      ).toEqual([{ message: "agent tool execution failed", outcome: "failure" }]);
+    }).pipe(Effect.provideService(Tracer.Tracer, tracer), Effect.provide(Logger.layer([logger])));
+  });
+
+  it("preserves a marker-free Tool Cause by referential identity", () => {
+    const failureReason = Cause.makeFailReason(new Error("ordinary tool failure"));
+    const defectReason = Cause.makeDieReason(new Error("ordinary tool defect"));
+    const interruptReason = Cause.makeInterruptReason(4242);
+    const original = Cause.fromReasons([failureReason, defectReason, interruptReason]);
+
+    const { found, restored } = restoreToolSpanFailureCause(
+      original,
+      ToolSpanFailure.marker(),
+      undefined,
+    );
+
+    expect(found).toBe(false);
+    expect(restored).toBe(original);
+    expect(restored.reasons).toEqual([failureReason, defectReason, interruptReason]);
+  });
+
+  it("does not consume an independently constructed Tool span failure", () => {
+    const privateMarker = ToolSpanFailure.marker();
+    const handlerFailure = ToolSpanFailure.marker();
+    const handlerCause = Cause.fail(handlerFailure);
+
+    const stripped = stripToolSpanFailures(handlerCause, privateMarker);
+
+    expect(privateMarker).toBeInstanceOf(ToolSpanFailure);
+    expect(handlerFailure).toBeInstanceOf(ToolSpanFailure);
+    expect(handlerFailure).not.toBe(privateMarker);
+    expect(stripped.found).toBe(false);
+    expect(stripped.residual).toBe(handlerCause);
+    expect(stripped.residual.reasons.filter(Cause.isFailReason).map(({ error }) => error)).toEqual([
+      handlerFailure,
+    ]);
+  });
+
+  it("removes only Tool span marker Reasons while preserving residual identity and order", () => {
+    const originalFailure = new Error("original tool cause");
+    const originalFailureReason = Cause.makeFailReason(originalFailure).annotate(
+      Context.make(TestCauseSource, "handler"),
+    );
+    const originalInterruptReason = Cause.makeInterruptReason(4242).annotate(
+      Context.make(TestCauseSource, "interrupt"),
+    );
+    const residualDefect = new Error("span wrapper residual");
+    const residualFailure = new Error("span wrapper typed residual");
+    const residualDefectReason = Cause.makeDieReason(residualDefect).annotate(
+      Context.make(TestCauseSource, "span-finalizer"),
+    );
+    const residualFailureReason = Cause.makeFailReason(residualFailure).annotate(
+      Context.make(TestCauseSource, "span-wrapper"),
+    );
+    const marker = ToolSpanFailure.marker();
+    const firstMarker = Cause.makeFailReason(marker);
+    const secondMarker = Cause.makeFailReason(marker);
+    const foreignMarker = Cause.makeFailReason(ToolSpanFailure.marker()).annotate(
+      Context.make(TestCauseSource, "handler-lookalike"),
+    );
+    const original = Cause.fromReasons([originalFailureReason, originalInterruptReason]);
+    const observed = Cause.fromReasons<Error | ToolSpanFailure>([
+      residualDefectReason,
+      firstMarker,
+      residualFailureReason,
+      foreignMarker,
+      secondMarker,
+    ]);
+
+    const stripped = stripToolSpanFailures<Error | ToolSpanFailure>(observed, marker);
+    expect(stripped.found).toBe(true);
+    expect(stripped.residual.reasons).toEqual([
+      residualDefectReason,
+      residualFailureReason,
+      foreignMarker,
+    ]);
+    expect(stripped.residual.reasons[0]).toBe(residualDefectReason);
+    expect(stripped.residual.reasons[1]).toBe(residualFailureReason);
+    expect(stripped.residual.reasons[2]).toBe(foreignMarker);
+    expect([...stripped.residual.reasons[0]!.annotations.values()]).toContain("span-finalizer");
+    expect([...stripped.residual.reasons[1]!.annotations.values()]).toContain("span-wrapper");
+    expect([...stripped.residual.reasons[2]!.annotations.values()]).toContain("handler-lookalike");
+
+    const { found, restored } = restoreToolSpanFailureCause(observed, marker, original);
+
+    expect(found).toBe(true);
+    expect(restored.reasons).toEqual([
+      originalFailureReason,
+      originalInterruptReason,
+      residualDefectReason,
+      residualFailureReason,
+      foreignMarker,
+    ]);
+    expect(restored.reasons[0]).toBe(originalFailureReason);
+    expect(restored.reasons[1]).toBe(originalInterruptReason);
+    expect(restored.reasons[2]).toBe(residualDefectReason);
+    expect(restored.reasons[3]).toBe(residualFailureReason);
+    expect(restored.reasons[4]).toBe(foreignMarker);
+    expect(restored.reasons.filter(Cause.isFailReason).some(({ error }) => error === marker)).toBe(
+      false,
+    );
   });
 
   it.effect("rejects a provider Tool result whose name differs from its declared call", () => {
@@ -1032,6 +2762,14 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
 
   it.effect("emits Started and Failed before propagating the concrete typed Tool failure", () =>
     Effect.gen(function* () {
+      const spans: Array<Tracer.NativeSpan> = [];
+      const tracer = Tracer.make({
+        span(options) {
+          const span = new Tracer.NativeSpan(options);
+          spans.push(span);
+          return span;
+        },
+      });
       const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
       const finalized = yield* Deferred.make<void>();
       const Fail = Tool.make("fail", {
@@ -1062,7 +2800,8 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
         },
         { type: "finish", reason: "tool-calls", usage },
       ]);
-      const expected = ScheduledToolFailure.make({ message: "scheduled failure" });
+      const failureSecret = "typed-scheduled-failure-must-not-be-exported";
+      const expected = ScheduledToolFailure.make({ message: failureSecret });
       const toolLayer = tools.toLayer({
         fail: () =>
           Effect.acquireUseRelease(
@@ -1078,6 +2817,7 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
         Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
         Stream.runDrain,
         Effect.provide(toolLayer),
+        Effect.provideService(Tracer.Tracer, tracer),
         Effect.exit,
       );
       const failure = failureFrom(exit);
@@ -1095,6 +2835,17 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
           .map((event) => event._tag),
       ).toEqual(["ToolCallStarted", "ToolCallFailed", "RunFailed"]);
       expect(observed.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(1);
+      const span = spans.find((candidate) => candidate.name === "execute_tool fail");
+      expect(span?.attributes.get("effect_agent.tool.outcome")).toBe("failure");
+      expect(span?.status._tag).toBe("Ended");
+      if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
+        throw new Error("Expected the typed Tool failure to close its span with a failed Exit");
+      }
+      const exportedValues = reachableTelemetryValues(exportedSpanObservation(span));
+      expect(exportedValues).not.toContain(expected);
+      expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+        failureSecret,
+      );
       expect(yield* Deferred.isDone(finalized)).toBe(true);
     }),
   );
@@ -1175,7 +2926,252 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
     }),
   );
 
-  it.effect("rejects duplicate terminal Tool results without inventing a second terminal", () =>
+  it.effect("stamps staged provider results only in their actual emission order", () =>
+    Effect.gen(function* () {
+      const parts: ReadonlyArray<Response.StreamPartEncoded> = [
+        {
+          type: "tool-call",
+          id: "hosted-sequence",
+          name: "HostedSearch",
+          params: { query: "sequence" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-result",
+          id: "hosted-sequence",
+          name: "HostedSearch",
+          result: { status: "searching" },
+          isFailure: false,
+          providerExecuted: true,
+          preliminary: true,
+        },
+        { type: "text-start", id: "hosted-answer" },
+        {
+          type: "text-delta",
+          id: "hosted-answer",
+          delta: '{"answer":"sequence-safe"}',
+        },
+        { type: "text-end", id: "hosted-answer" },
+        {
+          type: "tool-result",
+          id: "hosted-sequence",
+          name: "HostedSearch",
+          result: { status: "complete" },
+          isFailure: false,
+          providerExecuted: true,
+        },
+        { type: "finish", reason: "stop", usage },
+      ];
+
+      const events = yield* AgentRuntime.stream(
+        Agent.withModel(hostedDefinition, modelFromParts(parts)),
+        { question: "sequence" },
+      ).pipe(Stream.runCollect);
+      const observed = [...events];
+
+      expect(observed.map(({ sequence }) => sequence)).toEqual(
+        Array.from({ length: observed.length }, (_, sequence) => sequence),
+      );
+      expect(observed.map(({ _tag }) => _tag)).toEqual([
+        "RunStarted",
+        "TurnStarted",
+        "ModelStarted",
+        "ToolCallDeclared",
+        "TextDelta",
+        "ToolProgress",
+        "ToolCallSucceeded",
+        "TurnCompleted",
+        "RunCompleted",
+      ]);
+    }),
+  );
+
+  it.effect("bounds progress, terminal, and Turn-completion staged provider events together", () =>
+    Effect.gen(function* () {
+      const preliminaryResults: Array<Response.StreamPartEncoded> = Array.from(
+        { length: 255 },
+        (_, index) => ({
+          type: "tool-result" as const,
+          id: "hosted-count-bound",
+          name: "HostedSearch",
+          result: { status: String(index) },
+          isFailure: false,
+          providerExecuted: true,
+          preliminary: true,
+        }),
+      );
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const exit = yield* AgentRuntime.stream(
+        Agent.withModel(
+          hostedDefinition,
+          modelFromParts([
+            {
+              type: "tool-call",
+              id: "hosted-count-bound",
+              name: "HostedSearch",
+              params: { query: "count" },
+              providerExecuted: true,
+            },
+            ...preliminaryResults,
+            {
+              type: "tool-result",
+              id: "hosted-count-bound",
+              name: "HostedSearch",
+              result: { status: "complete" },
+              isFailure: false,
+              providerExecuted: true,
+            },
+            { type: "finish", reason: "stop", usage },
+          ]),
+        ),
+        { question: "count" },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(ModelProtocolError);
+      expect(failure.message).toContain("256-event staged provider event limit");
+      expect(observed.filter((event) => event._tag === "ToolProgress")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "TurnCompleted")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+    }),
+  );
+
+  it.effect("bounds the encoded bytes of staged provider results", () =>
+    Effect.gen(function* () {
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const exit = yield* AgentRuntime.stream(
+        Agent.withModel(
+          hostedDefinition,
+          modelFromParts([
+            {
+              type: "tool-call",
+              id: "hosted-byte-bound",
+              name: "HostedSearch",
+              params: { query: "bytes" },
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              id: "hosted-byte-bound",
+              name: "HostedSearch",
+              result: { status: "x".repeat(1024 * 1024) },
+              isFailure: false,
+              providerExecuted: true,
+              preliminary: true,
+            },
+          ]),
+        ),
+        { question: "bytes" },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(ModelProtocolError);
+      expect(failure.message).toContain("1048576-byte staged provider event limit");
+      expect(observed.filter((event) => event._tag === "ToolProgress")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+    }),
+  );
+
+  it("normalizes one bounded JSON snapshot without invoking dynamic serialization behavior", () => {
+    let suffixReads = 0;
+    const payload: Array<unknown> = ["x".repeat(32)];
+    Object.defineProperty(payload, 1, {
+      enumerable: true,
+      get: () => {
+        suffixReads += 1;
+        throw new Error("the rejected suffix must not be traversed");
+      },
+    });
+
+    expect(boundedJsonSnapshot(payload, 8)).toBeUndefined();
+    expect(suffixReads).toBe(0);
+
+    let toJsonCalls = 0;
+    const inheritedToJson = Object.create({
+      toJSON: () => {
+        toJsonCalls += 1;
+        return "x".repeat(2_000_000);
+      },
+    });
+    inheritedToJson.safe = "small";
+    expect(boundedJsonSnapshot(inheritedToJson, 128)).toBeUndefined();
+
+    const ownToJson = { safe: "small" };
+    Object.defineProperty(ownToJson, "toJSON", {
+      value: () => {
+        toJsonCalls += 1;
+        return "x".repeat(2_000_000);
+      },
+    });
+    expect(boundedJsonSnapshot(ownToJson, 128)).toBeUndefined();
+
+    let accessorReads = 0;
+    const accessorBacked = {};
+    Object.defineProperty(accessorBacked, "result", {
+      enumerable: true,
+      get: () => {
+        accessorReads += 1;
+        return accessorReads === 1 ? "small" : "x".repeat(2_000_000);
+      },
+    });
+    expect(boundedJsonSnapshot(accessorBacked, 128)).toBeUndefined();
+    expect(accessorReads).toBe(0);
+    expect(toJsonCalls).toBe(0);
+
+    let proxyReads = 0;
+    const proxyTarget = { result: "small" };
+    const dynamicProxy = new Proxy(proxyTarget, {
+      get: (target, key, receiver) => {
+        proxyReads += 1;
+        return key === "result" ? "x".repeat(2_000_000) : Reflect.get(target, key, receiver);
+      },
+    });
+    const proxySnapshot = boundedJsonSnapshot(dynamicProxy, 128);
+    expect(proxySnapshot).toBeDefined();
+    expect(proxyReads).toBe(0);
+    expect(proxySnapshot?.value).toEqual({ result: "small" });
+    expect(JSON.stringify(proxySnapshot?.value)).toBe('{"result":"small"}');
+    proxyTarget.result = "changed-after-normalization";
+    expect(JSON.stringify(proxySnapshot?.value)).toBe('{"result":"small"}');
+
+    expect(boundedJsonSnapshot('é\n"', 8)).toEqual({ value: 'é\n"', bytes: 8 });
+    expect(boundedJsonSnapshot('é\n"', 7)).toBeUndefined();
+  });
+
+  it("rejects invalid bounded-snapshot limits before traversing provider data", () => {
+    let reflectionAttempts = 0;
+    const payload = new Proxy(
+      { result: "small" },
+      {
+        getPrototypeOf: (target) => {
+          reflectionAttempts += 1;
+          return Reflect.getPrototypeOf(target);
+        },
+      },
+    );
+
+    for (const maxBytes of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(boundedJsonSnapshot(payload, maxBytes)).toBeUndefined();
+    }
+    for (const maxDepth of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(boundedJsonSnapshot(payload, 128, maxDepth)).toBeUndefined();
+    }
+    expect(reflectionAttempts).toBe(0);
+  });
+
+  it.effect("rejects duplicate provider terminals before appending any Tool success", () =>
     Effect.gen(function* () {
       const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
       const agent = Agent.withModel(
@@ -1218,7 +3214,49 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
 
       expect(failure).toBeInstanceOf(ModelProtocolError);
       expect(failure.message).toContain("more than one terminal result");
-      expect(observed.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(1);
+      expect(observed.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+    }),
+  );
+
+  it.effect("rejects post-finish provider content before appending staged terminal events", () =>
+    Effect.gen(function* () {
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const agent = Agent.withModel(
+        hostedDefinition,
+        modelFromParts([
+          {
+            type: "tool-call",
+            id: "hosted-late-content",
+            name: "HostedSearch",
+            params: { query: "late" },
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            id: "hosted-late-content",
+            name: "HostedSearch",
+            result: { status: "complete" },
+            isFailure: false,
+            providerExecuted: true,
+          },
+          { type: "finish", reason: "tool-calls", usage },
+          { type: "text-start", id: "after-finish" },
+        ]),
+      );
+
+      const exit = yield* AgentRuntime.stream(agent, { question: "late" }).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(ModelProtocolError);
+      expect(failure.message).toContain("content after its finish part");
+      expect(observed.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "TurnCompleted")).toHaveLength(0);
       expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
     }),
   );
@@ -1422,6 +3460,105 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
         model: yield* Deferred.isDone(modelFinalized),
         tool: yield* Deferred.isDone(toolFinalized),
       }).toEqual({ model: true, tool: true });
+    }),
+  );
+
+  it.effect("preserves interruption-only Tool handler Causes without failure telemetry", () =>
+    Effect.gen(function* () {
+      const spans: Array<Tracer.NativeSpan> = [];
+      const logs: Array<ExportedLogObservation> = [];
+      const tracer = Tracer.make({
+        span(options) {
+          const span = new Tracer.NativeSpan(options);
+          spans.push(span);
+          return span;
+        },
+      });
+      const logger = Logger.make<unknown, void>((options) => {
+        logs.push(exportedLogObservation(options));
+      });
+      const toolStarted = yield* Deferred.make<void>();
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const Wait = Tool.make("wait_interrupted", {
+        parameters: Schema.Struct({}),
+        success: Schema.String,
+      });
+      const tools = Toolkit.make(Wait);
+      const definition = Agent.define("interrupted-tool-observability", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Wait for interruption.",
+        toolkit: tools,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const model = modelFromParts([
+        {
+          type: "tool-call",
+          id: "wait-interrupted-1",
+          name: "wait_interrupted",
+          params: {},
+          providerExecuted: false,
+        },
+        { type: "finish", reason: "tool-calls", usage },
+      ]);
+      const toolLayer = tools.toLayer({
+        wait_interrupted: () =>
+          Deferred.succeed(toolStarted, undefined).pipe(Effect.andThen(Effect.never)),
+      });
+
+      const fiber = yield* AgentRuntime.stream(Agent.withModel(definition, model), {
+        question: "wait",
+      }).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.provideService(Tracer.Tracer, tracer),
+        Effect.provide(Logger.layer([logger])),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(toolStarted);
+      const interruptor = 7335;
+      fiber.interruptUnsafe(interruptor);
+      const exit = yield* Fiber.await(fiber);
+
+      if (Exit.isSuccess(exit)) throw new Error("Expected the Tool handler to be interrupted");
+      expect(exit.cause.reasons).toHaveLength(1);
+      expect(exit.cause.reasons[0]?._tag).toBe("Interrupt");
+      if (!Cause.isInterruptReason(exit.cause.reasons[0])) {
+        throw new Error("Expected an interruption-only Tool Cause");
+      }
+      expect(exit.cause.reasons[0].fiberId).toBe(interruptor);
+
+      const observed = yield* Ref.get(events);
+      expect(
+        observed.filter(
+          (event) => event._tag === "ToolCallSucceeded" || event._tag === "ToolCallFailed",
+        ),
+      ).toEqual([]);
+      const span = spans.find((candidate) => candidate.name === "execute_tool wait_interrupted");
+      expect(Object.fromEntries(span?.attributes ?? [])).not.toHaveProperty(
+        "effect_agent.tool.outcome",
+      );
+      if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
+        throw new Error("Expected the interrupted Tool span to end with interruption");
+      }
+      expect(span.status.exit.cause.reasons).toHaveLength(1);
+      expect(span.status.exit.cause.reasons[0]?._tag).toBe("Interrupt");
+      if (!Cause.isInterruptReason(span.status.exit.cause.reasons[0])) {
+        throw new Error("Expected the Tool span to retain interruption");
+      }
+      expect(
+        logs.filter((entry) =>
+          ["agent tool execution completed", "agent tool execution failed"].includes(
+            renderedLogMessage(entry.message),
+          ),
+        ),
+      ).toEqual([]);
     }),
   );
 
@@ -2766,10 +4903,10 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       }
       // Official history carries the wire form: plain JSON, not the decoded
       // Schema.Class instance with its DateTime field.
-      expect(Option.isSome(Schema.decodeUnknownOption(Schema.Json)(callPart.params))).toBe(true);
-      const params = callPart.params as { readonly city: string; readonly departAt: unknown };
-      expect(params.city).toBe("Kyoto");
-      expect(typeof params.departAt).toBe("string");
+      const params = yield* Schema.decodeUnknownEffect(
+        Schema.Struct({ city: Schema.String, departAt: Schema.String }),
+      )(callPart.params);
+      expect(params).toEqual({ city: "Kyoto", departAt: "2026-08-12T09:00:00.000Z" });
       // The full official history round-trips through the Prompt codec into
       // plain JSON — the property the canonical persistence boundary needs.
       const encodedHistory = yield* Schema.encodeEffect(Prompt.Prompt)(finalHistory);

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -516,6 +516,81 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
     });
   });
 
+  it.effect("retains an owned normalized snapshot of provider Tool results", () => {
+    const providerResult = { status: "completed" };
+    let observedPromptResult: unknown;
+    const model = Model.make(
+      "scripted",
+      "owned-provider-result",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        Effect.gen(function* () {
+          const turn = yield* Ref.make(0);
+          return yield* LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: (request) =>
+              Stream.unwrap(
+                Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                  Effect.map((value) => {
+                    if (value > 0) {
+                      const observedPart = request.prompt.content
+                        .find((message) => message.role === "assistant")
+                        ?.content.find(
+                          (part) => part.type === "tool-result" && part.id === "owned-result-1",
+                        );
+                      observedPromptResult =
+                        observedPart?.type === "tool-result" ? observedPart.result : undefined;
+                      return Stream.fromIterable(finalParts('{"answer":"owned"}'));
+                    }
+                    return Stream.fromIterable<Response.StreamPartEncoded>([
+                      {
+                        type: "tool-call",
+                        id: "owned-result-1",
+                        name: "HostedSearch",
+                        params: { query: "ownership" },
+                        providerExecuted: true,
+                      },
+                      {
+                        type: "tool-result",
+                        id: "owned-result-1",
+                        name: "HostedSearch",
+                        result: providerResult,
+                        isFailure: false,
+                        providerExecuted: true,
+                      },
+                    ]).pipe(
+                      Stream.concat(
+                        Stream.fromEffect(
+                          Effect.sync(() => {
+                            providerResult.status = "mutated-after-emission";
+                            return {
+                              type: "finish" as const,
+                              reason: "tool-calls" as const,
+                              usage,
+                            };
+                          }),
+                        ),
+                      ),
+                    );
+                  }),
+                ),
+              ),
+          });
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const events = yield* AgentRuntime.stream(Agent.withModel(hostedDefinition, model), {
+        question: "Who owns the result?",
+      }).pipe(Stream.runCollect);
+
+      expect(events.at(-1)?._tag).toBe("RunCompleted");
+      expect(observedPromptResult).toEqual({ status: "completed" });
+      expect(observedPromptResult).not.toBe(providerResult);
+    });
+  });
+
   it.effect("exports content-free canonical Tool spans and bounded terminal logs", () => {
     const spans: Array<Tracer.NativeSpan> = [];
     const logs: Array<ExportedLogObservation> = [];
@@ -793,6 +868,108 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(observed.some((event) => event._tag === "ToolCallFailed")).toBe(false);
     }),
   );
+
+  it.effect("rejects every retained or correlated model response-part identifier", () => {
+    const invalidIdSecret = "invalid-response-part-id-must-not-enter-runtime-state";
+    const invalidId = `unsafe/${invalidIdSecret}/${"x".repeat(256)}`;
+    const cases: ReadonlyArray<{
+      readonly label: string;
+      readonly part: Response.StreamPartEncoded;
+    }> = [
+      { label: "text start", part: { type: "text-start", id: invalidId } },
+      { label: "text delta", part: { type: "text-delta", id: invalidId, delta: "ignored" } },
+      { label: "text end", part: { type: "text-end", id: invalidId } },
+      { label: "reasoning start", part: { type: "reasoning-start", id: invalidId } },
+      {
+        label: "reasoning delta",
+        part: { type: "reasoning-delta", id: invalidId, delta: "ignored" },
+      },
+      { label: "reasoning end", part: { type: "reasoning-end", id: invalidId } },
+      {
+        label: "Tool parameters start",
+        part: {
+          type: "tool-params-start",
+          id: invalidId,
+          name: "unknown",
+          providerExecuted: false,
+        },
+      },
+      {
+        label: "Tool parameters delta",
+        part: { type: "tool-params-delta", id: invalidId, delta: "{}" },
+      },
+      { label: "Tool parameters end", part: { type: "tool-params-end", id: invalidId } },
+      {
+        label: "source",
+        part: {
+          type: "source",
+          sourceType: "url",
+          id: invalidId,
+          url: "https://example.invalid/source",
+          title: "source",
+        },
+      },
+      {
+        label: "response metadata",
+        part: { type: "response-metadata", id: invalidId },
+      },
+      {
+        label: "approval",
+        part: {
+          type: "tool-approval-request",
+          approvalId: invalidId,
+          toolCallId: "valid-tool-call",
+        },
+      },
+      {
+        label: "approval Tool Call",
+        part: {
+          type: "tool-approval-request",
+          approvalId: "valid-approval",
+          toolCallId: invalidId,
+        },
+      },
+    ];
+
+    return Effect.gen(function* () {
+      yield* Effect.forEach(
+        cases,
+        ({ label, part }) =>
+          AgentRuntime.stream(makeAgent([part]), { question: label }).pipe(
+            Stream.runDrain,
+            Effect.exit,
+            Effect.map((exit) => {
+              const failure = failureFrom(exit);
+              expect(failure).toBeInstanceOf(ModelProtocolError);
+              expect(failure.message).toContain("invalid");
+              expect(failure.message).not.toContain(invalidIdSecret);
+            }),
+          ),
+        { discard: true },
+      );
+
+      const toolResultExit = yield* AgentRuntime.stream(
+        Agent.withModel(
+          hostedDefinition,
+          modelFromParts([
+            {
+              type: "tool-result",
+              id: invalidId,
+              name: "HostedSearch",
+              result: { status: "ignored" },
+              isFailure: false,
+              providerExecuted: true,
+            },
+          ]),
+        ),
+        { question: "Tool result" },
+      ).pipe(Stream.runDrain, Effect.exit);
+      const toolResultFailure = failureFrom(toolResultExit);
+      expect(toolResultFailure).toBeInstanceOf(ModelProtocolError);
+      expect(toolResultFailure.message).toContain("invalid Tool Call ID");
+      expect(toolResultFailure.message).not.toContain(invalidIdSecret);
+    });
+  });
 
   it.effect("exports one failed Tool outcome when downstream stops at its terminal event", () => {
     const spans: Array<Tracer.NativeSpan> = [];
@@ -1489,6 +1666,42 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       ).pipe(Effect.provide(ErrorReporter.layer([reporter])));
     },
   );
+
+  it.effect("does not let host tracer context substitute a primitive result", () => {
+    let evaluations = 0;
+    const delegateContext: NonNullable<Tracer.Tracer["context"]> = <X>(
+      primitive: Tracer.EffectPrimitive<X>,
+      fiber: Fiber.Fiber<unknown, unknown>,
+    ): X => primitive["~effect/Effect/evaluate"](fiber);
+    const substitutingContext = new Proxy(delegateContext, {
+      apply(target, thisArgument, argumentsList) {
+        Reflect.apply(target, thisArgument, argumentsList);
+        return "host-substituted-result";
+      },
+    });
+    const isolated = makeIsolatedToolTracer(
+      Tracer.make({
+        span: (options) => new Tracer.NativeSpan(options),
+        context: substitutingContext,
+      }),
+    );
+    const primitive: Tracer.EffectPrimitive<string> = {
+      ["~effect/Effect/evaluate"]: () => {
+        evaluations += 1;
+        return "engine-result";
+      },
+    };
+
+    return Effect.withFiber((fiber) =>
+      Effect.sync(() => {
+        const context = isolated.tracer.context;
+        if (context === undefined) throw new Error("Expected the isolated tracer context");
+
+        expect(context(primitive, fiber)).toBe("engine-result");
+        expect(evaluations).toBe(1);
+      }),
+    );
+  });
 
   it.effect("rethrows the original primitive error once when host tracer context wraps it", () => {
     const primitiveError = new Error("primitive-evaluation-error");

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -956,13 +956,17 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(reports[0]?.reasons).toHaveLength(1);
       expect(reports[0]?.reasons[0]?._tag).toBe("Fail");
       if (reports[0]?.reasons[0]?._tag !== "Fail") {
-        throw new Error("Expected the early-close typed failure to reach ErrorReporter");
+        return yield* Effect.die(
+          new Error("Expected the early-close typed failure to reach ErrorReporter"),
+        );
       }
       expect(reports[0].reasons[0].error).toBe(typedFailure);
       expect(reports[1]?.reasons).toHaveLength(1);
       expect(reports[1]?.reasons[0]?._tag).toBe("Die");
       if (reports[1]?.reasons[0]?._tag !== "Die") {
-        throw new Error("Expected the early-close defect to reach ErrorReporter");
+        return yield* Effect.die(
+          new Error("Expected the early-close defect to reach ErrorReporter"),
+        );
       }
       expect(reports[1].reasons[0].defect).toBe(defect);
     }).pipe(Effect.provide(ErrorReporter.layer([reporter])));

--- a/packages/engine/test/durable-tool-seam.test.ts
+++ b/packages/engine/test/durable-tool-seam.test.ts
@@ -210,6 +210,146 @@ layer(identifiers)("P5 WP1 durable Tool seams", (it) => {
     }),
   );
 
+  it.effect(
+    "emits every staged provider event before usage and response persistence mutations",
+    () =>
+      Effect.gen(function* () {
+        const marks = yield* Ref.make<ReadonlyArray<string>>([]);
+        const observed = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+        const mutationChecks = yield* Ref.make<ReadonlyArray<string>>([]);
+        const HostedLookup = Tool.providerDefined({
+          id: "test.hosted_lookup",
+          customName: "HostedLookup",
+          providerName: "hosted_lookup",
+          parameters: Schema.Struct({ query: Schema.String }),
+          success: Schema.Struct({ status: Schema.String }),
+        })(undefined);
+        const Read = Tool.make("read", {
+          parameters: Schema.Struct({ path: Schema.String }),
+          success: Schema.String,
+        });
+        const tools = Toolkit.make(HostedLookup, Read);
+        const definition = Agent.define("staged-provider-before-mutations", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ answer: Schema.String }),
+          instructions: "Use both tools.",
+          toolkit: tools,
+          policy: policy({ maxToolCalls: 2 }),
+        });
+        const model = scriptedModel(
+          [
+            {
+              type: "tool-call",
+              id: "hosted-before-mutation",
+              name: "HostedLookup",
+              params: { query: "safe ordering" },
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              id: "hosted-before-mutation",
+              name: "HostedLookup",
+              result: { status: "complete" },
+              isFailure: false,
+              providerExecuted: true,
+            },
+            {
+              type: "tool-call",
+              id: "read-after-provider",
+              name: "read",
+              params: { path: "/safe" },
+              providerExecuted: false,
+            },
+            { type: "finish", reason: "tool-calls", usage },
+          ],
+          '{"answer":"complete"}',
+        );
+        const assertStagedEventsObserved = (mutation: string) =>
+          Effect.gen(function* () {
+            const events = yield* Ref.get(observed);
+            const providerSequence = events.filter(
+              (event) =>
+                ("toolCallId" in event && event.toolCallId === "hosted-before-mutation") ||
+                (event._tag === "TurnCompleted" && event.turn === 1),
+            );
+            expect(providerSequence).toMatchObject([
+              {
+                _tag: "ToolCallDeclared",
+                toolCallId: "hosted-before-mutation",
+                toolName: "HostedLookup",
+                providerExecuted: true,
+              },
+              {
+                _tag: "ToolCallSucceeded",
+                toolCallId: "hosted-before-mutation",
+                toolName: "HostedLookup",
+                result: { status: "complete" },
+                providerExecuted: true,
+              },
+              { _tag: "TurnCompleted", turn: 1, finishReason: "tool-calls" },
+            ]);
+            const providerSequences = providerSequence.map(({ sequence }) => sequence);
+            expect(providerSequences).toEqual(
+              [...providerSequences].sort((left, right) => left - right),
+            );
+            yield* Ref.update(mutationChecks, (all) => [...all, mutation]);
+          });
+        const durability: RunDurabilityHook = {
+          commitResponse: () =>
+            assertStagedEventsObserved("commit-response").pipe(
+              Effect.andThen(Ref.update(marks, (all) => [...all, "commit-response"])),
+            ),
+          prepareToolCalls: () =>
+            assertStagedEventsObserved("prepare").pipe(
+              Effect.andThen(Ref.update(marks, (all) => [...all, "prepare"])),
+            ),
+          step: inertStepHook,
+        };
+        let modelConsumptions = 0;
+
+        const events = yield* AgentRuntime.stream(
+          Agent.withModel(definition, model),
+          { question: "order the mixed response" },
+          {
+            durability,
+            budget: {
+              guard: (effect) => effect,
+              consume: () => {
+                modelConsumptions += 1;
+                return assertStagedEventsObserved(`consume:${modelConsumptions}`).pipe(
+                  Effect.andThen(Ref.update(marks, (all) => [...all, "consume"])),
+                );
+              },
+            },
+          },
+        ).pipe(
+          Stream.tap((event) => Ref.update(observed, (all) => [...all, event])),
+          Stream.runCollect,
+          Effect.provide(
+            tools.toLayer({
+              read: () =>
+                Ref.update(marks, (all) => [...all, "handler"]).pipe(Effect.as("read-complete")),
+            }),
+          ),
+        );
+
+        expect(yield* Ref.get(marks)).toEqual([
+          "consume",
+          "commit-response",
+          "prepare",
+          "handler",
+          "consume",
+        ]);
+        expect(events.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(2);
+        expect(yield* Ref.get(mutationChecks)).toEqual([
+          "consume:1",
+          "commit-response",
+          "prepare",
+          "consume:2",
+        ]);
+      }),
+  );
+
   it.effect("prepareToolCalls fires after every approval and before any handler permit", () =>
     Effect.gen(function* () {
       const marks = yield* Ref.make<ReadonlyArray<string>>([]);

--- a/packages/platform-cloudflare/src/config.ts
+++ b/packages/platform-cloudflare/src/config.ts
@@ -103,6 +103,8 @@ export class CloudflareDurableRuntimeConfigValue extends Schema.Class<Cloudflare
   abortPollInterval: PositiveMillis,
   /** Canonical observation poll cadence of the Durable Object store. */
   observationPollInterval: NonNegativeMillis,
+  /** Cooperative background-export budget; native Object delivery never awaits the flush. */
+  telemetryFlushTimeout: PositiveMillis,
   /** Per-value byte bound; must stay under the platform's 2 MB SQLite value limit. */
   maxStoredValueBytes: Schema.Int.check(
     Schema.isGreaterThan(0),
@@ -129,6 +131,7 @@ export const CLOUDFLARE_RUNTIME_DEFAULTS = {
   leaseRenewalInterval: 10_000,
   abortPollInterval: 500,
   observationPollInterval: 25,
+  telemetryFlushTimeout: 2_000,
   maxStoredValueBytes: DEFAULT_MAX_STORED_VALUE_BYTES,
   verifyOnOpen: false,
   maxQueueDepthPerLane: 256,

--- a/packages/platform-cloudflare/src/conversation-object.ts
+++ b/packages/platform-cloudflare/src/conversation-object.ts
@@ -782,8 +782,9 @@ export const makeConversationObjectClass = <
         (cause) => {
           // Native entrypoints run only after blockConcurrencyWhile has built the cached runtime.
           // Effect Logger invocation is synchronous; runSyncExit captures a broken logger without
-          // starting an unscoped fiber or changing the delivery Promise. The structured Cause keeps
-          // the exact synchronous platform rejection available to the host-owned diagnostic sink.
+          // starting an unscoped fiber or changing the delivery Promise. The exact platform value
+          // stays confined to this registration callback; the automatic Logger diagnostic is
+          // deliberately content-free.
           void this.#runtime.runSyncExit(logCloudflareWaitUntilRegistrationFailure(cause));
         },
       );

--- a/packages/platform-cloudflare/src/conversation-object.ts
+++ b/packages/platform-cloudflare/src/conversation-object.ts
@@ -38,6 +38,7 @@ import {
   DurableObjectContext,
   conversationNamespaceLayer,
   type CloudflareBindingError,
+  type ConversationObjectNamespace,
 } from "./bindings.ts";
 import {
   AbortRecorded,
@@ -67,9 +68,17 @@ import {
   type CloudflareDurableRuntimeOptions,
   type CloudflareDurableRuntimeServices,
 } from "./layers.ts";
+import {
+  flushCloudflareRuntimeTelemetry,
+  makeCloudflareTelemetryFlushCoordinator,
+  registerCloudflareTelemetryAfterNativeSettlement,
+  withCloudflareNativeSpanFailure,
+  type CloudflareTelemetryFlushCoordinator,
+} from "./telemetry-internal.ts";
+import { CloudflareRuntimeTelemetry } from "./telemetry.ts";
 
 /**
- * `makeConversationObjectClass(options)` — the Conversation Durable Object (plan §1.4,
+ * `makeConversationObjectClass(options, telemetry?)` — the Conversation Durable Object (plan §1.4,
  * D-P6-1): a factory returning a class that applications export from their Worker entry.
  * One SQLite-backed Object per Conversation is the serialized owner (durability §6); the
  * Object never runs `runResolvedWorker`'s infinite loop — each ingress event or alarm runs
@@ -95,7 +104,10 @@ export interface ConversationObjectOptions extends CloudflareDurableRuntimeOptio
   readonly namespaceBinding: string;
 }
 
-type ConversationObjectError = CloudflareDurableRuntimeInitializationError | CloudflareBindingError;
+type ConversationObjectError<TelemetryError> =
+  | CloudflareDurableRuntimeInitializationError
+  | CloudflareBindingError
+  | TelemetryError;
 
 type EndpointServices = CloudflareDurableRuntimeServices | DurableObjectContext;
 
@@ -608,6 +620,54 @@ const gateEndpoint: Effect.Effect<void, unknown, EndpointServices> = Effect.gen(
   yield* maintenance.ensureAlarm;
 });
 
+const NATIVE_ENTRYPOINTS = [
+  "submit",
+  "await_settlement",
+  "observe",
+  "abort",
+  "resolve_approval",
+  "resolve_unknown",
+  "explain",
+  "verify",
+  "retry",
+  "obligations",
+  "port_call",
+  "wake",
+  "alarm",
+] as const;
+
+type NativeEntrypoint = (typeof NATIVE_ENTRYPOINTS)[number];
+
+/**
+ * Owner-side delivery measurement. The exact endpoint Cause is hidden behind a bounded typed
+ * marker while the span closes, then restored together with any newly composed real reasons.
+ */
+const observeNativeEntrypoint = <A, E>(
+  entrypoint: NativeEntrypoint,
+  effect: Effect.Effect<A, E, EndpointServices>,
+): Effect.Effect<A, E, EndpointServices> =>
+  Effect.gen(function* () {
+    const identity = yield* ConversationObjectIdentity;
+    const config = yield* CloudflareDurableRuntimeConfig;
+    return yield* withCloudflareNativeSpanFailure(effect, (masked) =>
+      masked.pipe(
+        Effect.withSpan(`effect_agent.cloudflare.conversation_object.${entrypoint}`, {
+          kind: "server",
+          attributes: {
+            "effect_agent.cloudflare.entrypoint": entrypoint,
+            "effect_agent.deployment.id": config.deploymentId,
+            conversationId: identity.conversationId,
+            producerId: identity.producerId,
+          },
+        }),
+      ),
+    );
+  });
+
+const flushNativeEntrypointTelemetry = Effect.flatMap(CloudflareDurableRuntimeConfig, (config) =>
+  flushCloudflareRuntimeTelemetry(config.telemetryFlushTimeout),
+);
+
 /** The public endpoint surface of one Conversation Object instance. */
 export interface ConversationObjectInstance extends DurableObject {
   submitEncoded(encoded: unknown): Promise<unknown>;
@@ -631,84 +691,156 @@ export interface ConversationObjectClass {
 }
 
 /**
- * Build the application's Conversation Object class (export it from the
- * Worker entry). The explicit return type is what makes declaration emit
- * possible: the class body carries a private runtime field, and TS4094
- * rejects inferring an exported anonymous class type around it.
+ * Build the application's Conversation Object class (export it from the Worker entry).
+ * `telemetry` is the host composition boundary: it may require the Object context/namespace and
+ * retain a typed acquisition error, while any additional output services remain available to the
+ * cached runtime. `TelemetryError` stays the first explicit generic for source compatibility;
+ * additional outputs infer from the Layer. Omitting it installs the content-free no-op service.
+ * The explicit return type is what makes declaration emit possible: the class body carries a
+ * private runtime field, and TS4094 rejects inferring an exported anonymous class type around it.
  */
-export const makeConversationObjectClass = (
+export const makeConversationObjectClass = <
+  TelemetryError = never,
+  AdditionalTelemetryOutputs = never,
+>(
   options: ConversationObjectOptions,
+  telemetry?: Layer.Layer<
+    CloudflareRuntimeTelemetry | AdditionalTelemetryOutputs,
+    TelemetryError,
+    DurableObjectContext | ConversationObjectNamespace
+  >,
 ): ConversationObjectClass => {
   class ConversationObject extends DurableObject {
-    readonly #runtime: ManagedRuntime.ManagedRuntime<EndpointServices, ConversationObjectError>;
+    readonly #runtime: ManagedRuntime.ManagedRuntime<
+      EndpointServices,
+      ConversationObjectError<TelemetryError>
+    >;
+    readonly #ctx: DurableObjectState;
+    readonly #telemetryFlush: CloudflareTelemetryFlushCoordinator;
 
     constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
       super(ctx, env);
+      this.#ctx = ctx;
+      const platform = Layer.mergeAll(
+        DurableObjectContext.layer(ctx, env),
+        conversationNamespaceLayer(env, options.namespaceBinding),
+      );
+      // Host observability is composed at the Worker edge, not hidden in runtime options. Its
+      // typed acquisition failure remains in the ManagedRuntime error, while the Object context
+      // and namespace are available to Layers that derive exporter configuration from `env`.
+      const hostTelemetry = (telemetry ?? CloudflareRuntimeTelemetry.layerNoop).pipe(
+        Layer.provideMerge(platform),
+      );
       this.#runtime = ManagedRuntime.make(
         CloudflareDurableRuntime.layer(options).pipe(
-          Layer.provideMerge(
-            Layer.mergeAll(
-              DurableObjectContext.layer(ctx, env),
-              conversationNamespaceLayer(env, options.namespaceBinding),
-            ),
-          ),
+          // Supplying the host Layer outermost makes its Logger/Tracer/Metric runtime
+          // configuration observe application Layer acquisition and every native endpoint.
+          Layer.provideMerge(hostTelemetry),
         ),
+      );
+      this.#telemetryFlush = makeCloudflareTelemetryFlushCoordinator(
+        () => this.#runtime.runPromise(flushNativeEntrypointTelemetry),
+        {
+          onReservationDropped: () => {
+            void this.#runtime.runSyncExit(
+              Effect.logWarning(
+                "Cloudflare telemetry delivery coalesced at the batch reservation limit",
+              ).pipe(
+                Effect.annotateLogs({
+                  "effect_agent.cloudflare.telemetry.failure_kind": "reservation_limit",
+                }),
+              ),
+            );
+          },
+        },
       );
       // The constructor gate: local-only checks; never the recovery pass (deadlock argument,
       // plan §1.4). A failure here fails every delivery with the typed construction error.
       ctx.blockConcurrencyWhile(() => this.#runtime.runPromise(gateEndpoint));
     }
 
+    #runNative<A, E>(
+      entrypoint: NativeEntrypoint,
+      effect: Effect.Effect<A, E, EndpointServices>,
+    ): Promise<A> {
+      const delivery = this.#runtime.runPromise(observeNativeEntrypoint(entrypoint, effect));
+      // Reserve synchronously with the current native delivery, but do not await export from the
+      // RPC/alarm Promise. Each pending/trailing/queued batch waits for its assigned deliveries to
+      // settle and only its first owner registers the shared background Promise. Even an
+      // uninterruptible exporter therefore cannot delay a caller, suppress alarm retry, accumulate
+      // concurrent exporter work, an unbounded waitUntil registration queue, or unbounded retained
+      // delivery Promises. Excess arrivals are diagnosed and lossy-coalesced at the batch cap.
+      // Registration failure and every asynchronous flush failure remain isolated from delivery.
+      return registerCloudflareTelemetryAfterNativeSettlement(
+        (background) => this.#ctx.waitUntil(background),
+        delivery,
+        this.#telemetryFlush.reserve,
+        () => {
+          // Native entrypoints run only after blockConcurrencyWhile has built the cached runtime.
+          // Effect Logger invocation is synchronous; runSyncExit captures a broken logger without
+          // starting an unscoped fiber or changing the delivery Promise. The caught platform Cause
+          // is intentionally unavailable here: only a framework-owned classification is logged.
+          void this.#runtime.runSyncExit(
+            Effect.logError("Cloudflare telemetry waitUntil registration failed").pipe(
+              Effect.annotateLogs({
+                "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
+              }),
+            ),
+          );
+        },
+      );
+    }
+
     async submitEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(submitEndpoint(encoded));
+      return this.#runNative("submit", submitEndpoint(encoded));
     }
 
     async awaitSettlementEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(awaitSettlementEndpoint(encoded));
+      return this.#runNative("await_settlement", awaitSettlementEndpoint(encoded));
     }
 
     async observePage(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(observePageEndpoint(encoded));
+      return this.#runNative("observe", observePageEndpoint(encoded));
     }
 
     async abortEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(abortEndpoint(encoded));
+      return this.#runNative("abort", abortEndpoint(encoded));
     }
 
     async resolveApprovalEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(resolveApprovalEndpoint(encoded));
+      return this.#runNative("resolve_approval", resolveApprovalEndpoint(encoded));
     }
 
     async resolveUnknownEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(resolveUnknownEndpoint(encoded));
+      return this.#runNative("resolve_unknown", resolveUnknownEndpoint(encoded));
     }
 
     async explainEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(explainEndpoint(encoded));
+      return this.#runNative("explain", explainEndpoint(encoded));
     }
 
     async verifyEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(verifyEndpoint(encoded));
+      return this.#runNative("verify", verifyEndpoint(encoded));
     }
 
     async retryEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(retryEndpoint(encoded));
+      return this.#runNative("retry", retryEndpoint(encoded));
     }
 
     async obligationsEncoded(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(obligationsEndpoint(encoded));
+      return this.#runNative("obligations", obligationsEndpoint(encoded));
     }
 
     async portCall(encoded: unknown): Promise<unknown> {
-      return this.#runtime.runPromise(portCallEndpoint(encoded));
+      return this.#runNative("port_call", portCallEndpoint(encoded));
     }
 
     async wake(): Promise<void> {
-      await this.#runtime.runPromise(wakeEndpoint);
+      await this.#runNative("wake", wakeEndpoint);
     }
 
     override async alarm(): Promise<void> {
-      await this.#runtime.runPromise(alarmEndpoint);
+      await this.#runNative("alarm", alarmEndpoint);
     }
   }
 

--- a/packages/platform-cloudflare/src/conversation-object.ts
+++ b/packages/platform-cloudflare/src/conversation-object.ts
@@ -70,6 +70,7 @@ import {
 } from "./layers.ts";
 import {
   flushCloudflareRuntimeTelemetry,
+  logCloudflareWaitUntilRegistrationFailure,
   makeCloudflareTelemetryFlushCoordinator,
   registerCloudflareTelemetryAfterNativeSettlement,
   withCloudflareNativeSpanFailure,
@@ -109,7 +110,10 @@ type ConversationObjectError<TelemetryError> =
   | CloudflareBindingError
   | TelemetryError;
 
-type EndpointServices = CloudflareDurableRuntimeServices | DurableObjectContext;
+type EndpointServices =
+  | CloudflareDurableRuntimeServices
+  | DurableObjectContext
+  | CloudflareRuntimeTelemetry;
 
 /** Port envelope tags whose owner-side execution durably mutates this Object's lane. */
 const MUTATING_PORT_TAGS: ReadonlySet<string> = new Set([
@@ -775,18 +779,12 @@ export const makeConversationObjectClass = <
         (background) => this.#ctx.waitUntil(background),
         delivery,
         this.#telemetryFlush.reserve,
-        () => {
+        (cause) => {
           // Native entrypoints run only after blockConcurrencyWhile has built the cached runtime.
           // Effect Logger invocation is synchronous; runSyncExit captures a broken logger without
-          // starting an unscoped fiber or changing the delivery Promise. The caught platform Cause
-          // is intentionally unavailable here: only a framework-owned classification is logged.
-          void this.#runtime.runSyncExit(
-            Effect.logError("Cloudflare telemetry waitUntil registration failed").pipe(
-              Effect.annotateLogs({
-                "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
-              }),
-            ),
-          );
+          // starting an unscoped fiber or changing the delivery Promise. The structured Cause keeps
+          // the exact synchronous platform rejection available to the host-owned diagnostic sink.
+          void this.#runtime.runSyncExit(logCloudflareWaitUntilRegistrationFailure(cause));
         },
       );
     }

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -17,6 +17,7 @@ export * from "./config.ts";
 export * from "./alarm.ts";
 export * from "./wake-scheduler.ts";
 export * from "./transport.ts";
+export * from "./telemetry.ts";
 export * from "./layers.ts";
 export * from "./conversation-object.ts";
 export * from "./client.ts";

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -31,8 +31,8 @@ import { Context, Duration, Effect, Layer, Schema } from "effect";
 import { ConversationMaintenance, DurableAlarmService } from "./alarm.ts";
 import {
   ConversationObjectIdentity,
-  ConversationObjectNamespace,
   DurableObjectContext,
+  type ConversationObjectNamespace,
 } from "./bindings.ts";
 import {
   CLOUDFLARE_RUNTIME_DEFAULTS,
@@ -40,6 +40,7 @@ import {
   CloudflareDurableRuntimeConfigValue,
   CloudflarePlatformConfigError,
 } from "./config.ts";
+import { CloudflareRuntimeTelemetry } from "./telemetry.ts";
 import { conversationPortTransportLayer } from "./transport.ts";
 import { cloudflareWakeSchedulerLayer } from "./wake-scheduler.ts";
 
@@ -69,6 +70,11 @@ export interface CloudflareDurableRuntimeOptions {
   readonly abortPollInterval?: number | undefined;
   /** Milliseconds; default 25. */
   readonly observationPollInterval?: number | undefined;
+  /**
+   * Milliseconds; default 2000. Cooperative budget for the background exporter flush registered
+   * after each native RPC, wake, or alarm span. Delivery never awaits the flush.
+   */
+  readonly telemetryFlushTimeout?: number | undefined;
   /** Bytes; default just under the 2 MB platform value limit. */
   readonly maxStoredValueBytes?: number | undefined;
   /** Default false. */
@@ -143,7 +149,8 @@ export type CloudflareDurableRuntimeServices =
   | ConversationObjectIdentity
   | DurableAlarmService
   | ConversationMaintenance
-  | ConversationObjectPorts;
+  | ConversationObjectPorts
+  | CloudflareRuntimeTelemetry;
 
 /**
  * Owner-side endpoint body for the Conversation Object's `portCall` (plan §1.3): decode,
@@ -180,6 +187,8 @@ const configFromOptions = (
     abortPollInterval: options.abortPollInterval ?? CLOUDFLARE_RUNTIME_DEFAULTS.abortPollInterval,
     observationPollInterval:
       options.observationPollInterval ?? CLOUDFLARE_RUNTIME_DEFAULTS.observationPollInterval,
+    telemetryFlushTimeout:
+      options.telemetryFlushTimeout ?? CLOUDFLARE_RUNTIME_DEFAULTS.telemetryFlushTimeout,
     maxStoredValueBytes:
       options.maxStoredValueBytes ?? CLOUDFLARE_RUNTIME_DEFAULTS.maxStoredValueBytes,
     verifyOnOpen: options.verifyOnOpen ?? CLOUDFLARE_RUNTIME_DEFAULTS.verifyOnOpen,
@@ -254,9 +263,10 @@ const resolveBindings = (
  * Storage compatibility is verified during construction: an incompatible database fails the
  * Layer typed (`DoStorageCompatibilityError`) before anything is mutated (DEPLOY-008).
  *
- * Requires only the two binding services (`DurableObjectContext`,
- * `ConversationObjectNamespace`) — platform values enter exclusively through Layers
- * (DEPLOY-010).
+ * Requires the two binding services (`DurableObjectContext`, `ConversationObjectNamespace`) plus
+ * the host-owned `CloudflareRuntimeTelemetry` capability. Platform values and observability enter
+ * exclusively through Layers (DEPLOY-010); the Worker composition edge chooses the telemetry
+ * implementation and its acquisition error/dependencies remain visible there.
  */
 export class CloudflareDurableRuntime {
   static layer(
@@ -264,7 +274,7 @@ export class CloudflareDurableRuntime {
   ): Layer.Layer<
     CloudflareDurableRuntimeServices,
     CloudflareDurableRuntimeInitializationError,
-    DurableObjectContext | ConversationObjectNamespace
+    DurableObjectContext | ConversationObjectNamespace | CloudflareRuntimeTelemetry
   > {
     return Layer.unwrap(
       Effect.gen(function* () {
@@ -365,11 +375,19 @@ export class CloudflareDurableRuntime {
           Layer.provideMerge(base),
         );
 
-        return Layer.mergeAll(
+        const application = Layer.mergeAll(
           runtimeStack,
           ConversationMaintenance.layer.pipe(Layer.provide(runtimeStack)),
           portsEndpointLayer,
         );
+
+        // Re-export the required host capability into the runtime used by native endpoint effects.
+        // The Worker composition edge supplies its concrete Layer outermost, preserving that
+        // Layer's acquisition error and platform requirements.
+        const telemetryRequirement = Layer.effect(CloudflareRuntimeTelemetry)(
+          CloudflareRuntimeTelemetry,
+        );
+        return application.pipe(Layer.provideMerge(telemetryRequirement));
       }),
     );
   }

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -40,7 +40,6 @@ import {
   CloudflareDurableRuntimeConfigValue,
   CloudflarePlatformConfigError,
 } from "./config.ts";
-import { CloudflareRuntimeTelemetry } from "./telemetry.ts";
 import { conversationPortTransportLayer } from "./transport.ts";
 import { cloudflareWakeSchedulerLayer } from "./wake-scheduler.ts";
 
@@ -149,8 +148,7 @@ export type CloudflareDurableRuntimeServices =
   | ConversationObjectIdentity
   | DurableAlarmService
   | ConversationMaintenance
-  | ConversationObjectPorts
-  | CloudflareRuntimeTelemetry;
+  | ConversationObjectPorts;
 
 /**
  * Owner-side endpoint body for the Conversation Object's `portCall` (plan §1.3): decode,
@@ -263,10 +261,9 @@ const resolveBindings = (
  * Storage compatibility is verified during construction: an incompatible database fails the
  * Layer typed (`DoStorageCompatibilityError`) before anything is mutated (DEPLOY-008).
  *
- * Requires the two binding services (`DurableObjectContext`, `ConversationObjectNamespace`) plus
- * the host-owned `CloudflareRuntimeTelemetry` capability. Platform values and observability enter
- * exclusively through Layers (DEPLOY-010); the Worker composition edge chooses the telemetry
- * implementation and its acquisition error/dependencies remain visible there.
+ * Requires the two binding services (`DurableObjectContext`, `ConversationObjectNamespace`).
+ * Host observability belongs to the Worker composition edge because native entrypoint lifecycle
+ * instrumentation, rather than this durable runtime assembly, consumes it (DEPLOY-010).
  */
 export class CloudflareDurableRuntime {
   static layer(
@@ -274,7 +271,7 @@ export class CloudflareDurableRuntime {
   ): Layer.Layer<
     CloudflareDurableRuntimeServices,
     CloudflareDurableRuntimeInitializationError,
-    DurableObjectContext | ConversationObjectNamespace | CloudflareRuntimeTelemetry
+    DurableObjectContext | ConversationObjectNamespace
   > {
     return Layer.unwrap(
       Effect.gen(function* () {
@@ -381,13 +378,7 @@ export class CloudflareDurableRuntime {
           portsEndpointLayer,
         );
 
-        // Re-export the required host capability into the runtime used by native endpoint effects.
-        // The Worker composition edge supplies its concrete Layer outermost, preserving that
-        // Layer's acquisition error and platform requirements.
-        const telemetryRequirement = Layer.effect(CloudflareRuntimeTelemetry)(
-          CloudflareRuntimeTelemetry,
-        );
-        return application.pipe(Layer.provideMerge(telemetryRequirement));
+        return application;
       }),
     );
   }

--- a/packages/platform-cloudflare/src/telemetry-internal.ts
+++ b/packages/platform-cloudflare/src/telemetry-internal.ts
@@ -423,9 +423,9 @@ export const registerCloudflareTelemetryAfterNativeSettlement = <A>(
   return delivery;
 };
 
-/** @internal Synchronous host diagnostic for a rejected Cloudflare waitUntil registration. */
-export const logCloudflareWaitUntilRegistrationFailure = (cause: unknown): Effect.Effect<void> =>
-  Effect.logError(Cause.die(cause), "Cloudflare telemetry waitUntil registration failed").pipe(
+/** @internal Content-free diagnostic for a rejected Cloudflare waitUntil registration. */
+export const logCloudflareWaitUntilRegistrationFailure = (_cause: unknown): Effect.Effect<void> =>
+  Effect.logError("Cloudflare telemetry waitUntil registration failed").pipe(
     Effect.annotateLogs({
       "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
     }),

--- a/packages/platform-cloudflare/src/telemetry-internal.ts
+++ b/packages/platform-cloudflare/src/telemetry-internal.ts
@@ -406,19 +406,27 @@ export const registerCloudflareTelemetryAfterNativeSettlement = <A>(
   waitUntil: (promise: Promise<void>) => void,
   delivery: Promise<A>,
   reserve: (delivery: Promise<A>) => CloudflareTelemetryFlushReservation,
-  diagnoseRegistrationFailure: () => void,
+  diagnoseRegistrationFailure: (cause: unknown) => void,
 ): Promise<A> => {
   const reservation = reserve(delivery);
   if (!reservation.owner) return delivery;
   try {
     waitUntil(reservation.background);
-  } catch {
+  } catch (cause) {
     reservation.cancel();
     try {
-      diagnoseRegistrationFailure();
+      diagnoseRegistrationFailure(cause);
     } catch {
       // Even a broken diagnostic sink is derivative and cannot create an uncertain native outcome.
     }
   }
   return delivery;
 };
+
+/** @internal Synchronous host diagnostic for a rejected Cloudflare waitUntil registration. */
+export const logCloudflareWaitUntilRegistrationFailure = (cause: unknown): Effect.Effect<void> =>
+  Effect.logError(Cause.die(cause), "Cloudflare telemetry waitUntil registration failed").pipe(
+    Effect.annotateLogs({
+      "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
+    }),
+  );

--- a/packages/platform-cloudflare/src/telemetry-internal.ts
+++ b/packages/platform-cloudflare/src/telemetry-internal.ts
@@ -1,0 +1,424 @@
+import { Cause, Duration, Effect, Exit } from "effect";
+
+import { CloudflareRuntimeTelemetry, type CloudflareTelemetryExportError } from "./telemetry.ts";
+
+/** Bounded typed control signal used only while a native entrypoint span is active. */
+class CloudflareNativeSpanFailure extends Error {
+  override readonly name = "ConversationObjectDeliveryFailed";
+
+  constructor() {
+    super("Cloudflare Conversation Object delivery failed");
+  }
+}
+
+const stripCloudflareNativeSpanFailures = <E>(
+  cause: Cause.Cause<E | CloudflareNativeSpanFailure>,
+): { readonly found: boolean; readonly residual: Cause.Cause<E> } => {
+  const found = cause.reasons.some(
+    (reason) => Cause.isFailReason(reason) && reason.error instanceof CloudflareNativeSpanFailure,
+  );
+  if (!found) {
+    // Effect v4 Cause is flat. Preserve the exact marker-free Cause object and narrow only its
+    // covariant error parameter after the complete Reason scan.
+    return { found: false, residual: cause as Cause.Cause<E> };
+  }
+  const reasons = cause.reasons.filter((reason): reason is Cause.Reason<E> => {
+    if (Cause.isFailReason(reason) && reason.error instanceof CloudflareNativeSpanFailure) {
+      return false;
+    }
+    return true;
+  });
+  return { found: true, residual: Cause.fromReasons(reasons) };
+};
+
+/**
+ * @internal Replace an entrypoint Cause with a bounded typed marker inside a span, then remove
+ * only that marker and restore the exact invocation-local Cause plus any newly composed reasons.
+ */
+export const withCloudflareNativeSpanFailure = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  trace: (
+    masked: Effect.Effect<A, E | CloudflareNativeSpanFailure, R>,
+  ) => Effect.Effect<A, E | CloudflareNativeSpanFailure, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.suspend(() => {
+    let original: Cause.Cause<E> | undefined;
+    return trace(
+      effect.pipe(
+        Effect.catchCause((cause) => {
+          original = cause;
+          return Effect.fail(new CloudflareNativeSpanFailure());
+        }),
+      ),
+    ).pipe(
+      Effect.catchCause((cause) => {
+        const { found, residual } = stripCloudflareNativeSpanFailures(cause);
+        if (!found) return Effect.failCause(residual);
+        const restored = original === undefined ? residual : Cause.combine(original, residual);
+        return Effect.failCause(restored);
+      }),
+    );
+  });
+
+const logCloudflareTelemetryCause = (
+  cause: Cause.Cause<CloudflareTelemetryExportError | Cause.TimeoutError>,
+): Effect.Effect<void> => {
+  type FailureKind = "exporter" | "timeout" | "defect" | "interrupted";
+  const kinds = new Set<FailureKind>();
+  for (const reason of cause.reasons) {
+    if (Cause.isFailReason(reason)) {
+      kinds.add(Cause.isTimeoutError(reason.error) ? "timeout" : "exporter");
+    } else if (Cause.isDieReason(reason)) {
+      kinds.add("defect");
+    } else {
+      kinds.add("interrupted");
+    }
+  }
+  return Effect.forEach(
+    kinds,
+    (kind) => {
+      const diagnostic =
+        kind === "defect"
+          ? Effect.logError("Cloudflare telemetry flush defect")
+          : Effect.logWarning(
+              kind === "exporter"
+                ? "Cloudflare telemetry exporter failed"
+                : kind === "timeout"
+                  ? "Cloudflare telemetry flush exceeded its time budget"
+                  : "Cloudflare telemetry flush interrupted",
+            );
+      // The typed error retains its foreign Cause for explicit host-controlled inspection. Never
+      // pass untrusted exporter, defect, interrupt, or platform values to the configured Logger.
+      return diagnostic.pipe(
+        Effect.annotateLogs({
+          "effect_agent.cloudflare.telemetry.failure_kind": kind,
+        }),
+      );
+    },
+    { discard: true },
+  );
+};
+
+/**
+ * @internal Cooperative background flush budget. Interruptible exporters stop at the configured
+ * timeout; uninterruptible exporters remain bounded by Cloudflare's waitUntil lifecycle instead
+ * of holding the native delivery open.
+ */
+export const flushCloudflareRuntimeTelemetry = (
+  timeoutMillis: number,
+): Effect.Effect<
+  void,
+  CloudflareTelemetryExportError | Cause.TimeoutError,
+  CloudflareRuntimeTelemetry
+> =>
+  Effect.flatMap(CloudflareRuntimeTelemetry, ({ flush }) => flush).pipe(
+    Effect.interruptible,
+    Effect.timeout(Duration.millis(timeoutMillis)),
+    Effect.onExit((exit) =>
+      Exit.isFailure(exit) ? logCloudflareTelemetryCause(exit.cause) : Effect.void,
+    ),
+    Effect.asVoid,
+  );
+
+/** @internal Convert the shared exporter result into the always-fulfilled waitUntil bridge. */
+export const fulfillCloudflareTelemetryBackground = (result: Promise<unknown>): Promise<void> =>
+  result.then(
+    () => undefined,
+    () => undefined,
+  );
+
+export interface CloudflareTelemetryFlushReservation {
+  /** Shared, always-fulfilled background Promise registered by this batch's first owner only. */
+  readonly background: Promise<void>;
+  /** Shared raw cycle result used by deterministic coordinator tests and diagnostics. */
+  readonly cycle: Promise<void>;
+  /** True only for the first delivery reserved into this bounded batch. */
+  readonly owner: boolean;
+  /** True when this delivery was coalesced without retaining its settlement Promise. */
+  readonly dropped: boolean;
+  /** Cancel this batch when its synchronous waitUntil registration fails. */
+  readonly cancel: () => void;
+}
+
+/** @internal One active exporter attempt plus bounded trailing/queued batches. */
+export interface CloudflareTelemetryFlushCoordinator {
+  readonly reserve: <A>(delivery: Promise<A>) => CloudflareTelemetryFlushReservation;
+}
+
+type FlushCyclePhase = "pending" | "first" | "trailing" | "settling";
+type FlushBatchPhase = "pending" | "waiting" | "running" | "settled" | "cancelled";
+
+/** @internal Hard cap on delivery Promises retained by one exporter batch. */
+export const MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES = 64;
+
+interface FlushBatch {
+  readonly result: Promise<void>;
+  readonly background: Promise<void>;
+  readonly resolveResult: () => void;
+  readonly rejectResult: (cause: unknown) => void;
+  readonly ready: Promise<void>;
+  readonly resolveReady: () => void;
+  phase: FlushBatchPhase;
+  reservations: number;
+  unsettledDeliveries: number;
+  dropDiagnosed: boolean;
+}
+
+interface FlushCycle {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly reject: (cause: unknown) => void;
+  readonly first: FlushBatch;
+  phase: FlushCyclePhase;
+  trailing: FlushBatch | undefined;
+}
+
+const makeFlushBatch = (): FlushBatch => {
+  let resolveResult = (): void => undefined;
+  let rejectResult = (_cause: unknown): void => undefined;
+  const result = new Promise<void>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  let resolveReady = (): void => undefined;
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  return {
+    result,
+    background: fulfillCloudflareTelemetryBackground(result),
+    resolveResult,
+    rejectResult,
+    ready,
+    resolveReady,
+    phase: "pending",
+    reservations: 0,
+    unsettledDeliveries: 0,
+    dropDiagnosed: false,
+  };
+};
+
+const makeFlushCycle = (): FlushCycle => {
+  let resolveCycle = (): void => undefined;
+  let rejectCycle = (_cause: unknown): void => undefined;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolveCycle = resolve;
+    rejectCycle = reject;
+  });
+  // Runtime delivery does not consume the raw cycle result. Attach a bounded rejection observer
+  // immediately while retaining the original Promise for deterministic tests/host diagnostics.
+  void fulfillCloudflareTelemetryBackground(promise);
+  return {
+    promise,
+    resolve: resolveCycle,
+    reject: rejectCycle,
+    first: makeFlushBatch(),
+    phase: "pending",
+    trailing: undefined,
+  };
+};
+
+/**
+ * @internal Coordinate exporter attempts for one Conversation Object incarnation. Each cycle is
+ * capped at a first attempt plus one trailing attempt. Each batch is reserved synchronously and
+ * waits for every delivery assigned to it before exporting. Only the first owner of the pending,
+ * trailing, or queued batch registers that batch's shared background Promise, so a stalled
+ * exporter cannot accumulate per-delivery waitUntil registrations. Each batch retains at most
+ * `MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES` settlement Promises; excess deliveries are lossy-
+ * coalesced into the already-requested export without settlement ownership and diagnosed once for
+ * that batch. Failures remain rejected by the raw cycle after every requested attempt runs; each
+ * shared waitUntil bridge always fulfills.
+ */
+export const makeCloudflareTelemetryFlushCoordinator = (
+  flush: () => Promise<void>,
+  options: {
+    /** @internal Synchronous test hook for the exact final-settlement boundary. */
+    readonly onSettling?: () => void;
+    /** Bounded synchronous diagnostic invoked once for each batch that reaches its hard cap. */
+    readonly onReservationDropped?: () => void;
+  } = {},
+): CloudflareTelemetryFlushCoordinator => {
+  let active: FlushCycle | undefined;
+  let queued: FlushCycle | undefined;
+
+  const closeBatch = (batch: FlushBatch): void => {
+    if (batch.phase !== "pending") return;
+    batch.phase = "waiting";
+    if (batch.unsettledDeliveries === 0) batch.resolveReady();
+  };
+
+  const cancelBatch = (batch: FlushBatch): void => {
+    if (batch.phase === "settled" || batch.phase === "cancelled") return;
+    batch.phase = "cancelled";
+    batch.resolveReady();
+    batch.resolveResult();
+  };
+
+  const reserveDelivery = <A>(
+    batch: FlushBatch,
+    delivery: Promise<A>,
+  ): { readonly owner: boolean; readonly dropped: boolean } => {
+    if (batch.reservations >= MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES) {
+      if (!batch.dropDiagnosed) {
+        batch.dropDiagnosed = true;
+        try {
+          options.onReservationDropped?.();
+        } catch {
+          // A derivative diagnostic sink cannot change native delivery or exporter coordination.
+        }
+      }
+      return { owner: false, dropped: true };
+    }
+    const owner = batch.reservations === 0;
+    batch.reservations += 1;
+    batch.unsettledDeliveries += 1;
+    const settled = (): void => {
+      batch.unsettledDeliveries -= 1;
+      if (batch.phase === "waiting" && batch.unsettledDeliveries === 0) {
+        batch.resolveReady();
+      }
+    };
+    void delivery.then(settled, settled);
+    return { owner, dropped: false };
+  };
+
+  const runCycle = async (cycle: FlushCycle): Promise<void> => {
+    const failures: Array<unknown> = [];
+
+    const runAttempt = async (): Promise<void> => {
+      try {
+        await flush();
+      } catch (cause) {
+        // Each cycle is capped at two attempts, so retaining every cause is bounded.
+        failures.push(cause);
+      }
+    };
+
+    const runBatch = async (batch: FlushBatch): Promise<void> => {
+      closeBatch(batch);
+      await batch.ready;
+      if (batch.phase === "cancelled") return;
+      batch.phase = "running";
+      const failureStart = failures.length;
+      await runAttempt();
+      batch.phase = "settled";
+      if (failures.length === failureStart) {
+        batch.resolveResult();
+      } else {
+        batch.rejectResult(failures[failures.length - 1]);
+      }
+    };
+
+    try {
+      // Requests reserved before this first exporter microtask starts share the first batch.
+      cycle.phase = "first";
+      await runBatch(cycle.first);
+      const trailing = cycle.trailing;
+      if (trailing !== undefined) {
+        cycle.phase = "trailing";
+        await runBatch(trailing);
+      }
+      // Once no more attempts can join this capped cycle, later requests must route to the queued
+      // cycle. The synchronous hook lets tests re-enter `reserve` at this exact boundary without
+      // relying on Promise reaction ordering.
+      cycle.phase = "settling";
+      options.onSettling?.();
+    } finally {
+      // Advance in the same continuation that completes the capped cycle. A request queued on the
+      // just-completed exporter Promise therefore either joined the next cycle while this one was
+      // trailing or sees the promoted pending cycle; it can never attach to a settling old Promise.
+      const next = queued;
+      queued = undefined;
+      active = next;
+      if (next !== undefined) startCycle(next);
+    }
+
+    if (failures.length === 0) return;
+    if (failures.length === 1) throw failures[0];
+    throw new AggregateError(
+      failures,
+      `${failures.length} Cloudflare telemetry flush attempts failed`,
+    );
+  };
+
+  const startCycle = (cycle: FlushCycle): void => {
+    // Start in a microtask after active is assigned, including when flush throws synchronously.
+    void Promise.resolve()
+      .then(() => runCycle(cycle))
+      .then(cycle.resolve, cycle.reject);
+  };
+
+  const reserve = <A>(delivery: Promise<A>): CloudflareTelemetryFlushReservation => {
+    let cycle: FlushCycle;
+    let batch: FlushBatch;
+    let shouldStart = false;
+
+    if (active === undefined) {
+      cycle = makeFlushCycle();
+      active = cycle;
+      batch = cycle.first;
+      shouldStart = true;
+    } else if (active.phase === "pending" && active.first.phase !== "cancelled") {
+      cycle = active;
+      batch = active.first;
+    } else if (active.phase === "first") {
+      cycle = active;
+      batch = active.trailing ??= makeFlushBatch();
+    } else {
+      // The current cycle has spent its trailing attempt, entered settlement, or had its pending
+      // registration cancelled. Route later traffic to one pending next cycle.
+      if (queued === undefined) queued = makeFlushCycle();
+      cycle = queued;
+      batch = queued.first;
+    }
+
+    const { dropped, owner } = reserveDelivery(batch, delivery);
+    if (shouldStart) startCycle(cycle);
+
+    return {
+      background: batch.background,
+      cycle: cycle.promise,
+      owner,
+      dropped,
+      cancel: () => {
+        if (!owner) return;
+        cancelBatch(batch);
+        if (cycle.trailing === batch && cycle.phase === "first") {
+          cycle.trailing = undefined;
+        } else if (queued === cycle && active !== cycle) {
+          queued = undefined;
+          cycle.resolve();
+        }
+      },
+    };
+  };
+
+  return { reserve };
+};
+
+/**
+ * @internal Reserve telemetry before registration without allowing a synchronous platform failure
+ * to replace the already-running native delivery Promise. Only a batch owner calls waitUntil; its
+ * shared bridge is already always fulfilled, and registration failure cancels export for that
+ * unowned batch.
+ */
+export const registerCloudflareTelemetryAfterNativeSettlement = <A>(
+  waitUntil: (promise: Promise<void>) => void,
+  delivery: Promise<A>,
+  reserve: (delivery: Promise<A>) => CloudflareTelemetryFlushReservation,
+  diagnoseRegistrationFailure: () => void,
+): Promise<A> => {
+  const reservation = reserve(delivery);
+  if (!reservation.owner) return delivery;
+  try {
+    waitUntil(reservation.background);
+  } catch {
+    reservation.cancel();
+    try {
+      diagnoseRegistrationFailure();
+    } catch {
+      // Even a broken diagnostic sink is derivative and cannot create an uncertain native outcome.
+    }
+  }
+  return delivery;
+};

--- a/packages/platform-cloudflare/src/telemetry.ts
+++ b/packages/platform-cloudflare/src/telemetry.ts
@@ -13,9 +13,9 @@ export class CloudflareTelemetryExportError extends Schema.TaggedError<Cloudflar
  * Host-owned exporter lifecycle for one Cloudflare Conversation Object incarnation.
  *
  * The platform package creates measurements but deliberately does not select an exporter or
- * vendor. `CloudflareDurableRuntime.layer` requires this service explicitly; applications pass its
- * provider as the second `makeConversationObjectClass` argument together with their Effect Logger,
- * Tracer, and Metric layers. That provider may read `DurableObjectContext` or
+ * vendor. Native entrypoint instrumentation consumes this service at the Worker composition edge;
+ * applications pass its provider as the second `makeConversationObjectClass` argument together
+ * with their Effect Logger, Tracer, and Metric layers. That provider may read `DurableObjectContext` or
  * `ConversationObjectNamespace`, and its typed acquisition error remains visible in construction.
  * `flush` must attempt to export every configured signal. After the native span closes, the
  * Conversation Object reserves it into a shared post-settlement batch before `ctx.waitUntil` under

--- a/packages/platform-cloudflare/src/telemetry.ts
+++ b/packages/platform-cloudflare/src/telemetry.ts
@@ -1,0 +1,37 @@
+import { Context, Effect, Layer, Schema } from "effect";
+
+/** A host exporter failed during one coalesced background export attempt. */
+export class CloudflareTelemetryExportError extends Schema.TaggedError<CloudflareTelemetryExportError>()(
+  "CloudflareTelemetryExportError",
+  {
+    /** The original exporter failure, retained for host-side diagnostics. */
+    cause: Schema.Defect(),
+  },
+) {}
+
+/**
+ * Host-owned exporter lifecycle for one Cloudflare Conversation Object incarnation.
+ *
+ * The platform package creates measurements but deliberately does not select an exporter or
+ * vendor. `CloudflareDurableRuntime.layer` requires this service explicitly; applications pass its
+ * provider as the second `makeConversationObjectClass` argument together with their Effect Logger,
+ * Tracer, and Metric layers. That provider may read `DurableObjectContext` or
+ * `ConversationObjectNamespace`, and its typed acquisition error remains visible in construction.
+ * `flush` must attempt to export every configured signal. After the native span closes, the
+ * Conversation Object reserves it into a shared post-settlement batch before `ctx.waitUntil` under
+ * a cooperative timeout. Only each pending/trailing/queued batch's first owner registers its
+ * shared Promise. Cycles remain capped at one first exporter attempt plus at most one trailing
+ * attempt, with one queued cycle while trailing runs; exporter completion never holds endpoint
+ * delivery open and exporter failure never replaces endpoint behavior.
+ */
+export class CloudflareRuntimeTelemetry extends Context.Service<
+  CloudflareRuntimeTelemetry,
+  {
+    readonly flush: Effect.Effect<void, CloudflareTelemetryExportError>;
+  }
+>()("@effect-agent/platform-cloudflare/CloudflareRuntimeTelemetry") {
+  /** Content-free default selected by `makeConversationObjectClass` when no host Layer is passed. */
+  static readonly layerNoop = Layer.succeed(CloudflareRuntimeTelemetry)({
+    flush: Effect.void,
+  });
+}

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -22,6 +22,8 @@ import type {
   EffectBindingsConversationObject,
   LimitedConversationObject,
   SubagentConversationObject,
+  TelemetryAcquisitionConversationObject,
+  TelemetryConversationObject,
   TestConversationObject,
   TinyDatabaseConversationObject,
 } from "./worker.ts";
@@ -36,6 +38,8 @@ declare global {
       DYNAMIC_BINDINGS: DurableObjectNamespace<DynamicBindingsConversationObject>;
       ARRAY_BINDINGS: DurableObjectNamespace<ArrayBindingsConversationObject>;
       EFFECT_BINDINGS: DurableObjectNamespace<EffectBindingsConversationObject>;
+      TELEMETRY: DurableObjectNamespace<TelemetryConversationObject>;
+      TELEMETRY_ACQUISITION: DurableObjectNamespace<TelemetryAcquisitionConversationObject>;
     }
   }
 }
@@ -54,7 +58,9 @@ export type TestNamespace =
   | "SUBAGENTS"
   | "DYNAMIC_BINDINGS"
   | "ARRAY_BINDINGS"
-  | "EFFECT_BINDINGS";
+  | "EFFECT_BINDINGS"
+  | "TELEMETRY"
+  | "TELEMETRY_ACQUISITION";
 
 /** A FRESH stub for the named Conversation (never cache stubs across aborts). */
 export const stubFor = (conversation: string, namespace: TestNamespace = "CONVERSATIONS") => {

--- a/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
+++ b/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
@@ -55,6 +55,24 @@ const reachableValues = (root: unknown): ReadonlyArray<unknown> => {
   return values;
 };
 
+const exportedLogObservation = ({ cause, fiber, logLevel, message }: Logger.Options<unknown>) => ({
+  message,
+  level: logLevel,
+  cause,
+  annotations: { ...fiber.getRef(References.CurrentLogAnnotations) },
+  logSpans: fiber
+    .getRef(References.CurrentLogSpans)
+    .map(([label, startTime]) => ({ label, startTime })),
+  fiberId: fiber.id,
+  currentSpan:
+    fiber.currentSpan === undefined
+      ? undefined
+      : {
+          traceId: fiber.currentSpan.traceId,
+          spanId: fiber.currentSpan.spanId,
+        },
+});
+
 describe("Cloudflare telemetry flush boundary", () => {
   it.effect("dispose releases an exporter gate after the flush has claimed it", () => {
     const probe = makeTelemetryProbeFixture();
@@ -208,28 +226,25 @@ describe("Cloudflare telemetry flush boundary", () => {
     expect(diagnosedCause).toBe(registrationFailure);
   });
 
-  it.effect("logs the exact synchronous waitUntil registration Cause structurally", () => {
-    const registrationFailure = new Error("waitUntil rejected this lifecycle");
-    const observations: Array<{
-      readonly cause: Cause.Cause<unknown>;
-      readonly annotations: Readonly<Record<string, unknown>>;
-    }> = [];
-    const logger = Logger.make<unknown, void>(({ cause, fiber }) => {
-      observations.push({
-        cause,
-        annotations: fiber.getRef(References.CurrentLogAnnotations),
-      });
+  it.effect("logs only a bounded waitUntil registration classification", () => {
+    const registrationFailure = new Error("secret waitUntil platform rejection");
+    const observations: Array<ReturnType<typeof exportedLogObservation>> = [];
+    const logger = Logger.make<unknown, void>((options) => {
+      observations.push(exportedLogObservation(options));
     });
 
     return Effect.gen(function* () {
       yield* logCloudflareWaitUntilRegistrationFailure(registrationFailure);
 
       expect(observations).toHaveLength(1);
-      expect(observations[0]?.cause.reasons).toEqual([Cause.makeDieReason(registrationFailure)]);
-      expect(observations[0]?.cause.reasons[0]).toMatchObject({ defect: registrationFailure });
+      expect(observations[0]?.cause.reasons).toEqual([]);
       expect(observations[0]?.annotations).toMatchObject({
         "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
       });
+      const values = reachableValues(observations);
+      expect(values).not.toContain(registrationFailure);
+      const strings = values.filter((value) => typeof value === "string").join("\n");
+      expect(strings).not.toContain(registrationFailure.message);
     }).pipe(Effect.provide(Logger.layer([logger])));
   });
 
@@ -256,6 +271,36 @@ describe("Cloudflare telemetry flush boundary", () => {
 
     expect(returned).toBe(delivery);
     await expect(returned).resolves.toBe("delivered");
+    if (registered === undefined) throw new Error("Expected successful background registration");
+    await expect(registered).resolves.toBeUndefined();
+    expect(flushAttempts).toBe(1);
+    expect(diagnosticCalls).toBe(0);
+  });
+
+  it("flushes after a rejected delivery whose background registration succeeds", async () => {
+    const deliveryFailure = new Error("native delivery rejected");
+    const delivery = Promise.reject(deliveryFailure);
+    let registered: Promise<void> | undefined;
+    let flushAttempts = 0;
+    let diagnosticCalls = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(() => {
+      flushAttempts += 1;
+      return Promise.resolve();
+    });
+
+    const returned = registerCloudflareTelemetryAfterNativeSettlement(
+      (background) => {
+        registered = background;
+      },
+      delivery,
+      coordinator.reserve,
+      () => {
+        diagnosticCalls += 1;
+      },
+    );
+
+    expect(returned).toBe(delivery);
+    await expect(returned).rejects.toBe(deliveryFailure);
     if (registered === undefined) throw new Error("Expected successful background registration");
     await expect(registered).resolves.toBeUndefined();
     expect(flushAttempts).toBe(1);

--- a/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
+++ b/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
@@ -16,6 +16,7 @@ import { TestClock } from "effect/testing";
 import {
   flushCloudflareRuntimeTelemetry,
   fulfillCloudflareTelemetryBackground,
+  logCloudflareWaitUntilRegistrationFailure,
   makeCloudflareTelemetryFlushCoordinator,
   MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES,
   registerCloudflareTelemetryAfterNativeSettlement,
@@ -178,6 +179,7 @@ describe("Cloudflare telemetry flush boundary", () => {
     let registered: Promise<void> | undefined;
     let flushAttempts = 0;
     let diagnosticCalls = 0;
+    let diagnosedCause: unknown;
     const coordinator = makeCloudflareTelemetryFlushCoordinator(() => {
       flushAttempts += 1;
       return Promise.resolve();
@@ -190,8 +192,9 @@ describe("Cloudflare telemetry flush boundary", () => {
       },
       delivery,
       coordinator.reserve,
-      () => {
+      (cause) => {
         diagnosticCalls += 1;
+        diagnosedCause = cause;
         throw diagnosticFailure;
       },
     );
@@ -202,6 +205,32 @@ describe("Cloudflare telemetry flush boundary", () => {
     await expect(registered).resolves.toBeUndefined();
     expect(flushAttempts).toBe(0);
     expect(diagnosticCalls).toBe(1);
+    expect(diagnosedCause).toBe(registrationFailure);
+  });
+
+  it.effect("logs the exact synchronous waitUntil registration Cause structurally", () => {
+    const registrationFailure = new Error("waitUntil rejected this lifecycle");
+    const observations: Array<{
+      readonly cause: Cause.Cause<unknown>;
+      readonly annotations: Readonly<Record<string, unknown>>;
+    }> = [];
+    const logger = Logger.make<unknown, void>(({ cause, fiber }) => {
+      observations.push({
+        cause,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+
+    return Effect.gen(function* () {
+      yield* logCloudflareWaitUntilRegistrationFailure(registrationFailure);
+
+      expect(observations).toHaveLength(1);
+      expect(observations[0]?.cause.reasons).toEqual([Cause.makeDieReason(registrationFailure)]);
+      expect(observations[0]?.cause.reasons[0]).toMatchObject({ defect: registrationFailure });
+      expect(observations[0]?.annotations).toMatchObject({
+        "effect_agent.cloudflare.telemetry.failure_kind": "wait_until_registration",
+      });
+    }).pipe(Effect.provide(Logger.layer([logger])));
   });
 
   it("issues one flush attempt for a successfully registered settled delivery", async () => {

--- a/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
+++ b/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts
@@ -1,0 +1,890 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  Cause,
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Logger,
+  References,
+  Scope,
+  Tracer,
+} from "effect";
+import { TestClock } from "effect/testing";
+
+import {
+  flushCloudflareRuntimeTelemetry,
+  fulfillCloudflareTelemetryBackground,
+  makeCloudflareTelemetryFlushCoordinator,
+  MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES,
+  registerCloudflareTelemetryAfterNativeSettlement,
+  withCloudflareNativeSpanFailure,
+} from "../../src/telemetry-internal.ts";
+import { CloudflareRuntimeTelemetry, CloudflareTelemetryExportError } from "../../src/telemetry.ts";
+import { makeTelemetryProbeFixture, type TelemetryFlushBlock } from "../telemetry-fixtures.ts";
+
+class TestCauseSource extends Context.Service<TestCauseSource, string>()(
+  "@effect-agent/platform-cloudflare/test/TestCauseSource",
+) {}
+
+const promiseGate = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resume) => {
+    resolve = resume;
+  });
+  return { promise, resolve };
+};
+
+const reachableValues = (root: unknown): ReadonlyArray<unknown> => {
+  const values: Array<unknown> = [];
+  const visited = new WeakSet<object>();
+  const visit = (value: unknown): void => {
+    values.push(value);
+    if ((typeof value !== "object" && typeof value !== "function") || value === null) return;
+    if (visited.has(value)) return;
+    visited.add(value);
+    for (const key of Reflect.ownKeys(value)) {
+      visit(key);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && "value" in descriptor) visit(descriptor.value);
+    }
+  };
+  visit(root);
+  return values;
+};
+
+describe("Cloudflare telemetry flush boundary", () => {
+  it.effect("dispose releases an exporter gate after the flush has claimed it", () => {
+    const probe = makeTelemetryProbeFixture();
+
+    return Effect.gen(function* () {
+      const telemetry = yield* CloudflareRuntimeTelemetry;
+      yield* probe.withFlushBlock((block) =>
+        Effect.gen(function* () {
+          const flushFiber = yield* telemetry.flush.pipe(Effect.forkChild);
+          yield* probe.awaitFlushBlock(block);
+          expect(block.isActive()).toBe(true);
+          expect(block.isCompleted()).toBe(false);
+
+          probe.dispose();
+          const exit = yield* Fiber.await(flushFiber);
+          expect(Exit.isSuccess(exit)).toBe(true);
+          yield* probe.awaitFlushBlockCompleted(block);
+          expect(block.isCompleted()).toBe(true);
+        }),
+      );
+    }).pipe(Effect.provide(probe.layer), Effect.ensuring(Effect.sync(() => probe.dispose())));
+  });
+
+  it.effect("releases a global Workerd registration when its Effect scope fails", () => {
+    const first = makeTelemetryProbeFixture();
+    const second = makeTelemetryProbeFixture();
+    const conversationId = "scoped-registration-after-failure";
+    const expected = new Error("registration owner failed");
+
+    return Effect.gen(function* () {
+      const failedExit = yield* first
+        .registerConversation(conversationId)
+        .pipe(Effect.andThen(Effect.fail(expected)), Effect.scoped, Effect.exit);
+      if (Exit.isSuccess(failedExit)) throw new Error("Expected the registration owner to fail");
+      expect(failedExit.cause.reasons).toHaveLength(1);
+      expect(failedExit.cause.reasons[0]?._tag).toBe("Fail");
+      if (failedExit.cause.reasons[0]?._tag !== "Fail") {
+        throw new Error("Expected the exact registration-owner failure");
+      }
+      expect(failedExit.cause.reasons[0].error).toBe(expected);
+
+      yield* Effect.scoped(second.registerConversation(conversationId));
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          first.dispose();
+          second.dispose();
+        }),
+      ),
+    );
+  });
+
+  it.effect(
+    "rejects overlapping registrations without prematurely releasing the first owner",
+    () => {
+      const first = makeTelemetryProbeFixture();
+      const second = makeTelemetryProbeFixture();
+      const conversationId = "overlapping-registration-ownership";
+
+      const expectDuplicateRegistration = (exit: Exit.Exit<void, never>) => {
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isSuccess(exit)) throw new Error("Expected duplicate registration to fail");
+        expect(exit.cause.reasons).toHaveLength(1);
+        const reason = exit.cause.reasons[0];
+        expect(reason?._tag).toBe("Die");
+        if (reason?._tag !== "Die" || !(reason.defect instanceof Error)) {
+          throw new Error("Expected one duplicate-registration defect");
+        }
+        expect(reason.defect.message).toBe(
+          `Telemetry fixture already registered for ${conversationId}`,
+        );
+      };
+
+      return Effect.acquireUseRelease(
+        Scope.make(),
+        (ownerScope) =>
+          Effect.gen(function* () {
+            yield* first
+              .registerConversation(conversationId)
+              .pipe(Effect.provideService(Scope.Scope, ownerScope));
+
+            const sameFixtureDuplicate = yield* Effect.scoped(
+              first.registerConversation(conversationId),
+            ).pipe(Effect.exit);
+            expectDuplicateRegistration(sameFixtureDuplicate);
+
+            const otherFixtureWhileOwnerLives = yield* Effect.scoped(
+              second.registerConversation(conversationId),
+            ).pipe(Effect.exit);
+            expectDuplicateRegistration(otherFixtureWhileOwnerLives);
+          }),
+        (ownerScope, exit) => Scope.close(ownerScope, exit),
+      ).pipe(
+        Effect.andThen(Effect.scoped(second.registerConversation(conversationId))),
+        Effect.ensuring(
+          Effect.sync(() => {
+            first.dispose();
+            second.dispose();
+          }),
+        ),
+      );
+    },
+  );
+
+  it("always fulfills the shared waitUntil bridge across background failures", async () => {
+    const firstFailure = new Error("first background failure");
+    const trailingFailure = new Error("trailing background failure");
+
+    await expect(
+      fulfillCloudflareTelemetryBackground(Promise.reject(firstFailure)),
+    ).resolves.toBeUndefined();
+    await expect(
+      fulfillCloudflareTelemetryBackground(Promise.reject(trailingFailure)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns the exact native delivery when waitUntil registration throws synchronously", async () => {
+    const deliveryFailure = new Error("native delivery failure");
+    const registrationFailure = new Error("waitUntil registration failure");
+    const diagnosticFailure = new Error("synchronous diagnostic failure");
+    const delivery = Promise.reject(deliveryFailure);
+    let registered: Promise<void> | undefined;
+    let flushAttempts = 0;
+    let diagnosticCalls = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(() => {
+      flushAttempts += 1;
+      return Promise.resolve();
+    });
+
+    const returned = registerCloudflareTelemetryAfterNativeSettlement(
+      (background) => {
+        registered = background;
+        throw registrationFailure;
+      },
+      delivery,
+      coordinator.reserve,
+      () => {
+        diagnosticCalls += 1;
+        throw diagnosticFailure;
+      },
+    );
+
+    expect(returned).toBe(delivery);
+    await expect(returned).rejects.toBe(deliveryFailure);
+    if (registered === undefined) throw new Error("Expected background registration attempt");
+    await expect(registered).resolves.toBeUndefined();
+    expect(flushAttempts).toBe(0);
+    expect(diagnosticCalls).toBe(1);
+  });
+
+  it("issues one flush attempt for a successfully registered settled delivery", async () => {
+    const delivery = Promise.resolve("delivered");
+    let registered: Promise<void> | undefined;
+    let flushAttempts = 0;
+    let diagnosticCalls = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(() => {
+      flushAttempts += 1;
+      return Promise.resolve();
+    });
+
+    const returned = registerCloudflareTelemetryAfterNativeSettlement(
+      (background) => {
+        registered = background;
+      },
+      delivery,
+      coordinator.reserve,
+      () => {
+        diagnosticCalls += 1;
+      },
+    );
+
+    expect(returned).toBe(delivery);
+    await expect(returned).resolves.toBe("delivered");
+    if (registered === undefined) throw new Error("Expected successful background registration");
+    await expect(registered).resolves.toBeUndefined();
+    expect(flushAttempts).toBe(1);
+    expect(diagnosticCalls).toBe(0);
+  });
+
+  it("bounds shared waitUntil registrations across stalled first, trailing, and queued batches", async () => {
+    const started = [promiseGate(), promiseGate(), promiseGate()];
+    const release = [promiseGate(), promiseGate(), promiseGate()];
+    const registrations: Array<Promise<void>> = [];
+    let attempts = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(async () => {
+      const index = attempts++;
+      started[index]?.resolve();
+      await release[index]?.promise;
+    });
+    const register = (delivery: Promise<string>): Promise<string> =>
+      registerCloudflareTelemetryAfterNativeSettlement(
+        (background) => {
+          registrations.push(background);
+        },
+        delivery,
+        coordinator.reserve,
+        () => undefined,
+      );
+
+    try {
+      const firstDeliveries = Array.from({ length: 64 }, (_, index) =>
+        Promise.resolve(`first-${index}`),
+      );
+      expect(firstDeliveries.map(register)).toEqual(firstDeliveries);
+      await started[0]?.promise;
+      expect(registrations).toHaveLength(1);
+
+      const trailingDeliveries = Array.from({ length: 64 }, (_, index) =>
+        Promise.resolve(`trailing-${index}`),
+      );
+      expect(trailingDeliveries.map(register)).toEqual(trailingDeliveries);
+      expect(registrations).toHaveLength(2);
+      release[0]?.resolve();
+      await started[1]?.promise;
+
+      const queuedDeliveries = Array.from({ length: 64 }, (_, index) =>
+        Promise.resolve(`queued-${index}`),
+      );
+      expect(queuedDeliveries.map(register)).toEqual(queuedDeliveries);
+      expect(registrations).toHaveLength(3);
+      expect(new Set(registrations).size).toBe(3);
+
+      release[1]?.resolve();
+      await started[2]?.promise;
+      release[2]?.resolve();
+      await Promise.all(registrations);
+      expect(attempts).toBe(3);
+    } finally {
+      for (const gate of release) gate.resolve();
+    }
+  });
+
+  it("caps retained delivery settlements and diagnoses lossy coalescing once per batch", async () => {
+    const started = promiseGate();
+    const release = promiseGate();
+    const droppedDelivery = promiseGate();
+    let attempts = 0;
+    let dropDiagnostics = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(
+      async () => {
+        attempts += 1;
+        started.resolve();
+        await release.promise;
+      },
+      {
+        onReservationDropped: () => {
+          dropDiagnostics += 1;
+        },
+      },
+    );
+
+    const retained = Array.from({ length: MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES }, () =>
+      coordinator.reserve(Promise.resolve()),
+    );
+    const dropped = Array.from({ length: MAX_CLOUDFLARE_TELEMETRY_BATCH_DELIVERIES * 4 }, () =>
+      coordinator.reserve(droppedDelivery.promise),
+    );
+
+    try {
+      expect(retained.filter(({ owner }) => owner)).toHaveLength(1);
+      expect(retained.every(({ dropped }) => !dropped)).toBe(true);
+      expect(dropped.every((reservation) => reservation.dropped && !reservation.owner)).toBe(true);
+      expect(new Set([...retained, ...dropped].map(({ background }) => background)).size).toBe(1);
+      expect(dropDiagnostics).toBe(1);
+
+      // The unresolved overflow Promise is deliberately not retained by the batch, so export can
+      // start and settle without waiting for it.
+      await started.promise;
+      expect(attempts).toBe(1);
+      release.resolve();
+      await expect(retained[0]?.cycle).resolves.toBeUndefined();
+      expect(dropDiagnostics).toBe(1);
+    } finally {
+      droppedDelivery.resolve();
+      release.resolve();
+    }
+  });
+
+  it("coalesces same-turn requests into the not-yet-started exporter attempt", async () => {
+    const started = promiseGate();
+    const release = promiseGate();
+    let attempts = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(async () => {
+      attempts += 1;
+      started.resolve();
+      await release.promise;
+    });
+
+    const requests = Array.from({ length: 64 }, () => coordinator.reserve(Promise.resolve()));
+    await started.promise;
+    expect(attempts).toBe(1);
+    expect(requests.filter(({ owner }) => owner)).toHaveLength(1);
+    expect(new Set(requests.map(({ background }) => background)).size).toBe(1);
+    expect(new Set(requests.map(({ cycle }) => cycle)).size).toBe(1);
+    release.resolve();
+    await Promise.all(requests.map(({ background }) => background));
+    await requests[0]?.cycle;
+    expect(attempts).toBe(1);
+  });
+
+  it("runs one active exporter attempt plus one trailing attempt for a concurrent burst", async () => {
+    const started = [promiseGate(), promiseGate()];
+    const release = [promiseGate(), promiseGate()];
+    let attempts = 0;
+    let activeAttempts = 0;
+    let maximumActiveAttempts = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(async () => {
+      const index = attempts++;
+      activeAttempts += 1;
+      maximumActiveAttempts = Math.max(maximumActiveAttempts, activeAttempts);
+      started[index]?.resolve();
+      await release[index]?.promise;
+      activeAttempts -= 1;
+    });
+
+    const first = coordinator.reserve(Promise.resolve());
+    await started[0]?.promise;
+    const concurrent = Array.from({ length: 64 }, () => coordinator.reserve(Promise.resolve()));
+    expect(attempts).toBe(1);
+    expect(concurrent.every(({ cycle }) => cycle === first.cycle)).toBe(true);
+    expect(concurrent.filter(({ owner }) => owner)).toHaveLength(1);
+    expect(new Set(concurrent.map(({ background }) => background)).size).toBe(1);
+    expect(concurrent[0]?.background).not.toBe(first.background);
+
+    release[0]?.resolve();
+    await started[1]?.promise;
+    expect(attempts).toBe(2);
+    expect(maximumActiveAttempts).toBe(1);
+    release[1]?.resolve();
+    await Promise.all([first.background, ...concurrent.map(({ background }) => background)]);
+    await first.cycle;
+    expect(attempts).toBe(2);
+    expect(activeAttempts).toBe(0);
+  });
+
+  it("caps each cycle at two attempts and routes trailing traffic into a fresh cycle", async () => {
+    const started = [promiseGate(), promiseGate(), promiseGate()];
+    const release = [promiseGate(), promiseGate(), promiseGate()];
+    let attempts = 0;
+    let activeAttempts = 0;
+    let maximumActiveAttempts = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(async () => {
+      const index = attempts++;
+      activeAttempts += 1;
+      maximumActiveAttempts = Math.max(maximumActiveAttempts, activeAttempts);
+      started[index]?.resolve();
+      await release[index]?.promise;
+      activeAttempts -= 1;
+    });
+
+    const firstCycle = coordinator.reserve(Promise.resolve());
+    let nextCycle: ReturnType<typeof coordinator.reserve> | undefined;
+    try {
+      await started[0]?.promise;
+      const trailing = coordinator.reserve(Promise.resolve());
+      expect(trailing.cycle).toBe(firstCycle.cycle);
+
+      release[0]?.resolve();
+      await started[1]?.promise;
+      nextCycle = coordinator.reserve(Promise.resolve());
+      expect(nextCycle.cycle).not.toBe(firstCycle.cycle);
+      let nextCycleSettled = false;
+      void nextCycle.cycle.then(
+        () => {
+          nextCycleSettled = true;
+        },
+        () => {
+          nextCycleSettled = true;
+        },
+      );
+      expect(
+        Array.from({ length: 64 }, () => coordinator.reserve(Promise.resolve())).every(
+          ({ background, cycle }) =>
+            background === nextCycle?.background && cycle === nextCycle.cycle,
+        ),
+      ).toBe(true);
+
+      release[1]?.resolve();
+      await started[2]?.promise;
+      await expect(firstCycle.cycle).resolves.toBeUndefined();
+      expect(activeAttempts).toBe(1);
+      expect(nextCycleSettled).toBe(false);
+
+      release[2]?.resolve();
+      await expect(nextCycle.cycle).resolves.toBeUndefined();
+      expect(attempts).toBe(3);
+      expect(maximumActiveAttempts).toBe(1);
+      expect(activeAttempts).toBe(0);
+    } finally {
+      for (const gate of release) gate.resolve();
+    }
+  });
+
+  it("retains both exporter failures from a capped two-attempt cycle", async () => {
+    const firstStarted = promiseGate();
+    const firstRelease = promiseGate();
+    const firstFailure = new Error("first exporter failure");
+    const trailingFailure = new Error("trailing exporter failure");
+    let attempts = 0;
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        firstStarted.resolve();
+        await firstRelease.promise;
+        throw firstFailure;
+      }
+      throw trailingFailure;
+    });
+
+    const cycle = coordinator.reserve(Promise.resolve());
+    await firstStarted.promise;
+    expect(coordinator.reserve(Promise.resolve()).cycle).toBe(cycle.cycle);
+    firstRelease.resolve();
+
+    let rejection: unknown;
+    try {
+      await cycle.cycle;
+    } catch (cause) {
+      rejection = cause;
+    }
+    expect(rejection).toBeInstanceOf(AggregateError);
+    if (!(rejection instanceof AggregateError)) throw new Error("Expected the bounded aggregate");
+    expect(rejection.errors).toEqual([firstFailure, trailingFailure]);
+    expect(attempts).toBe(2);
+  });
+
+  it("rejects directly with the sole exporter failure from a one-attempt cycle", async () => {
+    const failure = new Error("sole exporter failure");
+    const coordinator = makeCloudflareTelemetryFlushCoordinator(() => Promise.reject(failure));
+
+    await expect(coordinator.reserve(Promise.resolve()).cycle).rejects.toBe(failure);
+  });
+
+  it("starts a fresh attempt for a request reentered at the final-settlement boundary", async () => {
+    let attempts = 0;
+    let requestAtSettlement:
+      | ReturnType<ReturnType<typeof makeCloudflareTelemetryFlushCoordinator>["reserve"]>
+      | undefined;
+    let coordinator: ReturnType<typeof makeCloudflareTelemetryFlushCoordinator>;
+    coordinator = makeCloudflareTelemetryFlushCoordinator(
+      () => {
+        attempts += 1;
+        return Promise.resolve();
+      },
+      {
+        onSettling: () => {
+          if (requestAtSettlement === undefined) {
+            requestAtSettlement = coordinator.reserve(Promise.resolve());
+          }
+        },
+      },
+    );
+
+    const first = coordinator.reserve(Promise.resolve());
+    await first.cycle;
+    if (requestAtSettlement === undefined) {
+      throw new Error("Expected a request from the synchronous settlement hook");
+    }
+    expect(requestAtSettlement.cycle).not.toBe(first.cycle);
+    await requestAtSettlement.cycle;
+    expect(attempts).toBe(2);
+  });
+
+  it.effect(
+    "logs only bounded failure classes while preserving exact typed, defect, and interrupt exits",
+    () => {
+      const logs: Array<{
+        readonly message: unknown;
+        readonly cause: Cause.Cause<unknown>;
+        readonly annotations: Readonly<Record<string, unknown>>;
+      }> = [];
+      const logger = Logger.make<unknown, void>(({ cause, fiber, message }) => {
+        logs.push({
+          message,
+          cause,
+          annotations: fiber.getRef(References.CurrentLogAnnotations),
+        });
+      });
+      const foreignCause = new Error("typed exporter diagnostic");
+      const expectedError = CloudflareTelemetryExportError.make({ cause: foreignCause });
+      const defect = new Error("exporter defect diagnostic");
+
+      return Effect.gen(function* () {
+        const typedExit = yield* flushCloudflareRuntimeTelemetry(20).pipe(
+          Effect.provideService(
+            CloudflareRuntimeTelemetry,
+            CloudflareRuntimeTelemetry.of({ flush: Effect.fail(expectedError) }),
+          ),
+          Effect.exit,
+        );
+        if (Exit.isSuccess(typedExit)) throw new Error("Expected the typed exporter failure");
+        expect(typedExit.cause.reasons).toEqual([Cause.makeFailReason(expectedError)]);
+
+        const defectExit = yield* flushCloudflareRuntimeTelemetry(20).pipe(
+          Effect.provideService(
+            CloudflareRuntimeTelemetry,
+            CloudflareRuntimeTelemetry.of({ flush: Effect.die(defect) }),
+          ),
+          Effect.exit,
+        );
+        if (Exit.isSuccess(defectExit)) throw new Error("Expected the exporter defect");
+        expect(defectExit.cause.reasons).toEqual([Cause.makeDieReason(defect)]);
+
+        const flushStarted = yield* Deferred.make<void>();
+        const interruptedFiber = yield* flushCloudflareRuntimeTelemetry(20).pipe(
+          Effect.provideService(
+            CloudflareRuntimeTelemetry,
+            CloudflareRuntimeTelemetry.of({
+              flush: Deferred.succeed(flushStarted, undefined).pipe(Effect.andThen(Effect.never)),
+            }),
+          ),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(flushStarted);
+        yield* Fiber.interrupt(interruptedFiber);
+        const interruptedExit = yield* Fiber.await(interruptedFiber);
+        if (Exit.isSuccess(interruptedExit)) throw new Error("Expected external interruption");
+        expect(interruptedExit.cause.reasons).toHaveLength(1);
+        expect(Cause.isInterruptReason(interruptedExit.cause.reasons[0]!)).toBe(true);
+
+        const loggedValues = reachableValues(logs);
+        expect(loggedValues).not.toContain(expectedError);
+        expect(loggedValues).not.toContain(foreignCause);
+        expect(loggedValues).not.toContain(defect);
+        const loggedStrings = loggedValues.filter((value) => typeof value === "string").join("\n");
+        expect(loggedStrings).not.toContain(foreignCause.message);
+        expect(loggedStrings).not.toContain(defect.message);
+        expect(loggedStrings).toContain("Cloudflare telemetry flush interrupted");
+        expect(logs.map(({ cause }) => cause.reasons)).toEqual([[], [], []]);
+        expect(
+          logs
+            .map(({ annotations }) => annotations["effect_agent.cloudflare.telemetry.failure_kind"])
+            .toSorted(),
+        ).toEqual(["defect", "exporter", "interrupted"]);
+      }).pipe(Effect.provide(Logger.layer([logger])));
+    },
+  );
+
+  it.effect("interrupts a cooperative stalled exporter at the configured background budget", () =>
+    Effect.gen(function* () {
+      const flushStarted = yield* Deferred.make<void>();
+      const flushInterrupted = yield* Deferred.make<void>();
+      const flush = Deferred.succeed(flushStarted, undefined).pipe(
+        Effect.andThen(Effect.never),
+        Effect.onInterrupt(() => Deferred.succeed(flushInterrupted, undefined)),
+      );
+      const fiber = yield* flushCloudflareRuntimeTelemetry(20).pipe(
+        Effect.provideService(CloudflareRuntimeTelemetry, CloudflareRuntimeTelemetry.of({ flush })),
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(flushStarted);
+      expect(fiber.pollUnsafe()).toBeUndefined();
+      yield* TestClock.adjust(19);
+      expect(fiber.pollUnsafe()).toBeUndefined();
+      expect(yield* Deferred.isDone(flushInterrupted)).toBe(false);
+
+      yield* TestClock.adjust(1);
+      const exit = yield* Fiber.await(fiber);
+      if (Exit.isSuccess(exit)) throw new Error("Expected the cooperative flush timeout");
+      expect(exit.cause.reasons).toHaveLength(1);
+      const timeoutReason = exit.cause.reasons[0]!;
+      expect(Cause.isFailReason(timeoutReason)).toBe(true);
+      if (!Cause.isFailReason(timeoutReason)) throw new Error("Expected only a timeout failure");
+      expect(timeoutReason.error._tag).toBe("TimeoutError");
+      expect(yield* Deferred.isDone(flushInterrupted)).toBe(true);
+    }),
+  );
+
+  it.effect("does not claim the cooperative budget can interrupt an uninterruptible exporter", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const flushStarted = yield* Deferred.make<void>();
+        const releaseFlush = yield* Effect.acquireRelease(Deferred.make<void>(), (release) =>
+          Deferred.succeed(release, undefined).pipe(Effect.asVoid),
+        );
+        const flush = Deferred.succeed(flushStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseFlush)),
+          Effect.uninterruptible,
+        );
+        const fiber = yield* flushCloudflareRuntimeTelemetry(20).pipe(
+          Effect.provideService(
+            CloudflareRuntimeTelemetry,
+            CloudflareRuntimeTelemetry.of({ flush }),
+          ),
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(flushStarted);
+        yield* TestClock.adjust(20);
+        expect(fiber.pollUnsafe()).toBeUndefined();
+
+        yield* Deferred.succeed(releaseFlush, undefined);
+        const exit = yield* Fiber.await(fiber);
+        if (Exit.isSuccess(exit)) throw new Error("Expected the delayed cooperative timeout");
+        expect(exit.cause.reasons).toHaveLength(1);
+        const timeoutReason = exit.cause.reasons[0]!;
+        expect(Cause.isFailReason(timeoutReason)).toBe(true);
+        if (!Cause.isFailReason(timeoutReason)) throw new Error("Expected only a timeout failure");
+        expect(timeoutReason.error._tag).toBe("TimeoutError");
+      }),
+    ),
+  );
+
+  it.effect("releases a blocked same-scope child before propagating bracket body failure", () => {
+    const probe = makeTelemetryProbeFixture();
+    return Effect.gen(function* () {
+      const bodyFailure = new Error("flush block bracket body failed");
+      let observedBlock: TelemetryFlushBlock | undefined;
+      let observedFiber: Fiber.Fiber<void, CloudflareTelemetryExportError> | undefined;
+
+      const bodyExit = yield* probe
+        .withFlushBlock((block) =>
+          Effect.gen(function* () {
+            observedBlock = block;
+            const telemetry = yield* CloudflareRuntimeTelemetry;
+            observedFiber = yield* telemetry.flush.pipe(Effect.forkChild);
+            yield* probe.awaitFlushBlock(block);
+            return yield* Effect.fail(bodyFailure);
+          }),
+        )
+        .pipe(Effect.provide(probe.layer), Effect.exit);
+
+      if (Exit.isSuccess(bodyExit)) throw new Error("Expected the bracket body failure");
+      expect(bodyExit.cause.reasons).toEqual([Cause.makeFailReason(bodyFailure)]);
+      if (observedBlock === undefined || observedFiber === undefined) {
+        throw new Error("Expected the bracket body to start its blocked flush child");
+      }
+      expect(Exit.isSuccess(yield* Fiber.await(observedFiber))).toBe(true);
+      yield* probe.awaitFlushBlockCompleted(observedBlock);
+      expect(observedBlock.isCompleted()).toBe(true);
+    }).pipe(Effect.ensuring(Effect.sync(probe.dispose)));
+  });
+
+  it.effect("interrupts a bracket body that directly executes a blocked flush", () => {
+    const probe = makeTelemetryProbeFixture();
+    return Effect.gen(function* () {
+      const blockReady = yield* Deferred.make<TelemetryFlushBlock>();
+      const bracketFiber = yield* probe
+        .withFlushBlock((block) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(blockReady, block);
+            const telemetry = yield* CloudflareRuntimeTelemetry;
+            return yield* telemetry.flush;
+          }),
+        )
+        .pipe(Effect.provide(probe.layer), Effect.forkChild);
+
+      const block = yield* Deferred.await(blockReady);
+      yield* probe.awaitFlushBlock(block);
+      yield* Fiber.interrupt(bracketFiber).pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      const bracketExit = yield* Fiber.await(bracketFiber);
+      if (Exit.isSuccess(bracketExit)) throw new Error("Expected the bracket body interruption");
+      expect(bracketExit.cause.reasons).toHaveLength(1);
+      expect(Cause.isInterruptReason(bracketExit.cause.reasons[0]!)).toBe(true);
+      yield* probe.awaitFlushBlockCompleted(block);
+      expect(block.isCompleted()).toBe(true);
+    }).pipe(Effect.ensuring(Effect.sync(probe.dispose)));
+  });
+
+  it.effect("dequeues a bracketed flush block released before any exporter claims it", () => {
+    const probe = makeTelemetryProbeFixture();
+    return Effect.gen(function* () {
+      const unusedObservation = yield* probe.withFlushBlock((unused) =>
+        Effect.sync(() => {
+          unused.release();
+          return unused;
+        }),
+      );
+
+      yield* probe.withFlushBlock((claimed) =>
+        Effect.gen(function* () {
+          const telemetry = yield* CloudflareRuntimeTelemetry;
+          const flushFiber = yield* telemetry.flush.pipe(Effect.forkChild);
+
+          yield* probe.awaitFlushBlock(claimed);
+          expect(unusedObservation.isActive()).toBe(false);
+          expect(unusedObservation.isCompleted()).toBe(false);
+          expect(claimed.isActive()).toBe(true);
+          claimed.release();
+          expect(Exit.isSuccess(yield* Fiber.await(flushFiber))).toBe(true);
+          yield* probe.awaitFlushBlockCompleted(claimed);
+          expect(claimed.isCompleted()).toBe(true);
+        }),
+      );
+    }).pipe(Effect.provide(probe.layer), Effect.ensuring(Effect.sync(probe.dispose)));
+  });
+
+  it.effect("keeps delayed exporter controls isolated between per-test fixtures", () => {
+    const staleProbe = makeTelemetryProbeFixture();
+    const currentProbe = makeTelemetryProbeFixture();
+    return Effect.gen(function* () {
+      const staleAttempt = staleProbe.expectFlushAttempt();
+      const currentAttempt = currentProbe.expectFlushAttempt();
+      const staleTelemetry = yield* CloudflareRuntimeTelemetry.pipe(
+        Effect.provide(staleProbe.layer),
+      );
+      const currentTelemetry = yield* CloudflareRuntimeTelemetry.pipe(
+        Effect.provide(currentProbe.layer),
+      );
+      const startStale = yield* Deferred.make<void>();
+      const staleFiber = yield* Deferred.await(startStale).pipe(
+        Effect.andThen(staleTelemetry.flush),
+        Effect.forkChild,
+      );
+      const currentFailure = new Error("current-fixture exporter failure");
+      currentProbe.failNextFlush(currentFailure);
+
+      yield* currentProbe.withFlushBlock((currentBlock) =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(startStale, undefined);
+          yield* Fiber.join(staleFiber);
+          yield* staleProbe.awaitFlushAttempt(staleAttempt);
+          expect(currentAttempt.isActive()).toBe(false);
+          expect(currentBlock.isActive()).toBe(false);
+          expect(currentProbe.exportErrors).toEqual([]);
+
+          const currentFiber = yield* currentTelemetry.flush.pipe(Effect.forkChild);
+          yield* currentProbe.awaitFlushBlock(currentBlock);
+          currentBlock.release();
+          const currentExit = yield* Fiber.await(currentFiber);
+          if (Exit.isSuccess(currentExit)) throw new Error("Expected the tagged current failure");
+          expect(currentExit.cause.reasons).toHaveLength(1);
+          const failureReason = currentExit.cause.reasons[0]!;
+          expect(Cause.isFailReason(failureReason)).toBe(true);
+          if (!Cause.isFailReason(failureReason)) {
+            throw new Error("Expected only the typed export failure");
+          }
+          expect(failureReason.error).toMatchObject({
+            _tag: "CloudflareTelemetryExportError",
+            cause: currentFailure,
+          });
+          yield* currentProbe.awaitFlushAttempt(currentAttempt);
+          yield* currentProbe.awaitFlushBlockCompleted(currentBlock);
+          expect(currentProbe.exportErrors.map(({ cause }) => cause)).toEqual([currentFailure]);
+          expect(staleProbe.exportErrors).toEqual([]);
+        }),
+      );
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          staleProbe.dispose();
+          currentProbe.dispose();
+        }),
+      ),
+    );
+  });
+
+  it.effect("restores the original Cause plus residual trace-finalizer reasons", () => {
+    const spans: Array<Tracer.NativeSpan> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const expected = new Error("typed endpoint secret");
+    const finalizerDefect = new Error("endpoint finalizer secret");
+    const finalizerDefectReason = Cause.makeDieReason(finalizerDefect).annotate(
+      Context.make(TestCauseSource, "native-span-finalizer"),
+    );
+    const finalizerInterruptReason = Cause.makeInterruptReason(4242).annotate(
+      Context.make(TestCauseSource, "native-span-interrupt"),
+    );
+
+    return Effect.gen(function* () {
+      const exit = yield* withCloudflareNativeSpanFailure(Effect.fail(expected), (masked) =>
+        masked.pipe(
+          Effect.withSpan("cloudflare-native-marker-test"),
+          Effect.onExit((spanExit) =>
+            Exit.isFailure(spanExit)
+              ? Effect.failCause(
+                  Cause.combine(
+                    spanExit.cause,
+                    Cause.fromReasons([finalizerDefectReason, finalizerInterruptReason]),
+                  ),
+                )
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) throw new Error("Expected the composed endpoint Cause");
+      expect(exit.cause.reasons).toHaveLength(3);
+      const restoredFailureReason = exit.cause.reasons[0]!;
+      expect(Cause.isFailReason(restoredFailureReason)).toBe(true);
+      if (!Cause.isFailReason(restoredFailureReason)) {
+        throw new Error("Expected the restored typed failure first");
+      }
+      expect(restoredFailureReason.error).toBe(expected);
+      expect(exit.cause.reasons[1]).toBe(finalizerDefectReason);
+      expect(exit.cause.reasons[2]).toBe(finalizerInterruptReason);
+      expect([...exit.cause.reasons[1]!.annotations.values()]).toContain("native-span-finalizer");
+      expect([...exit.cause.reasons[2]!.annotations.values()]).toContain("native-span-interrupt");
+      expect(Cause.interruptors(exit.cause)).toEqual(new Set([4242]));
+      const publicFailureText = Cause.pretty(exit.cause);
+      expect(publicFailureText).not.toContain("ConversationObjectDeliveryFailed");
+      expect(publicFailureText).not.toContain("Cloudflare Conversation Object delivery failed");
+
+      const span = spans.find(({ name }) => name === "cloudflare-native-marker-test");
+      if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
+        throw new Error("Expected the native marker span to end failed");
+      }
+      const spanFailureText = Cause.pretty(span.status.exit.cause);
+      expect(spanFailureText).toContain("Cloudflare Conversation Object delivery failed");
+      expect(spanFailureText).not.toContain(expected.message);
+      expect(spanFailureText).not.toContain(finalizerDefect.message);
+    }).pipe(Effect.provideService(Tracer.Tracer, tracer));
+  });
+
+  it.effect("preserves a marker-free native span Cause by referential identity", () => {
+    const failureReason = Cause.makeFailReason(new Error("ordinary native failure")).annotate(
+      Context.make(TestCauseSource, "trace"),
+    );
+    const defectReason = Cause.makeDieReason(new Error("ordinary native defect"));
+    const markerFree = Cause.fromReasons([failureReason, defectReason]);
+
+    return Effect.gen(function* () {
+      const exit = yield* withCloudflareNativeSpanFailure(Effect.void, () =>
+        Effect.failCause(markerFree),
+      ).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) throw new Error("Expected the marker-free native Cause");
+      expect(exit.cause).toBe(markerFree);
+      expect(exit.cause.reasons[0]).toBe(failureReason);
+      expect([...exit.cause.reasons[0]!.annotations.values()]).toContain("trace");
+      expect(exit.cause.reasons[1]).toBe(defectReason);
+    });
+  });
+});

--- a/packages/platform-cloudflare/test/telemetry-fixtures.ts
+++ b/packages/platform-cloudflare/test/telemetry-fixtures.ts
@@ -1,0 +1,369 @@
+import { Cause, Effect, Exit, Layer, Option, Schema, type Scope, Tracer } from "effect";
+
+import { DurableObjectContext } from "../src/bindings.ts";
+import { CloudflareRuntimeTelemetry, CloudflareTelemetryExportError } from "../src/telemetry.ts";
+
+/** Typed test-only failure proving host telemetry acquisition remains in the runtime Layer error. */
+export class TelemetryLayerAcquisitionError extends Schema.TaggedError<TelemetryLayerAcquisitionError>()(
+  "TelemetryLayerAcquisitionError",
+  {
+    envHasTelemetryBinding: Schema.Boolean,
+  },
+) {}
+
+export interface TelemetrySpanObservation {
+  readonly phase: "span-ended";
+  readonly entrypoint: string;
+  readonly conversationId: string;
+  readonly spanName: string;
+  readonly spanId: string;
+  readonly traceId: string;
+  readonly parentSpanId: string | undefined;
+  readonly sampled: boolean;
+  readonly kind: Tracer.SpanKind;
+  readonly startTime: bigint;
+  readonly endTime: bigint;
+  readonly failed: boolean;
+  readonly failureText: string | undefined;
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly events: ReadonlyArray<Tracer.NativeSpan["events"][number]>;
+  readonly links: ReadonlyArray<{
+    readonly traceId: string;
+    readonly spanId: string;
+    readonly attributes: Readonly<Record<string, unknown>>;
+  }>;
+}
+
+export interface TelemetryFlushObservation {
+  readonly phase: "flush-started" | "flush-completed" | "flush-failed";
+}
+
+export type TelemetryObservation = TelemetrySpanObservation | TelemetryFlushObservation;
+
+interface PendingFlushGate {
+  active: boolean;
+  completed: boolean;
+  released: boolean;
+  readonly release: () => void;
+}
+
+interface PendingFlushAttempt {
+  active: boolean;
+  completed: boolean;
+}
+
+/** Hold one exporter attempt until the test explicitly releases it or its owner is interrupted. */
+export interface TelemetryFlushBlock {
+  readonly release: () => void;
+  readonly isActive: () => boolean;
+  readonly isCompleted: () => boolean;
+}
+
+/** Causal token claimed and completed by the next real exporter attempt in this fixture. */
+export interface TelemetryFlushAttempt {
+  readonly isActive: () => boolean;
+  readonly isCompleted: () => boolean;
+}
+
+class TelemetryProbeSynchronizationError extends Error {
+  override readonly name = "TelemetryProbeSynchronizationError";
+}
+
+const MAX_SYNCHRONIZATION_YIELDS = 10_000;
+const ENTRYPOINT_SPAN_PREFIX = "effect_agent.cloudflare.conversation_object.";
+
+const requiredStringAttribute = (
+  attributes: Readonly<Record<string, unknown>>,
+  name: string,
+): string => {
+  const value = attributes[name];
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `Telemetry probe expected ${name} to be a string, received ${typeof value}`,
+    );
+  }
+  return value;
+};
+
+const takeFirst = <A>(values: Array<A>): A | undefined => values.shift();
+
+export interface TelemetryProbeFixture {
+  readonly observations: Array<TelemetryObservation>;
+  readonly exportErrors: Array<CloudflareTelemetryExportError>;
+  readonly acquisitionErrors: Array<TelemetryLayerAcquisitionError>;
+  readonly layer: Layer.Layer<CloudflareRuntimeTelemetry>;
+  readonly failNextFlush: (cause: unknown) => void;
+  readonly expectFlushAttempt: () => TelemetryFlushAttempt;
+  readonly withFlushBlock: <A, E, R>(
+    use: (block: TelemetryFlushBlock) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+  readonly awaitFlushBlock: (
+    block: TelemetryFlushBlock,
+    remainingYields?: number,
+  ) => Effect.Effect<void, TelemetryProbeSynchronizationError>;
+  readonly awaitFlushBlockCompleted: (
+    block: TelemetryFlushBlock,
+    remainingYields?: number,
+  ) => Effect.Effect<void, TelemetryProbeSynchronizationError>;
+  readonly awaitFlushAttempt: (
+    attempt: TelemetryFlushAttempt,
+    remainingYields?: number,
+  ) => Effect.Effect<void, TelemetryProbeSynchronizationError>;
+  readonly awaitObservationCount: (
+    count: number,
+    remainingYields?: number,
+  ) => Effect.Effect<void, TelemetryProbeSynchronizationError>;
+  readonly registerConversation: (
+    conversationId: string,
+  ) => Effect.Effect<void, never, Scope.Scope>;
+  readonly dispose: () => void;
+}
+
+// Workerd requires its Durable Object class to be exported statically. This registry routes that
+// class to fixture-owned state by the unique per-test Conversation identity; it contains no probe
+// controls or observations itself, and a late old-incarnation completion retains its old fixture.
+interface WorkerdFixtureRegistration {
+  readonly fixture: TelemetryProbeFixture;
+  readonly owner: object;
+}
+
+const workerdFixtures = new Map<string, WorkerdFixtureRegistration>();
+
+const fixtureForContext = Effect.map(DurableObjectContext, ({ ctx }) => {
+  const conversationId = ctx.id.name;
+  if (conversationId === undefined) {
+    throw new Error("Telemetry probe requires a named Durable Object identity");
+  }
+  const registration = workerdFixtures.get(conversationId);
+  if (registration === undefined) {
+    throw new Error(`No telemetry probe fixture registered for ${conversationId}`);
+  }
+  return registration.fixture;
+});
+
+/** Static Worker bridge selecting the fixture registered for this Conversation Object. */
+export const telemetryProbeRouterLayer: Layer.Layer<
+  CloudflareRuntimeTelemetry,
+  never,
+  DurableObjectContext
+> = Layer.unwrap(Effect.map(fixtureForContext, ({ layer }) => layer));
+
+/** Static typed-acquisition bridge selecting the fixture registered for this Object. */
+export const failingTelemetryAcquisitionRouterLayer: Layer.Layer<
+  CloudflareRuntimeTelemetry,
+  TelemetryLayerAcquisitionError,
+  DurableObjectContext
+> = Layer.effect(
+  CloudflareRuntimeTelemetry,
+  Effect.gen(function* () {
+    const fixture = yield* fixtureForContext;
+    const { env } = yield* DurableObjectContext;
+    const error = TelemetryLayerAcquisitionError.make({
+      envHasTelemetryBinding:
+        typeof env === "object" && env !== null && "TELEMETRY_ACQUISITION" in env,
+    });
+    fixture.acquisitionErrors.push(error);
+    return yield* error;
+  }),
+);
+
+/** Create one independent exporter/tracer probe and its complete control surface for one test. */
+export const makeTelemetryProbeFixture = (): TelemetryProbeFixture => {
+  const observations: Array<TelemetryObservation> = [];
+  const exportErrors: Array<CloudflareTelemetryExportError> = [];
+  const acquisitionErrors: Array<TelemetryLayerAcquisitionError> = [];
+  const pendingFailures: Array<unknown> = [];
+  const pendingGates: Array<PendingFlushGate> = [];
+  const unreleasedGates = new Set<PendingFlushGate>();
+  const pendingAttempts: Array<PendingFlushAttempt> = [];
+
+  const blockNextFlush = (): TelemetryFlushBlock => {
+    const gate: PendingFlushGate = {
+      active: false,
+      completed: false,
+      released: false,
+      release: () => {
+        if (gate.released) return;
+        gate.released = true;
+        const pendingIndex = pendingGates.indexOf(gate);
+        if (pendingIndex !== -1) pendingGates.splice(pendingIndex, 1);
+        if (!gate.active) unreleasedGates.delete(gate);
+      },
+    };
+    pendingGates.push(gate);
+    unreleasedGates.add(gate);
+    return {
+      release: gate.release,
+      isActive: () => gate.active,
+      isCompleted: () => gate.completed,
+    };
+  };
+
+  const awaitFlushGate = (gate: PendingFlushGate): Effect.Effect<void> =>
+    Effect.whileLoop({
+      while: () => !gate.released,
+      body: () => Effect.yieldNow,
+      step: () => undefined,
+    });
+
+  const awaitCondition = (
+    condition: () => boolean,
+    exhaustedMessage: () => string,
+    remainingYields: number,
+  ): Effect.Effect<void, TelemetryProbeSynchronizationError> =>
+    Effect.suspend(() => {
+      if (condition()) return Effect.void;
+      if (remainingYields <= 0) {
+        return Effect.fail(new TelemetryProbeSynchronizationError(exhaustedMessage()));
+      }
+      return Effect.yieldNow.pipe(
+        Effect.andThen(awaitCondition(condition, exhaustedMessage, remainingYields - 1)),
+      );
+    });
+
+  const layer: Layer.Layer<CloudflareRuntimeTelemetry> = Layer.unwrap(
+    Effect.sync(() => {
+      class ProbeSpan extends Tracer.NativeSpan {
+        override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+          super.end(endTime, exit);
+          if (!this.name.startsWith(ENTRYPOINT_SPAN_PREFIX)) return;
+          const attributes = Object.fromEntries(this.attributes);
+          const entrypoint = requiredStringAttribute(
+            attributes,
+            "effect_agent.cloudflare.entrypoint",
+          );
+          const conversationId = requiredStringAttribute(attributes, "conversationId");
+          observations.push({
+            phase: "span-ended",
+            entrypoint,
+            conversationId,
+            spanName: this.name,
+            spanId: this.spanId,
+            traceId: this.traceId,
+            parentSpanId: Option.getOrUndefined(this.parent)?.spanId,
+            sampled: this.sampled,
+            kind: this.kind,
+            startTime: this.startTime,
+            endTime,
+            failed: Exit.isFailure(exit),
+            failureText: Exit.isFailure(exit) ? Cause.pretty(exit.cause) : undefined,
+            attributes,
+            events: this.events.map(([name, startTime, eventAttributes]) => [
+              name,
+              startTime,
+              { ...eventAttributes },
+            ]),
+            links: this.links.map(({ span, attributes: linkAttributes }) => ({
+              traceId: span.traceId,
+              spanId: span.spanId,
+              attributes: { ...linkAttributes },
+            })),
+          });
+        }
+      }
+
+      const tracerLayer = Layer.effect(
+        Tracer.Tracer,
+        Effect.succeed(
+          Tracer.make({
+            span: (options) => new ProbeSpan(options),
+          }),
+        ),
+      );
+      const flushLayer = Layer.succeed(CloudflareRuntimeTelemetry)({
+        flush: Effect.suspend(() => {
+          const gate = takeFirst(pendingGates);
+          const failure = takeFirst(pendingFailures);
+          const expectedAttempt = takeFirst(pendingAttempts);
+          if (expectedAttempt !== undefined) expectedAttempt.active = true;
+          observations.push({ phase: "flush-started" });
+          return Effect.gen(function* () {
+            yield* Effect.yieldNow;
+            if (gate !== undefined && !gate.released) {
+              gate.active = true;
+              yield* awaitFlushGate(gate).pipe(Effect.interruptible);
+            }
+            if (failure !== undefined) {
+              const error = CloudflareTelemetryExportError.make({ cause: failure });
+              exportErrors.push(error);
+              observations.push({ phase: "flush-failed" });
+              return yield* error;
+            }
+            observations.push({ phase: "flush-completed" });
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                if (gate !== undefined) gate.completed = true;
+                if (gate !== undefined) unreleasedGates.delete(gate);
+                if (expectedAttempt !== undefined) expectedAttempt.completed = true;
+              }),
+            ),
+          );
+        }),
+      });
+      return flushLayer.pipe(Layer.provideMerge(tracerLayer));
+    }),
+  );
+
+  const fixture: TelemetryProbeFixture = {
+    observations,
+    exportErrors,
+    acquisitionErrors,
+    layer,
+    failNextFlush: (cause) => pendingFailures.push(cause),
+    expectFlushAttempt: () => {
+      const attempt: PendingFlushAttempt = { active: false, completed: false };
+      pendingAttempts.push(attempt);
+      return {
+        isActive: () => attempt.active,
+        isCompleted: () => attempt.completed,
+      };
+    },
+    withFlushBlock: (use) =>
+      Effect.acquireUseRelease(Effect.sync(blockNextFlush), use, (block) =>
+        Effect.sync(block.release),
+      ),
+    awaitFlushBlock: (block, remainingYields = MAX_SYNCHRONIZATION_YIELDS) =>
+      awaitCondition(
+        block.isActive,
+        () => "Telemetry flush did not become active",
+        remainingYields,
+      ),
+    awaitFlushBlockCompleted: (block, remainingYields = MAX_SYNCHRONIZATION_YIELDS) =>
+      awaitCondition(block.isCompleted, () => "Telemetry flush did not complete", remainingYields),
+    awaitFlushAttempt: (attempt, remainingYields = MAX_SYNCHRONIZATION_YIELDS) =>
+      awaitCondition(
+        attempt.isCompleted,
+        () => "Expected exporter attempt did not complete",
+        remainingYields,
+      ),
+    awaitObservationCount: (count, remainingYields = MAX_SYNCHRONIZATION_YIELDS) =>
+      awaitCondition(
+        () => observations.length >= count,
+        () => `Expected ${count} telemetry observations, saw ${observations.length}`,
+        remainingYields,
+      ),
+    registerConversation: (conversationId) =>
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          const existing = workerdFixtures.get(conversationId);
+          if (existing !== undefined) {
+            throw new Error(`Telemetry fixture already registered for ${conversationId}`);
+          }
+          const owner = {};
+          workerdFixtures.set(conversationId, { fixture, owner });
+          return owner;
+        }),
+        (owner) =>
+          Effect.sync(() => {
+            if (workerdFixtures.get(conversationId)?.owner === owner) {
+              workerdFixtures.delete(conversationId);
+            }
+          }),
+      ).pipe(Effect.asVoid),
+    dispose: () => {
+      for (const gate of unreleasedGates) gate.release();
+    },
+  };
+  return fixture;
+};

--- a/packages/platform-cloudflare/test/telemetry.test.ts
+++ b/packages/platform-cloudflare/test/telemetry.test.ts
@@ -1,0 +1,636 @@
+import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { Cause, Effect, Exit, Scope } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  makeTelemetryProbeFixture,
+  TelemetryLayerAcquisitionError,
+  type TelemetryFlushBlock,
+  type TelemetryObservation,
+  type TelemetryProbeFixture,
+  type TelemetrySpanObservation,
+} from "./telemetry-fixtures.ts";
+
+let conversationCounter = 0;
+let telemetryFixture: TelemetryProbeFixture;
+let telemetryFixtureScope: Scope.Closeable;
+let telemetryObservations: Array<TelemetryObservation>;
+let telemetryExportErrors: TelemetryProbeFixture["exportErrors"];
+let telemetryLayerAcquisitionErrors: TelemetryProbeFixture["acquisitionErrors"];
+
+const conversation = (label: string): string => {
+  const conversationId = `cf-telemetry-${label}-${conversationCounter++}`;
+  Effect.runSync(
+    telemetryFixture
+      .registerConversation(conversationId)
+      .pipe(Effect.provideService(Scope.Scope, telemetryFixtureScope)),
+  );
+  return conversationId;
+};
+
+const expectTelemetryFlushAttempt = () => telemetryFixture.expectFlushAttempt();
+const awaitTelemetryFlushAttempt: TelemetryProbeFixture["awaitFlushAttempt"] = (...args) =>
+  telemetryFixture.awaitFlushAttempt(...args);
+const awaitTelemetryFlushBlock: TelemetryProbeFixture["awaitFlushBlock"] = (...args) =>
+  telemetryFixture.awaitFlushBlock(...args);
+const awaitTelemetryFlushBlockCompleted: TelemetryProbeFixture["awaitFlushBlockCompleted"] = (
+  ...args
+) => telemetryFixture.awaitFlushBlockCompleted(...args);
+const awaitTelemetryObservationCount: TelemetryProbeFixture["awaitObservationCount"] = (...args) =>
+  telemetryFixture.awaitObservationCount(...args);
+const failNextTelemetryFlush = (cause: unknown): void => telemetryFixture.failNextFlush(cause);
+const withTelemetryFlushBlock: TelemetryProbeFixture["withFlushBlock"] = (use) =>
+  telemetryFixture.withFlushBlock(use);
+
+const observationsFor = (
+  conversationId: string,
+  entrypoint: string,
+): ReadonlyArray<TelemetrySpanObservation> =>
+  telemetryObservations.filter(
+    (observation): observation is TelemetrySpanObservation =>
+      observation.phase === "span-ended" &&
+      observation.conversationId === conversationId &&
+      observation.entrypoint === entrypoint,
+  );
+
+const observeDelivery = async <A>(delivery: () => Promise<A>) => {
+  const start = telemetryObservations.length;
+  const attempt = expectTelemetryFlushAttempt();
+  const result = await delivery();
+  await Effect.runPromise(awaitTelemetryFlushAttempt(attempt));
+  return {
+    result,
+    observations: telemetryObservations.slice(start),
+  } satisfies { readonly result: A; readonly observations: ReadonlyArray<TelemetryObservation> };
+};
+
+const settle = <A>(delivery: Promise<A>): Promise<Exit.Exit<A, unknown>> =>
+  delivery.then(Exit.succeed, Exit.fail);
+
+const awaitSettlement = <A>(
+  settlement: Promise<Exit.Exit<A, unknown>>,
+): Promise<Exit.Exit<A, unknown>> =>
+  Effect.runPromise(Effect.promise(() => settlement).pipe(Effect.timeout("5 seconds")));
+
+/** Own an external Workerd exporter gate for the complete asynchronous test body. */
+const withWorkerdTelemetryFlushBlock = <A>(
+  use: (block: TelemetryFlushBlock) => Promise<A>,
+): Effect.Effect<A, Cause.UnknownError> =>
+  withTelemetryFlushBlock((block) => Effect.tryPromise(() => use(block)));
+
+/** Own both coordinator gates in one scope so either test failure releases both. */
+const withTelemetryFlushBlockPair = <A>(
+  use: (active: TelemetryFlushBlock, trailing: TelemetryFlushBlock) => Promise<A>,
+): Effect.Effect<A, Cause.UnknownError> =>
+  withTelemetryFlushBlock((active) =>
+    withTelemetryFlushBlock((trailing) => Effect.tryPromise(() => use(active, trailing))),
+  );
+
+/** Own a first/trailing/queued coordinator sequence under one cleanup-safe bracket tree. */
+const withTelemetryFlushBlockTriple = <A>(
+  use: (
+    active: TelemetryFlushBlock,
+    trailing: TelemetryFlushBlock,
+    queued: TelemetryFlushBlock,
+  ) => Promise<A>,
+): Effect.Effect<A, Cause.UnknownError> =>
+  withTelemetryFlushBlock((active) =>
+    withTelemetryFlushBlock((trailing) =>
+      withTelemetryFlushBlock((queued) => Effect.tryPromise(() => use(active, trailing, queued))),
+    ),
+  );
+
+/** Traverse own data properties, including non-enumerable Error fields such as `message`. */
+const reachableObservationValues = (root: unknown): ReadonlyArray<unknown> => {
+  const values: Array<unknown> = [];
+  const visited = new WeakSet<object>();
+  const visit = (value: unknown): void => {
+    values.push(value);
+    if ((typeof value !== "object" && typeof value !== "function") || value === null) return;
+    if (visited.has(value)) return;
+    visited.add(value);
+    if (value instanceof Map) {
+      for (const [key, item] of value) {
+        visit(key);
+        visit(item);
+      }
+    } else if (value instanceof Set) {
+      for (const item of value) visit(item);
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      visit(key);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && "value" in descriptor) visit(descriptor.value);
+    }
+  };
+  visit(root);
+  return values;
+};
+
+/** Normalize only the generated lane identity when comparing otherwise exact encoded results. */
+const remapEncodedIdentity = (value: unknown, from: string, to: string): unknown => {
+  if (value === from) return to;
+  if (Array.isArray(value)) {
+    return value.map((item) => remapEncodedIdentity(item, from, to));
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, remapEncodedIdentity(item, from, to)]),
+    );
+  }
+  return value;
+};
+
+describe("Cloudflare native telemetry lifecycle", () => {
+  beforeEach(() => {
+    telemetryFixtureScope = Scope.makeUnsafe();
+    telemetryFixture = makeTelemetryProbeFixture();
+    const ownedFixture = telemetryFixture;
+    Effect.runSync(
+      Scope.addFinalizer(
+        telemetryFixtureScope,
+        Effect.sync(() => ownedFixture.dispose()),
+      ),
+    );
+    telemetryObservations = telemetryFixture.observations;
+    telemetryExportErrors = telemetryFixture.exportErrors;
+    telemetryLayerAcquisitionErrors = telemetryFixture.acquisitionErrors;
+  });
+
+  afterEach(() => Effect.runPromise(Scope.close(telemetryFixtureScope, Exit.void)));
+
+  it("provides the DO context to host telemetry and retains typed acquisition failure", async () => {
+    const conversationId = conversation("telemetry-acquisition-failure");
+    const stub = env.TELEMETRY_ACQUISITION.get(
+      env.TELEMETRY_ACQUISITION.idFromName(conversationId),
+    );
+
+    const rejection = await stub.wake().then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    // Workerd transports a constructor-gate failure as a reset Error, while the Layer-side probe
+    // retains the exact typed value that ManagedRuntime rejected with.
+    if (!(rejection instanceof Error)) throw new Error("Expected the typed acquisition rejection");
+    expect(rejection.message).toBe("TelemetryLayerAcquisitionError");
+    expect(Object.getOwnPropertyDescriptor(rejection, "durableObjectReset")?.value).toBe(true);
+    expect(telemetryLayerAcquisitionErrors).toHaveLength(1);
+    expect(telemetryLayerAcquisitionErrors[0]).toBeInstanceOf(TelemetryLayerAcquisitionError);
+    expect(telemetryLayerAcquisitionErrors[0]).toMatchObject({
+      _tag: "TelemetryLayerAcquisitionError",
+      envHasTelemetryBinding: true,
+    });
+  });
+
+  it("preserves every native RPC and wake result while flushing content-free owner spans", async () => {
+    const conversationId = conversation("native-success");
+    const controlConversationId = conversation("native-control");
+    const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+    const controlStub = env.TELEMETRY.get(env.TELEMETRY.idFromName(controlConversationId));
+    const marker = "encoded-request-must-not-be-exported";
+    const protocolFailure = (
+      responseTag: "HostFailed" | "AdminFailed" | "PortFailed",
+      failureTag: "HostProtocolError" | "PortProtocolError",
+    ): unknown => ({
+      _tag: responseTag,
+      failure: { _tag: failureTag, message: expect.any(String) },
+    });
+    const calls: ReadonlyArray<{
+      readonly entrypoint: string;
+      readonly expected: unknown;
+      readonly containsConversationIdentity?: true;
+      readonly call: (target: typeof stub) => Promise<unknown>;
+    }> = [
+      {
+        entrypoint: "submit",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.submitEncoded(marker),
+      },
+      {
+        entrypoint: "await_settlement",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.awaitSettlementEncoded(marker),
+      },
+      {
+        entrypoint: "observe",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.observePage(marker),
+      },
+      {
+        entrypoint: "abort",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.abortEncoded(marker),
+      },
+      {
+        entrypoint: "resolve_approval",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.resolveApprovalEncoded(marker),
+      },
+      {
+        entrypoint: "resolve_unknown",
+        expected: protocolFailure("HostFailed", "HostProtocolError"),
+        call: (target) => target.resolveUnknownEncoded(marker),
+      },
+      {
+        entrypoint: "explain",
+        expected: { _tag: "ExplainedRecovery", explanations: [] },
+        call: (target) => target.explainEncoded({ marker }),
+      },
+      {
+        entrypoint: "verify",
+        expected: {
+          _tag: "AdminFailed",
+          failure: { _tag: "ConversationNotMaterialized", conversationId },
+        },
+        containsConversationIdentity: true,
+        call: (target) => target.verifyEncoded({ marker }),
+      },
+      {
+        entrypoint: "retry",
+        expected: protocolFailure("AdminFailed", "HostProtocolError"),
+        call: (target) => target.retryEncoded(marker),
+      },
+      {
+        entrypoint: "obligations",
+        expected: protocolFailure("AdminFailed", "HostProtocolError"),
+        call: (target) => target.obligationsEncoded(marker),
+      },
+      {
+        entrypoint: "port_call",
+        expected: protocolFailure("PortFailed", "PortProtocolError"),
+        call: (target) => target.portCall(marker),
+      },
+    ];
+
+    for (const { entrypoint, expected, containsConversationIdentity, call } of calls) {
+      // The bounded Schema diagnostics are renderer-owned; the successful-flush control proves
+      // exact envelope preservation without coupling this lifecycle test to diagnostic wording.
+      const { result: controlResult } = await observeDelivery(() => call(controlStub));
+      const { result, observations } = await observeDelivery(() => call(stub));
+      expect(result).toEqual(
+        containsConversationIdentity === true
+          ? remapEncodedIdentity(controlResult, controlConversationId, conversationId)
+          : controlResult,
+      );
+      expect(result).toEqual(expected);
+      expect(observations.map(({ phase }) => phase)).toEqual([
+        "span-ended",
+        "flush-started",
+        "flush-completed",
+      ]);
+      const span = observations.find(
+        (observation): observation is TelemetrySpanObservation =>
+          observation.phase === "span-ended",
+      );
+      expect(span).toMatchObject({
+        failed: false,
+        spanName: `effect_agent.cloudflare.conversation_object.${entrypoint}`,
+        kind: "server",
+        attributes: {
+          "effect_agent.cloudflare.entrypoint": entrypoint,
+          "effect_agent.deployment.id": "cf-test-deployment",
+          conversationId,
+          producerId: `cf-test-producer:${conversationId}`,
+        },
+      });
+      expect(Object.keys(span?.attributes ?? {}).toSorted()).toEqual([
+        "conversationId",
+        "effect_agent.cloudflare.entrypoint",
+        "effect_agent.deployment.id",
+        "producerId",
+      ]);
+      expect(span?.events).toEqual([]);
+      expect(span?.links).toEqual([]);
+    }
+
+    const { result: wakeResult, observations: wakeObservations } = await observeDelivery(() =>
+      stub.wake(),
+    );
+    expect(wakeResult).toBeUndefined();
+    expect(wakeObservations.map(({ phase }) => phase)).toEqual([
+      "span-ended",
+      "flush-started",
+      "flush-completed",
+    ]);
+    const wakeSpan = observationsFor(conversationId, "wake")[0];
+    expect(wakeSpan?.events).toEqual([]);
+    expect(wakeSpan?.links).toEqual([]);
+    const exportedValues = reachableObservationValues(telemetryObservations);
+    expect(exportedValues).not.toContain(marker);
+    expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+      marker,
+    );
+  });
+
+  it("does not hold an RPC response on a blocked background flush", () =>
+    Effect.runPromise(
+      withWorkerdTelemetryFlushBlock(async (flushBlock) => {
+        const conversationId = conversation("uninterruptible-rpc");
+        const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+        const observationStart = telemetryObservations.length;
+        const deliverySettlement = settle(stub.submitEncoded("uninterruptible-rpc-marker"));
+
+        await Effect.runPromise(awaitTelemetryObservationCount(observationStart + 2));
+        await Effect.runPromise(awaitTelemetryFlushBlock(flushBlock));
+        expect(flushBlock.isActive()).toBe(true);
+        const deliveryExit = await awaitSettlement(deliverySettlement);
+        if (Exit.isFailure(deliveryExit)) {
+          throw new Error("Expected the RPC response while its exporter remained pending");
+        }
+        expect(deliveryExit.value).toMatchObject({
+          _tag: "HostFailed",
+          failure: { _tag: "HostProtocolError" },
+        });
+        expect(flushBlock.isCompleted()).toBe(false);
+        expect(observationsFor(conversationId, "submit")).toHaveLength(1);
+
+        flushBlock.release();
+        await Effect.runPromise(awaitTelemetryFlushBlockCompleted(flushBlock));
+        expect(flushBlock.isCompleted()).toBe(true);
+      }),
+    ));
+
+  it("releases an external exporter gate when its owning test scope fails", async () => {
+    const conversationId = conversation("scoped-gate-cleanup");
+    const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+    const expectedFailure = new Error("intentional scoped gate cleanup failure");
+    let claimedBlock: TelemetryFlushBlock | undefined;
+
+    const exit = await Effect.runPromiseExit(
+      withWorkerdTelemetryFlushBlock(async (flushBlock) => {
+        claimedBlock = flushBlock;
+        const deliverySettlement = settle(stub.submitEncoded("scoped-gate-cleanup-marker"));
+        await Effect.runPromise(awaitTelemetryFlushBlock(flushBlock));
+        const deliveryExit = await awaitSettlement(deliverySettlement);
+        if (Exit.isFailure(deliveryExit)) {
+          throw new Error("Expected the cleanup-probe RPC response");
+        }
+        throw expectedFailure;
+      }),
+    );
+
+    if (Exit.isSuccess(exit)) throw new Error("Expected the scoped test body to fail");
+    const failures = exit.cause.reasons.filter(Cause.isFailReason).map(({ error }) => error);
+    expect(failures).toHaveLength(1);
+    const failure = failures[0];
+    expect(Cause.isUnknownError(failure)).toBe(true);
+    if (!Cause.isUnknownError(failure)) throw new Error("Expected the tryPromise boundary error");
+    expect(failure.cause).toBe(expectedFailure);
+    if (claimedBlock === undefined) throw new Error("Expected the fixture gate to be acquired");
+    await Effect.runPromise(awaitTelemetryFlushBlockCompleted(claimedBlock));
+    expect(claimedBlock.isCompleted()).toBe(true);
+  });
+
+  it("preserves a failed alarm retry signal while its background flush is pending", () =>
+    Effect.runPromise(
+      withWorkerdTelemetryFlushBlock(async (flushBlock) => {
+        const conversationId = conversation("alarm-failure");
+        const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+        try {
+          await runInDurableObject(stub, (_instance, state) => {
+            state.storage.sql.exec(
+              "ALTER TABLE effect_agent_submissions RENAME TO effect_agent_submissions_missing",
+            );
+            return state.storage.setAlarm(Date.UTC(2100, 0, 1));
+          });
+
+          const observationStart = telemetryObservations.length;
+          const alarmSettlement = settle(runDurableObjectAlarm(stub));
+          let alarmFailure: Error | undefined;
+
+          await Effect.runPromise(awaitTelemetryObservationCount(observationStart + 2));
+          await Effect.runPromise(awaitTelemetryFlushBlock(flushBlock));
+          expect(flushBlock.isActive()).toBe(true);
+          const alarmExit = await awaitSettlement(alarmSettlement);
+          if (Exit.isSuccess(alarmExit)) {
+            throw new Error("Expected the alarm delivery to preserve its rejection");
+          }
+          const failures = alarmExit.cause.reasons
+            .filter(Cause.isFailReason)
+            .map(({ error }) => error);
+          expect(failures).toHaveLength(1);
+          const failure = failures[0];
+          if (!(failure instanceof Error)) throw new Error("Expected the alarm rejection Error");
+          alarmFailure = failure;
+          expect(failure.message).toContain("Failed to execute statement");
+          expect(flushBlock.isCompleted()).toBe(false);
+          expect(observationsFor(conversationId, "alarm")).toHaveLength(1);
+
+          flushBlock.release();
+          await Effect.runPromise(awaitTelemetryFlushBlockCompleted(flushBlock));
+          const observations = telemetryObservations.slice(observationStart);
+          expect(observations.map(({ phase }) => phase)).toEqual([
+            "span-ended",
+            "flush-started",
+            "flush-completed",
+          ]);
+          const failedDelivery = observationsFor(conversationId, "alarm").find(
+            ({ failed }) => failed,
+          );
+          if (failedDelivery === undefined || alarmFailure === undefined) {
+            throw new Error("Expected the failed alarm observation and rejection");
+          }
+          expect(failedDelivery.events).toEqual([]);
+          expect(failedDelivery.links).toEqual([]);
+          const exportedValues = reachableObservationValues(failedDelivery);
+          expect(exportedValues).not.toContain(alarmFailure);
+          expect(
+            exportedValues.filter((value) => typeof value === "string").join("\n"),
+          ).not.toContain(alarmFailure.message);
+        } finally {
+          try {
+            await runInDurableObject(stub, async (_instance, state) => {
+              const renamed = state.storage.sql
+                .exec<{ readonly name: string }>(
+                  "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'effect_agent_submissions_missing'",
+                )
+                .toArray();
+              if (renamed.length > 0) {
+                state.storage.sql.exec(
+                  "ALTER TABLE effect_agent_submissions_missing RENAME TO effect_agent_submissions",
+                );
+              }
+              await state.storage.deleteAlarm();
+            });
+          } finally {
+            const claimed = flushBlock.isActive();
+            flushBlock.release();
+            if (claimed) {
+              await Effect.runPromise(awaitTelemetryFlushBlockCompleted(flushBlock));
+            }
+          }
+        }
+      }),
+    ));
+
+  it("retains a typed exporter cause without changing the RPC result", async () => {
+    const conversationId = conversation("flush-failure");
+    const controlConversationId = conversation("flush-control");
+    const foreignCause = new Error("foreign exporter diagnostic must stay out of spans");
+    const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+    const controlStub = env.TELEMETRY.get(env.TELEMETRY.idFromName(controlConversationId));
+    const { result: controlResult } = await observeDelivery(() =>
+      Promise.resolve(controlStub.submitEncoded({ malformed: true })),
+    );
+    failNextTelemetryFlush(foreignCause);
+    const { result, observations } = await observeDelivery(() =>
+      Promise.resolve(stub.submitEncoded({ malformed: true })),
+    );
+
+    expect(result).toEqual(controlResult);
+    expect(observations.map(({ phase }) => phase)).toEqual([
+      "span-ended",
+      "flush-started",
+      "flush-failed",
+    ]);
+    expect(telemetryExportErrors).toHaveLength(1);
+    expect(telemetryExportErrors[0]).toMatchObject({ _tag: "CloudflareTelemetryExportError" });
+    expect(telemetryExportErrors[0]?.cause).toBe(foreignCause);
+    const endedObservation = observationsFor(conversationId, "submit")[0];
+    expect(endedObservation?.events).toEqual([]);
+    expect(endedObservation?.links).toEqual([]);
+    const exportedValues = reachableObservationValues(telemetryObservations);
+    expect(exportedValues.some((value) => value === foreignCause)).toBe(false);
+    expect(exportedValues.filter((value) => typeof value === "string").join("\n")).not.toContain(
+      foreignCause.message,
+    );
+  });
+
+  it("flushes successful alarm and wake lifecycles through the same native boundary", async () => {
+    const wakeConversationId = conversation("wake-success");
+    const wakeStub = env.TELEMETRY.get(env.TELEMETRY.idFromName(wakeConversationId));
+    const { result: wakeResult, observations: wakeObservations } = await observeDelivery(() =>
+      wakeStub.wake(),
+    );
+
+    expect(wakeResult).toBeUndefined();
+    expect(wakeObservations.map(({ phase }) => phase)).toEqual([
+      "span-ended",
+      "flush-started",
+      "flush-completed",
+    ]);
+    expect(observationsFor(wakeConversationId, "wake")[0]?.events).toEqual([]);
+    expect(observationsFor(wakeConversationId, "wake")[0]?.links).toEqual([]);
+
+    const alarmConversationId = conversation("alarm-success");
+    const alarmStub = env.TELEMETRY.get(env.TELEMETRY.idFromName(alarmConversationId));
+    await runInDurableObject(alarmStub, (_instance, state) =>
+      state.storage.setAlarm(Date.UTC(2100, 0, 1)),
+    );
+    const { alarmExit, alarmObservations, queuedWakeExit, trailingWakeExit } =
+      await Effect.runPromise(
+        withTelemetryFlushBlockTriple(async (activeBlock, trailingBlock, queuedBlock) => {
+          const alarmObservationStart = telemetryObservations.length;
+          const alarmSettlement = settle(runDurableObjectAlarm(alarmStub));
+          await Effect.runPromise(awaitTelemetryFlushBlock(activeBlock));
+          // Wait for every alarm delivery to settle and request export while A remains blocked. Then
+          // one additional native delivery deterministically requests the single trailing export B.
+          const settledAlarm = await awaitSettlement(alarmSettlement);
+          const settledWake = await awaitSettlement(settle(alarmStub.wake()));
+          activeBlock.release();
+          await Effect.runPromise(awaitTelemetryFlushBlockCompleted(activeBlock));
+          await Effect.runPromise(awaitTelemetryFlushBlock(trailingBlock));
+          // A delivery while B is active deterministically promotes the coordinator's one queued
+          // cycle C, covering the complete capped lifecycle without scheduler-idle inference.
+          const settledQueuedWake = await awaitSettlement(settle(alarmStub.wake()));
+          trailingBlock.release();
+          await Effect.runPromise(awaitTelemetryFlushBlockCompleted(trailingBlock));
+          await Effect.runPromise(awaitTelemetryFlushBlock(queuedBlock));
+          queuedBlock.release();
+          await Effect.runPromise(awaitTelemetryFlushBlockCompleted(queuedBlock));
+          return {
+            alarmExit: settledAlarm,
+            queuedWakeExit: settledQueuedWake,
+            trailingWakeExit: settledWake,
+            alarmObservations: telemetryObservations.slice(alarmObservationStart),
+          };
+        }),
+      );
+    expect(alarmExit).toEqual(Exit.succeed(true));
+    expect(trailingWakeExit).toEqual(Exit.succeed(undefined));
+    expect(queuedWakeExit).toEqual(Exit.succeed(undefined));
+    const alarmSpans = alarmObservations.filter(
+      (observation): observation is TelemetrySpanObservation =>
+        observation.phase === "span-ended" && observation.entrypoint === "alarm",
+    );
+    const alarmFlushStarted = alarmObservations.filter(
+      ({ phase }) => phase === "flush-started",
+    ).length;
+    const alarmFlushCompleted = alarmObservations.filter(
+      ({ phase }) => phase === "flush-completed",
+    ).length;
+    expect(alarmSpans.length).toBeGreaterThanOrEqual(1);
+    expect(alarmSpans.every(({ failed }) => !failed)).toBe(true);
+    expect(alarmSpans.every(({ events }) => events.length === 0)).toBe(true);
+    expect(alarmSpans.every(({ links }) => links.length === 0)).toBe(true);
+    expect(alarmFlushStarted).toBe(3);
+    expect(alarmFlushCompleted).toBe(3);
+    expect(alarmObservations.some(({ phase }) => phase === "flush-failed")).toBe(false);
+  });
+
+  it("keeps concurrent waitUntil flush observations correlation-free", () =>
+    Effect.runPromise(
+      withTelemetryFlushBlockPair(async (activeBlock, trailingBlock) => {
+        const conversationId = conversation("concurrent");
+        const stub = env.TELEMETRY.get(env.TELEMETRY.idFromName(conversationId));
+        const observationStart = telemetryObservations.length;
+        const submitSettlement = settle(stub.submitEncoded("concurrent-submit-marker"));
+
+        await Effect.runPromise(awaitTelemetryFlushBlock(activeBlock));
+        // Start B only after A's exporter is definitely active. B must settle immediately while its
+        // flush request coalesces into exactly one trailing attempt behind A.
+        const observeSettlement = settle(stub.observePage("concurrent-observe-marker"));
+        const [submitExit, observeExit] = await Promise.all([
+          awaitSettlement(submitSettlement),
+          awaitSettlement(observeSettlement),
+        ]);
+        if (Exit.isFailure(submitExit) || Exit.isFailure(observeExit)) {
+          throw new Error("Expected both concurrent RPC responses");
+        }
+        expect(submitExit.value).toMatchObject({
+          _tag: "HostFailed",
+          failure: { _tag: "HostProtocolError" },
+        });
+        expect(observeExit.value).toMatchObject({
+          _tag: "HostFailed",
+          failure: { _tag: "HostProtocolError" },
+        });
+        expect(trailingBlock.isActive()).toBe(false);
+
+        activeBlock.release();
+        await Effect.runPromise(awaitTelemetryFlushBlockCompleted(activeBlock));
+        await Effect.runPromise(awaitTelemetryFlushBlock(trailingBlock));
+        expect(activeBlock.isCompleted()).toBe(true);
+        expect(trailingBlock.isActive()).toBe(true);
+
+        trailingBlock.release();
+        await Effect.runPromise(awaitTelemetryFlushBlockCompleted(trailingBlock));
+        await Effect.runPromise(awaitTelemetryObservationCount(observationStart + 6));
+        const observations = telemetryObservations.slice(observationStart);
+        const spans = observations.filter(
+          (observation): observation is TelemetrySpanObservation =>
+            observation.phase === "span-ended",
+        );
+        const flushes = observations.filter(({ phase }) => phase !== "span-ended");
+        expect(spans.map(({ entrypoint }) => entrypoint).toSorted()).toEqual(["observe", "submit"]);
+        expect(flushes.map(({ phase }) => phase).toSorted()).toEqual([
+          "flush-completed",
+          "flush-completed",
+          "flush-started",
+          "flush-started",
+        ]);
+        expect(flushes.map((observation) => Object.keys(observation))).toEqual([
+          ["phase"],
+          ["phase"],
+          ["phase"],
+          ["phase"],
+        ]);
+        const exportedStrings = reachableObservationValues(observations)
+          .filter((value) => typeof value === "string")
+          .join("\n");
+        expect(exportedStrings).not.toContain("concurrent-submit-marker");
+        expect(exportedStrings).not.toContain("concurrent-observe-marker");
+      }),
+    ));
+});

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Context, Effect, Layer } from "effect";
 
 import { makeConversationObjectClass, type ConversationObjectOptions } from "../src/index.ts";
 import {
@@ -11,6 +11,11 @@ import {
   storageEvictionFailpoint,
 } from "./fixtures.ts";
 import { makeSubagentTestBindings, transportFaultReason } from "./subagent-fixtures.ts";
+import {
+  failingTelemetryAcquisitionRouterLayer,
+  telemetryProbeRouterLayer,
+  type TelemetryLayerAcquisitionError,
+} from "./telemetry-fixtures.ts";
 
 /**
  * The WP3 test Worker entry: the REAL `makeConversationObjectClass` output under three
@@ -69,6 +74,18 @@ const dynamicBindings: NonNullable<ConversationObjectOptions["bindings"]> = ({
     return [];
   });
 
+class TelemetryHostOutput extends Context.Service<TelemetryHostOutput, string>()(
+  "@effect-agent/platform-cloudflare/test/TelemetryHostOutput",
+) {}
+
+// Compile-time public-API proof: a host observability Layer may provide additional runtime
+// services alongside the required flush capability. The Workerd span assertions below prove the
+// merged Tracer Reference is also installed in the same ManagedRuntime.
+const telemetryHostLayer = Layer.merge(
+  telemetryProbeRouterLayer,
+  Layer.succeed(TelemetryHostOutput, "host-observability-output"),
+);
+
 /** The eviction/alarm/chaos suites' Conversation Object. */
 export class TestConversationObject extends makeConversationObjectClass(baseOptions) {}
 
@@ -121,6 +138,28 @@ export class EffectBindingsConversationObject extends makeConversationObjectClas
     return "effect";
   }
 }
+
+/** Host-telemetry probe; timeout behavior is virtual-time tested below the Workerd boundary. */
+export class TelemetryConversationObject extends makeConversationObjectClass(
+  {
+    ...baseOptions,
+    namespaceBinding: "TELEMETRY",
+    // Public waitUntil tests control exporter completion explicitly. Virtual-time unit coverage
+    // pins the configured cooperative budget without racing the Workerd wall clock.
+    telemetryFlushTimeout: 60_000,
+    wakeScanInterval: 60_000,
+  },
+  telemetryHostLayer,
+) {}
+
+/** Compile/runtime probe: host telemetry may require the DO context and fail acquisition typed. */
+export class TelemetryAcquisitionConversationObject extends makeConversationObjectClass<TelemetryLayerAcquisitionError>(
+  {
+    ...baseOptions,
+    namespaceBinding: "TELEMETRY_ACQUISITION",
+  },
+  failingTelemetryAcquisitionRouterLayer,
+) {}
 
 /**
  * The WP4 cross-Object subagent matrix's Conversation Object: parent and child Conversations

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -50,12 +50,23 @@ export default defineConfig({
                   className: "EffectBindingsConversationObject",
                   useSQLite: true,
                 },
+                TELEMETRY: {
+                  className: "TelemetryConversationObject",
+                  useSQLite: true,
+                },
+                TELEMETRY_ACQUISITION: {
+                  className: "TelemetryAcquisitionConversationObject",
+                  useSQLite: true,
+                },
               },
             },
           }),
         ],
         test: {
           name: "workerd",
+          // Telemetry fixture controls are intentionally sequential within their one test file.
+          // Pin Vitest's default so no future suite-wide concurrency toggle can invalidate them.
+          sequence: { concurrent: false },
           include: ["test/**/*.test.ts"],
           exclude: ["test/restart/**", "test/code-mode/**", "test/travel-planner-dc.test.ts"],
         },
@@ -96,6 +107,9 @@ export default defineConfig({
       {
         test: {
           name: "restart",
+          // A separate project/runtime module graph from workerd; its fixture controls are also
+          // sequential within the deterministic lifecycle unit file.
+          sequence: { concurrent: false },
           include: ["test/restart/**/*.test.ts"],
         },
       },


### PR DESCRIPTION
## Summary

- make the engine's logical application-Tool measurement the canonical OpenTelemetry `execute_tool <tool-name>` span with stable GenAI identity, framework correlation, execution class, and bounded terminal outcome
- classify returned Tool failures as failed spans while preserving value/event behavior and exact typed Cause, defect, interruption, and finalizer semantics
- prevent Effect AI Toolkit parameters and raw handler Causes from entering exported spans
- emit one searchable, content-free terminal log for each successful or failed in-memory application-handler attempt; interrupted attempts have no terminal outcome log
- expose a vendor-neutral, host-provided Cloudflare telemetry Layer at the Worker composition boundary, including typed acquisition failure and platform requirements
- close every native RPC, port, wake, and alarm span before requesting coordinated background export through `waitUntil`, without holding delivery or alarm retry open
- restore the postinstall Effect TypeScript-Go patch explicitly after script-suppressed CI installs, before every check, test, build, and release-build path

## Causal chain

The engine already wrapped application handler execution in a logical span, but its name and attributes were framework-local and it did not classify terminal values. Effect AI can return a failed Tool result as a value, so ordinary Effect span-exit inference marked that execution successful. Operators therefore could not reliably search successful calls such as `fs_read` / `fs_grep` or distinguish their bounded outcome.

The original implementation also exported a child span around `Toolkit.handle`. Effect AI annotates its current span with decoded Tool parameters, and a failing handler can end that child with its raw Cause. Sanitizing only the outer span was insufficient. The implementation now places Toolkit annotations on a manually constructed, non-exported `NativeSpan` parented by the canonical span. `Tracer.DisablePropagation=true` keeps decoded parameters local while explicit host-owned handler spans filter past it and remain enabled as children of `execute_tool`.

On Cloudflare, each Conversation Object constructed a private cached `ManagedRuntime` around the durable runtime Layer. There was no host-owned Logger/Tracer/Metric/exporter lifecycle seam, and native methods returned directly from `runtime.runPromise`. Even correct engine measurements could remain buffered when a delivery ended.

[Kommunikasie PR #353](https://github.com/reve-ai/kommunikasie/pull/353) bridged both gaps at the application loopback executor. This PR moves the canonical Tool measurement into the engine and native-delivery export ownership into the Cloudflare platform instead of standardizing that downstream wrapper.

## Architectural ownership

- The engine owns logical Tool execution. [The canonical span and terminal classifier](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/src/index.ts#L739-L1059) measure one in-memory handler attempt from `ToolCallStarted` until it settles or is interrupted; approval suspension, denial, and provider execution do not create such an attempt. Success/failure telemetry is emitted only after the handler stream settles. A post-terminal Cause, waiting signal, or duplicate result commits one `ToolCallFailed`, never the provisional success, then preserves the original Cause or protocol error for batch failure. The terminal Tool Run event and trace result remain provisional until settlement, preventing contradictory append-only success state. Provider-executed progress/results and Turn completion are likewise staged until the complete streamed response validates every call/result correlation. The complete staged provider suffix is capped at 256 events total across progress, terminal results, and Turn completion, 1,048,576 UTF-8 bytes across all retained event payloads, and 128 nested JSON levels; each untrusted result is normalized once into the same owned frozen plain-JSON snapshot that is byte-counted and retained, rejecting accessors, toJSON hooks, non-plain prototypes, and reflection failures without materializing the entire untrusted value. They receive Run sequence/timestamp only at actual emission; duplicate, post-finish, or over-bound model output emits zero staged Tool successes. An internal emission boundary returns the committed event first, then gives derivative telemetry to the next pull or structured finalization when downstream stops at that event; a phase gate permits one attempt and never retries an in-flight interrupted action, while early-close cleanup reports owned typed failures/defects through ErrorReporter and restores external interruption exactly.
- [The engine-owned `ToolSpanTelemetry` capability](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/src/tool-telemetry-internal.ts#L221-L390) derives span-lifecycle isolation from the host's ambient Tracer at the [`AgentRuntime.stream` composition edge](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/src/index.ts#L2860-L2868). `executePreparedToolCall` consumes that capability transparently; it neither selects nor provides a Tracer locally, and host Logger/Tracer composition remains intact. Missing current-span context runs the Toolkit effect unchanged with its typed error channel, each reusable Stream execution gets independent isolation state, and identity-authenticated module-private state—not the mutable public outcome attribute—controls canonical span status.
- [The private typed marker boundary](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/src/tool-telemetry-internal.ts#L12-L69) gives `withSpan` a failed Exit without exporting the original Cause. Outside the span it preserves marker-free Causes by referential identity; when a marker is present, it removes only private marker Reasons, retaining residual Reason identity, order, and annotations before combining the exact saved original Cause.
- Terminal measurement is derivative. [A Logger/Tracer defect is reported through Effect's ErrorReporter](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/src/index.ts#L800-L830); even a defective reporter is isolated and cannot change the Tool event or make a completed side effect eligible for recovery. External interruption of terminal telemetry or its reporter remains interruption.
- `CloudflareDurableRuntime.layer` remains transport-focused and neither consumes nor passes through `CloudflareRuntimeTelemetry`; the Conversation Object endpoint service set owns that host capability. [The Worker factory accepts the host Layer as its second argument](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/platform-cloudflare/src/conversation-object.ts#L700-L766), supplies `DurableObjectContext | ConversationObjectNamespace`, preserves its typed acquisition error and any additional output services, and provides it outermost so its Logger/Tracer/Metric configuration observes runtime acquisition and native work. The no-op default is selected only at this composition edge.
- The Cloudflare platform owns native-delivery lifecycle. The owner-side boundary wraps every encoded RPC, cross-Object port, wake, and alarm, returns the exact delivery Promise, and registers post-settlement background export through `ctx.waitUntil`.
- [The vendor-neutral public service](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/platform-cloudflare/src/telemetry.ts#L1-L39) exposes `flush: Effect<void, CloudflareTelemetryExportError>`; the typed error retains the foreign cause.
- [The internal coordinator and settlement bridge](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/platform-cloudflare/src/telemetry-internal.ts#L129-L330) synchronously reserve deliveries into shared pending/trailing/queued batches, retain at most 64 delivery settlement Promises and wait for those retained deliveries to settle, register only each batch's first owner's shared always-fulfilled background Promise, serialize export, retain both bounded cycle failures, and invoke no exporter when registration fails.
- Telemetry remains derivative: event schemas, the canonical event stream, wire protocol, replay/recovery, settlement, and the alarm state machine are unchanged.

## Privacy and logging

The canonical Tool span/logs contain only bounded framework identity and outcome fields: GenAI operation/tool/type/call/agent identity, the real framework conversation ID, execution class, `success | failure`, and run/turn/Tool Call correlation. The conversation ID is exported as `gen_ai.conversation.id` plus backward-compatible `conversationId`; no value is synthesized from traces or content. Cloudflare native spans contain only entrypoint, deployment, conversation, and producer identity.

Tool parameters, results, prompts, source code, commands, conversation content, and failure messages are never recorded by framework instrumentation. Span-facing failures use one fresh bounded private marker object per handler attempt and match only that exact identity, then restore the exact original Cause outside the span. The local `DisablePropagation` span prevents Toolkit parameter annotations from reaching framework spans while preserving explicit host-owned handler spans beneath the canonical Tool span. There is no implicit content-capture switch. Every retained or correlated model response identifier must match the complete bounded grammar `[A-Za-z0-9][A-Za-z0-9._:-]{0,127}`. Text and reasoning lifecycle IDs, source IDs, response metadata IDs, and Tool parameter, call, result, approval, and correlation IDs fail closed with a typed ModelProtocolError before retention, Turn correlation, canonical emission, diagnostics, or handler scheduling.

The logging policy emits one content-free terminal record for each successful or failed in-memory application-handler attempt: info for success and warning for failure. Interrupted attempts emit no terminal outcome record, and start logs remain debug-only. At-least-once recovery can create a later attempt with its own telemetry; no exactly-once external-side-effect claim is made.

Cloudflare automatic diagnostics likewise contain only the bounded framework-owned `effect_agent.cloudflare.telemetry.failure_kind` classification. Foreign exporter causes, arbitrary exporter defects, and fiber IDs are never passed to the configured Logger; `CloudflareTelemetryExportError.cause` retains a raw foreign exporter cause only for an explicit host-controlled diagnostic boundary. A synchronous `waitUntil` registration failure emits only the bounded `wait_until_registration` classification; its arbitrary platform Cause is never passed to the configured Logger. Delivery remains unchanged and export is never attempted after registration failure.

## Cloudflare lifecycle and public configuration

Hosts pass their Effect observability/exporter Layer as the second `makeConversationObjectClass(options, telemetry)` argument. That Layer may require `DurableObjectContext | ConversationObjectNamespace`, may fail acquisition with a typed error, and may provide additional Logger/Tracer/Metric/exporter services retained in the cached runtime. The existing first explicit factory generic remains `TelemetryError`; additional outputs infer as the appended generic. Omitting it installs `CloudflareRuntimeTelemetry.layerNoop` at the Worker edge. `CloudflareDurableRuntimeOptions` contains policy only and no hidden Layer.

After each native span closes, export is registered in Cloudflare's background `waitUntil` lifetime. Native RPC/alarm delivery never awaits export, so exporter latency, failure, or uninterruptibility cannot delay a response or suppress a failed alarm retry signal. `telemetryFlushTimeout` is a cooperative budget for interruptible exporters, not a hard deadline for code that masks interruption.

Deliveries synchronously reserve a shared pending, trailing, or queued batch before `waitUntil`; each batch waits for its deliveries to settle and only its first owner registers the shared background Promise. Cycles remain capped at a first plus one trailing attempt with one queued cycle, so a stalled exporter cannot accumulate concurrent attempts, per-delivery registrations, or unbounded retained delivery Promises. Excess arrivals are lossy-coalesced into the requested export with one bounded reservation_limit diagnostic per capped batch. A two-attempt failure rejects with an `AggregateError` retaining both exact causes; one failure is thrown directly. Only the final always-fulfilled Promise bridge isolates telemetry from delivery.

The [observability guide](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/docs/guide/observability.md) includes the public API, Effect OTLP example, privacy/logging policy, effect-cf ownership guidance, and beta.5/preview migration. [ADR-0018](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/docs/adr/0018-native-tool-observability.md) records the ownership, attempt scope, background lifecycle, bounds, diagnostics, and rejected alternatives.

## Migration

Downstream applications can remove loopback spans/logs that duplicate `execute_tool`, Tool name, execution class, or outcome. Cloudflare hosts pass their existing observability Layer plus `CloudflareRuntimeTelemetry` as the factory's second argument and remove per-RPC manual flushes. An earlier preview using `telemetry: Telemetry` inside runtime options must move that Layer to `makeConversationObjectClass(options, Telemetry)`. An effect-cf integration should choose one native-delivery flush owner to avoid duplicate export requests.

## Test evidence

Validated commit: `5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b`

- `vp run --no-cache check` — all 22 tasks passed with 0 errors and 317 existing/upstream warnings
- `vp run --no-cache test` — full repository matrix passed; engine 127/127, platform-cloudflare 143/143, testing 194/194
- `vp run --no-cache build` — all packages, examples, and VitePress docs passed
- `vp run requirements:coverage` — 171 requirements: 41 test-title references, 109 executable-evidence references, 9 documented deferrals, 12 process requirements
- focused engine observability 86/86; focused Workerd telemetry 8/8; deterministic Cloudflare lifecycle unit coverage 25/25

Workerd still prints configured test-only fault-injection diagnostics from eviction and cross-Object recovery suites; the complete command exits successfully and reports platform-cloudflare 143/143.

Focused evidence:

- [Engine exporter/privacy regressions](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/engine/test/agent-runtime.test.ts#L479-L1520) inspect every captured span's exporter-visible identity, sampling, status Cause, attributes, events, and links plus every OTLP-facing log message, level, Cause, annotation, log span, fiber ID, and active trace/span ID using an Error-aware own-property traversal. They prove delegate sampling fidelity, one-evaluation isolation for host context defects before/after primitive evaluation and wrapped primitive failure, bounded attributes/outcomes, absence of Toolkit spans/parameters/results/raw failure content, an exported host-owned handler span parented by `execute_tool` with empty attributes/events/links, post-terminal override, exact original-plus-residual Cause restoration, non-forgeable per-attempt marker identity, and isolation of both a terminal Logger defect and a defecting ErrorReporter while preserving exact Tool success. Direct pull, early-close, and concurrent-merge regressions prove the terminal event is observed before derivative telemetry, full drain and `take(1)` each run one telemetry attempt, failed/unpulled events run none, and an in-flight interrupted action is not retried. A real returned Tool failure consumed only through `ToolCallFailed` still emits one failure log and closes the canonical span failed; annotated success/failure remain authoritative over cancellation, while unannotated interruption is preserved. Provider-result regressions prove lazy monotonic sequence stamping across intervening live deltas, full staged-suffix emission before usage and response-persistence mutations, typed fail-closed 256-event/1,048,576-byte/128-level bounds shared by progress, terminal, and Turn-completion staging with zero provisional progress/success/completion emission, rejection of invalid limits before traversal, interruption-only handler classification without failure telemetry, and Schema-decoded persisted Tool parameters, and early byte-budget termination plus adversarial inherited/own toJSON, accessor, and proxy cases without re-reading dynamic values. The early-close regression interrupts an in-flight finalizer and asserts the complete exact interruption Cause. An exhaustive invalid-ID table covers every retained or correlated provider part category and proves a content-free typed protocol failure before correlation, canonical events, diagnostics, or handler execution. Provider Tool results are rebuilt from the same bounded owned snapshot used for validation and staging; mutation of the original provider object cannot alter later prompt history. The lifecycle regression also proves host span create/wrapper/close defects never rerun a Tool, never leak raw defect content, and best-effort close an allocated delegate when wrapper construction fails so no exportable span is orphaned.
- [Workerd lifecycle regressions](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/platform-cloudflare/test/telemetry.test.ts#L125-L580) prove typed Layer acquisition through the public DO edge, exact RPC/wake/alarm outcomes, span-before-flush order, complete span privacy, successful alarm first/trailing/queued flush completion, exporter-failure noninterference, non-blocking delivery, concurrency, scope-owned global fixture registration, and claimed-gate cleanup.
- [Deterministic lifecycle/coordinator regressions](https://github.com/danieljvdm/effect-agent/blob/5a4e7fdf35f3dd5b24c7f820f07a1aa72acdd00b/packages/platform-cloudflare/test/restart/telemetry-lifecycle-unit.test.ts#L67-L735) prove synchronous reservation, exact delivery preservation, one shared background registration identity per stalled pending/trailing/queued batch, resolved and rejected delivery-settlement gating, active/trailing/queued promotion, final-settlement-gap safety, bounded failure aggregation, Cause-free typed/defect/interruption diagnostics, cooperative timeout behavior, all-exit gate completion, dispose-driven release of an already-claimed exporter gate, scope-driven release and owner-token rejection of overlapping global Workerd registrations without premature unregister, fixture-owned delayed-start isolation, cleanup-safe bracketed exporter gates, and native marker-plus-residual Cause restoration. The probes strictly reject non-string required attributes without coercion. The waitUntil diagnostic regression captures every OTLP-facing Logger field and uses Error-aware own-property traversal to prove that neither the foreign Error identity nor its non-enumerable secret message is reachable. Each test owns an independent probe instance—observations, failures, gates, and causal attempt tokens—and the static Workerd class routes only by its unique Conversation identity. A deterministic delayed-start regression proves an old fixture cannot consume a new fixture’s controls.











