### PR TITLE
fix(pr-review): give reasoning reviews enough headroom

### DIFF
--- a/.changeset/quiet-review-headroom.md
+++ b/.changeset/quiet-review-headroom.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Give OpenAI reasoning models enough output-token and wall-clock headroom to
+finish high-effort delegated reviews instead of leaving fully read units
+unreviewed with protocol or duration failures.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -41083,7 +41083,7 @@ var fileReviewerInstructions = makeFileReviewerInstructions();
 var defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 8,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "4 minutes",
+  maxDuration: "6 minutes",
   toolConcurrency: 2,
   tokenBudget: 200000,
   contextTokenLimit: 150000,
@@ -41113,7 +41113,7 @@ var fileReviewPolicy = SubagentPolicy.make({
   maxConcurrency: 3,
   maxTurns: 8,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "4 minutes"
+  maxDuration: "6 minutes"
 });
 var delegationDescription = "Delegate the review of one planned unit to a bounded file-reviewer child and return its line-anchored findings. Call it exactly once per unit from list_review_units; never retry a failed unit.";
 var mapFileReviewChildFailure = (failure) => FileReviewUnitFailed.make({
@@ -53564,7 +53564,7 @@ var PROVIDER_EFFORT_RUNGS = {
   anthropic: ["low", "medium", "high"]
 };
 var makeOpenAiReviewModel = (model3, effort) => exports_OpenAiLanguageModel.model(model3 ?? DEFAULT_MODEL.openai, {
-  max_output_tokens: 8000,
+  max_output_tokens: 32000,
   store: false,
   strictJsonSchema: true,
   ...effort === undefined ? {} : { reasoning: { effort: resolveEffortRung(effort, PROVIDER_EFFORT_RUNGS.openai) } }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format:write": "vp fmt --write",
     "lint": "vp lint",
     "action:build": "bun scripts/build-action.ts",
-    "check": "vp check && vp run -F './packages/*' check && vp run -F './examples/*' check && tsc --noEmit -p scripts/tsconfig.json && bun scripts/build-action.ts --check",
+    "check": "vp check && vp run --concurrency-limit 1 -F './packages/*' check && vp run -F './examples/*' check && tsc --noEmit -p scripts/tsconfig.json && bun scripts/build-action.ts --check",
     "test": "vp run -F './packages/*' test && vp run -F './examples/*' test",
     "build": "vp run -F './packages/*' build && vp run -F './examples/*' build && bun run docs:build",
     "ready": "bun run check && bun run test && bun run build"

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -135,7 +135,7 @@ export const fileReviewerInstructions = makeFileReviewerInstructions();
 export const defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 8,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "4 minutes",
+  maxDuration: "6 minutes",
   toolConcurrency: 2,
   tokenBudget: 200_000,
   // Bound one live prompt independently from cumulative usage. The engine
@@ -201,7 +201,7 @@ export const fileReviewPolicy = SubagentPolicy.make({
   maxConcurrency: 3,
   maxTurns: 8,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "4 minutes",
+  maxDuration: "6 minutes",
 });
 
 const delegationDescription =

--- a/packages/pr-review/src/internal/providers.ts
+++ b/packages/pr-review/src/internal/providers.ts
@@ -46,7 +46,10 @@ export const PROVIDER_EFFORT_RUNGS = {
 /** One OpenAI review model binding with the package's structured-output settings. */
 export const makeOpenAiReviewModel = (model?: string, effort?: EffortPosition) =>
   OpenAiLanguageModel.model(model ?? DEFAULT_MODEL.openai, {
-    max_output_tokens: 8_000,
+    // OpenAI counts hidden reasoning tokens and visible answer tokens against
+    // this same ceiling. High-effort reviews can exhaust an 8k allowance
+    // after reading every file but before emitting their structured report.
+    max_output_tokens: 32_000,
     store: false,
     strictJsonSchema: true,
     ...(effort === undefined

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -83,6 +83,7 @@ describe("GitHub prior reviews", () => {
         Layer.succeed(HttpClient.HttpClient)(client),
       );
       const priorReviewsLayer = gitHubPriorReviewsLayer.pipe(Layer.provide(dependencies));
+      const testLayer = Layer.merge(priorReviewsLayer, authenticatorLayer);
 
       const result = yield* Effect.gen(function* () {
         const priorReviews = yield* PriorReviews;
@@ -90,7 +91,7 @@ describe("GitHub prior reviews", () => {
           fingerprint: yield* priorReviews.latestFingerprint,
           state: yield* priorReviews.latestState,
         };
-      }).pipe(Effect.provide(priorReviewsLayer), Effect.provide(authenticatorLayer));
+      }).pipe(Effect.provide(testLayer));
 
       expect(Option.getOrUndefined(result.fingerprint)).toBe(FINGERPRINT);
       expect(Option.getOrUndefined(result.state)).toEqual(reviewState);

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Ref, Schema, Stream } from "effect";
+import { Duration, Effect, Layer, Ref, Schema, Stream } from "effect";
 import {
   Agent,
   AgentSpawner,
@@ -279,6 +279,11 @@ describe("file-reviewer policy", () => {
     expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(MAX_UNIT_FILES * 2);
     expect(defaultFileReviewerPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
     expect(fileReviewPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
+  });
+
+  it("keeps the child and delegation deadlines aligned with reasoning-model headroom", () => {
+    expect(Duration.toMillis(defaultFileReviewerPolicy.maxDuration)).toBe(6 * 60_000);
+    expect(Duration.toMillis(fileReviewPolicy.maxDuration)).toBe(6 * 60_000);
   });
 });
 

--- a/packages/pr-review/test/providers.test.ts
+++ b/packages/pr-review/test/providers.test.ts
@@ -1,0 +1,52 @@
+import { OpenAiClient, OpenAiSchema } from "@effect/ai-openai";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Ref } from "effect";
+import { LanguageModel } from "effect/unstable/ai";
+import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { EFFORT_ALIASES, makeOpenAiReviewModel } from "../src/index.ts";
+
+const makeResponse = (): OpenAiSchema.Response => ({
+  id: "resp_test123",
+  object: "response",
+  created_at: 0,
+  model: "gpt-5.6-sol",
+  output: [],
+  usage: null,
+  error: null,
+  incomplete_details: null,
+});
+
+describe("makeOpenAiReviewModel", () => {
+  it.effect("reserves reasoning headroom for high-effort reviews", () =>
+    Effect.gen(function* () {
+      const requests = yield* Ref.make<ReadonlyArray<typeof OpenAiSchema.CreateResponse.Encoded>>(
+        [],
+      );
+      const request = HttpClientRequest.post("https://api.openai.com/v1/responses");
+      const response = HttpClientResponse.fromWeb(request, new Response(null, { status: 200 }));
+      const clientLayer = Layer.succeed(
+        OpenAiClient.OpenAiClient,
+        OpenAiClient.OpenAiClient.of({
+          client: undefined as never,
+          createResponse: (options) =>
+            Ref.update(requests, (captured) => [...captured, options]).pipe(
+              Effect.as([makeResponse(), response] as const),
+            ),
+          createResponseStream: () => Effect.die(new Error("unexpected streaming request")),
+          createEmbedding: () => Effect.die(new Error("unexpected embedding request")),
+        }),
+      );
+
+      yield* LanguageModel.generateText({ prompt: "Review this change." }).pipe(
+        Effect.provide(
+          makeOpenAiReviewModel(undefined, EFFORT_ALIASES.high).pipe(Layer.provide(clientLayer)),
+        ),
+      );
+
+      const [captured] = yield* Ref.get(requests);
+      expect(captured?.max_output_tokens).toBe(32_000);
+      expect(captured?.reasoning).toEqual({ effort: "high" });
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

- raise the OpenAI review response ceiling from 8,000 to 32,000 tokens because the Responses API counts hidden reasoning and visible output against the same limit
- extend both aligned per-unit deadlines from four to six minutes
- add request-boundary and policy regression coverage plus a patch changeset

## What went wrong

The review of [reve-ai/kommunikasie#407](https://github.com/reve-ai/kommunikasie/pull/407) repeatedly left `unit-002` unreviewed. In the protocol-failure attempt, the child successfully completed every diff and context read, then failed on its final high-effort model turn with `ModelProtocolError`; another attempt exhausted the four-minute child reservation.

The beta.10 containment work correctly kept those failures fail-closed, but it did not give the model enough capacity to finish. The configured 8k OpenAI ceiling was especially restrictive: OpenAI documents `max_output_tokens` as the combined ceiling for reasoning and answer tokens, and recommends initially reserving at least 25k tokens for reasoning workloads. This change uses 32k while preserving structured output and fail-closed coverage semantics.

Relevant code: [OpenAI model binding](https://github.com/danieljvdm/effect-agent/blob/ba412a1/packages/pr-review/src/internal/providers.ts#L46-L58), [aligned child policies](https://github.com/danieljvdm/effect-agent/blob/ba412a1/packages/pr-review/src/internal/fan-out.ts#L134-L205), and [request-boundary regression](https://github.com/danieljvdm/effect-agent/blob/ba412a1/packages/pr-review/test/providers.test.ts#L20-L51).

OpenAI references: [Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create), [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning).

## Evidence

- `vp run @effect-agent/pr-review#check`
- `vp run @effect-agent/pr-review#test` — 98 passed, 1 skipped
- `vp run @effect-agent/pr-review#build`
- `vp run action:build -- --check`
- `vp fmt --check`

A default-parallel full monorepo check also reached the package checks but exceeded local memory in unrelated concurrent TypeScript tasks (exit 137); the affected package check passes independently.