### PR TITLE
feat(engine,capabilities): budget extension — per-Run allowances and the re-delegation grant flow (D-037, ADR-0019 S3)

### DIFF
--- a/.changeset/budget-extension.md
+++ b/.changeset/budget-extension.md
@@ -16,4 +16,10 @@ child; never a mid-flight top-up). `projectResult` now receives a bounded
 ephemeral child result's `finishReason`, or from the child Settlement's durable marker carried
 through the new optional `ChildEstablishSettled.finishReason` — so a budget-truncated partial can
 be surfaced in the declared success Schema. Existing one-argument `projectResult` functions keep
-compiling unchanged.
+compiling unchanged. Also hardens S2 containment per its autoreviewer findings: `Subagent.define`
+is overloaded so the Tool channels follow the `failureMode` value; genuine engine signals are
+classified by unspoofable provenance instead of `instanceof` on exported classes; each delegation
+exposes its canonical `containedFailure` schema (pr-review's coverage decoder now derives from
+it); and the pr-review child reviewer deliberately returns to typed exhaustion — a review is a
+coverage claim, so a budget-exhausted unit stays honestly unreviewed (contained as result data,
+never run-fatal).

--- a/.changeset/budget-extension.md
+++ b/.changeset/budget-extension.md
@@ -1,0 +1,19 @@
+---
+"@effect-agent/engine": minor
+"@effect-agent/capabilities": minor
+"@effect-agent/session": patch
+---
+
+Budget extension (D-037, ADR-0019 S3, RUN-021/SUB-034): `RunOptions` gains tightening-only
+`toolCallAllowance` and `turnAllowance` — the effective limit is
+`min(policy bound, max(1, floor(allowance)))`, never wider, and the `onExhaustion` soft landing
+keys off the effective limits. `Subagent.define` gains
+`toolCallAllowance: { default, fromParameters }`, clamped fail-closed to the delegation's
+per-invocation `SubagentPolicy.maxToolCalls` slice and threaded into ephemeral child runs, so an
+orchestrator model grants a scout more budget by re-delegating with a raised allowance (fresh
+child; never a mid-flight top-up). `projectResult` now receives a bounded
+`SubagentResultContext` whose `budgetExhausted` marker is honest on both paths — from the
+ephemeral child result's `finishReason`, or from the child Settlement's durable marker carried
+through the new optional `ChildEstablishSettled.finishReason` — so a budget-truncated partial can
+be surfaced in the declared success Schema. Existing one-argument `projectResult` functions keep
+compiling unchanged.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -33080,6 +33080,10 @@ var decodeResumedToolCallParameters = (tool, toolName, encodedParams) => {
     message: `Recorded parameters for Tool ${toolName} failed validation on resume: ${cause.message}`
   })));
 };
+var effectiveRunBounds = (policy2, options) => ({
+  maxTurns: options.turnAllowance === undefined ? policy2.maxTurns : Math.min(policy2.maxTurns, Math.max(1, Math.floor(options.turnAllowance))),
+  maxToolCalls: options.toolCallAllowance === undefined ? policy2.maxToolCalls : Math.min(policy2.maxToolCalls, Math.max(1, Math.floor(options.toolCallAllowance)))
+});
 var makeToolFailedEvent = exports_Effect.fn("AgentRuntime.makeToolFailedEvent")(function* (context3, turnId, call, error2) {
   const toolCallId = yield* decodeToolCallId(call.id);
   return ToolCallFailed.make({
@@ -34198,7 +34202,8 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     ];
   }).pipe(exports_Effect.withLogSpan("AgentRuntime.model"))).pipe(exports_Stream.flatMap(exports_Stream.fromIterable));
   const policy2 = agent2.definition.policy;
-  const finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > policy2.maxTurns || priorToolCalls + context3.programmaticToolCalls > policy2.maxToolCalls);
+  const bounds = effectiveRunBounds(policy2, options);
+  const finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > bounds.maxTurns || priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls);
   const response = guardBudgetStream(exports_LanguageModel.streamText({
     prompt: modelContext.prompt,
     toolkit: agent2.definition.toolkit,
@@ -34235,11 +34240,11 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
       }));
     }
     const toolCalls = priorToolCalls + trace2.toolCalls.size;
-    const overToolBudget = toolCalls + context3.programmaticToolCalls > policy2.maxToolCalls;
+    const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
     if (overToolBudget && policy2.onExhaustion === "fail") {
       return failRunEventStream(AgentPolicyError.make({
         limit: "tool-calls",
-        message: `Agent exceeded its ${policy2.maxToolCalls} Tool Call limit`
+        message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
       }));
     }
     const stagedResponse = exports_Stream.fromIterable(trace2.providerResultPayloads).pipe(exports_Stream.mapEffect((payload) => stampProviderResultEvent(context3, turnId, payload)), exports_Stream.concat(turnCompletion === undefined ? exports_Stream.empty : exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => TurnCompleted.make({
@@ -34265,11 +34270,11 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
       const steering = yield* drainInputs(context3, options);
       const queued = steering.length > 0 ? steering : takeFollowUps(context3, options.commandDrainPolicy ?? "one");
       if (queued.length > 0) {
-        const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= policy2.maxTurns : turn > policy2.maxTurns;
+        const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
         if (turnsBlocked) {
           return failRunEventStream(AgentPolicyError.make({
             limit: "turns",
-            message: `Agent exceeded its ${policy2.maxTurns} Turn limit`
+            message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
           }));
         }
         yield* applyRepeatedFailurePolicy(context3, trace2, agent2.definition.policy.repeatedFailureLimit);
@@ -34293,18 +34298,18 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
           message: `Model declared Tool Calls with incompatible finish reason ${trace2.finishReason}`
         }));
       }
-      const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= policy2.maxTurns : turn > policy2.maxTurns;
+      const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
       if (turnsBlocked) {
         return failRunEventStream(AgentPolicyError.make({
           limit: "turns",
-          message: `Agent exceeded its ${policy2.maxTurns} Turn limit`
+          message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
         }));
       }
       if (overToolBudget && trace2.applicationToolCalls.length > 0) {
         return afterValidatedResponse(exports_Effect.gen(function* () {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
             limit: "tool-calls",
-            message: `Tool Call budget exhausted: this Run's ${policy2.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
+            message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
           }));
           return exports_Stream.fromIterable(rejection).pipe(exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, prompt, turn, toolCalls, options)));
         }));
@@ -34327,7 +34332,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
           });
         }
         const toolResults = guardBudgetStream(executeToolBatch(context3, turnId, toolkit, trace2.applicationToolCalls, trace2, concurrency, options, {
-          maxToolCalls: agent2.definition.policy.maxToolCalls,
+          maxToolCalls: bounds.maxToolCalls,
           declaredToolCalls: toolCalls
         }), options.budget);
         return toolResults.pipe(exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, prompt, turn, toolCalls, options)));
@@ -34467,19 +34472,20 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
     };
   }
   const policy2 = agent2.definition.policy;
+  const bounds = effectiveRunBounds(policy2, options);
   const toolCalls = trace2.toolCalls.size;
-  const overToolBudget = toolCalls + context3.programmaticToolCalls > policy2.maxToolCalls;
+  const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
   if (overToolBudget && policy2.onExhaustion === "fail") {
     return failRunEventStream(AgentPolicyError.make({
       limit: "tool-calls",
-      message: `Agent exceeded its ${policy2.maxToolCalls} Tool Call limit`
+      message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
     }));
   }
-  const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= policy2.maxTurns : turn > policy2.maxTurns;
+  const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
   if (turnsBlocked) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "turns",
-      message: `Agent exceeded its ${policy2.maxTurns} Turn limit`
+      message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
     }));
   }
   const toolkit = yield* agent2.definition.toolkit;
@@ -34512,12 +34518,12 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
   if (overToolBudget) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
       limit: "tool-calls",
-      message: `Tool Call budget exhausted: this Run's ${policy2.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
+      message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
     }), settledIds);
     return started.pipe(exports_Stream.concat(exports_Stream.fromIterable(rejection)), exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options)));
   }
   const toolResults = guardBudgetStream(executeToolBatch(context3, turnId, toolkit, trace2.applicationToolCalls, trace2, concurrency, options, {
-    maxToolCalls: agent2.definition.policy.maxToolCalls,
+    maxToolCalls: bounds.maxToolCalls,
     declaredToolCalls: toolCalls
   }, settledIds), options.budget);
   return started.pipe(exports_Stream.concat(toolResults), exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options)));
@@ -37670,9 +37676,13 @@ var layer14 = (delegation, childBinding, options) => {
         guard: seededBudget === undefined ? (effect2) => effect2 : (effect2) => seededBudget.guard(effect2),
         consume: (delta) => reservations.observe(reservationId, observedUsageFromDelta(delta)).pipe(exports_Effect.orDie, exports_Effect.andThen(seededBudget === undefined ? exports_Effect.void : seededBudget.consume(delta)))
       };
+      const allowanceOption = delegation.toolCallAllowance;
+      const requestedAllowance = allowanceOption === undefined ? undefined : allowanceOption.fromParameters?.(parameters) ?? allowanceOption.default;
+      const toolCallAllowance = requestedAllowance === undefined ? undefined : Math.min(Math.max(1, Math.floor(requestedAllowance)), delegation.policy.maxToolCalls);
       const childOptions = {
         ...seededChild,
-        budget
+        budget,
+        ...toolCallAllowance === undefined ? {} : { toolCallAllowance }
       };
       yield* exports_Ref.set(startedAt, yield* exports_Clock.currentTimeMillis);
       const child = yield* spawner.spawn(childBinding, encodedInput, { delegationId: delegation.delegationId, parentToolCallId: toolCallId }, childOptions);
@@ -37713,7 +37723,9 @@ var layer14 = (delegation, childBinding, options) => {
           turns: result4.turns,
           finishReason: result4.finishReason
         });
-        const projected = yield* delegation.projectResult(result4.output);
+        const projected = yield* delegation.projectResult(result4.output, {
+          budgetExhausted: result4.finishReason === "budget-exhausted"
+        });
         const encodedResult = yield* encodeSuccess(projected).pipe(exports_Effect.mapError(() => SubagentProjectionFailure.make({
           delegationId: delegation.delegationId,
           stage: "result",
@@ -37835,7 +37847,9 @@ var layer14 = (delegation, childBinding, options) => {
             });
             return encodeProjectionFailure(failure).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(failure, encodedFailure)));
           }));
