### PR TITLE
fix(cloudflare): publish effect-cf as a compatible peer

### DIFF
--- a/.changeset/friendly-cloudflare-peer.md
+++ b/.changeset/friendly-cloudflare-peer.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Publish `effect-cf` as a compatible host-owned peer and update the workspace integration to 0.27.0, avoiding consumer overrides and duplicate Effect service identities.

--- a/bun.lock
+++ b/bun.lock
@@ -216,7 +216,6 @@
         "@effect/platform-browser": "catalog:",
         "@effect/sql-sqlite-do": "catalog:",
         "effect": "catalog:",
-        "effect-cf": "catalog:",
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "catalog:",
@@ -225,11 +224,15 @@
         "@effect-agent/engine": "workspace:*",
         "@effect-agent/testing": "workspace:*",
         "@effect/vitest": "catalog:",
+        "effect-cf": "catalog:",
         "esbuild": "catalog:",
         "miniflare": "catalog:",
         "typescript": "catalog:",
         "vite-plus": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect-cf": "^0.27.0",
       },
     },
     "packages/platform-node": {
@@ -412,7 +415,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "effect": "4.0.0-beta.107",
-    "effect-cf": "0.25.3",
+    "effect-cf": "0.27.0",
     "esbuild": "0.28.1",
     "lucide-react": "1.27.0",
     "miniflare": "4.20260730.0",
@@ -1863,7 +1866,7 @@
 
     "effect-agent": ["effect-agent@workspace:packages/effect-agent"],
 
-    "effect-cf": ["effect-cf@0.25.3", "", { "peerDependencies": { "@cloudflare/vitest-pool-workers": "^0.21.3", "@cloudflare/workers-types": "^4.20260611.1", "@effect/sql-d1": "^4.0.0-beta.107 <4.0.0-rc.0", "@effect/sql-pg": "^4.0.0-beta.107 <4.0.0-rc.0", "@effect/sql-sqlite-do": "^4.0.0-beta.107 <4.0.0-rc.0", "effect": "^4.0.0-beta.107 <4.0.0-rc.0" }, "optionalPeers": ["@cloudflare/vitest-pool-workers", "@cloudflare/workers-types", "@effect/sql-pg"] }, "sha512-iLZsAfzdYJ0KUh9u2XZlDbDw7ZNALutpmMobV2pgE/wPasUuW3jy7lcw77+Bv/4BWzGddfIX08kPiQCmj8gOGQ=="],
+    "effect-cf": ["effect-cf@0.27.0", "", { "peerDependencies": { "@cloudflare/computer": "^0.2.0", "@cloudflare/vitest-pool-workers": "^0.21.3", "@cloudflare/workers-types": "^4.20260611.1", "@effect/sql-d1": "^4.0.0-beta.107 <4.0.0-rc.0", "@effect/sql-pg": "^4.0.0-beta.107 <4.0.0-rc.0", "@effect/sql-sqlite-do": "^4.0.0-beta.107 <4.0.0-rc.0", "effect": "^4.0.0-beta.107 <4.0.0-rc.0" }, "optionalPeers": ["@cloudflare/computer", "@cloudflare/vitest-pool-workers", "@cloudflare/workers-types", "@effect/sql-pg"] }, "sha512-x4+tAz1088ie4PJp/zdRP8MFn/kjcWw1u+SzebVOSlbn0xc6wHPgps+BG9NK82eGiv3LHcrzCBHkZL/kF21uaw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.398", "", {}, "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ=="],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -24,6 +24,7 @@ The root `package.json` is the only version source for shared dependencies.
 | `@effect/platform-browser`        |   `4.0.0-beta.107` | `BrowserCrypto` for the workerd runtime (Cloudflare packages)                     |
 | `@effect/sql-sqlite-do`           |   `4.0.0-beta.107` | Durable Object SQLite `SqlClient` and Migrator (Cloudflare packages)              |
 | `@effect/vitest`                  |   `4.0.0-beta.107` | Effect-aware test execution and scoped Layer composition                          |
+| `effect-cf`                       |           `0.27.0` | Effect-native Cloudflare runtime boundary used by `platform-cloudflare`           |
 | `@cloudflare/vitest-pool-workers` |           `0.21.3` | In-workerd Vitest pool for the Cloudflare package suites (vendors wrangler)       |
 | `@cloudflare/workers-types`       |     `5.20260813.1` | Cloudflare runtime types (types-only devDependency)                               |
 | Miniflare                         |     `4.20260730.0` | Programmatic workerd runtimes for the restart-persistence test lane               |
@@ -37,6 +38,11 @@ The root `package.json` is the only version source for shared dependencies.
 
 Workspace packages refer to shared versions with `catalog:`. They must not introduce a second
 Effect version. The Bun lockfile is committed and CI installs it with `--frozen-lockfile`.
+
+The root catalog selects one exact `effect-cf` version for reproducible workspace installs.
+`@effect-agent/platform-cloudflare` publishes `effect-cf` as the compatible `^0.27.0` host peer
+and uses the catalog entry only as a development dependency. Consumers therefore provide one
+shared runtime instance without needing a root override to replace a nested exact dependency.
 
 Root overrides align the contributor skills CLI with the repository's Effect and
 `@effect/platform-node` versions. Framework packages, repository scripts, and contributor tooling

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -300,6 +300,8 @@ Current platform references:
   in leaf `examples/*`, and there is no deployable `apps/` workspace;
 - the root Bun catalog pins the exact Effect v4 version before 1.0;
 - workspace manifests consume that version through `catalog:` and may not introduce another copy;
+- `platform-cloudflare` publishes `effect-cf` as a compatible caret peer while the root catalog
+  selects its exact development version, so the host owns one shared Effect service identity;
 - `platform-node` and `platform-cloudflare` are Layer-assembly libraries, not application
   entrypoints;
 - releases include generated API docs, changelog, and supported Effect/platform versions;

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "effect": "4.0.0-beta.107",
-    "effect-cf": "0.25.3",
+    "effect-cf": "0.27.0",
     "esbuild": "0.28.1",
     "lucide-react": "1.27.0",
     "miniflare": "4.20260730.0",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -31,8 +31,7 @@
     "@effect-agent/storage-cloudflare": "workspace:*",
     "@effect/platform-browser": "catalog:",
     "@effect/sql-sqlite-do": "catalog:",
-    "effect": "catalog:",
-    "effect-cf": "catalog:"
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "catalog:",
@@ -41,10 +40,14 @@
     "@effect-agent/engine": "workspace:*",
     "@effect-agent/testing": "workspace:*",
     "@effect/vitest": "catalog:",
+    "effect-cf": "catalog:",
     "esbuild": "catalog:",
     "miniflare": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect-cf": "^0.27.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade the workspace Cloudflare runtime to `effect-cf@0.27.0`.
- Publish `effect-cf` as a host-owned `^0.27.0` peer of [`@effect-agent/platform-cloudflare`](https://github.com/danieljvdm/effect-agent/blob/76e61b4cfae166bb30b6c5b89cde58e2b1ccfc3c/packages/platform-cloudflare/package.json), while retaining the exact catalog version only for local development.
- Document the single-instance ownership rule in the [toolchain guide](https://github.com/danieljvdm/effect-agent/blob/76e61b4cfae166bb30b6c5b89cde58e2b1ccfc3c/docs/TOOLCHAIN.md) and [deployment contract](https://github.com/danieljvdm/effect-agent/blob/76e61b4cfae166bb30b6c5b89cde58e2b1ccfc3c/docs/spec/deployment.md).

## What went wrong

`@effect-agent/platform-cloudflare` shipped `effect-cf` as an exact production dependency. When a host selected a newer compatible release, Bun could retain the package's exact nested copy, creating two `effect-cf`/Effect service identities. Consumers had to add a root override to force one instance.

The package now declares a compatible peer and leaves version selection with the host. The root catalog still pins `0.27.0` for reproducible repository installs, but that exact development selection no longer becomes a nested consumer dependency.

## Evidence

- Both custom esbuild Worker bundles run successfully against `effect-cf@0.27.0` without `@cloudflare/computer` externals: the restart lane and Code Mode Cloudflare example each pass all 3 tests.
- `vp why effect-cf` resolves one `effect-cf@0.27.0` instance satisfying the package's `^0.27.0` peer and catalog development dependency.
