### PR TITLE
fix(pr-review): review patchless text files

### DIFF
--- a/.changeset/review-patchless-text.md
+++ b/.changeset/review-patchless-text.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": minor
+---
+
+Recover GitHub-omitted textual patches through bounded UTF-8 base/head content so generated and oversized text files can complete review coverage without repository-specific ignores. Binary, unreadable, incomplete, and over-bound content remains fail-closed.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -40572,9 +40572,21 @@ class ChangedFile extends exports_Schema.Class("@effect-agent/pr-review/ChangedF
   additions: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
   deletions: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
   previousPath: exports_Schema.optionalKey(ChangedPath),
-  patch: exports_Schema.optionalKey(exports_Schema.String)
+  patch: exports_Schema.optionalKey(exports_Schema.String),
+  reviewBaseContent: exports_Schema.optionalKey(exports_Schema.String.check(exports_Schema.isMaxLength(200000))),
+  reviewHeadContent: exports_Schema.optionalKey(exports_Schema.String.check(exports_Schema.isMaxLength(200000)))
 }) {
 }
+var hasReviewableContent = (file2) => {
+  if (file2.patch !== undefined)
+    return false;
+  if (file2.status === "added")
+    return file2.reviewHeadContent !== undefined;
+  if (file2.status === "removed")
+    return file2.reviewBaseContent !== undefined;
+  return file2.reviewBaseContent !== undefined && file2.reviewHeadContent !== undefined;
+};
+var isReviewableFile = (file2) => file2.patch !== undefined || hasReviewableContent(file2);
 var HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 var parsePatch = (patch3) => {
   const lines = [];
@@ -40715,6 +40727,8 @@ class PullRequestSource extends exports_Context.Service()("@effect-agent/pr-revi
 var MAX_FINDINGS = 20;
 var MAX_CONCERNS = 10;
 var MAX_PATCH_CHARS = 60000;
+var MAX_CONTENT_REVIEW_CHARS = 220000;
+var REVIEW_TOOL_RESULT_MAX_BYTES = 2 * 1024 * 1024;
 var MAX_SLICE_LINES = 1000;
 var DEFAULT_SLICE_LINES = 400;
 
@@ -40723,7 +40737,8 @@ class ChangedFileSummary extends exports_Schema.Class("@effect-agent/pr-review/C
   status: ChangedFileStatus,
   additions: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
   deletions: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  hasTextualDiff: exports_Schema.Boolean
+  hasTextualDiff: exports_Schema.Boolean,
+  hasReviewableContent: exports_Schema.Boolean
 }) {
 }
 
@@ -40755,12 +40770,13 @@ class FileDiffQuery extends exports_Schema.Class("@effect-agent/pr-review/FileDi
 class FileDiffView extends exports_Schema.Class("@effect-agent/pr-review/FileDiffView")({
   path: ChangedPath,
   status: ChangedFileStatus,
+  reviewMode: exports_Schema.Literals(["diff", "content", "unavailable"]),
   annotatedPatch: exports_Schema.String,
   truncated: exports_Schema.Boolean
 }) {
 }
 var ReadFileDiff = exports_Tool.make("read_file_diff", {
-  description: "Read the annotated unified diff of one changed file. Lines marked R<number> exist in the new version and are the only valid finding anchors.",
+  description: "Read one changed file's review evidence. A normal unified diff marks valid anchors as R<number>. When GitHub omitted the diff, bounded base/head content is returned with B/H line labels for review but no valid inline anchors.",
   parameters: FileDiffQuery,
   success: FileDiffView,
   failure: exports_Schema.Union([PullRequestSourceFailure, ReviewInputViolation]),
@@ -40804,7 +40820,8 @@ var listChangedFilesHandler = (_query) => exports_Effect.gen(function* () {
       status: file2.status,
       additions: file2.additions,
       deletions: file2.deletions,
-      hasTextualDiff: file2.patch !== undefined
+      hasTextualDiff: file2.patch !== undefined,
+      hasReviewableContent: hasReviewableContent(file2)
     }))
   });
 });
@@ -40819,13 +40836,25 @@ var readFileDiffHandler = (query) => exports_Effect.gen(function* () {
       reason: "Path is not part of this pull request's changeset."
     });
   }
-  const annotated = file2.patch === undefined ? "" : annotatePatch(file2.patch);
-  const truncated = annotated.length > MAX_PATCH_CHARS;
+  const reviewMode = file2.patch !== undefined ? "diff" : hasReviewableContent(file2) ? "content" : "unavailable";
+  const annotateContent = (side, content) => content.split(`
+`).map((text2, index2) => `${side}${index2 + 1}   ${text2}`).join(`
+`);
+  const contentEvidence = reviewMode !== "content" ? "" : [
+    "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]",
+    ...file2.reviewBaseContent === undefined ? [] : ["[BASE VERSION]", annotateContent("B", file2.reviewBaseContent)],
+    ...file2.reviewHeadContent === undefined ? [] : ["[HEAD VERSION]", annotateContent("H", file2.reviewHeadContent)]
+  ].join(`
+`);
+  const annotated = file2.patch === undefined ? contentEvidence : annotatePatch(file2.patch);
+  const maximumChars = reviewMode === "content" ? MAX_CONTENT_REVIEW_CHARS : MAX_PATCH_CHARS;
+  const truncated = annotated.length > maximumChars;
   return FileDiffView.make({
     path: file2.path,
     status: file2.status,
-    annotatedPatch: truncated ? `${annotated.slice(0, MAX_PATCH_CHARS)}
-[diff truncated]` : annotated,
+    reviewMode,
+    annotatedPatch: truncated ? `${annotated.slice(0, maximumChars)}
+[review evidence truncated at the bounded tool limit]` : annotated,
     truncated
   });
 });
