### PR TITLE
fix(capabilities): clamp a broken allowance default to the reservation slice

### DIFF
--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -37687,7 +37687,7 @@ var layer14 = (delegation, childBinding, options) => {
       };
       const allowanceOption = delegation.toolCallAllowance;
       const extracted = allowanceOption?.fromParameters?.(parameters);
-      const requestedAllowance = extracted !== undefined && Number.isFinite(extracted) ? extracted : allowanceOption !== undefined && Number.isFinite(allowanceOption.default) ? allowanceOption.default : undefined;
+      const requestedAllowance = allowanceOption === undefined ? undefined : extracted !== undefined && Number.isFinite(extracted) ? extracted : Number.isFinite(allowanceOption.default) ? allowanceOption.default : delegation.policy.maxToolCalls;
       const toolCallAllowance = requestedAllowance === undefined ? undefined : Math.min(Math.max(1, Math.floor(requestedAllowance)), delegation.policy.maxToolCalls);
       const childOptions = {
         ...seededChild,

--- a/docs/adr/0019-budget-soft-landing-and-extension.md
+++ b/docs/adr/0019-budget-soft-landing-and-extension.md
@@ -21,13 +21,14 @@
   bounded `SubagentResultContext` with the honest `budgetExhausted` marker (from the ephemeral
   child result, or the child Settlement's durable marker carried through
   `ChildEstablishSettled.finishReason`). One scope delta from decision item 7: the allowance
-  reaches only EPHEMERAL children — a durable child's lane owns no per-run options channel, and
-  making the reservation slice binding on the child would contradict §7's never-clipped overrun
-  model, so durable allowance threading is deferred to its own proposal. On the durable path the
-  exhausted marker still travels (via `ChildEstablishSettled.finishReason`) and re-delegation
-  remains possible, but an allowance has no effect there — a durable child always runs at its
-  Definition policy — so allowance-based extension is meaningful only for ephemeral children
-  until the deferred proposal lands.
+  reaches only EPHEMERAL children — in the DN and DC assemblies a child's lane owns no per-run
+  options channel, and making the reservation slice binding on the child would contradict §7's
+  never-clipped overrun model, so DN/DC allowance threading is deferred to its own proposal. In
+  DN and DC the exhausted marker still travels (via `ChildEstablishSettled.finishReason`, session
+  coordinator, exercised in the DN-profile suites) and re-delegation remains possible, but an
+  allowance has no effect there — a DN/DC child always runs at its Definition policy — so
+  allowance-based extension is meaningful only for ephemeral children until the deferred
+  proposal lands.
 - Status note (2026-08-15, hardening after #50's autoreviewer): `define` is overloaded so the
   resolved Tool channels follow the `failureMode` VALUE (return mode cannot be claimed through a
   type argument while the runtime builds the error-mode Tool); containment classifies genuine

--- a/packages/capabilities/src/subagent.ts
+++ b/packages/capabilities/src/subagent.ts
@@ -1402,15 +1402,18 @@ const layer = <
       // Definition policy stays the engine-side ceiling (RUN-021).
       const allowanceOption = delegation.toolCallAllowance;
       // Fail closed on non-finite values (SUB-034): a model-derived NaN falls
-      // back to the author default, and a non-finite default yields no
-      // allowance at all — the child Definition policy stays the bound.
+      // back to the author default, and a non-finite default falls back to
+      // the delegation's own reservation slice — a CONFIGURED allowance never
+      // silently widens to the child Definition policy.
       const extracted = allowanceOption?.fromParameters?.(parameters);
       const requestedAllowance =
-        extracted !== undefined && Number.isFinite(extracted)
-          ? extracted
-          : allowanceOption !== undefined && Number.isFinite(allowanceOption.default)
-            ? allowanceOption.default
-            : undefined;
+        allowanceOption === undefined
+          ? undefined
+          : extracted !== undefined && Number.isFinite(extracted)
+            ? extracted
+            : Number.isFinite(allowanceOption.default)
+              ? allowanceOption.default
+              : delegation.policy.maxToolCalls;
       const toolCallAllowance =
         requestedAllowance === undefined
           ? undefined

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -2531,6 +2531,74 @@ layer(TestServices)("SubagentRuntime SUB-034 per-invocation allowance", (it) => 
   );
 
   it.effect(
+    "SUB-034 a configured allowance with a non-finite default clamps to the reservation slice, never the Definition policy",
+    () =>
+      Effect.gen(function* () {
+        const brokenDefaultDelegation = Subagent.define("delegate_allowance_broken", {
+          description: "Allowance configured with a broken default.",
+          target: probingChildDefinition,
+          parameters: ResearchParams,
+          success: ResearchFindings,
+          failure: ResearchDelegationFailed,
+          prepareInput: ({ topic }) => Effect.succeed({ question: `research:${topic}` }),
+          projectResult: (output, context) =>
+            Effect.succeed({
+              summary: `${context.budgetExhausted ? "partial:" : "finding:"}${output.answer}`,
+            }),
+          policy: allowancePolicy,
+          toolCallAllowance: { default: Number.NaN },
+        });
+        const brokenCoordinator = Agent.define("allowance-broken-coordinator", {
+          input: Schema.Struct({ mission: Schema.String }),
+          output: Schema.Struct({ report: Schema.String }),
+          instructions: "Delegate, then answer as JSON.",
+          toolkit: Toolkit.make(brokenDefaultDelegation.tool),
+          policy: AgentPolicy.make({
+            maxTurns: 3,
+            maxToolCalls: 3,
+            maxDuration: "30 seconds",
+            toolConcurrency: 2,
+          }),
+        });
+        const probeStarts = yield* Ref.make(0);
+        const childBinding = Agent.withModel(
+          probingChildDefinition,
+          // Declares 5: above the slice ceiling of 4, below the Definition's 8.
+          probingChildModel([{ topic: "small", declares: 5, answer: '{"answer":"sliced"}' }]),
+        );
+        const parent = Agent.withModel(
+          brokenCoordinator,
+          delegatingModel(
+            "parent-allowance-broken",
+            "delegate_allowance_broken",
+            [{ id: "call-1", params: { topic: "small" } }],
+            '{"report":"done"}',
+          ),
+        );
+        const probeLayer = probeToolkit.toLayer({
+          probe_doc: ({ ref }) =>
+            Ref.update(probeStarts, (count) => count + 1).pipe(Effect.as(`probed-${ref}`)),
+        });
+        const runtimeLayer = SubagentRuntime.layer(brokenDefaultDelegation, childBinding, {
+          mapChildFailure,
+        }).pipe(Layer.provide(probeLayer));
+
+        const detached = yield* AgentRuntime.start(
+          parent,
+          { mission: "m" },
+          { runId: decodeRunId("parent-run-allowance-broken") },
+        ).pipe(Effect.provide(runtimeLayer));
+        const result = yield* detached.await;
+
+        // A broken default clamps to the SLICE (4): the batch of 5 is
+        // rejected. Dropping the allowance entirely would have run all five
+        // probes under the Definition's ceiling of 8.
+        expect(result.output).toEqual({ report: "done" });
+        expect(yield* Ref.get(probeStarts)).toBe(0);
+      }),
+  );
+
+  it.effect(
     "SUB-034 a non-finite model-granted allowance falls back fail-closed to the default",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Applies the #57 autoreviewer's two findings: a non-finite `toolCallAllowance.default` previously dropped the allowance entirely, letting a child run to its Definition policy **past the delegation's configured per-invocation reservation slice** — it now falls back to the slice ceiling itself, so a configured allowance can never silently widen (regression: a batch of 5 is rejected at the slice of 4 under a Definition ceiling of 8; dropping the allowance would have executed all five). Also names the DN/DC assemblies in ADR-0019's durable-path statements per the repository durability-claim invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)