### PR TITLE
ci(release): fan out package publishes as concurrent background jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,7 +406,16 @@ jobs:
             )
           ' release-manifest.json > /dev/null
 
-          while IFS=$'\t' read -r PACKAGE VERSION TARBALL DIST_TAG; do
+          # Each package's verify-then-publish pipeline is independent (its
+          # npm process performs its own OIDC exchange), so the packages fan
+          # out as background jobs. Plain assignments, not `local`, keep
+          # errexit watching every command substitution.
+          publish_package() {
+            PACKAGE="$1"
+            VERSION="$2"
+            TARBALL="$3"
+            DIST_TAG="$4"
+
             TARBALL_BYTES="$(stat --format='%s' "$TARBALL")"
             test "$TARBALL_BYTES" -le 52428800
             tar -xOf "$TARBALL" package/package.json | jq --exit-status \
@@ -445,7 +454,38 @@ jobs:
               echo "Unexpected npm registry status ${STATUS} for ${PACKAGE}@${VERSION}." >&2
               exit 1
             fi
+          }
+
+          PUBLISH_LOG_DIRECTORY="$RUNNER_TEMP/publish-logs"
+          mkdir -p "$PUBLISH_LOG_DIRECTORY"
+          PUBLISH_COUNT=0
+          PUBLISH_PIDS=()
+          PUBLISH_NAMES=()
+          PUBLISH_LOGS=()
+          while IFS=$'\t' read -r PACKAGE VERSION TARBALL DIST_TAG; do
+            PUBLISH_COUNT=$((PUBLISH_COUNT + 1))
+            PUBLISH_LOG="$PUBLISH_LOG_DIRECTORY/${PUBLISH_COUNT}-${TARBALL##*/}.log"
+            publish_package "$PACKAGE" "$VERSION" "$TARBALL" "$DIST_TAG" > "$PUBLISH_LOG" 2>&1 &
+            PUBLISH_PIDS+=("$!")
+            PUBLISH_NAMES+=("${PACKAGE}@${VERSION}")
+            PUBLISH_LOGS+=("$PUBLISH_LOG")
           done < <(jq --raw-output '.packages[] | select(.tarball != null) | [.name, .version, .tarball, .distTag] | @tsv' release-manifest.json)
+
+          # Failures never interrupt sibling publishes: every background job
+          # is awaited, logs replay in manifest order, and any failure fails
+          # the step only after the full sweep.
+          PUBLISH_FAILURES=0
+          for PUBLISH_INDEX in "${!PUBLISH_PIDS[@]}"; do
+            if ! wait "${PUBLISH_PIDS[$PUBLISH_INDEX]}"; then
+              PUBLISH_FAILURES=$((PUBLISH_FAILURES + 1))
+              echo "Publishing ${PUBLISH_NAMES[$PUBLISH_INDEX]} failed." >&2
+            fi
+            cat "${PUBLISH_LOGS[$PUBLISH_INDEX]}"
+          done
+          if [ "$PUBLISH_FAILURES" -ne 0 ]; then
+            echo "${PUBLISH_FAILURES} package publish(es) failed; refusing to tag." >&2
+            exit 1
+          fi
 
   tag-release:
     name: Tag published packages

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -194,7 +194,10 @@ action-free job is the sole holder of `id-token: write`. It checks the artifact
 digests, requires the release manifest to contain the exact fourteen-package fixed set at one
 `X.Y.Z-beta.N` version and the policy-owned `beta` dist-tag, verifies a pinned npm CLI tarball, and
 publishes with provenance; it does not check out repository code, install dependencies, run a
