### PR TITLE
chore: ignore generated .d.ts that leak into package src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ docs/.vitepress/dist
 .wrangler
 .dev-kit
 .repos
+# Generated declarations that leak into package src when a build follows a
+# cross-package relative source import (e.g. the C4 conformance worker). No
+# .d.ts under src is hand-written; source is always .ts.
+packages/*/src/**/*.d.ts


### PR DESCRIPTION
## Summary

A package build (`vp pack`) that follows a cross-package **relative source** import emits the imported module's declaration next to the source rather than into its own `dist/`. Concretely: the C4 conformance worker imports `../../../testing/src/code-executor-conformance.ts` by relative path — a deliberate workaround so the `@effect-agent/testing` barrel doesn't drag `node:sqlite` into workerd — so `platform-cloudflare`'s pack writes `packages/testing/src/code-executor-conformance.d.ts` on every build.

It's untracked, CI-clean, and functionally harmless, but it re-dirties `git status` after every build. No `.d.ts` under any package `src` is hand-written (source is always `.ts`), so ignoring generated `.d.ts` there is safe.

## Note

This hides the symptom. The root-cause fix — a `@effect-agent/testing/code-executor-conformance` subpath export so the worker imports a package specifier instead of relative source (which the declaration emitter wouldn't follow into `src`) — is left for a follow-up; it touches the testing package's export surface and must preserve the no-`node:sqlite`-in-workerd property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)