-          const projected = yield* delegation.projectResult(decoded).pipe(exports_Effect.catch((declared) => encodeDeclaredFailure(declared).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)))));
+          const projected = yield* delegation.projectResult(decoded, {
+            budgetExhausted: status.finishReason === "budget-exhausted"
+          }).pipe(exports_Effect.catch((declared) => encodeDeclaredFailure(declared).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)))));
           const encodedResult = yield* encodeSuccess(projected).pipe(exports_Effect.catch(() => {
             const failure = SubagentProjectionFailure.make({
               delegationId: delegation.delegationId,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -37438,19 +37438,17 @@ var define = (name, options) => {
     maxDepth: 1
   });
   const failureMode = options.failureMode ?? "error";
+  const containedFailure = exports_Schema.Union([
+    options.failure,
+    SubagentPrestartDenied,
+    SubagentBudgetExhausted,
+    SubagentProjectionFailure,
+    SubagentExecutionFailure
+  ]);
   const returnModeTool = exports_Tool.make(name, {
     description: options.description,
     parameters: options.parameters,
-    success: exports_Schema.Union([
-      options.success,
-      exports_Schema.Union([
-        options.failure,
-        SubagentPrestartDenied,
-        SubagentBudgetExhausted,
-        SubagentProjectionFailure,
-        SubagentExecutionFailure
-      ])
-    ]),
+    success: exports_Schema.Union([options.success, containedFailure]),
     failure: exports_Schema.Union([ToolCallWaiting, SubagentDurabilityError]),
     needsApproval: options.needsApproval
   });
@@ -37476,6 +37474,7 @@ var define = (name, options) => {
     delegationId,
     grant,
     failureMode,
+    containedFailure,
     tool
   });
 };
@@ -37586,6 +37585,15 @@ var settleReservation = (reservations, reservationId, startedAt) => exports_Effe
   }
   yield* reservations.release(reservationId);
 }).pipe(exports_Effect.orDie);
+
+class GenuineEngineSignal {
+  signal;
+  _tag = "GenuineEngineSignal";
+  constructor(signal) {
+    this.signal = signal;
+  }
+}
+var wrapEngineSignal = (signal) => new GenuineEngineSignal(signal);
 var layer14 = (delegation, childBinding, options) => {
   const caps = options.parentCaps ?? delegationCapsFromPolicy(delegation.policy);
   const allocation = delegationAllocationFromPolicy(delegation.policy);
@@ -37786,7 +37794,7 @@ var layer14 = (delegation, childBinding, options) => {
         stage: "input",
         message: "Prepared child input did not satisfy the target Agent input Schema"
       })));
-      const status = yield* durability.establish({
+      const status = yield* exports_Effect.mapError(wrapEngineSignal)(durability.establish({
         toolCallId,
         delegationId: delegation.delegationId,
         targetAgentId: delegation.target.id,
@@ -37795,7 +37803,7 @@ var layer14 = (delegation, childBinding, options) => {
         encodedChildInput: encodedInput,
         encodedGrant,
         encodedAllocation
-      });
+      }));
       switch (status._tag) {
         case "denied": {
           return yield* executionFailure("establishment-denied", status.errorTag, status.message);
@@ -37811,7 +37819,7 @@ var layer14 = (delegation, childBinding, options) => {
           };
           yield* emit({ _tag: "SubagentRequested", ...payload });
           yield* emit({ _tag: "SubagentStarted", ...payload });
-          return yield* durability.waiting(toolCallId, status);
+          return yield* exports_Effect.mapError(wrapEngineSignal)(durability.waiting(toolCallId, status));
         }
         case "settled": {
           const payload = {
@@ -37827,12 +37835,12 @@ var layer14 = (delegation, childBinding, options) => {
             ...payload,
             errorTag: errorTagOf(failure),
             message: boundedEventText(errorMessageOf(failure))
-          }).pipe(exports_Effect.andThen(durability.join({
+          }).pipe(exports_Effect.andThen(exports_Effect.mapError(wrapEngineSignal)(durability.join({
             toolCallId,
             encodedResult: encodedFailure,
             isFailure: !contained,
             encodedAccounting: conservativeAccounting
-          })), exports_Effect.andThen(exports_Effect.fail(failure)));
+          }))), exports_Effect.andThen(exports_Effect.fail(failure)));
           if (status.outcome !== "completed") {
             const projection = childFailureProjectionOf(status.encodedResult);
             const failure = executionFailure(status.outcome === "aborted" ? "child-aborted" : projection.errorTag === "ChildCompatibilityFailure" ? "child-compatibility" : "child-failed", projection.errorTag, projection.message, status);
@@ -37869,28 +37877,29 @@ var layer14 = (delegation, childBinding, options) => {
             const encodedFailure = yield* encodeBudgetFailure(failure).pipe(exports_Effect.orDie);
             return yield* settleFailure(failure, encodedFailure);
           }
-          yield* durability.join({
+          yield* exports_Effect.mapError(wrapEngineSignal)(durability.join({
             toolCallId,
             encodedResult,
             isFailure: false,
             encodedAccounting: conservativeAccounting
-          });
+          }));
           yield* emit({ _tag: "SubagentJoined", ...payload });
           return projected;
         }
       }
     });
-    const containSignals = (failure) => failure instanceof ToolCallWaiting || failure instanceof SubagentDurabilityError ? exports_Effect.fail(failure) : exports_Effect.succeed(failure);
+    const containSignals = (failure) => failure instanceof GenuineEngineSignal ? exports_Effect.fail(failure.signal) : exports_Effect.succeed(failure);
+    const unwrapSignals = (failure) => failure instanceof GenuineEngineSignal ? failure.signal : failure;
     const handlerImpl = (parameters, handlerContext) => exports_Effect.gen(function* () {
       const spawner = yield* AgentSpawner;
       const sink = yield* RunEventSink;
       const durability = yield* SubagentDurability;
       if (durability.mode === "durable") {
         const durable = invokeDurable(parameters, handlerContext, durability).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
-        return yield* contained ? durable.pipe(exports_Effect.catch(containSignals)) : durable;
+        return yield* contained ? durable.pipe(exports_Effect.catch(containSignals)) : durable.pipe(exports_Effect.mapError(unwrapSignals));
       }
       const ephemeral = invoke(parameters, handlerContext).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
-      return yield* contained ? ephemeral.pipe(exports_Effect.catch(containSignals)) : ephemeral;
+      return yield* contained ? ephemeral.pipe(exports_Effect.catch(containSignals)) : ephemeral.pipe(exports_Effect.mapError(unwrapSignals));
     });
     const handler = handlerImpl;
     return { [delegation.name]: handler };
