### PR TITLE
fix(platform-cloudflare): quiesce conversation maintenance

### DIFF
--- a/.changeset/quiescent-conversation-maintenance.md
+++ b/.changeset/quiescent-conversation-maintenance.md
@@ -1,0 +1,14 @@
+---
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/session": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+---
+
+Make Cloudflare Conversation maintenance durably incremental and quiescent (#93). Stable
+externally-driven waits now clear their alarm after acknowledging the observed maintenance
+generation, while pre-armed public and routed mutations, restart recovery, and bounded autonomous
+rearming preserve liveness. A caught-up forced alarm takes an O(1) maintenance-record path without
+recovery, ledger scans, or canonical-history reads. Child settlements also commit the parent's
+durable wake before child ledger finalization, preventing eviction from losing a quiescent join.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -39,7 +39,7 @@ restart-recovery, hosted publication, or untrusted-code isolation claim. See
 - one SQLite-backed Durable Object per Conversation;
 - Cloudflare Workers provide stateless ingress;
 - Durable Object storage owns Conversation state and queue order;
-- alarms wake unsettled work;
+- alarms wake dirty or autonomously actionable work while stable external waits may quiesce;
 - no PostgreSQL dependency.
 
 No package or example may use “durable” without naming DN or DC and the tested adapter.
@@ -264,6 +264,32 @@ Durable Object storage is the only correctness-critical store for that Conversat
 object state is a cache because objects may stop unexpectedly. Alarm work is idempotent because
 alarms execute at least once.
 
+Conversation maintenance is incremental rather than a perpetual nonterminal poll. Each Object
+stores a versioned `dirty`/`processed` generation beside its single alarm slot:
+
+- every public or routed mutation advances `dirty` and establishes the alarm in one storage
+  transaction before its first durable effect;
+- a short incarnation-local gate serializes that pre-arm boundary with pass generation snapshots
+  and acknowledgements, but never spans the mutation body or cross-Object I/O;
+- a pass acknowledges only the generation it observed. It cannot acknowledge while an RPC/port
+  mutation remains in flight, and a later racing generation therefore retains its alarm;
+- after eviction the in-memory gate/count resets, while the durable unprocessed generation and
+  pre-armed alarm cause recovery to resume any committed autonomous work;
+- once classified as a stable externally-driven wait (`ApprovalPending`, unresolved ordinary
+  outcome, joined child, or child awaiting parent establishment), the observed generation is
+  acknowledged and the alarm clears. Its resolving mutation re-establishes both generation and
+  alarm before changing the wait;
+- autonomous retry, indeterminate admission/establishment, lease recovery, and other locally
+  actionable states leave the generation unprocessed and rearm with bounded backoff;
+- a forced alarm with `processed >= dirty` reads only the maintenance record, clears the alarm,
+  and returns. It performs no runtime recovery, ledger scan, or canonical-history read.
+
+Child-to-parent settlement follows the same quiescent contract. After the exact child Settlement
+record is canonical but before child ledger finalization, the child routes the idempotent durable
+settlement marker to the parent. That routed mutation pre-arms and dirties the parent, so child
+eviction after finalization cannot strand a quiescent parent. Same-store ledgers accept this
+notification only for the exact `terminalizing` reservation; earlier states fail closed.
+
 The target is no longer experimental: the generic durability conformance suite —
 the same adapter-neutral case arrays the Node adapters run — passes inside workerd, and the
 eviction (per-failpoint `ctx.abort()` with alarm-only convergence), alarm-retry (double-fire
@@ -336,3 +362,6 @@ Current platform references:
 - **DEPLOY-011**: The Dynamic Worker Code Mode executor denies ambient egress, enforces platform
   CPU and executor wall-clock limits, disposes Worker and RPC handles in Scope finalizers, and
   claims deployment class `E` only.
+- **DEPLOY-012**: Cloudflare Conversation maintenance is generation-incremental and quiescent for
+  stable external waits; pre-armed mutations, pass acknowledgement, restart recovery, and
+  autonomous rearming obey the protocol above.

--- a/docs/spec/persistence.md
+++ b/docs/spec/persistence.md
@@ -259,7 +259,9 @@ Purpose: first-class edge deployment alongside Node/SQLite.
 - Durable Object identity provides per-Conversation routing and serialized coordination;
 - Durable Object storage transactions implement local atomic methods;
 - important state is always written to storage rather than relying on in-memory object state;
-- alarms wake unsettled work without requiring a new client request;
+- a durable dirty/processed maintenance generation and pre-armed alarm wake committed autonomous
+  work without a new client request, while stable externally-driven waits quiesce until their
+  next mutation;
 - alarm handlers are idempotent because alarm delivery is at least once;
 - R2 may hold large immutable attachments/artifacts;
 - cross-Conversation indexes are optional projections, not recovery truth.

--- a/docs/spec/subagents.md
+++ b/docs/spec/subagents.md
@@ -682,7 +682,7 @@ capability because they weaken structured ownership and complicate accepted-work
 | Parent abort canonical, before child abort                    | Recovery emits the one idempotent child abort command                                       |
 | Child abort canonical, before parent propagation marker       | Recovery repairs the marker without a second command                                        |
 | Child terminal races with child abort                         | The one canonical child Settlement wins and is joined                                       |
-| After child Settlement, before parent observes it             | Parent wakes and reads the same Settlement                                                  |
+| After child Settlement append, before child ledger finalizes  | Parent marker/generation is durable first; parent wakes and reads the same Settlement       |
 | After result projection, before parent join append            | Projection is recomputed from canonical child output and fixed digests                      |
 | After join append, before budget `releasePending`             | Canonical join drives idempotent accounting repair                                          |
 | After `releasePending`, before `released`                     | The fixed consumed/released amounts are applied once                                        |

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -136,6 +136,12 @@ After recovery it asserts:
 - uncertain ordinary tools do not replay automatically;
 - terminalizing work eventually settles.
 
+The public Durable Object RPC/alarm seam also carries the maintenance regressions from
+[issue #93](https://github.com/danieljvdm/effect-agent/issues/93): a stable approval wait clears
+its alarm; a forced caught-up alarm performs no SQLite, ledger, recovery, or canonical-history
+work; mutations racing acknowledgement and mutations held after pre-arm remain dirty; and a child
+evicted after settlement finalization has already committed its parent marker/generation.
+
 The crash-point table in [durability.md](./durability.md) is a minimum coverage
 matrix and should be machine-linked to test names.
 

--- a/packages/platform-cloudflare/src/alarm.ts
+++ b/packages/platform-cloudflare/src/alarm.ts
@@ -5,8 +5,20 @@ import {
   type DurableBindingFailure,
   type DurableWorkerFailure,
   type RecoveryReport,
+  type SubmissionSnapshot,
 } from "@effect-agent/session";
-import { Clock, Context, Effect, Layer, Option, Random, Ref, Schema, Stream } from "effect";
+import {
+  Clock,
+  Context,
+  Effect,
+  Layer,
+  Option,
+  Random,
+  Ref,
+  Schema,
+  Semaphore,
+  Stream,
+} from "effect";
 
 import { ConversationObjectIdentity, DurableObjectContext } from "./bindings.ts";
 import { CloudflareDurableRuntimeConfig } from "./config.ts";
@@ -17,11 +29,10 @@ import { CloudflareDurableRuntimeConfig } from "./config.ts";
  * and abort re-checks, retry backoff) multiplexes into one idempotent maintenance pass, and
  * the slot always holds the EARLIEST deadline any caller asked for.
  *
- * The alarm invariant (plan §1.4): committed nonterminal work implies a committed alarm.
- * It is established by pre-arming — every mutating entry point and every pass arms the alarm
- * BEFORE its durable mutations — so an eviction at any failpoint leaves a persisted alarm
- * that workerd re-delivers to a fresh incarnation WITHOUT any incoming request. Spurious
- * alarms are harmless by design: a pass over an all-settled lane simply deletes the slot.
+ * The alarm invariant (plan §1.4): every committed actionable mutation carries a newer durable
+ * maintenance generation and a committed alarm. Stable externally-driven waits may be
+ * nonterminal without retaining an alarm; their resolving mutation advances the generation and
+ * restores the alarm atomically.
  */
 
 /** The Durable Object alarm API failed; surfaces on host entry points as a typed refusal. */
@@ -63,17 +74,16 @@ export class DurableAlarmService extends Context.Service<
      * caused, and routing open uncertain-class Tool Calls into spurious Unknown Outcomes.
      * Deferral is contract-safe: wakes are droppable hints, every mutating entry point
      * pre-arms BEFORE its first durable mutation (the alarm invariant never rests on this
-     * call), and the deferred wake is flushed when the pass completes.
+     * call). The pass's durable generation check observes any racing mutation, so the
+     * in-memory hint does not need to be flushed after a stable wait is acknowledged.
      */
     readonly scheduleNow: Effect.Effect<void, DurableAlarmError>;
     /**
-     * Run one maintenance pass with wake deferral (see `scheduleNow`): `scheduleNow` calls
-     * while `body` executes coalesce into one flag, flushed as an immediate re-arm after the
-     * pass — failures of the flush are logged and swallowed (hints are droppable; the pass's
-     * own re-arm policy already bounded the next delivery).
+     * Run one maintenance pass with wake deferral (see `scheduleNow`). Calls made while `body`
+     * executes are droppable promptness hints; correctness rests on the durable generation.
      */
     readonly withWakesDeferred: <A, E, R>(body: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>;
-    /** Clear the slot; only the maintenance pass does this, and only when all work settled. */
+    /** Clear the slot; correctness-sensitive clears live in maintenance generation transactions. */
     readonly cancel: Effect.Effect<void, DurableAlarmError>;
   }
 >()("@effect-agent/platform-cloudflare/DurableAlarmService") {
@@ -87,7 +97,6 @@ export class DurableAlarmService extends Context.Service<
          * on top of the already-committed pre-armed alarm.
          */
         const runningPasses = yield* Ref.make(0);
-        const wakeDeferred = yield* Ref.make(false);
         const scheduled = Effect.tryPromise({
           try: () => ctx.storage.getAlarm(),
           catch: alarmFailure("get alarm"),
@@ -113,33 +122,12 @@ export class DurableAlarmService extends Context.Service<
           Effect.flatMap((now) => ensureScheduledBy(now)),
         );
         const scheduleNow = Ref.get(runningPasses).pipe(
-          Effect.flatMap((passes) => (passes > 0 ? Ref.set(wakeDeferred, true) : armNow)),
-        );
-        /**
-         * Flush after the LAST concurrent pass: the re-arm lands at the very end of the alarm
-         * handler, where a superseding cancellation only re-delivers to the already-idempotent
-         * pass. Runs inside `Effect.ensuring`, so flush failures are logged, never raised.
-         */
-        const flushDeferredWake = Ref.get(runningPasses).pipe(
-          Effect.flatMap((passes) =>
-            passes > 0
-              ? Effect.void
-              : Ref.getAndSet(wakeDeferred, false).pipe(
-                  Effect.flatMap((wanted) => (wanted ? armNow : Effect.void)),
-                ),
-          ),
-          Effect.catch((error) =>
-            Effect.logWarning("DurableAlarmService: deferred wake flush failed", error),
-          ),
+          Effect.flatMap((passes) => (passes > 0 ? Effect.void : armNow)),
         );
         const withWakesDeferred = <A, E, R>(body: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
           Ref.update(runningPasses, (passes) => passes + 1).pipe(
             Effect.andThen(body),
-            Effect.ensuring(
-              Ref.update(runningPasses, (passes) => passes - 1).pipe(
-                Effect.andThen(flushDeferredWake),
-              ),
-            ),
+            Effect.ensuring(Ref.update(runningPasses, (passes) => passes - 1)),
           );
         const cancel = Effect.tryPromise({
           try: () => ctx.storage.deleteAlarm(),
@@ -161,15 +149,112 @@ export class DurableAlarmService extends Context.Service<
 export class MaintenancePassReport extends Schema.Class<MaintenancePassReport>(
   "@effect-agent/platform-cloudflare/MaintenancePassReport",
 )({
+  /** `caught-up` is generation-only; `actionable` ran recovery and one bounded drain. */
+  phase: Schema.Literals(["caught-up", "actionable"]),
   /** Recovery decisions executed (or deferred) BEFORE any new claim in this pass. */
   recovered: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   /** Settlements the drain pass finalized. */
   settled: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   /** Submissions still nonterminal after the pass (suspended/unknown lanes stay honest). */
   nonterminal: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
-  /** `rearmed` while nonterminal work remains, `cleared` once everything settled. */
+  /** `rearmed` for dirty/autonomous work, `cleared` for stable waits or settlement. */
   alarm: Schema.Literals(["rearmed", "cleared"]),
 }) {}
+
+/** Fault boundaries around every maintenance-owned durable mutation. */
+export type ConversationMaintenanceFailpointLocation =
+  | "maintenance:dirty:before"
+  | "maintenance:dirty:after"
+  | "maintenance:mutation:armed"
+  | "maintenance:mutation:finished"
+  | "maintenance:ensure:before"
+  | "maintenance:ensure:after"
+  | "maintenance:begin:before"
+  | "maintenance:begin:after"
+  | "maintenance:finish:before"
+  | "maintenance:finish:after";
+
+export type ConversationMaintenanceFailpointHandler = (
+  location: ConversationMaintenanceFailpointLocation,
+) => Effect.Effect<void>;
+
+/** Test-only fault authority; production uses the inert layer. */
+export class ConversationMaintenanceFailpoint extends Context.Service<
+  ConversationMaintenanceFailpoint,
+  {
+    readonly hit: ConversationMaintenanceFailpointHandler;
+  }
+>()("@effect-agent/platform-cloudflare/ConversationMaintenanceFailpoint") {
+  static readonly layer = Layer.succeed(this)({ hit: () => Effect.void });
+}
+
+const MaintenanceGeneration = Schema.BigIntFromString.check(
+  Schema.isGreaterThanOrEqualToBigInt(0n),
+);
+
+/** Versioned, platform-private maintenance state stored through Durable Object KV. */
+class ConversationMaintenanceState extends Schema.Class<ConversationMaintenanceState>(
+  "@effect-agent/platform-cloudflare/ConversationMaintenanceState",
+)({
+  schemaVersion: Schema.Literal(1),
+  dirty: MaintenanceGeneration,
+  processed: MaintenanceGeneration,
+  nonterminal: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+}) {}
+
+const MAINTENANCE_STATE_KEY = "effect-agent:conversation-maintenance:v1";
+const decodeMaintenanceState = Schema.decodeUnknownSync(ConversationMaintenanceState);
+const encodeMaintenanceState = Schema.encodeSync(ConversationMaintenanceState);
+
+const initialMaintenanceState = (): ConversationMaintenanceState =>
+  ConversationMaintenanceState.make({
+    schemaVersion: 1,
+    // Bootstrap Objects created by the pre-generation release without scanning the ledger in
+    // the constructor. One useful pass classifies and acknowledges any existing obligation.
+    dirty: 1n,
+    processed: 0n,
+    nonterminal: 0,
+  });
+
+const readMaintenanceState = async (
+  transaction: DurableObjectTransaction,
+): Promise<{ readonly state: ConversationMaintenanceState; readonly initialized: boolean }> => {
+  const encoded = await transaction.get(MAINTENANCE_STATE_KEY);
+  return encoded === undefined
+    ? { state: initialMaintenanceState(), initialized: false }
+    : { state: decodeMaintenanceState(encoded), initialized: true };
+};
+
+const ensureTransactionAlarmBy = async (
+  transaction: DurableObjectTransaction,
+  deadline: number,
+): Promise<void> => {
+  const scheduled = await transaction.getAlarm();
+  if (scheduled === null || scheduled > deadline) {
+    await transaction.setAlarm(deadline);
+  }
+};
+
+const stableExternalWait = (
+  snapshot: SubmissionSnapshot,
+  reports: ReadonlyMap<string, RecoveryReport>,
+): boolean => {
+  switch (snapshot.state) {
+    case "suspended":
+    case "unknown":
+    case "joined":
+      return true;
+    case "admitted":
+      return reports.get(snapshot.submissionId)?.decision._tag === "AwaitParentEstablishment";
+    case "input-applied":
+    case "joining":
+    case "ready":
+    case "running":
+    case "settled":
+    case "terminalizing":
+      return false;
+  }
+};
 
 export type MaintenancePassFailure =
   | DurableWorkerFailure
@@ -177,25 +262,17 @@ export type MaintenancePassFailure =
   | DurableAlarmError;
 
 /**
- * The idempotent maintenance pass and the alarm-invariant helpers (plan §1.4, D-P6-1/2).
+ * Incremental, quiescent maintenance over a durable dirty/processed generation (issue #93).
  *
- * `pass` = pre-arm → `runRecovery` → `processConversationResolved` → re-arm-or-clear:
+ * `pass` = generation snapshot/pre-arm → recovery → bounded drain → generation acknowledgement:
  *
- * 1. **Pre-arm**: the alarm is re-armed at `now + wakeScanInterval` BEFORE any work, so an
- *    eviction (or thrown failure → workerd alarm retry) at any point of the pass leaves a
- *    committed alarm and the fresh incarnation converges without an incoming request.
- * 2. **Reconcile before new work** (exit gate): every pass classifies and repairs every
- *    nonterminal Submission before the drain claims anything; the pure classifier and the
- *    repair executors are idempotent, so at-least-once alarm delivery re-runs them safely.
- * 3. **Drain**: one bounded `processConversationResolved` pass over this Object's lane — the
- *    D-P6-1 shape; no infinite `runResolvedWorker` loop ever pins the Object.
- * 4. **Re-arm policy**: nonterminal work re-arms at `now + min(backoff-with-jitter,
- *    wakeScanInterval)` — the scan interval bounds every wait (lease expiry of a dead
- *    incarnation included, since claims retry each pass) and the backoff (reset on progress,
- *    grown otherwise) keeps stuck lanes from busy-spinning; all settled clears the slot.
- *
- * Every step is a durability-protocol step that already tolerates re-execution, which is
- * what makes double-fired alarms harmless (the alarm.test.ts gate).
+ * 1. One storage transaction reads dirty/processed and re-arms before work. A caught-up forced
+ *    alarm takes an O(1) path without recovery, ledger scans, or canonical-history reads.
+ * 2. Recovery still strictly precedes a new claim, and one bounded drain advances the lane.
+ * 3. The final transaction acknowledges only the generation observed at pass start. A racing
+ *    mutation therefore remains `dirty > processed` and retains its atomically-established alarm.
+ * 4. Stable external waits acknowledge and clear. Autonomous retry, indeterminate, and lease
+ *    recovery states leave their generation dirty and retain bounded backoff rearming.
  */
 export class ConversationMaintenance extends Context.Service<
   ConversationMaintenance,
@@ -203,17 +280,18 @@ export class ConversationMaintenance extends Context.Service<
     /** One idempotent maintenance pass; failures propagate so workerd retries the alarm. */
     readonly pass: Effect.Effect<MaintenancePassReport, MaintenancePassFailure>;
     /**
-     * Defensive half of the alarm invariant, run by the constructor gate: if any local
-     * Submission is nonterminal and no alarm is scheduled, arm one within the scan interval.
-     * Local-only (one ledger scan + the alarm slot) — never a recovery pass, never transport.
+     * Constructor gate: initialize/inspect only the O(1) maintenance record and ensure a dirty
+     * generation has an alarm. It never scans the ledger or canonical history.
      */
     readonly ensureAlarm: Effect.Effect<void, MaintenancePassFailure>;
     /**
-     * The pre-arm every mutating entry point runs BEFORE its first durable mutation: with
-     * the alarm committed first, a committed admission (or any other committed nonterminal
-     * transition) can never be observed without the alarm that will finish it.
+     * Serialize the pre-arm boundary with pass acknowledgement, advance the durable dirty
+     * generation and arm the alarm in one transaction BEFORE running the caller's mutation.
+     * A pass cannot acknowledge while that mutation remains in flight.
      */
-    readonly preArm: Effect.Effect<void, DurableAlarmError>;
+    readonly withMutation: <A, E, R>(
+      body: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | DurableAlarmError, R>;
   }
 >()("@effect-agent/platform-cloudflare/ConversationMaintenance") {
   static readonly layer: Layer.Layer<
@@ -223,8 +301,10 @@ export class ConversationMaintenance extends Context.Service<
     | AgentBindingResolver
     | SubmissionLedger
     | DurableAlarmService
+    | ConversationMaintenanceFailpoint
     | CloudflareDurableRuntimeConfig
     | ConversationObjectIdentity
+    | DurableObjectContext
   > = Layer.effect(ConversationMaintenance)(
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
@@ -233,20 +313,113 @@ export class ConversationMaintenance extends Context.Service<
       const alarm = yield* DurableAlarmService;
       const config = yield* CloudflareDurableRuntimeConfig;
       const identity = yield* ConversationObjectIdentity;
+      const { ctx } = yield* DurableObjectContext;
+      const failpoint = yield* ConversationMaintenanceFailpoint;
 
       /**
        * Consecutive no-progress passes — an in-memory CACHE, not state: a fresh incarnation
        * restarts at zero and merely re-arms sooner than a long-lived one would have.
        */
       const stalls = yield* Ref.make(0);
+      /**
+       * Incarnation-local mutation count guarded with the generation transactions below. It is
+       * deliberately not durable: after eviction every begun mutation has stopped, while its
+       * pre-armed dirty generation remains durable for recovery. The short gate never spans the
+       * caller's mutation or cross-Object I/O.
+       */
+      const activeMutations = yield* Ref.make(0);
+      const generationGate = yield* Semaphore.make(1);
+      // At-least-once deliveries are idempotent, but overlapping pass bodies could otherwise
+      // acknowledge state while a sibling pass is still mutating it. Port/RPC mutations do not
+      // take this permit, so cross-Object I/O cannot deadlock the maintenance serialization.
+      const maintenancePassGate = yield* Semaphore.make(1);
+      const minimumAlarmDelay = Math.max(1, Math.ceil(config.alarmBackoffBase / 2));
 
-      const preArm = Clock.currentTimeMillis.pipe(
-        Effect.flatMap((now) => alarm.ensureScheduledBy(now + config.wakeScanInterval)),
+      const runTransaction = <A>(
+        operation: string,
+        transaction: () => Promise<A>,
+      ): Effect.Effect<A, DurableAlarmError> =>
+        Effect.tryPromise({
+          try: transaction,
+          catch: alarmFailure(operation),
+        });
+
+      const beginMutation = Effect.fn("ConversationMaintenance.beginMutation")(function* () {
+        yield* failpoint.hit("maintenance:dirty:before");
+        const now = yield* Clock.currentTimeMillis;
+        yield* runTransaction("advance maintenance generation", () =>
+          ctx.storage.transaction(async (transaction) => {
+            const { state } = await readMaintenanceState(transaction);
+            const next = ConversationMaintenanceState.make({
+              ...state,
+              dirty: state.dirty + 1n,
+            });
+            await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(next));
+            // The earliest configured retry bounds a newly actionable mutation without relying
+            // on its best-effort immediate wake hint.
+            await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
+          }),
+        );
+        yield* failpoint.hit("maintenance:dirty:after");
+        yield* Ref.update(activeMutations, (active) => active + 1);
+      });
+
+      const endMutation = generationGate.withPermit(
+        Ref.update(activeMutations, (active) => Math.max(0, active - 1)),
       );
 
-      const countNonterminal = Stream.runCollect(ledger.scanNonterminal).pipe(
-        Effect.map((snapshots) => snapshots.length),
-      );
+      const withMutation = <A, E, R>(
+        body: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, E | DurableAlarmError, R> =>
+        Effect.acquireUseRelease(
+          generationGate.withPermit(beginMutation()),
+          () =>
+            failpoint.hit("maintenance:mutation:armed").pipe(
+              Effect.andThen(body),
+              Effect.tap(() => failpoint.hit("maintenance:mutation:finished")),
+            ),
+          () => endMutation,
+        );
+
+      const ensureAlarm = Effect.fn("ConversationMaintenance.ensureAlarm")(function* () {
+        yield* failpoint.hit("maintenance:ensure:before");
+        const now = yield* Clock.currentTimeMillis;
+        yield* runTransaction("ensure maintenance alarm", () =>
+          ctx.storage.transaction(async (transaction) => {
+            const { state, initialized } = await readMaintenanceState(transaction);
+            if (!initialized) {
+              await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(state));
+            }
+            if (state.dirty > state.processed) {
+              await ensureTransactionAlarmBy(transaction, now + config.wakeScanInterval);
+            }
+          }),
+        );
+        yield* failpoint.hit("maintenance:ensure:after");
+      });
+
+      const beginPass = Effect.fn("ConversationMaintenance.beginPass")(function* () {
+        yield* failpoint.hit("maintenance:begin:before");
+        const now = yield* Clock.currentTimeMillis;
+        const result = yield* runTransaction("begin maintenance pass", () =>
+          ctx.storage.transaction(async (transaction) => {
+            const { state, initialized } = await readMaintenanceState(transaction);
+            if (!initialized) {
+              await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(state));
+            }
+            if (state.processed >= state.dirty) {
+              await transaction.deleteAlarm();
+              return { _tag: "CaughtUp" as const, nonterminal: state.nonterminal };
+            }
+            // Pre-arm the earliest retry before recovery. A successful finish may move this slot
+            // LATER to its bounded backoff, which does not cancel the running handler.
+            await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
+            return { _tag: "Actionable" as const, generation: state.dirty };
+          }),
+        );
+        yield* failpoint.hit("maintenance:begin:after");
+        return result;
+      });
 
       const rearmDelay = Effect.fn("ConversationMaintenance.rearmDelay")(function* (
         progressed: boolean,
@@ -268,66 +441,110 @@ export class ConversationMaintenance extends Context.Service<
         MaintenancePassReport,
         MaintenancePassFailure
       > {
-        // Step 1 — pre-arm: an abort or throw anywhere below leaves a committed alarm.
-        yield* preArm;
+        const annotate = (report: MaintenancePassReport) =>
+          Effect.annotateCurrentSpan({
+            phase: report.phase,
+            recovered: report.recovered,
+            settled: report.settled,
+            nonterminal: report.nonterminal,
+            alarm: report.alarm,
+          }).pipe(Effect.as(report));
+
+        const started = yield* generationGate.withPermit(
+          Effect.gen(function* () {
+            const activeAtStart = yield* Ref.get(activeMutations);
+            const generation = yield* beginPass();
+            return { ...generation, activeAtStart };
+          }),
+        );
+        if (started._tag === "CaughtUp") {
+          return yield* annotate(
+            MaintenancePassReport.make({
+              phase: "caught-up",
+              recovered: 0,
+              settled: 0,
+              nonterminal: started.nonterminal,
+              alarm: "cleared",
+            }),
+          );
+        }
         // Step 2 — reconciliation strictly precedes new work in this pass (exit gate).
         const recovered: ReadonlyArray<RecoveryReport> = yield* runtime.runRecovery;
         // Step 3 — one bounded drain pass over this Object's own lane.
         const settlements = yield* runtime
           .processConversationResolved(identity.conversationId)
           .pipe(Effect.provideService(AgentBindingResolver, resolver));
-        // Step 4 — re-arm or clear.
-        const nonterminal = yield* countNonterminal;
-        if (nonterminal === 0) {
-          yield* alarm.cancel;
-          yield* Ref.set(stalls, 0);
-          // Close the cancel/admission interleaving window: a submission committing between
-          // the count and the cancel (Durable Object events interleave at storage-operation
-          // boundaries) must not be left without its alarm. The recount re-arms if anything
-          // appeared; the submit entry's own `scheduleNow` covers commits after the recount.
-          const appeared = yield* countNonterminal;
-          if (appeared > 0) {
-            yield* preArm;
-            return MaintenancePassReport.make({
-              recovered: recovered.length,
-              settled: settlements.length,
-              nonterminal: appeared,
-              alarm: "rearmed",
-            });
-          }
-          return MaintenancePassReport.make({
-            recovered: recovered.length,
-            settled: settlements.length,
-            nonterminal,
-            alarm: "cleared",
-          });
-        }
+        // Observe residual state before acknowledging this exact pass-start generation.
+        const remaining = yield* Stream.runCollect(ledger.scanNonterminal);
+        const reports = new Map(recovered.map((report) => [report.submissionId, report]));
+        const autonomous = remaining.some((snapshot) => !stableExternalWait(snapshot, reports));
         const progressed =
           settlements.length > 0 || recovered.some((report) => report.disposition === "repaired");
-        const delay = yield* rearmDelay(progressed);
+        const delay = autonomous ? yield* rearmDelay(progressed) : 0;
         const now = yield* Clock.currentTimeMillis;
-        yield* alarm.ensureScheduledBy(now + delay);
-        return MaintenancePassReport.make({
-          recovered: recovered.length,
-          settled: settlements.length,
-          nonterminal,
-          alarm: "rearmed",
-        });
-      });
-
-      const ensureAlarm = Effect.fn("ConversationMaintenance.ensureAlarm")(function* () {
-        const nonterminal = yield* countNonterminal;
-        if (nonterminal === 0) return;
-        yield* preArm;
+        yield* failpoint.hit("maintenance:finish:before");
+        const alarmDisposition = yield* generationGate.withPermit(
+          Effect.gen(function* () {
+            const active = yield* Ref.get(activeMutations);
+            return yield* runTransaction("finish maintenance pass", () =>
+              ctx.storage.transaction(async (transaction) => {
+                const { state } = await readMaintenanceState(transaction);
+                // Autonomous work and in-flight mutations intentionally leave the observed
+                // generation dirty. Otherwise acknowledge only the pass-start generation.
+                const processed =
+                  autonomous || started.activeAtStart > 0 || active > 0
+                    ? state.processed
+                    : state.processed > started.generation
+                      ? state.processed
+                      : started.generation;
+                const next = ConversationMaintenanceState.make({
+                  ...state,
+                  processed,
+                  nonterminal: remaining.length,
+                });
+                await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(next));
+                if (autonomous) {
+                  // Replace the crash-fallback slot with this pass's bounded backoff. The target
+                  // is never earlier than the begin-pass fallback, so workerd does not cancel
+                  // this running alarm handler before its report/span can complete.
+                  await transaction.setAlarm(now + delay);
+                  return "rearmed" as const;
+                }
+                if (started.activeAtStart > 0 || active > 0 || next.dirty > next.processed) {
+                  // A mutation overlapped this pass's observation window or raced
+                  // acknowledgement. It stays dirty and its pre-armed bounded alarm survives;
+                  // unseen effects are never acknowledged. Do not accelerate that future alarm
+                  // from inside the current handler: workerd cancels a running handler when it
+                  // writes an earlier slot.
+                  await ensureTransactionAlarmBy(transaction, now + config.wakeScanInterval);
+                  return "rearmed" as const;
+                }
+                await transaction.deleteAlarm();
+                return "cleared" as const;
+              }),
+            );
+          }),
+        );
+        yield* failpoint.hit("maintenance:finish:after");
+        if (alarmDisposition === "cleared") {
+          yield* Ref.set(stalls, 0);
+        }
+        return yield* annotate(
+          MaintenancePassReport.make({
+            phase: "actionable",
+            recovered: recovered.length,
+            settled: settlements.length,
+            nonterminal: remaining.length,
+            alarm: alarmDisposition,
+          }),
+        );
       });
 
       return ConversationMaintenance.of({
-        // Wake deferral (see `DurableAlarmService.scheduleNow`): an immediate wake written
-        // while THIS handler runs would make workerd cancel it mid-Attempt; deferring keeps
-        // the running pass alive and flushes the hint as the pass's final re-arm.
-        pass: alarm.withWakesDeferred(pass()),
+        // A mid-pass immediate hint is droppable; durable dirty state decides the final alarm.
+        pass: alarm.withWakesDeferred(maintenancePassGate.withPermit(pass())),
         ensureAlarm: ensureAlarm(),
-        preArm,
+        withMutation,
       });
     }),
   );

--- a/packages/platform-cloudflare/src/conversation-object.ts
+++ b/packages/platform-cloudflare/src/conversation-object.ts
@@ -246,17 +246,15 @@ const submitEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpoin
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
         yield* gateAdmissionLimits(request);
-        // Alarm invariant: the alarm commits BEFORE the admission it will finish (D-P6-2).
-        yield* maintenance.preArm;
-        const receipt = yield* runtime.submit(
-          passthroughSubmitAgent(request.agentId),
-          request.inputPayload,
-          {
+        // Alarm invariant: the generation + alarm commit BEFORE the admission, and maintenance
+        // cannot acknowledge that generation until this mutation leaves its public RPC seam.
+        const receipt = yield* maintenance.withMutation(
+          runtime.submit(passthroughSubmitAgent(request.agentId), request.inputPayload, {
             conversationId: identity.conversationId,
             principal: request.principal,
             idempotencyKey: request.idempotencyKey,
             definitions: request.definitions,
-          },
+          }),
         );
         return SubmitSucceeded.make({ receipt });
       }),
@@ -324,8 +322,7 @@ const abortEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpoint
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        yield* maintenance.preArm;
-        const intent = yield* runtime.abort(command);
+        const intent = yield* maintenance.withMutation(runtime.abort(command));
         return AbortRecorded.make({ intent });
       }),
     ),
