### PR TITLE
feat(session): persist typed budget dimension in durable settlements

### DIFF
--- a/.changeset/typed-budget-settlement.md
+++ b/.changeset/typed-budget-settlement.md
@@ -1,0 +1,15 @@
+---
+"@effect-agent/core": minor
+"@effect-agent/session": minor
+---
+
+Typed budget dimension on durable settlements (RUN-011, #83): the canonical `SubmissionSettled`
+record additively persists `exhausted` (`"tokens" | "tool-calls" | "turns"`) beside
+`finishReason: "budget-exhausted"` for a completed soft landing, and `policyLimit` (the typed
+`AgentPolicyError.limit`) beside the bounded `{errorTag, message}` failure projection for a
+`failed` hard-rail settlement — consumers read the dimension typed instead of parsing message
+text. Decode is family-bound fail-closed (`exhausted` only with the budget-exhausted
+finishReason, `policyLimit` only on a failed outcome) and histories persisted before the
+metadata existed keep decoding with it absent (schemaVersion 1 unchanged).
+`@effect-agent/core` now exports the `ExhaustedLimit` and `PolicyLimit` literal schemas backing
+the fields.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -28913,17 +28913,18 @@ class AgentOutputError extends exports_Schema.TaggedError()("AgentOutputError", 
   message: exports_Schema.String
 }) {
 }
