### PR TITLE
harden(code-mode): incorporate C4 and demo review findings

### DIFF
--- a/examples/code-mode-cloudflare/.dev.vars.example
+++ b/examples/code-mode-cloudflare/.dev.vars.example
@@ -1,2 +1,5 @@
 # Optional: set to run the live OpenAI profile instead of the scripted one.
 OPENAI_API_KEY=
+# Optional shared secret. When set, /ask requires `Authorization: Bearer <token>`.
+# Set this whenever OPENAI_API_KEY is deployed so the paid endpoint is gated.
+DEMO_AUTH_TOKEN=

--- a/examples/code-mode-cloudflare/README.md
+++ b/examples/code-mode-cloudflare/README.md
@@ -74,8 +74,14 @@ bunx wrangler secret put DEMO_AUTH_TOKEN
 bun run --filter @effect-agent/example-code-mode-cloudflare deploy
 curl -X POST https://<your-worker>/ask \
   -H 'content-type: application/json' \
+  -H 'authorization: Bearer <your DEMO_AUTH_TOKEN>' \
   -d '{"question":"Which customers have more than $10,000 in revenue?"}'
 ```
+
+When `OPENAI_API_KEY` is set the Worker **requires** `DEMO_AUTH_TOKEN` and
+rejects requests without a matching bearer token, so the paid path never
+serves anonymous callers. The offline scripted default (no `OPENAI_API_KEY`)
+needs no token.
 
 `wrangler.jsonc` wires the `WAREHOUSE` Durable Object, the `LOADER`
 (`worker_loaders`) binding the Dynamic Worker executor loads generated programs

--- a/examples/code-mode-cloudflare/README.md
+++ b/examples/code-mode-cloudflare/README.md
@@ -33,13 +33,21 @@ store, not a Conversation store.
 
 The plan (§8.4) prescribes database authority as the read-only boundary. On
 Durable Object SQLite the `PRAGMA query_only` lock is blocked by the storage
-authorizer (`SQLITE_AUTH`), so this demo enforces read-only with a
-leading-keyword denylist over the literal-stripped statement, and denies the
-escape hatches (`PRAGMA`, `ATTACH`, `load_extension`, multi-statement). A
-production warehouse should back this with a read-only database identity or
-curated read-only views. The Node reference fixture in `@effect-agent/testing`
-(`warehouseDbLayer`) proves the stronger database-authority path (`PRAGMA
-query_only = ON` → `SQLITE_READONLY`) that Node SQLite allows.
+authorizer (`SQLITE_AUTH`), so this demo enforces read-only in application
+code. Because a denylist of write keywords is bypassable — a `WITH … DELETE`
+common-table expression does not _start_ with a write keyword — the scan is an
+**allowlist**: the statement must be a single read (`SELECT`, or a `WITH` whose
+body is a read) and must contain no write, DDL, transaction, or escape-hatch
+token (`INSERT`/`UPDATE`/`DELETE`/`DROP`/`PRAGMA`/`ATTACH`/`load_extension`/…)
+anywhere in the literal-stripped text. Row and byte caps are enforced while
+draining the cursor, so a query that would return a huge result set never
+fully materializes.
+
+This text scan is a demo-grade boundary. A production warehouse should back
+this with a read-only database identity or curated read-only views. The Node
+reference fixture in `@effect-agent/testing` (`warehouseDbLayer`) proves the
+stronger _database-authority_ path (`PRAGMA query_only = ON` →
+`SQLITE_READONLY`) that Node SQLite allows.
 
 ## Run the tests (no credentials)
 
@@ -58,6 +66,10 @@ default profile is a deterministic scripted model, so no API key is needed.
 ```sh
 # Optional: run the live OpenAI profile instead of the scripted one.
 bunx wrangler secret put OPENAI_API_KEY
+# When OPENAI_API_KEY is set, also set a shared secret so the paid /ask
+# endpoint cannot be driven anonymously (callers must then send
+# `Authorization: Bearer <token>`):
+bunx wrangler secret put DEMO_AUTH_TOKEN
 
 bun run --filter @effect-agent/example-code-mode-cloudflare deploy
 curl -X POST https://<your-worker>/ask \

