### PR TITLE
fix(release): close trusted publishing review gaps

### DIFF
--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -168,7 +168,11 @@ failing `ready`; path routing is not its security boundary. A later human
 mutation with an unexpected path invokes the ordinary PR workflows, while a
 generated-only mutation has a new head without a verified check and remains
 unmergeable. The exact-tree verifier runs in a fresh read-only job checked out from the triggering
-`main` SHA; the Changesets action's workspace never reaches it.
+`main` SHA; the Changesets action's workspace never reaches it. Inside the detached trusted-base
+worktree, the verifier performs a script-suppressed frozen install before invoking that worktree's
+Changesets binary, then performs a second script-suppressed install only to regenerate the release
+lockfile. Cleanup attempts every Git and filesystem operation and reports any cleanup failure in
+the typed verification result instead of silently accepting a leaked worktree.
 
 The version job and every external action are pinned to full commit SHAs and have neither Checks
 API nor npm OIDC permission. The action-free reporting job alone has `checks: write`; immediately
@@ -182,7 +186,9 @@ After a version PR merge, an unprivileged preparation job frozen-installs and re
 versioned tree, packs every public workspace with Bun into a scope-owned staging directory, and
 atomically renames that directory into place only after every tarball and the manifest are
 complete. Failure or interruption removes the partial staging tree, so a retry never inherits an
-incomplete release artifact. The job then uploads one checksummed immutable artifact. A separate
+incomplete release artifact. The atomic rename itself is uninterruptible, and a failed preparation,
+commit, cleanup, or temporary manifest restoration remains a typed release failure with preceding
+causes preserved. The job then uploads one checksummed immutable artifact. A separate
 action-free job is the sole holder of `id-token: write`. It checks the artifact
 digests, requires the release manifest to contain the exact fourteen-package fixed set at one
 `X.Y.Z-beta.N` version and the policy-owned `beta` dist-tag, verifies a pinned npm CLI tarball, and
@@ -197,7 +203,8 @@ Each package on npmjs.com lists `release.yml` in `danieljvdm/effect-agent` as
 its trusted publisher (package Settings, a one-time registration; "Allow npm
 publish" only). In CI the release script runs in `--pack-directory` mode in
 the unprivileged preparation job: `bun pm pack` resolves the
-`workspace:`/`catalog:` protocols into the tarball. The isolated publisher
+`workspace:`/`catalog:` protocols into the tarball without consulting the npm registry. The
+transferred manifest accepts only safe `packages/<basename>.tgz` relative paths. The isolated publisher
 then uploads that tarball with the pinned npm CLI, because only npm implements
 the OIDC exchange.
 

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -5,6 +5,7 @@ import { Yaml } from "effect/unstable/encoding";
 import { ChildProcess } from "effect/unstable/process";
 
 import { prepareReleaseArtifactDirectory } from "../../../scripts/release-artifact-directory.ts";
+import { PreparedReleaseManifest, PublishManifest } from "../../../scripts/release-publish.ts";
 import {
   InvalidCommitSha,
   ReleaseTreeMismatch,
@@ -301,6 +302,8 @@ if [ "\${1:-}" = "--method" ]; then
   exit 0
 fi
 
+ENDPOINT="\${1:-}"
+
 QUERY=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--jq" ]; then
@@ -312,12 +315,30 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$QUERY" in
-  ".head.sha") printf '%s\\n' "$GH_STUB_HEAD_SHA" ;;
-  ".head.repo.full_name") printf '%s\\n' "$GH_STUB_HEAD_REPOSITORY" ;;
-  ".head.ref") printf '%s\\n' "$GH_STUB_HEAD_REF" ;;
-  ".base.sha") printf '%s\\n' "$GH_STUB_BASE_SHA" ;;
-  ".base.ref") printf '%s\\n' "$GH_STUB_BASE_REF" ;;
-  *"strict_required_status_checks_policy"*) printf '%s\\n' "$GH_STUB_STRICT_READY" ;;
+  ".head.sha")
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+    printf '%s\\n' "$GH_STUB_HEAD_SHA"
+    ;;
+  ".head.repo.full_name")
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+    printf '%s\\n' "$GH_STUB_HEAD_REPOSITORY"
+    ;;
+  ".head.ref")
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+    printf '%s\\n' "$GH_STUB_HEAD_REF"
+    ;;
+  ".base.sha")
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+    printf '%s\\n' "$GH_STUB_BASE_SHA"
+    ;;
+  ".base.ref")
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+    printf '%s\\n' "$GH_STUB_BASE_REF"
+    ;;
+  *"strict_required_status_checks_policy"*)
+    test "$ENDPOINT" = "repos/$GITHUB_REPOSITORY/rules/branches/main"
+    printf '%s\\n' "$GH_STUB_STRICT_READY"
+    ;;
   *) echo "Unexpected gh query: $QUERY" >&2; exit 64 ;;
 esac
 `,
@@ -360,8 +381,10 @@ esac
 const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(function* (
   script: string,
   options: {
+    readonly checksumFailure?: "artifact" | "npm";
     readonly packageMetadata: string;
     readonly registryStatus: "200" | "404";
+    readonly tarball?: string;
     readonly versionMetadata: string;
   },
 ) {
@@ -372,6 +395,7 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
   });
   const artifactDirectory = path.join(temporaryRoot, "artifact-source");
   const binDirectory = path.join(temporaryRoot, "bin");
+  const expectedSumsPath = path.join(temporaryRoot, "expected-SHA256SUMS");
   const publishCapture = path.join(temporaryRoot, "npm-publish-invoked");
   const trustedManifestDirectory = path.join(temporaryRoot, "trusted-manifests");
   const version = "0.0.1-beta.7";
@@ -397,7 +421,8 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
     releases.push({
       distTag: "beta",
       name: manifest.name,
-      tarball: directory === "capabilities" ? "packages/capabilities.tgz" : null,
+      tarball:
+        directory === "capabilities" ? (options.tarball ?? "packages/capabilities.tgz") : null,
       version,
     });
   }
@@ -405,7 +430,14 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
     path.join(artifactDirectory, "release-manifest.json"),
     `${JSON.stringify({ version: 1, packages: releases })}\n`,
   );
-  yield* fs.writeFileString(path.join(artifactDirectory, "SHA256SUMS"), "fixture\n");
+  const expectedSums = [
+    "fixture-sha  npm-12.0.2.tgz",
+    "fixture-sha  packages/capabilities.tgz",
+    "fixture-sha  release-manifest.json",
+    "",
+  ].join("\n");
+  yield* fs.writeFileString(path.join(artifactDirectory, "SHA256SUMS"), expectedSums);
+  yield* fs.writeFileString(expectedSumsPath, expectedSums);
   yield* fs.writeFileString(path.join(artifactDirectory, "npm-12.0.2.tgz"), "fixture\n");
   yield* fs.writeFileString(
     path.join(artifactDirectory, "packages", "capabilities.tgz"),
@@ -424,11 +456,13 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
       `#!/usr/bin/env bash
 set -euo pipefail
 REQUEST="$*"