@@ -360,10 +357,11 @@ const resolveApprovalEndpoint = (
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        yield* maintenance.preArm;
-        const intent = yield* runtime
-          .resolveApproval(command)
-          .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure));
+        const intent = yield* maintenance.withMutation(
+          runtime
+            .resolveApproval(command)
+            .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure)),
+        );
         return ApprovalRecorded.make({ intent });
       }),
     ),
@@ -380,10 +378,11 @@ const resolveUnknownEndpoint = (
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        yield* maintenance.preArm;
-        const intent = yield* runtime
-          .resolveUnknown(command)
-          .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure));
+        const intent = yield* maintenance.withMutation(
+          runtime
+            .resolveUnknown(command)
+            .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure)),
+        );
         return UnknownResolutionRecorded.make({ intent });
       }),
     ),
@@ -541,10 +540,8 @@ const retryEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpoint
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        // Alarm invariant: retry may repair durable state, so the alarm that will finish the
-        // lane commits BEFORE the mutation (D-P6-2), exactly like abort.
-        yield* maintenance.preArm;
-        const report = yield* runtime.retry(command);
+        // Retry may repair durable state, so its generation + alarm commit before the mutation.
+        const report = yield* maintenance.withMutation(runtime.retry(command));
         return RetryExecuted.make({ report });
       }),
     ),
