### PR TITLE
fix(pr-review): skip patch-equivalent rebases

### DIFF
--- a/.changeset/skip-equivalent-rebase-review.md
+++ b/.changeset/skip-equivalent-rebase-review.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Skip model execution for authenticated, patch-equivalent pull-request rebases while preserving the prior review conclusion. Changeset fingerprints now ignore unified-diff hunk coordinate shifts but remain sensitive to changed diff content and review configuration.

--- a/action/README.md
+++ b/action/README.md
@@ -61,12 +61,22 @@ paths changed or reverted since the baseline are reconsidered. A compatible
 ancestor advance of the base includes overlapping PR paths as affected
 context.
 
+Before ancestry-based range selection, the action compares the current
+accepted-scope fingerprint with the authenticated prior state. The fingerprint
+hashes the ignore-filtered file paths, statuses, addition/deletion counts,
+unified-diff content and context (excluding hunk line coordinates), bounded
+patchless base/head evidence, pull-request framing, and reviewer profile. It
+does not hash commit IDs or base ancestry. An equivalent rebase therefore
+creates the new head-bound workflow check but skips model execution and posts
+no duplicate review or findings; the stored blocking/success conclusion is
+preserved. A changed diff, PR framing, model, guidance, bounds, or ignore
+configuration reviews again.
+
 The action visibly falls back to the full current PR diff when state is
 missing or unreadable, PR/base/head/profile identity is incompatible, a prior
 head is no longer an ancestor, a comparison is unavailable or truncated, or
-the base lineage changed materially. `skip-unchanged: "true"` (the default)
-avoids model execution when the same head was already covered, but preserves
-the stored blocking or successful conclusion.
+the base lineage changed materially and the accepted-scope fingerprint does
+not match. `skip-unchanged: "true"` is the default.
 Only terminal markers authored by the configured `review-author` identity,
 authenticated with the same stable `state-secret`, and pinned to the review's
 commit may narrow scope. The author defaults to `github-actions[bot]`; when
@@ -77,6 +87,16 @@ do not expose it to the model or derive it from pull-request content.
 The authenticated marker itself is capped at 24,000 characters. Signing or
 size failures omit state, render a bounded warning, and force the next run to
 review fully instead of posting continuity data that cannot be recovered.
+
+The workflow needs `contents: read` for bounded base/head file fallback (and a
+checked-out guidance file), plus `pull-requests: write` to read/post reviews
+and maintain progress comments.
+GitHub attaches the workflow job's check to each new head SHA; the action does
+not need `checks: write` for that lightweight check. Fingerprint equivalence is
+textual, not semantic: if a base change alters runtime meaning without changing
+the effective diff/context, the cache cannot detect that. Use
+`review-mode: final` (or disable `skip-unchanged`) when such a base change needs
+a deliberate fresh audit.
 
 After a new state-bearing review posts, `retire-stale-reviews: "true"` (the
 default) turns earlier marker-bearing bot reviews into collapsed, superseded

--- a/action/action.yml
+++ b/action/action.yml
@@ -85,9 +85,10 @@ inputs:
     default: "never"
   skip-unchanged:
     description: >-
-      Skip model execution when the current head is already the last
-      successfully reviewed head ('true', default), while preserving the
-      stored blocking/success conclusion. Set 'false' to force execution.
+      Skip model execution when the current effective patch matches the last
+      completely reviewed patch ('true', default), including commit-ID-only
+      rebases, while preserving the stored blocking/success conclusion. Set
+      'false' to force execution.
     required: false
     default: "true"
   retire-stale-reviews:
@@ -126,7 +127,7 @@ inputs:
     default: "Info"
 outputs:
   skipped:
