### PR TITLE
harden(engine,capabilities): fail closed on non-finite allowances; prove the observe-then-grant sequence

### DIFF
--- a/.changeset/budget-extension.md
+++ b/.changeset/budget-extension.md
@@ -14,8 +14,9 @@ orchestrator model grants a scout more budget by re-delegating with a raised all
 child; never a mid-flight top-up). `projectResult` now receives a bounded
 `SubagentResultContext` whose `budgetExhausted` marker is honest on both paths — from the
 ephemeral child result's `finishReason`, or from the child Settlement's durable marker carried
-through the new optional `ChildEstablishSettled.finishReason` — so a budget-truncated partial can
-be surfaced in the declared success Schema. Existing one-argument `projectResult` functions keep
+through the new optional `ChildEstablishSettled.finishReason` (threaded by the session
+coordinator shared by the DN and DC assemblies; exercised in the DN-profile durable-subagent
+suites) — so a budget-truncated partial can be surfaced in the declared success Schema. Existing one-argument `projectResult` functions keep
 compiling unchanged. Also hardens S2 containment per its autoreviewer findings: `Subagent.define`
 is overloaded so the Tool channels follow the `failureMode` value; genuine engine signals are
 classified by unspoofable provenance instead of `instanceof` on exported classes; each delegation

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -33080,9 +33080,10 @@ var decodeResumedToolCallParameters = (tool, toolName, encodedParams) => {
     message: `Recorded parameters for Tool ${toolName} failed validation on resume: ${cause.message}`
   })));
 };
