### PR TITLE
ci(release): publish tarballs with an explicit ./ path prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,7 +432,10 @@ jobs:
               fi
               echo "- ${PACKAGE}@${VERSION}: already published, skipped"
             elif [ "$STATUS" = "404" ]; then
-              node "$NPM_CLI" publish "$TARBALL" \
+              # npm 12's npm-package-arg reads a bare "packages/….tgz" as the
+              # hosted-git shorthand "github:packages/…" and dies with
+              # EALLOWGIT; the ./ prefix forces the local-file interpretation.
+              node "$NPM_CLI" publish "./$TARBALL" \
                 --access public \
                 --ignore-scripts \
                 --registry https://registry.npmjs.org \


### PR DESCRIPTION
## Summary

- Fixes the failed beta.7 publish ([run 31904708875](https://github.com/danieljvdm/effect-agent/actions/runs/31904708875/job/95061702495)): the publish job's [`npm publish` invocation](https://github.com/danieljvdm/effect-agent/blob/dan/fix-ci-job-failure/.github/workflows/release.yml#L435-L444) now passes `"./$TARBALL"` instead of the bare `"$TARBALL"`.
- The manifest's `tarball` values and their [validation regex](https://github.com/danieljvdm/effect-agent/blob/dan/fix-ci-job-failure/.github/workflows/release.yml#L403-L406) are unchanged; only the spec handed to the npm CLI gains the prefix.

## What went wrong

This was the first push to main where the rewritten OIDC publish job actually reached `npm publish` (every earlier run of the new workflow took the version-PR maintenance path), so the bug shipped silently with the workflow rewrite and surfaced on the first real release.

npm resolves its positional argument through `npm-package-arg`, and npm 12 no longer treats a bare `packages/effect-agent-capabilities-0.1.0-beta.7.tgz` as a file path — the `owner/repo`-shaped string parses as the hosted-git shorthand `github:packages/effect-agent-capabilities-0.1.0-beta.7.tgz`. Because npm 12 refuses git-type specs by default, the job died on the first package with:

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "github:packages/effect-agent-capabilities-0.1.0-beta.7.tgz"
```

A `./` prefix makes the spec unambiguously a local file in every npm version, so publish proceeds. No package was published before the failure, so merging this fix lets the next main run publish beta.7 cleanly through the normal 404 → publish path.

## Evidence

Parsing both spec forms with the exact npm CLI the workflow pins (sha256 of the downloaded tarball matches `NPM_CLI_SHA256`):

```
$ shasum -a 256 npm-12.tgz
5dbb86c71d07a1957f2e90734092dd6a58bdcd9ebc2d8d41ca1c6e6a21d364e1  npm-12.tgz

$ node -e '… npm-package-arg from the pinned npm 12.0.2 …'
{"spec":"packages/effect-agent-capabilities-0.1.0-beta.7.tgz","type":"git","saveSpec":"github:packages/effect-agent-capabilities-0.1.0-beta.7.tgz"}
{"spec":"./packages/effect-agent-capabilities-0.1.0-beta.7.tgz","type":"file","saveSpec":"file:packages/effect-agent-capabilities-0.1.0-beta.7.tgz"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)