@@ -40915,7 +40944,7 @@ ${mission.body}` : "The author provided no description.",
     ...resolveGuidance(options3.guidance, mission),
     "Work in this order:",
     "1. Call list_changed_files once to see the changeset.",
-    "2. Call read_file_diff for every file you review. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
+    "2. Call read_file_diff for every file you review. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
     "3. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap honestly in your summary when it matters.",
     "4. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
     "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
@@ -40936,6 +40965,7 @@ var defaultReviewPolicy = AgentPolicy.make({
   toolConcurrency: 2,
   tokenBudget: 300000,
   contextTokenLimit: 150000,
+  toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   onExhaustion: "final-answer"
 });
 var PullRequestReviewer = Agent.define("pr-reviewer", {
@@ -40971,7 +41001,11 @@ class ReviewUnitPlan extends exports_Schema.Class("@effect-agent/pr-review/Revie
   unassignedPaths: exports_Schema.Array(ChangedPath).check(exports_Schema.isMaxLength(300))
 }) {
 }
-var fileCost = (file2) => file2.additions + file2.deletions + FILE_OVERHEAD_LINES;
+var fileCost = (file2) => {
+  const contentChars = (file2.reviewBaseContent?.length ?? 0) + (file2.reviewHeadContent?.length ?? 0);
+  const contentWeight = Math.ceil(contentChars / 200);
+  return file2.additions + file2.deletions + contentWeight + FILE_OVERHEAD_LINES;
+};
 var unitOf = (index2, files) => ReviewUnit.make({
   unitId: `unit-${String(index2 + 1).padStart(3, "0")}`,
   paths: files.map((file2) => file2.path),
@@ -40979,13 +41013,13 @@ var unitOf = (index2, files) => ReviewUnit.make({
 });
 var planReviewUnits = (files, options3) => {
   const ordered = [...files].sort((left, right) => left.path < right.path ? -1 : 1);
-  const diffable = ordered.filter((file2) => file2.patch !== undefined);
-  const undiffable = ordered.filter((file2) => file2.patch === undefined);
+  const reviewable = ordered.filter(isReviewableFile);
+  const undiffable = ordered.filter((file2) => !isReviewableFile(file2));
   const groups = [];
   const unassigned = [];
   let current = [];
   let currentCost = 0;
-  for (const file2 of diffable) {
+  for (const file2 of reviewable) {
     const cost = fileCost(file2);
     const wouldOverflow = current.length >= MAX_UNIT_FILES || current.length > 0 && currentCost + cost > UNIT_CHANGED_LINE_BUDGET;
     if (wouldOverflow) {
@@ -41070,7 +41104,7 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => [
   `You are a code reviewer for one unit of a pull request: unit ${brief.unitId}, covering exactly these changed files: ${brief.paths.join(", ")}. Focus: ${brief.focus}.`,
   ...staticGuidanceLines(options3.guidance),
   "Work in this order:",
-  "1. Call read_file_diff for every file in your unit. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
+  "1. Call read_file_diff for every file in your unit. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
   "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
   "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
   "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
@@ -41087,6 +41121,7 @@ var defaultFileReviewerPolicy = AgentPolicy.make({
   toolConcurrency: 2,
   tokenBudget: 200000,
   contextTokenLimit: 150000,
+  toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   onExhaustion: "fail"
 });
 
@@ -41250,7 +41285,7 @@ var sha256Hex = (text2) => exports_Effect.promise(async () => {
 var FIELD = "\x00";
 var RECORD = "\x01";
 var SECTION = "\x02";
-var canonicalChangeset = (files) => files.map((file2) => `${file2.path}${FIELD}${file2.status}${FIELD}${String(file2.additions)}${FIELD}${String(file2.deletions)}${FIELD}${file2.patch ?? ""}`).sort().join(RECORD);
+var canonicalChangeset = (files) => files.map((file2) => `${file2.path}${FIELD}${file2.status}${FIELD}${String(file2.additions)}${FIELD}${String(file2.deletions)}${FIELD}${file2.patch ?? ""}${FIELD}${file2.reviewBaseContent ?? ""}${FIELD}${file2.reviewHeadContent ?? ""}`).sort().join(RECORD);
 var computeChangesetFingerprint = (files, signature) => sha256Hex(`${canonicalChangeset(files)}${SECTION}${signature}`);
 
 // packages/pr-review/src/internal/ignore.ts
@@ -41559,9 +41594,22 @@ class ReviewExecutionContext extends exports_Context.Service()("@effect-agent/pr
 var selectedPullRequestSourceLayer = (selection) => exports_Layer.effect(PullRequestSource)(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
   const selectedPaths = new Set(selection.files.map((file2) => file2.path));
+  const selectedFiles = source.changedFiles.pipe(exports_Effect.map((fullFiles) => {
+    const fullByPath = new Map(fullFiles.map((file2) => [file2.path, file2]));
+    return selection.files.map((file2) => {
+      if (file2.patch !== undefined)
+        return file2;
+      const full = fullByPath.get(file2.path);
+      return full === undefined ? file2 : ChangedFile.make({
+        ...file2,
+        ...full.reviewBaseContent === undefined ? {} : { reviewBaseContent: full.reviewBaseContent },
+        ...full.reviewHeadContent === undefined ? {} : { reviewHeadContent: full.reviewHeadContent }
+      });
+    });
+  }));
   return PullRequestSource.of({
     metadata: source.metadata,
-    changedFiles: exports_Effect.succeed(selection.files),
+    changedFiles: selectedFiles,
     anchorFiles: source.anchorFiles,
     readFile: (path) => selectedPaths.has(path) ? source.readFile(path) : exports_Effect.fail(ReviewInputViolation.make({
       input: path,
@@ -41648,14 +41696,14 @@ var flatCoverage = (files, totalFiles, trace3) => {
     if (trace3.failed.has(toolCallId))
       failedPaths.add(query.value.path);
   }
-  const undiffable = files.filter((file2) => file2.patch === undefined).map((file2) => file2.path);
+  const undiffable = files.filter((file2) => !isReviewableFile(file2)).map((file2) => file2.path);
   const unreviewed = requiredPaths.filter((path) => !reviewed.has(path) || undiffable.includes(path) || failedPaths.has(path));
   const reasons = [];
   if (files.length < totalFiles) {
     reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
   }
   if (undiffable.length > 0) {
-    reasons.push(boundedListReason("required paths have no textual diff", undiffable));
+    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", undiffable));
   }
   if (failedPaths.size > 0) {
     reasons.push(boundedListReason("diff reads failed", failedPaths));
@@ -41718,7 +41766,7 @@ var fanOutCoverage = (files, totalFiles, trace3) => {
     reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
   }
   if (plan.undiffablePaths.length > 0) {
-    reasons.push(boundedListReason("required paths have no textual diff", plan.undiffablePaths));
+    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", plan.undiffablePaths));
   }
   if (plan.unassignedPaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
@@ -42095,20 +42143,31 @@ var gitHubPullRequestSourceLayer = exports_Layer.effect(PullRequestSource)(expor
     return all6;
   });
   const metadata = yield* exports_Effect.cached(fetchMetadata.pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client)));
-  const changedFiles = yield* exports_Effect.cached(fetchFiles.pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client)));
-  const readFile3 = (path) => exports_Effect.gen(function* () {
+  const rawFiles = yield* exports_Effect.cached(fetchFiles.pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client)));
+  const readRepositoryFile = (path, ref) => exports_Effect.gen(function* () {
     const relative = yield* normalizeRepoRelativePath(path);
-    const files = yield* changedFiles;
-    if (!files.some((file2) => file2.path === relative)) {
+    const encodedPath = relative.split("/").map(encodeURIComponent).join("/");
+    const response = yield* executeOk("readFile", withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/contents/${encodedPath}`).pipe(exports_HttpClientRequest.accept("application/vnd.github.raw+json"), exports_HttpClientRequest.setUrlParams({ ref })), target.token)).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
+    const buffer3 = yield* response.arrayBuffer.pipe(exports_Effect.mapError(failWith("readFile")));
+    if (buffer3.byteLength > MAX_FILE_CHARS) {
       return yield* ReviewInputViolation.make({
         input: relative,
-        reason: "Path is not part of this pull request's changeset."
+        reason: `File is larger than the ${MAX_FILE_CHARS}-byte read bound.`
       });
     }