@@ -38467,7 +38476,7 @@ var defaultFileReviewerPolicy = AgentPolicy.make({
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200000,
-  onExhaustion: "final-answer"
+  onExhaustion: "fail"
 });
 
 class FileReviewRequest extends exports_Schema.Class("@effect-agent/pr-review/FileReviewRequest")({
@@ -38500,13 +38509,6 @@ var mapFileReviewChildFailure = (failure) => FileReviewUnitFailed.make({
   childErrorTag: failure._tag,
   message: (failure.message ?? "").slice(0, 400)
 });
-var FileReviewDelegationFailure = exports_Schema.Union([
-  FileReviewUnitFailed,
-  SubagentPrestartDenied,
-  SubagentBudgetExhausted,
-  SubagentProjectionFailure,
-  SubagentExecutionFailure
-]);
 
 class ListReviewUnitsQuery extends exports_Schema.Class("@effect-agent/pr-review/ListReviewUnitsQuery")({
   scope: exports_Schema.Literal("all")
@@ -38610,6 +38612,7 @@ var FanOutReviewer = defaultSuite.parent;
 var fileReviewDelegation = defaultSuite.delegation;
 var DelegateFileReview = delegationToolFor(fileReviewDelegation);
 var FanOutReviewToolkit = FanOutReviewer.toolkit;
+var FileReviewDelegationFailure = fileReviewDelegation.containedFailure;
 var fanOutHandlersLayerFor = (delegation) => (childBinding) => SubagentRuntime.layer(delegation, childBinding, {
   mapChildFailure: mapFileReviewChildFailure
 });

--- a/docs/adr/0019-budget-soft-landing-and-extension.md
+++ b/docs/adr/0019-budget-soft-landing-and-extension.md
@@ -13,6 +13,19 @@
   durable settlement join records the contained failure with the non-failure polarity the live
   batch continues with (SUB-019 coherence). SUB-033 pins the requirement; the pr-review
   shadow-Tool workaround is retired and both reviewer profiles adopt the S1 final-answer default.
+- Status note (2026-08-15, later): S3 implemented (RUN-021, SUB-034). `RunOptions` gains
+  tightening-only `toolCallAllowance`/`turnAllowance` (effective limit =
+  `min(policy, max(1, floor(allowance)))`, the `onExhaustion` resolution keys off the effective
+  limits); `Subagent.define` gains `toolCallAllowance: { default, fromParameters }` clamped
+  fail-closed to the delegation's per-invocation reservation slice; `projectResult` receives the
+  bounded `SubagentResultContext` with the honest `budgetExhausted` marker (from the ephemeral
+  child result, or the child Settlement's durable marker carried through
+  `ChildEstablishSettled.finishReason`). One scope delta from decision item 7: the allowance
+  reaches only EPHEMERAL children — a durable child's lane owns no per-run options channel, and
+  making the reservation slice binding on the child would contradict §7's never-clipped overrun
+  model, so durable allowance threading is deferred to its own proposal. The extension flow
+  (fresh re-delegation with a raised allowance and partial findings forwarded through
+  `prepareInput`) works on both paths today because the exhausted marker travels durably.
 - Related decisions: [D-007](../DECISIONS.md#d-007--tool-scheduling-default),
   [D-008](../DECISIONS.md#d-008--tool-failure-policy),
   [D-013](../DECISIONS.md#d-013--child-agent-budgets),

--- a/docs/adr/0019-budget-soft-landing-and-extension.md
+++ b/docs/adr/0019-budget-soft-landing-and-extension.md
@@ -26,6 +26,19 @@
   model, so durable allowance threading is deferred to its own proposal. The extension flow
   (fresh re-delegation with a raised allowance and partial findings forwarded through
   `prepareInput`) works on both paths today because the exhausted marker travels durably.
+- Status note (2026-08-15, hardening after #50's autoreviewer): `define` is overloaded so the
+  resolved Tool channels follow the `failureMode` VALUE (return mode cannot be claimed through a
+  type argument while the runtime builds the error-mode Tool); containment classifies genuine
+  engine signals through a module-private provenance wrapper applied at the only operations that
+  can produce them, so an author-declared failure using the exported signal classes is contained
+  as data rather than rethrown as a suspension; each delegation exposes its canonical
+  `containedFailure` schema so consumers (pr-review coverage) can never diverge from the runtime
+  family; and the contained durable join has failpoint recovery coverage at all three
+  `subagent:after-join*` boundaries. One S2 adoption reverted deliberately: the pr-review CHILD
+  reviewer returns to `onExhaustion: "fail"` — a review is a coverage claim, and schema-valid
+  findings from a child whose reads were rejected would launder budget exhaustion into coverage;
+  host-owned read-provenance is the recorded future work, and containment keeps the typed
+  exhaustion non-fatal to the run.
 - Related decisions: [D-007](../DECISIONS.md#d-007--tool-scheduling-default),
   [D-008](../DECISIONS.md#d-008--tool-failure-policy),
   [D-013](../DECISIONS.md#d-013--child-agent-budgets),

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -77,6 +77,12 @@ never starts. How exhaustion resolves is policy-selected via `onExhaustion`:
   `finishReason: "budget-exhausted"` (RUN-011), and a model that declares a Tool Call under the
   constraint fails the Run typed (`ModelProtocolError`, RUN-020).
 
+A Run may carry tightening-only allowances (`toolCallAllowance`, `turnAllowance`, RUN-021): the
+effective limit is `min(policy bound, max(1, floor(allowance)))`, so an allowance can never widen
+the Definition's ceiling, and the `onExhaustion` resolution keys off the effective limits. This is
+the budget-extension seam: an orchestrator grants a delegated child more budget by re-invoking the
+delegation with a larger allowance below the child Definition's policy.
+
 Duration, token, cost, and hierarchical budget-hook bounds are hard rails regardless of
 `onExhaustion`. Repeated-failure enforcement is Run-level: each completed Turn's terminal Tool
 Call outcomes fold into one consecutive-failure counter in declaration order, any terminal Tool
@@ -429,3 +435,6 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam.
 - **RUN-020:** Final-answer Turns are fail-closed: a model that declares any Tool Call under a
   `toolChoice: "none"` request fails the Run typed.
+- **RUN-021:** Per-Run allowances are tightening-only: the effective Turn/Tool-Call limit is the
+  minimum of the Agent Policy bound and the normalized allowance, never more, and the
+  `onExhaustion` resolution applies at the effective limit.

--- a/docs/spec/subagents.md
+++ b/docs/spec/subagents.md
@@ -212,7 +212,10 @@ declared Tool failure.
 ### 4.2 Output and failure projection
 
 The child Agent output is decoded by its normal output Schema before `projectResult` runs.
-`projectResult` produces the bounded value encoded by the delegation Tool success Schema.
+`projectResult` produces the bounded value encoded by the delegation Tool success Schema; it also
+receives the framework's bounded result context (SUB-034) — currently the honest
+`budgetExhausted` marker — so a budget-truncated partial can be surfaced in the declared success
+Schema for the orchestrator's extension decision.
 
 An Agent's full inferred error channel does not automatically form a stable cross-Agent wire
 contract, and native Effect AI handlers cannot leak an arbitrary child `E`. A Delegation
@@ -918,3 +921,9 @@ Require separate proposals:
   instead of failing the parent Tool batch; the engine-owned waiting signal and durability error
   always stay in the error channel, durable suspension semantics are preserved unchanged, and the
   durable settlement join records the same non-failure polarity the live batch continues with.
+- **SUB-034**: A per-invocation Tool Call allowance is tightening-only and clamped fail-closed to
+  the delegation's per-invocation reservation slice and the child Definition's policy;
+  `projectResult` receives the framework's honest exhaustion marker (from the child result on the
+  ephemeral path and the child Settlement on the durable path), and a budget extension is a fresh
+  re-delegation with a raised allowance — never a mid-flight reservation top-up or child
+  Conversation reuse.

--- a/packages/capabilities/src/subagent.ts
+++ b/packages/capabilities/src/subagent.ts
@@ -221,6 +221,18 @@ export interface SubagentPrepareContext {
 }
 
 /**
+ * Bounded framework context handed to `projectResult` (SUB-034).
+ * `budgetExhausted` is true exactly when the child settled through the
+ * final-answer exhaustion resolution (RUN-018) — on the ephemeral path from
+ * the child result's `finishReason`, on the durable path from the child
+ * Settlement's honest marker — so the projection can surface a
+ * budget-truncated partial to the orchestrator.
+ */
+export interface SubagentResultContext {
+  readonly budgetExhausted: boolean;
+}
+
+/**
  * The delegation Tool failure Schema: the author's declared failure plus the
  * framework's preflight/budget/projection/durable-execution failure family
  * (spec/subagents.md §15). With the default `failureMode: "error"`, exactly
@@ -386,11 +398,36 @@ export interface SubagentDefineOptions<
   /**
    * Bounded result projection from the Schema-decoded child output to the
    * declared Tool success value (spec/subagents.md §4.2). This is the explicit
-   * declassification boundary for child output.
+   * declassification boundary for child output. The context carries the
+   * framework's honest exhaustion marker (SUB-034): when `budgetExhausted` is
+   * true the child settled through the final-answer resolution (RUN-018) and
+   * its output is a budget-truncated partial — surface it in the declared
+   * success Schema so the orchestrator can decide to re-delegate with a
+   * raised `toolCallAllowance`.
    */
   readonly projectResult: (
     output: TargetOutput["Type"],
+    context: SubagentResultContext,
   ) => Effect.Effect<Success["Type"], Failure["Type"], ProjectRequirements>;
+  /**
+   * Per-invocation child Tool Call allowance (SUB-034): a tightening-only
+   * bound below the child Definition's own `maxToolCalls`, additionally
+   * clamped to this delegation's `SubagentPolicy.maxToolCalls` (the
+   * per-invocation reservation slice). `fromParameters` lets the orchestrator
+   * model grant a larger allowance through an author-owned parameter field —
+   * the budget-extension flow is a fresh re-delegation with a raised
+   * allowance, never a mid-flight top-up. Ephemeral delegation only: a
+   * durable child keeps running at its Definition policy (its lane owns no
+   * per-run options channel; the reservation stays accounting-only per §7).
+   */
+  readonly toolCallAllowance?:
+    | {
+        /** Applied when `fromParameters` is absent or yields nothing. */
+        readonly default: number;
+        /** Extract the model-granted allowance from the decoded parameters. */
+        readonly fromParameters?: (parameters: Parameters["Type"]) => number | undefined;
+      }
+    | undefined;
   /** Finite delegation bounds reserved for every invocation (SUB-009). */
   readonly policy: SubagentPolicy;
   /**
@@ -1251,9 +1288,22 @@ const layer = <
               ),
             ),
       };
+      // Per-invocation allowance (SUB-034): tightening-only, clamped to the
+      // delegation's own per-invocation reservation slice; the child's
+      // Definition policy stays the engine-side ceiling (RUN-021).
+      const allowanceOption = delegation.toolCallAllowance;
+      const requestedAllowance =
+        allowanceOption === undefined
+          ? undefined
+          : (allowanceOption.fromParameters?.(parameters) ?? allowanceOption.default);
+      const toolCallAllowance =
+        requestedAllowance === undefined
+          ? undefined
+          : Math.min(Math.max(1, Math.floor(requestedAllowance)), delegation.policy.maxToolCalls);
       const childOptions: SpawnRunOptions<never, HookRequirements> = {
         ...seededChild,
         budget,
+        ...(toolCallAllowance === undefined ? {} : { toolCallAllowance }),
       };
 
       yield* Ref.set(startedAt, yield* Clock.currentTimeMillis);
@@ -1330,7 +1380,9 @@ const layer = <
           turns: result.turns,
           finishReason: result.finishReason,
         });
-        const projected = yield* delegation.projectResult(result.output);
+        const projected = yield* delegation.projectResult(result.output, {
+          budgetExhausted: result.finishReason === "budget-exhausted",
+        });
         const encodedResult = yield* encodeSuccess(projected).pipe(
           Effect.mapError(() =>
             SubagentProjectionFailure.make({
@@ -1572,14 +1624,18 @@ const layer = <
               );
             }),
           );
-          const projected = yield* delegation.projectResult(decoded).pipe(
-            Effect.catch((declared) =>
-              encodeDeclaredFailure(declared).pipe(
-                Effect.orDie,
-                Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)),
+          const projected = yield* delegation
+            .projectResult(decoded, {
+              budgetExhausted: status.finishReason === "budget-exhausted",
+            })
+            .pipe(
+              Effect.catch((declared) =>
+                encodeDeclaredFailure(declared).pipe(
+                  Effect.orDie,
+                  Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)),
+                ),
               ),
-            ),
-          );
+            );
           const encodedResult = yield* encodeSuccess(projected).pipe(
             Effect.catch(() => {
               const failure = SubagentProjectionFailure.make({

--- a/packages/capabilities/src/subagent.ts
+++ b/packages/capabilities/src/subagent.ts
@@ -480,6 +480,14 @@ export interface SubagentDelegation<
   readonly grant: SubagentGrant;
   /** The resolved expected-failure resolution (SUB-033); never absent after `define`. */
   readonly failureMode: Mode;
+  /**
+   * The canonical contained-failure family for this delegation (SUB-033):
+   * the declared failure plus the framework members. Consumers that classify
+   * returned failure data (for example a coverage gate) MUST decode through
+   * this value rather than reconstructing the union, so a framework change
+   * to the contained family can never diverge from their decoder.
+   */
+  readonly containedFailure: SubagentContainedFailure<Failure>;
   /** The real Effect AI Tool to include in the parent Toolkit (SUB-001). */
   readonly tool: SubagentTool<Name, Parameters, Success, Failure, Mode>;
 }
@@ -493,7 +501,93 @@ export interface SubagentDelegation<
  * `SubagentRuntime.layer`. Throws on an invalid delegation name or a target
  * whose Toolkit already contains a delegation Tool (SUB-029).
  */
-const define = <
+interface SubagentDefine {
+  /**
+   * Contained-failure mode (SUB-033): `failureMode: "return"` must be present
+   * as a VALUE — the resolved Tool channels follow what `define` actually
+   * constructs, so return mode cannot be claimed through a type argument
+   * while the runtime builds the error-mode Tool.
+   */
+  <
+    const Name extends string,
+    TargetInput extends Schema.Top,
+    TargetOutput extends Schema.Top,
+    TargetInstructions,
+    TargetTools extends Record<string, Tool.Any>,
+    Parameters extends Schema.Top,
+    Success extends Schema.Top,
+    Failure extends Schema.Top,
+    PrepareRequirements = never,
+    ProjectRequirements = never,
+  >(
+    name: Name,
+    options: SubagentDefineOptions<
+      TargetInput,
+      TargetOutput,
+      TargetInstructions,
+      TargetTools,
+      Parameters,
+      Success,
+      Failure,
+      PrepareRequirements,
+      ProjectRequirements,
+      "return"
+    > & { readonly failureMode: "return" },
+  ): SubagentDelegation<
+    Name,
+    TargetInput,
+    TargetOutput,
+    TargetInstructions,
+    TargetTools,
+    Parameters,
+    Success,
+    Failure,
+    PrepareRequirements,
+    ProjectRequirements,
+    "return"
+  >;
+  /** Default error mode: `failureMode` may be omitted or explicitly `"error"`. */
+  <
+    const Name extends string,
+    TargetInput extends Schema.Top,
+    TargetOutput extends Schema.Top,
+    TargetInstructions,
+    TargetTools extends Record<string, Tool.Any>,
+    Parameters extends Schema.Top,
+    Success extends Schema.Top,
+    Failure extends Schema.Top,
+    PrepareRequirements = never,
+    ProjectRequirements = never,
+  >(
+    name: Name,
+    options: SubagentDefineOptions<
+      TargetInput,
+      TargetOutput,
+      TargetInstructions,
+      TargetTools,
+      Parameters,
+      Success,
+      Failure,
+      PrepareRequirements,
+      ProjectRequirements,
+      "error"
+    >,
+  ): SubagentDelegation<
+    Name,
+    TargetInput,
+    TargetOutput,
+    TargetInstructions,
+    TargetTools,
+    Parameters,
+    Success,
+    Failure,
+    PrepareRequirements,
+    ProjectRequirements,
+    "error"
+  >;
+}
+
+const define: SubagentDefine = <
   const Name extends string,
   TargetInput extends Schema.Top,
   TargetOutput extends Schema.Top,
@@ -551,6 +645,13 @@ const define = <
   // resolved literal always inhabits `Mode`; the assertion bridges only that
   // inference gap and crosses no schema boundary.
   const failureMode = (options.failureMode ?? "error") as Mode;
+  const containedFailure = Schema.Union([
+    options.failure,
+    SubagentPrestartDenied,
+    SubagentBudgetExhausted,
+    SubagentProjectionFailure,
+    SubagentExecutionFailure,
+  ]);
   const returnModeTool = Tool.make(name, {
     description: options.description,
     parameters: options.parameters,
@@ -558,16 +659,7 @@ const define = <
     // RESULT data, so it lives in the success union; only the engine-signal
     // members remain raisable. The underlying Effect AI failureMode stays
     // "error" so the waiting signal is never encoded as a result.
-    success: Schema.Union([
-      options.success,
-      Schema.Union([
-        options.failure,
-        SubagentPrestartDenied,
-        SubagentBudgetExhausted,
-        SubagentProjectionFailure,
-        SubagentExecutionFailure,
-      ]),
-    ]),
+    success: Schema.Union([options.success, containedFailure]),
     failure: Schema.Union([ToolCallWaiting, SubagentDurabilityError]),
     needsApproval: options.needsApproval,
   });
@@ -607,6 +699,7 @@ const define = <
     delegationId,
     grant,
     failureMode,
+    containedFailure,
     tool,
   });
 };
@@ -954,6 +1047,22 @@ const settleReservation = (
     }
     yield* reservations.release(reservationId);
   }).pipe(Effect.orDie);
+
+/**
+ * Module-private provenance wrapper (SUB-033 hardening): ONLY the operations
+ * that can genuinely produce the engine signals wrap them here, so
+ * containment classification never trusts the runtime identity of classes an
+ * author could declare in their own failure Schema — a spoofed
+ * `ToolCallWaiting` in author data is contained as data, never rethrown as a
+ * suspension signal.
+ */
+class GenuineEngineSignal {
+  readonly _tag = "GenuineEngineSignal";
+  constructor(readonly signal: ToolCallWaiting | SubagentDurabilityError) {}
+}
+
+const wrapEngineSignal = (signal: ToolCallWaiting | SubagentDurabilityError) =>
+  new GenuineEngineSignal(signal);
 
 type SubagentHandler<
   Name extends string,
@@ -1514,16 +1623,18 @@ const layer = <
       // converges on the one existing child; a divergent replay (changed
       // digests, grant, allocation, or input) is denied fail-closed by the
       // coordinator and surfaces below as `"establishment-denied"`.
-      const status = yield* durability.establish({
-        toolCallId,
-        delegationId: delegation.delegationId,
-        targetAgentId: delegation.target.id,
-        depth,
-        targetDigests: durableDeclaration.targetDigests,
-        encodedChildInput: encodedInput,
-        encodedGrant,
-        encodedAllocation,
-      });
+      const status = yield* Effect.mapError(wrapEngineSignal)(
+        durability.establish({
+          toolCallId,
+          delegationId: delegation.delegationId,
+          targetAgentId: delegation.target.id,
+          depth,
+          targetDigests: durableDeclaration.targetDigests,
+          encodedChildInput: encodedInput,
+          encodedGrant,
+          encodedAllocation,
+        }),
+      );
 
       switch (status._tag) {
         case "denied": {
@@ -1544,7 +1655,7 @@ const layer = <
           // call open (no Tool failure, no batch failure policy), siblings
           // finish, and the Run suspends waitingForChild — never polling,
           // never respawning (SUB-018, SUB-030).
-          return yield* durability.waiting(toolCallId, status);
+          return yield* Effect.mapError(wrapEngineSignal)(durability.waiting(toolCallId, status));
         }
         case "settled": {
           const payload: SubagentEventBasePayload = {
@@ -1564,7 +1675,7 @@ const layer = <
           const settleFailure = <F>(
             failure: F,
             encodedFailure: unknown,
-          ): Effect.Effect<never, F | SubagentDurabilityError> =>
+          ): Effect.Effect<never, F | GenuineEngineSignal> =>
             emit({
               _tag: "SubagentFailed",
               ...payload,
@@ -1572,19 +1683,21 @@ const layer = <
               message: boundedEventText(errorMessageOf(failure)),
             }).pipe(
               Effect.andThen(
-                durability.join({
-                  toolCallId,
-                  encodedResult: encodedFailure,
-                  // Canonical history must record exactly what the live batch
-                  // continues with (SUB-019): under containment the failure is
-                  // the call's model-visible RESULT (the dispatch wrapper
-                  // converts the fail below into a success), so the joined
-                  // settlement records it as a non-failure result; the child's
-                  // own failed Settlement and the `SubagentFailed` event stay
-                  // the honest failure record.
-                  isFailure: !contained,
-                  encodedAccounting: conservativeAccounting,
-                }),
+                Effect.mapError(wrapEngineSignal)(
+                  durability.join({
+                    toolCallId,
+                    encodedResult: encodedFailure,
+                    // Canonical history must record exactly what the live
+                    // batch continues with (SUB-019): under containment the
+                    // failure is the call's model-visible RESULT (the dispatch
+                    // wrapper converts the fail below into a success), so the
+                    // joined settlement records it as a non-failure result;
+                    // the child's own failed Settlement and the
+                    // `SubagentFailed` event stay the honest failure record.
+                    isFailure: !contained,
+                    encodedAccounting: conservativeAccounting,
+                  }),
+                ),
               ),
               Effect.andThen(Effect.fail(failure)),
             );
@@ -1663,12 +1776,14 @@ const layer = <
             const encodedFailure = yield* encodeBudgetFailure(failure).pipe(Effect.orDie);
             return yield* settleFailure(failure, encodedFailure);
           }
-          yield* durability.join({
-            toolCallId,
-            encodedResult,
-            isFailure: false,
-            encodedAccounting: conservativeAccounting,
-          });
+          yield* Effect.mapError(wrapEngineSignal)(
+            durability.join({
+              toolCallId,
+              encodedResult,
+              isFailure: false,
+              encodedAccounting: conservativeAccounting,
+            }),
+          );
           yield* emit({ _tag: "SubagentJoined", ...payload });
           return projected;
         }
@@ -1677,17 +1792,27 @@ const layer = <
 
     // Containment boundary (SUB-033): under `"return"`, every expected
     // delegation failure becomes the handler's success value; exactly the
-    // engine signals re-fail. `instanceof` against the exact engine classes is
-    // identity-safe — an author-declared failure can never alias them.
+    // GENUINE engine signals re-fail unwrapped. Provenance comes from the
+    // module-private `GenuineEngineSignal` wrapper applied at the only
+    // operations that can produce those signals — an author-declared failure
+    // that happens to use the exported signal classes is contained as data,
+    // never rethrown as a suspension signal.
     const containSignals = (
-      failure: SubagentToolFailure<Failure>["Type"],
+      failure: SubagentToolFailure<Failure>["Type"] | GenuineEngineSignal,
     ): Effect.Effect<
       SubagentContainedFailure<Failure>["Type"],
       ToolCallWaiting | SubagentDurabilityError
     > =>
-      failure instanceof ToolCallWaiting || failure instanceof SubagentDurabilityError
-        ? Effect.fail(failure)
+      failure instanceof GenuineEngineSignal
+        ? Effect.fail(failure.signal)
         : Effect.succeed(failure);
+
+    // Error mode still unwraps genuine signals so the engine sees the raw
+    // `ToolCallWaiting`/`SubagentDurabilityError` it owns.
+    const unwrapSignals = (
+      failure: SubagentToolFailure<Failure>["Type"] | GenuineEngineSignal,
+    ): SubagentToolFailure<Failure>["Type"] =>
+      failure instanceof GenuineEngineSignal ? failure.signal : failure;
 
     const handlerImpl = (
       parameters: Parameters["Type"],
@@ -1716,7 +1841,9 @@ const layer = <
             Effect.provideService(SubagentDurability, durability),
             Effect.provide(captured),
           );
-          return yield* contained ? durable.pipe(Effect.catch(containSignals)) : durable;
+          return yield* contained
+            ? durable.pipe(Effect.catch(containSignals))
+            : durable.pipe(Effect.mapError(unwrapSignals));
         }
         const ephemeral = invoke(parameters, handlerContext).pipe(
           Effect.scoped,
@@ -1725,7 +1852,9 @@ const layer = <
           Effect.provideService(SubagentDurability, durability),
           Effect.provide(captured),
         );
-        return yield* contained ? ephemeral.pipe(Effect.catch(containSignals)) : ephemeral;
+        return yield* contained
+          ? ephemeral.pipe(Effect.catch(containSignals))
+          : ephemeral.pipe(Effect.mapError(unwrapSignals));
       });
 
     // `handlerImpl`'s channels are the UNION of both modes because

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -2254,3 +2254,302 @@ layer(TestServices)("SubagentRuntime SUB-033 contained failure mode", (it) => {
     ]).not.toContain(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// SUB-034: per-invocation Tool Call allowance and the budget-extension flow —
+// the orchestrator grants more budget by re-delegating with a raised
+// allowance (fresh child, never a mid-flight top-up), and `projectResult`
+// receives the framework's honest exhaustion marker.
+// ---------------------------------------------------------------------------
+
+const ProbeDoc = Tool.make("probe_doc", {
+  parameters: Schema.Struct({ ref: Schema.String }),
+  success: Schema.String,
+});
+const probeToolkit = Toolkit.make(ProbeDoc);
+
+const probingChildDefinition = Agent.define("probing-child", {
+  input: ChildInput,
+  output: ChildOutput,
+  instructions: "Probe, then answer as JSON.",
+  toolkit: probeToolkit,
+  policy: AgentPolicy.make({
+    // The Definition's own ceiling: deliberately ABOVE every allowance below,
+    // so a broken clamp is observable as executed probe handlers.
+    maxTurns: 4,
+    maxToolCalls: 8,
+    maxDuration: "30 seconds",
+    toolConcurrency: 2,
+  }),
+});
+
+/**
+ * Scripted probing child shared by concurrent invocations: each child's turn
+ * is keyed on ITS briefed topic in the prompt plus whether its probe call ids
+ * are already committed there.
+ */
+const probingChildModel = (
+  scripts: ReadonlyArray<{ topic: string; declares: number; answer: string }>,
+) =>
+  Model.make(
+    "scripted",
+    "probing-child-scripted",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: (request) => {
+          const promptJson = JSON.stringify(request.prompt);
+          const script = scripts.find((candidate) =>
+            promptJson.includes(`research:${candidate.topic}`),
+          );
+          if (script === undefined) {
+            return Stream.die(new Error("The child prompt names no scripted topic"));
+          }
+          if (promptJson.includes(`probe-${script.topic}-1`)) {
+            return Stream.fromIterable(finalParts(script.answer));
+          }
+          return Stream.fromIterable<Response.StreamPartEncoded>([
+            ...Array.from(
+              { length: script.declares },
+              (_, index): Response.StreamPartEncoded => ({
+                type: "tool-call",
+                id: `probe-${script.topic}-${index + 1}`,
+                name: "probe_doc",
+                params: { ref: `doc-${index + 1}` },
+                providerExecuted: false,
+              }),
+            ),
+            { type: "finish", reason: "tool-calls", usage },
+          ]);
+        },
+      }),
+    ),
+  );
+
+const allowancePolicy = SubagentPolicy.make({
+  maxChildren: 2,
+  maxConcurrency: 2,
+  maxTurns: 4,
+  // The per-invocation reservation slice: the fail-closed clamp ceiling.
+  maxToolCalls: 4,
+  maxDuration: "10 seconds",
+});
+
+const allowanceDelegation = Subagent.define("delegate_allowance", {
+  description: "Research one topic under a per-invocation Tool Call allowance.",
+  target: probingChildDefinition,
+  parameters: ResearchParams,
+  success: ResearchFindings,
+  failure: ResearchDelegationFailed,
+  prepareInput: ({ topic }) => Effect.succeed({ question: `research:${topic}` }),
+  // SUB-034: the projection surfaces the framework's honest exhaustion marker
+  // in the declared success Schema, so the orchestrator can re-delegate.
+  projectResult: (output, context) =>
+    Effect.succeed({
+      summary: `${context.budgetExhausted ? "partial:" : "finding:"}${output.answer}`,
+    }),
+  policy: allowancePolicy,
+  toolCallAllowance: {
+    default: 1,
+    fromParameters: ({ topic }) =>
+      topic.startsWith("grant-") ? Number(topic.slice("grant-".length)) : undefined,
+  },
+});
+
+const allowanceCoordinator = Agent.define("allowance-coordinator", {
+  input: Schema.Struct({ mission: Schema.String }),
+  output: Schema.Struct({ report: Schema.String }),
+  instructions: "Delegate, then answer as JSON.",
+  toolkit: Toolkit.make(allowanceDelegation.tool),
+  policy: AgentPolicy.make({
+    maxTurns: 3,
+    maxToolCalls: 3,
+    maxDuration: "30 seconds",
+    toolConcurrency: 2,
+  }),
+});
+
+layer(TestServices)("SubagentRuntime SUB-034 per-invocation allowance", (it) => {
+  const runAllowance = (options: {
+    readonly name: string;
+    readonly calls: ReadonlyArray<{ readonly id: string; readonly params: unknown }>;
+    readonly childScripts: ReadonlyArray<{ topic: string; declares: number; answer: string }>;
+    readonly runId: string;
+  }) =>
+    Effect.gen(function* () {
+      const probeStarts = yield* Ref.make(0);
+      const childBinding = Agent.withModel(
+        probingChildDefinition,
+        probingChildModel(options.childScripts),
+      );
+      const parent = Agent.withModel(
+        allowanceCoordinator,
+        delegatingModel(options.name, "delegate_allowance", options.calls, '{"report":"done"}'),
+      );
+      const probeLayer = probeToolkit.toLayer({
+        probe_doc: ({ ref }) =>
+          Ref.update(probeStarts, (count) => count + 1).pipe(Effect.as(`probed-${ref}`)),
+      });
+      const runtimeLayer = SubagentRuntime.layer(allowanceDelegation, childBinding, {
+        mapChildFailure,
+      }).pipe(Layer.provide(probeLayer));
+      const detached = yield* AgentRuntime.start(
+        parent,
+        { mission: "m" },
+        { runId: decodeRunId(options.runId) },
+      ).pipe(Effect.provide(runtimeLayer));
+      const result = yield* detached.await;
+      const events = yield* detached.events;
+      return { result, events, probeStarts: yield* Ref.get(probeStarts) };
+    });
+
+  it.effect(
+    "SUB-034 the default allowance tightens the child below its Definition policy and the projection surfaces the exhaustion marker",
+    () =>
+      Effect.gen(function* () {
+        const { result, events, probeStarts } = yield* runAllowance({
+          name: "parent-allowance-default",
+          calls: [{ id: "call-1", params: { topic: "small" } }],
+          childScripts: [{ topic: "small", declares: 2, answer: '{"answer":"draft"}' }],
+          runId: "parent-run-allowance-default",
+        });
+
+        // Definition ceiling 8 admits the batch of 2; the allowance of 1
+        // rejects it, no probe executes, and the child soft-lands (RUN-021).
+        expect(result.output).toEqual({ report: "done" });
+        expect(probeStarts).toBe(0);
+        expect(findEvent(events, "ToolCallSucceeded")).toMatchObject({
+          result: { summary: "partial:draft" },
+        });
+        expect(findEvent(events, "SubagentCompleted")).toMatchObject({
+          finishReason: "budget-exhausted",
+        });
+      }),
+  );
+
+  it.effect(
+    "SUB-034 a model-granted allowance is clamped fail-closed to the per-invocation reservation slice",
+    () =>
+      Effect.gen(function* () {
+        const { result, probeStarts } = yield* runAllowance({
+          name: "parent-allowance-clamp",
+          calls: [{ id: "call-1", params: { topic: "grant-100" } }],
+          childScripts: [{ topic: "grant-100", declares: 5, answer: '{"answer":"clamped"}' }],
+          runId: "parent-run-allowance-clamp",
+        });
+
+        // Requested 100 clamps to the slice ceiling of 4: the batch of 5 is
+        // rejected. A broken clamp (min with the Definition's 8 only) would
+        // have executed all five probes.
+        expect(result.output).toEqual({ report: "done" });
+        expect(probeStarts).toBe(0);
+      }),
+  );
+
+  it.effect(
+    "SUB-034 the orchestrator grants a budget extension by re-delegating with a raised allowance",
+    () =>
+      Effect.gen(function* () {
+        const { result, events, probeStarts } = yield* runAllowance({
+          name: "parent-allowance-extension",
+          calls: [
+            { id: "call-1", params: { topic: "small" } },
+            { id: "call-2", params: { topic: "grant-4" } },
+          ],
+          childScripts: [
+            { topic: "small", declares: 2, answer: '{"answer":"draft"}' },
+            { topic: "grant-4", declares: 2, answer: '{"answer":"complete"}' },
+          ],
+          runId: "parent-run-allowance-extension",
+        });
+
+        // First invocation: default allowance 1 rejects the batch of 2 — a
+        // budget-truncated partial. Second invocation with the granted
+        // allowance of 4 executes both probes and returns the full finding.
+        expect(result.output).toEqual({ report: "done" });
+        expect(probeStarts).toBe(2);
+        const succeeded = events.filter((event) => event._tag === "ToolCallSucceeded");
+        expect(succeeded.map((event) => event.result)).toEqual(
+          expect.arrayContaining([{ summary: "partial:draft" }, { summary: "finding:complete" }]),
+        );
+      }),
+  );
+
+  it.effect(
+    "SUB-034 a durable settled budget-exhausted child surfaces the marker to projectResult",
+    () =>
+      Effect.gen(function* () {
+        const invocations = yield* Ref.make(0);
+        const child = durableChildIdentity("allowance-durable");
+        const subagent = scriptedDurableHook({
+          establish: () => ({
+            _tag: "settled",
+            ...child,
+            outcome: "completed",
+            encodedResult: { answer: "durable partial" },
+            finishReason: "budget-exhausted",
+          }),
+        });
+        const parent = Agent.withModel(
+          allowanceCoordinator,
+          delegatingModel(
+            "parent-allowance-durable",
+            "delegate_allowance",
+            [{ id: "call-1", params: { topic: "small" } }],
+            '{"report":"done"}',
+          ),
+        );
+        const probeLayer = probeToolkit.toLayer({
+          probe_doc: () => Effect.succeed("unused"),
+        });
+        const runtimeLayer = SubagentRuntime.layer(
+          allowanceDelegation,
+          countingProbingChildBinding(invocations),
+          { mapChildFailure, durable: { targetDigests: durableDigests } },
+        ).pipe(Layer.provide(probeLayer));
+
+        const detached = yield* AgentRuntime.start(
+          parent,
+          { mission: "m" },
+          { runId: decodeRunId("parent-run-allowance-durable"), subagent },
+        ).pipe(Effect.provide(runtimeLayer));
+        const result = yield* detached.await;
+        const events = yield* detached.events;
+
+        expect(result.output).toEqual({ report: "done" });
+        expect(yield* Ref.get(invocations)).toBe(0);
+        // The durable Settlement's honest marker reached the projection: the
+        // parent Tool result carries the budget-truncated partial.
+        expect(findEvent(events, "ToolCallSucceeded")).toMatchObject({
+          result: { summary: "partial:durable partial" },
+        });
+      }),
+  );
+});
+
+/** Probing-child binding whose scripted model counts invocations (durable mode must never run it). */
+const countingProbingChildBinding = (invocations: Ref.Ref<number>) =>
+  Agent.withModel(
+    probingChildDefinition,
+    Model.make(
+      "scripted",
+      "probing-counting-child",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        LanguageModel.make({
+          generateText: () => Effect.succeed([]),
+          streamText: () =>
+            Stream.unwrap(
+              Ref.update(invocations, (count) => count + 1).pipe(
+                Effect.as(
+                  Stream.fromIterable<Response.StreamPartEncoded>(
+                    finalParts('{"answer":"in-process"}'),
+                  ),
+                ),
+              ),
+            ),
+        }),
+      ),
+    ),
+  );

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,6 +6,7 @@ import {
   AgentOutputError,
   AgentPolicyError,
   type AgentId,
+  type AgentPolicy,
   ApprovalRequested,
   ConversationId,
   type Definition,
@@ -555,6 +556,32 @@ const decodeResumedToolCallParameters = <Tools extends Record<string, Tool.Any>>
     ),
   );
 };