-if [[ "$REQUEST" == *"/actions/runs/"*"/artifacts"* ]]; then
+if [[ "$REQUEST" == "api repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts --jq "* ]]; then
   printf '731\n'
-elif [[ "$REQUEST" == *"/actions/artifacts/731/zip"* ]]; then
+elif [ "$REQUEST" = "api repos/$GITHUB_REPOSITORY/actions/artifacts/731/zip" ]; then
   printf 'fixture archive\n'
 elif [[ "$REQUEST" =~ /contents/packages/([^/]+)/package.json ]]; then
+  EXPECTED_CONTENT="repos/$GITHUB_REPOSITORY/contents/packages/\${BASH_REMATCH[1]}/package.json?ref=$GITHUB_SHA"
+  [[ " $REQUEST " == *" $EXPECTED_CONTENT"* ]]
   cat "$PUBLISH_TRUSTED_MANIFESTS/\${BASH_REMATCH[1]}.json"
 else
   echo "Unexpected gh invocation: $REQUEST" >&2
@@ -456,7 +490,20 @@ cp -R "$PUBLISH_ARTIFACT_SOURCE"/. "$DESTINATION"/
     writeExecutable(
       "sha256sum",
       `#!/usr/bin/env bash
-exit 0
+set -euo pipefail
+if [ "$#" = "3" ] && [ "$1" = "--check" ] && [ "$2" = "--strict" ] && [ "$3" = "SHA256SUMS" ]; then
+  cmp SHA256SUMS "$PUBLISH_EXPECTED_SUMS"
+  test "$PUBLISH_CHECKSUM_FAILURE" != "artifact"
+  exit 0
+fi
+if [ "$#" = "2" ] && [ "$1" = "--check" ] && [ "$2" = "--strict" ]; then
+  IFS= read -r EXPECTED_LINE
+  test "$EXPECTED_LINE" = "$NPM_CLI_SHA256  npm-$NPM_CLI_VERSION.tgz"
+  test "$PUBLISH_CHECKSUM_FAILURE" != "npm"
+  exit 0
+fi
+echo "Unexpected sha256sum invocation: $*" >&2
+exit 64
 `,
     ),
     writeExecutable(
@@ -467,7 +514,7 @@ if [ "\${1:-}" = "--eval" ]; then
   exit 0
 fi
 if [ "\${2:-}" = "publish" ]; then
-  printf '%s\n' "$*" > "$PUBLISH_CAPTURE"
+  printf '%s\n' "$@" > "$PUBLISH_CAPTURE"
   exit 0
 fi
 echo "Unexpected node invocation: $*" >&2
@@ -543,6 +590,8 @@ printf 'fixture-integrity'
       PATH: `${binDirectory}:${globalThis.process.env["PATH"] ?? ""}`,
       PUBLISH_ARTIFACT_SOURCE: artifactDirectory,
       PUBLISH_CAPTURE: publishCapture,
+      PUBLISH_CHECKSUM_FAILURE: options.checksumFailure ?? "none",
+      PUBLISH_EXPECTED_SUMS: expectedSumsPath,
       PUBLISH_PACKAGE_METADATA: options.packageMetadata,
       PUBLISH_REGISTRY_STATUS: options.registryStatus,
       PUBLISH_TRUSTED_MANIFESTS: trustedManifestDirectory,
@@ -557,10 +606,14 @@ printf 'fixture-integrity'
     Stream.mkString(Stream.decodeText(child.all)),
     child.exitCode,
   ]);
+  const publishInvocation = (yield* fs.exists(publishCapture))
+    ? (yield* fs.readFileString(publishCapture)).trim().split("\n")
+    : [];
   return {
     exitCode,
     output,
-    publishInvoked: yield* fs.exists(publishCapture),
+    publishInvocation,
+    publishInvoked: publishInvocation.length > 0,
   } as const;
 });
 
