### PR TITLE
chore(release): publish packages in lockstep

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,5 +2,10 @@
 
 This directory contains release notes for published `@effect-agent/*` workspaces.
 
-Create a changeset with `bun run changeset`, review the generated version plan, then use
-`bun run changeset:version` and `bun run changeset:publish` from a release environment.
+All public framework workspaces belong to one Changesets fixed group. A changeset names only the
+packages whose behavior changed, while versioning advances every public workspace to the same
+version and publishes unchanged packages on the same release train.
+
+Create a changeset, review the generated version plan, and merge the automated version PR to
+publish. The repository-specific publisher must be used instead of `changeset publish`; see the
+release runbook in `docs/TOOLCHAIN.md` for the automated path and manual fallback.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,22 @@
   ],
   "commit": false,
   "fixed": [
-    ["effect-agent", "@effect-agent/core", "@effect-agent/engine", "@effect-agent/capabilities"]
+    [
+      "@effect-agent/capabilities",
+      "@effect-agent/core",
+      "@effect-agent/engine",
+      "@effect-agent/platform-cloudflare",
+      "@effect-agent/platform-node",
+      "@effect-agent/pr-review",
+      "@effect-agent/sandbox",
+      "@effect-agent/sandbox-local",
+      "@effect-agent/session",
+      "@effect-agent/storage-cloudflare",
+      "@effect-agent/storage-memory",
+      "@effect-agent/storage-sqlite",
+      "@effect-agent/testing",
+      "effect-agent"
+    ]
   ],
   "linked": [],
   "access": "public",

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -395,12 +395,14 @@ Record: [ADR-0002](adr/0002-use-effect-ai-primitives.md)
 
 ### D-023 — Project identity and distribution
 
-**Status:** Accepted (amended 2026-08-14)
+**Status:** Accepted (amended 2026-08-14 and 2026-08-15)
 **Decision:** The project is private for now. `effect-agent` and `@effect-agent/*` remain working
 names. Public naming and governance are deferred until open-source preparation. Two halves were
 resolved by owner decision on 2026-08-14: the packages publish to npm on the opt-in **beta
 dist-tag** for live integration testing (see the TOOLCHAIN release runbook), and they carry the
-**MIT license**.
+**MIT license**. Owner decision on 2026-08-15 places every public framework workspace on one
+fixed Changesets release train: a release advances all packages to the same version even when only
+some packages have behavioral changes.
 
 ### D-024 — Repository toolchain and shape
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -139,6 +139,13 @@ install with `bun add @effect-agent/core@beta` (or an exact version).
 Leaving the channel for a stable release is `bun x changeset pre exit`
 followed by the normal sequence.
 
+All public framework workspaces form one Changesets `fixed` group. Any package changeset advances
+all fourteen packages to one shared version, including packages with no behavioral change in that
+release. This deliberately spends additional package versions in exchange for a single compatible
+release coordinate across the framework. When adding a public package, add its manifest name to
+the fixed group in `.changeset/config.json`; the toolchain test fails if the workspace and group
+diverge.
+
 Releases are automated: on every push to `main`, `.github/workflows/release.yml`
 maintains a "Version Packages (beta)" PR from the pending changesets, and
 merging that PR publishes via npm **trusted publishing** — the workflow's OIDC
@@ -247,7 +254,8 @@ D-034):
 2. use the working `@effect-agent/<name>` scope with the sibling manifest shape (MIT,
    `publishConfig.access: public`, source-first exports) — packages publish on the `beta`
    dist-tag per D-023, and each new package needs its one-time npm trusted-publisher
