### PR TITLE
test(testing): align publish assertions with the ./ tarball prefix

### DIFF
--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -876,7 +876,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(publishStep?.run).toContain('REMOTE_BETA_VERSION="$(jq');
       expect(publishStep?.run).toContain('if [ "$REMOTE_INTEGRITY" != "$LOCAL_INTEGRITY" ]');
       expect(publishStep?.run).toContain('if [ "$REMOTE_BETA_VERSION" != "$VERSION" ]');
-      expect(publishStep?.run).toContain('node "$NPM_CLI" publish "$TARBALL"');
+      expect(publishStep?.run).toContain('node "$NPM_CLI" publish "./$TARBALL"');
       expect(publishStep?.run).toContain("--ignore-scripts");
       expect(publishStep?.run).toContain("--registry https://registry.npmjs.org");
       expect(publishStep?.run).not.toContain("node_modules");
@@ -1112,7 +1112,9 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         );
         expect(unpublishedVersion.publishInvocation.slice(1)).toEqual([
           "publish",
-          "packages/capabilities.tgz",
+          // The ./ prefix is load-bearing: npm 12 parses a bare
+          // "packages/….tgz" as a hosted-git shorthand and refuses it.
+          "./packages/capabilities.tgz",
           "--access",
           "public",
           "--ignore-scripts",


### PR DESCRIPTION
## Summary

- Unbreaks main's test suite: the toolchain contract test still asserted the pre-#69 publish invocation, so the Tests job fails on every PR (first seen on #66, which is otherwise innocent).
- Updates the two stale expectations to the prefixed form: the [workflow substring check](https://github.com/danieljvdm/effect-agent/blob/dan/fix-toolchain-tarball-assertions/packages/testing/test/toolchain.test.ts#L879) and the [captured `npm publish` argv](https://github.com/danieljvdm/effect-agent/blob/dan/fix-toolchain-tarball-assertions/packages/testing/test/toolchain.test.ts#L1113-L1127). The manifest fixture keeps bare `packages/….tgz` values because the manifest contract itself did not change — only the spec handed to npm gained the `./`.

## What went wrong

Two PRs merged around each other. #67 added exact assertions on the publish invocation (`node "$NPM_CLI" publish "$TARBALL"` and the argv `packages/capabilities.tgz`), and #69 — force-merged with red checks — changed that invocation to `"./$TARBALL"` so npm 12 stops parsing the bare path as the hosted-git shorthand `github:packages/….tgz` (`EALLOWGIT`). Each PR was green against the main it branched from; their intersection made the toolchain suite fail on every merge commit since.

After this lands, re-running the failed checks on #66 should go green — its only change to this file is an unrelated `repositoryRoot` anchoring fix.

## Evidence

```
$ vp test toolchain   # packages/testing
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)