--- a/examples/code-mode-cloudflare/src/warehouse-object.ts
+++ b/examples/code-mode-cloudflare/src/warehouse-object.ts
@@ -1,15 +1,16 @@
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import { DurableObject } from "cloudflare:workers";
-import { Context, Effect, Layer, Option, Predicate, Schema } from "effect";
+import { Context, Effect, Layer, Option, Schema } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
-import { SqlError } from "effect/unstable/sql/SqlError";
 
 /**
  * The warehouse Durable Object: a SQLite-backed store of curated invoice data
- * that generated Code Mode programs query through a read-only SQL Tool. The
- * database is the trust boundary — it is locked with `PRAGMA query_only = ON`
- * so the connection denies every write, and only a curated `invoice_summary`
- * view is exposed. Nothing about the connection, credentials, or storage ever
+ * that generated Code Mode programs query through a read-only SQL Tool. Only a
+ * single curated `invoice_summary` table is exposed, and every query goes
+ * through the read-only ALLOWLIST scan (`scanReadOnly`) — Durable Object
+ * SQLite cannot lock the connection with `PRAGMA query_only`, so the demo
+ * permits only single read statements (see the README for the production
+ * guidance). Nothing about the connection, credentials, or storage ever
  * reaches the isolated executor: generated code sees only the brokered
  * `warehouse.query` method and its Schema-bounded result.
  *
@@ -79,13 +80,16 @@ const stripLiteralsAndComments = (sql: string): string => {
 // statement authorizer (SQLITE_AUTH), so — unlike the Node reference fixture,
 // which locks the connection read-only and lets database authority deny every
 // write (the primary boundary the plan §8.4 prescribes) — this demo enforces
-// read-only with a leading-keyword denylist over the literal-stripped
-// statement. A production deployment should back the warehouse with a
-// read-only database identity or curated read-only views instead of relying
-// on this scan.
-const writeKeywords =
-  /^\s*(insert|update|delete|replace|drop|create|alter|truncate|reindex|analyze)\b/i;
-const escapeHatchKeywords = /\b(pragma|attach|detach|vacuum|load_extension)\b/i;
+// read-only in application code. Because a denylist of write keywords is
+// bypassable (e.g. a `WITH … DELETE` common-table expression does not START
+// with a write keyword), the scan is an ALLOWLIST: the statement must be a
+// single read (`SELECT`, or a `WITH` whose body is a read) and must contain
+// no write, DDL, or escape-hatch token ANYWHERE in the literal-stripped text.
+// A production deployment should still back the warehouse with a read-only
+// database identity or curated read-only views rather than a text scan.
+const readOnlyPrefix = /^\s*(select|with)\b/i;
+const disallowedTokens =
+  /\b(insert|update|delete|replace|drop|create|alter|truncate|reindex|analyze|pragma|attach|detach|vacuum|load_extension|savepoint|release|begin|commit|rollback)\b/i;
 
 const scanReadOnly = (sql: string): string | undefined => {
   const stripped = stripLiteralsAndComments(sql);
@@ -93,21 +97,13 @@ const scanReadOnly = (sql: string): string | undefined => {
   if (semicolon !== -1 && stripped.slice(semicolon + 1).trim().length > 0) {
     return "exactly one statement is allowed per call";
   }
-  if (writeKeywords.test(stripped)) {
-    return "the warehouse is read-only";
+  if (!readOnlyPrefix.test(stripped)) {
+    return "only read-only SELECT statements are allowed";
   }
-  const denied = escapeHatchKeywords.exec(stripped);
-  return denied === null ? undefined : `${denied[1].toUpperCase()} is not available`;
-};
-
-const isWriteDenial = (error: SqlError): boolean => {
-  const cause = (error.reason as { readonly cause?: unknown }).cause;
-  return (
-    Predicate.isObject(cause) &&
-    "errcode" in cause &&
-    typeof cause.errcode === "number" &&
-    (cause.errcode & 0xff) === 8
-  );
+  const disallowed = disallowedTokens.exec(stripped);
+  return disallowed === null
+    ? undefined
+    : `${disallowed[1].toUpperCase()} is not allowed in a read-only query`;
 };
 
 const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).byteLength;
@@ -115,54 +111,45 @@ const utf8ByteLength = (value: string): number => new TextEncoder().encode(value
 const decodeRow = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.Json));
 
 /**
- * Run one bounded read-only query over the DO's SQLite storage. Write denial
- * comes from `PRAGMA query_only = ON` (structural `SQLITE_READONLY`), not from
- * the scanner, which only covers the escape hatches the authority cannot
- * police.
+ * Run one bounded read-only query over the DO's SQLite storage. The read-only
+ * boundary is the ALLOWLIST scan (`scanReadOnly`) — Durable Object SQLite
+ * cannot lock the connection with `PRAGMA query_only`, so this demo permits
+ * only single read statements. The row and byte caps are enforced WHILE
+ * draining the cursor (early break), so a query that would return a huge
+ * result set never fully materializes.
  */
 const runQuery = (
   storage: DurableObjectStorage,
   sql: string,
   parameters: ReadonlyArray<string | number | boolean | null>,
 ): Effect.Effect<WarehouseQueryOutcome> =>
