### PR TITLE
fix(release): complete post-merge hardening

### DIFF
--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -187,8 +187,9 @@ versioned tree, packs every public workspace with Bun into a scope-owned staging
 atomically renames that directory into place only after every tarball and the manifest are
 complete. Failure or interruption removes the partial staging tree, so a retry never inherits an
 incomplete release artifact. The atomic rename itself is uninterruptible, and a failed preparation,
-commit, cleanup, or temporary manifest restoration remains a typed release failure with preceding
-causes preserved. The job then uploads one checksummed immutable artifact. A separate
+commit, cleanup, or temporary manifest installation/restoration remains a typed release failure
+with preceding causes preserved. Even a partial installation failure attempts to restore the
+original manifest bytes before returning. The job then uploads one checksummed immutable artifact. A separate
 action-free job is the sole holder of `id-token: write`. It checks the artifact
 digests, requires the release manifest to contain the exact fourteen-package fixed set at one
 `X.Y.Z-beta.N` version and the policy-owned `beta` dist-tag, verifies a pinned npm CLI tarball, and

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -5,7 +5,11 @@ import { Yaml } from "effect/unstable/encoding";
 import { ChildProcess } from "effect/unstable/process";
 
 import { prepareReleaseArtifactDirectory } from "../../../scripts/release-artifact-directory.ts";
-import { PreparedReleaseManifest, PublishManifest } from "../../../scripts/release-publish.ts";
+import {
+  PreparedReleaseManifest,
+  PublishManifest,
+  withTemporaryManifest,
+} from "../../../scripts/release-publish.ts";
 import {
   InvalidCommitSha,
   ReleaseTreeMismatch,
@@ -703,6 +707,98 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       }),
   );
 