@@ -616,6 +669,38 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect([...(config.fixed[0] ?? [])].sort()).toEqual(publicPackageNames.sort());
       expect(config.linked).toEqual([]);
     }),
+  );
+
+  it.effect(
+    "validates mutable package fields and transferred tarball paths at Schema boundaries",
+    () =>
+      Effect.gen(function* () {
+        const decoded = yield* Schema.decodeUnknownEffect(PublishManifest)({
+          name: "@effect-agent/fixture",
+          version: "0.0.1-beta.7",
+          description: "preserved package metadata",
+          dependencies: { "@effect-agent/core": "workspace:*" },
+        });
+        expect(decoded.description).toBe("preserved package metadata");
+        expect(decoded.dependencies).toEqual({ "@effect-agent/core": "workspace:*" });
+
+        yield* Schema.decodeUnknownEffect(PublishManifest)({
+          name: "@effect-agent/fixture",
+          version: "0.0.1-beta.7",
+          dependencies: { "@effect-agent/core": 7 },
+        }).pipe(Effect.flip);
+        yield* Schema.decodeUnknownEffect(PreparedReleaseManifest)({
+          version: 1,
+          packages: [
+            {
+              name: "@effect-agent/fixture",
+              version: "0.0.1-beta.7",
+              distTag: "beta",
+              tarball: "../outside.tgz",
+            },
+          ],
+        }).pipe(Effect.flip);
+      }),
   );
 
   it.effect("keeps generated release PRs behind a trusted integrity gate", () =>
@@ -1002,14 +1087,6 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
             versionMetadata: JSON.stringify({ dist: { integrity: "sha512-other" } }),
           },
           {
-            packageMetadata: "not-json",
-            versionMetadata: validVersionMetadata,
-          },
-          {
-            packageMetadata: JSON.stringify({ "dist-tags": {} }),
-            versionMetadata: validVersionMetadata,
-          },
-          {
             packageMetadata: JSON.stringify({ "dist-tags": { beta: "0.0.1-beta.6" } }),
             versionMetadata: validVersionMetadata,
           },
@@ -1030,8 +1107,43 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
           versionMetadata: validVersionMetadata,
         });
         expect(unpublishedVersion).toMatchObject({ exitCode: 0, publishInvoked: true });
+        expect(unpublishedVersion.publishInvocation[0]).toMatch(
+          /[/]release-artifact[/][.]npm-cli[/]package[/]bin[/]npm-cli[.]js$/,
+        );
+        expect(unpublishedVersion.publishInvocation.slice(1)).toEqual([
+          "publish",
+          "packages/capabilities.tgz",
+          "--access",
+          "public",
+          "--ignore-scripts",
+          "--registry",
+          "https://registry.npmjs.org",
+          "--tag",
+          "beta",
+          "--provenance",
+        ]);
+
+        for (const checksumFailure of ["artifact", "npm"] as const) {
+          const checksumResult = yield* runReleasePublisher(publishScript, {
+            checksumFailure,
+            packageMetadata: validPackageMetadata,
+            registryStatus: "404",
+            versionMetadata: validVersionMetadata,
+          });
+          expect(checksumResult.exitCode).not.toBe(0);
+          expect(checksumResult.publishInvoked).toBe(false);
+        }
+
+        const unsafeTarball = yield* runReleasePublisher(publishScript, {
+          packageMetadata: validPackageMetadata,
+          registryStatus: "404",
+          tarball: "../outside.tgz",
+          versionMetadata: validVersionMetadata,
+        });
+        expect(unsafeTarball.exitCode).not.toBe(0);
+        expect(unsafeTarball.publishInvoked).toBe(false);
       }),
-    40_000,
+    60_000,
   );
 
   it.effect("publishes prepared release directories atomically and cleans failed staging", () =>
@@ -1118,6 +1230,14 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         const packageDirectory = path.join(fixtureRoot, "packages", "fixture");
         const changesetDirectory = path.join(fixtureRoot, ".changeset");
         const changesetBinary = path.resolve(repositoryRoot, "node_modules", ".bin", "changeset");
+        const verifierSource = yield* readRepositoryFile("scripts/verify-changesets-release.ts");
+        expect(verifierSource).toContain('"--frozen-lockfile"');
+        expect(verifierSource).toContain(
+          'path.join(expectedWorktree, "node_modules", ".bin", "changeset")',
+        );
+        expect(verifierSource).not.toContain(
+          'path.join(root, "node_modules", ".bin", "changeset")',
+        );
 
         yield* fs.makeDirectory(packageDirectory, { recursive: true });
         yield* fs.makeDirectory(changesetDirectory, { recursive: true });
@@ -1192,6 +1312,38 @@ Exercise the generated release verifier.
           "--porcelain",
         ]);
         expect(worktreesAfterSuccess.match(/^worktree /gm)).toHaveLength(1);