@@ -567,10 +564,11 @@ const obligationsEndpoint = (encoded: unknown): Effect.Effect<unknown, never, En
   );
 
 /**
- * Owner-side `portCall`: pre-arm before a mutating envelope (a routed admission committed by
- * THIS Object must already carry the alarm that will finish it), execute on the LOCAL facets
- * (never the routed decorators), then arm an immediate alarm so the mutated lane is
- * processed promptly. Protocol anomalies answer `PortFailed(PortProtocolError)`.
+ * Owner-side `portCall`: wrap a mutating envelope in the same pre-armed generation protocol as
+ * public RPC (a routed mutation committed by THIS Object must already carry the alarm that will
+ * finish it), execute on the LOCAL facets (never the routed decorators), then arm an immediate
+ * alarm so the mutated lane is processed promptly. Protocol anomalies answer
+ * `PortFailed(PortProtocolError)`.
  */
 const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, EndpointServices> =>
   Effect.gen(function* () {
@@ -578,16 +576,17 @@ const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpo
     const maintenance = yield* ConversationMaintenance;
     const alarm = yield* DurableAlarmService;
     const mutating = isMutatingPortRequest(encoded);
-    if (mutating) {
-      const preArmed = yield* maintenance.preArm.pipe(Effect.exit);
-      if (preArmed._tag === "Failure") {
-        // Without the committed alarm the invariant cannot be promised; refuse the mutation.
-        return encodedPortProtocolFailure(
-          "The owner Object could not arm its maintenance alarm before the mutation.",
-        );
-      }
+    const handled = yield* (
+      mutating ? maintenance.withMutation(ports.handle(encoded)) : ports.handle(encoded)
+    ).pipe(Effect.exit);
+    if (handled._tag === "Failure") {
+      // Without the committed generation/alarm the invariant cannot be promised; refuse before
+      // the port mutation runs. `ports.handle` itself is total, so this is the maintenance error.
+      return encodedPortProtocolFailure(
+        "The owner Object could not arm its maintenance alarm before the mutation.",
+      );
     }
-    const response = yield* ports.handle(encoded);
+    const response = handled.value;
     if (mutating) {
       // Prompt processing hint; the pre-armed alarm already guarantees convergence.
       yield* alarm.scheduleNow.pipe(
@@ -612,7 +611,7 @@ const alarmEndpoint: Effect.Effect<void, MaintenancePassFailure, EndpointService
   function* () {
     const maintenance = yield* ConversationMaintenance;
     // Typed pass failures propagate: the rejected promise makes workerd retry the alarm
-    // (at-least-once delivery), and the pass's own pre-arm keeps the slot committed meanwhile.
+    // (at-least-once delivery), and the dirty generation retains a committed slot meanwhile.
     yield* maintenance.pass;
   },
 );

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -6,8 +6,9 @@
  * `makeConversationObjectClass` builds the class applications export from their Worker,
  * `CloudflareDurableRuntime.layer` assembles the coordinator over the storage-cloudflare
  * adapters and the WP2 cross-Object routing, `DurableAlarmService`/`ConversationMaintenance`
- * multiplex every cadence into the Object's single alarm slot (nonterminal work implies a
- * committed alarm, so eviction recovers without an incoming request), and
+ * multiplex every cadence into the Object's single alarm slot (dirty or autonomously
+ * actionable work retains a committed alarm; stable external waits quiesce until their next
+ * durably pre-armed mutation), and
  * `CloudflareConversationClient` is the Worker-side ingress. Platform bindings enter ONLY
  * through the `bindings.ts` Layers (DEPLOY-010). This is the only workspace package allowed
  * to import the `cloudflare:workers` runtime module.

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -1,16 +1,16 @@
 import { ConversationId } from "@effect-agent/core";
 import {
   AgentBindingResolver,
-  ConversationStore,
   DurableAgentRuntime,
   DurableRuntimeConfig,
   DurableRuntimeFailpoint,
   ProducerId,
-  SubmissionLedger,
   ToolReconciler,
-  WakeScheduler,
+  type ConversationStore,
   type DurableRuntimeFailpointHandler,
   type ResolvedBinding,
+  type SubmissionLedger,
+  type WakeScheduler,
 } from "@effect-agent/session";
 import {
   conversationStoreLayer,
@@ -28,11 +28,16 @@ import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import { Context, Duration, Effect, Layer, Schema } from "effect";
 
-import { ConversationMaintenance, DurableAlarmService } from "./alarm.ts";
+import {
+  ConversationMaintenance,
+  ConversationMaintenanceFailpoint,
+  DurableAlarmService,
+  type ConversationMaintenanceFailpointHandler,
+} from "./alarm.ts";
 import {
   ConversationObjectIdentity,
-  ConversationObjectNamespace,
   DurableObjectContext,
+  type ConversationObjectNamespace,
 } from "./bindings.ts";
 import {
   CLOUDFLARE_RUNTIME_DEFAULTS,
@@ -88,6 +93,10 @@ export interface CloudflareDurableRuntimeOptions {
   /** Coordinator fault injection (`submit:*` / `terminalize:*` locations); default none. */
   readonly runtimeFailpoint?:
     | ((ctx: DurableObjectState) => DurableRuntimeFailpointHandler)
+    | undefined;
+  /** Conversation-maintenance generation/alarm fault injection; default none. */
+  readonly maintenanceFailpoint?:
+    | ((ctx: DurableObjectState) => ConversationMaintenanceFailpointHandler)
     | undefined;
   /**
    * Reconciliation policy consulted for open ordinary Tool Calls before an Unknown Outcome
@@ -340,6 +349,12 @@ export class CloudflareDurableRuntime {
           options.runtimeFailpoint === undefined
             ? DurableRuntimeFailpoint.layer
             : Layer.succeed(DurableRuntimeFailpoint)({ hit: options.runtimeFailpoint(ctx) });
+        const maintenanceFailpointLayer =
+          options.maintenanceFailpoint === undefined
+            ? ConversationMaintenanceFailpoint.layer
+            : Layer.succeed(ConversationMaintenanceFailpoint)({
+                hit: options.maintenanceFailpoint(ctx),
+              });
         const reconcilerLayer = options.toolReconciler ?? ToolReconciler.uncertain;
         const bindingResolverLayer = Layer.effect(AgentBindingResolver)(
           Effect.map(
@@ -352,6 +367,7 @@ export class CloudflareDurableRuntime {
           identityLayer,
           cloudflareConfigLayer,
           DurableAlarmService.layer,
+          maintenanceFailpointLayer,
         );
 
         const runtimeStack = DurableAgentRuntime.layer.pipe(

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -169,6 +169,7 @@ describe("DC alarm semantics", () => {
       "maintenance:begin:after",
       "maintenance:mutation:finished",
       "maintenance:finish:before",
+      "maintenance:finish:after",
     );
     const resolution = runClient(
       Effect.gen(function* () {
@@ -201,9 +202,12 @@ describe("DC alarm semantics", () => {
     releaseMaintenancePause(conversation, "maintenance:mutation:finished");
     releaseMaintenancePause(conversation, "maintenance:begin:after");
     await awaitMaintenancePause(conversation, "maintenance:finish:before");
+    releaseMaintenancePause(conversation, "maintenance:finish:before");
+    await awaitMaintenancePause(conversation, "maintenance:finish:after");
     const generation = await maintenanceGeneration(conversation);
     expect(generation.dirty > generation.processed).toBe(true);
-    releaseMaintenancePause(conversation, "maintenance:finish:before");
+    expect(await scheduledAlarm(conversation)).not.toBeNull();
+    releaseMaintenancePause(conversation, "maintenance:finish:after");
     await resolution;
     await forcedPass;
     await drainAlarmsUntil(conversation, allSettled(conversation));

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -4,7 +4,7 @@ import {
   UnknownResolutionCommand,
 } from "@effect-agent/session";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import { CloudflareConversationClient } from "../src/index.ts";
@@ -17,7 +17,7 @@ import {
   bookDefinition,
   decodeConversationId,
   armMaintenancePause,
-  maintenancePauseReached,
+  awaitMaintenancePause,
   plannerDefinition,
   releaseMaintenancePause,
   submitOptions,
@@ -71,6 +71,19 @@ const canonicalFingerprint = async (conversation: string): Promise<string> => {
   );
 };
 
+const MaintenanceGenerationProbe = Schema.Struct({
+  schemaVersion: Schema.Literal(1),
+  dirty: Schema.BigIntFromString,
+  processed: Schema.BigIntFromString,
+});
+
+const maintenanceGeneration = (conversation: string) =>
+  runInDurableObject(stubFor(conversation), async (_instance, state) =>
+    Schema.decodeUnknownSync(MaintenanceGenerationProbe)(
+      await state.storage.get<unknown>("effect-agent:conversation-maintenance:v1"),
+    ),
+  );
+
 describe("DC alarm semantics", () => {
   it("issue #93: a stable approval wait quiesces and a forced caught-up alarm performs no SQL work", async () => {
     const conversation = lane("issue-93-quiescent-approval");
@@ -117,10 +130,7 @@ describe("DC alarm semantics", () => {
     armMaintenancePause(conversation, "maintenance:finish:before");
     const receipt = await submitTo(approvalDefinition, conversation);
 
-    for (let round = 0; round < 400 && !maintenancePauseReached(conversation); round++) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(maintenancePauseReached(conversation)).toBe(true);
+    await awaitMaintenancePause(conversation, "maintenance:finish:before");
     expect((await laneRows(conversation))[0]?.state).toBe("suspended");
 
     // The alarm pass has observed the stable wait but has not acknowledged/cancelled yet.
@@ -158,6 +168,7 @@ describe("DC alarm semantics", () => {
       "maintenance:mutation:armed",
       "maintenance:begin:after",
       "maintenance:mutation:finished",
+      "maintenance:finish:before",
     );
     const resolution = runClient(
       Effect.gen(function* () {
@@ -174,45 +185,27 @@ describe("DC alarm semantics", () => {
         );
       }),
     );
-    for (
-      let round = 0;
-      round < 400 && !maintenancePauseReached(conversation, "maintenance:mutation:armed");
-      round++
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(maintenancePauseReached(conversation, "maintenance:mutation:armed")).toBe(true);
+    await awaitMaintenancePause(conversation, "maintenance:mutation:armed");
 
     // Start a forced pass while the RPC is still between pre-arm and body. It snapshots both the
     // new generation and the active-mutation count, then pauses before recovery.
     const forcedPass = runDurableObjectAlarm(stubFor(conversation)).catch(() => undefined);
-    for (
-      let round = 0;
-      round < 400 && !maintenancePauseReached(conversation, "maintenance:begin:after");
-      round++
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(maintenancePauseReached(conversation, "maintenance:begin:after")).toBe(true);
+    await awaitMaintenancePause(conversation, "maintenance:begin:after");
 
     // Let the mutation body finish BEFORE the pass observes durable state, but hold the RPC at
     // its body-complete boundary. The pass may see the approval decision, but must conservatively
     // retain this overlapped generation rather than acknowledge a body that was not visible at
     // its snapshot boundary.
     releaseMaintenancePause(conversation, "maintenance:mutation:armed");
-    for (
-      let round = 0;
-      round < 400 && !maintenancePauseReached(conversation, "maintenance:mutation:finished");
-      round++
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(maintenancePauseReached(conversation, "maintenance:mutation:finished")).toBe(true);
+    await awaitMaintenancePause(conversation, "maintenance:mutation:finished");
     releaseMaintenancePause(conversation, "maintenance:mutation:finished");
     releaseMaintenancePause(conversation, "maintenance:begin:after");
+    await awaitMaintenancePause(conversation, "maintenance:finish:before");
+    const generation = await maintenanceGeneration(conversation);
+    expect(generation.dirty > generation.processed).toBe(true);
+    releaseMaintenancePause(conversation, "maintenance:finish:before");
     await resolution;
     await forcedPass;
-    expect(await scheduledAlarm(conversation)).not.toBeNull();
     await drainAlarmsUntil(conversation, allSettled(conversation));
     await assertConvergence(conversation);
   }, 30_000);

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -3,9 +3,9 @@ import {
   ResolutionNeverHappened,
   UnknownResolutionCommand,
 } from "@effect-agent/session";
-import { runDurableObjectAlarm } from "cloudflare:test";
+import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { Effect } from "effect";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import { CloudflareConversationClient } from "../src/index.ts";
 import {
@@ -16,7 +16,10 @@ import {
   armedRuntimeFailures,
   bookDefinition,
   decodeConversationId,
+  armMaintenancePause,
+  maintenancePauseReached,
   plannerDefinition,
+  releaseMaintenancePause,
   submitOptions,
 } from "./fixtures.ts";
 import {
@@ -35,8 +38,8 @@ import {
  * Alarm semantics (plan §3, D-P6-2; exit gate 2): the single multiplexed alarm's maintenance
  * pass is idempotent under at-least-once delivery (double-fired alarms change nothing), a
  * typed failure inside the pass REJECTS the delivery so workerd redelivers while the pass's
- * own pre-arm keeps the slot committed, and the alarm invariant — committed nonterminal work
- * implies a committed alarm — holds from admission to settlement.
+ * dirty generation keeps the slot committed, stable external waits quiesce, and autonomous work
+ * retains bounded rearming through settlement.
  */
 
 let laneCounter = 0;
@@ -69,6 +72,151 @@ const canonicalFingerprint = async (conversation: string): Promise<string> => {
 };
 
 describe("DC alarm semantics", () => {
+  it("issue #93: a stable approval wait quiesces and a forced caught-up alarm performs no SQL work", async () => {
+    const conversation = lane("issue-93-quiescent-approval");
+    const receipt = await submitTo(approvalDefinition, conversation);
+    await drainAlarmsUntil(conversation, anyInState(conversation, "suspended"));
+    await drainAlarmsUntil(conversation, async () => (await scheduledAlarm(conversation)) === null);
+
+    const suspendedFingerprint = await canonicalFingerprint(conversation);
+    await runInDurableObject(stubFor(conversation), async (instance, state) => {
+      const sql = vi.spyOn(state.storage.sql, "exec").mockImplementation(() => {
+        throw new Error("a caught-up maintenance pass must not touch SQLite");
+      });
+      try {
+        await expect(instance.alarm()).resolves.toBeUndefined();
+        expect(sql).not.toHaveBeenCalled();
+      } finally {
+        sql.mockRestore();
+      }
+    });
+    expect(await canonicalFingerprint(conversation)).toBe(suspendedFingerprint);
+    expect(await scheduledAlarm(conversation)).toBeNull();
+
+    await runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        return yield* client.resolveApproval(
+          decodeConversationId(conversation),
+          ApprovalDecisionCommand.make({
+            submissionId: receipt.submissionId,
+            toolCallId: BOOK_TOOL_CALL_ID,
+            decision: "approved",
+            resolver: "cf-issue-93-approver",
+            reason: "durable input must wake a quiescent lane exactly once",
+          }),
+        );
+      }),
+    );
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+    await assertConvergence(conversation);
+  }, 30_000);
+
+  it("issue #93: a mutation racing stable-wait cancellation remains dirty and resumes exactly once", async () => {
+    const conversation = lane("issue-93-cancel-race");
+    armMaintenancePause(conversation, "maintenance:finish:before");
+    const receipt = await submitTo(approvalDefinition, conversation);
+
+    for (let round = 0; round < 400 && !maintenancePauseReached(conversation); round++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(maintenancePauseReached(conversation)).toBe(true);
+    expect((await laneRows(conversation))[0]?.state).toBe("suspended");
+
+    // The alarm pass has observed the stable wait but has not acknowledged/cancelled yet.
+    // This public resolving mutation advances a NEW durable generation before its intent.
+    await runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        return yield* client.resolveApproval(
+          decodeConversationId(conversation),
+          ApprovalDecisionCommand.make({
+            submissionId: receipt.submissionId,
+            toolCallId: BOOK_TOOL_CALL_ID,
+            decision: "approved",
+            resolver: "cf-issue-93-race-approver",
+            reason: "race the pass's stable-wait acknowledgement",
+          }),
+        );
+      }),
+    );
+    expect(await scheduledAlarm(conversation)).not.toBeNull();
+
+    releaseMaintenancePause(conversation);
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+    await assertConvergence(conversation);
+  }, 30_000);
+
+  it("issue #93: a pass cannot acknowledge a pre-armed generation while its RPC mutation is in flight", async () => {
+    const conversation = lane("issue-93-in-flight-mutation");
+    const receipt = await submitTo(approvalDefinition, conversation);
+    await drainAlarmsUntil(conversation, anyInState(conversation, "suspended"));
+    await drainAlarmsUntil(conversation, async () => (await scheduledAlarm(conversation)) === null);
+
+    armMaintenancePause(
+      conversation,
+      "maintenance:mutation:armed",
+      "maintenance:begin:after",
+      "maintenance:mutation:finished",
+    );
+    const resolution = runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        return yield* client.resolveApproval(
+          decodeConversationId(conversation),
+          ApprovalDecisionCommand.make({
+            submissionId: receipt.submissionId,
+            toolCallId: BOOK_TOOL_CALL_ID,
+            decision: "approved",
+            resolver: "cf-issue-93-in-flight-approver",
+            reason: "hold the RPC after its pre-arm and before its durable decision",
+          }),
+        );
+      }),
+    );
+    for (
+      let round = 0;
+      round < 400 && !maintenancePauseReached(conversation, "maintenance:mutation:armed");
+      round++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(maintenancePauseReached(conversation, "maintenance:mutation:armed")).toBe(true);
+
+    // Start a forced pass while the RPC is still between pre-arm and body. It snapshots both the
+    // new generation and the active-mutation count, then pauses before recovery.
+    const forcedPass = runDurableObjectAlarm(stubFor(conversation)).catch(() => undefined);
+    for (
+      let round = 0;
+      round < 400 && !maintenancePauseReached(conversation, "maintenance:begin:after");
+      round++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(maintenancePauseReached(conversation, "maintenance:begin:after")).toBe(true);
+
+    // Let the mutation body finish BEFORE the pass observes durable state, but hold the RPC at
+    // its body-complete boundary. The pass may see the approval decision, but must conservatively
+    // retain this overlapped generation rather than acknowledge a body that was not visible at
+    // its snapshot boundary.
+    releaseMaintenancePause(conversation, "maintenance:mutation:armed");
+    for (
+      let round = 0;
+      round < 400 && !maintenancePauseReached(conversation, "maintenance:mutation:finished");
+      round++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(maintenancePauseReached(conversation, "maintenance:mutation:finished")).toBe(true);
+    releaseMaintenancePause(conversation, "maintenance:mutation:finished");
+    releaseMaintenancePause(conversation, "maintenance:begin:after");
+    await resolution;
+    await forcedPass;
+    expect(await scheduledAlarm(conversation)).not.toBeNull();
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+    await assertConvergence(conversation);
+  }, 30_000);
+
   it("double-fired alarms are idempotent on a ready lane: one settlement, no duplicate records", async () => {
     const conversation = lane("ready-double");
     await submitTo(plannerDefinition, conversation);
@@ -119,12 +267,17 @@ describe("DC alarm semantics", () => {
     armRuntimeEviction(conversation, "tools:after-prepared-append");
     const receipt = await submitTo(bookDefinition, conversation);
     await drainAlarmsUntil(conversation, anyInState(conversation, "unknown"));
+    await drainAlarmsUntil(conversation, async () => (await scheduledAlarm(conversation)) === null);
     const blockedFingerprint = await canonicalFingerprint(conversation);
     await runDurableObjectAlarm(stubFor(conversation)).catch(() => undefined);
     await runDurableObjectAlarm(stubFor(conversation)).catch(() => undefined);
     // DUR-009: the unresolved ordinary call is never auto-replayed by redelivered alarms.
     expect(await canonicalFingerprint(conversation)).toBe(blockedFingerprint);
     expect((await laneRows(conversation))[0]?.state).toBe("unknown");
+    expect(
+      await scheduledAlarm(conversation),
+      "AwaitUnknownResolution must quiesce (#93)",
+    ).toBeNull();
     await runClient(
       Effect.gen(function* () {
         const client = yield* CloudflareConversationClient;
@@ -159,18 +312,17 @@ describe("DC alarm semantics", () => {
     await assertConvergence(conversation);
   }, 30_000);
 
-  it("the alarm invariant holds while work is nonterminal and clears once everything settles", async () => {
+  it("the alarm invariant quiesces an external wait and its resolving mutation restores liveness", async () => {
     const conversation = lane("invariant");
     const receipt = await submitTo(approvalDefinition, conversation);
-    // A durably suspended lane is STABLE nonterminal state: passes must keep the slot armed
-    // (the slot is only transiently empty while a delivered pass is mid-execution).
+    // A durably suspended lane is a stable externally-driven wait: elapsed time is not work.
     await drainAlarmsUntil(conversation, anyInState(conversation, "suspended"));
-    let observedArmed = false;
-    for (let round = 0; round < 100 && !observedArmed; round++) {
-      observedArmed = (await scheduledAlarm(conversation)) !== null;
+    let observedCleared = false;
+    for (let round = 0; round < 100 && !observedCleared; round++) {
+      observedCleared = (await scheduledAlarm(conversation)) === null;
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    expect(observedArmed, "a suspended lane must keep a committed alarm").toBe(true);
+    expect(observedCleared, "a suspended lane must quiesce its autonomous alarm").toBe(true);
     await runClient(
       Effect.gen(function* () {
         const client = yield* CloudflareConversationClient;

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -23,6 +23,11 @@ import {
 import { Duration, Effect, Layer, Schema, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
+import type {
+  ConversationMaintenanceFailpointHandler,
+  ConversationMaintenanceFailpointLocation,
+} from "../src/index.ts";
+
 /**
  * Workerd-safe eviction-harness fixtures (plan §3, §4 WP3). The vitest pool runs test files
  * and the worker entry in ONE isolate, so this module's state is shared between the tests
@@ -115,6 +120,71 @@ export const runtimeEvictionFailpoint =
         });
       }
       return Effect.void;
+    });
+
+// ---------------------------------------------------------------------------
+// Conversation-maintenance race gate (issue #93)
+// ---------------------------------------------------------------------------
+
+const maintenancePauses = new Map<string, Array<ConversationMaintenanceFailpointLocation>>();
+const reachedMaintenancePauses = new Set<string>();
+const releasedMaintenancePauses = new Set<string>();
+
+const maintenancePauseKey = (
+  conversation: string,
+  location: ConversationMaintenanceFailpointLocation,
+): string => `${conversation}:${location}`;
+
+export const armMaintenancePause = (
+  conversation: string,
+  ...locations: ReadonlyArray<ConversationMaintenanceFailpointLocation>
+): void => {
+  maintenancePauses.set(conversation, [...locations]);
+  for (const location of locations) {
+    const key = maintenancePauseKey(conversation, location);
+    reachedMaintenancePauses.delete(key);
+    releasedMaintenancePauses.delete(key);
+  }
+};
+
+export const maintenancePauseReached = (
+  conversation: string,
+  location?: ConversationMaintenanceFailpointLocation,
+): boolean =>
+  location === undefined
+    ? [...reachedMaintenancePauses].some((key) => key.startsWith(`${conversation}:`))
+    : reachedMaintenancePauses.has(maintenancePauseKey(conversation, location));
+
+export const releaseMaintenancePause = (
+  conversation: string,
+  location?: ConversationMaintenanceFailpointLocation,
+): void => {
+  if (location === undefined) {
+    for (const key of reachedMaintenancePauses) {
+      if (key.startsWith(`${conversation}:`)) releasedMaintenancePauses.add(key);
+    }
+    return;
+  }
+  releasedMaintenancePauses.add(maintenancePauseKey(conversation, location));
+};
+
+export const maintenanceRaceFailpoint =
+  (ctx: DurableObjectState): ConversationMaintenanceFailpointHandler =>
+  (location) =>
+    Effect.gen(function* () {
+      const conversation = ctx.id.name;
+      if (conversation === undefined) return;
+      const queue = maintenancePauses.get(conversation);
+      if (queue?.[0] !== location) return;
+      queue.shift();
+      if (queue.length === 0) maintenancePauses.delete(conversation);
+      const key = maintenancePauseKey(conversation, location);
+      reachedMaintenancePauses.add(key);
+      while (!releasedMaintenancePauses.has(key)) {
+        yield* Effect.sleep(Duration.millis(1));
+      }
+      releasedMaintenancePauses.delete(key);
+      reachedMaintenancePauses.delete(key);
     });
 
 // ---------------------------------------------------------------------------

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -127,8 +127,16 @@ export const runtimeEvictionFailpoint =
 // ---------------------------------------------------------------------------
 
 const maintenancePauses = new Map<string, Array<ConversationMaintenanceFailpointLocation>>();
-const reachedMaintenancePauses = new Set<string>();
-const releasedMaintenancePauses = new Set<string>();
+
+interface MaintenancePauseGate {
+  readonly reached: Promise<void>;
+  readonly released: Promise<void>;
+  readonly resolveReached: () => void;
+  readonly resolveReleased: () => void;
+  reachedFlag: boolean;
+}
+
+const maintenancePauseGates = new Map<string, MaintenancePauseGate>();
 
 const maintenancePauseKey = (
   conversation: string,
@@ -142,30 +150,46 @@ export const armMaintenancePause = (
   maintenancePauses.set(conversation, [...locations]);
   for (const location of locations) {
     const key = maintenancePauseKey(conversation, location);
-    reachedMaintenancePauses.delete(key);
-    releasedMaintenancePauses.delete(key);
+    let resolveReached!: () => void;
+    let resolveReleased!: () => void;
+    maintenancePauseGates.set(key, {
+      reached: new Promise<void>((resolve) => {
+        resolveReached = resolve;
+      }),
+      released: new Promise<void>((resolve) => {
+        resolveReleased = resolve;
+      }),
+      resolveReached: () => resolveReached(),
+      resolveReleased: () => resolveReleased(),
+      reachedFlag: false,
+    });
   }
 };
 
-export const maintenancePauseReached = (
+export const awaitMaintenancePause = (
   conversation: string,
-  location?: ConversationMaintenanceFailpointLocation,
-): boolean =>
-  location === undefined
-    ? [...reachedMaintenancePauses].some((key) => key.startsWith(`${conversation}:`))
-    : reachedMaintenancePauses.has(maintenancePauseKey(conversation, location));
+  location: ConversationMaintenanceFailpointLocation,
+): Promise<void> => {
+  const gate = maintenancePauseGates.get(maintenancePauseKey(conversation, location));
+  if (gate === undefined) {
+    return Promise.reject(
+      new Error(`Maintenance pause ${location} is not armed for ${conversation}.`),
+    );
+  }
+  return gate.reached;
+};
 
 export const releaseMaintenancePause = (
   conversation: string,
   location?: ConversationMaintenanceFailpointLocation,
 ): void => {
   if (location === undefined) {
-    for (const key of reachedMaintenancePauses) {
-      if (key.startsWith(`${conversation}:`)) releasedMaintenancePauses.add(key);
+    for (const [key, gate] of maintenancePauseGates) {
+      if (key.startsWith(`${conversation}:`) && gate.reachedFlag) gate.resolveReleased();
     }
     return;
   }
-  releasedMaintenancePauses.add(maintenancePauseKey(conversation, location));
+  maintenancePauseGates.get(maintenancePauseKey(conversation, location))?.resolveReleased();
 };
 
 export const maintenanceRaceFailpoint =
@@ -179,12 +203,12 @@ export const maintenanceRaceFailpoint =
       queue.shift();
       if (queue.length === 0) maintenancePauses.delete(conversation);
       const key = maintenancePauseKey(conversation, location);
-      reachedMaintenancePauses.add(key);
-      while (!releasedMaintenancePauses.has(key)) {
-        yield* Effect.sleep(Duration.millis(1));
-      }
-      releasedMaintenancePauses.delete(key);
-      reachedMaintenancePauses.delete(key);
+      const gate = maintenancePauseGates.get(key);
+      if (gate === undefined) return;
+      gate.reachedFlag = true;
+      gate.resolveReached();
+      yield* Effect.promise(() => gate.released);
+      maintenancePauseGates.delete(key);
     });
 
 // ---------------------------------------------------------------------------

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -154,13 +154,14 @@ export const scheduledAlarm = (
 
 /**
  * Alarm-only convergence: fire the persisted alarm (at-least-once; an armed eviction or a
- * typed pass failure rejects the delivery and the pass's pre-arm keeps the slot committed)
+ * typed pass failure rejects the delivery and the dirty generation keeps the slot committed)
  * until the predicate holds. NO client entry point is ever called — this is the exit gate's
  * "recovers without an incoming request" in its deterministic form: `runDurableObjectAlarm`
  * is accelerated delivery of the alarm that would fire on its own.
  *
- * Built-in invariant audit: nonterminal work observed WITHOUT a scheduled alarm repeatedly
- * is a broken alarm invariant and fails the row immediately instead of timing out.
+ * Built-in invariant audit: locally actionable states observed WITHOUT a scheduled alarm
+ * repeatedly are broken. Stable external waits (`suspended`, `unknown`, `joined`, and an
+ * admitted child awaiting parent establishment) are intentionally allowed to quiesce.
  */
 export const drainAlarmsUntil = async (
   conversation: string,
@@ -182,14 +183,16 @@ export const drainAlarmsUntil = async (
     }
     if (!fired) {
       const rows = await laneRows(conversation, namespace);
-      const nonterminal = rows.some((row) => row.state !== "settled");
-      if (nonterminal) {
+      const actionable = rows.some((row) =>
+        ["ready", "input-applied", "running", "joining", "terminalizing"].includes(row.state),
+      );
+      if (actionable) {
         consecutiveIdleWithWork += 1;
-        // The alarm invariant: committed nonterminal work implies a committed alarm. Allow
-        // a few rounds for a concurrently-running pass to re-arm before declaring it broken.
+        // Actionable committed work implies a committed alarm. Allow a few rounds for a
+        // concurrently-running pass to re-arm before declaring it broken.
         if (consecutiveIdleWithWork >= 20) {
           throw new Error(
-            `Alarm invariant broken for ${conversation}: nonterminal work with no scheduled alarm`,
+            `Alarm invariant broken for ${conversation}: actionable work with no scheduled alarm`,
           );
         }
       } else {

--- a/packages/platform-cloudflare/test/subagents-cross-do.test.ts
+++ b/packages/platform-cloudflare/test/subagents-cross-do.test.ts
@@ -25,7 +25,14 @@ import {
   decodeConversationId,
   submitOptions,
 } from "./fixtures.ts";
-import { anyInState, laneRows, readCanonical, runClient, stubFor } from "./harness.ts";
+import {
+  anyInState,
+  laneRows,
+  readCanonical,
+  runClient,
+  scheduledAlarm,
+  stubFor,
+} from "./harness.ts";
 import {
   armTransportFault,
   childModelInvocations,
@@ -61,8 +68,8 @@ import {
  * SAME `DurableRuntimeFailpointLocation` strings the Node process-kill suite uses.
  *
  * On top of the failpoint rows: `recordChildSettled` at-least-once redelivery (not-waiting,
- * idempotent), lost-notification healing by the parent's own alarm re-poll, cross-Object
- * abort propagation (request-abort-and-join), and the DO-unreachable `Indeterminate`
+ * idempotent), pre-finalization durable parent wake, cross-Object abort propagation
+ * (request-abort-and-join), and the DO-unreachable `Indeterminate`
  * establishment row (SUB-031: an unreachable admission authority NEVER admits a second
  * child; convergence resumes when transport heals).
  */
@@ -249,6 +256,10 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
       expect(rows[0]?.state, `child state in probe round ${round}`).toBe("admitted");
     }
     expect(childModelInvocations(ref)).toBe(0);
+    expect(
+      await scheduledAlarm(child, SUBAGENTS),
+      "AwaitParentEstablishment is a stable external wait and must quiesce (#93)",
+    ).toBeNull();
 
     // The WP1 admin surface names the deferral: the child Object explains its own lane.
     const explainedRaw: unknown = await Promise.resolve(
@@ -369,10 +380,10 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
   }, 40_000);
 
   // -------------------------------------------------------------------------
-  // Lost notification — the parent's own alarm re-poll heals it (plan §1.3).
+  // Issue #93: parent wake is durable before child finalization can commit.
   // -------------------------------------------------------------------------
 
-  it("a child evicted between its settlement finalize and the parent wake is healed by the parent's own alarm re-poll", async () => {
+  it("issue #93: child eviction after finalize cannot lose its precommitted parent wake", async () => {
     const ref = lane("lost-notification");
     const key = `${ref}-key`;
     // The researcher hangs mid-stream so the eviction can be armed with the child provably
@@ -385,9 +396,13 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
       kickWithoutAwaiting(child);
       return childModelInvocations(ref) === 1;
     }, "the hanging researcher invocation");
+    await waitFor(
+      async () => (await scheduledAlarm(ref, SUBAGENTS)) === null,
+      "the parent AwaitChildSettlement alarm to quiesce (#93)",
+    );
 
-    // The child's Object dies right AFTER its settlement finalize commits and BEFORE
-    // `recordChildSettled` reaches the parent's Object: the notification is lost.
+    // The child's Object dies right AFTER its settlement finalize commits. The protocol must
+    // have durably routed `recordChildSettled` and dirtied the parent BEFORE this can happen.
     armStorageEviction(child, "ledger:finalize-settlement:after");
     releaseChildModel(ref);
     await waitFor(async () => {
@@ -395,13 +410,10 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
       return rows.length === 1 && rows[0]?.state === "settled";
     }, "the child settlement to commit before the eviction");
     expect(armedEvictionsRemaining(child)).toBe(0);
-    // (The marker's absence right after the abort is not asserted: the parent's own alarm
-    // auto-fires in the pool and can heal the lost wake within milliseconds — which is the
-    // very property this row exists to prove.)
+    expect(await settlementMarkers(ref)).toHaveLength(1);
 
-    // Fire ONLY the parent's persisted alarm: its recovery re-polls the settled-but-silent
-    // child by routed lookup against the child's (fresh) Object, records the durable marker
-    // itself, and joins — a dropped notification is never a lost obligation.
+    // Fire ONLY the parent's persisted alarm: the precommitted marker/generation resumes the
+    // join after quiescence; no background polling contract is needed.
     await drainDelegationUntil([ref], allLanesSettled(ref, child));
     await assertDelegationConverged(completedDelegation(receipt, ref));
   }, 40_000);
@@ -529,6 +541,10 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
     const duringFault = await readCanonical(ref, SUBAGENTS);
     expect(payloadsOf(duringFault, "SubagentStarted")).toHaveLength(0);
     expect(childModelInvocations(ref)).toBe(0);
+    expect(
+      await scheduledAlarm(ref, SUBAGENTS),
+      "indeterminate establishment is autonomous retry state and must retain an alarm (#93)",
+    ).not.toBeNull();
 
     // Heal the transport: the next alarm passes resolve the admission (fresh), establish the
     // ONE child, and the delegation completes — no duplicate was ever possible.

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -6,6 +6,7 @@ import {
   DEPLOYMENT_ID,
   PRODUCER_PREFIX,
   fixtureReconcilerLayer,
+  maintenanceRaceFailpoint,
   makeTestBindings,
   runtimeEvictionFailpoint,
   storageEvictionFailpoint,
@@ -38,6 +39,7 @@ const baseOptions: ConversationObjectOptions = {
   toolReconciler: fixtureReconcilerLayer,
   storageFailpoint: storageEvictionFailpoint,
   runtimeFailpoint: runtimeEvictionFailpoint,
+  maintenanceFailpoint: maintenanceRaceFailpoint,
 };
 
 interface BindingSourceProbe {

--- a/packages/platform-node/test/crash/crash-subagents.test.ts
+++ b/packages/platform-node/test/crash/crash-subagents.test.ts
@@ -380,7 +380,7 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
     );
 
     it.effect(
-      "kill after the precommitted parent wake and child finalize: recovery resumes without replaying the wake",
+      "kill after the precommitted parent wake and child finalize: recovery replays the wake idempotently",
       () =>
         withCrashSite((site) =>
           Effect.gen(function* () {
@@ -423,10 +423,10 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
                 const report = host.startupRecovery.find(
                   (entry) => entry.submissionId === ids.parent,
                 );
-                // Recovery resumes from the already-committed child result. It does not need a
-                // scan-seeded `ResumeWaitingParent` repair for newly written data.
-                expect(report?.decision._tag).toBe("ResumeFromTurnBoundary");
-                expect(report?.disposition).toBe("deferred");
+                // The parent wake was already committed before the kill. Recovery still repairs
+                // the open canonical delegation through the same idempotent wake operation.
+                expect(report?.decision._tag).toBe("ResumeWaitingParent");
+                expect(report?.disposition).toBe("repaired");
                 expect((yield* submissionSnapshot(ids.parent)).state).toBe("input-applied");
 
                 const settlements = yield* drive(conversation);

--- a/packages/platform-node/test/crash/crash-subagents.test.ts
+++ b/packages/platform-node/test/crash/crash-subagents.test.ts
@@ -380,15 +380,15 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
     );
 
     it.effect(
-      "kill between the child settlement finalize and the parent wake: recovery replays the wake",
+      "kill after the precommitted parent wake and child finalize: recovery resumes without replaying the wake",
       () =>
         withCrashSite((site) =>
           Effect.gen(function* () {
             const conversation = "conversation-s2-wake";
             const key = "s2-wake-1";
-            // The FIRST settlement finalization of the scenario is the child's: the kill lands
-            // after the child is durably settled but before `recordChildSettled` wakes the
-            // suspended parent (spec §14 "after child Settlement, before parent observes it").
+            // The FIRST settlement finalization of the scenario is the child's. The parent wake
+            // is now durably committed before this boundary, so the kill cannot strand a
+            // suspended parent after the child becomes settled (issue #93).
             const result = yield* runWorkerToExit({
               db: site.db,
               scenario: "subagent-run",
@@ -401,12 +401,12 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
             expectKilled(result);
             yield* waitOutChildLease;
 
-            // Before recovery: the child is settled, the parent still durably suspended.
+            // Before recovery: the child is settled and its parent wake is already durable.
             const ids = yield* withRuntime(
               site.db,
               Effect.gen(function* () {
                 const parent = yield* lookupByKey(conversation, key);
-                expect(parent.state).toBe("suspended");
+                expect(parent.state).toBe("input-applied");
                 const started = yield* startedPayloadOf(conversation);
                 const child = yield* submissionSnapshot(started.childSubmissionId);
                 expect(child.state).toBe("settled");
@@ -423,10 +423,10 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
                 const report = host.startupRecovery.find(
                   (entry) => entry.submissionId === ids.parent,
                 );
-                // Scan-seeded recovery replays the idempotent wake: a dropped wake is never a
-                // lost obligation (plan §1.3).
-                expect(report?.decision._tag).toBe("ResumeWaitingParent");
-                expect(report?.disposition).toBe("repaired");
+                // Recovery resumes from the already-committed child result. It does not need a
+                // scan-seeded `ResumeWaitingParent` repair for newly written data.
+                expect(report?.decision._tag).toBe("ResumeFromTurnBoundary");
+                expect(report?.disposition).toBe("deferred");
                 expect((yield* submissionSnapshot(ids.parent)).state).toBe("input-applied");
 
                 const settlements = yield* drive(conversation);

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -1692,9 +1692,11 @@ const make = Effect.gen(function* () {
    * Cross-lane drive-forward after one child Submission settles (spec §12 step 10): the child's
    * canonical Settlement is already durable, so the idempotent `recordChildSettled` wake is the
    * durable notification — `suspended(WaitingForChild) → input-applied` once every listed child
-   * settled — and the parent-lane wake hint is liveness only. Invoked from every settlement
-   * finalization path; a crash between the child's finalize and this notification is repaired by
-   * the `ResumeWaitingParent` recovery row (a dropped wake is never a lost obligation).
+   * settled — and the parent-lane wake hint is liveness only. Invoked after the exact canonical
+   * append but BEFORE child ledger finalization: once a child may become terminal, its parent's
+   * durable marker and maintenance generation already exist. Finalization replays the same
+   * notification for single-store parent re-suspension races; `ResumeWaitingParent` remains the
+   * repair for older data and any already-recorded canonical settlement.
    */
   const notifyParentOfChildSettlement = Effect.fn(
     "DurableAgentRuntime.notifyParentOfChildSettlement",
@@ -1783,6 +1785,7 @@ const make = Effect.gen(function* () {
       Effect.asVoid,
     );
     yield* hit("terminalize:after-canonical-append");
+    yield* notifyParentOfChildSettlement(submission);
     const settlement = yield* ledger.finalizeSettlement(
       SettlementFinalization.make({ submissionId, settlementId }),
     );
@@ -1879,6 +1882,7 @@ const make = Effect.gen(function* () {
       Effect.asVoid,
     );
     yield* hit("terminalize:after-canonical-append");
+    yield* notifyParentOfChildSettlement(submission);
     const settlement = yield* ledger.finalizeSettlement(
       SettlementFinalization.make({ submissionId, settlementId }),
     );
@@ -1911,6 +1915,7 @@ const make = Effect.gen(function* () {
       );
       yield* hit("terminalize:after-canonical-append");
     }
+    yield* notifyParentOfChildSettlement(submission);
     const settlement = yield* ledger.finalizeSettlement(
       SettlementFinalization.make({
         submissionId: submission.submissionId,
@@ -1928,6 +1933,7 @@ const make = Effect.gen(function* () {
     submission: SubmissionSnapshot,
     settlementId: Settlement["settlementId"],
   ): Effect.fn.Return<Settlement, LedgerError | SettlementConflict> {
+    yield* notifyParentOfChildSettlement(submission);
     const settlement = yield* ledger.finalizeSettlement(
       SettlementFinalization.make({ submissionId: submission.submissionId, settlementId }),
     );

--- a/packages/session/src/ledger-conformance.ts
+++ b/packages/session/src/ledger-conformance.ts
@@ -2754,7 +2754,7 @@ const releaseAppliedExactlyOnce = conformanceCase(
 );
 
 const recordChildSettledWake = conformanceCase(
-  "recordChildSettled wakes only when every listed child settled",
+  "recordChildSettled accepts canonical terminalizing prefixes and wakes only when all are covered",
   ({ ensure, expectFailure, expectSome }) =>
     Effect.gen(function* () {
       const parentLane = decodeConversationId("ledger-conformance-child-wake");
@@ -2814,7 +2814,13 @@ const recordChildSettledWake = conformanceCase(
         "the first child claim",
         yield* claimLane(childLaneA, PRODUCER_A),
       );
-      yield* settleClaimed(childA, childClaimA.ownershipToken);
+      const childReservationA = yield* settlementReservation({
+        submissionId: childA.submissionId,
+        ownershipToken: childClaimA.ownershipToken,
+        receiptId: childA.receiptId,
+        outcome: "completed",
+      });
+      yield* ledger.reserveSettlement(childReservationA);
       const partial = yield* ledger.recordChildSettled(
         ChildSettledNotification.make({
           parentSubmissionId: parent.submissionId,
@@ -2824,6 +2830,12 @@ const recordChildSettledWake = conformanceCase(
       yield* ensure(
         partial === "still-waiting",
         "A settlement notification must not wake the parent while a listed child is unsettled",
+      );
+      yield* ledger.finalizeSettlement(
+        SettlementFinalization.make({
+          submissionId: childA.submissionId,
+          settlementId: childReservationA.settlementId,
+        }),
       );
       const stillSuspended = yield* expectSome(
         "lookup while one child is outstanding",
@@ -2839,7 +2851,13 @@ const recordChildSettledWake = conformanceCase(
         "the second child claim",
         yield* claimLane(childLaneB, PRODUCER_A),
       );
-      yield* settleClaimed(childB, childClaimB.ownershipToken);
+      const childReservationB = yield* settlementReservation({
+        submissionId: childB.submissionId,
+        ownershipToken: childClaimB.ownershipToken,
+        receiptId: childB.receiptId,
+        outcome: "completed",
+      });
+      yield* ledger.reserveSettlement(childReservationB);
       const woken = yield* ledger.recordChildSettled(
         ChildSettledNotification.make({
           parentSubmissionId: parent.submissionId,
@@ -2848,7 +2866,13 @@ const recordChildSettledWake = conformanceCase(
       );
       yield* ensure(
         woken === "woken",
-        "The covering child settlement must wake the parent exactly once",
+        "The covering canonical settlement prefix must wake the parent before child finalization",
+      );
+      yield* ledger.finalizeSettlement(
+        SettlementFinalization.make({
+          submissionId: childB.submissionId,
+          settlementId: childReservationB.settlementId,
+        }),
       );
       const awake = yield* expectSome(
         "lookup after the covering settlement",

--- a/packages/session/src/ledger.ts
+++ b/packages/session/src/ledger.ts
@@ -960,9 +960,11 @@ export type SubmissionLedgerFailure =
  *   `suspended(WaitingForChild) → input-applied` exactly when EVERY listed child is settled,
  *   answering `woken`; `still-waiting` while any listed child is unsettled; `not-waiting` when
  *   the parent is not suspended waiting on this child (including replays after the wake). The
- *   child's canonical Settlement is the authority — a notification for an unsettled child is an
- *   adapter-checked caller error (`LedgerError` on single-store adapters). It never settles the
- *   parent and requires no ownership token: the recorded child settlement authorizes the wake.
+ *   child's canonical Settlement is the authority. The runtime reports it after the exact
+ *   reserved record is appended and before ledger finalization, so same-store adapters accept
+ *   `terminalizing` only when its exact reservation exists; an earlier child is an
+ *   adapter-checked caller error. It never settles the parent and requires no ownership token:
+ *   the canonically recorded child settlement authorizes the wake.
  * - `reserveChildBudget` — idempotent get-or-create of the parent-owned child budget
  *   reservation (spec §12 step 2), fenced by the parent lane's live `OwnershipToken`. An
  *   identical replay returns the stored row with `replayed` set (unfenced, mirroring

--- a/packages/session/src/recovery.ts
+++ b/packages/session/src/recovery.ts
@@ -337,10 +337,10 @@ export class AwaitChildSettlement extends Schema.TaggedClass<AwaitChildSettlemen
   "@effect-agent/session/AwaitChildSettlement",
 )("AwaitChildSettlement", { submissionId: SubmissionId }) {}
 
-/** Every relevant child is provably settled but the parent has not joined (a dropped wake or a
- * crash between child finalization and `recordChildSettled`): replay the idempotent wake so a
- * claiming worker resumes the declared batch and joins each child's canonical Settlement — the
- * join itself needs the parent Binding and is deferred to that worker (spec §13). */
+/** Every relevant child is provably settled but the parent has not joined (legacy data, or a
+ * canonical settlement whose idempotent wake still needs replay): record/replay the durable wake
+ * so a claiming worker resumes the declared batch and joins each child's canonical Settlement —
+ * the join itself needs the parent Binding and is deferred to that worker (spec §13). */
 export class ResumeWaitingParent extends Schema.TaggedClass<ResumeWaitingParent>(
   "@effect-agent/session/ResumeWaitingParent",
 )("ResumeWaitingParent", {

--- a/packages/session/test/recovery-classifier.test.ts
+++ b/packages/session/test/recovery-classifier.test.ts
@@ -865,7 +865,7 @@ describe("recovery classifier S2 subagent establishment rows (spec §13)", () =>
     expect(decision._tag).toBe("AwaitChildSettlement");
   });
 
-  it("kill between child finalize and recordChildSettled — child terminal on a live parent replays the wake (row 9)", () => {
+  it("legacy settled child without a parent marker replays the idempotent wake (row 9)", () => {
     const decision = classifyRecovery(
       running({
         childAttachments: [childAttachment(CALL_DELEGATE, CHILD_ONE, "settled", "completed")],

--- a/packages/storage-cloudflare/src/do-ledger.ts
+++ b/packages/storage-cloudflare/src/do-ledger.ts
@@ -2254,12 +2254,18 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
       Effect.gen(function* () {
         const parent = yield* requireSubmission(operation, validated.parentSubmissionId);
         // The child's canonical Settlement is the authority for this wake. When the child's
-        // row lives in THIS store (single-store latitude, and every conformance lane), an
-        // unsettled child makes the notification a caller error exactly as on Node. When it
-        // does not — the normal cross-DO case — the routed notification from the child's
-        // owning Durable Object is the settlement evidence this store records durably.
+        // row lives in THIS store (single-store latitude, and every conformance lane), either a
+        // finalized row or an exact terminalizing reservation admits the notification: the
+        // runtime calls only after the canonical append and before ledger finalization. When the
+        // row does not live here — the normal cross-DO case — the routed notification from the
+        // child's owning Durable Object is the settlement evidence this store records durably.
         const child = yield* readSubmission(operation, validated.childSubmissionId);
-        if (Option.isSome(child) && child.value.state !== "settled") {
+        const childReservation = yield* readReservation(operation, validated.childSubmissionId);
+        if (
+          Option.isSome(child) &&
+          child.value.state !== "settled" &&
+          !(child.value.state === "terminalizing" && Option.isSome(childReservation))
+        ) {
           return yield* LedgerError.make({
             operation,
             message: `Child submission ${validated.childSubmissionId} has no recorded settlement.`,
@@ -2279,7 +2285,13 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
           ) VALUES (
             ${validated.parentSubmissionId},
             ${validated.childSubmissionId},
-            ${Option.isSome(child) ? child.value.settled_outcome : null},
+            ${
+              Option.isSome(child) && child.value.state === "settled"
+                ? child.value.settled_outcome
+                : Option.isSome(childReservation)
+                  ? childReservation.value.outcome
+                  : null
+            },
             ${now.iso}
           )
           ON CONFLICT (parent_submission_id, child_submission_id) DO NOTHING

--- a/packages/storage-memory/src/memory-ledger.ts
+++ b/packages/storage-memory/src/memory-ledger.ts
@@ -1651,10 +1651,16 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
                 current,
               ];
             }
-            // The child's canonical Settlement is the authority for this wake; a notification
-            // for an unsettled (or unknown) child is a caller error in a single-store adapter.
+            // The caller may notify after the canonical Settlement append but before ledger
+            // finalization. In a single store, an exact reservation plus `terminalizing` is the
+            // narrow durable prefix that makes that ordering admissible; earlier states remain
+            // a caller error.
             const child = current.submissions.get(request.childSubmissionId);
-            if (child === undefined || child.row.state !== "settled") {
+            const announced =
+              child !== undefined &&
+              (child.row.state === "settled" ||
+                (child.row.state === "terminalizing" && child.reservation !== undefined));
+            if (!announced) {
               return [
                 failure(
                   ledgerError(
@@ -1676,12 +1682,15 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
             if (!children.some((entry) => entry.childSubmissionId === request.childSubmissionId)) {
               return [success("not-waiting" as const), current];
             }
-            // The parent wakes exactly when EVERY listed child is settled (spec §12 step 10);
-            // replays re-run the coverage check so a recovering caller wakes the lane
-            // idempotently.
-            const allSettled = children.every(
-              (entry) => current.submissions.get(entry.childSubmissionId)?.row.state === "settled",
-            );
+            // Every listed child must be either finalized or canonically announced from the
+            // exact terminalizing reservation. Replays re-run this coverage check idempotently.
+            const allSettled = children.every((entry) => {
+              const listed = current.submissions.get(entry.childSubmissionId);
+              return (
+                listed?.row.state === "settled" ||
+                (listed?.row.state === "terminalizing" && listed.reservation !== undefined)
+              );
+            });
             if (!allSettled) return [success("still-waiting" as const), current];
             return [
               success("woken" as const),

--- a/packages/storage-sqlite/src/sqlite-ledger.ts
+++ b/packages/storage-sqlite/src/sqlite-ledger.ts
@@ -2173,10 +2173,16 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
       operation,
       Effect.gen(function* () {
         const parent = yield* requireSubmission(operation, validated.parentSubmissionId);
-        // The child's canonical Settlement is the authority for this wake; a notification for
-        // an unsettled (or unknown) child is a caller error in a single-store adapter.
+        // The caller may notify after the canonical Settlement append but before ledger
+        // finalization. An exact reservation plus `terminalizing` is the narrow durable prefix
+        // that makes that ordering admissible; earlier states remain a caller error.
         const child = yield* readSubmission(operation, validated.childSubmissionId);
-        if (Option.isNone(child) || child.value.state !== "settled") {
+        const childReservation = yield* readReservation(operation, validated.childSubmissionId);
+        const announced =
+          Option.isSome(child) &&
+          (child.value.state === "settled" ||
+            (child.value.state === "terminalizing" && Option.isSome(childReservation)));
+        if (!announced) {
           return yield* LedgerError.make({
             operation,
             message: `Child submission ${validated.childSubmissionId} has no recorded settlement.`,
@@ -2205,11 +2211,16 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
         ) {
           return "not-waiting" as ChildSettledOutcome;
         }
-        // The parent wakes exactly when EVERY listed child is settled (spec §12 step 10);
-        // replays re-run the coverage check so a recovering caller wakes the lane idempotently.
+        // Every listed child must be either finalized or canonically announced from the exact
+        // terminalizing reservation. Replays re-run this coverage check idempotently.
         for (const entry of reason.children) {
           const listed = yield* readSubmission(operation, entry.childSubmissionId);
-          if (Option.isNone(listed) || listed.value.state !== "settled") {
+          const reservation = yield* readReservation(operation, entry.childSubmissionId);
+          const covered =
+            Option.isSome(listed) &&
+            (listed.value.state === "settled" ||
+              (listed.value.state === "terminalizing" && Option.isSome(reservation)));
+          if (!covered) {
             return "still-waiting" as ChildSettledOutcome;
           }
         }


### PR DESCRIPTION
Fixes #93.

## What changed

- Persist a dirty/processed maintenance generation for each conversation object so an alarm acknowledges only the generation it observed.
- Pre-arm durable maintenance before exposed mutations, serialize maintenance passes, and retain the alarm when a mutation overlaps cancellation.
- Quiesce stable externally driven waits and make a forced caught-up alarm return from durable metadata without recovery, ledger scans, or canonical-history reads.
- Keep bounded rearming for autonomous retry, lease-recovery, and indeterminate states; committed autonomous work resumes after eviction.
- Make child settlement durably wake its parent before child finalization, with an idempotent post-finalization wake for the same-store resuspension race. This preserves the parent-wake guarantee without polling.
- Document the durability contract and add the required patch changeset.

The canonical-history N+1 is deliberately separate and tracked in #96.

## Correctness notes

- A pass records its observed generation and only advances `processed` to that value.
- A mutation increments `dirty` and installs an alarm transactionally before its body runs.
- In-process mutation/pass overlap is gated, while durable generations preserve correctness across eviction and restart.
- The caught-up path reads only the small maintenance record and exits in O(1).

## Validation

- `vp run check` — green.
- `vp run build` — 20/20 tasks green.
- `packages/platform-cloudflare/test/alarm.test.ts` — 9/9 green, including the three public DO RPC/alarm regressions citing #93.
- `packages/platform-cloudflare/test/subagents-cross-do.test.ts -t "issue #93"` — green; proves eviction after child finalization cannot lose the precommitted parent wake.
- `@effect-agent/platform-cloudflare` — 118/118 green.
- Affected package suites: session 136/136, storage-memory 55/55, storage-sqlite 64/64, storage-cloudflare 68/68.

The root test task was attempted twice and not repeated again. Its only emitted leaf failure was unrelated to this change:

- task: `@effect-agent/sandbox-local#test`
- test: `packages/sandbox-local/test/local-sandbox.test.ts > unisolated local Sandbox > fails wall-clock timeout through the typed channel and finalizes the process scope`
- observed failure: the parallel run tried to read its PID fixture before `/tmp/effect-agent-sandbox-*/pid` existed (`ENOENT`, line 80).
- focused classification: `vp test run test/local-sandbox.test.ts -t 'fails wall-clock timeout'` passed 1/1 from `packages/sandbox-local`.

The other failed status was the enclosing `effect-agent-monorepo#test` task propagating that package exit; no session, storage, Cloudflare, alarm, or settlement test failed.