-  Effect.gen(function* () {
+  Effect.sync(() => {
     const denied = scanReadOnly(sql);
     if (denied !== undefined) {
       return { ok: false, columns: [], rows: [], rowCount: 0, truncated: false, reason: denied };
     }
-    const client = yield* SqlClient.SqlClient;
-    const rawRows = yield* client
-      .unsafe<Record<string, unknown>>(sql, parameters as Array<unknown>)
-      .withoutTransform.pipe(
-        Effect.map((rows) => ({ ok: true as const, rows })),
-        Effect.catchTag("SqlError", (error) =>
-          Effect.succeed({
-            ok: false as const,
-            reason: isWriteDenial(error)
-              ? "the warehouse database is read-only"
-              : `query failed: ${String(error.reason.message ?? "unknown").slice(0, 500)}`,
-          }),
-        ),
-      );
-    if (!rawRows.ok) {
+    let cursor;
+    try {
+      cursor = storage.sql.exec(sql, ...parameters);
+    } catch (cause) {
       return {
         ok: false,
         columns: [],
         rows: [],
         rowCount: 0,
         truncated: false,
-        reason: rawRows.reason,
+        reason: `query failed: ${(cause instanceof Error ? cause.message : String(cause)).slice(0, 500)}`,
       };
     }
     const rows: Array<Record<string, unknown>> = [];
     let truncated = false;
     let usedBytes = 0;
-    for (const raw of rawRows.rows) {
+    for (const raw of cursor) {
       if (rows.length >= MAX_ROWS) {
         truncated = true;
         break;
       }
-      const decoded = decodeRow(raw);
+      const decoded = decodeRow(raw as Record<string, unknown>);
       if (Option.isNone(decoded)) {
         return {
           ok: false,
@@ -188,7 +175,7 @@ const runQuery = (
       rowCount: rows.length,
       truncated,
     };
-  }).pipe(Effect.provide(SqliteClient.layer({ storage })), Effect.orDie);
+  });
 
 export class WarehouseObject extends DurableObject {
   #ready = false;
@@ -250,6 +237,9 @@ export class Warehouse extends Context.Service<
   }
 >()("@effect-agent/example-code-mode-cloudflare/Warehouse") {}
 
+/** A safe tenant name: the DO is addressed by this, so bound it tightly. */
+export const isValidTenant = (tenant: string): boolean => /^[a-z0-9-]{1,32}$/.test(tenant);
+
 /** Build the Warehouse service from a resolved DO namespace + tenant name. */
 export const warehouseLayer = (
   namespace: DurableObjectNamespace<WarehouseObject>,
@@ -257,8 +247,25 @@ export const warehouseLayer = (
 ): Layer.Layer<Warehouse> =>
   Layer.succeed(Warehouse)({
     query: (sql, parameters) =>
-      Effect.promise(() => {
+      // A Durable Object RPC failure (transport, DO exception) is an EXPECTED
+      // outcome the tool handler branches on, not a defect — surface it as a
+      // typed denied outcome rather than dying the pass.
+      Effect.tryPromise((): Promise<WarehouseQueryOutcome> => {
         const stub = namespace.get(namespace.idFromName(tenant));
-        return stub.query(sql, [...parameters]);
-      }),
+        return stub.query(sql, [...parameters]) as Promise<WarehouseQueryOutcome>;
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.succeed<WarehouseQueryOutcome>({
+            ok: false,
+            columns: [],
+            rows: [],
+            rowCount: 0,
+            truncated: false,
+            reason: `warehouse unavailable: ${(error.cause instanceof Error
+              ? error.cause.message
+              : String(error.cause)
+            ).slice(0, 300)}`,
+          }),
+        ),
+      ),
   });

--- a/examples/code-mode-cloudflare/src/worker.ts
+++ b/examples/code-mode-cloudflare/src/worker.ts
@@ -9,7 +9,7 @@ import { Effect, Layer, Stream } from "effect";
 
 import { codeModeHandlersLayer } from "./agent.ts";
 import { liveAgent, scriptedAgent, scriptedWriteProbeAgent } from "./profiles.ts";
-import { Warehouse, WarehouseObject, warehouseLayer } from "./warehouse-object.ts";
+import { isValidTenant, Warehouse, WarehouseObject, warehouseLayer } from "./warehouse-object.ts";
 
 /**
  * The demo Worker: it answers a natural-language question about the invoice
@@ -33,6 +33,12 @@ interface WorkerEnv {
   readonly LOADER: WorkerLoader;
   readonly CODE_MODE_HOST: CodeModeHostStub;
   readonly OPENAI_API_KEY?: string;
+  /**
+   * Optional shared secret. When set, `/ask` requires a matching
+   * `Authorization: Bearer <token>` header — set it whenever `OPENAI_API_KEY`
+   * is deployed so the paid live endpoint cannot be driven anonymously.
+   */
+  readonly DEMO_AUTH_TOKEN?: string;
 }
 
 interface AskResult {
@@ -75,6 +81,7 @@ const runBound = (
     // observable evidence that the isolated program queried the real DO.
     let programResult: unknown;
     let answer = "";
+    let completed = false;
     yield* AgentRuntime.stream(agent, { question }).pipe(
       Stream.runForEach((event) =>
         Effect.sync(() => {
@@ -82,6 +89,7 @@ const runBound = (
             programResult = event.result;
           }
           if (event._tag === "RunCompleted") {
+            completed = true;
             const output = event.output as { readonly answer?: unknown };
             if (typeof output.answer === "string") {
               answer = output.answer;
@@ -92,6 +100,12 @@ const runBound = (
       Effect.provide(layers),
       Effect.scoped,
     );
+    // A Run that ended without emitting RunCompleted (e.g. it hit a policy
+    // limit) is NOT a success — surface it as a defect so `runPromise` rejects
+    // and the fetch handler returns 500, rather than a 200 with an empty answer.
+    if (!completed) {
+      return yield* Effect.die(new Error("the agent run did not complete"));
+    }
     return { answer, program: programResult, profile };
   }) as Effect.Effect<AskResult>;
 };
@@ -124,16 +138,32 @@ export default {
         { status: url.pathname === "/" ? 200 : 404 },
       );
     }
+    if (request.method !== "POST") {
+      return Response.json({ error: "POST required" }, { status: 405 });
+    }
+    // When a shared secret is configured, require it — this gates the paid
+    // live model path. The offline scripted default needs no secret.
+    if (env.DEMO_AUTH_TOKEN !== undefined && env.DEMO_AUTH_TOKEN.length > 0) {
+      if (request.headers.get("authorization") !== `Bearer ${env.DEMO_AUTH_TOKEN}`) {
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
+    }
     let question = "Which customers have more than $10,000 in revenue?";
     try {
       const body = (await request.json()) as { readonly question?: unknown };
       if (typeof body.question === "string" && body.question.trim().length > 0) {
-        question = body.question;
+        // Bound the question so an oversized body cannot drive an unbounded prompt.
+        question = body.question.slice(0, 2_000);
       }
     } catch {
       // fall back to the default question
     }
+    // The tenant addresses a Durable Object, so reject anything that is not a
+    // short, safe identifier rather than minting an arbitrary Object.
     const tenant = url.searchParams.get("tenant") ?? "acme";
+    if (!isValidTenant(tenant)) {
+      return Response.json({ error: "tenant must match /^[a-z0-9-]{1,32}$/" }, { status: 400 });
+    }
     try {
       const result = await Effect.runPromise(
         runAsk(env, question, tenant, url.searchParams.get("probe")),

--- a/examples/code-mode-cloudflare/src/worker.ts
+++ b/examples/code-mode-cloudflare/src/worker.ts
@@ -141,12 +141,21 @@ export default {
     if (request.method !== "POST") {
       return Response.json({ error: "POST required" }, { status: 405 });
     }
-    // When a shared secret is configured, require it — this gates the paid
-    // live model path. The offline scripted default needs no secret.
-    if (env.DEMO_AUTH_TOKEN !== undefined && env.DEMO_AUTH_TOKEN.length > 0) {
-      if (request.headers.get("authorization") !== `Bearer ${env.DEMO_AUTH_TOKEN}`) {
-        return Response.json({ error: "unauthorized" }, { status: 401 });
-      }
+    const liveMode = env.OPENAI_API_KEY !== undefined && env.OPENAI_API_KEY.length > 0;
+    const authToken = env.DEMO_AUTH_TOKEN;
+    const hasAuthToken = authToken !== undefined && authToken.length > 0;
+    // Fail CLOSED on the paid path: if the live model is enabled but no shared
+    // secret is configured, refuse rather than serve paid inference to
+    // anonymous callers. The offline scripted default needs no secret.
+    if (liveMode && !hasAuthToken) {
+      return Response.json(
+        { error: "server misconfigured: DEMO_AUTH_TOKEN must be set when OPENAI_API_KEY is" },
+        { status: 503 },
+      );
+    }
+    // When a shared secret is configured, require a matching bearer token.
+    if (hasAuthToken && request.headers.get("authorization") !== `Bearer ${authToken}`) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
     }
     let question = "Which customers have more than $10,000 in revenue?";
     try {

--- a/examples/code-mode-cloudflare/test/demo.test.ts
+++ b/examples/code-mode-cloudflare/test/demo.test.ts
@@ -105,10 +105,10 @@ describe("Code Mode over a SQLite Durable Object warehouse", () => {
     expect(result.program?.logs).toContain("scanned 5 customers, kept 3");
   }, 120_000);
 
-  it("runs a write-attempting program whose mutation is denied by the database authority", async () => {
-    // The write-denying `?probe=write` program attempts an UPDATE inside the
-    // isolated Dynamic Worker; the read-only Durable Object (query_only /
-    // SQLITE_READONLY) denies it, and the program catches the typed envelope.
+  it("denies a write-attempting program through the read-only allowlist", async () => {
+    // The `?probe=write` program attempts an UPDATE inside the isolated
+    // Dynamic Worker; the read-only allowlist denies it and the program
+    // catches the typed WarehouseQueryDenied envelope.
     const response = await runtime.dispatchFetch("http://demo/ask?probe=write", {
       method: "POST",
       body: JSON.stringify({ question: "try to zero out revenue" }),
@@ -119,5 +119,40 @@ describe("Code Mode over a SQLite Durable Object warehouse", () => {
       readonly program?: { readonly result: { readonly writeDenied: boolean } };
     };
     expect(result.program?.result.writeDenied).toBe(true);
+  });
+
+  it("rejects a CTE-prefixed write that a leading-keyword denylist would miss", async () => {
+    // Direct-to-DO evidence that the allowlist is not bypassable by a
+    // statement that merely does not START with a write keyword. The row
+    // count is unchanged afterward.
+    const warehouse = await runtime.getDurableObjectNamespace("WAREHOUSE");
+    const stub = warehouse.get(warehouse.idFromName("acme")) as unknown as {
+      query: (
+        sql: string,
+        parameters: ReadonlyArray<string | number | boolean | null>,
+      ) => Promise<{
+        readonly ok: boolean;
+        readonly rows: ReadonlyArray<Record<string, unknown>>;
+        readonly reason?: string;
+      }>;
+    };
+
+    // Seed and confirm the baseline read works.
+    const before = await stub.query("SELECT COUNT(*) AS n FROM invoice_summary", []);
+    expect(before.ok).toBe(true);
+    expect(before.rows[0]?.n).toBe(5);
+
+    // A denylist keyed on the leading token would let this through; the
+    // allowlist rejects it because DELETE appears anywhere in the statement.
+    const bypass = await stub.query(
+      "WITH doomed AS (SELECT customer FROM invoice_summary) DELETE FROM invoice_summary",
+      [],
+    );
+    expect(bypass.ok).toBe(false);
+    expect(bypass.reason).toMatch(/DELETE|read-only/i);
+
+    const after = await stub.query("SELECT COUNT(*) AS n FROM invoice_summary", []);
+    expect(after.ok).toBe(true);
+    expect(after.rows[0]?.n).toBe(5);
   });
 });

--- a/packages/platform-cloudflare/src/code-mode-executor.ts
+++ b/packages/platform-cloudflare/src/code-mode-executor.ts
@@ -169,7 +169,14 @@ export default class CodeModeHarness extends WorkerEntrypoint {
     // syntactically invalid program fails the whole harness at load (mapped
     // to a source error by the host). Using a static import keeps this module
     // free of dynamic-import expressions, which single-script Miniflare hosts
-    // reject.
+    // reject. The isolation boundary does NOT depend on the ordering of this
+    // import versus the console/namespace shims installed below: the loaded
+    // Worker has globalOutbound: null and no bindings, secrets, or env from
+    // the Worker Loader config BEFORE any module in the graph evaluates, so
+    // module-level program code has no ambient authority regardless. The
+    // shims below are usability wrappers (bounded console, namespace globals),
+    // and the accepted program is a single async-function expression whose
+    // body runs only when invoked here — after the shims exist.
     const program = programDefault;
     if (typeof program !== "function") {
       return { _tag: "source-not-a-function", actual: typeof program };
@@ -378,9 +385,12 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
 
     const host = yield* CodeExecutionHost;
     passCounterState.next += 1;
-    const passId = `code-mode-pass-${passCounterState.next}-${Math.floor(
-      (yield* Clock.currentTimeMillis) % 1_000_000_000,
-    )}`;
+    // The pass id is the only credential a loaded program presents to reach
+    // its host authority, so it must be unguessable: a program cannot forge
+    // another pass's id even if two passes were ever concurrent (the broker
+    // keeps them sequential, but the id must not rely on that). The counter
+    // prefix keeps ids debuggable; the random suffix makes them unforgeable.
+    const passId = `code-mode-pass-${passCounterState.next}-${crypto.randomUUID()}`;
 
     // Promise-side host calls bridge into the Effect world through a pending
     // list served by a scoped fiber, exactly like the deterministic
@@ -501,10 +511,10 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
         try: () => options.loader.load(workerCode as never),
         catch: (cause) => {
           const text = cause instanceof Error ? cause.message : String(cause);
-          // A module-compile error at load is invalid generated source, not
-          // an infrastructure failure — the fixed harness is valid, so the
-          // fault is in program.js.
-          if (/syntaxerror|failed to start worker/i.test(text)) {
+          // Blame the program's source ONLY on a genuine compile diagnostic;
+          // any other load rejection is an infrastructure start failure, not
+          // the model's fault (see classifyWorkerFailure for the same split).
+          if (/syntaxerror|failed to (compile|parse)/i.test(text)) {
             return CodeSourceError.make({
               implementation: dynamicWorkerImplementation,
               reason: "invalid",
@@ -659,10 +669,13 @@ const classifyWorkerFailure = (
     }
   })();
   // `WorkerLoader.load()` is lazy, so a module-compile error in the generated
-  // program surfaces here at first use. Invalid generated source is a
-  // `CodeSourceError`, not an infrastructure failure — the fixed harness is
-  // valid, so the fault is in program.js.
-  if (/syntaxerror|failed to start worker|failed to compile/i.test(text)) {
+  // program surfaces here at first use. Blame the program's source ONLY on a
+  // genuine compile diagnostic (a `SyntaxError` or an explicit compile
+  // failure) — the fixed harness is valid, so the fault is in program.js. A
+  // bare "failed to start Worker" without a compile diagnostic is an
+  // infrastructure start failure, not the model's fault, so it must NOT be
+  // misclassified as a source error.
+  if (/syntaxerror|failed to (compile|parse)/i.test(text)) {
     return CodeSourceError.make({
       implementation: dynamicWorkerImplementation,
       reason: "invalid",
@@ -675,6 +688,13 @@ const classifyWorkerFailure = (
       kind: "cpu",
       maxWallTime,
       logs: [],
+    });
+  }
+  if (/failed to start worker/i.test(text)) {
+    return CodeExecutorStartError.make({
+      implementation: dynamicWorkerImplementation,
+      message: text.slice(0, 8_000),
+      cause,
     });
   }
   return CodeExecutorTerminatedError.make({


### PR DESCRIPTION
## Summary

Follow-up incorporating the autoreviewer findings from the C4 adapter (#34) and the Cloudflare demo (#35) that were worth acting on. Two commits, one per surface.

## Adapter — `@effect-agent/platform-cloudflare`

- **Unforgeable pass ids.** The pass id is the only credential a loaded program presents to reach its host authority. It was a counter plus a truncated timestamp — predictable. It is now `code-mode-pass-<n>-<crypto.randomUUID()>`, so a program cannot forge another pass's id even if two passes were ever concurrent (the broker keeps them sequential, but the id no longer *relies* on that).
- **Precise failure classification.** A worker-load/RPC failure is blamed on the program's source ONLY on a genuine compile diagnostic (`SyntaxError` / `failed to compile|parse`). A bare "failed to start Worker" without a compile diagnostic is now a `CodeExecutorStartError` (infrastructure), not a misclassified `CodeSourceError`.
- **Documented isolation ordering.** Clarified that the isolation boundary (`globalOutbound: null`, no bindings/secrets/env) is enforced by the Worker Loader config *before any module in the graph evaluates*, so the static program import's ordering versus the usability shims carries no security weight.

## Demo — `examples/code-mode-cloudflare`

- **The read-only boundary is now an allowlist, not a bypassable denylist.** A leading-keyword denylist misses a CTE-prefixed write (`WITH … DELETE` does not *start* with a write keyword), and Durable Object SQLite blocks `PRAGMA query_only` (`SQLITE_AUTH`), so the connection can't be locked. The scan now requires a single read (`SELECT`, or a `WITH` whose body reads) with no write/DDL/transaction/escape-hatch token anywhere in the literal-stripped text. A new direct-to-DO test proves the `WITH … DELETE` bypass is rejected and the data is unchanged.
- **Bounds enforced while draining the cursor** — row and byte caps break early, so a huge result set never fully materializes.
- **Typed Durable Object RPC failures** — a DO RPC failure is a typed denied outcome the tool branches on, not an untyped defect that dies the pass.
- **Input validation** — the tenant param is validated (`/^[a-z0-9-]{1,32}$/`) before it addresses a Durable Object; the question body is length-bounded; non-POST is rejected.
- **No incomplete run returned as success** — a Run that ends without `RunCompleted` becomes a 500, not a 200 with an empty answer.
- **The paid live endpoint is gated** by an optional `DEMO_AUTH_TOKEN` bearer secret when configured; the README and `.dev.vars.example` document setting it alongside `OPENAI_API_KEY`, and no longer overstate the read-only guarantee.

## Evidence

`bun run ready` green across the workspace. The demo's workerd/Miniflare suite covers the main Code Mode run, the write-denial through the allowlist, and the new CTE-bypass rejection. The C4 conformance lane stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)