### PR TITLE
feat(capabilities,pr-review): delegation containment — Subagent failureMode "return" (D-037, ADR-0019 S2, SUB-033)

### DIFF
--- a/.changeset/delegation-containment.md
+++ b/.changeset/delegation-containment.md
@@ -1,0 +1,19 @@
+---
+"@effect-agent/capabilities": minor
+"@effect-agent/pr-review": minor
+---
+
+Delegation containment (D-037, ADR-0019 S2, SUB-033): `Subagent.define` gains
+`failureMode: "error" | "return"` (default `"error"`, today's semantics). Under `"return"` every
+expected delegation failure — the declared child failure plus `SubagentPrestartDenied`,
+`SubagentBudgetExhausted`, `SubagentProjectionFailure`, and `SubagentExecutionFailure` — becomes
+model-visible result data in the Tool success union instead of failing the parent Run, so one
+dead child cannot detonate a fan-out. The engine signals (`ToolCallWaiting`,
+`SubagentDurabilityError`) always stay in the error channel, preserving durable suspension by
+construction, and the durable settlement join records the contained failure with the same
+non-failure polarity the live batch continues with. pr-review retires its same-name shadow-Tool
+workaround for the first-party option, adopts the S1 `final-answer` soft landing in all three
+default reviewer policies (an exhausted child or coordinator now returns a partial review instead
+of "unit unreviewed: AgentPolicyError"), and reverts the fan-out `repeatedFailureLimit` sizing
+hack. Contained unit failures reach coverage classification with richer tags
+(`FileReviewUnitFailed:<childErrorTag>`).

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -37431,7 +37431,24 @@ var define = (name, options) => {
     allowedToolNames: Object.keys(options.target.toolkit.tools),
     maxDepth: 1
   });
-  const tool = exports_Tool.make(name, {
+  const failureMode = options.failureMode ?? "error";
+  const returnModeTool = exports_Tool.make(name, {
+    description: options.description,
+    parameters: options.parameters,
+    success: exports_Schema.Union([
+      options.success,
+      exports_Schema.Union([
+        options.failure,
+        SubagentPrestartDenied,
+        SubagentBudgetExhausted,
+        SubagentProjectionFailure,
+        SubagentExecutionFailure
+      ])
+    ]),
+    failure: exports_Schema.Union([ToolCallWaiting, SubagentDurabilityError]),
+    needsApproval: options.needsApproval
+  });
+  const errorModeTool = exports_Tool.make(name, {
     description: options.description,
     parameters: options.parameters,
     success: options.success,
@@ -37445,12 +37462,14 @@ var define = (name, options) => {
       SubagentDurabilityError
     ]),
     needsApproval: options.needsApproval
-  }).addDependency(AgentSpawner).addDependency(RunEventSink).addDependency(SubagentDurability).addDependency(IdGenerator);
+  });
+  const tool = (failureMode === "return" ? returnModeTool : errorModeTool).addDependency(AgentSpawner).addDependency(RunEventSink).addDependency(SubagentDurability).addDependency(IdGenerator);
   return Object.freeze({
     ...options,
     name,
     delegationId,
     grant,
+    failureMode,
     tool
   });
 };
@@ -37565,6 +37584,7 @@ var layer14 = (delegation, childBinding, options) => {
   const caps = options.parentCaps ?? delegationCapsFromPolicy(delegation.policy);
   const allocation = delegationAllocationFromPolicy(delegation.policy);
   const toolkit = exports_Toolkit.make(delegation.tool);
+  const contained = delegation.failureMode === "return";
   const encodeChildInput = exports_Schema.encodeEffect(delegation.target.input);
   const encodeSuccess = exports_Schema.encodeEffect(delegation.success);
   const decodeChildOutput = exports_Schema.decodeUnknownEffect(delegation.target.output);
@@ -37798,7 +37818,7 @@ var layer14 = (delegation, childBinding, options) => {
           }).pipe(exports_Effect.andThen(durability.join({
             toolCallId,
             encodedResult: encodedFailure,
-            isFailure: true,
+            isFailure: !contained,
             encodedAccounting: conservativeAccounting
           })), exports_Effect.andThen(exports_Effect.fail(failure)));
           if (status.outcome !== "completed") {
@@ -37846,15 +37866,19 @@ var layer14 = (delegation, childBinding, options) => {
         }
       }
     });
-    const handler = (parameters, handlerContext) => exports_Effect.gen(function* () {
+    const containSignals = (failure) => failure instanceof ToolCallWaiting || failure instanceof SubagentDurabilityError ? exports_Effect.fail(failure) : exports_Effect.succeed(failure);
+    const handlerImpl = (parameters, handlerContext) => exports_Effect.gen(function* () {
       const spawner = yield* AgentSpawner;
       const sink = yield* RunEventSink;
       const durability = yield* SubagentDurability;
       if (durability.mode === "durable") {
-        return yield* invokeDurable(parameters, handlerContext, durability).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
+        const durable = invokeDurable(parameters, handlerContext, durability).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
+        return yield* contained ? durable.pipe(exports_Effect.catch(containSignals)) : durable;
       }
-      return yield* invoke(parameters, handlerContext).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
+      const ephemeral = invoke(parameters, handlerContext).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
+      return yield* contained ? ephemeral.pipe(exports_Effect.catch(containSignals)) : ephemeral;
     });
+    const handler = handlerImpl;
     return { [delegation.name]: handler };
   });
   return toolkit.toLayer(build2);
