### PR TITLE
fix(pr-review): align delegated tool budget

### DIFF
--- a/.changeset/pr-review-incremental-continuity.md
+++ b/.changeset/pr-review-incremental-continuity.md
@@ -1,0 +1,9 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Make GitHub Action PR reviews incremental across corrective pushes using authenticated,
+lineage-validated review state, preserve unresolved findings and accepted scope, provide an
+explicit final full-diff audit, and fail the review check for blocking findings or incomplete
+coverage. Align delegated file-review tool-call bounds with the maximum review-unit size so
+normal diff and context reads can complete without deterministic policy exhaustion.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38263,6 +38263,7 @@ var rankAndDedupeFindings = (findings) => {
 // packages/pr-review/src/internal/fan-out.ts
 var MAX_CHILD_FINDINGS = 8;
 var MAX_CHILD_CONCERNS = 3;
+var MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 2;
 var FileReviewToolkit = exports_Toolkit.make(ReadFileDiff, ReadFile);
 var FileReviewToolkitLayer = FileReviewToolkit.toLayer({
   read_file_diff: readFileDiffHandler,
@@ -38305,7 +38306,7 @@ var makeFileReviewerInstructions = (options = {}) => (brief) => [
 var fileReviewerInstructions = makeFileReviewerInstructions();
 var defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 8,
-  maxToolCalls: 16,
+  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200000
@@ -38333,7 +38334,7 @@ var fileReviewPolicy = SubagentPolicy.make({
   maxChildren: MAX_REVIEW_UNITS,
   maxConcurrency: 3,
   maxTurns: 8,
-  maxToolCalls: 16,
+  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
   maxDuration: "4 minutes"
 });
 var delegationDescription = "Delegate the review of one planned unit to a bounded file-reviewer child and return its line-anchored findings. Call it exactly once per unit from list_review_units; never retry a failed unit.";

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -59,6 +59,12 @@ export const MAX_CHILD_FINDINGS = 8;
 /** One child returns at most this many non-anchored concerns. */
 export const MAX_CHILD_CONCERNS = 3;
 
+/**
+ * One mandatory diff read plus one bounded context read for every path in a
+ * maximum-size unit. Keep the child and delegation reservation aligned.
+ */
+export const MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 2;
+
 // ---------------------------------------------------------------------------
 // The child: a file reviewer over one unit. Its toolkit is intentionally
 // smaller than the flat reviewer's — diff and head-file reads only, no
@@ -138,7 +144,7 @@ export const fileReviewerInstructions = makeFileReviewerInstructions();
 /** The default per-unit child execution bounds. */
 export const defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 8,
-  maxToolCalls: 16,
+  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200_000,
@@ -193,7 +199,7 @@ export const fileReviewPolicy = SubagentPolicy.make({
   maxChildren: MAX_REVIEW_UNITS,
   maxConcurrency: 3,
   maxTurns: 8,
-  maxToolCalls: 16,
+  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
   maxDuration: "4 minutes",
 });
 

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -34,6 +34,7 @@ import {
   ListReviewUnits,
   makeFanOutReviewInstructions,
   makeFanOutReviewSuite,
+  MAX_FILE_REVIEW_TOOL_CALLS,
   MAX_REVIEW_UNITS,
   MAX_UNIT_FILES,
   planReviewUnits,
@@ -44,6 +45,8 @@ import {
   ReviewFinding,
   ReviewMission,
   ReviewPublicationPlan,
+  defaultFileReviewerPolicy,
+  fileReviewPolicy,
 } from "../src/index.ts";
 import {
   collectingReviewPublisherLayer,
@@ -266,6 +269,14 @@ describe("coordinator instructions", () => {
       focus: "defects-first",
     });
     expect(suite.child.instructions(brief)).toContain("Architecture first.");
+  });
+});
+
+describe("file-reviewer policy", () => {
+  it("budgets one diff and one context read for every path in a maximum-size unit", () => {
+    expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(MAX_UNIT_FILES * 2);
+    expect(defaultFileReviewerPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
+    expect(fileReviewPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
   });
 });
 
@@ -630,7 +641,10 @@ describe("offline fan-out review run", () => {
           unitId: "unit-002",
           diffPath: "src/core/gamma.ts",
           // One more declared call than the child AgentPolicy allows.
-          outcome: { _tag: "budget-runaway", declaredCalls: 17 },
+          outcome: {
+            _tag: "budget-runaway",
+            declaredCalls: MAX_FILE_REVIEW_TOOL_CALLS + 1,
+          },
         },
       ];
       const honestReview = CodeReview.make({
@@ -651,7 +665,7 @@ describe("offline fan-out review run", () => {
       const finalPrompt = result.coordinatorPrompts[2] ?? "";
       expect(finalPrompt).toContain("FileReviewUnitFailed");
       expect(finalPrompt).toContain("AgentPolicyError");
-      expect(finalPrompt).toContain("16 Tool Call limit");
+      expect(finalPrompt).toContain(`${MAX_FILE_REVIEW_TOOL_CALLS} Tool Call limit`);
       expect(result.outcome.review.summary).toContain("unit-002 unreviewed: AgentPolicyError");
       expect(result.published).toHaveLength(1);
       expect(result.outcome.coverage.status).toBe("incomplete");


### PR DESCRIPTION
## Summary

- Derive the delegated file-review tool budget from the maximum unit size: 24 calls cover the mandatory diff read plus one bounded head-context read for each path in a 12-file unit. The [child runtime and coordinator reservation](https://github.com/danieljvdm/effect-agent/blob/ac9f28c/packages/pr-review/src/internal/fan-out.ts#L62-L68) now share that constant.
- Lock the relationship and the fail-closed overflow behavior in the [fan-out regression suite](https://github.com/danieljvdm/effect-agent/blob/ac9f28c/packages/pr-review/test/pr-review-fanout.test.ts#L272-L280).
- Add the [missing patch changeset](https://github.com/danieljvdm/effect-agent/blob/ac9f28c/.changeset/pr-review-incremental-continuity.md) for the incremental authenticated-state/check-gate work merged in #38 and #40, together with this correction. The committed Action bundle is regenerated.

## What went wrong

PR #40 was split into two roughly nine-file review units, but every child and its delegation reservation were capped at 16 tool calls. A child must read every file diff and may legitimately need one head-file context read for each path, so a valid nine-file review can require 18 calls. That mismatch made `AgentPolicyError` possible during ordinary coverage and produced the misleadingly noisy incomplete result even though the new fail-closed check conclusion behaved correctly.

The budget is now calculated from the planner's 12-file maximum and used at both enforcement boundaries. Calls beyond that bounded allowance still fail closed.

## Evidence

- Focused `@effect-agent/pr-review` suite: 89 passed, 1 skipped.
- The new regression verifies the maximum-size unit allowance and the existing incomplete-coverage path at one call over the limit.