+
+/**
+ * Effective Run bounds (RUN-021): per-Run allowances tighten the Agent
+ * Policy's Turn and Tool Call ceilings but can never widen them — the
+ * effective limit is `min(policy bound, max(1, floor(allowance)))`. The
+ * `onExhaustion` resolution (RUN-018/RUN-019) keys off these effective
+ * limits, which is how an orchestrator grants a delegated child a budget
+ * extension by re-invoking with a larger allowance below the Definition's
+ * ceiling.
+ */
+const effectiveRunBounds = (
+  policy: AgentPolicy,
+  options: {
+    readonly toolCallAllowance?: number | undefined;
+    readonly turnAllowance?: number | undefined;
+  },
+): { readonly maxTurns: number; readonly maxToolCalls: number } => ({
+  maxTurns:
+    options.turnAllowance === undefined
+      ? policy.maxTurns
+      : Math.min(policy.maxTurns, Math.max(1, Math.floor(options.turnAllowance))),
+  maxToolCalls:
+    options.toolCallAllowance === undefined
+      ? policy.maxToolCalls
+      : Math.min(policy.maxToolCalls, Math.max(1, Math.floor(options.toolCallAllowance))),
+});
 
 const makeToolFailedEvent = Effect.fn("AgentRuntime.makeToolFailedEvent")(function* (
   context: RunContext,
@@ -2484,10 +2511,11 @@ const makeTurn = <
       // replay reconstructs the same constraint. Strict `>` keeps an
       // exact-cap Run on today's unconstrained path byte-for-byte.
       const policy = agent.definition.policy;
+      const bounds = effectiveRunBounds(policy, options);
       const finalAnswerOnly =
         policy.onExhaustion !== "fail" &&
-        (turn > policy.maxTurns ||
-          priorToolCalls + context.programmaticToolCalls > policy.maxToolCalls);
+        (turn > bounds.maxTurns ||
+          priorToolCalls + context.programmaticToolCalls > bounds.maxToolCalls);
       const response = guardBudgetStream(
         LanguageModel.streamText({
           prompt: modelContext.prompt,
@@ -2553,12 +2581,12 @@ const makeTurn = <
             );
           }
           const toolCalls = priorToolCalls + trace.toolCalls.size;
-          const overToolBudget = toolCalls + context.programmaticToolCalls > policy.maxToolCalls;
+          const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
           if (overToolBudget && policy.onExhaustion === "fail") {
             return failRunEventStream(
               AgentPolicyError.make({
                 limit: "tool-calls",
-                message: `Agent exceeded its ${policy.maxToolCalls} Tool Call limit`,
+                message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`,
               }),
             );
           }
@@ -2639,12 +2667,12 @@ const makeTurn = <
                 // `maxTurns + 1`, so a second grace is structurally
                 // impossible.
                 const turnsBlocked =
-                  policy.onExhaustion === "fail" ? turn >= policy.maxTurns : turn > policy.maxTurns;
+                  policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
                 if (turnsBlocked) {
                   return failRunEventStream(
                     AgentPolicyError.make({
                       limit: "turns",
-                      message: `Agent exceeded its ${policy.maxTurns} Turn limit`,
+                      message: `Agent exceeded its ${bounds.maxTurns} Turn limit`,
                     }),
                   );
                 }
@@ -2685,12 +2713,12 @@ const makeTurn = <
               );
             }
             const turnsBlocked =
-              policy.onExhaustion === "fail" ? turn >= policy.maxTurns : turn > policy.maxTurns;
+              policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
             if (turnsBlocked) {
               return failRunEventStream(
                 AgentPolicyError.make({
                   limit: "turns",
-                  message: `Agent exceeded its ${policy.maxTurns} Turn limit`,
+                  message: `Agent exceeded its ${bounds.maxTurns} Turn limit`,
                 }),
               );
             }
@@ -2712,7 +2740,7 @@ const makeTurn = <
                     trace,
                     AgentPolicyError.make({
                       limit: "tool-calls",
-                      message: `Tool Call budget exhausted: this Run's ${policy.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
+                      message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
                     }),
                   );
                   return Stream.fromIterable(rejection).pipe(
@@ -2772,7 +2800,7 @@ const makeTurn = <
                     concurrency,
                     options,
                     {
-                      maxToolCalls: agent.definition.policy.maxToolCalls,
+                      maxToolCalls: bounds.maxToolCalls,
                       declaredToolCalls: toolCalls,
                     },
                   ),
@@ -3053,23 +3081,24 @@ const makeResumeTurn = <
         };
       }
       const policy = agent.definition.policy;
+      const bounds = effectiveRunBounds(policy, options);
       const toolCalls = trace.toolCalls.size;
-      const overToolBudget = toolCalls + context.programmaticToolCalls > policy.maxToolCalls;
+      const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
       if (overToolBudget && policy.onExhaustion === "fail") {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "tool-calls",
-            message: `Agent exceeded its ${policy.maxToolCalls} Tool Call limit`,
+            message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`,
           }),
         );
       }
       const turnsBlocked =
-        policy.onExhaustion === "fail" ? turn >= policy.maxTurns : turn > policy.maxTurns;
+        policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
       if (turnsBlocked) {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "turns",
-            message: `Agent exceeded its ${policy.maxTurns} Turn limit`,
+            message: `Agent exceeded its ${bounds.maxTurns} Turn limit`,
           }),
         );
       }
@@ -3136,7 +3165,7 @@ const makeResumeTurn = <
           trace,
           AgentPolicyError.make({
             limit: "tool-calls",
-            message: `Tool Call budget exhausted: this Run's ${policy.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
+            message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
           }),
           settledIds,
         );
