### PR TITLE
fix(platform-cloudflare): avoid Code Mode host-call deadlock

### DIFF
--- a/.changeset/cloudflare-code-mode-host-bridge.md
+++ b/.changeset/cloudflare-code-mode-host-bridge.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Run Dynamic Worker Code Mode host callbacks on retained independent Effect fibers so guest RPC
+callbacks can complete without deadlocking the in-flight worker RPC. Bound callback execution by
+the pass deadline and host-call limits, and close, interrupt, and settle callback work on teardown.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -277,8 +277,11 @@ explicitly allowed structured values, applies the configured Dynamic Worker CPU 
 limits plus an executor-owned wall-clock deadline (an asynchronously suspended pass consumes no
 CPU and must not outlive its deadline), invokes one fixed entrypoint, validates the returned
 envelope through Effect Schema, and disposes the entrypoint and Worker handles in Scope
-finalizers. A synchronous runaway program is stopped by platform CPU limits, not only by a
-JavaScript timer.
+finalizers. Host callbacks run one at a time on retained independent root Effect fibers so their
+return RPC is not coupled to the still-open guest RPC; pass teardown closes callback admission,
+interrupts and awaits active work, and settles queued calls. One absolute monotonic deadline
+applies to the worker RPC and every host callback. A synchronous runaway program is stopped by
+platform CPU limits, not only by a JavaScript timer.
 
 The adapter records no persistent state and adds no deployment-class claim beyond `E`: the `DN`
 and `DC` assemblies make no Code Mode claim until this specification says otherwise. The tested harness is