-    description: "'true' when the event is not reviewable or the head already has stored coverage."
+    description: "'true' when the event is not reviewable or the effective patch already has stored coverage."
   skip-reason:
     description: "Why the run skipped (set only when skipped is 'true')."
   fingerprint:

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -41833,7 +41833,8 @@ var sha256Hex = (text2) => exports_Effect.promise(async () => {
 var FIELD = "\x00";
 var RECORD = "\x01";
 var SECTION = "\x02";
-var canonicalChangeset = (files) => files.map((file2) => `${file2.path}${FIELD}${file2.status}${FIELD}${String(file2.additions)}${FIELD}${String(file2.deletions)}${FIELD}${file2.patch ?? ""}${FIELD}${file2.reviewBaseContent ?? ""}${FIELD}${file2.reviewHeadContent ?? ""}`).sort().join(RECORD);
+var canonicalPatch = (patch3) => patch3.replace(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/gm, "@@ -_ +_ @@");
+var canonicalChangeset = (files) => files.map((file2) => `${file2.path}${FIELD}${file2.status}${FIELD}${String(file2.additions)}${FIELD}${String(file2.deletions)}${FIELD}${file2.patch === undefined ? "" : canonicalPatch(file2.patch)}${FIELD}${file2.reviewBaseContent ?? ""}${FIELD}${file2.reviewHeadContent ?? ""}`).sort().join(RECORD);
 var computeChangesetFingerprint = (files, signature) => sha256Hex(`${canonicalChangeset(files)}${SECTION}${signature}`);
 
 // packages/pr-review/src/internal/ignore.ts
@@ -54806,6 +54807,30 @@ var concludeReviewState = (state) => {
   });
   return reasons.length > 0 ? { conclusion: "blocking", reasons } : { conclusion: "success", reasons: [] };
 };
+var skipCoveredReview = exports_Effect.fn("skipCoveredReview")(function* (input) {
+  const result4 = concludeReviewState(input.state);
+  yield* exports_Console.log(`Skipping review of ${input.repository}#${input.pullRequestNumber}: ${input.reason}.`);
+  yield* writeActionOutputs([
+    ["skipped", "true"],
+    ["skip-reason", input.reason],
+    ...input.fingerprint === undefined ? [] : [["fingerprint", input.fingerprint]],
+    ["conclusion", result4.conclusion],
+    ["coverage", "complete"],
+    ["review-mode", "incremental"]
+  ]);
+  yield* writeStepSummary([
+    "### Pull-request review skipped",
+    `- Reason: ${input.reason}`,
+    `- Preserved check conclusion: **${result4.conclusion}**`
+  ]);
+  if (result4.conclusion === "blocking") {
+    return yield* ReviewGateFailed.make({
+      conclusion: "blocking",
+      reasons: result4.reasons
+    });
+  }
+  return { _tag: "Skipped", reason: input.reason };
+});
 var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* () {
   const event = yield* readGitHubEvent();
   if (exports_Option.isSome(event)) {
@@ -54821,9 +54846,12 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
     let selection;
     if (reviewer.profileFingerprint !== undefined) {
       const source = yield* PullRequestSource;
-      const [snapshot2, profileFingerprint] = yield* exports_Effect.all([
+      const [snapshot2, profileFingerprint, currentFingerprint] = yield* exports_Effect.all([
         reviewer.snapshot ?? exports_Effect.all({ metadata: source.metadata, files: source.anchorFiles }),
-        reviewer.profileFingerprint
+        reviewer.profileFingerprint,
+        reviewer.fingerprint === undefined ? exports_Effect.succeed(undefined) : reviewer.fingerprint.pipe(exports_Effect.map((fingerprint) => fingerprint), exports_Effect.orElseSucceed(() => {
+          return;
+        }))
       ]);
       const { metadata, files: fullFiles } = snapshot2;
       const history = options3.priorReviews ?? (yield* PriorReviews);
@@ -54838,6 +54866,16 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           failure: undefined
         })
       }));