+
+        let failedCleanupPath = "";
+        const cleanupCause = PlatformError.systemError({
+          _tag: "Busy",
+          module: "FileSystem",
+          method: "remove",
+        });
+        const cleanupFailingFileSystem = FileSystem.FileSystem.of({
+          ...fs,
+          remove: (target, options) => {
+            if (String(target).includes("effect-agent-changesets-release-")) {
+              failedCleanupPath = String(target);
+              return Effect.fail(cleanupCause);
+            }
+            return fs.remove(target, options);
+          },
+        });
+        const cleanupFailure = yield* Effect.flip(
+          verifyChangesetsRelease({
+            baseSha,
+            changesetBinary,
+            headSha: generatedHead,
+            repositoryRoot: fixtureRoot,
+          }).pipe(Effect.provideService(FileSystem.FileSystem, cleanupFailingFileSystem)),
+        );
+        expect(cleanupFailure).toMatchObject({
+          _tag: "VerificationCleanupError",
+          operation: "temporary directory removal",
+          message: expect.stringContaining("Busy: FileSystem.remove"),
+        });
+        expect(failedCleanupPath).not.toBe("");
+        yield* fs.remove(failedCleanupPath, { force: true, recursive: true });
 
         yield* fs.writeFileString(
           path.join(packageDirectory, "package.json"),

--- a/scripts/release-artifact-directory.ts
+++ b/scripts/release-artifact-directory.ts
@@ -52,24 +52,32 @@ export const prepareReleaseArtifactDirectory = <A, E, R>(
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const directory = yield* acquire;
-        const useExit = yield* restore(
-          Effect.gen(function* () {
-            const result = yield* prepare(directory);
-            yield* fs
-              .rename(directory, destination)
-              .pipe(Effect.mapError(artifactDirectoryError(destination, "commit")));
-            return result;
-          }),
-        ).pipe(Effect.exit);
-        if (Exit.isSuccess(useExit)) return useExit.value;
-
-        const cleanupExit = yield* fs
-          .remove(directory, { force: true, recursive: true })
-          .pipe(Effect.mapError(artifactDirectoryError(destination, "cleanup")), Effect.exit);
-        if (Exit.isFailure(cleanupExit)) {
-          return yield* Effect.failCause(Cause.combine(useExit.cause, cleanupExit.cause));
+        const prepareExit = yield* restore(prepare(directory)).pipe(Effect.exit);
+        if (Exit.isFailure(prepareExit)) {
+          const cleanupExit = yield* fs
+            .remove(directory, { force: true, recursive: true })
+            .pipe(Effect.mapError(artifactDirectoryError(destination, "cleanup")), Effect.exit);
+          return yield* Effect.failCause(
+            Exit.isFailure(cleanupExit)
+              ? Cause.combine(prepareExit.cause, cleanupExit.cause)
+              : prepareExit.cause,
+          );
         }
-        return yield* Effect.failCause(useExit.cause);
+
+        const commitExit = yield* fs
+          .rename(directory, destination)
+          .pipe(Effect.mapError(artifactDirectoryError(destination, "commit")), Effect.exit);
+        if (Exit.isFailure(commitExit)) {
+          const cleanupExit = yield* fs
+            .remove(directory, { force: true, recursive: true })
+            .pipe(Effect.mapError(artifactDirectoryError(destination, "cleanup")), Effect.exit);
+          return yield* Effect.failCause(
+            Exit.isFailure(cleanupExit)
+              ? Cause.combine(commitExit.cause, cleanupExit.cause)
+              : commitExit.cause,
+          );
+        }
+        return prepareExit.value;
       }),
     );
   });

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -1,6 +1,10 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Console, Effect, FileSystem, Path, Schema, Stream } from "effect";
+import { Cause, Console, Effect, Exit, FileSystem, Layer, Path, Schema, Stream } from "effect";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
+import { FetchHttpClient, HttpClient } from "effect/unstable/http";
 import { ChildProcess } from "effect/unstable/process";
 
 import { prepareReleaseArtifactDirectory } from "./release-artifact-directory.ts";
@@ -51,18 +55,41 @@ class CommandError extends Schema.TaggedError<CommandError>()("CommandError", {
   }
 }
 