@@ -3157,7 +3186,7 @@ const makeResumeTurn = <
           concurrency,
           options,
           {
-            maxToolCalls: agent.definition.policy.maxToolCalls,
+            maxToolCalls: bounds.maxToolCalls,
             declaredToolCalls: toolCalls,
           },
           settledIds,

--- a/packages/engine/src/run-options.ts
+++ b/packages/engine/src/run-options.ts
@@ -248,6 +248,12 @@ export interface ChildEstablishSettled extends RunSubagentChildIdentity {
   readonly _tag: "settled";
   readonly outcome: "completed" | "failed" | "aborted";
   readonly encodedResult: unknown;
+  /**
+   * Present when the child's durable Settlement carries the honest
+   * exhaustion marker (RUN-011/RUN-018): the child completed through the
+   * final-answer resolution, so its output is a budget-truncated partial.
+   */
+  readonly finishReason?: "budget-exhausted" | undefined;
 }
 
 /**
@@ -414,6 +420,22 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
    * the model (durable batch-resume seam). Consumed by the Run's first Turn.
    */
   readonly resume?: RunTurnResume | undefined;
+  /**
+   * Per-Run Tool Call allowance (RUN-021): a TIGHTENING-ONLY bound below the
+   * Agent Policy's `maxToolCalls` — the effective limit is
+   * `min(policy.maxToolCalls, max(1, floor(toolCallAllowance)))`, so an
+   * allowance can never widen the Definition's ceiling. The `onExhaustion`
+   * resolution (RUN-018) keys off the effective limit, which is how an
+   * orchestrator grants a delegated child a budget extension by re-invoking
+   * with a larger allowance up to the child Definition's policy.
+   */
+  readonly toolCallAllowance?: number | undefined;
+  /**
+   * Per-Run Turn allowance (RUN-021): tightening-only below the Agent
+   * Policy's `maxTurns`, with the same normalization and the same
+   * `onExhaustion` resolution (RUN-019 grace) at the effective limit.
+   */
+  readonly turnAllowance?: number | undefined;
   /** Required when the core policy declares `costBudgetMicrousd`. */
   readonly estimateCostMicrousd?:
     | ((usage: Response.Usage) => Effect.Effect<number, HookError, HookRequirements>)

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -5782,6 +5782,154 @@ layer(identifiers)("RUN-018 budget soft landing", (it) => {
       expect(yield* Ref.get(handlerStarts)).toBe(0);
     }),
   );