+var PolicyLimit = exports_Schema.Literals([
+  "turns",
+  "tool-calls",
+  "duration",
+  "usage",
+  "tokens",
+  "cost",
+  "repeated-failures"
+]);
 
 class AgentPolicyError extends exports_Schema.TaggedError()("AgentPolicyError", {
-  limit: exports_Schema.Literals([
-    "turns",
-    "tool-calls",
-    "duration",
-    "usage",
-    "tokens",
-    "cost",
-    "repeated-failures"
-  ]),
+  limit: PolicyLimit,
   message: exports_Schema.String
 }) {
 }

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -33,22 +33,25 @@ AgentPolicy.make({
 });
 ```
 
-| Bound                  | What it limits                                      | On exhaustion           |
-| ---------------------- | --------------------------------------------------- | ----------------------- |
-| `maxTurns`             | model requests per Run                              | `onExhaustion` resolves |
-| `maxToolCalls`         | declared Tool Calls per Run (programmatic included) | `onExhaustion` resolves |
-| `maxDuration`          | wall clock per Run                                  | always fails typed      |
-| `tokenBudget`          | input + output tokens per Run                       | always fails typed      |
-| `costBudgetMicrousd`   | estimated cost per Run (needs a cost estimator)     | always fails typed      |
-| `repeatedFailureLimit` | consecutive terminal Tool failures                  | always fails typed      |
-| `toolConcurrency`      | parallel Tool Handlers per batch                    | not a failure — a gate  |
+| Bound                  | What it limits                                      | On exhaustion                     |
+| ---------------------- | --------------------------------------------------- | --------------------------------- |
+| `maxTurns`             | model requests per Run                              | `onExhaustion` resolves           |
+| `maxToolCalls`         | declared Tool Calls per Run (programmatic included) | `onExhaustion` resolves           |
+| `maxDuration`          | wall clock per Run                                  | always fails typed                |
+| `tokenBudget`          | input + output tokens per Run                       | `onExhaustion` resolves (RUN-025) |
+| `costBudgetMicrousd`   | estimated cost per Run (needs a cost estimator)     | always fails typed                |
+| `repeatedFailureLimit` | consecutive terminal Tool failures                  | always fails typed                |
+| `toolConcurrency`      | parallel Tool Handlers per batch                    | not a failure — a gate            |
 
 A typed exhaustion failure is `AgentPolicyError` with a `limit` literal naming which bound bound.
+In the DN and DC assemblies a Run failed this way settles with that literal preserved as the
+canonical settlement's `policyLimit` (RUN-011) — consumers read the dimension typed, never from
+the failure message.
 
 ## Exhaustion: soft landing or fail
 
-`onExhaustion` selects the resolution for the two _countable work_ bounds — Turns and Tool Calls
-(runtime spec RUN-018/RUN-019):
+`onExhaustion` selects the resolution for the countable work bounds — Turns and Tool Calls
+(runtime spec RUN-018/RUN-019) — and, one-shot, for the token budget (RUN-025):
 
 **`"final-answer"` (the default).** The Run gets one constrained opportunity to deliver:
 
@@ -60,9 +63,10 @@ A typed exhaustion failure is `AgentPolicyError` with a `limit` literal naming w
    A second grace is structurally impossible.
 4. The Run settles _completed_ — with the honest `finishReason: "budget-exhausted"`, never a
    plain `"model-stop"` (RUN-011: budget exhaustion cannot masquerade as success). In the DN and
-   DC assemblies the canonical `SubmissionSettled` record carries the same marker, so a rebuilt
-   projection can distinguish an exhaustion-truncated answer from an ordinary one without the
-   live event stream.
+   DC assemblies the canonical `SubmissionSettled` record carries the same marker plus the
+   typed `exhausted` dimension (`tokens`, `tool-calls`, or `turns`), so a rebuilt projection
+   can tell an exhaustion-truncated answer from an ordinary one — and name which bound bound —
+   without the live event stream or message-text parsing.
 5. A model that declares a Tool Call under the constraint fails the Run typed
    (`ModelProtocolError`, RUN-020) — fail-closed, no rejection loops.
 
@@ -74,8 +78,9 @@ exceeding work starts. Choose it for pipelines that must never accept a truncate
 repository's own PR reviewer pins it for review _children_, because a review is a coverage claim
 and a partial produced without reading the diff would launder exhaustion into "reviewed".
 
-Duration, token, cost, and repeated-failure bounds are hard rails regardless: a soft landing can
-never loop or spend unboundedly, because the rails that measure spending stay fatal.
+Duration, cost, and repeated-failure bounds are hard rails regardless — and the token dimension's
+soft landing is one-shot (RUN-025): a soft landing can never loop or spend unboundedly, because
+the rails that measure spending stay fatal.
 
 ## Per-Run allowances
 
@@ -176,9 +181,9 @@ declared-plus-programmatic count.
   one Tool Call and each batch one Turn, so `maxTurns` usually binds before `maxToolCalls`; raise
   them together, and let the soft landing convert the residual tail into a partial cited answer
   instead of provisioning for the worst case.
-- **The token budget is the honest spend ceiling.** It stays fatal by design — one more turn
-  costs tokens the Run does not have — so pair a generous soft-landing surface with a firm
-  `tokenBudget`.
+- **The token budget is the honest spend ceiling.** Its soft landing is one-shot and constrained
+  (RUN-025) — one more turn costs tokens the Run does not have — so pair a generous soft-landing
+  surface with a firm `tokenBudget`.
 - **Delegate instead of raising.** A single window that needs 100 tool calls is usually a fan-out
   of five scouts needing 20 — with per-invocation allowances, containment, and extension grants
   where depth is actually warranted.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -281,6 +281,17 @@ rewrites history from the cached ledger status.
 Each step is idempotent. Conflicting terminal outcomes are rejected. Cleanup failure
 is recorded separately and cannot erase an accepted settlement.
 
+The settlement payload carries typed budget metadata alongside its outcome (RUN-011):
+a `completed` soft landing persists `finishReason: "budget-exhausted"` with the
+`exhausted` dimension (`tokens`, `tool-calls`, or `turns`), and a Run failed by
+`AgentPolicyError` persists the typed `limit` as `policyLimit` alongside the bounded
+`{errorTag, message}` failure projection in `result`. Because the metadata rides the
+exact reserved record, it survives reservation replay, canonical append, recovery,
+and every later read unchanged. Decode is family-bound fail-closed: metadata on the
+wrong settlement family rejects rather than becoming trusted audit history, and
+records persisted before the metadata existed decode with it absent (additive,
+schemaVersion 1).
+
 ## 13. Abort
 
 Abort is a durable command with identity, author, reason, and target.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -288,8 +288,9 @@ a `completed` soft landing persists `finishReason: "budget-exhausted"` with the
 `{errorTag, message}` failure projection in `result`. Because the metadata rides the
 exact reserved record, it survives reservation replay, canonical append, recovery,
 and every later read unchanged. Decode is family-bound fail-closed: metadata on the
-wrong settlement family rejects rather than becoming trusted audit history, and
-records persisted before the metadata existed decode with it absent (additive,
+wrong settlement family — or a `policyLimit` whose `result` does not carry the
+`AgentPolicyError` projection — rejects rather than becoming trusted audit history,
+and records persisted before the metadata existed decode with it absent (additive,
 schemaVersion 1).
 
 ## 13. Abort

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -486,11 +486,17 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
 - **RUN-008:** Interruption propagates to all attached children.
 - **RUN-009:** Concurrency is bounded.
 - **RUN-010:** Slow detached observers cannot determine durable liveness.
-- **RUN-011:** Budget exhaustion cannot masquerade as success. A Run that settles through the
-  final-answer resolution — Turn, Tool Call, or token exhaustion — carries
-  `finishReason: "budget-exhausted"` and the `exhausted` dimension marker — never
-  `"model-stop"` — on the live terminal event and on the durable `SubmissionSettled` record;
-  `onExhaustion: "fail"` fails typed before any successful stop.
+- **RUN-011:** Budget exhaustion cannot masquerade as success, and its dimension survives
+  durably typed. A Run that settles through the final-answer resolution — Turn, Tool Call, or
+  token exhaustion — carries `finishReason: "budget-exhausted"` and the `exhausted` dimension
+  marker — never `"model-stop"` — on the live terminal event and on the durable
+  `SubmissionSettled` record; `onExhaustion: "fail"` fails typed before any successful stop,
+  and a Run failed by `AgentPolicyError` settles with the typed `limit` preserved as the
+  durable record's `policyLimit`. Consumers never reconstruct either dimension from message
+  text. The metadata is family-bound fail-closed: `exhausted` decodes only alongside
+  `finishReason: "budget-exhausted"` on a `completed` settlement, `policyLimit` only on a
+  `failed` settlement, and histories persisted before the dimensions became durable decode with
+  the metadata absent.
 - **RUN-012:** Provider SDK types do not enter Conversation records; Effect AI Prompt and Response
   values remain the model-facing boundary.
 - **RUN-013:** No retry policy can blindly repeat an uncertain external effect.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -495,8 +495,8 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   durable record's `policyLimit`. Consumers never reconstruct either dimension from message
   text. The metadata is family-bound fail-closed: `exhausted` decodes only alongside
   `finishReason: "budget-exhausted"` on a `completed` settlement, `policyLimit` only on a
-  `failed` settlement, and histories persisted before the dimensions became durable decode with
-  the metadata absent.
+  `failed` settlement whose recorded failure projection is the `AgentPolicyError` it names, and
+  histories persisted before the dimensions became durable decode with the metadata absent.
 - **RUN-012:** Provider SDK types do not enter Conversation records; Effect AI Prompt and Response
   values remain the model-facing boundary.
 - **RUN-013:** No retry policy can blindly repeat an uncertain external effect.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -10,17 +10,21 @@ export class AgentOutputError extends Schema.TaggedError<AgentOutputError>()("Ag
   message: Schema.String,
 }) {}
 
+/** The finite policy dimension a run exhausted; shared with durable settlement metadata. */
+export const PolicyLimit = Schema.Literals([
+  "turns",
+  "tool-calls",
+  "duration",
+  "usage",
+  "tokens",
+  "cost",
+  "repeated-failures",
+]);
+export type PolicyLimit = typeof PolicyLimit.Type;
+
 /** A run exhausted one of its finite policy limits. */
 export class AgentPolicyError extends Schema.TaggedError<AgentPolicyError>()("AgentPolicyError", {
-  limit: Schema.Literals([
-    "turns",
-    "tool-calls",
-    "duration",
-    "usage",
-    "tokens",
-    "cost",
-    "repeated-failures",
-  ]),
+  limit: PolicyLimit,
   message: Schema.String,
 }) {}
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -137,9 +137,11 @@ export class CompactionPerformed extends Schema.TaggedClass<CompactionPerformed>
 /**
  * Dimension that bound when a Run settled through the final-answer resolution
  * (RUN-018; the token dimension per RUN-025). This is the exhausted marker
- * the re-delegation grant flow (RUN-021) consumes.
+ * the re-delegation grant flow (RUN-021) consumes and the durable
+ * `SubmissionSettled` record persists (RUN-011).
  */
-const ExhaustedLimit = Schema.Literals(["tokens", "tool-calls", "turns"]);
+export const ExhaustedLimit = Schema.Literals(["tokens", "tool-calls", "turns"]);
+export type ExhaustedLimit = typeof ExhaustedLimit.Type;
 
 /**
  * Successful terminal event carrying Schema-compatible output and the completed turn count.

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -5,6 +5,7 @@ import {
   DelegationDepth,
   IdGenerator,
   isDelegationToolName,
+  PolicyLimit,
   ReceiptId,
   SubagentParentLink,
   SubmissionId,
@@ -12,6 +13,7 @@ import {
   type Agent,
   type AgentId,
   type AttemptId,
+  type ExhaustedLimit,
   type RunEvent,
   type RunId,
   type TurnId,
@@ -624,8 +626,15 @@ type AttemptOutcome =
       readonly result: PersistedJson;
       /** Set when the Run settled through the final-answer exhaustion resolution (RUN-018). */
       readonly finishReason?: "budget-exhausted";
+      /** The dimension that bound; set exactly alongside `finishReason` (RUN-011). */
+      readonly exhausted?: ExhaustedLimit;
     }
-  | { readonly _tag: "failed"; readonly result: PersistedJson }
+  | {
+      readonly _tag: "failed";
+      readonly result: PersistedJson;
+      /** The typed limit of an `AgentPolicyError` failure; absent otherwise (RUN-011). */
+      readonly policyLimit?: PolicyLimit;
+    }
   | { readonly _tag: "aborted" };
 
 /**
@@ -654,8 +663,13 @@ class CoordinatorHalt {
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const ErrorTag = Schema.Struct({ _tag: Schema.NonEmptyString });
+const PolicyFailure = Schema.Struct({
+  _tag: Schema.Literal("AgentPolicyError"),
+  limit: PolicyLimit,
+});
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 const decodeErrorTag = Schema.decodeUnknownOption(ErrorTag);
+const decodePolicyFailure = Schema.decodeUnknownOption(PolicyFailure);
 
 const errorMessageOf = (error: unknown): string =>
   Option.match(decodeErrorMessage(error), {
@@ -1830,6 +1844,12 @@ const make = Effect.gen(function* () {
       ...(outcome._tag === "completed" && outcome.finishReason !== undefined
         ? { finishReason: outcome.finishReason }
         : {}),
+      ...(outcome._tag === "completed" && outcome.exhausted !== undefined
+        ? { exhausted: outcome.exhausted }
+        : {}),
+      ...(outcome._tag === "failed" && outcome.policyLimit !== undefined
+        ? { policyLimit: outcome.policyLimit }
+        : {}),
     });
     const record = yield* makeEnvelope(submissionSettlementRecordId(submissionId), payload);
     // The envelope was constructed from validated parts, so an encode failure is a defect.
@@ -2608,7 +2628,16 @@ const make = Effect.gen(function* () {
     }).pipe(
       // Two bounded strings always satisfy the canonical persistence limits.
       Effect.orDie,
-      Effect.map((result) => ({ _tag: "failed" as const, result })),
+      Effect.map((result) => ({
+        _tag: "failed" as const,
+        result,
+        // A hard-rail policy failure keeps its typed limit durable (RUN-011):
+        // the bounded message stays diagnostic, never the dimension authority.
+        ...Option.match(decodePolicyFailure(error), {
+          onNone: () => ({}),
+          onSome: ({ limit }) => ({ policyLimit: limit }),
+        }),
+      })),
     );
 
   const halt = <A, R>(
@@ -2876,6 +2905,7 @@ const make = Effect.gen(function* () {
         readonly pendingTurn: { readonly turn: number; readonly turnId: TurnId } | undefined;
         readonly completedOutput: PersistedJson | undefined;
         readonly completedFinishReason: "budget-exhausted" | undefined;
+        readonly completedExhausted: ExhaustedLimit | undefined;
       }
       const stateRef = yield* Ref.make<RunState>({
         baseLen: undefined,
@@ -2884,6 +2914,7 @@ const make = Effect.gen(function* () {
         pendingTurn: undefined,
         completedOutput: undefined,
         completedFinishReason: undefined,
+        completedExhausted: undefined,
       });
       const turnCounter = yield* Ref.make(journal.committedTurns);
       const idGenerator: (typeof IdGenerator)["Service"] = {
@@ -3942,6 +3973,7 @@ const make = Effect.gen(function* () {
       const recordCompleted = (
         output: unknown,
         finishReason: "completed" | "model-stop" | "budget-exhausted",
+        exhausted: ExhaustedLimit | undefined,
       ): Effect.Effect<void, DurableWorkerFailure> =>
         Schema.decodeUnknownEffect(PersistedJson)(output).pipe(
           Effect.mapError(
@@ -3957,6 +3989,9 @@ const make = Effect.gen(function* () {
               ...state,
               completedOutput: result,
               completedFinishReason: finishReason === "budget-exhausted" ? finishReason : undefined,
+              // The pair travels together or not at all (RUN-011 fail-safe): a
+              // divergent event never persists a lone dimension.
+              completedExhausted: finishReason === "budget-exhausted" ? exhausted : undefined,
             })),
           ),
         );
@@ -3975,7 +4010,7 @@ const make = Effect.gen(function* () {
           }
           case "RunCompleted": {
             return commitPendingTurn.pipe(
-              Effect.andThen(recordCompleted(event.output, event.finishReason)),
+              Effect.andThen(recordCompleted(event.output, event.finishReason, event.exhausted)),
             );
           }
           case "RunFailed": {
@@ -4213,6 +4248,9 @@ const make = Effect.gen(function* () {
         ...(state.completedFinishReason === undefined
           ? {}
           : { finishReason: state.completedFinishReason }),
+        ...(state.completedFinishReason === undefined || state.completedExhausted === undefined
+          ? {}
+          : { exhausted: state.completedExhausted }),
       } as RunPhaseOutcome;
     });
 

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -441,23 +441,30 @@ export class SubmissionSettled extends Schema.TaggedClass<SubmissionSettled>(
   policyLimit: Schema.optionalKey(PolicyLimit),
 }) {}
 
+const isPolicyFailureProjection = Schema.is(
+  Schema.Struct({ errorTag: Schema.Literal("AgentPolicyError") }),
+);
+
 /**
  * Canonical-boundary view of `SubmissionSettled`: `finishReason` is valid
  * only on a `completed` outcome, `exhausted` only alongside
  * `finishReason: "budget-exhausted"`, and `policyLimit` only on a `failed`
- * outcome, so a malformed persisted combination such as
- * `{ outcome: "failed", finishReason: "budget-exhausted" }` fails closed at
- * decode instead of becoming trusted audit history (STORE-006, RUN-011).
+ * outcome whose `result` carries the `AgentPolicyError` failure projection —
+ * so a malformed persisted combination such as
+ * `{ outcome: "failed", finishReason: "budget-exhausted" }` or a
+ * `policyLimit` contradicting `result.errorTag` fails closed at decode
+ * instead of becoming trusted audit history (STORE-006, RUN-011).
  */
 const SubmissionSettledRecord = SubmissionSettled.pipe(
   Schema.refine(
     (settled): settled is SubmissionSettled =>
       (settled.finishReason === undefined || settled.outcome === "completed") &&
       (settled.exhausted === undefined || settled.finishReason === "budget-exhausted") &&
-      (settled.policyLimit === undefined || settled.outcome === "failed"),
+      (settled.policyLimit === undefined ||
+        (settled.outcome === "failed" && isPolicyFailureProjection(settled.result))),
     {
       expected:
-        "finishReason only on a completed settlement, exhausted only with finishReason budget-exhausted, policyLimit only on a failed settlement",
+        "finishReason only on a completed settlement, exhausted only with finishReason budget-exhausted, policyLimit only on a failed AgentPolicyError settlement",
     },
   ),
 );

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -3,6 +3,8 @@ import {
   AttemptId,
   ConversationId,
   DelegationId,
+  ExhaustedLimit,
+  PolicyLimit,
   ReceiptId,
   RunId,
   SettlementId,
@@ -421,19 +423,42 @@ export class SubmissionSettled extends Schema.TaggedClass<SubmissionSettled>(
    * existing histories and goldens byte-stable (additive, schemaVersion 1).
    */
   finishReason: Schema.optionalKey(Schema.Literal("budget-exhausted")),
+  /**
+   * The dimension that bound a budget-exhausted completion (RUN-011,
+   * RUN-025), carried verbatim from the live `RunCompleted` event so
+   * consumers never reconstruct it from message text. Valid only alongside
+   * `finishReason: "budget-exhausted"`; absent on histories persisted before
+   * the dimension became durable (additive, schemaVersion 1).
+   */
+  exhausted: Schema.optionalKey(ExhaustedLimit),
+  /**
+   * The typed `AgentPolicyError.limit` of a `failed` hard-rail settlement
+   * (RUN-011): which finite policy dimension failed the Run, preserved
+   * alongside the bounded `{errorTag, message}` failure projection in
+   * `result`. Absent for every non-policy failure and on histories persisted
+   * before the limit became durable (additive, schemaVersion 1).
+   */
+  policyLimit: Schema.optionalKey(PolicyLimit),
 }) {}
 
 /**
  * Canonical-boundary view of `SubmissionSettled`: `finishReason` is valid
- * only on a `completed` outcome, so a malformed persisted combination such as
+ * only on a `completed` outcome, `exhausted` only alongside
+ * `finishReason: "budget-exhausted"`, and `policyLimit` only on a `failed`
+ * outcome, so a malformed persisted combination such as
  * `{ outcome: "failed", finishReason: "budget-exhausted" }` fails closed at
  * decode instead of becoming trusted audit history (STORE-006, RUN-011).
  */
 const SubmissionSettledRecord = SubmissionSettled.pipe(
   Schema.refine(
     (settled): settled is SubmissionSettled =>
-      settled.finishReason === undefined || settled.outcome === "completed",
-    { expected: "finishReason only on a completed settlement" },
+      (settled.finishReason === undefined || settled.outcome === "completed") &&
+      (settled.exhausted === undefined || settled.finishReason === "budget-exhausted") &&
+      (settled.policyLimit === undefined || settled.outcome === "failed"),
+    {
+      expected:
+        "finishReason only on a completed settlement, exhausted only with finishReason budget-exhausted, policyLimit only on a failed settlement",
+    },
   ),
 );
 

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -388,14 +388,35 @@ describe("phase 4 durable canonical payloads", () => {
       deploymentId: "test-deployment",
       payload,
     });
+    const policyFailureResult = {
+      errorTag: "AgentPolicyError",
+      message: "Agent exceeded its 100 token budget",
+    };
     const failures: ReadonlyArray<unknown> = [
       { ...encodedSubmissionSettled, outcome: "failed", finishReason: "budget-exhausted" },
       { ...encodedSubmissionSettled, exhausted: "turns" },
       { ...encodedSubmissionSettled, outcome: "failed", exhausted: "tokens" },
-      { ...encodedSubmissionSettled, policyLimit: "duration" },
-      { ...encodedSubmissionSettled, outcome: "aborted", policyLimit: "cost" },
+      { ...encodedSubmissionSettled, policyLimit: "duration", result: policyFailureResult },
+      {
+        ...encodedSubmissionSettled,
+        outcome: "aborted",
+        policyLimit: "cost",
+        result: policyFailureResult,
+      },
       { ...encodedSubmissionSettled, finishReason: "budget-exhausted", exhausted: "duration" },
       { ...encodedSubmissionSettled, outcome: "failed", policyLimit: "context" },
+      // A policyLimit contradicting the recorded failure projection is not audit truth.
+      {
+        ...encodedSubmissionSettled,
+        outcome: "failed",
+        policyLimit: "tokens",
+        result: { errorTag: "ModelProtocolError", message: "not a policy failure" },
+      },
+      // A policyLimit without any recorded failure projection fails closed too.
+      (() => {
+        const { result: _result, ...withoutResult } = encodedSubmissionSettled;
+        return { ...withoutResult, outcome: "failed", policyLimit: "tokens" };
+      })(),
     ];
     for (const payload of failures) {
       expect(Schema.decodeUnknownExit(RecordEnvelope)(envelope(payload))._tag).toBe("Failure");

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -352,6 +352,56 @@ describe("phase 4 durable canonical payloads", () => {
     }
   });
 
+  it("RUN-011: round-trips typed budget metadata and decodes legacy settlements without it", () => {
+    const payloads = [
+      // A completed soft landing persists the finishReason with its typed dimension.
+      {
+        ...encodedSubmissionSettled,
+        finishReason: "budget-exhausted",
+        exhausted: "tool-calls",
+      } as const,
+      // A hard-rail policy failure persists the typed limit beside the bounded projection.
+      {
+        ...encodedSubmissionSettled,
+        outcome: "failed",
+        result: { errorTag: "AgentPolicyError", message: "Agent exceeded its 100 token budget" },
+        policyLimit: "tokens",
+      } as const,
+      // Histories persisted before the dimension became durable carry the finishReason alone.
+      { ...encodedSubmissionSettled, finishReason: "budget-exhausted" } as const,
+    ];
+    for (const [index, payload] of payloads.entries()) {
+      const record = decodeRecord(`record-run011-${index}`, payload);
+      expect(record.schemaVersion).toBe(1);
+      const encoded = Schema.encodeSync(RecordEnvelope)(record);
+      expect(encoded.payload).toEqual(payload);
+      expect(Schema.decodeUnknownSync(RecordEnvelope)(encoded)).toEqual(record);
+    }
+  });
+
+  it("RUN-011: rejects budget metadata on the wrong settlement family", () => {
+    const envelope = (payload: unknown): unknown => ({
+      recordId: "record-run011-invalid",
+      family: "conversation",
+      schemaVersion: 1,
+      createdAt: "2026-07-29T12:00:00.000Z",
+      deploymentId: "test-deployment",
+      payload,
+    });
+    const failures: ReadonlyArray<unknown> = [
+      { ...encodedSubmissionSettled, outcome: "failed", finishReason: "budget-exhausted" },
+      { ...encodedSubmissionSettled, exhausted: "turns" },
+      { ...encodedSubmissionSettled, outcome: "failed", exhausted: "tokens" },
+      { ...encodedSubmissionSettled, policyLimit: "duration" },
+      { ...encodedSubmissionSettled, outcome: "aborted", policyLimit: "cost" },
+      { ...encodedSubmissionSettled, finishReason: "budget-exhausted", exhausted: "duration" },
+      { ...encodedSubmissionSettled, outcome: "failed", policyLimit: "context" },
+    ];
+    for (const payload of failures) {
+      expect(Schema.decodeUnknownExit(RecordEnvelope)(envelope(payload))._tag).toBe("Failure");
+    }
+  });
+
   it("reduces settlements and abort requests while model responses only advance the sequence", () => {
     const created = decodeEnvelope(
       1,

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -466,6 +466,8 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(settled.outcome).toBe("completed");
           expect(settled.runId).toBe(runId);
           expect(settled.finishReason).toBe("budget-exhausted");
+          expect(settled.exhausted).toBe("tool-calls");
+          expect(settled.policyLimit).toBeUndefined();
           expect(settled.result).toEqual({ answer: "partial, budget exhausted" });
         }
 
@@ -492,7 +494,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
   );
 
   it.effect(
-    "RUN-018 recovery preserves the budget-exhausted finishReason across both terminalize failpoints",
+    "RUN-018 recovery preserves the budget-exhausted finishReason and exhausted dimension across both terminalize failpoints",
     () =>
       Effect.gen(function* () {
         const runtime = yield* DurableAgentRuntime;
@@ -577,6 +579,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(settledRecords[0]).toMatchObject({
             outcome: "completed",
             finishReason: "budget-exhausted",
+            exhausted: "tool-calls",
           });
         }
       }),
@@ -1844,5 +1847,283 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
       expect(payload.inputTokens).toBe(90);
       expect(payload.outputTokens).toBe(5);
     }),
+  );
+});
+
+layer(testLayer)("RUN-011 durable typed budget settlement", (it) => {
+  const usageOf = (input: number, output: number) => ({
+    inputTokens: { total: input },
+    outputTokens: { total: output },
+  });
+
+  const finalPartsWithUsage = (
+    text: string,
+    used: ReturnType<typeof usageOf>,
+  ): ReadonlyArray<Response.StreamPartEncoded> => [
+    { type: "text-start", id: "answer" },
+    { type: "text-delta", id: "answer", delta: text },
+    { type: "text-end", id: "answer" },
+    { type: "finish", reason: "stop", usage: used },
+  ];
+
+  const lastSettlement = (records: ReadonlyArray<CanonicalRecordEnvelope>) => {
+    const payload = records.at(-1)?.record.payload;
+    if (payload?._tag !== "SubmissionSettled") {
+      throw new Error("expected the canonical settlement to close the log");
+    }
+    return payload;
+  };
+
+  const policyOf = (overrides?: Partial<Parameters<typeof AgentPolicy.make>[0]>) =>
+    AgentPolicy.make({
+      maxTurns: 3,
+      maxToolCalls: 2,
+      maxDuration: "30 seconds",
+      toolConcurrency: 1,
+      ...overrides,
+    });
+
+  it.effect('RUN-011: a Turn-exhausted soft landing settles with exhausted: "turns"', () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const definition = Agent.define("durable-turns-landing", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Search before answering.",
+        toolkit: searchTools,
+        policy: policyOf({ maxTurns: 1 }),
+      });
+      // Turn 1 declares the permitted batch; the grace Turn past `maxTurns`
+      // delivers the constrained final answer (RUN-019).
+      const scripted = yield* makeScriptedModel((call) =>
+        call === 0 ? toolCallParts : finalParts('{"answer":"turn-bound partial"}'),
+      );
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-turns-landing";
+
+      yield* runtime.submit(agent, { question: "turns?" }, submitOptions(conversation, "turns-1"));
+      const settlements = yield* runtime
+        .processConversation(agent, decodeConversationId(conversation))
+        .pipe(Effect.provide(searchToolLayer));
+      expect(settlements[0]?.outcome).toBe("completed");
+
+      const settled = lastSettlement(yield* readLog(conversation));
+      expect(settled.outcome).toBe("completed");
+      expect(settled.finishReason).toBe("budget-exhausted");
+      expect(settled.exhausted).toBe("turns");
+      expect(settled.policyLimit).toBeUndefined();
+      expect(settled.result).toEqual({ answer: "turn-bound partial" });
+    }),
+  );
+
+  it.effect('RUN-011: a token-exhausted soft landing settles with exhausted: "tokens"', () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const definition = Agent.define("durable-tokens-landing", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Answer immediately.",
+        toolkit: Toolkit.empty,
+        policy: policyOf({ tokenBudget: 100 }),
+      });
+      // A token-breaching stop response that already decodes settles directly
+      // (RUN-025): 90 + 20 tokens against the 100-token budget.
+      const scripted = yield* makeScriptedModel(() =>
+        finalPartsWithUsage('{"answer":"token-bound partial"}', usageOf(90, 20)),
+      );
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-tokens-landing";
+
+      yield* runtime.submit(
+        agent,
+        { question: "tokens?" },
+        submitOptions(conversation, "tokens-1"),
+      );
+      const settlements = yield* runtime.processConversation(
+        agent,
+        decodeConversationId(conversation),
+      );
+      expect(settlements[0]?.outcome).toBe("completed");
+
+      const settled = lastSettlement(yield* readLog(conversation));
+      expect(settled.outcome).toBe("completed");
+      expect(settled.finishReason).toBe("budget-exhausted");
+      expect(settled.exhausted).toBe("tokens");
+      expect(settled.policyLimit).toBeUndefined();
+      expect(settled.result).toEqual({ answer: "token-bound partial" });
+    }),
+  );
+
+  it.effect("RUN-011: a fail-mode token breach settles failed with the typed policyLimit", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const definition = Agent.define("durable-tokens-rail", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Answer immediately.",
+        toolkit: Toolkit.empty,
+        policy: policyOf({ tokenBudget: 100, onExhaustion: "fail" }),
+      });
+      const scripted = yield* makeScriptedModel(() =>
+        finalPartsWithUsage('{"answer":"expensive"}', usageOf(90, 20)),
+      );
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-tokens-rail";
+
+      yield* runtime.submit(
+        agent,
+        { question: "tokens?" },
+        submitOptions(conversation, "tokens-rail-1"),
+      );
+      const settlements = yield* runtime.processConversation(
+        agent,
+        decodeConversationId(conversation),
+      );
+      expect(settlements[0]?.outcome).toBe("failed");
+
+      const settled = lastSettlement(yield* readLog(conversation));
+      expect(settled.outcome).toBe("failed");
+      expect(settled.policyLimit).toBe("tokens");
+      expect(settled.finishReason).toBeUndefined();
+      expect(settled.exhausted).toBeUndefined();
+      expect(settled.result).toMatchObject({ errorTag: "AgentPolicyError" });
+    }),
+  );
+
+  it.effect("RUN-011: a hard cost rail settles failed with the typed policyLimit", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const definition = Agent.define("durable-cost-rail", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Answer immediately.",
+        toolkit: Toolkit.empty,
+        // The durable runtime provides no cost estimator, so a configured cost
+        // budget fails the Run typed on the first usage consumption — the hard
+        // cost rail regardless of `onExhaustion` (runtime spec §3).
+        policy: policyOf({ costBudgetMicrousd: 1_000 }),
+      });
+      const scripted = yield* makeScriptedModel(() =>
+        finalPartsWithUsage('{"answer":"priced"}', usageOf(10, 10)),
+      );
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-cost-rail";
+
+      yield* runtime.submit(agent, { question: "cost?" }, submitOptions(conversation, "cost-1"));
+      const settlements = yield* runtime.processConversation(
+        agent,
+        decodeConversationId(conversation),
+      );
+      expect(settlements[0]?.outcome).toBe("failed");
+
+      const settled = lastSettlement(yield* readLog(conversation));
+      expect(settled.outcome).toBe("failed");
+      expect(settled.policyLimit).toBe("cost");
+      expect(settled.result).toMatchObject({ errorTag: "AgentPolicyError" });
+    }),
+  );
+
+  it.effect("RUN-011: a duration-exhausted Run settles failed with the typed policyLimit", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const definition = Agent.define("durable-duration-rail", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Answer immediately.",
+        toolkit: Toolkit.empty,
+        policy: policyOf({ maxDuration: "5 seconds" }),
+      });
+      // A model that never finishes streaming: only the duration rail can end
+      // this Run.
+      const hangingModel = Model.make(
+        "scripted",
+        "durable-test",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () => Stream.never,
+          }),
+        ),
+      );
+      const agent = Agent.withModel(definition, hangingModel);
+      const conversation = "conversation-duration-rail";
+
+      yield* runtime.submit(
+        agent,
+        { question: "slow?" },
+        submitOptions(conversation, "duration-1"),
+      );
+      const worker = yield* Effect.forkChild(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      yield* TestClock.adjust(Duration.seconds(6));
+      const settlements = yield* Fiber.join(worker);
+      expect(settlements[0]?.outcome).toBe("failed");
+
+      const settled = lastSettlement(yield* readLog(conversation));
+      expect(settled.outcome).toBe("failed");
+      expect(settled.policyLimit).toBe("duration");
+      expect(settled.result).toMatchObject({ errorTag: "AgentPolicyError" });
+    }),
+  );
+
+  it.effect(
+    "RUN-011: recovery preserves the typed policyLimit across both terminalize failpoints",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const scenarios = [
+          {
+            location: "terminalize:after-reserve" as const,
+            conversation: "conversation-policy-reserve",
+            key: "policy-reserve-1",
+          },
+          {
+            location: "terminalize:after-canonical-append" as const,
+            conversation: "conversation-policy-append",
+            key: "policy-append-1",
+          },
+        ];
+        for (const scenario of scenarios) {
+          const definition = Agent.define("durable-policy-recovery", {
+            input: Schema.Struct({ question: Schema.String }),
+            output: Schema.Struct({ answer: Schema.String }),
+            instructions: "Answer immediately.",
+            toolkit: Toolkit.empty,
+            policy: policyOf({ tokenBudget: 100, onExhaustion: "fail" }),
+          });
+          const scripted = yield* makeScriptedModel(() =>
+            finalPartsWithUsage('{"answer":"expensive"}', usageOf(90, 20)),
+          );
+          const agent = Agent.withModel(definition, scripted.model);
+
+          const receipt = yield* runtime.submit(
+            agent,
+            { question: "tokens?" },
+            submitOptions(scenario.conversation, scenario.key),
+          );
+          yield* armFailpoint(scenario.location);
+          const killed = yield* Effect.exit(
+            runtime.processConversation(agent, decodeConversationId(scenario.conversation)),
+          );
+          expect(failureTag(killed)).toBe("DurableRuntimeFailpointError");
+          yield* clearFailpoint;
+
+          yield* runtime.runRecovery;
+          const settlement = yield* runtime.awaitSettlement(receipt);
+          expect(settlement.outcome).toBe("failed");
+          const records = yield* readLog(scenario.conversation);
+          const settledRecords = records
+            .map((envelope) => envelope.record.payload)
+            .filter((payload) => payload._tag === "SubmissionSettled");
+          expect(settledRecords).toHaveLength(1);
+          expect(settledRecords[0]).toMatchObject({
+            outcome: "failed",
+            policyLimit: "tokens",
+            result: { errorTag: "AgentPolicyError" },
+          });
+        }
+      }),
   );
 });


### PR DESCRIPTION
Closes #83.

## Summary

- The canonical `SubmissionSettled` record now persists the typed budget dimension for both settlement families, additively under `schemaVersion: 1`: a completed soft landing carries [`exhausted` (`"tokens" | "tool-calls" | "turns"`) beside `finishReason: "budget-exhausted"`, and a failed hard-rail settlement carries `policyLimit` (the typed `AgentPolicyError.limit`)](https://github.com/danieljvdm/effect-agent/blob/cf253a12/packages/session/src/records.ts#L426-L442) beside the existing bounded `{errorTag, message}` failure projection in `result`.
- Why: the live APIs already expose the exact dimension (`RunCompleted.exhausted`, `AgentPolicyError.limit`), but the durable record dropped it — a consumer replaying canonical history had to emit `budget_kind: unknown` or parse message prose (reve-ai/kommunikasie#394). Notably, spec RUN-011 already *claimed* the durable record carries the exhausted marker; this closes that spec–code gap and extends [RUN-011](https://github.com/danieljvdm/effect-agent/blob/cf253a12/docs/spec/runtime.md#L489-L499) to the failed family.
- Decode is family-bound fail-closed via the [canonical-boundary refinement](https://github.com/danieljvdm/effect-agent/blob/5223aa25/packages/session/src/records.ts#L444-L474): `exhausted` only alongside the budget-exhausted `finishReason`, `policyLimit` only on a `failed` outcome whose `result` carries the `AgentPolicyError` projection (tightened after the bot review caught the contradictory-tag hole) — malformed combinations reject instead of becoming trusted audit history. Histories persisted before the metadata existed keep decoding with it absent, and the committed phase-6 golden is byte-stable.
- `@effect-agent/core` newly exports the backing literal schemas `ExhaustedLimit` and `PolicyLimit` (previously inline/private), so session and consumers share one definition.

## Architecture

- **Completed side:** the `RunCompleted` event's `exhausted` now rides `AttemptOutcome` into [the reserved settlement payload](https://github.com/danieljvdm/effect-agent/blob/cf253a12/packages/session/src/durable-runtime.ts#L1837-L1853). The pairing is enforced at the construction seam ([`recordCompleted`](https://github.com/danieljvdm/effect-agent/blob/cf253a12/packages/session/src/durable-runtime.ts#L3973-L3999) stores the dimension only when `finishReason` is `"budget-exhausted"`), matching the engine-side fail-safe convention for divergent pairs.
- **Failed side:** [`failureOutcome`](https://github.com/danieljvdm/effect-agent/blob/cf253a12/packages/session/src/durable-runtime.ts#L2621-L2641) Schema-decodes the typed limit off an `AgentPolicyError` (same `decodeUnknownOption` idiom as the existing tag/message projection — no type assertions) and threads it to the settlement.
- Because the metadata lives inside the **exact reserved record** (DUR-011), it survives reservation replay, canonical append, recovery, and every later read with no ledger-port or storage-adapter change — adapters store the envelope opaquely. Projections/checkpoints fold the whole payload, so they carry it for free; old checkpoints still decode (optional fields).
- Spec updates: [RUN-011](https://github.com/danieljvdm/effect-agent/blob/cf253a12/docs/spec/runtime.md#L489-L499) and [durability §12 Terminalization](https://github.com/danieljvdm/effect-agent/blob/cf253a12/docs/spec/durability.md#L284-L294) now state the settlement payload contract; `docs/concepts/budgets.md` mirrors it (and fixes two stale claims that predated RUN-025's token soft landing).

## Rejected alternatives

- **Parsing the failure message** for the dimension — explicitly rejected in #83; the message stays diagnostic, never the authority.
- **Extending the ledger `Settlement` row / `awaitSettlement` return** — the canonical record is the outcome authority (DUR-015) and already the only carrier of `result`/`finishReason`; widening the operational row would touch every storage adapter for data the log already owns.
- **A ledger-conformance knob for the new fields** — adapters persist the `RecordEnvelope` opaquely, so per-adapter conformance adds nothing; the terminalize-failpoint recovery tests prove the reserve → append → finalize round-trip end-to-end.

## Evidence (issue acceptance mapping)

Exact canonical settlement assertions in [`durable-runtime.test.ts`](https://github.com/danieljvdm/effect-agent/blob/cf253a12/packages/testing/test/durable-runtime.test.ts):

- soft **Turn** / **Tool Call** / **token** exhaustion → `exhausted: "turns" | "tool-calls" | "tokens"` (new RUN-011 block + extended RUN-018 tests);
- hard **duration** (TestClock-driven hanging model), **cost**, and fail-mode **token** rails → `outcome: "failed"`, `policyLimit`, `result.errorTag: "AgentPolicyError"`;
- recovery/failpoint coverage: both `terminalize:after-reserve` and `terminalize:after-canonical-append` kills preserve `exhausted` (completed) and `policyLimit` (failed) across restart and replay;
- legacy decode: schema tests round-trip settlements without the metadata (including `finishReason` alone) and reject every wrong-family combination.

```
packages/session  test/session.test.ts        33 passed
packages/testing  test/durable-runtime.test.ts 32 passed
bun run ready — check, full test sweep, build all green
```

Follow-up (out of scope): the durable parent-side delegation projection (`ChildEstablishStatus`) still surfaces only the boolean `finishReason` marker to the parent handler; with the child settlement now carrying `exhausted`, surfacing the dimension there is a separate additive change. #48 (result-less failed settlements) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