+      const equivalentPatchState = (options3.reviewMode ?? "incremental") === "incremental" && options3.skipUnchanged !== false && recovered.state !== undefined && currentFingerprint !== undefined && validateReviewState(recovered.state, metadata, profileFingerprint) === undefined && recovered.state.acceptedScopeFingerprint === currentFingerprint ? recovered.state : undefined;
+      if (equivalentPatchState !== undefined) {
+        return yield* skipCoveredReview({
+          repository: target.repository,
+          pullRequestNumber: target.number,
+          reason: equivalentPatchState.reviewedHeadSha === metadata.headSha ? "the current head already has complete stored review coverage" : "the effective pull-request patch is unchanged since the last complete review",
+          state: equivalentPatchState,
+          fingerprint: currentFingerprint
+        });
+      }
       let comparison;
       let baseComparison;
       if ((options3.reviewMode ?? "incremental") === "incremental" && recovered.state !== undefined) {
@@ -54887,28 +54925,13 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
         stateAuthenticator
       };
       if (options3.skipUnchanged !== false && selection.mode === "incremental" && selection.files.length === 0 && selection.priorState !== undefined) {
-        const result4 = concludeReviewState(selection.priorState);
         const reason = "no changed review scope since the last successfully reviewed head";
-        yield* exports_Console.log(`Skipping review of ${target.repository}#${target.number}: ${reason}.`);
-        yield* writeActionOutputs([
-          ["skipped", "true"],
-          ["skip-reason", reason],
-          ["conclusion", result4.conclusion],
-          ["coverage", "complete"],
-          ["review-mode", "incremental"]
-        ]);
-        yield* writeStepSummary([
-          "### Pull-request review skipped",
-          `- Reason: ${reason}`,
-          `- Preserved check conclusion: **${result4.conclusion}**`
-        ]);
-        if (result4.conclusion === "blocking") {
-          return yield* ReviewGateFailed.make({
-            conclusion: "blocking",
-            reasons: result4.reasons
-          });
-        }
-        return { _tag: "Skipped", reason };
+        return yield* skipCoveredReview({
+          repository: target.repository,
+          pullRequestNumber: target.number,
+          reason,
+          state: selection.priorState
+        });
       }
     } else if (options3.skipUnchanged !== false && reviewer.fingerprint !== undefined) {
       const current = yield* reviewer.fingerprint;

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -150,8 +150,14 @@ and comparison checks are fail-closed for scope selection: missing, stale,
 incompatible, or truncated state/comparisons produce a visible full-diff
 fallback. An ancestor base advance remains incremental and adds overlapping
 PR paths as affected context; a materially changed base lineage falls back to
-full. Re-running the same covered head skips model execution by default while
-preserving its stored blocking/success conclusion.
+full unless the authenticated accepted-scope fingerprint still matches. That
+fingerprint hashes the ignore-filtered effective diff, patchless base/head
+evidence, PR framing, and review-shaping profile while excluding commit IDs,
+base ancestry, and unified-diff hunk coordinates. Re-running the same covered
+head or a patch-equivalent rebase skips model execution by default while
+preserving its stored blocking/success conclusion and posting no duplicate
+review comments. Missing/corrupt state and any fingerprint or profile mismatch
+review conservatively.
 
 After a new state-bearing Action review posts, prior marker-bearing bot reviews
 are retired by default: their bodies become collapsed, superseded history,
@@ -172,6 +178,9 @@ and with a bounded warning, so the next run safely performs a full review.
 `review-mode: final` is the explicit bounded merge-readiness audit. It reviews
 the full current PR diff and resets the incremental baseline; normal
 `synchronize` events use `incremental` and do not perform this audit.
+Because equivalence is based on the textual review surface, a base change that
+alters runtime meaning without changing the diff/context is not detectable;
+request `final` mode (or disable unchanged skipping) for that case.
 
 ## Hosts
 

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -28,6 +28,7 @@ import {
   selectReviewRange,
   selectedPullRequestSourceLayer,
   unavailableReviewStateAuthenticatorLayer,
+  validateReviewState,
   webCryptoReviewStateAuthenticatorLayer,
 } from "./internal/review-state.ts";
 import { fanOutReviewBudgetLimits, reviewBudgetLimits } from "./internal/run.ts";
@@ -391,6 +392,39 @@ const concludeReviewState = (state: ReviewState) => {
     : ({ conclusion: "success", reasons: [] } as const);
 };
 
+const skipCoveredReview = Effect.fn("skipCoveredReview")(function* (input: {
+  readonly repository: string;
+  readonly pullRequestNumber: number;
+  readonly reason: string;
+  readonly state: ReviewState;
+  readonly fingerprint?: string | undefined;
+}) {
+  const result = concludeReviewState(input.state);
+  yield* Console.log(
+    `Skipping review of ${input.repository}#${input.pullRequestNumber}: ${input.reason}.`,
+  );
+  yield* writeActionOutputs([
+    ["skipped", "true"],
+    ["skip-reason", input.reason],
+    ...(input.fingerprint === undefined ? [] : ([["fingerprint", input.fingerprint]] as const)),
+    ["conclusion", result.conclusion],
+    ["coverage", "complete"],
+    ["review-mode", "incremental"],
+  ]);
+  yield* writeStepSummary([
+    "### Pull-request review skipped",
+    `- Reason: ${input.reason}`,
+    `- Preserved check conclusion: **${result.conclusion}**`,
+  ]);
+  if (result.conclusion === "blocking") {
+    return yield* ReviewGateFailed.make({
+      conclusion: "blocking",
+      reasons: result.reasons,
+    });
+  }
+  return { _tag: "Skipped", reason: input.reason } satisfies ReviewActionResult;
+});
+
 /**
  * Harness one already-built reviewer inside the Actions environment: resolve
  * the target from the event, provide the GitHub source/publisher/prior
@@ -441,9 +475,15 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
       let selection: ReturnType<typeof selectReviewRange> | undefined;
       if (reviewer.profileFingerprint !== undefined) {
         const source = yield* PullRequestSource;
-        const [snapshot, profileFingerprint] = yield* Effect.all([
+        const [snapshot, profileFingerprint, currentFingerprint] = yield* Effect.all([
           reviewer.snapshot ?? Effect.all({ metadata: source.metadata, files: source.anchorFiles }),
           reviewer.profileFingerprint,
+          reviewer.fingerprint === undefined
+            ? Effect.succeed(undefined)
+            : reviewer.fingerprint.pipe(
+                Effect.map((fingerprint): string | undefined => fingerprint),
+                Effect.orElseSucceed(() => undefined),
+              ),
         ]);
         const { metadata, files: fullFiles } = snapshot;
         const history = options.priorReviews ?? (yield* PriorReviews);
@@ -465,6 +505,27 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
                   }),
                 }),
               );
+        const equivalentPatchState =
+          (options.reviewMode ?? "incremental") === "incremental" &&
+          options.skipUnchanged !== false &&
+          recovered.state !== undefined &&
+          currentFingerprint !== undefined &&
+          validateReviewState(recovered.state, metadata, profileFingerprint) === undefined &&
+          recovered.state.acceptedScopeFingerprint === currentFingerprint
+            ? recovered.state
+            : undefined;
+        if (equivalentPatchState !== undefined) {
+          return yield* skipCoveredReview({
+            repository: target.repository,
+            pullRequestNumber: target.number,
+            reason:
+              equivalentPatchState.reviewedHeadSha === metadata.headSha
+                ? "the current head already has complete stored review coverage"
+                : "the effective pull-request patch is unchanged since the last complete review",
+            state: equivalentPatchState,
+            fingerprint: currentFingerprint,
+          });
+        }
         let comparison: ReviewHeadComparison | undefined;
         let baseComparison: ReviewHeadComparison | undefined;
         if (
@@ -522,30 +583,13 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
           selection.files.length === 0 &&
           selection.priorState !== undefined
         ) {
-          const result = concludeReviewState(selection.priorState);
           const reason = "no changed review scope since the last successfully reviewed head";
-          yield* Console.log(
-            `Skipping review of ${target.repository}#${target.number}: ${reason}.`,
-          );
-          yield* writeActionOutputs([
-            ["skipped", "true"],
-            ["skip-reason", reason],
-            ["conclusion", result.conclusion],
-            ["coverage", "complete"],
-            ["review-mode", "incremental"],
-          ]);
-          yield* writeStepSummary([
-            "### Pull-request review skipped",
-            `- Reason: ${reason}`,
-            `- Preserved check conclusion: **${result.conclusion}**`,
-          ]);
-          if (result.conclusion === "blocking") {
-            return yield* ReviewGateFailed.make({
-              conclusion: "blocking",
-              reasons: result.reasons,
-            });
-          }
-          return { _tag: "Skipped", reason } satisfies ReviewActionResult;
+          return yield* skipCoveredReview({
+            repository: target.repository,
+            pullRequestNumber: target.number,
+            reason,
+            state: selection.priorState,
+          });
         }
       } else if (options.skipUnchanged !== false && reviewer.fingerprint !== undefined) {
         // Preserve the pre-state custom harness contract explicitly. The

--- a/packages/pr-review/src/internal/fingerprint.ts
+++ b/packages/pr-review/src/internal/fingerprint.ts
@@ -50,6 +50,15 @@ const RECORD = "\u0001";
 const SECTION = "\u0002";
 
 /**
+ * Unified-diff hunk coordinates describe where a patch applies, not what it
+ * changes. A content-equivalent rebase can shift both coordinates while
+ * leaving every context/addition/deletion line unchanged, so exclude only
+ * those coordinates from the canonical patch representation.
+ */
+const canonicalPatch = (patch: string): string =>
+  patch.replace(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/gm, "@@ -_ +_ @@");
+
+/**
  * Canonical changeset encoding: sorted by path so provider ordering never
  * matters, with every review-relevant field of every file.
  */
@@ -57,7 +66,7 @@ const canonicalChangeset = (files: ReadonlyArray<ChangedFile>): string =>
   files
     .map(
       (file) =>
-        `${file.path}${FIELD}${file.status}${FIELD}${String(file.additions)}${FIELD}${String(file.deletions)}${FIELD}${file.patch ?? ""}${FIELD}${file.reviewBaseContent ?? ""}${FIELD}${file.reviewHeadContent ?? ""}`,
+        `${file.path}${FIELD}${file.status}${FIELD}${String(file.additions)}${FIELD}${String(file.deletions)}${FIELD}${file.patch === undefined ? "" : canonicalPatch(file.patch)}${FIELD}${file.reviewBaseContent ?? ""}${FIELD}${file.reviewHeadContent ?? ""}`,
     )
     .sort()
     .join(RECORD);

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -26,6 +26,7 @@ import {
   type ReviewActionResult,
 } from "../src/action.ts";
 import {
+  ChangedFile,
   CodeReview,
   InvalidEffortInput,
   planPublication,
@@ -588,6 +589,134 @@ describe("runReviewAction", () => {
       const outputs = yield* Ref.get(harness.written);
       expect(outputs).toContain("skipped=true");
       expect(outputs).toContain("conclusion=blocking");
+    }),
+  );
+
+  it.effect("skips a patch-equivalent rebase without requiring head ancestry", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const reviewedHeadSha = "1".repeat(40);
+      const currentHeadSha = "2".repeat(40);
+      const profileFingerprint = "a".repeat(64);
+      const patchFingerprint = "b".repeat(64);
+      const metadata = PullRequestMetadata.make({
+        repository: "acme/widgets",
+        number: 5,
+        title: "Review target",
+        body: "",
+        baseRef: "main",
+        baseSha: "3".repeat(40),
+        headRef: "fix/review",
+        headSha: currentHeadSha,
+        totalChangedFiles: 1,
+      });
+      const file = ChangedFile.make({
+        path: "src/a.ts",
+        status: "modified",
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -8 +8 @@\n-before\n+after",
+      });
+      const state = ReviewState.make({
+        version: 1,
+        repository: metadata.repository,
+        pullRequestNumber: metadata.number,
+        baseRef: metadata.baseRef,
+        baseSha: "4".repeat(40),
+        headRef: metadata.headRef,
+        reviewedHeadSha,
+        profileFingerprint,
+        acceptedScopeFingerprint: patchFingerprint,
+        reviewedPathCount: 1,
+        unresolvedFindings: [],
+        unresolvedConcerns: [],
+        lastReviewMode: "full",
+      });
+      const invoked = yield* Ref.make(0);
+      const result = yield* runReviewAction(
+        {
+          run: () =>
+            Ref.update(invoked, (count) => count + 1).pipe(
+              Effect.map(() => fakeOutcome("comment")),
+            ),
+          fingerprint: Effect.succeed(patchFingerprint),
+          profileFingerprint: Effect.succeed(profileFingerprint),
+          snapshot: Effect.succeed({ metadata, files: [file] }),
+        },
+        {
+          post: false,
+          priorReviews: staticPriorReviews(Option.none(), { state: Option.some(state) }),
+        },
+      ).pipe(Effect.provide(harness.layer));
+
+      expect(result._tag).toBe("Skipped");
+      expect(yield* Ref.get(invoked)).toBe(0);
+      const outputs = yield* Ref.get(harness.written);
+      expect(outputs).toContain("effective pull-request patch is unchanged");
+      expect(outputs).toContain("conclusion=success");
+    }),
+  );
+
+  it.effect("reviews a rebased head when the effective patch changed", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const profileFingerprint = "a".repeat(64);
+      const metadata = PullRequestMetadata.make({
+        repository: "acme/widgets",
+        number: 5,
+        title: "Review target",
+        body: "",
+        baseRef: "main",
+        baseSha: "3".repeat(40),
+        headRef: "fix/review",
+        headSha: "2".repeat(40),
+        totalChangedFiles: 0,
+      });
+      const state = ReviewState.make({
+        version: 1,
+        repository: metadata.repository,
+        pullRequestNumber: metadata.number,
+        baseRef: metadata.baseRef,
+        baseSha: "4".repeat(40),
+        headRef: metadata.headRef,
+        reviewedHeadSha: "1".repeat(40),
+        profileFingerprint,
+        acceptedScopeFingerprint: "b".repeat(64),
+        reviewedPathCount: 0,
+        unresolvedFindings: [],
+        unresolvedConcerns: [],
+        lastReviewMode: "full",
+      });
+      const invoked = yield* Ref.make(0);
+      const result = yield* runReviewAction(
+        {
+          run: () =>
+            Ref.update(invoked, (count) => count + 1).pipe(
+              Effect.map(() => fakeOutcome("comment")),
+            ),
+          fingerprint: Effect.succeed("c".repeat(64)),
+          profileFingerprint: Effect.succeed(profileFingerprint),
+          snapshot: Effect.succeed({ metadata, files: [] }),
+        },
+        {
+          post: false,
+          priorReviews: staticPriorReviews(Option.none(), { state: Option.some(state) }),
+        },
+      ).pipe(Effect.provide(harness.layer));
+
+      expect(result._tag).toBe("Completed");
+      expect(yield* Ref.get(invoked)).toBe(1);
+      expect(yield* Ref.get(harness.written)).toContain("skipped=false");
     }),
   );
 });