-const PublishManifest = Schema.Struct({
-  name: Schema.String,
-  version: Schema.String,
-  private: Schema.optionalKey(Schema.Boolean),
-  exports: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
-});
+class ReleaseManifestSwapError extends Schema.TaggedError<ReleaseManifestSwapError>()(
+  "ReleaseManifestSwapError",
+  {
+    cause: Schema.optionalKey(Schema.Defect()),
+    manifestPath: Schema.String,
+    message: Schema.String,
+    operation: Schema.Literals(["install", "restore"]),
+  },
+) {}
+
+const DependencyMap = Schema.Record(Schema.String, Schema.String);
+export const PublishManifest = Schema.StructWithRest(
+  Schema.Struct({
+    name: Schema.String,
+    version: Schema.String,
+    private: Schema.optionalKey(Schema.Boolean),
+    exports: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    dependencies: Schema.optionalKey(DependencyMap),
+    optionalDependencies: Schema.optionalKey(DependencyMap),
+    peerDependencies: Schema.optionalKey(DependencyMap),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+
+export const PreparedTarballPath = Schema.String.pipe(
+  Schema.refine((value): value is string => /^packages\/[A-Za-z0-9._-]+[.]tgz$/.test(value), {
+    expected: "a safe packages/<basename>.tgz relative path",
+  }),
+);
 
 export const PreparedReleasePackage = Schema.Struct({
   name: Schema.String,
   version: Schema.String,
   distTag: Schema.String,
-  tarball: Schema.NullOr(Schema.String),
+  tarball: Schema.NullOr(PreparedTarballPath),
 });
 
 export const PreparedReleaseManifest = Schema.Struct({
@@ -98,14 +125,14 @@ const runCommand = Effect.fn("runCommand")(function* (
 
 /** True when `name@version` already exists on the public registry. */
 const alreadyPublished = Effect.fn("alreadyPublished")(function* (name: string, version: string) {
-  const response = yield* Effect.tryPromise({
-    try: () => fetch(`${REGISTRY}/${name.replace("/", "%2f")}/${version}`),
-    catch: (cause) =>
+  const response = yield* HttpClient.get(`${REGISTRY}/${name.replace("/", "%2f")}/${version}`).pipe(
+    Effect.mapError((cause) =>
       ReleaseError.make({
         package: name,
         reason: `Registry lookup failed: ${String(cause)}`,
       }),
-  });
+    ),
+  );
   if (response.status === 200) return true;
   if (response.status === 404) return false;
   return yield* ReleaseError.make({
@@ -157,6 +184,43 @@ const distExport = (sourcePath: string): { types: string; default: string } | un
   return { types: `./dist/${match[1]}.d.mts`, default: `./dist/${match[1]}.mjs` };
 };
 
+const withTemporaryManifest = <A, E, R>(
+  manifestPath: string,
+  originalBytes: string,
+  publishBytes: string,
+  use: Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const manifestError = (operation: ReleaseManifestSwapError["operation"]) => (cause: unknown) =>
+      ReleaseManifestSwapError.make({
+        cause,
+        manifestPath,
+        message: `Could not ${operation} temporary publish manifest ${manifestPath}: ${String(cause)}`,
+        operation,
+      });
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        yield* fs
+          .writeFileString(manifestPath, publishBytes)
+          .pipe(Effect.mapError(manifestError("install")));
+        const useExit = yield* restore(use).pipe(Effect.exit);
+        const restoreExit = yield* fs
+          .writeFileString(manifestPath, originalBytes)
+          .pipe(Effect.mapError(manifestError("restore")), Effect.exit);
+        if (Exit.isFailure(useExit)) {
+          return yield* Effect.failCause(
+            Exit.isFailure(restoreExit)
+              ? Cause.combine(useExit.cause, restoreExit.cause)
+              : useExit.cause,
+          );
+        }
+        if (Exit.isFailure(restoreExit)) return yield* Effect.failCause(restoreExit.cause);
+        return useExit.value;
+      }),
+    );
+  });
+
 const publishOne = Effect.fn("publishOne")(function* (options: {
   readonly directory: string;
   readonly dryRun: boolean;
@@ -174,7 +238,10 @@ const publishOne = Effect.fn("publishOne")(function* (options: {
     return { _tag: "Private" as const };
   }
   const distTag = distTagFor(manifest.version);
-  const versionAlreadyPublished = yield* alreadyPublished(manifest.name, manifest.version);
+  const versionAlreadyPublished =
+    options.packDirectory === undefined
+      ? yield* alreadyPublished(manifest.name, manifest.version)
+      : false;
   if (versionAlreadyPublished && options.packDirectory === undefined) {
     yield* Console.log(`- ${manifest.name}@${manifest.version}: already on the registry, skipped`);
     return {
@@ -187,30 +254,19 @@ const publishOne = Effect.fn("publishOne")(function* (options: {
       }),
     };
   }
-  if (versionAlreadyPublished) {
-    yield* Console.log(
-      `- ${manifest.name}@${manifest.version}: already on the registry; packing for retry verification`,
-    );
-  }
-
   // Rewrite every source export to its dist entry, fail-closed on both an
   // unrecognized export shape and a missing built artifact.
-  const parsed: unknown = JSON.parse(originalBytes);
-  const mutable = parsed as {
-    exports?: Record<string, unknown>;
-    dependencies?: Record<string, string>;
-    optionalDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-  };
+  const mutable = { ...manifest };
 
   // Pin internal `workspace:*` ranges to the exact workspace versions
   // ourselves: `bun publish` resolves them from the lockfile, which does not
   // pick up changeset version bumps ("no changes" install), and 0.0.1-beta.0
   // shipped with dependencies on unpublished internal versions as a result.
   for (const section of ["dependencies", "optionalDependencies", "peerDependencies"] as const) {
-    const dependencies = mutable[section];
+    const dependencies = manifest[section];
     if (dependencies === undefined) continue;
-    for (const [dependency, range] of Object.entries(dependencies)) {
+    const rewrittenDependencies = { ...dependencies };
+    for (const [dependency, range] of Object.entries(rewrittenDependencies)) {
       if (!range.startsWith("workspace:")) continue;
       const version = options.workspaceVersions.get(dependency);
       if (version === undefined) {
@@ -219,8 +275,9 @@ const publishOne = Effect.fn("publishOne")(function* (options: {
           reason: `Workspace dependency '${dependency}' has no known version to pin.`,
         });
       }
-      dependencies[dependency] = version;
+      rewrittenDependencies[dependency] = version;
     }
+    mutable[section] = rewrittenDependencies;
   }
   const exportsMap = manifest.exports ?? {};
   const rewritten: Record<string, { types: string; default: string }> = {};
@@ -242,7 +299,7 @@ const publishOne = Effect.fn("publishOne")(function* (options: {
     }
     rewritten[key] = dist;
   }
-  mutable.exports = rewritten;
+  const publishManifest = { ...mutable, exports: rewritten };
 
   // Dry runs validate the packed artifact without registry credentials;
   // manual publishes require an authenticated npm session. CI stops at the
@@ -257,84 +314,89 @@ const publishOne = Effect.fn("publishOne")(function* (options: {
     }...`,
   );
 
-  // The manifest swap is scoped: acquireRelease restores the original bytes
-  // even when the publish fails or the fiber is interrupted.
-  yield* Effect.acquireRelease(
-    fs.writeFileString(manifestPath, JSON.stringify(parsed, null, 2)),
-    () => fs.writeFileString(manifestPath, originalBytes).pipe(Effect.orDie),
-  );
-  const environment = yield* publishEnvironment();
-  const publishFailure = (error: { readonly _tag: string; readonly message: string }) =>
-    error._tag === "CommandError"
-      ? ReleaseError.make({
-          package: manifest.name,
-          reason: `${error.message} (an expired --otp is the usual cause locally; re-run with a fresh code — published versions are skipped)`,
-        })
-      : ReleaseError.make({
-          package: manifest.name,
-          reason: `Process execution failed (${error._tag}): ${error.message}`,
-        });
-  if (options.packDirectory !== undefined) {
-    const before = new Set(yield* fs.readDirectory(options.packDirectory));
-    yield* runCommand(
-      options.directory,
-      "bun",
-      ["pm", "pack", "--destination", options.packDirectory],
-      environment,
-    ).pipe(Effect.mapError(publishFailure));
-    const tarballs = (yield* fs.readDirectory(options.packDirectory)).filter(
-      (entry) => entry.endsWith(".tgz") && !before.has(entry),
-    );
-    const tarball = tarballs[0];
-    if (tarball === undefined || tarballs.length !== 1 || !/^[A-Za-z0-9._-]+\.tgz$/.test(tarball)) {
-      return yield* ReleaseError.make({
-        package: manifest.name,
-        reason: `Expected one safely named tarball in ${options.packDirectory}, found ${tarballs.length}.`,
-      });
-    }
-    yield* Console.log(`- ${manifest.name}@${manifest.version}: prepared packages/${tarball}`);
-    return {
-      _tag: "Prepared" as const,
-      release: PreparedReleasePackage.make({
-        name: manifest.name,
-        version: manifest.version,
-        distTag,
-        tarball: `packages/${tarball}`,
-      }),
-    };
-  } else if (options.dryRun) {
-    yield* runCommand(options.directory, "bun", ["pm", "pack", "--dry-run"], environment).pipe(
-      Effect.mapError(publishFailure),
-    );
-  } else {
-    yield* runCommand(
-      options.directory,
-      "bun",
-      [
-        "publish",
-        "--access",
-        "public",
-        "--tag",
-        distTag,
-        ...(options.otp !== undefined ? ["--otp", options.otp] : []),
-      ],
-      environment,
-    ).pipe(Effect.mapError(publishFailure));
-  }
-  yield* Console.log(
-    `- ${manifest.name}@${manifest.version}: ${
-      options.dryRun ? `dry-run ok (tag: ${distTag})` : `published (tag: ${distTag})`
-    }`,
-  );
-  return {
-    _tag: "Published" as const,
-    release: PreparedReleasePackage.make({
-      name: manifest.name,
-      version: manifest.version,
-      distTag,
-      tarball: null,
+  return yield* withTemporaryManifest(
+    manifestPath,
+    originalBytes,
+    JSON.stringify(publishManifest, null, 2),
+    Effect.gen(function* () {
+      const environment = yield* publishEnvironment();
+      const publishFailure = (error: { readonly _tag: string; readonly message: string }) =>
+        error._tag === "CommandError"
+          ? ReleaseError.make({
+              package: manifest.name,
+              reason: `${error.message} (an expired --otp is the usual cause locally; re-run with a fresh code — published versions are skipped)`,
+            })
+          : ReleaseError.make({
+              package: manifest.name,
+              reason: `Process execution failed (${error._tag}): ${error.message}`,
+            });
+      if (options.packDirectory !== undefined) {
+        const before = new Set(yield* fs.readDirectory(options.packDirectory));
+        yield* runCommand(
+          options.directory,
+          "bun",
+          ["pm", "pack", "--destination", options.packDirectory],
+          environment,
+        ).pipe(Effect.mapError(publishFailure));
+        const tarballs = (yield* fs.readDirectory(options.packDirectory)).filter(
+          (entry) => entry.endsWith(".tgz") && !before.has(entry),
+        );
+        const tarball = tarballs[0];
+        if (
+          tarball === undefined ||
+          tarballs.length !== 1 ||
+          !/^[A-Za-z0-9._-]+\.tgz$/.test(tarball)
+        ) {
+          return yield* ReleaseError.make({
+            package: manifest.name,
+            reason: `Expected one safely named tarball in ${options.packDirectory}, found ${tarballs.length}.`,
+          });
+        }
+        yield* Console.log(`- ${manifest.name}@${manifest.version}: prepared packages/${tarball}`);
+        return {
+          _tag: "Prepared" as const,
+          release: PreparedReleasePackage.make({
+            name: manifest.name,
+            version: manifest.version,
+            distTag,
+            tarball: `packages/${tarball}`,
+          }),
+        };
+      } else if (options.dryRun) {
+        yield* runCommand(options.directory, "bun", ["pm", "pack", "--dry-run"], environment).pipe(
+          Effect.mapError(publishFailure),
+        );
+      } else {
+        yield* runCommand(
+          options.directory,
+          "bun",
+          [
+            "publish",
+            "--access",
+            "public",
+            "--tag",
+            distTag,
+            ...(options.otp !== undefined ? ["--otp", options.otp] : []),
+          ],
+          environment,
+        ).pipe(Effect.mapError(publishFailure));
+      }
+      yield* Console.log(
+        `- ${manifest.name}@${manifest.version}: ${
+          options.dryRun ? `dry-run ok (tag: ${distTag})` : `published (tag: ${distTag})`
+        }`,
+      );
+      return {
+        _tag: "Published" as const,
+        release: PreparedReleasePackage.make({
+          name: manifest.name,
+          version: manifest.version,
+          distTag,
+          tarball: null,
+        }),
+      };
     }),
-  };
+  );
 });
 
 const dryRunFlag = Flag.boolean("dry-run").pipe(
@@ -444,9 +506,11 @@ const command = CliCommand.make(
 );
 
 const program = CliCommand.run(command, { version: "1.0.0" }).pipe(
-  Effect.tapError((error) => Console.error(String(error))),
   Effect.scoped,
-  Effect.provide(NodeServices.layer),
+  Effect.provide(Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer)),
+  Effect.tapError((error) => Console.error(String(error))),
 );
 
-NodeRuntime.runMain(program, { disableErrorReporting: true });
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  NodeRuntime.runMain(program);
+}

--- a/scripts/verify-changesets-release.ts
+++ b/scripts/verify-changesets-release.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Console, Effect, FileSystem, Path, Schema, Stream } from "effect";
+import { Cause, Console, Effect, Exit, FileSystem, Path, Schema, Stream } from "effect";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 
@@ -56,6 +56,15 @@ export class ReleaseTreeMismatch extends Schema.TaggedError<ReleaseTreeMismatch>
   }
 }
 
+export class VerificationCleanupError extends Schema.TaggedError<VerificationCleanupError>()(
+  "VerificationCleanupError",
+  {
+    cause: Schema.optionalKey(Schema.Defect()),
+    message: Schema.String,
+    operation: Schema.String,
+  },
+) {}
+
 const decodeCommitSha = Effect.fn("verifyChangesetsRelease.decodeCommitSha")(function* (
   label: string,
   value: string,
@@ -97,50 +106,93 @@ const findRepositoryRoot = Effect.fn("verifyChangesetsRelease.findRepositoryRoot
   return path.resolve(path.dirname(scriptPath), "..");
 });
 
-const acquireExpectedWorktree = Effect.fn("verifyChangesetsRelease.acquireExpectedWorktree")(
-  function* (root: string, baseSha: string) {
+const cleanupError = (operation: string) => (cause: unknown) =>
+  VerificationCleanupError.make({
+    cause,
+    message: `Verification cleanup failed during ${operation}: ${String(cause)}`,
+    operation,
+  });
+
+const cleanupExpectedWorktree = Effect.fn("verifyChangesetsRelease.cleanupExpectedWorktree")(
+  function* (root: string, temporaryRoot: string, worktree: string) {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    return yield* Effect.acquireRelease(
-      Effect.gen(function* () {
-        const temporaryRoot = yield* fs.makeTempDirectory({
-          prefix: "effect-agent-changesets-release-",
-        });
-        const worktree = path.join(temporaryRoot, "expected");
-        yield* runCommand(root, "git", ["worktree", "add", "--detach", worktree, baseSha]).pipe(
-          Effect.tapError(() =>
-            fs.remove(temporaryRoot, { force: true, recursive: true }).pipe(Effect.ignore),
-          ),
-        );
-        return { temporaryRoot, worktree } as const;
-      }),
-      ({ temporaryRoot, worktree }) =>
-        Effect.gen(function* () {
-          yield* Effect.scoped(
-            runCommand(root, "git", ["worktree", "remove", "--force", worktree]),
-          ).pipe(
-            Effect.catch((error) =>
-              Console.error(`Failed to remove temporary verification worktree: ${String(error)}`),
-            ),
-          );
-          yield* fs
-            .remove(temporaryRoot, { force: true, recursive: true })
-            .pipe(
-              Effect.catch((error) =>
-                Console.error(
-                  `Failed to remove temporary verification directory: ${String(error)}`,
-                ),
-              ),
-            );
-          yield* Effect.scoped(runCommand(root, "git", ["worktree", "prune"])).pipe(
-            Effect.catch((error) =>
-              Console.error(`Failed to prune temporary Git worktree metadata: ${String(error)}`),
-            ),
-          );
-        }),
-    );
+    const worktreeExistsExit = yield* fs
+      .exists(worktree)
+      .pipe(Effect.mapError(cleanupError("worktree existence check")), Effect.exit);
+    const cleanupEffects = [
+      ...(Exit.isSuccess(worktreeExistsExit) && worktreeExistsExit.value
+        ? [
+            Effect.scoped(
+              runCommand(root, "git", ["worktree", "remove", "--force", worktree]),
+            ).pipe(Effect.asVoid, Effect.mapError(cleanupError("git worktree remove"))),
+          ]
+        : []),
+      fs
+        .remove(temporaryRoot, { force: true, recursive: true })
+        .pipe(Effect.mapError(cleanupError("temporary directory removal"))),
+      Effect.scoped(runCommand(root, "git", ["worktree", "prune"])).pipe(
+        Effect.asVoid,
+        Effect.mapError(cleanupError("git worktree prune")),
+      ),
+    ];
+    const exits = yield* Effect.forEach(cleanupEffects, (cleanup) => cleanup.pipe(Effect.exit), {
+      concurrency: 1,
+    });
+    let combined: Cause.Cause<VerificationCleanupError> | undefined = Exit.isFailure(
+      worktreeExistsExit,
+    )
+      ? worktreeExistsExit.cause
+      : undefined;
+    for (const exit of exits) {
+      if (Exit.isSuccess(exit)) continue;
+      combined = combined === undefined ? exit.cause : Cause.combine(combined, exit.cause);
+    }
+    if (combined !== undefined) return yield* Effect.failCause(combined);
   },
 );
+
+const withExpectedWorktree = <A, E, R>(
+  root: string,
+  baseSha: string,
+  use: (worktree: string) => Effect.Effect<A, E, R>,
+) =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const temporaryRoot = yield* fs.makeTempDirectory({
+        prefix: "effect-agent-changesets-release-",
+      });
+      const worktree = path.join(temporaryRoot, "expected");
+      const acquisitionExit = yield* restore(
+        runCommand(root, "git", ["worktree", "add", "--detach", worktree, baseSha]),
+      ).pipe(Effect.exit);
+      if (Exit.isFailure(acquisitionExit)) {
+        const cleanupExit = yield* cleanupExpectedWorktree(root, temporaryRoot, worktree).pipe(
+          Effect.exit,
+        );
+        return yield* Effect.failCause(
+          Exit.isFailure(cleanupExit)
+            ? Cause.combine(acquisitionExit.cause, cleanupExit.cause)
+            : acquisitionExit.cause,
+        );
+      }
+
+      const useExit = yield* restore(use(worktree)).pipe(Effect.exit);
+      const cleanupExit = yield* cleanupExpectedWorktree(root, temporaryRoot, worktree).pipe(
+        Effect.exit,
+      );
+      if (Exit.isFailure(useExit)) {
+        return yield* Effect.failCause(
+          Exit.isFailure(cleanupExit)
+            ? Cause.combine(useExit.cause, cleanupExit.cause)
+            : useExit.cause,
+        );
+      }
+      if (Exit.isFailure(cleanupExit)) return yield* Effect.failCause(cleanupExit.cause);
+      return useExit.value;
+    }),
+  );
 
 export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(function* (options: {
   readonly baseSha: string;
@@ -157,11 +209,17 @@ export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(func
   yield* runCommand(root, "git", ["cat-file", "-e", `${headSha}^{commit}`]);
   const actualTree = yield* runCommand(root, "git", ["rev-parse", `${headSha}^{tree}`]);
 
-  const changesetBinary =
-    options.changesetBinary ?? path.join(root, "node_modules", ".bin", "changeset");
-  const expectedTree = yield* Effect.scoped(
+  const expectedTree = yield* withExpectedWorktree(root, baseSha, (expectedWorktree) =>
     Effect.gen(function* () {
-      const { worktree: expectedWorktree } = yield* acquireExpectedWorktree(root, baseSha);
+      if (options.changesetBinary === undefined) {
+        yield* runCommand(expectedWorktree, "bun", [
+          "install",
+          "--frozen-lockfile",
+          "--ignore-scripts",
+        ]);
+      }
+      const changesetBinary =
+        options.changesetBinary ?? path.join(expectedWorktree, "node_modules", ".bin", "changeset");
       yield* runCommand(expectedWorktree, changesetBinary, ["version"]);
       yield* runCommand(expectedWorktree, "bun", ["install", "--ignore-scripts"]);
       yield* runCommand(expectedWorktree, "git", ["add", "--all"]);


### PR DESCRIPTION
## Summary

Follow-up to #53, which was merged while its automated review still reported incomplete coverage and blocking release-boundary findings.

- execute Changesets from a frozen install inside the detached trusted-base worktree, never from the triggering workspace
- make verifier cleanup, release staging commit/cleanup, and temporary package-manifest restoration typed and fail-closed while preserving prior causes
- validate dependency maps and transferred tarball paths with Effect Schema before mutation or publication
- keep artifact packing registry-independent and route manual registry reads through an owned Effect HTTP client
- make the release module safe to import, tighten executable workflow stubs, and assert exact checksum, GitHub API, and npm publish invocations

## Review guide

- [Trusted manifest and tarball boundaries](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/scripts/release-publish.ts#L58-L100) validate mutable dependency sections and restrict artifact paths to `packages/<basename>.tgz`.
- [Scoped manifest swap and pack path](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/scripts/release-publish.ts#L187-L365) preserve the original manifest across failure/interruption, skip registry access in pack mode, and keep failures typed.
- [Atomic artifact directory ownership](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/scripts/release-artifact-directory.ts#L23-L83) masks the commit/cleanup boundary and combines preparation, commit, and cleanup causes.
- [Trusted-base verification lifecycle](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/scripts/verify-changesets-release.ts#L59-L235) installs frozen dependencies in the detached base, invokes that worktree's Changesets binary, and reports cleanup failures.
- [Regression coverage](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/packages/testing/test/toolchain.test.ts#L671-L704) covers Schema rejection; the same suite executes checksum, publisher, reporter, and verifier failure boundaries.
- [Operator contract](https://github.com/danieljvdm/effect-agent/blob/f1c744f5738467ef58193c3ad18aa2f3a5b394a7/docs/TOOLCHAIN.md#L155-L209) documents the trusted-base install, typed cleanup semantics, registry-free preparation, and safe artifact paths.

## Validation

- `vp fmt --check`
- `vp run check`
- `vp run test` (all package and example tasks passed; `@effect-agent/testing`: 29 files / 207 tests)
- `vp run build` (packages, examples, and docs)
- `vp test test/toolchain.test.ts` from `packages/testing` (15/15)
- real `release:prepare` smoke: 14 tarballs, one `0.1.0-beta.7` version, one `beta` tag
- `git diff --check`

No changeset: this follow-up changes repository release automation, its tests, and operator documentation; it does not change published package contents.

## Merge note

Do not merge until every required check, including the automated `review` check, succeeds. This PR intentionally does not publish or merge anything itself.