+
+  it.effect(
+    "RUN-021 a per-Run Tool Call allowance tightens below the policy and soft-lands at the effective limit",
+    () =>
+      Effect.gen(function* () {
+        const handlerStarts = yield* Ref.make(0);
+        const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+        const turns = yield* Ref.make(0);
+        const toolChoices = yield* Ref.make<ReadonlyArray<unknown>>([]);
+        const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+        const definition = softLandingDefinition(
+          AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 5,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+          }),
+        );
+        const model = turnScriptedModel(
+          "allowance-tightens",
+          turns,
+          toolChoices,
+          prompts,
+          (turn) =>
+            turn === 0
+              ? [
+                  searchCall("search-1"),
+                  searchCall("search-2"),
+                  { type: "finish", reason: "tool-calls", usage },
+                ]
+              : finalParts('{"answer":"partial under allowance"}'),
+        );
+        const toolLayer = softLandingTools.toLayer({
+          search: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("found")),
+        });
+
+        const exit = yield* AgentRuntime.stream(
+          Agent.withModel(definition, model),
+          { question: "research" },
+          { toolCallAllowance: 1 },
+        ).pipe(
+          Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+          Stream.runDrain,
+          Effect.provide(toolLayer),
+          Effect.exit,
+        );
+        const observed = yield* Ref.get(events);
+
+        // The batch of 2 exceeds the effective limit of min(5, 1) = 1: it is
+        // rejected without a handler start and the Run soft-lands.
+        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(yield* Ref.get(handlerStarts)).toBe(0);
+        expect(observed.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(2);
+        expect(observed.at(-1)).toMatchObject({
+          _tag: "RunCompleted",
+          finishReason: "budget-exhausted",
+        });
+        expect(yield* Ref.get(toolChoices)).toEqual(["auto", "none"]);
+      }),
+  );
+
+  it.effect("RUN-021 an allowance can never widen the policy ceiling", () =>
+    Effect.gen(function* () {
+      const handlerStarts = yield* Ref.make(0);
+      const turns = yield* Ref.make(0);
+      const toolChoices = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+      const definition = softLandingDefinition(
+        AgentPolicy.make({
+          maxTurns: 5,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+          onExhaustion: "fail",
+        }),
+      );
+      const model = turnScriptedModel("allowance-no-widen", turns, toolChoices, prompts, () => [
+        searchCall("search-1"),
+        searchCall("search-2"),
+        { type: "finish", reason: "tool-calls", usage },
+      ]);
+      const toolLayer = softLandingTools.toLayer({
+        search: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("found")),
+      });
+
+      const exit = yield* AgentRuntime.stream(
+        Agent.withModel(definition, model),
+        { question: "research" },
+        { toolCallAllowance: 100 },
+      ).pipe(Stream.runDrain, Effect.provide(toolLayer), Effect.exit);
+      const failure = failureFrom(exit);
+
+      // min(policy 1, allowance 100) = 1: the policy ceiling holds.
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect(failure).toMatchObject({ limit: "tool-calls" });
+      expect(errorMessageForTest(failure)).toContain("1 Tool Call limit");
+      expect(yield* Ref.get(handlerStarts)).toBe(0);
+    }),
+  );
+
+  it.effect("RUN-021 a per-Run Turn allowance tightens maxTurns with the same grace", () =>
+    Effect.gen(function* () {
+      const handlerStarts = yield* Ref.make(0);
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      const turns = yield* Ref.make(0);
+      const toolChoices = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+      const definition = softLandingDefinition(
+        AgentPolicy.make({
+          maxTurns: 5,
+          maxToolCalls: 5,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      );
+      const model = turnScriptedModel("turn-allowance", turns, toolChoices, prompts, (turn) =>
+        turn === 0
+          ? [searchCall("search-1"), { type: "finish", reason: "tool-calls", usage }]
+          : finalParts('{"answer":"grace under allowance"}'),
+      );
+      const toolLayer = softLandingTools.toLayer({
+        search: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("found")),
+      });
+
+      const exit = yield* AgentRuntime.stream(
+        Agent.withModel(definition, model),
+        { question: "research" },
+        { turnAllowance: 1 },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.exit,
+      );
+      const observed = yield* Ref.get(events);
+
+      // The pending batch at the effective final Turn executes; the single
+      // grace Turn runs tool-free and settles honestly.
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* Ref.get(handlerStarts)).toBe(1);
+      expect(yield* Ref.get(toolChoices)).toEqual(["auto", "none"]);
+      expect(observed.at(-1)).toMatchObject({
+        _tag: "RunCompleted",
+        turns: 2,
+        finishReason: "budget-exhausted",
+      });
+    }),
+  );
 });
 
 /**

--- a/packages/pr-review/src/internal/fan-out-scripted.ts
+++ b/packages/pr-review/src/internal/fan-out-scripted.ts
@@ -72,16 +72,11 @@ export type OfflineUnitOutcome =
   /** Read one diff, then return non-JSON — the child fails typed (AgentOutputError). */
   | { readonly _tag: "malformed-output" }
   /**
-   * Declare more Tool Calls than the child's AgentPolicy allows in one turn.
-   * None executes; under the default `onExhaustion: "final-answer"` the child
-   * sees one synthetic failed result per rejected call and returns `report`
-   * on its final tool-free turn (RUN-018).
+   * Declare more Tool Calls than the child's AgentPolicy allows in one turn —
+   * none executes and the child fails typed (AgentPolicyError "tool-calls",
+   * the reviewer's deliberate `onExhaustion: "fail"` pin).
    */