--- a/packages/pr-review/test/fingerprint.test.ts
+++ b/packages/pr-review/test/fingerprint.test.ts
@@ -78,6 +78,27 @@ describe("computeChangesetFingerprint", () => {
       );
     }),
   );
+
+  it.effect("ignores rebase-only hunk coordinate shifts", () =>
+    Effect.gen(function* () {
+      const beforeRebase = ChangedFile.make({
+        ...fileA,
+        patch: "@@ -10,2 +10,3 @@ function configure() {\n const a = 1;\n+const b = 2;",
+      });
+      const afterRebase = ChangedFile.make({
+        ...beforeRebase,
+        patch: "@@ -27,2 +27,3 @@ function configure() {\n const a = 1;\n+const b = 2;",
+      });
+      const changedPatch = ChangedFile.make({
+        ...afterRebase,
+        patch: "@@ -27,2 +27,3 @@ function configure() {\n const a = 1;\n+const b = 3;",
+      });
+
+      const before = yield* computeChangesetFingerprint([beforeRebase], "sig");
+      expect(yield* computeChangesetFingerprint([afterRebase], "sig")).toBe(before);
+      expect(yield* computeChangesetFingerprint([changedPatch], "sig")).not.toBe(before);
+    }),
+  );
 });
 
 describe("plan fingerprint embedding", () => {


### PR DESCRIPTION
## Summary

- Short-circuit model execution when the [current full review fingerprint matches authenticated prior state](https://github.com/danieljvdm/effect-agent/blob/8ca59c4d3313647f163e7be938aaed0dd8ef1c39/packages/pr-review/src/action.ts#L508), before rewritten ancestry can force a full review.
- Make the [canonical patch representation ignore unified-diff hunk coordinates](https://github.com/danieljvdm/effect-agent/blob/8ca59c4d3313647f163e7be938aaed0dd8ef1c39/packages/pr-review/src/internal/fingerprint.ts#L52) while retaining paths, statuses, counts, textual diff/context, patchless evidence, PR framing, and reviewer configuration.
- Preserve the authenticated prior blocking/success conclusion for the new head-bound workflow check, without posting or retiring review comments on an equivalent patch.

## What went wrong

Complete Action reviews already persisted an accepted-scope fingerprint in authenticated review-body state. The packaged Action used that state only for head-ancestry-based incremental selection, however. A rebase rewrote the prior head out of the new head ancestry, so selection fell back to the full PR diff before the stored fingerprint was ever compared. That caused a fresh model run and another possible comment batch even when the authored patch was equivalent.

The new equivalence gate validates repository, PR, refs, and reviewer profile, then compares the current full-scope fingerprint before ancestry lookup. Missing or corrupt state, fingerprint failures, profile changes, substantive diff changes, and explicit final-audit mode all continue into the conservative review path.

## Architecture

GitHub review bodies remain the only cache/state store. No new external persistence or Checks API permission is introduced. GitHub still creates the ordinary workflow check for each head SHA; `contents: read`, `pull-requests: write`, a stable `state-secret`, and the correct bot `review-author` are documented in the [Action state and permission contract](https://github.com/danieljvdm/effect-agent/blob/8ca59c4d3313647f163e7be938aaed0dd8ef1c39/action/README.md#L64).

Fingerprint equivalence is textual, not semantic. If a base change alters runtime meaning without changing the effective diff/context, the cache cannot detect that; operators should request `review-mode: final` or disable unchanged skipping for that audit.

## Evidence

- [Action regression](https://github.com/danieljvdm/effect-agent/blob/8ca59c4d3313647f163e7be938aaed0dd8ef1c39/packages/pr-review/test/action.test.ts#L595): an equivalent rebase with rewritten head/base ancestry invokes the reviewer zero times, while a changed fingerprint invokes it once.
- [Fingerprint regression](https://github.com/danieljvdm/effect-agent/blob/8ca59c4d3313647f163e7be938aaed0dd8ef1c39/packages/pr-review/test/fingerprint.test.ts#L82): shifted hunk coordinates hash identically; changed added text does not.
- Focused regression run: 2 files, 28 tests passed. Full `vp run check`, all package/example builds, and docs build passed.
- The full local `vp run ready` test phase was rerun sequentially after a Vite+ parallel spawn fault. All product, reviewer, crash, certification, chaos, soak, Cloudflare, and example suites passed; two unrelated release-toolchain shell tests timed out at their fixed 15s/90s limits both in the graph and in isolation. CI remains authoritative for those two environment-sensitive tests.