+var boundedAllowance = (policyBound, allowance) => allowance === undefined || !Number.isFinite(allowance) ? policyBound : Math.min(policyBound, Math.max(1, Math.floor(allowance)));
 var effectiveRunBounds = (policy2, options) => ({
-  maxTurns: options.turnAllowance === undefined ? policy2.maxTurns : Math.min(policy2.maxTurns, Math.max(1, Math.floor(options.turnAllowance))),
-  maxToolCalls: options.toolCallAllowance === undefined ? policy2.maxToolCalls : Math.min(policy2.maxToolCalls, Math.max(1, Math.floor(options.toolCallAllowance)))
+  maxTurns: boundedAllowance(policy2.maxTurns, options.turnAllowance),
+  maxToolCalls: boundedAllowance(policy2.maxToolCalls, options.toolCallAllowance)
 });
 var makeToolFailedEvent = exports_Effect.fn("AgentRuntime.makeToolFailedEvent")(function* (context3, turnId, call, error2) {
   const toolCallId = yield* decodeToolCallId(call.id);
@@ -37685,7 +37686,8 @@ var layer14 = (delegation, childBinding, options) => {
         consume: (delta) => reservations.observe(reservationId, observedUsageFromDelta(delta)).pipe(exports_Effect.orDie, exports_Effect.andThen(seededBudget === undefined ? exports_Effect.void : seededBudget.consume(delta)))
       };
       const allowanceOption = delegation.toolCallAllowance;
-      const requestedAllowance = allowanceOption === undefined ? undefined : allowanceOption.fromParameters?.(parameters) ?? allowanceOption.default;
+      const extracted = allowanceOption?.fromParameters?.(parameters);
+      const requestedAllowance = extracted !== undefined && Number.isFinite(extracted) ? extracted : allowanceOption !== undefined && Number.isFinite(allowanceOption.default) ? allowanceOption.default : undefined;
       const toolCallAllowance = requestedAllowance === undefined ? undefined : Math.min(Math.max(1, Math.floor(requestedAllowance)), delegation.policy.maxToolCalls);
       const childOptions = {
         ...seededChild,

--- a/docs/adr/0019-budget-soft-landing-and-extension.md
+++ b/docs/adr/0019-budget-soft-landing-and-extension.md
@@ -23,9 +23,11 @@
   `ChildEstablishSettled.finishReason`). One scope delta from decision item 7: the allowance
   reaches only EPHEMERAL children — a durable child's lane owns no per-run options channel, and
   making the reservation slice binding on the child would contradict §7's never-clipped overrun
-  model, so durable allowance threading is deferred to its own proposal. The extension flow
-  (fresh re-delegation with a raised allowance and partial findings forwarded through
-  `prepareInput`) works on both paths today because the exhausted marker travels durably.
+  model, so durable allowance threading is deferred to its own proposal. On the durable path the
+  exhausted marker still travels (via `ChildEstablishSettled.finishReason`) and re-delegation
+  remains possible, but an allowance has no effect there — a durable child always runs at its
+  Definition policy — so allowance-based extension is meaningful only for ephemeral children
+  until the deferred proposal lands.
 - Status note (2026-08-15, hardening after #50's autoreviewer): `define` is overloaded so the
   resolved Tool channels follow the `failureMode` VALUE (return mode cannot be claimed through a
   type argument while the runtime builds the error-mode Tool); containment classifies genuine

--- a/packages/capabilities/src/subagent.ts
+++ b/packages/capabilities/src/subagent.ts
@@ -1401,10 +1401,16 @@ const layer = <
       // delegation's own per-invocation reservation slice; the child's
       // Definition policy stays the engine-side ceiling (RUN-021).
       const allowanceOption = delegation.toolCallAllowance;
+      // Fail closed on non-finite values (SUB-034): a model-derived NaN falls
+      // back to the author default, and a non-finite default yields no
+      // allowance at all — the child Definition policy stays the bound.
+      const extracted = allowanceOption?.fromParameters?.(parameters);
       const requestedAllowance =
-        allowanceOption === undefined
-          ? undefined
-          : (allowanceOption.fromParameters?.(parameters) ?? allowanceOption.default);
+        extracted !== undefined && Number.isFinite(extracted)
+          ? extracted
+          : allowanceOption !== undefined && Number.isFinite(allowanceOption.default)
+            ? allowanceOption.default
+            : undefined;
       const toolCallAllowance =
         requestedAllowance === undefined
           ? undefined

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -2448,31 +2448,104 @@ layer(TestServices)("SubagentRuntime SUB-034 per-invocation allowance", (it) => 
   );
 
   it.effect(
-    "SUB-034 the orchestrator grants a budget extension by re-delegating with a raised allowance",
+    "SUB-034 the orchestrator OBSERVES the budget-truncated partial, then grants an extension by re-delegating",
     () =>
       Effect.gen(function* () {
-        const { result, events, probeStarts } = yield* runAllowance({
-          name: "parent-allowance-extension",
-          calls: [
-            { id: "call-1", params: { topic: "small" } },
-            { id: "call-2", params: { topic: "grant-4" } },
-          ],
-          childScripts: [
+        const probeStarts = yield* Ref.make(0);
+        const childBinding = Agent.withModel(
+          probingChildDefinition,
+          probingChildModel([
             { topic: "small", declares: 2, answer: '{"answer":"draft"}' },
             { topic: "grant-4", declares: 2, answer: '{"answer":"complete"}' },
-          ],
-          runId: "parent-run-allowance-extension",
+          ]),
+        );
+        // Sequential, content-keyed coordinator: the granting call is
+        // declared ONLY after the partial result is visible in the prompt —
+        // the grant is a reaction to observed exhaustion, never preplanned.
+        const parentModel = Model.make(
+          "scripted",
+          "parent-allowance-sequential",
+          Layer.effect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: () => Effect.succeed([]),
+              streamText: (request) => {
+                const promptJson = JSON.stringify(request.prompt);
+                if (promptJson.includes("finding:complete")) {
+                  return Stream.fromIterable(finalParts('{"report":"done"}'));
+                }
+                if (promptJson.includes("partial:draft")) {
+                  return Stream.fromIterable<Response.StreamPartEncoded>([
+                    {
+                      type: "tool-call",
+                      id: "call-2",
+                      name: "delegate_allowance",
+                      params: { topic: "grant-4" },
+                      providerExecuted: false,
+                    },
+                    { type: "finish", reason: "tool-calls", usage },
+                  ]);
+                }
+                return Stream.fromIterable<Response.StreamPartEncoded>([
+                  {
+                    type: "tool-call",
+                    id: "call-1",
+                    name: "delegate_allowance",
+                    params: { topic: "small" },
+                    providerExecuted: false,
+                  },
+                  { type: "finish", reason: "tool-calls", usage },
+                ]);
+              },
+            }),
+          ),
+        );
+        const parent = Agent.withModel(allowanceCoordinator, parentModel);
+        const probeLayer = probeToolkit.toLayer({
+          probe_doc: ({ ref }) =>
+            Ref.update(probeStarts, (count) => count + 1).pipe(Effect.as(`probed-${ref}`)),
+        });
+        const runtimeLayer = SubagentRuntime.layer(allowanceDelegation, childBinding, {
+          mapChildFailure,
+        }).pipe(Layer.provide(probeLayer));
+
+        const detached = yield* AgentRuntime.start(
+          parent,
+          { mission: "m" },
+          { runId: decodeRunId("parent-run-allowance-sequential") },
+        ).pipe(Effect.provide(runtimeLayer));
+        const result = yield* detached.await;
+        const events = yield* detached.events;
+
+        // Turn 1: default allowance 1 rejects the first child's batch — the
+        // coordinator SEES "partial:draft" and only then grants allowance 4;
+        // the second child executes both probes and returns the full finding.
+        expect(result.output).toEqual({ report: "done" });
+        expect(yield* Ref.get(probeStarts)).toBe(2);
+        const succeeded = events.filter((event) => event._tag === "ToolCallSucceeded");
+        expect(succeeded.map((event) => event.result)).toEqual([
+          { summary: "partial:draft" },
+          { summary: "finding:complete" },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "SUB-034 a non-finite model-granted allowance falls back fail-closed to the default",
+    () =>
+      Effect.gen(function* () {
+        const { result, probeStarts } = yield* runAllowance({
+          name: "parent-allowance-nan",
+          // "grant-garbage" extracts Number("garbage") === NaN.
+          calls: [{ id: "call-1", params: { topic: "grant-garbage" } }],
+          childScripts: [{ topic: "grant-garbage", declares: 2, answer: '{"answer":"nan-safe"}' }],
+          runId: "parent-run-allowance-nan",
         });
 
-        // First invocation: default allowance 1 rejects the batch of 2 — a
-        // budget-truncated partial. Second invocation with the granted
-        // allowance of 4 executes both probes and returns the full finding.
+        // NaN never reaches the child options: the default of 1 applies, the
+        // batch of 2 is rejected, and the run still soft-lands bounded.
         expect(result.output).toEqual({ report: "done" });
-        expect(probeStarts).toBe(2);
-        const succeeded = events.filter((event) => event._tag === "ToolCallSucceeded");
-        expect(succeeded.map((event) => event.result)).toEqual(
-          expect.arrayContaining([{ summary: "partial:draft" }, { summary: "finding:complete" }]),
-        );
+        expect(probeStarts).toBe(0);
       }),
   );
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -566,6 +566,14 @@ const decodeResumedToolCallParameters = <Tools extends Record<string, Tool.Any>>
  * extension by re-invoking with a larger allowance below the Definition's
  * ceiling.
  */
+const boundedAllowance = (policyBound: number, allowance: number | undefined): number =>
+  // Fail closed on non-finite allowances (RUN-021): `NaN` propagates through
+  // floor/max/min and every later `>` comparison answers false, which would
+  // silently erase the bound — an invalid allowance keeps the policy bound.
+  allowance === undefined || !Number.isFinite(allowance)
+    ? policyBound
+    : Math.min(policyBound, Math.max(1, Math.floor(allowance)));
+
 const effectiveRunBounds = (
   policy: AgentPolicy,
   options: {
@@ -573,14 +581,8 @@ const effectiveRunBounds = (
     readonly turnAllowance?: number | undefined;
   },
 ): { readonly maxTurns: number; readonly maxToolCalls: number } => ({
-  maxTurns:
-    options.turnAllowance === undefined
-      ? policy.maxTurns
-      : Math.min(policy.maxTurns, Math.max(1, Math.floor(options.turnAllowance))),
-  maxToolCalls:
-    options.toolCallAllowance === undefined
-      ? policy.maxToolCalls
-      : Math.min(policy.maxToolCalls, Math.max(1, Math.floor(options.toolCallAllowance))),
+  maxTurns: boundedAllowance(policy.maxTurns, options.turnAllowance),
+  maxToolCalls: boundedAllowance(policy.maxToolCalls, options.toolCallAllowance),
 });
 
 const makeToolFailedEvent = Effect.fn("AgentRuntime.makeToolFailedEvent")(function* (

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -5882,6 +5882,47 @@ layer(identifiers)("RUN-018 budget soft landing", (it) => {
     }),
   );
 
+  it.effect(
+    "RUN-021 a non-finite allowance is ignored fail-closed and the policy bound holds",
+    () =>
+      Effect.gen(function* () {
+        const handlerStarts = yield* Ref.make(0);
+        const turns = yield* Ref.make(0);
+        const toolChoices = yield* Ref.make<ReadonlyArray<unknown>>([]);
+        const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+        const definition = softLandingDefinition(
+          AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 1,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            onExhaustion: "fail",
+          }),
+        );
+        const model = turnScriptedModel("allowance-nan", turns, toolChoices, prompts, () => [
+          searchCall("search-1"),
+          searchCall("search-2"),
+          { type: "finish", reason: "tool-calls", usage },
+        ]);
+        const toolLayer = softLandingTools.toLayer({
+          search: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("found")),
+        });
+
+        // NaN would poison every `>` comparison (always false) and silently
+        // erase the bound; the engine must keep the policy limit instead.
+        const exit = yield* AgentRuntime.stream(
+          Agent.withModel(definition, model),
+          { question: "research" },
+          { toolCallAllowance: Number.NaN },
+        ).pipe(Stream.runDrain, Effect.provide(toolLayer), Effect.exit);
+        const failure = failureFrom(exit);
+
+        expect(failure).toBeInstanceOf(AgentPolicyError);
+        expect(failure).toMatchObject({ limit: "tool-calls" });
+        expect(yield* Ref.get(handlerStarts)).toBe(0);
+      }),
+  );
+
   it.effect("RUN-021 a per-Run Turn allowance tightens maxTurns with the same grace", () =>
     Effect.gen(function* () {
       const handlerStarts = yield* Ref.make(0);


### PR DESCRIPTION
## Summary

Applies the #56 autoreviewer's findings (auto-merge landed before the review posted — the standing race):

- **The real bug**: a `NaN` allowance (e.g. a model-derived `Number("garbage")`) propagated through `floor/max/min`, and every later `>` comparison against `NaN` answers false — **silently erasing the Turn/Tool-Call bound entirely**. Both layers now fail closed: the engine's `effectiveRunBounds` ignores non-finite allowances (the policy bound holds), and the delegation falls back from a non-finite extraction to the author default, and from a non-finite default to no allowance. Regression tests pin both (RUN-021: `toolCallAllowance: NaN` still fails at the policy bound; SUB-034: `grant-garbage` falls back to the default and the run stays bounded).
- **The extension e2e now proves the actual sequence**: the scripted coordinator declares the granting call only after `partial:draft` is visible in its prompt — the grant is a content-keyed *reaction to observed exhaustion*, never a preplanned same-batch call.
- The ADR-0019 status note no longer overstates the durable path (an allowance has no effect on a durable child — it always runs at Definition policy — so allowance-based extension is ephemeral-only until the deferred proposal), and the changeset's durability claim names its assembly evidence (the session coordinator shared by DN and DC, exercised in the DN-profile suites).

## Evidence

Full gates green: `bun run check`, all 19 test tasks, coverage gate; 192 tests across the engine + capabilities suites including the three new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)