--- a/packages/platform-cloudflare/src/code-mode-executor.ts
+++ b/packages/platform-cloudflare/src/code-mode-executor.ts
@@ -1,6 +1,5 @@
 import {
   CodeExecutionHost,
-  CodeExecutionRequest,
   CodeExecutionResourceUse,
   CodeExecutionResult,
   CodeExecutionTimeoutError,
@@ -17,9 +16,10 @@ import {
   CodeSourceError,
   SandboxImplementation,
   type CodeExecutorExecute,
+  type CodeExecutionRequest,
 } from "@effect-agent/sandbox";
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { Clock, Duration, Effect, Fiber, Layer, Option, Schema } from "effect";
+import { Cause, Duration, Effect, Exit, Fiber, Layer, Option, Schema } from "effect";
 
 /**
  * The Cloudflare Dynamic Worker `CodeExecutor` adapter (C4 of ADR-0017;
@@ -301,6 +301,14 @@ const decodeHostCall = (value: unknown) => {
   }
 };
 
+const decodeHostCallResult = (value: unknown) => {
+  try {
+    return Schema.decodeUnknownOption(CodeHostCallResult)(value);
+  } catch {
+    return Option.none<CodeHostCallResult>();
+  }
+};
+
 /**
  * Project a host outcome to the plain JSON envelope the harness reads. A
  * `CodeExecutionHost` may return either real `CodeHostCallResult` instances
@@ -308,10 +316,26 @@ const decodeHostCall = (value: unknown) => {
  * Mode capability's broker route), so this reads the shared fields rather than
  * `Schema.encodeSync`, which would reject a plain object.
  */
-const hostResultEnvelope = (outcome: CodeHostCallResult): Record<string, unknown> =>
-  outcome._tag === "CodeHostCallSuccess"
-    ? { _tag: "CodeHostCallSuccess", value: outcome.value }
-    : { _tag: "CodeHostCallFailure", error: outcome.error };
+interface EncodedHostResultPayload {
+  readonly encodedPayload: string;
+  readonly resultBytes: number;
+}
+
+const encodeHostResultPayload = (
+  outcome: CodeHostCallResult,
+): EncodedHostResultPayload | undefined => {
+  try {
+    const payload = outcome._tag === "CodeHostCallSuccess" ? outcome.value : outcome.error;
+    const encodedPayload = JSON.stringify(payload);
+    if (encodedPayload === undefined) return undefined;
+    return {
+      encodedPayload,
+      resultBytes: utf8ByteLength(encodedPayload),
+    };
+  } catch {
+    return undefined;
+  }
+};
 
 const utf8ByteLength = (value: string): number => {
   let total = 0;
@@ -322,19 +346,22 @@ const utf8ByteLength = (value: string): number => {
   return total;
 };
 
-const encodedJsonByteLength = (value: unknown): number | undefined => {
-  try {
-    const encoded = JSON.stringify(value);
-    return encoded === undefined ? undefined : utf8ByteLength(encoded);
-  } catch {
-    return undefined;
-  }
-};
+type HostDispatchFailure =
+  | { readonly _tag: "host-call-limit" }
+  | { readonly _tag: "host-call-result-limit"; readonly observed: number }
+  | { readonly _tag: "host-call-protocol" }
+  | { readonly _tag: "wall-clock-timeout" }
+  | { readonly _tag: "host-call-defect"; readonly cause: Cause.Cause<never> };
 
-interface PendingHostCall {
-  readonly hostCall: unknown;
+interface QueuedHostCall {
+  readonly call: CodeHostCall;
   readonly resolve: (value: unknown) => void;
   readonly reject: (reason: unknown) => void;
+}
+
+interface ActiveHostCall {
+  readonly fiber: Fiber.Fiber<Record<string, unknown>, never>;
+  readonly settlement: Promise<void>;
 }
 
 /** Reserved global names the harness owns inside the dynamic worker. */
@@ -392,83 +419,193 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
     // prefix keeps ids debuggable; the random suffix makes them unforgeable.
     const passId = `code-mode-pass-${passCounterState.next}-${crypto.randomUUID()}`;
 
-    // Promise-side host calls bridge into the Effect world through a pending
-    // list served by a scoped fiber, exactly like the deterministic
-    // substitute: interruption reaches in-flight host calls, and pass-fatal
-    // conditions fail the pass by failing the server.
-    const pending: Array<PendingHostCall> = [];
-    let wake: (() => void) | undefined;
+    const startedAt = performance.now();
+    const passDeadline = startedAt + Duration.toMillis(request.limits.maxWallTime);
+    const remainingPassWallTime = (): Duration.Duration =>
+      Duration.millis(Math.max(0, passDeadline - performance.now()));
     let issuedHostCalls = 0;
-    const dispatch = (hostCall: unknown): Promise<unknown> =>
-      new Promise((resolve, reject) => {
-        issuedHostCalls += 1;
-        if (issuedHostCalls > request.limits.maxHostCalls + 1) {
-          reject(new Error("host-call limit exceeded"));
-          return;
-        }
-        pending.push({ hostCall, resolve, reject });
-        wake?.();
+    let passOpen = true;
+    const queuedHostCalls: Array<QueuedHostCall> = [];
+    let activeHostCall: ActiveHostCall | undefined;
+    let hostDispatchFailure: HostDispatchFailure | undefined;
+    let propagatedHostDispatchFailure: HostDispatchFailure | undefined;
+    let signalHostDispatchFailure = (_failure: HostDispatchFailure): void => undefined;
+    const hostDispatchFailureSignal = new Promise<HostDispatchFailure>((resolve) => {
+      signalHostDispatchFailure = resolve;
+    });
+    const rejectQueuedHostCalls = (reason: Error): void => {
+      for (const queued of queuedHostCalls.splice(0)) {
+        queued.reject(reason);
+      }
+    };
+    const recordHostDispatchFailure = (failure: HostDispatchFailure): void => {
+      if (hostDispatchFailure !== undefined) return;
+      hostDispatchFailure = failure;
+      signalHostDispatchFailure(failure);
+      rejectQueuedHostCalls(new Error("Code Mode pass failed"));
+    };
+    const failHostDispatch = (failure: HostDispatchFailure) => {
+      switch (failure._tag) {
+        case "host-call-limit":
+          return Effect.fail(
+            CodeHostCallLimitError.make({
+              implementation: dynamicWorkerImplementation,
+              limit: request.limits.maxHostCalls,
+              logs: [],
+            }),
+          );
+        case "host-call-result-limit":
+          return Effect.fail(
+            CodeOutputLimitError.make({
+              implementation: dynamicWorkerImplementation,
+              surface: "host-call-result",
+              limit: request.limits.maxHostCallResultBytes,
+              observed: failure.observed,
+              logs: [],
+            }),
+          );
+        case "host-call-protocol":
+          return Effect.fail(
+            CodeExecutionProtocolError.make({
+              implementation: dynamicWorkerImplementation,
+              message: "The execution host returned a value outside the CodeHostCallResult schema",
+            }),
+          );
+        case "wall-clock-timeout":
+          return Effect.fail(
+            CodeExecutionTimeoutError.make({
+              implementation: dynamicWorkerImplementation,
+              kind: "wall-clock",
+              maxWallTime: request.limits.maxWallTime,
+              logs: [],
+            }),
+          );
+        case "host-call-defect":
+          return Effect.failCause(failure.cause);
+      }
+    };
+    const propagateHostDispatchFailure = (failure: HostDispatchFailure) =>
+      Effect.gen(function* () {
+        propagatedHostDispatchFailure = failure;
+        return yield* failHostDispatch(failure);
       });
+
+    const startNextHostCall = (): void => {
+      if (!passOpen || hostDispatchFailure !== undefined || activeHostCall !== undefined) return;
+      const queued = queuedHostCalls.shift();
+      if (queued === undefined) return;
+
+      // A Dynamic Worker callback is a new Workers RPC into the loader isolate. Running the
+      // complete host call on an independent root fiber breaks its dependency on the still-open
+      // guest RPC. Retaining the handle and starting one call at a time preserves bounded,
+      // serialized execution and lets pass teardown interrupt and await the active call.
+      const fiber = Effect.runFork(
+        Effect.yieldNow.pipe(
+          Effect.andThen(host.call(queued.call)),
+          Effect.timeoutOrElse({
+            duration: remainingPassWallTime(),
+            orElse: () =>
+              Effect.sync(() => {
+                recordHostDispatchFailure({ _tag: "wall-clock-timeout" });
+                throw new Error("code-mode host call exceeded the pass wall-clock limit");
+              }),
+          }),
+          Effect.map((outcome) => {
+            const decoded = decodeHostCallResult(outcome);
+            if (Option.isNone(decoded)) {
+              recordHostDispatchFailure({ _tag: "host-call-protocol" });
+              throw new Error("host-call protocol violation");
+            }
+            const encoded = encodeHostResultPayload(decoded.value);
+            if (
+              encoded === undefined ||
+              encoded.resultBytes > request.limits.maxHostCallResultBytes
+            ) {
+              recordHostDispatchFailure({
+                _tag: "host-call-result-limit",
+                observed: encoded?.resultBytes ?? 0,
+              });
+              throw new Error("host-call result limit exceeded");
+            }
+            const normalizedPayload: unknown = JSON.parse(encoded.encodedPayload);
+            return decoded.value._tag === "CodeHostCallSuccess"
+              ? { _tag: "CodeHostCallSuccess", value: normalizedPayload }
+              : { _tag: "CodeHostCallFailure", error: normalizedPayload };
+          }),
+        ),
+      );
+      const settlement = Effect.runPromise(Fiber.await(fiber))
+        .then((exit) => {
+          if (Exit.isSuccess(exit)) {
+            queued.resolve(exit.value);
+            return;
+          }
+          if (!Cause.hasInterruptsOnly(exit.cause)) {
+            recordHostDispatchFailure({ _tag: "host-call-defect", cause: exit.cause });
+          }
+          queued.reject(new Error("Code Mode host call failed"));
+        })
+        .finally(() => {
+          if (activeHostCall?.fiber === fiber) activeHostCall = undefined;
+          startNextHostCall();
+        });
+      activeHostCall = { fiber, settlement };
+    };
+
+    const dispatch = (hostCall: unknown): Promise<unknown> => {
+      if (!passOpen) {
+        return Promise.reject(new Error("Code Mode pass is closing"));
+      }
+      issuedHostCalls += 1;
+      if (issuedHostCalls > request.limits.maxHostCalls) {
+        recordHostDispatchFailure({ _tag: "host-call-limit" });
+        return Promise.reject(new Error("host-call limit exceeded"));
+      }
+      const decoded = decodeHostCall(hostCall);
+      if (Option.isNone(decoded)) {
+        return Promise.reject(new TypeError("host calls must match the CodeHostCall schema"));
+      }
+      return new Promise((resolve, reject) => {
+        queuedHostCalls.push({ call: decoded.value, resolve, reject });
+        startNextHostCall();
+      });
+    };
+
+    const closeHostDispatch = Effect.gen(function* () {
+      passOpen = false;
+      passRegistry.delete(passId);
+      rejectQueuedHostCalls(new Error("Code Mode pass is closing"));
+      const active = activeHostCall;
+      if (active !== undefined) {
+        yield* Fiber.interrupt(active.fiber);
+        yield* Effect.promise(() => active.settlement);
+        if (activeHostCall === active) activeHostCall = undefined;
+      }
+      return hostDispatchFailure;
+    });
+    const stopHostDispatch = closeHostDispatch.pipe(
+      Effect.flatMap((failure) =>
+        failure !== undefined && propagatedHostDispatchFailure !== failure
+          ? propagateHostDispatchFailure(failure)
+          : Effect.void,
+      ),
+    );
+    const releaseHostDispatch = closeHostDispatch.pipe(
+      Effect.flatMap((failure) => {
+        if (failure?._tag !== "host-call-defect" || propagatedHostDispatchFailure === failure) {
+          return Effect.void;
+        }
+        propagatedHostDispatchFailure = failure;
+        return Effect.failCause(failure.cause);
+      }),
+    );
 
     yield* Effect.acquireRelease(
       Effect.sync(() => {
         passRegistry.set(passId, { dispatch });
       }),
-      () =>
-        Effect.sync(() => {
-          passRegistry.delete(passId);
-        }),
+      () => releaseHostDispatch,
     );
-
-    const nextPending = Effect.suspend(() => {
-      const item = pending.shift();
-      if (item !== undefined) {
-        return Effect.succeed(item);
-      }
-      return Effect.callback<PendingHostCall>((resume) => {
-        wake = () => {
-          wake = undefined;
-          const next = pending.shift();
-          if (next !== undefined) {
-            resume(Effect.succeed(next));
-          }
-        };
-      });
-    });
-
-    const serveHostCalls = Effect.gen(function* () {
-      let served = 0;
-      while (true) {
-        const item = yield* nextPending;
-        served += 1;
-        if (served > request.limits.maxHostCalls) {
-          return yield* CodeHostCallLimitError.make({
-            implementation: dynamicWorkerImplementation,
-            limit: request.limits.maxHostCalls,
-            logs: [],
-          });
-        }
-        const decoded = decodeHostCall(item.hostCall);
-        if (Option.isNone(decoded)) {
-          item.reject(new TypeError("host calls must match the CodeHostCall schema"));
-          continue;
-        }
-        const outcome = yield* host.call(decoded.value);
-        if (outcome._tag === "CodeHostCallSuccess") {
-          const bytes = encodedJsonByteLength(outcome.value);
-          if (bytes === undefined || bytes > request.limits.maxHostCallResultBytes) {
-            return yield* CodeOutputLimitError.make({
-              implementation: dynamicWorkerImplementation,
-              surface: "host-call-result",
-              limit: request.limits.maxHostCallResultBytes,
-              observed: bytes ?? 0,
-              logs: [],
-            });
-          }
-        }
-        item.resolve(hostResultEnvelope(outcome));
-      }
-    });
 
     const workerCode = {
       compatibilityDate: options.compatibilityDate ?? "2025-05-01",
@@ -505,7 +642,6 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
           }),
     };
 
-    const startedAt = yield* Clock.currentTimeMillis;
     const worker = yield* Effect.acquireRelease(
       Effect.try({
         try: () => options.loader.load(workerCode as never),
@@ -534,8 +670,6 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
         }),
     );
 
-    const server = yield* serveHostCalls.pipe(Effect.forkScoped);
-
     const rpc = Effect.tryPromise({
       try: async () => {
         const entrypoint = worker.getEntrypoint() as unknown as {
@@ -546,20 +680,29 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
       catch: (cause) => classifyWorkerFailure(cause, request.limits.maxWallTime),
     });
 
-    const raw = yield* Effect.raceFirst(rpc, Fiber.join(server)).pipe(
-      Effect.timeoutOrElse({
-        duration: request.limits.maxWallTime,
-        orElse: () =>
-          CodeExecutionTimeoutError.make({
-            implementation: dynamicWorkerImplementation,
-            kind: "wall-clock",
-            maxWallTime: request.limits.maxWallTime,
-            logs: [],
-          }),
-      }),
-      Effect.ensuring(Fiber.interrupt(server)),
+    const raw = yield* Effect.raceFirst(
+      rpc.pipe(
+        Effect.timeoutOrElse({
+          duration: remainingPassWallTime(),
+          orElse: () =>
+            CodeExecutionTimeoutError.make({
+              implementation: dynamicWorkerImplementation,
+              kind: "wall-clock",
+              maxWallTime: request.limits.maxWallTime,
+              logs: [],
+            }),
+        }),
+      ),
+      Effect.promise(() => hostDispatchFailureSignal).pipe(
+        Effect.flatMap(propagateHostDispatchFailure),
+      ),
     );
-    const finishedAt = yield* Clock.currentTimeMillis;
+    yield* stopHostDispatch;
+    const finishedAt = performance.now();
+
+    if (hostDispatchFailure !== undefined) {
+      return yield* propagateHostDispatchFailure(hostDispatchFailure);
+    }
 
     const outcome = decodeHarnessOutcome(raw);
     if (Option.isNone(outcome)) {

--- a/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
+++ b/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
@@ -72,6 +72,15 @@ describe("DEPLOY-011 Cloudflare Dynamic Worker CodeExecutor", () => {
     const response = await runtime.dispatchFetch("http://placeholder/run");
     const payload = (await response.json()) as { readonly failures: ReadonlyArray<string> };
     expect(response.ok).toBe(true);
-    expect(payload.failures, JSON.stringify(payload.failures, null, 2)).toEqual([]);
+    expect(payload.failures).toEqual([]);
   }, 120_000);
+
+  it("runs guest host calls outside the in-flight executor fiber", async () => {
+    const response = await runtime.dispatchFetch("http://placeholder/host-call-root-fiber");
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toMatchObject({
+      tag: "success",
+      detail: { value: "root" },
+    });
+  }, 30_000);
 });

--- a/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
+++ b/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
@@ -4,13 +4,15 @@ import {
   CodeExecutionNamespace,
   CodeExecutionRequest,
   CodeExecutor,
+  CodeHostCallFailure,
+  CodeHostCallSuccess,
   NetworkAllowlist,
   NetworkDisabled,
   type CodeExecutionError,
   type CodeHostCall,
   type CodeHostCallResult,
 } from "@effect-agent/sandbox";
-import { Cause, Duration, Effect, Exit, Layer, Option } from "effect";
+import { Cause, Context, Duration, Effect, Exit, Option, Predicate, type Layer } from "effect";
 
 // Workspace-relative source import: esbuild bundles it, and the package
 // barrel would pull in Node-only storage fixtures the worker cannot load.
@@ -101,6 +103,7 @@ const workerdConformanceCaseNames: ReadonlyArray<string> = [
   "TEST-015 fails typed when the expression is not one async function",
   "TEST-015 fails typed when the final result exceeds its byte budget",
   "TEST-015 fails typed when host calls exceed the executor cap",
+  "TEST-015 fails typed on a host outcome outside the protocol schema",
   "TEST-015 surfaces an uncaught program throw with its bounded log capture",
   "TEST-015 fails typed when the program returns a non-JSON value",
   "CAP-015 rejects a network allowlist it cannot enforce with a typed unsupported error",
@@ -208,12 +211,66 @@ const runAllChecks = (env: WorkerEnv): Effect.Effect<ReadonlyArray<string>> =>
       failures.push(`host composition: expected 1 host call, observed ${calls.length}`);
     }
 
+    const resultLimit = CodeExecutionLimits.make({
+      ...baseLimits,
+      maxHostCallResultBytes: 128,
+    });
+    for (const [label, hostCallResult] of [
+      ["success", CodeHostCallSuccess.make({ value: "x".repeat(256) })],
+      [
+        "failure",
+        CodeHostCallFailure.make({ error: { _tag: "OversizedFailure", detail: "x".repeat(256) } }),
+      ],
+    ] as const) {
+      const outcome = yield* runOutcome(
+        request("async () => warehouse.query({})", {
+          namespaces: [namespace],
+          limits: resultLimit,
+        }),
+        layer,
+        { call: () => Effect.succeed(hostCallResult) },
+      );
+      if (
+        outcome.tag !== "CodeOutputLimitError" ||
+        !Predicate.isObject(outcome.detail) ||
+        outcome.detail.surface !== "host-call-result"
+      ) {
+        failures.push(
+          `oversized host ${label}: expected a host-call-result limit error, got ${JSON.stringify(outcome)}`,
+        );
+      }
+    }
+
     return failures;
   });
 
+const ExecutorFiberMarker = Context.Reference<"root" | "executor">(
+  "@effect-agent/platform-cloudflare/test/ExecutorFiberMarker",
+  { defaultValue: () => "root" },
+);
+
+const runHostCallRegression = (env: WorkerEnv) => {
+  const layer = executorLayerFor(env);
+  const namespace = CodeExecutionNamespace.make({ name: "warehouse", methods: ["query"] });
+  const host: CodeExecutionHost["Service"] = {
+    call: () =>
+      ExecutorFiberMarker.pipe(Effect.map((value) => CodeHostCallSuccess.make({ value }))),
+  };
+  return runOutcome(
+    request("async () => warehouse.query({ sql: 'select 1' })", {
+      namespaces: [namespace],
+    }),
+    layer,
+    host,
+  ).pipe(Effect.provideService(ExecutorFiberMarker, "executor"));
+};
+
 export default {
-  async fetch(_request: Request, env: WorkerEnv): Promise<Response> {
+  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     try {
+      if (new URL(request.url).pathname === "/host-call-root-fiber") {
+        return Response.json(await Effect.runPromise(runHostCallRegression(env)));
+      }
       const failures = await Effect.runPromise(runAllChecks(env));
       return Response.json({ failures });
     } catch (cause) {


### PR DESCRIPTION
## Summary

- run each complete Dynamic Worker host callback on a retained independent root Effect fiber
- keep host calls serialized and bounded, with explicit queue settlement and active-fiber cleanup
- share one monotonic deadline across the guest RPC and host callbacks, and fail the pass promptly on host limits, timeouts, protocol violations, or defects
- validate and byte-limit both successful and failed host outcomes before returning them across RPC
- add a workerd regression that exercises a guest-to-host callback through the real Dynamic Worker bridge

## What went wrong

The Dynamic Worker `run()` RPC remains open until guest code finishes. When that guest calls an injected namespace method, the harness makes a second Workers RPC back to the loader isolate through `CodeModeHostEntrypoint`, and the guest cannot finish until that callback returns.

Previously, the callback only enqueued the decoded call. An executor-owned Effect fiber, scoped under the still-open `run()` operation, was responsible for calling `CodeExecutionHost.call` and resolving the callback. On the hosted Workers runtime that creates a cycle: the guest waits for the callback, while the host-serving path coupled to the in-flight guest RPC does not make progress, so neither RPC can complete.

The bridge now starts the complete host call on an independent root Effect fiber. The executor retains its handle, admits one call at a time, and explicitly interrupts and awaits active work during pass teardown, so the scheduling dependency is broken without creating unowned background work.

## Architecture and hardening

The pass registry remains the only callback authority. A callback is decoded and queued synchronously, then the serialized dispatcher starts the host Effect, validates its schema result, serializes the success or failure payload once, enforces `maxHostCallResultBytes`, and returns the normalized JSON value. `maxHostCalls` is enforced before dispatch, and queued plus active work stays bounded by that cap.

The worker RPC and every host call derive their remaining time from one absolute `performance.now()` deadline. Pass-fatal limit, timeout, protocol, and host-defect signals race the worker RPC, so a guest cannot catch and hide an executor-level failure. Guest code receives a generic callback rejection, while an original host defect remains an Effect cause on the executor side.

Closing a pass removes its registry entry, rejects queued callbacks, interrupts and awaits the retained active fiber, and preserves any unpropagated host defect for the Scope finalizer.

Key code and tests:

- [independent serialized host dispatcher](https://github.com/danieljvdm/effect-agent/blob/13fc0025efdda6441ce25a68b0aa991a827c3894/packages/platform-cloudflare/src/code-mode-executor.ts#L422-L608)
- [worker-RPC/fatal-signal race](https://github.com/danieljvdm/effect-agent/blob/13fc0025efdda6441ce25a68b0aa991a827c3894/packages/platform-cloudflare/src/code-mode-executor.ts#L673-L704)
- [real bridge regression](https://github.com/danieljvdm/effect-agent/blob/13fc0025efdda6441ce25a68b0aa991a827c3894/packages/platform-cloudflare/test/code-mode/conformance-worker.ts#L247-L265)
- [success and failure payload bounds](https://github.com/danieljvdm/effect-agent/blob/13fc0025efdda6441ce25a68b0aa991a827c3894/packages/platform-cloudflare/test/code-mode/conformance-worker.ts#L214-L242)
- [documented deployment behavior](https://github.com/danieljvdm/effect-agent/blob/13fc0025efdda6441ce25a68b0aa991a827c3894/docs/spec/deployment.md#L271-L284)

## Regression coverage

Miniflare/workerd does not reproduce the hosted scheduler stall directly. The focused regression therefore makes the scheduling boundary observable: the executor Effect is given an `"executor"` fiber-local service, the host reads the same service, and a guest program returns the value through the real Dynamic Worker loopback RPC. The old scoped serving fiber inherits `"executor"` and fails the assertion; the independent root fiber reads its default `"root"`, and the guest callback completes successfully.

The workerd suite also covers exact host-call caps, malformed host outcomes, and oversized success and failure payloads.

## Validation

- `vp fmt` — passed (479 files)
- `vp check` — passed with 0 errors (331 existing repository warnings)
- `vp check packages/platform-cloudflare/src/code-mode-executor.ts packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts packages/platform-cloudflare/test/code-mode/conformance-worker.ts` — passed with 0 warnings and 0 errors
- `vp test run packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts --reporter=verbose` — passed (1 file, 2 tests)
- `vp run --log grouped @effect-agent/platform-cloudflare#test` — passed (12 files, 115 tests; 27 expected injected-error events under the suite's configured unhandled-error policy)
- `vp run check` — passed, including formatting, type checks, tests, and generated action-dist freshness
- `git diff --check` — passed

No generated package `dist` artifact is edited.