-    const head3 = yield* metadata;
-    const encodedPath = relative.split("/").map(encodeURIComponent).join("/");
-    const response = yield* executeOk("readFile", withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/contents/${encodedPath}`).pipe(exports_HttpClientRequest.accept("application/vnd.github.raw+json"), exports_HttpClientRequest.setUrlParams({ ref: head3.headSha })), target.token)).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
-    const text2 = yield* response.text.pipe(exports_Effect.mapError(failWith("readFile")));
+    const text2 = yield* exports_Effect.try({
+      try: () => new TextDecoder("utf-8", { fatal: true }).decode(buffer3),
+      catch: () => ReviewInputViolation.make({
+        input: relative,
+        reason: "File is not valid UTF-8 text."
+      })
+    });
+    if (text2.includes("\x00")) {
+      return yield* ReviewInputViolation.make({
+        input: relative,
+        reason: "File contains binary NUL bytes."
+      });
+    }
     if (text2.length > MAX_FILE_CHARS) {
       return yield* ReviewInputViolation.make({
         input: relative,
@@ -42116,6 +42175,36 @@ var gitHubPullRequestSourceLayer = exports_Layer.effect(PullRequestSource)(expor
       });
     }
     return text2;
+  });
+  const changedFiles = yield* exports_Effect.cached(exports_Effect.gen(function* () {
+    const [files, pullRequest] = yield* exports_Effect.all([rawFiles, metadata]);
+    return yield* exports_Effect.forEach(files, (file2) => {
+      if (file2.patch !== undefined)
+        return exports_Effect.succeed(file2);
+      const basePath = file2.previousPath ?? file2.path;
+      const base2 = file2.status === "added" ? exports_Effect.succeed(exports_Option.none()) : readRepositoryFile(basePath, pullRequest.baseSha ?? pullRequest.baseRef).pipe(exports_Effect.option);
+      const head3 = file2.status === "removed" ? exports_Effect.succeed(exports_Option.none()) : readRepositoryFile(file2.path, pullRequest.headSha).pipe(exports_Effect.option);
+      return exports_Effect.all({ base: base2, head: head3 }).pipe(exports_Effect.map(({ base: base3, head: head4 }) => ChangedFile.make({
+        ...file2,
+        ...exports_Option.isSome(base3) ? { reviewBaseContent: base3.value } : {},
+        ...exports_Option.isSome(head4) ? { reviewHeadContent: head4.value } : {}
+      })));
+    }, { concurrency: 4 });
+  }));
+  const readFile3 = (path) => exports_Effect.gen(function* () {
+    const relative = yield* normalizeRepoRelativePath(path);
+    const files = yield* changedFiles;
+    const file2 = files.find((candidate) => candidate.path === relative);
+    if (file2 === undefined) {
+      return yield* ReviewInputViolation.make({
+        input: relative,
+        reason: "Path is not part of this pull request's changeset."
+      });
+    }
+    if (file2.reviewHeadContent !== undefined)
+      return file2.reviewHeadContent;
+    const head3 = yield* metadata;
+    return yield* readRepositoryFile(relative, head3.headSha);
   });
   return PullRequestSource.of({ metadata, changedFiles, anchorFiles: changedFiles, readFile: readFile3 });
 }));
@@ -42435,7 +42524,7 @@ var anchorViolation = (finding, files) => {
   if (file2 === undefined)
     return "path is not part of the changeset";
   if (file2.patch === undefined)
-    return "file has no textual diff";
+    return "file has no anchorable textual diff";
   if (finding.endLine < finding.startLine)
     return "endLine precedes startLine";
   if (finding.endLine - finding.startLine + 1 > 100)

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -40577,15 +40577,51 @@ class ChangedFile extends exports_Schema.Class("@effect-agent/pr-review/ChangedF
   reviewHeadContent: exports_Schema.optionalKey(exports_Schema.String.check(exports_Schema.isMaxLength(200000)))
 }) {
 }
-var hasReviewableContent = (file2) => {
+var MAX_REVIEW_CONTENT_CHARS = 220000;
+var renderReviewContent = (file2) => {
   if (file2.patch !== undefined)
-    return false;
-  if (file2.status === "added")
-    return file2.reviewHeadContent !== undefined;
-  if (file2.status === "removed")
-    return file2.reviewBaseContent !== undefined;
-  return file2.reviewBaseContent !== undefined && file2.reviewHeadContent !== undefined;
+    return;
+  const includeBase = file2.status !== "added";
+  const includeHead = file2.status !== "removed";
+  const sections = [
+    "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]"
+  ];
+  let renderedLength = sections[0]?.length ?? 0;
+  const append4 = (part) => {
+    const nextLength = renderedLength + 1 + part.length;
+    if (nextLength > MAX_REVIEW_CONTENT_CHARS)
+      return false;
+    sections.push(part);
+    renderedLength = nextLength;
+    return true;
+  };
+  const appendSide = (side, header, content) => {
+    if (!append4(header))
+      return false;
+    const lines = content.split(`
+`);
+    for (let index2 = 0;index2 < lines.length; index2 += 1) {
+      if (!append4(`${side}${index2 + 1}   ${lines[index2] ?? ""}`))
+        return false;
+    }
+    return true;
+  };
+  if (includeBase) {
+    if (file2.reviewBaseContent === undefined)
+      return;
+    if (!appendSide("B", "[BASE VERSION]", file2.reviewBaseContent))
+      return;
+  }
+  if (includeHead) {
+    if (file2.reviewHeadContent === undefined)
+      return;
+    if (!appendSide("H", "[HEAD VERSION]", file2.reviewHeadContent))
+      return;
+  }
+  return sections.join(`
+`);
 };
+var hasReviewableContent = (file2) => renderReviewContent(file2) !== undefined;
 var isReviewableFile = (file2) => file2.patch !== undefined || hasReviewableContent(file2);
 var HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 var parsePatch = (patch3) => {
@@ -40727,7 +40763,6 @@ class PullRequestSource extends exports_Context.Service()("@effect-agent/pr-revi
 var MAX_FINDINGS = 20;
 var MAX_CONCERNS = 10;
 var MAX_PATCH_CHARS = 60000;
-var MAX_CONTENT_REVIEW_CHARS = 220000;
 var REVIEW_TOOL_RESULT_MAX_BYTES = 2 * 1024 * 1024;
 var MAX_SLICE_LINES = 1000;
 var DEFAULT_SLICE_LINES = 400;
@@ -40836,25 +40871,16 @@ var readFileDiffHandler = (query) => exports_Effect.gen(function* () {
       reason: "Path is not part of this pull request's changeset."
     });
   }
-  const reviewMode = file2.patch !== undefined ? "diff" : hasReviewableContent(file2) ? "content" : "unavailable";
-  const annotateContent = (side, content) => content.split(`
-`).map((text2, index2) => `${side}${index2 + 1}   ${text2}`).join(`
-`);
-  const contentEvidence = reviewMode !== "content" ? "" : [
-    "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]",
-    ...file2.reviewBaseContent === undefined ? [] : ["[BASE VERSION]", annotateContent("B", file2.reviewBaseContent)],
-    ...file2.reviewHeadContent === undefined ? [] : ["[HEAD VERSION]", annotateContent("H", file2.reviewHeadContent)]
-  ].join(`
-`);
-  const annotated = file2.patch === undefined ? contentEvidence : annotatePatch(file2.patch);
-  const maximumChars = reviewMode === "content" ? MAX_CONTENT_REVIEW_CHARS : MAX_PATCH_CHARS;
-  const truncated = annotated.length > maximumChars;
+  const contentEvidence = renderReviewContent(file2);
+  const reviewMode = file2.patch !== undefined ? "diff" : contentEvidence !== undefined ? "content" : "unavailable";
+  const annotated = file2.patch === undefined ? contentEvidence ?? "" : annotatePatch(file2.patch);
+  const truncated = reviewMode === "diff" && annotated.length > MAX_PATCH_CHARS;
   return FileDiffView.make({
     path: file2.path,
     status: file2.status,
     reviewMode,
-    annotatedPatch: truncated ? `${annotated.slice(0, maximumChars)}
-[review evidence truncated at the bounded tool limit]` : annotated,
+    annotatedPatch: truncated ? `${annotated.slice(0, MAX_PATCH_CHARS)}
+[diff truncated]` : annotated,
     truncated
   });
 });

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -70,7 +70,8 @@ UTF-8 base/head content: additions require the head, deletions require the
 base, and other changes require both. Reviewers receive that content through
 the ordinary diff-read tool with non-anchorable `B`/`H` line labels and must
 report defects as review-body concerns. Invalid UTF-8, binary NUL content,
-missing sides, and files beyond the read bound remain explicit coverage gaps.
+missing sides, files beyond the per-side read bound, and complete B/H evidence
+beyond the model-facing render bound remain explicit coverage gaps.
 
 ## What a posted review looks like
 
@@ -176,8 +177,10 @@ variables inside Actions.
 ## Bounds, spelled out
 
 Finite `AgentPolicy` on every definition plus run-level `UsageBudgetLimits`
-(tokens, tool calls, cost, duration). Reading a file head version beyond 200k
-characters is refused typed. The changeset surface is bounded at 300 files:
+(tokens, tool calls, cost, duration). Reading either file version beyond 200k
+bytes or characters is refused typed; patchless content is reviewable only
+when its complete B/H rendering fits 220k characters. The changeset surface is
+bounded at 300 files:
 files beyond the bound are not fetched, and the review body reports
 `Reviewed N of M changed files` instead of claiming completeness. Fan-out
 capacity overflow is reported in the review summary, never dropped. Any

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -64,6 +64,14 @@ ephemeral delegation) merged under the same output contract and the same
 publication path; the shared `guidance` and `maxFindings` shape the
 coordinator's merge as well as the children.
 
+GitHub may omit the `patch` field for large textual files as well as binary
+files. The GitHub source recovers a missing patch by reading bounded, strict
+UTF-8 base/head content: additions require the head, deletions require the
+base, and other changes require both. Reviewers receive that content through
+the ordinary diff-read tool with non-anchorable `B`/`H` line labels and must
+report defects as review-body concerns. Invalid UTF-8, binary NUL content,
+missing sides, and files beyond the read bound remain explicit coverage gaps.
+
 ## What a posted review looks like
 
 The body opens with a host-derived callout tier — `[!CAUTION]` when any
@@ -174,5 +182,6 @@ files beyond the bound are not fetched, and the review body reports
 `Reviewed N of M changed files` instead of claiming completeness. Fan-out
 capacity overflow is reported in the review summary, never dropped. Any
 blocking active finding fails the Action check. Any required-file coverage
-gap — undiffable/unassigned paths, failed units (including policy exhaustion),
-truncation, or coordinator/run failure — is non-success rather than green.
+gap — paths with neither a patch nor bounded textual fallback, unassigned
+paths, failed units (including policy exhaustion), truncation, or
+coordinator/run failure — is non-success rather than green.

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -2,6 +2,7 @@ import { Option, Schema } from "effect";
 import type { RunEvent } from "effect-agent";
 
 import type { ChangedFile } from "./diff.ts";
+import { isReviewableFile } from "./diff.ts";
 import { FileReviewDelegationFailure, FileReviewRequest, FileReviewUnitResult } from "./fan-out.ts";
 import { FileDiffQuery } from "./review-agent.ts";
 import { planReviewUnits } from "./review-units.ts";
@@ -95,7 +96,7 @@ const flatCoverage = (
     if (trace.succeeded.has(toolCallId)) reviewed.add(query.value.path);
     if (trace.failed.has(toolCallId)) failedPaths.add(query.value.path);
   }
-  const undiffable = files.filter((file) => file.patch === undefined).map((file) => file.path);
+  const undiffable = files.filter((file) => !isReviewableFile(file)).map((file) => file.path);
   const unreviewed = requiredPaths.filter(
     (path) => !reviewed.has(path) || undiffable.includes(path) || failedPaths.has(path),
   );
@@ -104,7 +105,9 @@ const flatCoverage = (
     reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
   }
   if (undiffable.length > 0) {
-    reasons.push(boundedListReason("required paths have no textual diff", undiffable));
+    reasons.push(
+      boundedListReason("required paths have no reviewable diff or bounded text", undiffable),
+    );
   }
   if (failedPaths.size > 0) {
     reasons.push(boundedListReason("diff reads failed", failedPaths));
@@ -196,7 +199,12 @@ const fanOutCoverage = (
     reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
   }
   if (plan.undiffablePaths.length > 0) {
-    reasons.push(boundedListReason("required paths have no textual diff", plan.undiffablePaths));
+    reasons.push(
+      boundedListReason(
+        "required paths have no reviewable diff or bounded text",
+        plan.undiffablePaths,
+      ),
+    );
   }
   if (plan.unassignedPaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));

--- a/packages/pr-review/src/internal/diff.ts
+++ b/packages/pr-review/src/internal/diff.ts
@@ -31,7 +31,27 @@ export class ChangedFile extends Schema.Class<ChangedFile>("@effect-agent/pr-rev
   previousPath: Schema.optionalKey(ChangedPath),
   /** Unified-diff hunks; absent for binary or oversized files. */
   patch: Schema.optionalKey(Schema.String),
+  /**
+   * Bounded UTF-8 content used only when the provider omitted `patch`.
+   * Modified files require both sides; additions require head content and
+   * deletions require base content. These values are review evidence, never
+   * GitHub inline-comment anchors.
+   */
+  reviewBaseContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(200_000))),
+  reviewHeadContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(200_000))),
 }) {}
+
+/** Whether a patchless file carries the complete bounded sides needed for review. */
+export const hasReviewableContent = (file: ChangedFile): boolean => {
+  if (file.patch !== undefined) return false;
+  if (file.status === "added") return file.reviewHeadContent !== undefined;
+  if (file.status === "removed") return file.reviewBaseContent !== undefined;
+  return file.reviewBaseContent !== undefined && file.reviewHeadContent !== undefined;
+};
+
+/** Whether the reviewer has either a real patch or bounded textual fallback evidence. */
+export const isReviewableFile = (file: ChangedFile): boolean =>
+  file.patch !== undefined || hasReviewableContent(file);
 
 /** One parsed line of a unified diff, with both coordinate systems. */
 export interface PatchLine {

--- a/packages/pr-review/src/internal/diff.ts
+++ b/packages/pr-review/src/internal/diff.ts
@@ -41,13 +41,52 @@ export class ChangedFile extends Schema.Class<ChangedFile>("@effect-agent/pr-rev
   reviewHeadContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(200_000))),
 }) {}
 
-/** Whether a patchless file carries the complete bounded sides needed for review. */
-export const hasReviewableContent = (file: ChangedFile): boolean => {
-  if (file.patch !== undefined) return false;
-  if (file.status === "added") return file.reviewHeadContent !== undefined;
-  if (file.status === "removed") return file.reviewBaseContent !== undefined;
-  return file.reviewBaseContent !== undefined && file.reviewHeadContent !== undefined;
+/** Complete rendered fallback evidence must fit one ordinary model context. */
+export const MAX_REVIEW_CONTENT_CHARS = 220_000;
+
+/**
+ * Render complete patchless evidence, or refuse it when a required side is
+ * absent or B/H annotation would exceed the model-facing bound. Callers use
+ * this same value for planning and tool output so truncated fallback evidence
+ * can never count as complete coverage.
+ */
+export const renderReviewContent = (file: ChangedFile): string | undefined => {
+  if (file.patch !== undefined) return undefined;
+  const includeBase = file.status !== "added";
+  const includeHead = file.status !== "removed";
+  const sections: Array<string> = [
+    "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]",
+  ];
+  let renderedLength = sections[0]?.length ?? 0;
+  const append = (part: string): boolean => {
+    const nextLength = renderedLength + 1 + part.length;
+    if (nextLength > MAX_REVIEW_CONTENT_CHARS) return false;
+    sections.push(part);
+    renderedLength = nextLength;
+    return true;
+  };
+  const appendSide = (side: "B" | "H", header: string, content: string): boolean => {
+    if (!append(header)) return false;
+    const lines = content.split("\n");
+    for (let index = 0; index < lines.length; index += 1) {
+      if (!append(`${side}${index + 1}   ${lines[index] ?? ""}`)) return false;
+    }
+    return true;
+  };
+  if (includeBase) {
+    if (file.reviewBaseContent === undefined) return undefined;
+    if (!appendSide("B", "[BASE VERSION]", file.reviewBaseContent)) return undefined;
+  }
+  if (includeHead) {
+    if (file.reviewHeadContent === undefined) return undefined;
+    if (!appendSide("H", "[HEAD VERSION]", file.reviewHeadContent)) return undefined;
+  }
+  return sections.join("\n");
 };
+
+/** Whether complete patchless evidence fits the model-facing review bound. */
+export const hasReviewableContent = (file: ChangedFile): boolean =>
+  renderReviewContent(file) !== undefined;
 
 /** Whether the reviewer has either a real patch or bounded textual fallback evidence. */
 export const isReviewableFile = (file: ChangedFile): boolean =>

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -6,6 +6,7 @@ import {
   SubagentPolicy,
   SubagentRuntime,
   ToolExecutionClass,
+  ToolResultBounds,
   type RuntimeBinding,
 } from "effect-agent";
 import { Tool, Toolkit } from "effect/unstable/ai";
@@ -19,6 +20,7 @@ import {
   ReadFileDiff,
   readFileDiffHandler,
   readFileHandler,
+  REVIEW_TOOL_RESULT_MAX_BYTES,
   ReviewConcern,
   ReviewFinding,
   ReviewMission,
@@ -120,7 +122,7 @@ export const makeFileReviewerInstructions =
       `You are a code reviewer for one unit of a pull request: unit ${brief.unitId}, covering exactly these changed files: ${brief.paths.join(", ")}. Focus: ${brief.focus}.`,
       ...staticGuidanceLines(options.guidance),
       "Work in this order:",
-      "1. Call read_file_diff for every file in your unit. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
+      "1. Call read_file_diff for every file in your unit. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
       "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
       "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
       "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
@@ -141,6 +143,7 @@ export const defaultFileReviewerPolicy = AgentPolicy.make({
   // Bound one live prompt independently from cumulative usage. The engine
   // prunes old diff/file results before paying for a summary.
   contextTokenLimit: 150_000,
+  toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   // Typed exhaustion, deliberately NOT the final-answer soft landing: a
   // review is a coverage claim, and a child whose reads were rejected could
   // still emit schema-valid findings — laundering budget exhaustion into

--- a/packages/pr-review/src/internal/fingerprint.ts
+++ b/packages/pr-review/src/internal/fingerprint.ts
@@ -57,7 +57,7 @@ const canonicalChangeset = (files: ReadonlyArray<ChangedFile>): string =>
   files
     .map(
       (file) =>
-        `${file.path}${FIELD}${file.status}${FIELD}${String(file.additions)}${FIELD}${String(file.deletions)}${FIELD}${file.patch ?? ""}`,
+        `${file.path}${FIELD}${file.status}${FIELD}${String(file.additions)}${FIELD}${String(file.deletions)}${FIELD}${file.patch ?? ""}${FIELD}${file.reviewBaseContent ?? ""}${FIELD}${file.reviewHeadContent ?? ""}`,
     )
     .sort()
     .join(RECORD);

--- a/packages/pr-review/src/internal/fixtures.ts
+++ b/packages/pr-review/src/internal/fixtures.ts
@@ -28,6 +28,7 @@ import {
 /** One fixture file: its changeset entry plus optional head content. */
 export class FixtureFile extends Schema.Class<FixtureFile>("@effect-agent/pr-review/FixtureFile")({
   file: ChangedFile,
+  baseContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(MAX_FILE_CHARS))),
   headContent: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(MAX_FILE_CHARS))),
 }) {}
 
@@ -57,12 +58,21 @@ const requireChanged = (
 /** Deterministic `PullRequestSource` over one fixture pull request. */
 export const fixturePullRequestSourceLayer = (
   fixture: FixturePullRequest,
-): Layer.Layer<PullRequestSource> =>
-  Layer.succeed(PullRequestSource)(
+): Layer.Layer<PullRequestSource> => {
+  const files = fixture.files.map((entry) =>
+    entry.file.patch !== undefined
+      ? entry.file
+      : ChangedFile.make({
+          ...entry.file,
+          ...(entry.baseContent === undefined ? {} : { reviewBaseContent: entry.baseContent }),
+          ...(entry.headContent === undefined ? {} : { reviewHeadContent: entry.headContent }),
+        }),
+  );
+  return Layer.succeed(PullRequestSource)(
     PullRequestSource.of({
       metadata: Effect.succeed(fixture.metadata),
-      changedFiles: Effect.succeed(fixture.files.map((entry) => entry.file)),
-      anchorFiles: Effect.succeed(fixture.files.map((entry) => entry.file)),
+      changedFiles: Effect.succeed(files),
+      anchorFiles: Effect.succeed(files),
       readFile: (path) =>
         Effect.gen(function* () {
           const relative = yield* normalizeRepoRelativePath(path);
@@ -77,6 +87,7 @@ export const fixturePullRequestSourceLayer = (
         }),
     }),
   );
+};
 
 /** In-memory publisher: records every plan and mints a deterministic receipt. */
 export const collectingReviewPublisherLayer = (

--- a/packages/pr-review/src/internal/github.ts
+++ b/packages/pr-review/src/internal/github.ts
@@ -313,21 +313,13 @@ export const gitHubPullRequestSourceLayer: Layer.Layer<
     const metadata = yield* Effect.cached(
       fetchMetadata.pipe(Effect.provideService(HttpClient.HttpClient, client)),
     );
-    const changedFiles = yield* Effect.cached(
+    const rawFiles = yield* Effect.cached(
       fetchFiles.pipe(Effect.provideService(HttpClient.HttpClient, client)),
     );
 
-    const readFile = (path: string) =>
+    const readRepositoryFile = (path: string, ref: string) =>
       Effect.gen(function* () {
         const relative = yield* normalizeRepoRelativePath(path);
-        const files = yield* changedFiles;
-        if (!files.some((file) => file.path === relative)) {
-          return yield* ReviewInputViolation.make({
-            input: relative,
-            reason: "Path is not part of this pull request's changeset.",
-          });
-        }
-        const head = yield* metadata;
         const encodedPath = relative.split("/").map(encodeURIComponent).join("/");
         const response = yield* executeOk(
           "readFile",
@@ -336,12 +328,32 @@ export const gitHubPullRequestSourceLayer: Layer.Layer<
               `${target.apiUrl}/repos/${target.repository}/contents/${encodedPath}`,
             ).pipe(
               HttpClientRequest.accept("application/vnd.github.raw+json"),
-              HttpClientRequest.setUrlParams({ ref: head.headSha }),
+              HttpClientRequest.setUrlParams({ ref }),
             ),
             target.token,
           ),
         ).pipe(Effect.provideService(HttpClient.HttpClient, client));
-        const text = yield* response.text.pipe(Effect.mapError(failWith("readFile")));
+        const buffer = yield* response.arrayBuffer.pipe(Effect.mapError(failWith("readFile")));
+        if (buffer.byteLength > MAX_FILE_CHARS) {
+          return yield* ReviewInputViolation.make({
+            input: relative,
+            reason: `File is larger than the ${MAX_FILE_CHARS}-byte read bound.`,
+          });
+        }
+        const text = yield* Effect.try({
+          try: () => new TextDecoder("utf-8", { fatal: true }).decode(buffer),
+          catch: () =>
+            ReviewInputViolation.make({
+              input: relative,
+              reason: "File is not valid UTF-8 text.",
+            }),
+        });
+        if (text.includes("\u0000")) {
+          return yield* ReviewInputViolation.make({
+            input: relative,
+            reason: "File contains binary NUL bytes.",
+          });
+        }
         if (text.length > MAX_FILE_CHARS) {
           return yield* ReviewInputViolation.make({
             input: relative,
@@ -349,6 +361,55 @@ export const gitHubPullRequestSourceLayer: Layer.Layer<
           });
         }
         return text;
+      });
+
+    const changedFiles = yield* Effect.cached(
+      Effect.gen(function* () {
+        const [files, pullRequest] = yield* Effect.all([rawFiles, metadata]);
+        return yield* Effect.forEach(
+          files,
+          (file) => {
+            if (file.patch !== undefined) return Effect.succeed(file);
+            const basePath = file.previousPath ?? file.path;
+            const base =
+              file.status === "added"
+                ? Effect.succeed(Option.none<string>())
+                : readRepositoryFile(basePath, pullRequest.baseSha ?? pullRequest.baseRef).pipe(
+                    Effect.option,
+                  );
+            const head =
+              file.status === "removed"
+                ? Effect.succeed(Option.none<string>())
+                : readRepositoryFile(file.path, pullRequest.headSha).pipe(Effect.option);
+            return Effect.all({ base, head }).pipe(
+              Effect.map(({ base, head }) =>
+                ChangedFile.make({
+                  ...file,
+                  ...(Option.isSome(base) ? { reviewBaseContent: base.value } : {}),
+                  ...(Option.isSome(head) ? { reviewHeadContent: head.value } : {}),
+                }),
+              ),
+            );
+          },
+          { concurrency: 4 },
+        );
+      }),
+    );
+
+    const readFile = (path: string) =>
+      Effect.gen(function* () {
+        const relative = yield* normalizeRepoRelativePath(path);
+        const files = yield* changedFiles;
+        const file = files.find((candidate) => candidate.path === relative);
+        if (file === undefined) {
+          return yield* ReviewInputViolation.make({
+            input: relative,
+            reason: "Path is not part of this pull request's changeset.",
+          });
+        }
+        if (file.reviewHeadContent !== undefined) return file.reviewHeadContent;
+        const head = yield* metadata;
+        return yield* readRepositoryFile(relative, head.headSha);
       });
 
     return PullRequestSource.of({ metadata, changedFiles, anchorFiles: changedFiles, readFile });

--- a/packages/pr-review/src/internal/render.ts
+++ b/packages/pr-review/src/internal/render.ts
@@ -192,7 +192,7 @@ export const anchorViolation = (
 ): string | undefined => {
   const file = files.find((candidate) => candidate.path === finding.path);
   if (file === undefined) return "path is not part of the changeset";
-  if (file.patch === undefined) return "file has no textual diff";
+  if (file.patch === undefined) return "file has no anchorable textual diff";
   if (finding.endLine < finding.startLine) return "endLine precedes startLine";
   if (finding.endLine - finding.startLine + 1 > 100) return "range is implausibly large";
   const anchors = commentableLines(file.patch);

--- a/packages/pr-review/src/internal/review-agent.ts
+++ b/packages/pr-review/src/internal/review-agent.ts
@@ -2,7 +2,13 @@ import { Effect, Schema } from "effect";
 import { Agent, AgentPolicy, ToolExecutionClass, ToolResultBounds } from "effect-agent";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
-import { annotatePatch, ChangedFileStatus, ChangedPath, hasReviewableContent } from "./diff.ts";
+import {
+  annotatePatch,
+  ChangedFileStatus,
+  ChangedPath,
+  hasReviewableContent,
+  renderReviewContent,
+} from "./diff.ts";
 import {
   normalizeRepoRelativePath,
   PullRequestSource,
@@ -26,9 +32,6 @@ export const MAX_CONCERNS = 10;
 
 /** Annotated patches larger than this are truncated with an explicit marker. */
 const MAX_PATCH_CHARS = 60_000;
-
-/** Patchless content fallback stays below one ordinary model context window. */
-const MAX_CONTENT_REVIEW_CHARS = 220_000;
 
 /** The encoded Tool result must retain one complete bounded content fallback. */
 export const REVIEW_TOOL_RESULT_MAX_BYTES = 2 * 1024 * 1024;
@@ -191,38 +194,22 @@ export const readFileDiffHandler = (query: FileDiffQuery) =>
         reason: "Path is not part of this pull request's changeset.",
       });
     }
+    const contentEvidence = renderReviewContent(file);
     const reviewMode =
       file.patch !== undefined
         ? ("diff" as const)
-        : hasReviewableContent(file)
+        : contentEvidence !== undefined
           ? ("content" as const)
           : ("unavailable" as const);
-    const annotateContent = (side: "B" | "H", content: string): string =>
-      content
-        .split("\n")
-        .map((text, index) => `${side}${index + 1}   ${text}`)
-        .join("\n");
-    const contentEvidence =
-      reviewMode !== "content"
-        ? ""
-        : [
-            "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]",
-            ...(file.reviewBaseContent === undefined
-              ? []
-              : ["[BASE VERSION]", annotateContent("B", file.reviewBaseContent)]),
-            ...(file.reviewHeadContent === undefined
-              ? []
-              : ["[HEAD VERSION]", annotateContent("H", file.reviewHeadContent)]),
-          ].join("\n");
-    const annotated = file.patch === undefined ? contentEvidence : annotatePatch(file.patch);
-    const maximumChars = reviewMode === "content" ? MAX_CONTENT_REVIEW_CHARS : MAX_PATCH_CHARS;
-    const truncated = annotated.length > maximumChars;
+    const annotated =
+      file.patch === undefined ? (contentEvidence ?? "") : annotatePatch(file.patch);
+    const truncated = reviewMode === "diff" && annotated.length > MAX_PATCH_CHARS;
     return FileDiffView.make({
       path: file.path,
       status: file.status,
       reviewMode,
       annotatedPatch: truncated
-        ? `${annotated.slice(0, maximumChars)}\n[review evidence truncated at the bounded tool limit]`
+        ? `${annotated.slice(0, MAX_PATCH_CHARS)}\n[diff truncated]`
         : annotated,
       truncated,
     });

--- a/packages/pr-review/src/internal/review-agent.ts
+++ b/packages/pr-review/src/internal/review-agent.ts
@@ -1,8 +1,8 @@
 import { Effect, Schema } from "effect";
-import { Agent, AgentPolicy, ToolExecutionClass } from "effect-agent";
+import { Agent, AgentPolicy, ToolExecutionClass, ToolResultBounds } from "effect-agent";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
-import { annotatePatch, ChangedFileStatus, ChangedPath } from "./diff.ts";
+import { annotatePatch, ChangedFileStatus, ChangedPath, hasReviewableContent } from "./diff.ts";
 import {
   normalizeRepoRelativePath,
   PullRequestSource,
@@ -27,6 +27,12 @@ export const MAX_CONCERNS = 10;
 /** Annotated patches larger than this are truncated with an explicit marker. */
 const MAX_PATCH_CHARS = 60_000;
 
+/** Patchless content fallback stays below one ordinary model context window. */
+const MAX_CONTENT_REVIEW_CHARS = 220_000;
+
+/** The encoded Tool result must retain one complete bounded content fallback. */
+export const REVIEW_TOOL_RESULT_MAX_BYTES = 2 * 1024 * 1024;
+
 /** One `read_file` slice never exceeds this many lines. */
 const MAX_SLICE_LINES = 1_000;
 const DEFAULT_SLICE_LINES = 400;
@@ -43,6 +49,8 @@ export class ChangedFileSummary extends Schema.Class<ChangedFileSummary>(
   additions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   deletions: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   hasTextualDiff: Schema.Boolean,
+  /** True when a missing patch was recovered as bounded UTF-8 base/head content. */
+  hasReviewableContent: Schema.Boolean,
 }) {}
 
 export class ChangedFilesView extends Schema.Class<ChangedFilesView>(
@@ -82,10 +90,13 @@ export class FileDiffView extends Schema.Class<FileDiffView>(
 )({
   path: ChangedPath,
   status: ChangedFileStatus,
+  reviewMode: Schema.Literals(["diff", "content", "unavailable"]),
   /**
    * The unified diff with explicit RIGHT-side line numbers: `R<n>` marks a
    * line present in the new file version (only those may anchor findings);
-   * `-` marks removed lines. Empty when no textual diff exists.
+   * `-` marks removed lines. For content fallback, `B<n>` and `H<n>`
+   * identify base/head lines for reading only; they are never valid anchors.
+   * Empty only when neither a patch nor bounded textual content exists.
    */
   annotatedPatch: Schema.String,
   truncated: Schema.Boolean,
@@ -98,7 +109,7 @@ export class FileDiffView extends Schema.Class<FileDiffView>(
 // security (the run stays bounded by AgentPolicy regardless).
 export const ReadFileDiff = Tool.make("read_file_diff", {
   description:
-    "Read the annotated unified diff of one changed file. Lines marked R<number> exist in the new version and are the only valid finding anchors.",
+    "Read one changed file's review evidence. A normal unified diff marks valid anchors as R<number>. When GitHub omitted the diff, bounded base/head content is returned with B/H line labels for review but no valid inline anchors.",
   parameters: FileDiffQuery,
   success: FileDiffView,
   failure: Schema.Union([PullRequestSourceFailure, ReviewInputViolation]),
@@ -158,6 +169,7 @@ export const listChangedFilesHandler = (_query: ListChangedFilesQuery) =>
           additions: file.additions,
           deletions: file.deletions,
           hasTextualDiff: file.patch !== undefined,
+          hasReviewableContent: hasReviewableContent(file),
         }),
       ),
     });
@@ -179,13 +191,38 @@ export const readFileDiffHandler = (query: FileDiffQuery) =>
         reason: "Path is not part of this pull request's changeset.",
       });
     }
-    const annotated = file.patch === undefined ? "" : annotatePatch(file.patch);
-    const truncated = annotated.length > MAX_PATCH_CHARS;
+    const reviewMode =
+      file.patch !== undefined
+        ? ("diff" as const)
+        : hasReviewableContent(file)
+          ? ("content" as const)
+          : ("unavailable" as const);
+    const annotateContent = (side: "B" | "H", content: string): string =>
+      content
+        .split("\n")
+        .map((text, index) => `${side}${index + 1}   ${text}`)
+        .join("\n");
+    const contentEvidence =
+      reviewMode !== "content"
+        ? ""
+        : [
+            "[GitHub omitted the unified diff. B/H lines below are bounded full-file review content, not valid inline-comment anchors. Report defects from this evidence as non-anchored concerns.]",
+            ...(file.reviewBaseContent === undefined
+              ? []
+              : ["[BASE VERSION]", annotateContent("B", file.reviewBaseContent)]),
+            ...(file.reviewHeadContent === undefined
+              ? []
+              : ["[HEAD VERSION]", annotateContent("H", file.reviewHeadContent)]),
+          ].join("\n");
+    const annotated = file.patch === undefined ? contentEvidence : annotatePatch(file.patch);
+    const maximumChars = reviewMode === "content" ? MAX_CONTENT_REVIEW_CHARS : MAX_PATCH_CHARS;
+    const truncated = annotated.length > maximumChars;
     return FileDiffView.make({
       path: file.path,
       status: file.status,
+      reviewMode,
       annotatedPatch: truncated
-        ? `${annotated.slice(0, MAX_PATCH_CHARS)}\n[diff truncated]`
+        ? `${annotated.slice(0, maximumChars)}\n[review evidence truncated at the bounded tool limit]`
         : annotated,
       truncated,
     });
@@ -337,7 +374,7 @@ export const makeReviewInstructions =
       ...resolveGuidance(options.guidance, mission),
       "Work in this order:",
       "1. Call list_changed_files once to see the changeset.",
-      "2. Call read_file_diff for every file you review. In its output, only lines marked R<number> exist in the new version; those numbers are the only valid values for startLine and endLine. Never anchor a finding to a removed (-) line.",
+      "2. Call read_file_diff for every file you review. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
       "3. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap honestly in your summary when it matters.",
       "4. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
       "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
@@ -363,6 +400,7 @@ export const defaultReviewPolicy = AgentPolicy.make({
   // Keep enough output/summary headroom for the 200k-class provider window;
   // tool-heavy histories prune before the engine spends a summarization call.
   contextTokenLimit: 150_000,
+  toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   // Budget soft landing (RUN-018): an exhausted reviewer returns its partial
   // review on one final tool-free turn instead of failing the whole run.
   onExhaustion: "final-answer",

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -443,9 +443,29 @@ export const selectedPullRequestSourceLayer = (
     Effect.gen(function* () {
       const source = yield* PullRequestSource;
       const selectedPaths = new Set(selection.files.map((file) => file.path));
+      const selectedFiles = source.changedFiles.pipe(
+        Effect.map((fullFiles) => {
+          const fullByPath = new Map(fullFiles.map((file) => [file.path, file] as const));
+          return selection.files.map((file) => {
+            if (file.patch !== undefined) return file;
+            const full = fullByPath.get(file.path);
+            return full === undefined
+              ? file
+              : ChangedFile.make({
+                  ...file,
+                  ...(full.reviewBaseContent === undefined
+                    ? {}
+                    : { reviewBaseContent: full.reviewBaseContent }),
+                  ...(full.reviewHeadContent === undefined
+                    ? {}
+                    : { reviewHeadContent: full.reviewHeadContent }),
+                });
+          });
+        }),
+      );
       return PullRequestSource.of({
         metadata: source.metadata,
-        changedFiles: Effect.succeed(selection.files),
+        changedFiles: selectedFiles,
         anchorFiles: source.anchorFiles,
         readFile: (path) =>
           selectedPaths.has(path)

--- a/packages/pr-review/src/internal/review-units.ts
+++ b/packages/pr-review/src/internal/review-units.ts
@@ -1,7 +1,7 @@
 import { Schema } from "effect";
 
 import type { ChangedFile } from "./diff.ts";
-import { ChangedPath } from "./diff.ts";
+import { ChangedPath, isReviewableFile } from "./diff.ts";
 import type { FindingSeverity } from "./review-agent.ts";
 import { ReviewFinding } from "./review-agent.ts";
 
@@ -48,7 +48,7 @@ export class ReviewUnitPlan extends Schema.Class<ReviewUnitPlan>(
   /** True when the source returned fewer files than the pull request has. */
   truncated: Schema.Boolean,
   units: Schema.Array(ReviewUnit).check(Schema.isMaxLength(MAX_REVIEW_UNITS)),
-  /** Changed files without a textual diff; no finding can anchor to them. */
+  /** Changed files with neither a textual diff nor bounded base/head text. */
   undiffablePaths: Schema.Array(ChangedPath).check(Schema.isMaxLength(300)),
   /**
    * Diffable files beyond the fan-out capacity (MAX_REVIEW_UNITS units of
@@ -58,8 +58,12 @@ export class ReviewUnitPlan extends Schema.Class<ReviewUnitPlan>(
   unassignedPaths: Schema.Array(ChangedPath).check(Schema.isMaxLength(300)),
 }) {}
 
-const fileCost = (file: ChangedFile): number =>
-  file.additions + file.deletions + FILE_OVERHEAD_LINES;
+const fileCost = (file: ChangedFile): number => {
+  const contentChars =
+    (file.reviewBaseContent?.length ?? 0) + (file.reviewHeadContent?.length ?? 0);
+  const contentWeight = Math.ceil(contentChars / 200);
+  return file.additions + file.deletions + contentWeight + FILE_OVERHEAD_LINES;
+};
 
 const unitOf = (index: number, files: ReadonlyArray<ChangedFile>): ReviewUnit =>
   ReviewUnit.make({
@@ -76,10 +80,12 @@ const unitOf = (index: number, files: ReadonlyArray<ChangedFile>): ReviewUnit =>
  * then packed greedily in that order under the soft changed-line budget and
  * the hard per-unit file bound. Capacity is finite and explicit:
  *
- * - files without a textual diff are not delegated — no finding can anchor
- *   to them (anchor validation demands a parsed patch), so they surface in
- *   `undiffablePaths` instead of consuming a child's budget;
- * - diffable files beyond `MAX_REVIEW_UNITS` full units surface in
+ * - files without a textual diff are still delegated when the source
+ *   recovered complete bounded UTF-8 base/head content. Findings from that
+ *   evidence cannot anchor inline and are reported as concerns;
+ * - files with neither form of textual evidence surface in
+ *   `undiffablePaths` instead of laundering missing coverage;
+ * - reviewable files beyond `MAX_REVIEW_UNITS` full units surface in
  *   `unassignedPaths` so the review can report them as unreviewed, never
  *   silently truncated.
  */
@@ -88,14 +94,14 @@ export const planReviewUnits = (
   options: { readonly totalChangedFiles: number },
 ): ReviewUnitPlan => {
   const ordered = [...files].sort((left, right) => (left.path < right.path ? -1 : 1));
-  const diffable = ordered.filter((file) => file.patch !== undefined);
-  const undiffable = ordered.filter((file) => file.patch === undefined);
+  const reviewable = ordered.filter(isReviewableFile);
+  const undiffable = ordered.filter((file) => !isReviewableFile(file));
 
   const groups: Array<Array<ChangedFile>> = [];
   const unassigned: Array<ChangedFile> = [];
   let current: Array<ChangedFile> = [];
   let currentCost = 0;
-  for (const file of diffable) {
+  for (const file of reviewable) {
     const cost = fileCost(file);
     const wouldOverflow =
       current.length >= MAX_UNIT_FILES ||

--- a/packages/pr-review/test/fingerprint.test.ts
+++ b/packages/pr-review/test/fingerprint.test.ts
@@ -61,6 +61,21 @@ describe("computeChangesetFingerprint", () => {
       expect(yield* computeChangesetFingerprint([editedPatch, fileB], "sig")).not.toBe(forward);
       expect(yield* computeChangesetFingerprint([fileA, fileB], "other-sig")).not.toBe(forward);
       expect(yield* computeChangesetFingerprint([fileA], "sig")).not.toBe(forward);
+
+      const recovered = ChangedFile.make({
+        path: "db/snapshot.json",
+        status: "added",
+        additions: 1,
+        deletions: 0,
+        reviewHeadContent: '{"version":1}',
+      });
+      const editedRecovered = ChangedFile.make({
+        ...recovered,
+        reviewHeadContent: '{"version":2}',
+      });
+      expect(yield* computeChangesetFingerprint([editedRecovered], "sig")).not.toBe(
+        yield* computeChangesetFingerprint([recovered], "sig"),
+      );
     }),
   );
 });

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -4,8 +4,10 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import {
   GitHubReviewTarget,
+  gitHubPullRequestSourceLayer,
   gitHubPriorReviewsLayer,
   PriorReviews,
+  PullRequestSource,
   renderFingerprintMarker,
   ReviewState,
   ReviewStateAuthenticator,
@@ -95,6 +97,96 @@ describe("GitHub prior reviews", () => {
 
       expect(Option.getOrUndefined(result.fingerprint)).toBe(FINGERPRINT);
       expect(Option.getOrUndefined(result.state)).toEqual(reviewState);
+    }),
+  );
+});
+
+describe("GitHub pull-request source", () => {
+  it.effect("recovers omitted text patches without treating binary content as reviewable", () =>
+    Effect.gen(function* () {
+      const baseSha = "1".repeat(40);
+      const headSha = "2".repeat(40);
+      const snapshot = '{"version":"7","tables":{"widgets":{"columns":{"id":"uuid"}}}}';
+      const client = HttpClient.make((request, url) => {
+        if (url.pathname === "/repos/acme/widgets/pulls/30") {
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(
+                JSON.stringify({
+                  number: 30,
+                  title: "Add generated schema state",
+                  body: "",
+                  changed_files: 2,
+                  base: { ref: "main", sha: baseSha },
+                  head: { ref: "feature/schema", sha: headSha },
+                }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            ),
+          );
+        }
+        if (url.pathname === "/repos/acme/widgets/pulls/30/files") {
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(
+                JSON.stringify([
+                  {
+                    filename: "db/snapshot.json",
+                    status: "added",
+                    additions: 1,
+                    deletions: 0,
+                  },
+                  {
+                    filename: "assets/logo.png",
+                    status: "added",
+                    additions: 0,
+                    deletions: 0,
+                  },
+                ]),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            ),
+          );
+        }
+        if (url.pathname === "/repos/acme/widgets/contents/db/snapshot.json") {
+          expect(url.searchParams.get("ref")).toBe(headSha);
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(request, new Response(snapshot, { status: 200 })),
+          );
+        }
+        if (url.pathname === "/repos/acme/widgets/contents/assets/logo.png") {
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00]), { status: 200 }),
+            ),
+          );
+        }
+        return Effect.die(new Error(`Unexpected request: ${url}`));
+      });
+      const dependencies = Layer.merge(
+        GitHubReviewTarget.layer({
+          apiUrl: "https://api.github.test",
+          repository: "acme/widgets",
+          number: 30,
+          token: Option.none(),
+        }),
+        Layer.succeed(HttpClient.HttpClient)(client),
+      );
+      const sourceLayer = gitHubPullRequestSourceLayer.pipe(Layer.provide(dependencies));
+      const files = yield* Effect.gen(function* () {
+        const source = yield* PullRequestSource;
+        return yield* source.changedFiles;
+      }).pipe(Effect.provide(sourceLayer));
+
+      expect(files.find((file) => file.path === "db/snapshot.json")?.reviewHeadContent).toBe(
+        snapshot,
+      );
+      expect(
+        files.find((file) => file.path === "assets/logo.png")?.reviewHeadContent,
+      ).toBeUndefined();
     }),
   );
 });

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -192,6 +192,7 @@ const runOfflineFanOut = (script: {
   readonly children: ReadonlyArray<OfflineUnitScript>;
   readonly review: CodeReview;
   readonly unitCalls?: ReadonlyArray<OfflineUnitCall> | undefined;
+  readonly sourceFixture?: FixturePullRequest | undefined;
 }) =>
   Effect.gen(function* () {
     const coordinator = yield* makeOfflineFanOutCoordinatorModel({
@@ -202,7 +203,7 @@ const runOfflineFanOut = (script: {
     const parentBinding = Agent.withModel(FanOutReviewer, coordinator.model);
     const childBinding = Agent.withModel(FileReviewer, children.model);
     const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
-    const sourceLayer = fixturePullRequestSourceLayer(fixture);
+    const sourceLayer = fixturePullRequestSourceLayer(script.sourceFixture ?? fixture);
     const childSupportLayer = Layer.mergeAll(
       FileReviewToolkitLayer,
       SubagentReservationsMemoryLive,
@@ -341,6 +342,26 @@ describe("planReviewUnits", () => {
     expect(plan.units[1]?.changedLines).toBe(300);
     expect([...plan.undiffablePaths]).toEqual(["assets/logo.png"]);
     expect(plan.unassignedPaths).toHaveLength(0);
+  });
+
+  it("assigns patchless files recovered as bounded text and keeps binaries unreviewed", () => {
+    const snapshot = ChangedFile.make({
+      path: "db/snapshot.json",
+      status: "added",
+      additions: 1,
+      deletions: 0,
+      reviewHeadContent: '{"version":"7","tables":{}}',
+    });
+    const binary = ChangedFile.make({
+      path: "assets/logo.png",
+      status: "added",
+      additions: 0,
+      deletions: 0,
+    });
+    const plan = planReviewUnits([snapshot, binary], { totalChangedFiles: 2 });
+
+    expect(plan.units.flatMap((unit) => [...unit.paths])).toEqual([snapshot.path]);
+    expect([...plan.undiffablePaths]).toEqual([binary.path]);
   });
 
   it("is deterministic regardless of input order", () => {
@@ -498,6 +519,61 @@ describe("offline fan-out review run", () => {
         expect(finalPrompt).toContain(alphaFinding.title);
         expect(finalPrompt).toContain(gammaFinding.title);
       }),
+  );
+
+  it.effect("reviews a patchless generated text file through bounded head content", () =>
+    Effect.gen(function* () {
+      const snapshotPath = "packages/db/migrations/next/snapshot.json";
+      const snapshotContent = `{"version":"7","payload":"${"x".repeat(142_900)}","tail":"snapshot-tail"}`;
+      const snapshotFixture = FixturePullRequest.make({
+        metadata: PullRequestMetadata.make({
+          repository: "acme/widgets",
+          number: 203,
+          title: "Add generated migration snapshot",
+          body: "",
+          baseRef: "main",
+          headRef: "feature/migration",
+          headSha: FIXTURE_SHA,
+          totalChangedFiles: 1,
+        }),
+        files: [
+          FixtureFile.make({
+            file: ChangedFile.make({
+              path: snapshotPath,
+              status: "added",
+              additions: 1,
+              deletions: 0,
+            }),
+            headContent: snapshotContent,
+          }),
+        ],
+      });
+      const cleanReport = FileReviewReport.make({ unitId: "unit-001", findings: [] });
+      const cleanReview = CodeReview.make({
+        summary: "Reviewed the generated snapshot through bounded head content.",
+        verdict: "approve",
+        findings: [],
+      });
+
+      const result = yield* runOfflineFanOut({
+        sourceFixture: snapshotFixture,
+        unitCalls: [{ unitId: "unit-001", paths: [snapshotPath] }],
+        children: [
+          {
+            unitId: "unit-001",
+            diffPath: snapshotPath,
+            outcome: { _tag: "findings", report: cleanReport },
+          },
+        ],
+        review: cleanReview,
+      });
+
+      expect(result.outcome.coverage.status).toBe("complete");
+      expect(result.outcome.coverage.unreviewedPaths).toEqual([]);
+      expect(result.childPrompts.join("\n")).toContain("snapshot-tail");
+      expect(result.childPrompts.join("\n")).toContain("not valid inline-comment anchors");
+      expect(result.outcome.plan.body).not.toContain("Incomplete coverage");
+    }),
   );
 
   it.effect("projects child concerns to the coordinator and renders them as body sections", () =>

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -364,6 +364,30 @@ describe("planReviewUnits", () => {
     expect([...plan.undiffablePaths]).toEqual([binary.path]);
   });
 
+  it("keeps fallback evidence beyond the complete render bound unreviewed", () => {
+    const lineHeavyAddition = ChangedFile.make({
+      path: "db/line-heavy.json",
+      status: "added",
+      additions: 100_000,
+      deletions: 0,
+      reviewHeadContent: "x\n".repeat(100_000),
+    });
+    const largeModification = ChangedFile.make({
+      path: "db/large-modified.json",
+      status: "modified",
+      additions: 1,
+      deletions: 1,
+      reviewBaseContent: "b".repeat(120_000),
+      reviewHeadContent: "h".repeat(120_000),
+    });
+    const plan = planReviewUnits([lineHeavyAddition, largeModification], {
+      totalChangedFiles: 2,
+    });
+
+    expect(plan.units).toEqual([]);
+    expect([...plan.undiffablePaths]).toEqual(["db/large-modified.json", "db/line-heavy.json"]);
+  });
+
   it("is deterministic regardless of input order", () => {
     const shuffled = [...fixtureFiles].reverse();
     expect(planReviewUnits(shuffled, { totalChangedFiles: 5 })).toEqual(
@@ -572,6 +596,7 @@ describe("offline fan-out review run", () => {
       expect(result.outcome.coverage.unreviewedPaths).toEqual([]);
       expect(result.childPrompts.join("\n")).toContain("snapshot-tail");
       expect(result.childPrompts.join("\n")).toContain("not valid inline-comment anchors");
+      expect(result.childPrompts.join("\n")).toContain('"truncated":false');
       expect(result.outcome.plan.body).not.toContain("Incomplete coverage");
     }),
   );

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -277,7 +277,7 @@ describe("publication planning", () => {
     ).toContain("not part of the diff");
     expect(
       anchorViolation(ReviewFinding.make({ ...validFinding, path: "assets/logo.png" }), files),
-    ).toContain("no textual diff");
+    ).toContain("no anchorable textual diff");
     expect(
       anchorViolation(ReviewFinding.make({ ...validFinding, path: "not/changed.ts" }), files),
     ).toContain("not part of the changeset");
@@ -417,7 +417,7 @@ describe("publication planning", () => {
       totalChangedFiles: 2,
     });
     expect(plan.body).toContain("_(demoted: line 99 is not part of the diff)_");
-    expect(plan.body).toContain("_(demoted: file has no textual diff)_");
+    expect(plan.body).toContain("_(demoted: file has no anchorable textual diff)_");
   });
 });
 


### PR DESCRIPTION
## Summary

- Recover bounded UTF-8 base/head content when GitHub omits a patch, allowing generated text files such as the snapshot in [reve-ai/kommunikasie#433](https://github.com/reve-ai/kommunikasie/pull/433) to receive complete review coverage.
- Keep binary, unreadable, incomplete, and over-bound content fail-closed while ensuring fallback evidence cannot create invalid inline anchors or count truncated evidence as complete.
- Carry recovered evidence through [the GitHub source boundary](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/src/internal/github.ts#L320-L412), [review planning and coverage](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/src/internal/review-units.ts#L92-L145), and [the model evidence tool](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/src/internal/review-agent.ts#L185-L220).

## What went wrong

The GitHub pull-files response can omit patch for generated or oversized text. The reviewer modeled every missing patch as permanently undiffable, so the planner skipped the file and coverage correctly refused to pass. A large one-line JSON snapshot therefore caused incomplete coverage even though its raw text was available from the repository contents endpoint.

The source now reads the required side or sides from the exact pull-request base/head revisions with a 200 KB bound, strict UTF-8 decoding, and binary NUL rejection. Reviewable fallback content enters the normal unit and coverage flow; unavailable content remains an explicit coverage gap.

During review, the initial implementation also exposed a fail-open mismatch: valid raw sides could render beyond the model-facing limit after B/H labels, while coverage only observed a successful tool call. Planning and tool output now share one renderer, so fallback evidence is either returned whole under 220,000 characters or remains an explicit coverage gap. Content-mode evidence is never truncated.

## Architecture

- ChangedFile owns optional bounded base/head evidence. renderReviewContent is the shared planning/tool invariant and accepts only complete required sides whose final B/H rendering fits the model-facing bound.
- The GitHub adapter owns content recovery. Individual recovery failures degrade to unavailable evidence instead of aborting the whole source read.
- read_file_diff returns accepted fallback evidence whole and tells the model to report defects as non-anchored concerns. Only real unified-diff R lines remain valid GitHub comment anchors.
- Changeset fingerprints include fallback content so patchless text changes invalidate stored review continuity.

## Evidence

- [The live-source adapter regression](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/test/github.test.ts#L105-L197) recovers an omitted JSON patch while rejecting PNG bytes as reviewable text.
- [The end-to-end fan-out regression](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/test/pr-review-fanout.test.ts#L548-L626) reviews a 143 KB one-line snapshot through its tail sentinel, observes truncated=false, and completes coverage.
- [The render-bound regression](https://github.com/danieljvdm/effect-agent/blob/3ca0b3a93ad981c9129633b32894ae3f5d66a176/packages/pr-review/test/pr-review-fanout.test.ts#L367-L393) keeps both line-label expansion and two-sided overflow unreviewed.