@@ -38279,7 +38303,7 @@ var defaultReviewPolicy = AgentPolicy.make({
   maxDuration: "8 minutes",
   toolConcurrency: 2,
   tokenBudget: 300000,
-  onExhaustion: "fail"
+  onExhaustion: "final-answer"
 });
 var PullRequestReviewer = Agent.define("pr-reviewer", {
   input: ReviewMission,
@@ -38429,7 +38453,7 @@ var defaultFileReviewerPolicy = AgentPolicy.make({
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200000,
-  onExhaustion: "fail"
+  onExhaustion: "final-answer"
 });
 
 class FileReviewRequest extends exports_Schema.Class("@effect-agent/pr-review/FileReviewRequest")({
@@ -38467,17 +38491,8 @@ var FileReviewDelegationFailure = exports_Schema.Union([
   SubagentPrestartDenied,
   SubagentBudgetExhausted,
   SubagentProjectionFailure,
-  SubagentExecutionFailure,
-  ToolCallWaiting,
-  SubagentDurabilityError
+  SubagentExecutionFailure
 ]);
-var DelegateFileReview = exports_Tool.make("delegate_file_review", {
-  description: delegationDescription,
-  parameters: FileReviewRequest,
-  success: FileReviewUnitResult,
-  failure: FileReviewDelegationFailure,
-  failureMode: "return"
-}).addDependency(AgentSpawner).addDependency(RunEventSink).addDependency(SubagentDurability).addDependency(IdGenerator).annotate(ToolExecutionClass, "readonly");
 
 class ListReviewUnitsQuery extends exports_Schema.Class("@effect-agent/pr-review/ListReviewUnitsQuery")({
   scope: exports_Schema.Literal("all")
@@ -38500,7 +38515,6 @@ var FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
     return planReviewUnits(files, { totalChangedFiles: metadata.totalChangedFiles });
   })
 });
-var FanOutReviewToolkit = exports_Toolkit.make(ListReviewUnits, DelegateFileReview);
 var makeFanOutReviewInstructions = (options = {}) => (mission) => {
   const maxFindings = clampMaxFindings(options.maxFindings);
   return [
@@ -38525,9 +38539,9 @@ var defaultFanOutPolicy = AgentPolicy.make({
   maxToolCalls: 1 + MAX_REVIEW_UNITS,
   maxDuration: "15 minutes",
   toolConcurrency: 3,
-  repeatedFailureLimit: MAX_REVIEW_UNITS + 1,
+  repeatedFailureLimit: 3,
   tokenBudget: 300000,
-  onExhaustion: "fail"
+  onExhaustion: "final-answer"
 });
 var makeFileReviewerDefinition = (options = {}) => Agent.define("pr-file-reviewer", {
   input: FileReviewBrief,
@@ -38538,21 +38552,13 @@ var makeFileReviewerDefinition = (options = {}) => Agent.define("pr-file-reviewe
   description: "Review one bounded unit of a pull request's changeset read-only and return line-anchored findings for exactly those files.",
   metadata: { deploymentClass: "E", surface: "read-only" }
 });
-var makeFanOutReviewerDefinition = (options = {}) => Agent.define("pr-fanout-reviewer", {
-  input: ReviewMission,
-  output: CodeReview,
-  instructions: makeFanOutReviewInstructions(options),
-  toolkit: FanOutReviewToolkit,
-  policy: defaultFanOutPolicy,
-  description: "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
-  metadata: { deploymentClass: "E", surface: "read-only", delegation: "S1-attached" }
-});
 var makeFileReviewDelegation = (child) => Subagent.define("delegate_file_review", {
   description: delegationDescription,
   target: child,
   parameters: FileReviewRequest,
   success: FileReviewUnitResult,
   failure: FileReviewUnitFailed,
+  failureMode: "return",
   prepareInput: (request3) => exports_Effect.succeed(FileReviewBrief.make({
     unitId: request3.unitId,
     paths: request3.paths,
@@ -38565,18 +38571,31 @@ var makeFileReviewDelegation = (child) => Subagent.define("delegate_file_review"
   })),
   policy: fileReviewPolicy
 });
+var delegationToolFor = (delegation) => delegation.tool.annotate(ToolExecutionClass, "readonly");
+var makeFanOutReviewerDefinition = (options, delegation) => Agent.define("pr-fanout-reviewer", {
+  input: ReviewMission,
+  output: CodeReview,
+  instructions: makeFanOutReviewInstructions(options),
+  toolkit: exports_Toolkit.make(ListReviewUnits, delegationToolFor(delegation)),
+  policy: defaultFanOutPolicy,
+  description: "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
+  metadata: { deploymentClass: "E", surface: "read-only", delegation: "S1-attached" }
+});
 var makeFanOutReviewSuite = (options = {}) => {
   const child = makeFileReviewerDefinition({ guidance: options.guidance });
+  const delegation = makeFileReviewDelegation(child);
   return {
     child,
-    parent: makeFanOutReviewerDefinition(options),
-    delegation: makeFileReviewDelegation(child)
+    parent: makeFanOutReviewerDefinition(options, delegation),
+    delegation
   };
 };
 var defaultSuite = makeFanOutReviewSuite();
 var FileReviewer = defaultSuite.child;
 var FanOutReviewer = defaultSuite.parent;
 var fileReviewDelegation = defaultSuite.delegation;
+var DelegateFileReview = delegationToolFor(fileReviewDelegation);
+var FanOutReviewToolkit = FanOutReviewer.toolkit;
 var fanOutHandlersLayerFor = (delegation) => (childBinding) => SubagentRuntime.layer(delegation, childBinding, {
   mapChildFailure: mapFileReviewChildFailure
 });

--- a/docs/adr/0019-budget-soft-landing-and-extension.md
+++ b/docs/adr/0019-budget-soft-landing-and-extension.md
@@ -2,6 +2,17 @@
 
 - Status: Accepted (owner-directed, 2026-08-15; S1 engine soft landing assigned and implemented,
   S2 delegation containment and S3 budget extension assigned as follow-on slices)
+- Status note (2026-08-15): S2 implemented. Mechanics delta from decision item 6: Effect AI's
+  native `failureMode: "return"` converts EVERY handler failure into a result (`Toolkit.handle`'s
+  `Stream.catch` has no passthrough), which would encode the engine-owned `ToolCallWaiting`
+  suspension signal as data and silently orphan a durable child. The implemented containment
+  therefore keeps the underlying Tool on Effect AI `failureMode: "error"`, widens the Tool
+  success Schema to the union of the declared success and the contained failure family, and
+  catches exactly that family in the delegation handler — the contract of item 6 (contained
+  members model-visible, engine signals stay in the error channel) holds unchanged, and the
+  durable settlement join records the contained failure with the non-failure polarity the live
+  batch continues with (SUB-019 coherence). SUB-033 pins the requirement; the pr-review
+  shadow-Tool workaround is retired and both reviewer profiles adopt the S1 final-answer default.
 - Related decisions: [D-007](../DECISIONS.md#d-007--tool-scheduling-default),
   [D-008](../DECISIONS.md#d-008--tool-failure-policy),
   [D-013](../DECISIONS.md#d-013--child-agent-budgets),

--- a/docs/spec/subagents.md
+++ b/docs/spec/subagents.md
@@ -187,7 +187,8 @@ This syntax is illustrative. Before implementation, a compile-only proof MUST sh
 - every expected child and projection failure is total-mapped to the Tool's declared,
   Schema-backed failure before the handler returns;
 - with `failureMode: "error"`, only the declared Tool failure and Effect AI's permitted AI error
-  enter the parent handler `E`; with `"return"`, the declared failure is encoded in the Tool result;
+  enter the parent handler `E`; with `"return"` (SUB-033), the contained failure family is encoded
+  in the Tool success union and only the engine signals remain in `E`;
 - interruption remains interruption and defects remain defects rather than being coerced into an
   expected Tool failure;
 - no mutable global Agent registry is required;
@@ -221,10 +222,21 @@ Definition therefore MUST provide either:
 2. the framework's bounded `SubagentExecutionFailure` projection, which contains classification
    and child references but no raw Cause, stack, provider body, or secret-bearing payload.
 
-Effect AI `failureMode: "error"` remains the default. An application may deliberately choose
-`"return"` when a Schema-backed child failure should be model-visible. The mapping is exhaustive
-over expected child runtime failures. Ephemeral interruption propagates as interruption; a child
-defect fails the handler as a defect and is sandboxed by the ordinary Tool batch policy.
+`failureMode: "error"` remains the default. An application may deliberately choose `"return"`
+(SUB-033, implemented) when Schema-backed child failures should be model-visible: the declared
+failure plus the framework delegation-failure family become result data in the Tool success
+union, so one failed child cannot fail the parent Tool batch. The mechanics are deliberately NOT
+Effect AI's native `failureMode: "return"` — that would convert every handler failure into a
+result, including the engine-owned `ToolCallWaiting` suspension signal, silently orphaning a
+durable child. Instead the underlying Effect AI Tool keeps `failureMode: "error"`, the delegation
+handler contains exactly the expected failure family into the success channel, and
+`ToolCallWaiting` and `SubagentDurabilityError` stay raisable, preserving durable suspension by
+construction. On the durable path the settlement join records the contained failure with the
+same non-failure polarity the live batch continues with (SUB-019 coherence); the child's own
+failed Settlement and the `SubagentFailed` event remain the honest failure record. The mapping is
+exhaustive over expected child runtime failures. Ephemeral interruption propagates as
+interruption; a child defect fails the handler as a defect and is sandboxed by the ordinary Tool
+batch policy.
 
 ### 4.3 Package and service ownership
 
@@ -700,10 +712,11 @@ narrow details but may not erase the tag:
 | `SubagentInterrupted`            | Ephemeral fiber interruption or durable canonical abort                                                             | Ephemeral finalizers run; durable child writes the one abort Settlement when safe                       |
 | `SubagentDefectFailure`          | Durable boundary converts a child defect to a bounded framework failure record                                      | Ephemeral form remains a defect; durable form is terminal and redacted, never an application-domain `E` |
 
-For native Effect AI `failureMode: "error"`, every expected terminal tag is total-mapped to the
-declared Tool failure and the existing Tool batch failure policy applies. With `"return"`, that
-declared failure is result data visible to the model. Pending approval and unknown outcome are
-nonterminal runtime states. Raw `Cause`, stack, provider response, secret, and Tool payload values
+With `failureMode: "error"` (the default), every expected terminal tag is total-mapped to the
+declared Tool failure and the existing Tool batch failure policy applies. With `"return"`
+(SUB-033), that declared failure is result data visible to the model through the Tool success
+union; the engine-signal members (`ToolCallWaiting`, `SubagentDurabilityError`) are never
+contained. Pending approval and unknown outcome are nonterminal runtime states. Raw `Cause`, stack, provider response, secret, and Tool payload values
 are never persisted or returned as the public parent error.
 
 No recovery rule may blindly replay an unresolved ordinary child Tool or claim exactly-once child
@@ -900,3 +913,8 @@ Require separate proposals:
   `notAdmitted`, `admitted`, and `indeterminate` results; projection absence never proves absence.
 - **SUB-032**: Child-binding and parent-declaration compatibility failures have distinct,
   framework-owned Schema records and never substitute newer code.
+- **SUB-033**: Under `failureMode: "return"` every expected delegation failure — the declared
+  child failure and the framework failure family — is contained as model-visible result data
+  instead of failing the parent Tool batch; the engine-owned waiting signal and durability error
+  always stay in the error channel, durable suspension semantics are preserved unchanged, and the
+  durable settlement join records the same non-failure polarity the live batch continues with.

--- a/packages/capabilities/src/subagent.ts
+++ b/packages/capabilities/src/subagent.ts
@@ -246,6 +246,52 @@ export type SubagentToolFailure<Failure extends Schema.Top> = Schema.Union<
 >;
 
 /**
+ * Resolution for expected delegation failures (SUB-033, ADR-0019 S2).
+ * `"error"` (the default) keeps today's semantics: every expected failure
+ * travels the Effect error channel and fails the parent Tool batch (D-008).
+ * `"return"` contains them: the declared child failure and the framework
+ * failure family become model-visible result data instead of parent-fatal
+ * errors, so one dead child cannot detonate the whole parent Run.
+ *
+ * Effect AI's native `failureMode: "return"` is deliberately NOT used: its
+ * `Stream.catch` converts every handler failure into a result, which would
+ * encode the engine-owned `ToolCallWaiting` suspension signal as data and
+ * silently orphan a durable child. Containment therefore lives in the
+ * delegation handler — the underlying Tool keeps Effect AI
+ * `failureMode: "error"`, the Tool success Schema widens to a union of the
+ * declared success and the contained failure family, and exactly
+ * `ToolCallWaiting` and `SubagentDurabilityError` stay in the error channel,
+ * preserving durable suspension semantics by construction.
+ */
+export type SubagentFailureMode = "error" | "return";
+
+/**
+ * The failure family that becomes model-visible result data under
+ * `failureMode: "return"`: the author-declared failure plus every expected
+ * framework delegation failure. The engine-signal members are excluded by
+ * construction.
+ */
+export type SubagentContainedFailure<Failure extends Schema.Top> = Schema.Union<
+  readonly [
+    Failure,
+    typeof SubagentPrestartDenied,
+    typeof SubagentBudgetExhausted,
+    typeof SubagentProjectionFailure,
+    typeof SubagentExecutionFailure,
+  ]
+>;
+
+/**
+ * The only failures a `"return"`-mode delegation Tool can raise: the
+ * engine-owned waiting signal (consumed by the batch executor, never a Tool
+ * failure) and the durable coordinator-seam error. Neither ever reaches an
+ * ephemeral caller.
+ */
+export type SubagentReturnModeFailure = Schema.Union<
+  readonly [typeof ToolCallWaiting, typeof SubagentDurabilityError]
+>;
+
+/**
  * The native Effect AI Tool created by `Subagent.define` (SUB-001, SUB-003).
  * Its per-call dependencies are exactly the engine-provided `AgentSpawner`,
  * `RunEventSink`, and `SubagentDurability` plus `IdGenerator`; every child
@@ -258,16 +304,28 @@ export type SubagentTool<
   Parameters extends Schema.Top,
   Success extends Schema.Top,
   Failure extends Schema.Top,
-> = Tool.Tool<
-  Name,
-  {
-    readonly parameters: Parameters;
-    readonly success: Success;
-    readonly failure: SubagentToolFailure<Failure>;
-    readonly failureMode: "error";
-  },
-  AgentSpawner | RunEventSink | SubagentDurability | IdGenerator
->;
+  Mode extends SubagentFailureMode = "error",
+> = Mode extends "return"
+  ? Tool.Tool<
+      Name,
+      {
+        readonly parameters: Parameters;
+        readonly success: Schema.Union<readonly [Success, SubagentContainedFailure<Failure>]>;
+        readonly failure: SubagentReturnModeFailure;
+        readonly failureMode: "error";
+      },
+      AgentSpawner | RunEventSink | SubagentDurability | IdGenerator
+    >
+  : Tool.Tool<
+      Name,
+      {
+        readonly parameters: Parameters;
+        readonly success: Success;
+        readonly failure: SubagentToolFailure<Failure>;
+        readonly failureMode: "error";
+      },
+      AgentSpawner | RunEventSink | SubagentDurability | IdGenerator
+    >;
 
 /** Singleton Tool record provided by one `SubagentRuntime.layer`. */
 export type SubagentTools<
@@ -275,8 +333,9 @@ export type SubagentTools<
   Parameters extends Schema.Top,
   Success extends Schema.Top,
   Failure extends Schema.Top,
+  Mode extends SubagentFailureMode = "error",
 > = {
-  readonly [Key in Name]: SubagentTool<Name, Parameters, Success, Failure>;
+  readonly [Key in Name]: SubagentTool<Name, Parameters, Success, Failure, Mode>;
 };
 
 /** Options accepted by `Subagent.define`. */
@@ -290,7 +349,15 @@ export interface SubagentDefineOptions<
   Failure extends Schema.Top,
   PrepareRequirements = never,
   ProjectRequirements = never,
+  Mode extends SubagentFailureMode = "error",
 > {
+  /**
+   * Expected-failure resolution (SUB-033): `"error"` (default) fails the
+   * parent Tool batch; `"return"` contains the declared failure and the
+   * framework failure family as model-visible result data while
+   * `ToolCallWaiting`/`SubagentDurabilityError` stay in the error channel.
+   */
+  readonly failureMode?: Mode;
   /** Model-visible description of the delegated capability. */
   readonly description: string;
   /** The model-agnostic child Agent Definition this delegation targets (SUB-002). */
@@ -357,6 +424,7 @@ export interface SubagentDelegation<
   Failure extends Schema.Top,
   PrepareRequirements = never,
   ProjectRequirements = never,
+  Mode extends SubagentFailureMode = "error",
 > extends SubagentDefineOptions<
   TargetInput,
   TargetOutput,
@@ -366,14 +434,17 @@ export interface SubagentDelegation<
   Success,
   Failure,
   PrepareRequirements,
-  ProjectRequirements
+  ProjectRequirements,
+  Mode
 > {
   readonly name: Name;
   /** Stable delegation identity; S1 derives it from the unique Tool name. */
   readonly delegationId: DelegationId;
   readonly grant: SubagentGrant;
+  /** The resolved expected-failure resolution (SUB-033); never absent after `define`. */
+  readonly failureMode: Mode;
   /** The real Effect AI Tool to include in the parent Toolkit (SUB-001). */
-  readonly tool: SubagentTool<Name, Parameters, Success, Failure>;
+  readonly tool: SubagentTool<Name, Parameters, Success, Failure, Mode>;
 }
 
 /**
@@ -396,6 +467,7 @@ const define = <
   Failure extends Schema.Top,
   PrepareRequirements = never,
   ProjectRequirements = never,
+  Mode extends SubagentFailureMode = "error",
 >(
   name: Name,
   options: SubagentDefineOptions<
@@ -407,7 +479,8 @@ const define = <
     Success,
     Failure,
     PrepareRequirements,
-    ProjectRequirements
+    ProjectRequirements,
+    Mode
   >,
 ): SubagentDelegation<
   Name,
@@ -419,7 +492,8 @@ const define = <
   Success,
   Failure,
   PrepareRequirements,
-  ProjectRequirements
+  ProjectRequirements,
+  Mode
 > => {
   decodeDelegationToolName(name);
   for (const childToolName of Object.keys(options.target.toolkit.tools)) {
@@ -436,7 +510,31 @@ const define = <
       allowedToolNames: Object.keys(options.target.toolkit.tools),
       maxDepth: 1,
     });
-  const tool = Tool.make(name, {
+  // `Mode` defaults to `"error"` exactly when `failureMode` is absent, so the
+  // resolved literal always inhabits `Mode`; the assertion bridges only that
+  // inference gap and crosses no schema boundary.
+  const failureMode = (options.failureMode ?? "error") as Mode;
+  const returnModeTool = Tool.make(name, {
+    description: options.description,
+    parameters: options.parameters,
+    // Containment (SUB-033): the contained failure family is model-visible
+    // RESULT data, so it lives in the success union; only the engine-signal
+    // members remain raisable. The underlying Effect AI failureMode stays
+    // "error" so the waiting signal is never encoded as a result.
+    success: Schema.Union([
+      options.success,
+      Schema.Union([
+        options.failure,
+        SubagentPrestartDenied,
+        SubagentBudgetExhausted,
+        SubagentProjectionFailure,
+        SubagentExecutionFailure,
+      ]),
+    ]),
+    failure: Schema.Union([ToolCallWaiting, SubagentDurabilityError]),
+    needsApproval: options.needsApproval,
+  });
+  const errorModeTool = Tool.make(name, {
     description: options.description,
     parameters: options.parameters,
     success: options.success,
@@ -450,16 +548,28 @@ const define = <
       SubagentDurabilityError,
     ]),
     needsApproval: options.needsApproval,
-  })
+  });
+  // Each branch is exactly `SubagentTool<..., Mode>` at its concrete `Mode`;
+  // TypeScript cannot relate a runtime branch to the conditional generic, so
+  // this assertion bridges only that limitation and crosses no schema
+  // boundary (the schemas above are constructed per mode, never reinterpreted).
+  const tool = (failureMode === "return" ? returnModeTool : errorModeTool)
     .addDependency(AgentSpawner)
     .addDependency(RunEventSink)
     .addDependency(SubagentDurability)
-    .addDependency(IdGenerator);
+    .addDependency(IdGenerator) as unknown as SubagentTool<
+    Name,
+    Parameters,
+    Success,
+    Failure,
+    Mode
+  >;
   return Object.freeze({
     ...options,
     name,
     delegationId,
     grant,
+    failureMode,
     tool,
   });
 };
@@ -813,13 +923,16 @@ type SubagentHandler<
   Parameters extends Schema.Top,
   Success extends Schema.Top,
   Failure extends Schema.Top,
+  Mode extends SubagentFailureMode = "error",
 > = (
   parameters: Parameters["Type"],
-  context: Toolkit.HandlerContext<SubagentTool<Name, Parameters, Success, Failure>>,
+  context: Toolkit.HandlerContext<SubagentTool<Name, Parameters, Success, Failure, Mode>>,
 ) => Effect.Effect<
-  Success["Type"],
-  SubagentToolFailure<Failure>["Type"],
-  Tool.HandlerServices<SubagentTool<Name, Parameters, Success, Failure>>
+  Mode extends "return"
+    ? Success["Type"] | SubagentContainedFailure<Failure>["Type"]
+    : Success["Type"],
+  Mode extends "return" ? SubagentReturnModeFailure["Type"] : SubagentToolFailure<Failure>["Type"],
+  Tool.HandlerServices<SubagentTool<Name, Parameters, Success, Failure, Mode>>
 >;
 
 /**
@@ -861,6 +974,7 @@ const layer = <
   ModelProvides,
   ModelRequires,
   HookRequirements = never,
+  Mode extends SubagentFailureMode = "error",
   InstructionError = InstructionErrorOf<TargetInstructions, TargetInput["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<TargetInstructions, TargetInput["Type"]>,
 >(
@@ -874,7 +988,8 @@ const layer = <
     Success,
     Failure,
     PrepareRequirements,
-    ProjectRequirements
+    ProjectRequirements,
+    Mode
   >,
   childBinding: RuntimeBinding<
     TargetInput,
@@ -903,7 +1018,7 @@ const layer = <
     HookRequirements
   >,
 ): Layer.Layer<
-  Tool.HandlersFor<SubagentTools<Name, Parameters, Success, Failure>>,
+  Tool.HandlersFor<SubagentTools<Name, Parameters, Success, Failure, Mode>>,
   never,
   SubagentLayerRequirements<
     TargetInput,
@@ -926,9 +1041,15 @@ const layer = <
   // generic (it degrades to a string index signature); at every concrete
   // `Name` the two records are identical, so this assertion bridges only that
   // compiler limitation and crosses no schema boundary.
-  const toolkit = Toolkit.make(delegation.tool) as unknown as Toolkit.Toolkit<
-    SubagentTools<Name, Parameters, Success, Failure>
+  const toolkit = Toolkit.make(delegation.tool as Tool.Any) as unknown as Toolkit.Toolkit<
+    SubagentTools<Name, Parameters, Success, Failure, Mode>
   >;
+  // Containment (SUB-033): under `failureMode: "return"` every expected
+  // delegation failure becomes the handler's SUCCESS value (the Tool success
+  // Schema is the union of the declared success and the contained family);
+  // exactly the engine signals stay raisable, so the durable waiting
+  // suspension and coordinator-seam errors keep their semantics.
+  const contained = delegation.failureMode === "return";
   const encodeChildInput = Schema.encodeEffect(delegation.target.input);
   const encodeSuccess = Schema.encodeEffect(delegation.success);
   const decodeChildOutput = Schema.decodeUnknownEffect(delegation.target.output);
@@ -1017,7 +1138,9 @@ const layer = <
 
     const invoke = Effect.fn(`SubagentRuntime.${delegation.name}`)(function* (
       parameters: Parameters["Type"],
-      handlerContext: Toolkit.HandlerContext<SubagentTool<Name, Parameters, Success, Failure>>,
+      handlerContext: Toolkit.HandlerContext<
+        SubagentTool<Name, Parameters, Success, Failure, Mode>
+      >,
     ) {
       const spawner = yield* AgentSpawner;
       const sink = yield* RunEventSink;
@@ -1269,7 +1392,9 @@ const layer = <
      */
     const invokeDurable = Effect.fn(`SubagentRuntime.${delegation.name}.durable`)(function* (
       parameters: Parameters["Type"],
-      handlerContext: Toolkit.HandlerContext<SubagentTool<Name, Parameters, Success, Failure>>,
+      handlerContext: Toolkit.HandlerContext<
+        SubagentTool<Name, Parameters, Success, Failure, Mode>
+      >,
       durability: SubagentDurabilityDurable,
     ) {
       const spawner = yield* AgentSpawner;
@@ -1398,7 +1523,14 @@ const layer = <
                 durability.join({
                   toolCallId,
                   encodedResult: encodedFailure,
-                  isFailure: true,
+                  // Canonical history must record exactly what the live batch
+                  // continues with (SUB-019): under containment the failure is
+                  // the call's model-visible RESULT (the dispatch wrapper
+                  // converts the fail below into a success), so the joined
+                  // settlement records it as a non-failure result; the child's
+                  // own failed Settlement and the `SubagentFailed` event stay
+                  // the honest failure record.
+                  isFailure: !contained,
                   encodedAccounting: conservativeAccounting,
                 }),
               ),
@@ -1487,9 +1619,25 @@ const layer = <
       }
     });
 
-    const handler: SubagentHandler<Name, Parameters, Success, Failure> = (
-      parameters,
-      handlerContext,
+    // Containment boundary (SUB-033): under `"return"`, every expected
+    // delegation failure becomes the handler's success value; exactly the
+    // engine signals re-fail. `instanceof` against the exact engine classes is
+    // identity-safe — an author-declared failure can never alias them.
+    const containSignals = (
+      failure: SubagentToolFailure<Failure>["Type"],
+    ): Effect.Effect<
+      SubagentContainedFailure<Failure>["Type"],
+      ToolCallWaiting | SubagentDurabilityError
+    > =>
+      failure instanceof ToolCallWaiting || failure instanceof SubagentDurabilityError
+        ? Effect.fail(failure)
+        : Effect.succeed(failure);
+
+    const handlerImpl = (
+      parameters: Parameters["Type"],
+      handlerContext: Toolkit.HandlerContext<
+        SubagentTool<Name, Parameters, Success, Failure, Mode>
+      >,
     ) =>
       Effect.gen(function* () {
         // Resolve the engine-provided per-call services before providing the
@@ -1505,29 +1653,39 @@ const layer = <
         // mode explicitly when no durable coordinator supplied the hook, so
         // absence keeps the S1 in-process spawn semantics honestly.
         if (durability.mode === "durable") {
-          return yield* invokeDurable(parameters, handlerContext, durability).pipe(
+          const durable = invokeDurable(parameters, handlerContext, durability).pipe(
             Effect.scoped,
             Effect.provideService(AgentSpawner, spawner),
             Effect.provideService(RunEventSink, sink),
             Effect.provideService(SubagentDurability, durability),
             Effect.provide(captured),
           );
+          return yield* contained ? durable.pipe(Effect.catch(containSignals)) : durable;
         }
-        return yield* invoke(parameters, handlerContext).pipe(
+        const ephemeral = invoke(parameters, handlerContext).pipe(
           Effect.scoped,
           Effect.provideService(AgentSpawner, spawner),
           Effect.provideService(RunEventSink, sink),
           Effect.provideService(SubagentDurability, durability),
           Effect.provide(captured),
         );
+        return yield* contained ? ephemeral.pipe(Effect.catch(containSignals)) : ephemeral;
       });
+
+    // `handlerImpl`'s channels are the UNION of both modes because
+    // `contained` is a runtime branch TypeScript cannot relate to the
+    // conditional generic `Mode`; at every concrete `Mode` the branch taken
+    // matches `SubagentHandler`'s channels exactly (proven by the mode type
+    // tests), so this assertion bridges only that limitation and crosses no
+    // schema boundary.
+    const handler = handlerImpl as SubagentHandler<Name, Parameters, Success, Failure, Mode>;
 
     // TypeScript cannot relate a computed single-key object literal to the
     // generic mapped key `Name`; `handler` is fully checked against the
     // Tool's declared handler signature above, so this assertion bridges only
     // that compiler limitation and crosses no schema boundary.
     return { [delegation.name]: handler } as Toolkit.HandlersFrom<
-      SubagentTools<Name, Parameters, Success, Failure>
+      SubagentTools<Name, Parameters, Success, Failure, Mode>
     >;
   });
 

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -1972,3 +1972,285 @@ describe("Subagent type proofs", () => {
     expect(unboundDefinitionRejected).toBeInstanceOf(Function);
   });
 });
+
+// ---------------------------------------------------------------------------
+// SUB-033 containment: `failureMode: "return"` turns expected delegation
+// failures into model-visible result data; only the engine signals
+// (`ToolCallWaiting`, `SubagentDurabilityError`) stay in the error channel.
+// ---------------------------------------------------------------------------
+
+const containedDelegation = Subagent.define("delegate_contained", {
+  description: "Research one bounded question; failures are contained result data.",
+  target: childDefinition,
+  parameters: ResearchParams,
+  success: ResearchFindings,
+  failure: ResearchDelegationFailed,
+  failureMode: "return",
+  prepareInput: ({ topic }) => Effect.succeed({ question: `research:${topic}` }),
+  projectResult: (output) => Effect.succeed({ summary: `finding:${output.answer}` }),
+  policy: researchPolicy,
+});
+
+const containedCoordinator = Agent.define("contained-coordinator", {
+  input: Schema.Struct({ mission: Schema.String }),
+  output: Schema.Struct({ report: Schema.String }),
+  instructions: "Delegate, then answer as JSON.",
+  toolkit: Toolkit.make(containedDelegation.tool),
+  policy: parentPolicy,
+});
+
+const containedLayer = <Provider, ModelProvides, ModelRequires>(
+  childBinding: RuntimeBinding<
+    typeof ChildInput,
+    typeof ChildOutput,
+    string,
+    {},
+    Provider,
+    ModelProvides,
+    ModelRequires
+  >,
+) => SubagentRuntime.layer(containedDelegation, childBinding, { mapChildFailure });
+
+const containedDurableLayer = (invocations: Ref.Ref<number>) =>
+  SubagentRuntime.layer(containedDelegation, countingChildBinding(invocations), {
+    mapChildFailure,
+    durable: { targetDigests: durableDigests },
+  });
+
+const containedParent = (name: string, topic: string, answer = '{"report":"handled"}') =>
+  Agent.withModel(
+    containedCoordinator,
+    delegatingModel(name, "delegate_contained", [{ id: "call-1", params: { topic } }], answer),
+  );
+
+layer(TestServices)("SubagentRuntime SUB-033 contained failure mode", (it) => {
+  it.effect("SUB-033 contains an expected child failure as the model-visible Tool result", () =>
+    Effect.gen(function* () {
+      const childBinding = Agent.withModel(
+        childDefinition,
+        answeringModel("contained-child-invalid", "not-json"),
+      );
+      const runId = decodeRunId("parent-run-contained-failure");
+
+      const detached = yield* AgentRuntime.start(
+        containedParent("parent-contained-failure", "berlin"),
+        { mission: "m" },
+        { runId },
+      ).pipe(Effect.provide(containedLayer(childBinding)));
+      const result = yield* detached.await;
+      const events = yield* detached.events;
+
+      // The parent Run COMPLETES: the child failure is the delegation call's
+      // result data, never a Tool batch failure.
+      expect(result.output).toEqual({ report: "handled" });
+      expect(events.some((event) => event._tag === "ToolCallFailed")).toBe(false);
+      expect(events.some((event) => event._tag === "RunFailed")).toBe(false);
+      expect(findEvent(events, "ToolCallSucceeded")).toMatchObject({
+        result: { _tag: "ResearchDelegationFailed", childErrorTag: "AgentOutputError" },
+      });
+      // The child failure stays honestly visible in the Subagent lifecycle.
+      expect(findEvent(events, "SubagentFailed")).toMatchObject({
+        errorTag: "AgentOutputError",
+      });
+      expect(findEvent(events, "SubagentJoined")).toBeUndefined();
+
+      const reservations = yield* SubagentReservations;
+      const snapshot = yield* reservations.parentSnapshot(runId);
+      expectSettledOnce(snapshot.reservations[0]);
+    }),
+  );
+
+  it.effect("SUB-033 contains parent-side budget exhaustion as result data", () =>
+    Effect.gen(function* () {
+      // A delegation whose budget admits exactly one child: the second call in
+      // the same batch is contained as `SubagentBudgetExhausted` result data
+      // while the first joins normally.
+      const tightDelegation = Subagent.define("delegate_contained_tight", {
+        description: "Single-child contained delegation.",
+        target: childDefinition,
+        parameters: ResearchParams,
+        success: ResearchFindings,
+        failure: ResearchDelegationFailed,
+        failureMode: "return",
+        prepareInput: ({ topic }) => Effect.succeed({ question: `research:${topic}` }),
+        projectResult: (output) => Effect.succeed({ summary: `finding:${output.answer}` }),
+        policy: SubagentPolicy.make({
+          maxChildren: 1,
+          maxConcurrency: 1,
+          maxTurns: 4,
+          maxToolCalls: 4,
+          maxDuration: "10 seconds",
+        }),
+      });
+      const tightCoordinator = Agent.define("contained-tight-coordinator", {
+        input: Schema.Struct({ mission: Schema.String }),
+        output: Schema.Struct({ report: Schema.String }),
+        instructions: "Delegate twice, then answer as JSON.",
+        toolkit: Toolkit.make(tightDelegation.tool),
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 2,
+          maxDuration: "30 seconds",
+          // Sequential batch: call-1 deterministically reserves the only slot.
+          toolConcurrency: 1,
+        }),
+      });
+      const childBinding = Agent.withModel(
+        childDefinition,
+        answeringModel("contained-tight-child", '{"answer":"one"}'),
+      );
+      const parent = Agent.withModel(
+        tightCoordinator,
+        delegatingModel(
+          "parent-contained-tight",
+          "delegate_contained_tight",
+          [
+            { id: "call-1", params: { topic: "first" } },
+            { id: "call-2", params: { topic: "second" } },
+          ],
+          '{"report":"partial"}',
+        ),
+      );
+      const runId = decodeRunId("parent-run-contained-tight");
+
+      const detached = yield* AgentRuntime.start(parent, { mission: "m" }, { runId }).pipe(
+        Effect.provide(SubagentRuntime.layer(tightDelegation, childBinding, { mapChildFailure })),
+      );
+      const result = yield* detached.await;
+      const events = yield* detached.events;
+
+      expect(result.output).toEqual({ report: "partial" });
+      const succeeded = events.filter((event) => event._tag === "ToolCallSucceeded");
+      expect(succeeded).toHaveLength(2);
+      expect(succeeded[0]).toMatchObject({ result: { summary: "finding:one" } });
+      expect(succeeded[1]).toMatchObject({
+        result: { _tag: "SubagentBudgetExhausted", dimension: "total-child-invocations" },
+      });
+      expect(events.some((event) => event._tag === "ToolCallFailed")).toBe(false);
+    }),
+  );
+
+  it.effect("SUB-033 the waiting signal still suspends the Run under return mode", () =>
+    Effect.gen(function* () {
+      const invocations = yield* Ref.make(0);
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const child = durableChildIdentity("contained-waiting");
+      const subagent = scriptedDurableHook({ establish: () => ({ _tag: "waiting", ...child }) });
+      const runId = decodeRunId("parent-run-contained-waiting");
+
+      const exit = yield* AgentRuntime.stream(
+        containedParent("parent-contained-waiting", "waiting"),
+        { mission: "m" },
+        { runId, subagent },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(containedDurableLayer(invocations)),
+        Effect.exit,
+      );
+
+      // Containment must NEVER encode the engine-owned waiting signal as a
+      // model-visible result: the call stays open and the Run suspends.
+      const failure = failureFrom(exit);
+      expect(failure).toBeInstanceOf(AgentChildPending);
+      expect(yield* Ref.get(invocations)).toBe(0);
+      const observed = yield* Ref.get(events);
+      expect(observed.some((event) => event._tag === "ToolCallSucceeded")).toBe(false);
+      expect(observed.some((event) => event._tag === "ToolCallFailed")).toBe(false);
+      expect(observed.at(-1)?._tag).toBe("RunSuspended");
+    }),
+  );
+
+  it.effect("SUB-033 a settled failed durable child joins as a non-failure contained result", () =>
+    Effect.gen(function* () {
+      const invocations = yield* Ref.make(0);
+      const joins = yield* Ref.make<ReadonlyArray<RunSubagentJoinRequest>>([]);
+      const child = durableChildIdentity("contained-failed");
+      const subagent = scriptedDurableHook({
+        establish: () => ({
+          _tag: "settled",
+          ...child,
+          outcome: "failed",
+          encodedResult: { errorTag: "TravelPlanningFailed", message: "child failed typed" },
+        }),
+        joins,
+      });
+
+      const result = yield* AgentRuntime.run(
+        containedParent("parent-contained-durable-failed", "failed"),
+        { mission: "m" },
+        { runId: decodeRunId("parent-run-contained-durable-failed"), subagent },
+      ).pipe(Effect.provide(containedDurableLayer(invocations)), Effect.scoped);
+
+      // The parent Run completes: the bounded execution failure is the call's
+      // contained result.
+      expect(result.output).toEqual({ report: "handled" });
+      expect(yield* Ref.get(invocations)).toBe(0);
+
+      // Canonical coherence (SUB-019): the join records exactly what the live
+      // batch continues with — a NON-failure result carrying the bounded
+      // failure projection.
+      const recordedJoins = yield* Ref.get(joins);
+      expect(recordedJoins).toHaveLength(1);
+      expect(recordedJoins[0]).toMatchObject({
+        toolCallId: "call-1",
+        isFailure: false,
+        encodedAccounting: expectedConservativeAccounting,
+      });
+      expect(recordedJoins[0]?.encodedResult).toMatchObject({
+        _tag: "SubagentExecutionFailure",
+        classification: "child-failed",
+        errorTag: "TravelPlanningFailed",
+      });
+    }),
+  );
+
+  it("SUB-033 keeps the contained Tool channels typed (mode type proofs)", () => {
+    type ContainedTool = typeof containedDelegation.tool;
+    type ErrorTool = typeof researchDelegation.tool;
+
+    // Under "return" only the engine signals (plus Effect AI's own permitted
+    // error) remain raisable.
+    type ContainedHandlerErrorProof = Assert<
+      Equal<
+        Tool.HandlerError<ContainedTool>,
+        AiError.AiError | ToolCallWaiting | SubagentDurabilityError
+      >
+    >;
+    // The declared failure family is model-visible RESULT data.
+    type ContainedSuccessProof = Assert<
+      Equal<
+        Tool.Success<ContainedTool>,
+        | { readonly summary: string }
+        | ResearchDelegationFailed
+        | SubagentPrestartDenied
+        | SubagentBudgetExhausted
+        | SubagentProjectionFailure
+        | SubagentExecutionFailure
+      >
+    >;
+    // The default mode keeps today's full error-channel union.
+    type ErrorModeUnchangedProof = Assert<
+      Equal<
+        Tool.HandlerError<ErrorTool>,
+        | AiError.AiError
+        | ResearchDelegationFailed
+        | SubagentPrestartDenied
+        | SubagentBudgetExhausted
+        | SubagentProjectionFailure
+        | SubagentExecutionFailure
+        | ToolCallWaiting
+        | SubagentDurabilityError
+      >
+    >;
+
+    const containedHandlerErrorProof: ContainedHandlerErrorProof = true;
+    const containedSuccessProof: ContainedSuccessProof = true;
+    const errorModeUnchangedProof: ErrorModeUnchangedProof = true;
+    expect([
+      containedHandlerErrorProof,
+      containedSuccessProof,
+      errorModeUnchangedProof,
+    ]).not.toContain(false);
+  });
+});

--- a/packages/pr-review/src/internal/fan-out-scripted.ts
+++ b/packages/pr-review/src/internal/fan-out-scripted.ts
@@ -72,10 +72,16 @@ export type OfflineUnitOutcome =
   /** Read one diff, then return non-JSON — the child fails typed (AgentOutputError). */
   | { readonly _tag: "malformed-output" }
   /**
-   * Declare more Tool Calls than the child's AgentPolicy allows in one turn —
-   * the child fails typed (AgentPolicyError "tool-calls") before any executes.
+   * Declare more Tool Calls than the child's AgentPolicy allows in one turn.
+   * None executes; under the default `onExhaustion: "final-answer"` the child
+   * sees one synthetic failed result per rejected call and returns `report`
+   * on its final tool-free turn (RUN-018).
    */
-  | { readonly _tag: "budget-runaway"; readonly declaredCalls: number };
+  | {
+      readonly _tag: "budget-runaway";
+      readonly declaredCalls: number;
+      readonly report: FileReviewReport;
+    };
 
 export interface OfflineUnitScript {
   readonly unitId: string;
@@ -102,6 +108,13 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
       if (script === undefined) return undefined;
       switch (script.outcome._tag) {
         case "budget-runaway": {
+          // Turn 2: the rejected batch's synthetic results are in history, so
+          // the child soft-lands with its partial report.
+          if (promptJson.includes(`runaway-${script.unitId}-1`)) {
+            return scriptedFinalParts(
+              JSON.stringify(Schema.encodeSync(FileReviewReport)(script.outcome.report)),
+            );
+          }
           return scriptedToolTurn(
             ...Array.from(
               { length: script.outcome.declaredCalls },

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -2,19 +2,13 @@ import { Effect, Schema } from "effect";
 import {
   Agent,
   AgentPolicy,
-  AgentSpawner,
-  IdGenerator,
-  RunEventSink,
   Subagent,
   SubagentBudgetExhausted,
-  SubagentDurability,
-  SubagentDurabilityError,
   SubagentExecutionFailure,
   SubagentPolicy,
   SubagentPrestartDenied,
   SubagentProjectionFailure,
   SubagentRuntime,
-  ToolCallWaiting,
   ToolExecutionClass,
   type RuntimeBinding,
 } from "effect-agent";
@@ -148,10 +142,11 @@ export const defaultFileReviewerPolicy = AgentPolicy.make({
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200_000,
-  // S1 soft landing is not yet adopted here: the fan-out contract pins the
-  // typed "unit unreviewed" failure flow until the containment slice reworks
-  // it (planned S2/S3 of the budget arc).
-  onExhaustion: "fail",
+  // Budget soft landing (RUN-018): a child that exhausts its Turn or Tool
+  // Call budget returns its partial line-anchored report on one final
+  // tool-free turn instead of failing the unit — the standing "unit-00N
+  // unreviewed: AgentPolicyError" failure mode on big units.
+  onExhaustion: "final-answer",
 });
 
 // ---------------------------------------------------------------------------
@@ -223,44 +218,20 @@ export const mapFileReviewChildFailure = (failure: {
     message: (failure.message ?? "").slice(0, 400),
   });
 
-// ---------------------------------------------------------------------------
-// The parent-facing view of the delegation Tool.
-//
-// `Subagent.define` fixes `failureMode: "error"`, so a failed child would
-// fail the WHOLE parent Run typed — one unreviewable unit would abort the
-// entire fan-out review. This coordinator wants partial results with honest
-// reporting instead, so its Toolkit carries a same-name Tool value with the
-// identical parameter/success/failure Schemas but `failureMode: "return"`:
-// Effect AI resolves handlers by Tool NAME, so the real S1 delegation handler
-// from `SubagentRuntime.layer` still executes, and a typed unit failure
-// reaches the model as a failed tool result (bounded, encoded through the
-// declared failure union) instead of aborting the Run.
-// ---------------------------------------------------------------------------
-
-/** Exactly the failure union `Subagent.define` declares for this delegation. */
+/**
+ * The contained failure family this delegation can surface as result data
+ * under the first-party `failureMode: "return"` (SUB-033). The engine-signal
+ * members (`ToolCallWaiting`, `SubagentDurabilityError`) are deliberately not
+ * here: they stay in the error channel by construction. Used by the coverage
+ * gate to classify returned unit failures.
+ */
 export const FileReviewDelegationFailure = Schema.Union([
   FileReviewUnitFailed,
   SubagentPrestartDenied,
   SubagentBudgetExhausted,
   SubagentProjectionFailure,
   SubagentExecutionFailure,
-  ToolCallWaiting,
-  SubagentDurabilityError,
 ]);
-
-export const DelegateFileReview = Tool.make("delegate_file_review", {
-  description: delegationDescription,
-  parameters: FileReviewRequest,
-  success: FileReviewUnitResult,
-  failure: FileReviewDelegationFailure,
-  failureMode: "return",
-})
-  .addDependency(AgentSpawner)
-  .addDependency(RunEventSink)
-  .addDependency(SubagentDurability)
-  .addDependency(IdGenerator)
-  // The delegated child's whole tool surface is read-only.
-  .annotate(ToolExecutionClass, "readonly");
 
 // ---------------------------------------------------------------------------
 // The coordinator's own tool: the deterministic unit plan over the changeset.
@@ -303,8 +274,6 @@ export const FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
 // apply unchanged.
 // ---------------------------------------------------------------------------
 
-export const FanOutReviewToolkit = Toolkit.make(ListReviewUnits, DelegateFileReview);
-
 /**
  * Build the coordinator's instructions. The same consumer guidance the
  * children receive is injected between the mission framing and the procedure
@@ -341,13 +310,14 @@ export const defaultFanOutPolicy = AgentPolicy.make({
   maxToolCalls: 1 + MAX_REVIEW_UNITS,
   maxDuration: "15 minutes",
   toolConcurrency: 3,
-  // One declared batch may legitimately contain a failed result for every
-  // review unit. Leave the coordinator one turn to report all of them, while
-  // still stopping a model that declares another failed delegation.
-  repeatedFailureLimit: MAX_REVIEW_UNITS + 1,
+  // Contained unit failures (SUB-033) are ordinary successful Tool results,
+  // so they no longer fold into the repeated-failure counter; the default
+  // bound suffices.
+  repeatedFailureLimit: 3,
   tokenBudget: 300_000,
-  // See defaultFileReviewerPolicy: soft-landing adoption is the S2/S3 rework.
-  onExhaustion: "fail",
+  // Budget soft landing (RUN-018): an exhausted coordinator merges what it
+  // has into one best-effort review instead of discarding every child report.
+  onExhaustion: "final-answer",
 });
 
 /** Everything one fan-out configuration is made of, built as one unit so the
@@ -375,18 +345,6 @@ export interface FanOutSuiteOptions extends FanOutInstructionOptions {
   readonly maxFindings?: number | undefined;
 }
 
-const makeFanOutReviewerDefinition = (options: FanOutSuiteOptions = {}) =>
-  Agent.define("pr-fanout-reviewer", {
-    input: ReviewMission,
-    output: CodeReview,
-    instructions: makeFanOutReviewInstructions(options),
-    toolkit: FanOutReviewToolkit,
-    policy: defaultFanOutPolicy,
-    description:
-      "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
-    metadata: { deploymentClass: "E", surface: "read-only", delegation: "S1-attached" },
-  });
-
 const makeFileReviewDelegation = (child: ReturnType<typeof makeFileReviewerDefinition>) =>
   Subagent.define("delegate_file_review", {
     description: delegationDescription,
@@ -394,6 +352,11 @@ const makeFileReviewDelegation = (child: ReturnType<typeof makeFileReviewerDefin
     parameters: FileReviewRequest,
     success: FileReviewUnitResult,
     failure: FileReviewUnitFailed,
+    // First-party containment (SUB-033): a failed unit is model-visible
+    // result data instead of a parent-Run-fatal error, so the coordinator
+    // reports it honestly and keeps reviewing the other units. This retires
+    // the former same-name shadow-Tool workaround (FRICTION #7).
+    failureMode: "return",
     prepareInput: (request) =>
       Effect.succeed(
         FileReviewBrief.make({
@@ -416,13 +379,38 @@ const makeFileReviewDelegation = (child: ReturnType<typeof makeFileReviewerDefin
     policy: fileReviewPolicy,
   });
 
+/**
+ * The coordinator-facing delegation Tool: the delegation's own first-party
+ * contained Tool plus the read-only execution class (the delegated child's
+ * whole tool surface is read-only). Effect AI resolves handlers by Tool name,
+ * so `SubagentRuntime.layer`'s handler serves this annotated copy unchanged.
+ */
+const delegationToolFor = (delegation: ReturnType<typeof makeFileReviewDelegation>) =>
+  delegation.tool.annotate(ToolExecutionClass, "readonly");
+
+const makeFanOutReviewerDefinition = (
+  options: FanOutSuiteOptions,
+  delegation: ReturnType<typeof makeFileReviewDelegation>,
+) =>
+  Agent.define("pr-fanout-reviewer", {
+    input: ReviewMission,
+    output: CodeReview,
+    instructions: makeFanOutReviewInstructions(options),
+    toolkit: Toolkit.make(ListReviewUnits, delegationToolFor(delegation)),
+    policy: defaultFanOutPolicy,
+    description:
+      "Coordinate one pull-request review by fanning bounded per-unit file reviews out to delegated children and merging their findings into one structured review.",
+    metadata: { deploymentClass: "E", surface: "read-only", delegation: "S1-attached" },
+  });
+
 /** Build one coherent fan-out suite: child, coordinator, and delegation. */
 export const makeFanOutReviewSuite = (options: FanOutSuiteOptions = {}): FanOutReviewSuite => {
   const child = makeFileReviewerDefinition({ guidance: options.guidance });
+  const delegation = makeFileReviewDelegation(child);
   return {
     child,
-    parent: makeFanOutReviewerDefinition(options),
-    delegation: makeFileReviewDelegation(child),
+    parent: makeFanOutReviewerDefinition(options, delegation),
+    delegation,
   };
 };
 
@@ -436,6 +424,12 @@ export const FanOutReviewer = defaultSuite.parent;
 
 /** The default delegation over the default child. */
 export const fileReviewDelegation = defaultSuite.delegation;
+
+/** The default coordinator-facing delegation Tool (first-party contained mode). */
+export const DelegateFileReview = delegationToolFor(fileReviewDelegation);
+
+/** The default coordinator Toolkit. */
+export const FanOutReviewToolkit = FanOutReviewer.toolkit;
 
 /** Runtime wiring: one delegation plus one explicit child Binding. */
 export const fanOutHandlersLayerFor =

--- a/packages/pr-review/src/internal/review-agent.ts
+++ b/packages/pr-review/src/internal/review-agent.ts
@@ -360,9 +360,9 @@ export const defaultReviewPolicy = AgentPolicy.make({
   maxDuration: "8 minutes",
   toolConcurrency: 2,
   tokenBudget: 300_000,
-  // Soft-landing adoption for the reviewer is the budget arc's S2/S3 rework;
-  // until then the reviewer keeps its typed exhaustion failure.
-  onExhaustion: "fail",
+  // Budget soft landing (RUN-018): an exhausted reviewer returns its partial
+  // review on one final tool-free turn instead of failing the whole run.
+  onExhaustion: "final-answer",
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -7,11 +7,13 @@ import {
   RunEventSink,
   SubagentBudgetExhausted,
   SubagentDurability,
+  SubagentDurabilityError,
   SubagentExecutionFailure,
   SubagentReservations,
   SubagentReservationsMemoryLive,
+  ToolCallWaiting,
 } from "effect-agent";
-import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
+import { type AiError, LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
 import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 
 import {
@@ -581,9 +583,11 @@ describe("offline fan-out review run", () => {
         "src/api/alpha.ts",
       ]);
       expect(result.outcome.coverage.status).toBe("incomplete");
+      // The contained failure carries the child error tag through the
+      // coverage classification (first-party return mode, SUB-033).
       expect(result.outcome.coverage.failedUnits).toContainEqual({
         unitId: "unit-002",
-        errorTag: "FileReviewUnitFailed",
+        errorTag: "FileReviewUnitFailed:AgentOutputError",
       });
     }),
   );
@@ -633,47 +637,52 @@ describe("offline fan-out review run", () => {
     }),
   );
 
-  it.effect("bounds a runaway child by its policy: typed failure, reported, never retried", () =>
-    Effect.gen(function* () {
-      const runawayChildren: ReadonlyArray<OfflineUnitScript> = [
-        happyChildren[0] as OfflineUnitScript,
-        {
-          unitId: "unit-002",
-          diffPath: "src/core/gamma.ts",
-          // One more declared call than the child AgentPolicy allows.
-          outcome: {
-            _tag: "budget-runaway",
-            declaredCalls: MAX_FILE_REVIEW_TOOL_CALLS + 1,
+  it.effect(
+    "RUN-018 a runaway child soft-lands: none of the over-budget calls execute and the unit completes with its partial report",
+    () =>
+      Effect.gen(function* () {
+        const runawayChildren: ReadonlyArray<OfflineUnitScript> = [
+          happyChildren[0] as OfflineUnitScript,
+          {
+            unitId: "unit-002",
+            diffPath: "src/core/gamma.ts",
+            // One more declared call than the child AgentPolicy allows: the
+            // whole batch is rejected without executing, and the child returns
+            // its partial report on the final tool-free turn.
+            outcome: {
+              _tag: "budget-runaway",
+              declaredCalls: MAX_FILE_REVIEW_TOOL_CALLS + 1,
+              report: unitTwoReport,
+            },
           },
-        },
-      ];
-      const honestReview = CodeReview.make({
-        summary: "unit-002 unreviewed: AgentPolicyError (exceeded its Tool Call budget).",
-        verdict: "comment",
-        findings: rankAndDedupeFindings([...unitOneReport.findings]),
-      });
+        ];
+        const mergedReview = CodeReview.make({
+          summary: "Reviewed unit-001 and unit-002 (unit-002 on a partial, budget-exhausted pass).",
+          verdict: "comment",
+          findings: rankAndDedupeFindings([...unitOneReport.findings, ...unitTwoReport.findings]),
+        });
 
-      const result = yield* runOfflineFanOut({ children: runawayChildren, review: honestReview });
+        const result = yield* runOfflineFanOut({ children: runawayChildren, review: mergedReview });
 
-      // The child failed typed on its Tool Call bound BEFORE any of the
-      // runaway calls executed: one model call, no second chance.
-      expect(result.childCalls).toBe(3);
-      expect(result.coordinatorCalls).toBe(3);
+        // Two child model calls: the rejected over-budget turn and the final
+        // answer — no third chance, and no handler ran for any runaway call.
+        expect(result.childCalls).toBe(4);
+        expect(result.coordinatorCalls).toBe(3);
 
-      // The typed policy failure crossed the delegation boundary bounded and
-      // was reported, not retried.
-      const finalPrompt = result.coordinatorPrompts[2] ?? "";
-      expect(finalPrompt).toContain("FileReviewUnitFailed");
-      expect(finalPrompt).toContain("AgentPolicyError");
-      expect(finalPrompt).toContain(`${MAX_FILE_REVIEW_TOOL_CALLS} Tool Call limit`);
-      expect(result.outcome.review.summary).toContain("unit-002 unreviewed: AgentPolicyError");
-      expect(result.published).toHaveLength(1);
-      expect(result.outcome.coverage.status).toBe("incomplete");
-      expect(result.outcome.coverage.failedUnits).toContainEqual({
-        unitId: "unit-002",
-        errorTag: "FileReviewUnitFailed",
-      });
-    }),
+        // The child saw the synthetic policy rejection as failed tool results
+        // and answered from what it had.
+        const runawayPrompt =
+          result.childPrompts.find((prompt) => prompt.includes("runaway-unit-002-1")) ?? "";
+        expect(runawayPrompt).toContain("Tool Call budget exhausted");
+
+        // The unit COMPLETED: findings from both units, no failed units, and
+        // nothing retried. (Coverage stays "incomplete" only for the fixture's
+        // undiffable binary, exactly like the fully-happy run.)
+        expect(result.outcome.review).toEqual(mergedReview);
+        expect(result.published).toHaveLength(1);
+        expect(result.outcome.coverage.failedUnits).toEqual([]);
+        expect(result.outcome.coverage.unreviewedPaths).toEqual(["assets/logo.png"]);
+      }),
   );
 });
 
@@ -711,10 +720,14 @@ type FanOutProgramFailure = EffectError<typeof typedFanOutProgram>;
 type FanOutProgramServices = Effect.Services<typeof typedFanOutProgram>;
 type DelegateHandlerError = Tool.HandlerError<typeof DelegateFileReview>;
 
-// The parent-facing Tool contains failures: nothing reaches the Run's `E`
-// through it (failureMode "return"), so one failed unit cannot abort the
+// The first-party contained delegation Tool (SUB-033): every expected unit
+// failure is result data, so only the engine signals — the durable waiting
+// suspension and coordinator-seam error, neither of which can occur on this
+// class-E path — remain in the Run's `E`; one failed unit cannot abort the
 // fan-out review.
-type ContainedHandlerErrorProof = Assert<Equal<DelegateHandlerError, never>>;
+type ContainedHandlerErrorProof = Assert<
+  Equal<DelegateHandlerError, AiError.AiError | ToolCallWaiting | SubagentDurabilityError>
+>;
 type ContainedUnitFailureProof = Assert<
   Equal<Extract<FanOutProgramFailure, FileReviewUnitFailed>, never>
 >;


### PR DESCRIPTION
## Summary

- `Subagent.define` gains [`failureMode: "error" | "return"`](../blob/dan/budget-containment/packages/capabilities/src/subagent.ts) (default `"error"`, today's semantics). Under `"return"`, every **expected** delegation failure — the author-declared child failure plus `SubagentPrestartDenied`, `SubagentBudgetExhausted`, `SubagentProjectionFailure`, and `SubagentExecutionFailure` — becomes model-visible **result data** instead of a parent-Run-fatal error: one dead scout can no longer detonate a whole fan-out. This is slice S2 of the budget arc (D-037, [ADR-0019](../blob/dan/budget-containment/docs/adr/0019-budget-soft-landing-and-extension.md), requirement SUB-033), closing recorded FRICTION #7.
- pr-review retires its same-name shadow-Tool workaround for the first-party option, adopts the S1 `final-answer` soft landing in all three default reviewer policies, and reverts the fan-out `repeatedFailureLimit` sizing hack. This is the fix for the reviewer's standing failure mode — the dogfood "review" job has been failing on every recent PR with `ReviewGateFailed: unit-00N (FileReviewUnitFailed)` because fan-out children exhaust their tool-call budget on big units; with this PR children soft-land and return partial reports instead.

## Architecture

- **Why not Effect AI's native `failureMode: "return"`** (the sharpest constraint, discovered against the Toolkit source): its `Stream.catch` converts *every* handler failure into a result with no passthrough — including the engine-owned `ToolCallWaiting` suspension signal — which would encode a durable child's waiting state as data and silently orphan it. The [containment therefore lives in the delegation handler](../blob/dan/budget-containment/packages/capabilities/src/subagent.ts): the underlying Effect AI Tool keeps `failureMode: "error"`, the Tool **success** Schema widens to the union of the declared success and the contained failure family, and the dispatch site catches exactly that family — `ToolCallWaiting` and `SubagentDurabilityError` stay raisable, so durable suspension semantics hold **by construction** (proven by a test that a waiting child still suspends the Run under `"return"`).
- **Canonical coherence (SUB-019)**: on the durable path, the settlement join records the contained failure with `isFailure: false` — the same polarity the live batch continues with — so replay reconstructs exactly what the model saw. The child's own failed Settlement and the `SubagentFailed` live event remain the honest failure record.
- **Typing**: a `Mode` type parameter threads through `SubagentTool`/`SubagentDefineOptions`/`SubagentDelegation`/`SubagentRuntime.layer` with default `"error"`, so every existing declaration compiles unchanged. Under `"return"` the tool's `HandlerError` is exactly `AiError | ToolCallWaiting | SubagentDurabilityError` (mode type proofs pin both modes); consumers' parent-Run `E` no longer carries child failures.
- **pr-review**: the [shadow-Tool block](../blob/dan/budget-containment/packages/pr-review/src/internal/fan-out.ts) is replaced by the delegation's own tool plus the read-only execution-class annotation; contained unit failures reach coverage classification with richer `FileReviewUnitFailed:<childErrorTag>` tags; the offline runaway-child fixture now scripts the full S1+S2 story (over-budget batch rejected without executing → child returns its partial report → unit completes).

## Evidence

- New SUB-033 suite (`packages/capabilities/test/subagent.test.ts`): contained child failure → parent Run **completes** with the failure as the tool result and `SubagentFailed` still emitted; contained parent-side budget exhaustion in a two-call batch; **the durable waiting signal still suspends the Run under `"return"`** (no encoded result, `RunSuspended`, zero in-process child invocations); a settled failed durable child joins `isFailure: false` with the bounded `SubagentExecutionFailure` as the recorded result; mode type proofs for both modes.
- Rewritten fan-out test: `RUN-018 a runaway child soft-lands` — a child declaring `MAX_FILE_REVIEW_TOOL_CALLS + 1` calls executes **zero** handlers, sees the synthetic "Tool Call budget exhausted" results, returns its partial report on the final tool-free turn, and the unit completes with **no failed units** in coverage.
- Full gates green: `bun run check`, all 19 test tasks, `requirements:coverage` (175 IDs, SUB-033 covered via test titles), committed action bundle rebuilt and `--check`-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