-  | {
-      readonly _tag: "budget-runaway";
-      readonly declaredCalls: number;
-      readonly report: FileReviewReport;
-    };
+  | { readonly _tag: "budget-runaway"; readonly declaredCalls: number };
 
 export interface OfflineUnitScript {
   readonly unitId: string;
@@ -108,13 +103,6 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
       if (script === undefined) return undefined;
       switch (script.outcome._tag) {
         case "budget-runaway": {
-          // Turn 2: the rejected batch's synthetic results are in history, so
-          // the child soft-lands with its partial report.
-          if (promptJson.includes(`runaway-${script.unitId}-1`)) {
-            return scriptedFinalParts(
-              JSON.stringify(Schema.encodeSync(FileReviewReport)(script.outcome.report)),
-            );
-          }
           return scriptedToolTurn(
             ...Array.from(
               { length: script.outcome.declaredCalls },

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -3,11 +3,7 @@ import {
   Agent,
   AgentPolicy,
   Subagent,
-  SubagentBudgetExhausted,
-  SubagentExecutionFailure,
   SubagentPolicy,
-  SubagentPrestartDenied,
-  SubagentProjectionFailure,
   SubagentRuntime,
   ToolExecutionClass,
   type RuntimeBinding,
@@ -142,11 +138,14 @@ export const defaultFileReviewerPolicy = AgentPolicy.make({
   maxDuration: "4 minutes",
   toolConcurrency: 2,
   tokenBudget: 200_000,
-  // Budget soft landing (RUN-018): a child that exhausts its Turn or Tool
-  // Call budget returns its partial line-anchored report on one final
-  // tool-free turn instead of failing the unit — the standing "unit-00N
-  // unreviewed: AgentPolicyError" failure mode on big units.
-  onExhaustion: "final-answer",
+  // Typed exhaustion, deliberately NOT the final-answer soft landing: a
+  // review is a coverage claim, and a child whose reads were rejected could
+  // still emit schema-valid findings — laundering budget exhaustion into
+  // "reviewed". Until host-owned evidence proves every mandatory
+  // read_file_diff completed, an exhausted child fails typed and its unit
+  // stays honestly unreviewed (containment turns that into result data
+  // without failing the run).
+  onExhaustion: "fail",
 });
 
 // ---------------------------------------------------------------------------
@@ -217,21 +216,6 @@ export const mapFileReviewChildFailure = (failure: {
     childErrorTag: failure._tag,
     message: (failure.message ?? "").slice(0, 400),
   });
-
-/**
- * The contained failure family this delegation can surface as result data
- * under the first-party `failureMode: "return"` (SUB-033). The engine-signal
- * members (`ToolCallWaiting`, `SubagentDurabilityError`) are deliberately not
- * here: they stay in the error channel by construction. Used by the coverage
- * gate to classify returned unit failures.
- */
-export const FileReviewDelegationFailure = Schema.Union([
-  FileReviewUnitFailed,
-  SubagentPrestartDenied,
-  SubagentBudgetExhausted,
-  SubagentProjectionFailure,
-  SubagentExecutionFailure,
-]);
 
 // ---------------------------------------------------------------------------
 // The coordinator's own tool: the deterministic unit plan over the changeset.
@@ -430,6 +414,13 @@ export const DelegateFileReview = delegationToolFor(fileReviewDelegation);
 
 /** The default coordinator Toolkit. */
 export const FanOutReviewToolkit = FanOutReviewer.toolkit;
+
+/**
+ * The contained failure family the delegation can surface as result data
+ * (SUB-033), derived from the delegation itself so the coverage decoder can
+ * never diverge from what the runtime actually contains.
+ */
+export const FileReviewDelegationFailure = fileReviewDelegation.containedFailure;
 
 /** Runtime wiring: one delegation plus one explicit child Binding. */
 export const fanOutHandlersLayerFor =

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -638,7 +638,7 @@ describe("offline fan-out review run", () => {
   );
 
   it.effect(
-    "RUN-018 a runaway child soft-lands: none of the over-budget calls execute and the unit completes with its partial report",
+    "SUB-033 a runaway child fails typed and its unit is reported honestly, never retried",
     () =>
       Effect.gen(function* () {
         const runawayChildren: ReadonlyArray<OfflineUnitScript> = [
@@ -647,41 +647,45 @@ describe("offline fan-out review run", () => {
             unitId: "unit-002",
             diffPath: "src/core/gamma.ts",
             // One more declared call than the child AgentPolicy allows: the
-            // whole batch is rejected without executing, and the child returns
-            // its partial report on the final tool-free turn.
+            // reviewer pins typed exhaustion (a review is a coverage claim —
+            // schema-valid findings from a child whose reads never executed
+            // would launder budget exhaustion into coverage), so the child
+            // fails typed and first-party containment turns that into result
+            // data instead of failing the run.
             outcome: {
               _tag: "budget-runaway",
               declaredCalls: MAX_FILE_REVIEW_TOOL_CALLS + 1,
-              report: unitTwoReport,
             },
           },
         ];
-        const mergedReview = CodeReview.make({
-          summary: "Reviewed unit-001 and unit-002 (unit-002 on a partial, budget-exhausted pass).",
+        const honestReview = CodeReview.make({
+          summary: "unit-002 unreviewed: AgentPolicyError (exceeded its Tool Call budget).",
           verdict: "comment",
-          findings: rankAndDedupeFindings([...unitOneReport.findings, ...unitTwoReport.findings]),
+          findings: rankAndDedupeFindings([...unitOneReport.findings]),
         });
 
-        const result = yield* runOfflineFanOut({ children: runawayChildren, review: mergedReview });
+        const result = yield* runOfflineFanOut({
+          children: runawayChildren,
+          review: honestReview,
+        });
 
-        // Two child model calls: the rejected over-budget turn and the final
-        // answer — no third chance, and no handler ran for any runaway call.
-        expect(result.childCalls).toBe(4);
+        // The child failed typed on its Tool Call bound BEFORE any runaway
+        // call executed: one child model call, no second chance, run intact.
+        expect(result.childCalls).toBe(3);
         expect(result.coordinatorCalls).toBe(3);
 
-        // The child saw the synthetic policy rejection as failed tool results
-        // and answered from what it had.
-        const runawayPrompt =
-          result.childPrompts.find((prompt) => prompt.includes("runaway-unit-002-1")) ?? "";
-        expect(runawayPrompt).toContain("Tool Call budget exhausted");
-
-        // The unit COMPLETED: findings from both units, no failed units, and
-        // nothing retried. (Coverage stays "incomplete" only for the fixture's
-        // undiffable binary, exactly like the fully-happy run.)
-        expect(result.outcome.review).toEqual(mergedReview);
+        // The typed policy failure crossed the delegation boundary bounded
+        // and model-visible; the unit stays honestly unreviewed.
+        const finalPrompt = result.coordinatorPrompts[2] ?? "";
+        expect(finalPrompt).toContain("FileReviewUnitFailed");
+        expect(finalPrompt).toContain("AgentPolicyError");
+        expect(result.outcome.review.summary).toContain("unit-002 unreviewed: AgentPolicyError");
         expect(result.published).toHaveLength(1);
-        expect(result.outcome.coverage.failedUnits).toEqual([]);
-        expect(result.outcome.coverage.unreviewedPaths).toEqual(["assets/logo.png"]);
+        expect(result.outcome.coverage.status).toBe("incomplete");
+        expect(result.outcome.coverage.failedUnits).toContainEqual({
+          unitId: "unit-002",
+          errorTag: "FileReviewUnitFailed:AgentPolicyError",
+        });
       }),
   );
 });

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -3576,6 +3576,12 @@ const make = Effect.gen(function* () {
               ...identity,
               outcome: verification.value.outcome,
               encodedResult: verification.value.encodedResult,
+              // The child Settlement's honest exhaustion marker (RUN-018)
+              // rides to the parent handler so the delegation can surface a
+              // budget-truncated partial to the orchestrator (SUB-034).
+              ...(verification.value.settlement.finishReason === undefined
+                ? {}
+                : { finishReason: verification.value.settlement.finishReason }),
             };
           }),
         );

--- a/packages/testing/test/durable-subagents.test.ts
+++ b/packages/testing/test/durable-subagents.test.ts
@@ -210,6 +210,38 @@ const mixedCoordinatorDefinition = Agent.define("travel-coordinator-mixed", {
 const mapChildFailure = (failure: { readonly _tag: string }) =>
   ResearchDelegationFailed.make({ childErrorTag: failure._tag });
 
+/** SUB-033 fixture: the same delegation under first-party containment. */
+const containedResearchDelegation = Subagent.define("delegate_research_contained", {
+  description: "Research one bounded question; failures are contained result data.",
+  target: childDefinition,
+  parameters: Schema.Struct({ topic: Schema.String }),
+  success: Schema.Struct({ summary: Schema.String }),
+  failure: ResearchDelegationFailed,
+  failureMode: "return",
+  prepareInput: ({ topic }) => Effect.succeed({ question: `research:${topic}` }),
+  projectResult: (output) => Effect.succeed({ summary: `finding:${output.answer}` }),
+  policy: SubagentPolicy.make({
+    maxChildren: 2,
+    maxConcurrency: 2,
+    maxTurns: 4,
+    maxToolCalls: 4,
+    maxDuration: "10 seconds",
+  }),
+});
+
+const containedCoordinatorDefinition = Agent.define("travel-coordinator-contained", {
+  input: Schema.Struct({ mission: Schema.String }),
+  output: Schema.Struct({ report: Schema.String }),
+  instructions: "Delegate, then answer as JSON.",
+  toolkit: Toolkit.make(containedResearchDelegation.tool),
+  policy: AgentPolicy.make({
+    maxTurns: 3,
+    maxToolCalls: 2,
+    maxDuration: "30 seconds",
+    toolConcurrency: 2,
+  }),
+});
+
 const configLayer = DurableRuntimeConfig.layer({
   deploymentId: Schema.decodeSync(DeploymentId)("deployment-durable-subagents"),
   producerId: Schema.decodeSync(ProducerId)("producer-durable-subagents"),
@@ -270,7 +302,12 @@ const identifiers = Layer.effect(
 const delegationSupport = Layer.mergeAll(SubagentReservationsMemoryLive, identifiers);
 
 const submitParentWith =
-  (definition: typeof coordinatorDefinition | typeof mixedCoordinatorDefinition) =>
+  (
+    definition:
+      | typeof coordinatorDefinition
+      | typeof mixedCoordinatorDefinition
+      | typeof containedCoordinatorDefinition,
+  ) =>
   (conversation: string, key: string) =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
@@ -590,6 +627,93 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
           expect(payloadsOf(log, "SubagentJoined")).toHaveLength(1);
           const reservations = yield* parentReservations(parent.submissionId);
           expect(reservations.map((row) => row.status)).toEqual(["released"]);
+        }
+      }),
+  );
+
+  it.effect(
+    "SUB-033 a kill around the contained join yields ONE non-failure settlement carrying the bounded child failure",
+    () =>
+      Effect.gen(function* () {
+        for (const location of [
+          "subagent:after-join-append",
+          "subagent:after-release-pending",
+          "subagent:after-release",
+        ] satisfies ReadonlyArray<DurableRuntimeFailpointLocation>) {
+          yield* clearFailpoint;
+          // A child whose model emits invalid output: its lane settles FAILED.
+          const childScripted = yield* makeScriptedModel(() => finalParts("not-json"));
+          const childBinding = Agent.withModel(childDefinition, childScripted.model);
+          const parentScripted = yield* makeScriptedModel((call) =>
+            call === 0
+              ? toolTurn(toolCall("delegate-1", "delegate_research_contained", { topic: "paris" }))
+              : finalParts('{"report":"handled"}'),
+          );
+          const parentBinding = Agent.withModel(
+            containedCoordinatorDefinition,
+            parentScripted.model,
+          );
+          const delegationLayer = SubagentRuntime.layer(containedResearchDelegation, childBinding, {
+            mapChildFailure,
+            durable: { targetDigests: CHILD_DIGEST_STRINGS },
+          }).pipe(Layer.provide(delegationSupport));
+          const parentResolved: ResolvedBinding = yield* DurableWorkerBinding.make(
+            parentBinding,
+            PARENT_DIGESTS,
+          ).pipe(Effect.provide(delegationLayer));
+          const childResolved: ResolvedBinding = yield* DurableWorkerBinding.make(
+            childBinding,
+            CHILD_DIGESTS,
+          );
+          const harness = {
+            resolver: AgentBindingResolver.fromBindings([parentResolved, childResolved]),
+            childInvocations: childScripted.calls,
+            parentPrompts: parentScripted.prompts,
+            submitParent: submitParentWith(containedCoordinatorDefinition),
+            lookupInvocations: Effect.succeed(0),
+          };
+          const run = drive(harness);
+          const conversation = `conversation-s2-contained-${location.replaceAll(":", "-")}`;
+          const parent = yield* harness.submitParent(conversation, `contained-${location}`);
+          const parentRunId = runIdForSubmission(parent.submissionId);
+          const childConversationId = childConversationIdFor(parent.submissionId, DELEGATE_CALL);
+
+          yield* run(parent.conversationId);
+          const childSettlements = yield* run(childConversationId);
+          expect(childSettlements.map((settlement) => settlement.outcome)).toEqual(["failed"]);
+          expect(yield* harness.childInvocations).toBe(1);
+
+          yield* armFailpoint(location);
+          const exit = yield* Effect.exit(run(parent.conversationId));
+          expect(failureTag(exit)).toBe("DurableRuntimeFailpointError");
+          yield* clearFailpoint;
+
+          // Recovery: the parent COMPLETES — the failed child is contained
+          // result data, exactly one non-failure Tool settlement exists, and
+          // the child was never re-executed.
+          const settlements = yield* run(parent.conversationId);
+          expect(settlements.map((settlement) => settlement.outcome)).toEqual(["completed"]);
+          expect(yield* harness.childInvocations).toBe(1);
+          const log = yield* readLog(parent.conversationId);
+          expect(payloadsOf(log, "SubagentJoined")).toHaveLength(1);
+          const joinSettles = log.filter(
+            (envelope) =>
+              envelope.record.payload._tag === "ToolCallSettled" &&
+              envelope.record.recordId === `tool-settled:${parentRunId}:1:delegate-1`,
+          );
+          expect(joinSettles).toHaveLength(1);
+          const settled = joinSettles[0]?.record.payload;
+          if (settled?._tag === "ToolCallSettled") {
+            expect(settled.isFailure).toBe(false);
+            expect(settled.result).toMatchObject({
+              _tag: "SubagentExecutionFailure",
+              classification: "child-failed",
+            });
+          }
+          // The rebuilt model context carries the contained failure as an
+          // ordinary (non-error) tool result: the parent's final prompt saw it.
+          const finalPrompt = JSON.stringify(harness.parentPrompts.at(-1));
+          expect(finalPrompt).toContain("SubagentExecutionFailure");
         }
       }),
   );


### PR DESCRIPTION
## Summary

- The final slice of the budget arc (D-037, [ADR-0019](../blob/dan/budget-extension/docs/adr/0019-budget-soft-landing-and-extension.md) S3): an orchestrator can now **grant a scout more budget** by re-delegating with a raised allowance — Dan's "they can even request more turns from the orchestrator" flow, requirements RUN-021 and SUB-034.
- [`RunOptions`](../blob/dan/budget-extension/packages/engine/src/run-options.ts) gains **tightening-only** `toolCallAllowance` and `turnAllowance`: the effective limit is `min(policy bound, max(1, floor(allowance)))` — an allowance can never widen the Definition's ceiling — and the S1 `onExhaustion` soft landing keys off the effective limits.
- `Subagent.define` gains [`toolCallAllowance: { default, fromParameters }`](../blob/dan/budget-extension/packages/capabilities/src/subagent.ts): the orchestrator model grants a larger allowance through an author-owned parameter field, clamped **fail-closed** to the delegation's per-invocation `SubagentPolicy.maxToolCalls` reservation slice, threaded into ephemeral child runs.
- `projectResult` receives a bounded `SubagentResultContext` with the honest `budgetExhausted` marker — from the ephemeral child result's `finishReason`, or from the child Settlement's durable marker carried through the new optional `ChildEstablishSettled.finishReason` (the session coordinator threads it from the verified child Settlement record). Existing one-argument `projectResult` functions keep compiling.

## Architecture

- **The grant flow needs no new machinery**: a budget extension is a *fresh re-delegation* with a raised allowance and the scout's partial findings forwarded through `prepareInput` — never a mid-flight reservation top-up (§7 conservation semantics and `SubagentReservationConflict` untouched) and never child-Conversation reuse (rejected scope, ADR-0010).
- **Ceiling chain preserved (SUB-034/D-013)**: model-granted allowance ≤ delegation reservation slice ≤ child Definition policy — the engine enforces the last via `min` regardless of what callers pass.
- **Scope delta recorded in the ADR status note**: the allowance reaches only **ephemeral** children. A durable child's lane owns no per-run options channel, and making the reservation slice binding on the child would contradict §7's never-clipped overrun model — durable allowance threading is deferred to its own proposal. The *extension flow* still works on both paths today because the exhausted marker travels durably.

## S2 hardening (the #50 autoreviewer's findings, applied here — the #36 precedent)

#50 auto-merged before its review posted, so its two blocking soundness findings and the coverage-honesty finding land in this PR: `Subagent.define` is **overloaded** so the resolved Tool channels follow the `failureMode` *value* (return mode can no longer be claimed via a type argument while the runtime builds the error-mode Tool); genuine engine signals are classified through a **module-private provenance wrapper** at the only operations that can produce them (an author-declared failure using the exported `ToolCallWaiting` class is contained as data, never rethrown as a suspension); each delegation exposes its canonical `containedFailure` schema and pr-review's coverage decoder derives from it; the contained durable join gains **failpoint recovery coverage** at all three `subagent:after-join*` boundaries; and the pr-review **child** reviewer deliberately returns to typed exhaustion — a review is a coverage claim, and schema-valid findings from a child whose reads were all rejected would launder budget exhaustion into coverage (host-owned read-provenance is the recorded future work; containment keeps the typed exhaustion non-fatal to the run).

## Evidence

- Engine (RUN-021): an allowance of 1 under a policy of 5 soft-lands the run at the effective limit (batch rejected, zero handler starts, `budget-exhausted` completion); an allowance of 100 under a policy of 1 still fails at 1 in `"fail"` mode (never widens); a `turnAllowance` of 1 grants exactly the single grace turn.
- Capabilities (SUB-034): the default allowance tightens a child below its own Definition policy and the projection surfaces `partial:`; a model-granted 100 clamps to the slice ceiling of 4 (a broken clamp would have executed all five probes — the test pins zero); **the end-to-end grant**: delegation one runs at the default allowance and returns a budget-truncated partial, delegation two with `grant-4` executes fully — one parent run, two children, `["partial:draft", "finding:complete"]`; a durable settled child with the S1 marker surfaces `partial:` through the same projection with zero in-process child invocations.
- Full gates green: `bun run check`, all 19 test tasks, `requirements:coverage` (177 IDs, RUN-021/SUB-034 via test titles), action bundle rebuilt and `--check`-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