+  it.effect("restores the source manifest after a partial temporary-install failure", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const temporaryRoot = yield* fs.makeTempDirectoryScoped({
+        prefix: "effect-agent-manifest-swap-test-",
+      });
+      const manifestPath = path.join(temporaryRoot, "package.json");
+      const originalBytes = '{"name":"fixture","version":"1.0.0"}\n';
+      const publishBytes = '{"name":"fixture","version":"1.0.0","exports":{}}\n';
+      yield* fs.writeFileString(manifestPath, originalBytes);
+
+      const installCause = PlatformError.systemError({
+        _tag: "WriteZero",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: manifestPath,
+      });
+      let writes = 0;
+      let useStarted = false;
+      const installFailingFileSystem = FileSystem.FileSystem.of({
+        ...fs,
+        writeFileString: (target, contents) => {
+          if (target !== manifestPath) return fs.writeFileString(target, contents);
+          writes += 1;
+          if (writes === 1) {
+            return fs
+              .writeFileString(target, "partial\n")
+              .pipe(Effect.andThen(Effect.fail(installCause)));
+          }
+          return fs.writeFileString(target, contents);
+        },
+      });
+      const installFailure = yield* Effect.flip(
+        withTemporaryManifest(
+          manifestPath,
+          originalBytes,
+          publishBytes,
+          Effect.sync(() => {
+            useStarted = true;
+          }),
+        ).pipe(Effect.provideService(FileSystem.FileSystem, installFailingFileSystem)),
+      );
+      expect(installFailure).toMatchObject({
+        _tag: "ReleaseManifestSwapError",
+        operation: "install",
+      });
+      expect(writes).toBe(2);
+      expect(useStarted).toBe(false);
+      expect(yield* fs.readFileString(manifestPath)).toBe(originalBytes);
+
+      const restoreCause = PlatformError.systemError({
+        _tag: "Busy",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: manifestPath,
+      });
+      writes = 0;
+      const installAndRestoreFailingFileSystem = FileSystem.FileSystem.of({
+        ...fs,
+        writeFileString: (target, contents) => {
+          if (target !== manifestPath) return fs.writeFileString(target, contents);
+          writes += 1;
+          if (writes === 1) {
+            return fs
+              .writeFileString(target, "partial-again\n")
+              .pipe(Effect.andThen(Effect.fail(installCause)));
+          }
+          return Effect.fail(restoreCause);
+        },
+      });
+      const combinedExit = yield* withTemporaryManifest(
+        manifestPath,
+        originalBytes,
+        publishBytes,
+        Effect.void,
+      ).pipe(
+        Effect.provideService(FileSystem.FileSystem, installAndRestoreFailingFileSystem),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(combinedExit)).toBe(true);
+      if (Exit.isFailure(combinedExit)) {
+        expect(Cause.hasDies(combinedExit.cause)).toBe(false);
+        const diagnostics = Cause.pretty(combinedExit.cause);
+        expect(diagnostics).toContain("Could not install temporary publish manifest");
+        expect(diagnostics).toContain("WriteZero: FileSystem.writeFileString");
+        expect(diagnostics).toContain("Could not restore temporary publish manifest");
+        expect(diagnostics).toContain("Busy: FileSystem.writeFileString");
+      }
+    }),
+  );
+
   it.effect("keeps generated release PRs behind a trusted integrity gate", () =>
     Effect.gen(function* () {
       const [ciWorkflow, reviewWorkflow, releaseWorkflow, rootManifest] = yield* Effect.all([
@@ -1232,17 +1328,34 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         const packageDirectory = path.join(fixtureRoot, "packages", "fixture");
         const changesetDirectory = path.join(fixtureRoot, ".changeset");
         const changesetBinary = path.resolve(repositoryRoot, "node_modules", ".bin", "changeset");
-        const verifierSource = yield* readRepositoryFile("scripts/verify-changesets-release.ts");
-        expect(verifierSource).toContain('"--frozen-lockfile"');
-        expect(verifierSource).toContain(
-          'path.join(expectedWorktree, "node_modules", ".bin", "changeset")',
+        const commandCapture = path.join(temporaryRoot, "trusted-command-capture");
+        const bunStub = path.join(temporaryRoot, "bun-stub");
+        const changesetStub = path.join(temporaryRoot, "changeset-stub");
+
+        yield* fs.writeFileString(
+          changesetStub,
+          `#!/usr/bin/env bash
+set -euo pipefail
+printf 'changeset\\t%s\\t%s\\n' "$PWD" "$*" >> ${JSON.stringify(commandCapture)}
+exec ${JSON.stringify(changesetBinary)} "$@"
+`,
         );
-        expect(verifierSource).not.toContain(
-          'path.join(root, "node_modules", ".bin", "changeset")',
+        yield* fs.chmod(changesetStub, 0o755);
+        yield* fs.writeFileString(
+          bunStub,
+          `#!/usr/bin/env bash
+set -euo pipefail
+printf 'bun\\t%s\\t%s\\n' "$PWD" "$*" >> ${JSON.stringify(commandCapture)}
+bun "$@"
+mkdir -p node_modules/.bin
+ln -sf ${JSON.stringify(changesetStub)} node_modules/.bin/changeset
+`,
         );
+        yield* fs.chmod(bunStub, 0o755);
 
         yield* fs.makeDirectory(packageDirectory, { recursive: true });
         yield* fs.makeDirectory(changesetDirectory, { recursive: true });
+        yield* fs.writeFileString(path.join(fixtureRoot, ".gitignore"), "node_modules\n");
         yield* fs.writeFileString(
           path.join(fixtureRoot, "package.json"),
           `{
@@ -1281,6 +1394,8 @@ Exercise the generated release verifier.
 `,
         );
 
+        yield* runFixtureCommand(fixtureRoot, "bun", ["install", "--ignore-scripts"]);
+
         yield* runFixtureCommand(temporaryRoot, "git", [
           "init",
           "--initial-branch=main",
@@ -1314,6 +1429,28 @@ Exercise the generated release verifier.
           "--porcelain",
         ]);
         expect(worktreesAfterSuccess.match(/^worktree /gm)).toHaveLength(1);
+
+        yield* fs.writeFileString(commandCapture, "");
+        yield* verifyChangesetsRelease({
+          baseSha,
+          bunBinary: bunStub,
+          headSha: generatedHead,
+          repositoryRoot: fixtureRoot,
+        });
+        const trustedCommands = (yield* fs.readFileString(commandCapture))
+          .trim()
+          .split("\n")
+          .map((line) => line.split("\t"));
+        expect(trustedCommands.map(([tool, , args]) => [tool, args])).toEqual([
+          ["bun", "install --frozen-lockfile --ignore-scripts"],
+          ["changeset", "version"],
+          ["bun", "install --ignore-scripts"],
+        ]);
+        const trustedWorkingDirectories = new Set(trustedCommands.map(([, cwd]) => cwd));
+        expect(trustedWorkingDirectories.size).toBe(1);
+        const trustedWorkingDirectory = trustedCommands[0]?.[1];
+        expect(trustedWorkingDirectory).toMatch(/effect-agent-changesets-release-.+[/]expected$/);
+        expect(trustedWorkingDirectory).not.toBe(fixtureRoot);
 
         let failedCleanupPath = "";
         const cleanupCause = PlatformError.systemError({

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -55,7 +55,7 @@ class CommandError extends Schema.TaggedError<CommandError>()("CommandError", {
   }
 }
 
-class ReleaseManifestSwapError extends Schema.TaggedError<ReleaseManifestSwapError>()(
+export class ReleaseManifestSwapError extends Schema.TaggedError<ReleaseManifestSwapError>()(
   "ReleaseManifestSwapError",
   {
     cause: Schema.optionalKey(Schema.Defect()),
@@ -184,7 +184,7 @@ const distExport = (sourcePath: string): { types: string; default: string } | un
   return { types: `./dist/${match[1]}.d.mts`, default: `./dist/${match[1]}.mjs` };
 };
 
-const withTemporaryManifest = <A, E, R>(
+export const withTemporaryManifest = <A, E, R>(
   manifestPath: string,
   originalBytes: string,
   publishBytes: string,
@@ -201,9 +201,19 @@ const withTemporaryManifest = <A, E, R>(
       });
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
-        yield* fs
+        const installExit = yield* fs
           .writeFileString(manifestPath, publishBytes)
-          .pipe(Effect.mapError(manifestError("install")));
+          .pipe(Effect.mapError(manifestError("install")), Effect.exit);
+        if (Exit.isFailure(installExit)) {
+          const restoreExit = yield* fs
+            .writeFileString(manifestPath, originalBytes)
+            .pipe(Effect.mapError(manifestError("restore")), Effect.exit);
+          return yield* Effect.failCause(
+            Exit.isFailure(restoreExit)
+              ? Cause.combine(installExit.cause, restoreExit.cause)
+              : installExit.cause,
+          );
+        }
         const useExit = yield* restore(use).pipe(Effect.exit);
         const restoreExit = yield* fs
           .writeFileString(manifestPath, originalBytes)

--- a/scripts/verify-changesets-release.ts
+++ b/scripts/verify-changesets-release.ts
@@ -199,6 +199,7 @@ export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(func
   readonly headSha: string;
   readonly repositoryRoot?: string;
   readonly changesetBinary?: string;
+  readonly bunBinary?: string;
 }) {
   const baseSha = yield* decodeCommitSha("--base-sha", options.baseSha);
   const headSha = yield* decodeCommitSha("--head-sha", options.headSha);
@@ -211,8 +212,9 @@ export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(func
 
   const expectedTree = yield* withExpectedWorktree(root, baseSha, (expectedWorktree) =>
     Effect.gen(function* () {
+      const bunBinary = options.bunBinary ?? "bun";
       if (options.changesetBinary === undefined) {
-        yield* runCommand(expectedWorktree, "bun", [
+        yield* runCommand(expectedWorktree, bunBinary, [
           "install",
           "--frozen-lockfile",
           "--ignore-scripts",
@@ -221,7 +223,7 @@ export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(func
       const changesetBinary =
         options.changesetBinary ?? path.join(expectedWorktree, "node_modules", ".bin", "changeset");
       yield* runCommand(expectedWorktree, changesetBinary, ["version"]);
-      yield* runCommand(expectedWorktree, "bun", ["install", "--ignore-scripts"]);
+      yield* runCommand(expectedWorktree, bunBinary, ["install", "--ignore-scripts"]);
       yield* runCommand(expectedWorktree, "git", ["add", "--all"]);
       return yield* runCommand(expectedWorktree, "git", ["write-tree"]);
     }),


### PR DESCRIPTION
## Summary

Closes the two important findings left by [PR #67's automated review](https://github.com/danieljvdm/effect-agent/pull/67#pullrequestreview-4944606217) after that PR was merged externally:

- if installing the temporary publish manifest partially writes and then fails, always attempt to restore the exact original bytes; preserve both typed causes if restoration also fails
- replace source-text assertions with an integration path that executes the default trusted-worktree flow and captures its real working directories and command arguments

## Review guide

- [Manifest swap failure handling](https://github.com/danieljvdm/effect-agent/blob/5f1b46c837ad655e7afdf559320c19a887e6b313/scripts/release-publish.ts#L187-L232) masks installation/restoration, restores after installation failure, and combines both causes.
- [Trusted verifier seam](https://github.com/danieljvdm/effect-agent/blob/5f1b46c837ad655e7afdf559320c19a887e6b313/scripts/verify-changesets-release.ts#L197-L230) keeps production defaults unchanged while allowing the integration fixture to substitute only the Bun executable.
- [Partial-write regression](https://github.com/danieljvdm/effect-agent/blob/5f1b46c837ad655e7afdf559320c19a887e6b313/packages/testing/test/toolchain.test.ts#L710-L800) proves restoration, proves publish work never begins, and proves combined failures stay typed.
- [Trusted-worktree execution regression](https://github.com/danieljvdm/effect-agent/blob/5f1b46c837ad655e7afdf559320c19a887e6b313/packages/testing/test/toolchain.test.ts#L1316-L1451) runs frozen install → worktree-local Changesets → lock regeneration and asserts all three execute in the detached worktree.
- [Operator contract](https://github.com/danieljvdm/effect-agent/blob/5f1b46c837ad655e7afdf559320c19a887e6b313/docs/TOOLCHAIN.md#L184-L198) now states that even a partial temporary-manifest installation failure attempts exact restoration.

## Validation

- `vp fmt --check`
- `vp run check`
- `vp run test` (all package/example tasks passed; `@effect-agent/testing`: 29 files / 208 tests)
- `vp run build` (packages, examples, and docs)
- `vp test test/toolchain.test.ts` from `packages/testing` (16/16; rerun after rebasing onto #71)
- real `release:prepare` smoke: 14 tarballs, one lockstep beta version, one `beta` tag
- `git diff --check`

No changeset: this changes repository release automation, regression tests, and operator documentation, not published package contents.

## Merge note

Please leave this PR open until the automated review text is clean as well as its check conclusion. This PR does not publish or merge anything itself.