-   registration before CI can publish it;
+   registration before CI can publish it; add the package to the single fixed release group in
+   `.changeset/config.json`;
 3. use `catalog:` for shared external dependencies and `workspace:*` for internal packages;
 4. extend the root `tsconfig.base.json`;
 5. add it to root `tsconfig.json` references;

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -7,6 +7,7 @@ const Dependencies = Schema.Record(Schema.String, Schema.String);
 const PackageManifest = Schema.Struct({
   name: Schema.optionalKey(Schema.String),
   version: Schema.optionalKey(Schema.String),
+  private: Schema.optionalKey(Schema.Boolean),
   workspaces: Schema.optionalKey(Schema.Array(Schema.String)),
   catalog: Schema.optionalKey(Dependencies),
   dependencies: Schema.optionalKey(Dependencies),
@@ -16,6 +17,11 @@ const PackageManifest = Schema.Struct({
   peerDependencies: Schema.optionalKey(Dependencies),
 });
 type PackageManifest = typeof PackageManifest.Type;
+
+const ChangesetConfig = Schema.Struct({
+  fixed: Schema.Array(Schema.Array(Schema.String)),
+  linked: Schema.Array(Schema.Array(Schema.String)),
+});
 
 // Vite+ runs this package test from packages/testing; Bun is the pinned test runtime in CI and locally.
 const repositoryRoot = "../..";
@@ -166,6 +172,12 @@ const readManifest = (path: string) =>
     return yield* Schema.decodeEffect(Schema.fromJsonString(PackageManifest))(contents);
   });
 
+const readChangesetConfig = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const contents = yield* fs.readFileString(`${repositoryRoot}/.changeset/config.json`);
+  return yield* Schema.decodeEffect(Schema.fromJsonString(ChangesetConfig))(contents);
+});
+
 const readDirectory = (path: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -209,6 +221,26 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(rootEntries).not.toContain("wrangler.toml");
       expect(rootEntries).not.toContain("wrangler.json");
       expect(rootEntries).not.toContain("wrangler.jsonc");
+    }),
+  );
+
+  it.effect("keeps every public framework package on one fixed release train", () =>
+    Effect.gen(function* () {
+      const config = yield* readChangesetConfig;
+      const publicPackageNames: Array<string> = [];
+
+      for (const packageName of packageNames) {
+        const manifest = yield* readManifest(
+          `${repositoryRoot}/packages/${packageName}/package.json`,
+        );
+        if (manifest.private !== true && manifest.name !== undefined) {
+          publicPackageNames.push(manifest.name);
+        }
+      }
+
+      expect(config.fixed).toHaveLength(1);
+      expect([...(config.fixed[0] ?? [])].sort()).toEqual(publicPackageNames.sort());
+      expect(config.linked).toEqual([]);
     }),
   );
 


### PR DESCRIPTION
## Summary

- Put all 14 public framework workspaces in the [single Changesets fixed group](https://github.com/danieljvdm/effect-agent/blob/5670386/.changeset/config.json), so any package release advances every package to one shared version.
- Add a [workspace-derived invariant test](https://github.com/danieljvdm/effect-agent/blob/5670386/packages/testing/test/toolchain.test.ts#L224-L244) that fails when a public package is absent from the group, multiple fixed groups appear, or linked-version behavior is introduced.
- Record the lockstep policy and package-addition requirement in [D-023 and the release runbook](https://github.com/danieljvdm/effect-agent/blob/5670386/docs/TOOLCHAIN.md#L142-L149).

## What went wrong

The repository already used a Changesets fixed group, but it contained only `effect-agent`, `core`, `engine`, and `capabilities`. Every other public workspace could therefore advance independently, leaving the published beta line split across `beta.0`, `beta.5`, and `beta.6`.

The expanded fixed group makes Changesets include unchanged packages in every release and calculate one version from the highest current member. The invariant test keeps future packages from silently falling outside that release train.

## Evidence

- `changeset status` computes all 14 public packages at `0.0.1-beta.6`; unchanged packages have empty changeset lists but still receive the patch release.
- The focused toolchain suite passes all 195 tests. Serial uncached execution also passes all 14 package test tasks and all 5 example test tasks; the repository build and documentation build complete successfully.
