### PR TITLE
ci: persist per-package vitest caches so test tasks can replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,18 @@ jobs:
       - name: Patch Effect TypeScript-Go
         run: bun run patch:tsgo
 
+      # The test tasks' fingerprints include Vitest's own per-package cache
+      # directories (node_modules/.vite/vitest); when those are absent on a
+      # fresh runner every test task misses with "<hash> removed", so they are
+      # persisted alongside the task cache.
       - name: Restore Vite Task cache
         id: task-cache
         uses: actions/cache/restore@v4
         with:
-          path: node_modules/.vite/task-cache
+          path: |
+            node_modules/.vite/task-cache
+            packages/*/node_modules/.vite/vitest
+            examples/*/node_modules/.vite/vitest
           key: vite-task-test-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             vite-task-test-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
@@ -116,7 +123,10 @@ jobs:
         if: success()
         uses: actions/cache/save@v4
         with:
-          path: node_modules/.vite/task-cache
+          path: |
+            node_modules/.vite/task-cache
+            packages/*/node_modules/.vite/vitest
+            examples/*/node_modules/.vite/vitest
           key: ${{ steps.task-cache.outputs.cache-primary-key }}
 
   build:


### PR DESCRIPTION
## Summary

- The Tests job's Vite Task cache has **never hit in CI**: every run re-executed all package and example test suites (~4 minutes), even when nothing they depend on changed. Example: in [run 31894783571](https://github.com/danieljvdm/effect-agent/actions/runs/31894783571/job/95036353394), 13/14 package test tasks and 4/5 example test tasks missed, while the Build job replayed 13/14 tasks in the same run.
- Fix: the [Tests job's cache restore/save steps](https://github.com/danieljvdm/effect-agent/blob/dan/ci-overrides-test-caching/.github/workflows/ci.yml#L102-L129) now persist Vitest's per-package cache directories (`packages/*/node_modules/.vite/vitest`, `examples/*/node_modules/.vite/vitest`) alongside the root `node_modules/.vite/task-cache`. With them present, unchanged packages replay and only PR-touched packages re-run their suites.

## What went wrong

Every test task missed with the same reason:

```
~/packages/sandbox$ vp test --passWithNoTests ○ cache miss: 'da39a3ee…' removed from 'packages/sandbox/node_modules/.vite/vitest', executing
```

Vitest maintains its own cache directory inside each package (`node_modules/.vite/vitest/<hash>/results.json`), and Vite Task's automatic file tracking records it in the test task's input fingerprint. The workflow persisted only the workspace-root `node_modules/.vite/task-cache`, so on every fresh runner the per-package directories were absent, the fingerprint never matched, and every test task re-executed — including the long integration suites (70s/53s/48s/35s in the linked run). The Actions cache layer itself was working (entries saved and restored each run); the restored fingerprints just could never match.

Build and static checks were unaffected: their tasks don't depend on the Vitest cache directories.

## Evidence

Reproduced and verified locally in a fresh worktree:

```
$ vp run -F './packages/sandbox' test    # first run: executes
$ vp run -F './packages/sandbox' test    # second run
vp run: cache hit, 864ms saved.

$ rm -rf packages/sandbox/node_modules/.vite/vitest
$ vp run -F './packages/sandbox' test    # exact CI miss reproduced: "removed from …/.vite/vitest", executes

$ vp run -F './packages/sandbox' test    # directory present again
vp run: cache hit, 785ms saved.
```

The hit after re-execution shows the fingerprint is stable across runs as long as the directory survives, so restoring it in CI is sufficient. A new package with no saved directory simply misses once, executes, and is captured by the next save (self-healing).

Known limitation (pre-existing, not addressed here): `@effect-agent/storage-cloudflare#test` and `example-code-mode-cloudflare#test` are reported by Vite Task as "not cached because they modified their inputs" and will still re-run every time until their input tracking is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