-build, or invoke a repository script. If a same-version registry entry appears during a retry, the
+build, or invoke a repository script. Per-package verify-and-publish pipelines fan out as
+concurrent background jobs (each npm process performs its own OIDC exchange); every job is
+awaited, per-package logs replay in manifest order, and any failure fails the step only after the
+full sweep. If a same-version registry entry appears during a retry, the
 job skips it only when its SRI integrity matches the prepared tarball and the registry's `beta` tag
 already selects that version. A final action-free job has tag-write but no OIDC authority and
 creates only validated framework-package tags at the triggering `main` SHA; an existing lightweight

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -386,7 +386,9 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
   script: string,
   options: {
     readonly checksumFailure?: "artifact" | "npm";
+    readonly npmFailTarball?: string;
     readonly packageMetadata: string;
+    readonly publishablePackages?: ReadonlyArray<string>;
     readonly registryStatus: "200" | "404";
     readonly tarball?: string;
     readonly versionMetadata: string;
@@ -400,11 +402,14 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
   const artifactDirectory = path.join(temporaryRoot, "artifact-source");
   const binDirectory = path.join(temporaryRoot, "bin");
   const expectedSumsPath = path.join(temporaryRoot, "expected-SHA256SUMS");
-  const publishCapture = path.join(temporaryRoot, "npm-publish-invoked");
+  const publishCaptureDirectory = path.join(temporaryRoot, "npm-publish-invocations");
+  const tarballManifestDirectory = path.join(temporaryRoot, "tarball-manifests");
   const trustedManifestDirectory = path.join(temporaryRoot, "trusted-manifests");
   const version = "0.0.1-beta.7";
+  const publishablePackages = options.publishablePackages ?? ["capabilities"];
   yield* fs.makeDirectory(path.join(artifactDirectory, "packages"), { recursive: true });
   yield* fs.makeDirectory(binDirectory, { recursive: true });
+  yield* fs.makeDirectory(tarballManifestDirectory, { recursive: true });
   yield* fs.makeDirectory(trustedManifestDirectory, { recursive: true });
 
   const releases: Array<{
@@ -422,11 +427,26 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
       path.join(trustedManifestDirectory, `${directory}.json`),
       `${JSON.stringify({ name: manifest.name, version })}\n`,
     );
+    const publishable = publishablePackages.includes(directory);
+    const tarball = publishable
+      ? directory === "capabilities"
+        ? (options.tarball ?? "packages/capabilities.tgz")
+        : `packages/${directory}.tgz`
+      : null;
+    if (publishable) {
+      yield* fs.writeFileString(
+        path.join(tarballManifestDirectory, `${directory}.tgz.json`),
+        `${JSON.stringify({ name: manifest.name, version })}\n`,
+      );
+      yield* fs.writeFileString(
+        path.join(artifactDirectory, "packages", `${directory}.tgz`),
+        "fixture\n",
+      );
+    }
     releases.push({
       distTag: "beta",
       name: manifest.name,
-      tarball:
-        directory === "capabilities" ? (options.tarball ?? "packages/capabilities.tgz") : null,
+      tarball,
       version,
     });
   }
@@ -436,17 +456,13 @@ const runReleasePublisher = Effect.fn("toolchainTest.runReleasePublisher")(funct
   );
   const expectedSums = [
     "fixture-sha  npm-12.0.2.tgz",
-    "fixture-sha  packages/capabilities.tgz",
+    ...publishablePackages.map((directory) => `fixture-sha  packages/${directory}.tgz`),
     "fixture-sha  release-manifest.json",
     "",
   ].join("\n");
   yield* fs.writeFileString(path.join(artifactDirectory, "SHA256SUMS"), expectedSums);
   yield* fs.writeFileString(expectedSumsPath, expectedSums);
   yield* fs.writeFileString(path.join(artifactDirectory, "npm-12.0.2.tgz"), "fixture\n");
-  yield* fs.writeFileString(
-    path.join(artifactDirectory, "packages", "capabilities.tgz"),
-    "fixture\n",
-  );
 
   const writeExecutable = (name: string, contents: string) =>
     Effect.gen(function* () {
@@ -518,7 +534,10 @@ if [ "\${1:-}" = "--eval" ]; then
   exit 0
 fi
 if [ "\${2:-}" = "publish" ]; then
-  printf '%s\n' "$@" > "$PUBLISH_CAPTURE"
+  mkdir -p "$PUBLISH_CAPTURE"
+  TARBALL_BASENAME="$(basename "\${3:-}")"
+  printf '%s\n' "$@" > "$PUBLISH_CAPTURE/$TARBALL_BASENAME"
+  test "$TARBALL_BASENAME" != "$PUBLISH_NPM_FAIL_TARBALL"
   exit 0
 fi
 echo "Unexpected node invocation: $*" >&2
@@ -541,7 +560,7 @@ if [ "\${1:-}" = "-xzf" ]; then
   done
 fi
 if [ "\${1:-}" = "-xOf" ]; then
-  printf '{"name":"@effect-agent/capabilities","version":"0.0.1-beta.7"}\n'
+  cat "$PUBLISH_TARBALL_MANIFESTS/$(basename "\${2:-}").json"
   exit 0
 fi
 exit 64
@@ -593,11 +612,13 @@ printf 'fixture-integrity'
       NPM_CLI_VERSION: "12.0.2",
       PATH: `${binDirectory}:${globalThis.process.env["PATH"] ?? ""}`,
       PUBLISH_ARTIFACT_SOURCE: artifactDirectory,
-      PUBLISH_CAPTURE: publishCapture,
+      PUBLISH_CAPTURE: publishCaptureDirectory,
       PUBLISH_CHECKSUM_FAILURE: options.checksumFailure ?? "none",
       PUBLISH_EXPECTED_SUMS: expectedSumsPath,
+      PUBLISH_NPM_FAIL_TARBALL: options.npmFailTarball ?? "none",
       PUBLISH_PACKAGE_METADATA: options.packageMetadata,
       PUBLISH_REGISTRY_STATUS: options.registryStatus,
+      PUBLISH_TARBALL_MANIFESTS: tarballManifestDirectory,
       PUBLISH_TRUSTED_MANIFESTS: trustedManifestDirectory,
       PUBLISH_VERSION_METADATA: options.versionMetadata,
       RUNNER_TEMP: path.join(temporaryRoot, "runner"),
@@ -610,14 +631,20 @@ printf 'fixture-integrity'
     Stream.mkString(Stream.decodeText(child.all)),
     child.exitCode,
   ]);
-  const publishInvocation = (yield* fs.exists(publishCapture))
-    ? (yield* fs.readFileString(publishCapture)).trim().split("\n")
+  const publishInvocations = (yield* fs.exists(publishCaptureDirectory))
+    ? yield* Effect.forEach(
+        [...(yield* fs.readDirectory(publishCaptureDirectory))].sort(),
+        (entry) =>
+          Effect.map(fs.readFileString(path.join(publishCaptureDirectory, entry)), (capture) =>
+            capture.trim().split("\n"),
+          ),
+      )
     : [];
   return {
     exitCode,
     output,
-    publishInvocation,
-    publishInvoked: publishInvocation.length > 0,
+    publishInvocations,
+    publishInvoked: publishInvocations.length > 0,
   } as const;
 });
 
@@ -973,6 +1000,11 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(publishStep?.run).toContain('if [ "$REMOTE_INTEGRITY" != "$LOCAL_INTEGRITY" ]');
       expect(publishStep?.run).toContain('if [ "$REMOTE_BETA_VERSION" != "$VERSION" ]');
       expect(publishStep?.run).toContain('node "$NPM_CLI" publish "./$TARBALL"');
+      expect(publishStep?.run).toContain(
+        'publish_package "$PACKAGE" "$VERSION" "$TARBALL" "$DIST_TAG" > "$PUBLISH_LOG" 2>&1 &',
+      );
+      expect(publishStep?.run).toContain('if ! wait "${PUBLISH_PIDS[$PUBLISH_INDEX]}"');
+      expect(publishStep?.run).toContain("refusing to tag");
       expect(publishStep?.run).toContain("--ignore-scripts");
       expect(publishStep?.run).toContain("--registry https://registry.npmjs.org");
       expect(publishStep?.run).not.toContain("node_modules");
@@ -1203,10 +1235,11 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
           versionMetadata: validVersionMetadata,
         });
         expect(unpublishedVersion).toMatchObject({ exitCode: 0, publishInvoked: true });
-        expect(unpublishedVersion.publishInvocation[0]).toMatch(
+        expect(unpublishedVersion.publishInvocations).toHaveLength(1);
+        expect(unpublishedVersion.publishInvocations[0]?.[0]).toMatch(
           /[/]release-artifact[/][.]npm-cli[/]package[/]bin[/]npm-cli[.]js$/,
         );
-        expect(unpublishedVersion.publishInvocation.slice(1)).toEqual([
+        expect(unpublishedVersion.publishInvocations[0]?.slice(1)).toEqual([
           "publish",
           // The ./ prefix is load-bearing: npm 12 parses a bare
           // "packages/….tgz" as a hosted-git shorthand and refuses it.
@@ -1240,6 +1273,60 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         });
         expect(unsafeTarball.exitCode).not.toBe(0);
         expect(unsafeTarball.publishInvoked).toBe(false);
+      }),
+    90_000,
+  );
+
+  it.effect(
+    "fans out package publishes and aggregates background failures",
+    () =>
+      Effect.gen(function* () {
+        const releaseWorkflow = yield* readWorkflow(".github/workflows/release.yml");
+        const publishScript = workflowStep(
+          releaseWorkflow,
+          "publish-packages",
+          "Verify and publish prepared tarballs",
+        )?.run;
+        if (publishScript === undefined) {
+          return yield* Effect.die(new Error("Release publisher must have an executable body."));
+        }
+
+        const validVersionMetadata = JSON.stringify({
+          dist: { integrity: "sha512-fixture-integrity" },
+        });
+        const validPackageMetadata = JSON.stringify({
+          "dist-tags": { beta: "0.0.1-beta.7" },
+        });
+
+        const bothPublished = yield* runReleasePublisher(publishScript, {
+          packageMetadata: validPackageMetadata,
+          publishablePackages: ["capabilities", "sandbox"],
+          registryStatus: "404",
+          versionMetadata: validVersionMetadata,
+        });
+        expect(bothPublished).toMatchObject({ exitCode: 0, publishInvoked: true });
+        expect(bothPublished.publishInvocations.map((invocation) => invocation[2])).toEqual([
+          "./packages/capabilities.tgz",
+          "./packages/sandbox.tgz",
+        ]);
+
+        // One npm publish failing must not interrupt its sibling, and the
+        // step must still fail after the full sweep.
+        const isolatedFailure = yield* runReleasePublisher(publishScript, {
+          npmFailTarball: "capabilities.tgz",
+          packageMetadata: validPackageMetadata,
+          publishablePackages: ["capabilities", "sandbox"],
+          registryStatus: "404",
+          versionMetadata: validVersionMetadata,
+        });
+        expect(isolatedFailure.exitCode).not.toBe(0);
+        expect(isolatedFailure.publishInvocations.map((invocation) => invocation[2])).toContain(
+          "./packages/sandbox.tgz",
+        );
+        expect(isolatedFailure.output).toContain(
+          "Publishing @effect-agent/capabilities@0.0.1-beta.7 failed.",
+        );
+        expect(isolatedFailure.output).toContain("refusing to tag");
       }),
     60_000,
   );


### PR DESCRIPTION
## Summary

- The release publish job's per-package loop ran sequentially at ~4.5s per package (npm CLI startup, OIDC exchange, sigstore provenance signing, upload) — ~64s of the beta.8 run's 73s publish job. The [per-package pipeline now runs as a `publish_package` function fanned out as background jobs](https://github.com/danieljvdm/effect-agent/blob/dan/parallel-package-publish/.github/workflows/release.yml#L409-L490), which should bring the loop down to roughly the slowest single publish (~5–10s).
- The security invariant is unchanged: still one action-free step, no checkout, no dependency install, no repository script — the fan-out is ~25 lines of plain bash inside the same inline script. Each npm process performs its own independent OIDC exchange from the ambient env, and npm's content-addressable cache is safe under concurrent processes.
- Failure semantics are deliberate: [every background job is awaited, per-package logs replay in manifest order, and any failure fails the step only after the full sweep](https://github.com/danieljvdm/effect-agent/blob/dan/parallel-package-publish/.github/workflows/release.yml#L475-L490) — one bad package can neither interrupt a sibling mid-upload nor slip through. Publish order was already non-topological (capabilities published before core), so concurrency does not weaken ordering.
- One subtlety worth review: the function body keeps plain assignments instead of `local` — `local X="$(cmd)"` returns `local`'s status, masking the command substitution's failure and silently defeating errexit's fail-closed behavior. A comment in the script records this.
- `docs/TOOLCHAIN.md` gains a sentence describing the concurrency semantics.

## Architecture

- The [toolchain contract test harness](https://github.com/danieljvdm/effect-agent/blob/dan/parallel-package-publish/packages/testing/test/toolchain.test.ts#L385-L640) now supports multiple publishable fixture packages, captures each `npm publish` argv in a per-tarball file (the stub previously clobbered a single capture file, which concurrent publishes would race), serves per-tarball `package.json` fixtures to the `tar` stub, and can inject an npm failure for a chosen tarball.
- A [new test](https://github.com/danieljvdm/effect-agent/blob/dan/parallel-package-publish/packages/testing/test/toolchain.test.ts#L1281-L1339) executes the real workflow script with two publishable packages and proves both fan-out publishing (both argvs captured, `./`-prefixed) and failure isolation: when npm fails for one package, the sibling still publishes, the step exits nonzero, and the output names the failed package and refuses to tag.
- All pre-existing fail-closed fixtures (integrity mismatch, dist-tag mismatch, checksum failures, unsafe tarball path) now exercise failure propagation out of a background job.
- Timeouts on the two publisher-executing tests rise (60s→90s, 40s→60s): each test run spawns freshly written stub executables, which cold macOS machines scan on first exec.

## Evidence

Full toolchain suite against the new script:

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  35.05s
```

beta.8 timing baseline (sequential): publish job 73s, of which the loop was ~64s — each package a metronomic ~4.5s. The next release on this branch's workflow is the real-world verification.

Note for reviewers running the suite locally: run it from `packages/testing` (or with #66 merged) — the test file's `repositoryRoot = "../.."` is CWD-relative and escapes into the primary checkout when vitest runs from a nested worktree root, which is exactly what #66 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)