### PR TITLE
feat(session): add durable progress waits

### DIFF
--- a/.changeset/durable-progress-wait.md
+++ b/.changeset/durable-progress-wait.md
@@ -1,0 +1,10 @@
+---
+"@effect-agent/session": minor
+"@effect-agent/platform-cloudflare": minor
+---
+
+Add the Effect-native durable progress wait from #94. Runtime and Cloudflare callers now subscribe
+before an authoritative canonical read, wake from post-commit hints without polling, broadcast to
+concurrent same-conversation waiters, clean up on interruption, and reconnect safely after Durable
+Object eviction. Cloudflare observation and resolution calls also preserve typed authorization
+denials.

--- a/.changeset/durable-progress-wait.md
+++ b/.changeset/durable-progress-wait.md
@@ -7,4 +7,5 @@ Add the Effect-native durable progress wait from #94. Runtime and Cloudflare cal
 before an authoritative canonical read, wake from post-commit hints without polling, broadcast to
 concurrent same-conversation waiters, clean up on interruption, and reconnect safely after Durable
 Object eviction. Cloudflare observation and resolution calls also preserve typed authorization
-denials.
+denials, and the client Layer now requires an explicit `Crypto.Crypto` provider for cancellation
+identities.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -107,9 +107,11 @@ committed alarm), the alarm/RPC wake scheduler, the Durable Object RPC port tran
 `CloudflareDurableRuntime.layer`, `makeConversationObjectClass` (local-only constructor gates
 and the typed admission-limits gate before `submit`), and the Worker-side
 `CloudflareConversationClient`, whose `awaitProgress` RPC retries Object resets with a fresh stub
-and sends explicit scoped cancellation on interruption. `CloudflareBindingSource` may capture registered worker Bindings
-from `CloudflareBindingSourceContext` once per Object incarnation, after identity derivation. It
-is a Layer-assembly library, not an application entrypoint.
+and sends explicit scoped cancellation on interruption. The client Layer requires `Crypto.Crypto`
+so its composition root owns collision-resistant cancellation identity generation instead of the
+client reading ambient time or randomness. `CloudflareBindingSource` may capture registered worker
+Bindings from `CloudflareBindingSourceContext` once per Object incarnation, after identity
+derivation. It is a Layer-assembly library, not an application entrypoint.
 
 ### `@effect-agent/pr-review`
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -55,7 +55,9 @@ itself as `unisolated` and rejects isolation policy it cannot enforce.
 
 Owns canonical Conversation record Schemas, batches, digests, replay/checkpoints, the
 `ConversationStore`, `SubmissionLedger`, and `WakeScheduler` ports, the pure recovery classifier,
-the run journal, and the `DurableAgentRuntime` coordinator (Receipt, Attempt, Settlement). It
+the run journal, and the `DurableAgentRuntime` coordinator (Receipt, Attempt, Settlement), including
+the conversation-keyed `awaitProgress` boundary that subscribes before its authoritative canonical
+read. It
 depends on `@effect-agent/engine` to drive the interpreter through its public seams.
 It also owns the durable Subagent protocol: the requested/started/joined/lineage record
 Schemas, the child budget reservation and `waitingForChild` ledger operations, and the
@@ -104,7 +106,8 @@ configuration, the single multiplexed `DurableAlarmService` with the idempotent
 committed alarm), the alarm/RPC wake scheduler, the Durable Object RPC port transport,
 `CloudflareDurableRuntime.layer`, `makeConversationObjectClass` (local-only constructor gates
 and the typed admission-limits gate before `submit`), and the Worker-side
-`CloudflareConversationClient`. `CloudflareBindingSource` may capture registered worker Bindings
+`CloudflareConversationClient`, whose `awaitProgress` RPC retries Object resets with a fresh stub
+and sends explicit scoped cancellation on interruption. `CloudflareBindingSource` may capture registered worker Bindings
 from `CloudflareBindingSourceContext` once per Object incarnation, after identity derivation. It
 is a Layer-assembly library, not an application entrypoint.
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -300,6 +300,9 @@ best-effort hint after their authoritative commit. RPC interruption sends a scop
 an Object eviction rejects the old call, after which the client retries only a platform-classified
 reset with a fresh stub. The reconstructed Object subscribes and rereads canonical storage before
 parking, so disposable memory can neither strand the caller nor impersonate durable progress.
+Each logical client wait obtains one UUID from the explicit `Crypto.Crypto` capability and reuses it
+across reset attempts. That identity groups duplicate transport attempts for cancellation but
+remains disposable coordination state; canonical records alone establish durable progress.
 Host-supplied `CloudflareDurableRuntimeOptions.operationAuthorizer` decisions cross observation,
 progress, approval, and unknown-resolution RPCs as the typed `OperationDenied`.
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -103,7 +103,10 @@ class WakeScheduler extends Context.Service<WakeScheduler, {...}>()(
   It absorbs the earlier `AttemptOwnership` prose service; claims mint Attempt identity and
   fencing evidence atomically with queue-head selection.
 - `WakeScheduler` is a pure liveness hint whose notifications may be dropped, coalesced, or
-  duplicated; consumers must pair subscriptions with ledger scans.
+  duplicated. Workers pair the all-lanes stream with ledger scans. Public progress waits use a
+  separate conversation-keyed, Scope-owned one-shot registration: subscribe first, read one
+  canonical record second, then park. The canonical read is authoritative; the notification only
+  tells the caller to read again.
 
 Earlier drafts referred to a `DurableStorage` service; that was prose shorthand and no such port
 exists. Two further ports are explicitly deferred: an `AttachmentStore` (digest-addressed durable
@@ -289,6 +292,16 @@ record is canonical but before child ledger finalization, the child routes the i
 settlement marker to the parent. That routed mutation pre-arms and dirties the parent, so child
 eviction after finalization cannot strand a quiescent parent. Same-store ledgers accept this
 notification only for the exact `terminalizing` reservation; earlier states fail closed.
+
+`CloudflareConversationClient.awaitProgress(conversationId, afterSequence)` carries that same
+Effect-native boundary across RPC. A normal wait performs no periodic read and creates no alarm
+loop. Every canonical append and the durable approval/unknown/abort/settlement transitions emit a
+best-effort hint after their authoritative commit. RPC interruption sends a scoped cancellation;
+an Object eviction rejects the old call, after which the client retries only a platform-classified
+reset with a fresh stub. The reconstructed Object subscribes and rereads canonical storage before
+parking, so disposable memory can neither strand the caller nor impersonate durable progress.
+Host-supplied `CloudflareDurableRuntimeOptions.operationAuthorizer` decisions cross observation,
+progress, approval, and unknown-resolution RPCs as the typed `OperationDenied`.
 
 The target is no longer experimental: the generic durability conformance suite —
 the same adapter-neutral case arrays the Node adapters run — passes inside workerd, and the

--- a/docs/spec/persistence.md
+++ b/docs/spec/persistence.md
@@ -325,8 +325,14 @@ Projection consumers checkpoint their own canonical sequence and are idempotent.
 They may lag, fail, and rebuild without blocking the engine's canonical append,
 unless a specific projection is declared part of admission or settlement.
 
-Notifications use an outbox committed with canonical state. A dropped notification
-cannot cause lost work because schedulers also scan the ledger.
+Notifications are disposable liveness hints emitted only after the relevant durable mutation. A
+dropped notification cannot cause lost work because schedulers also scan the ledger. An
+interactive progress wait does not scan periodically: it installs a conversation-specific scoped
+registration before a strongly consistent one-record canonical read, returns immediately when a
+record after the caller's sequence already exists, and otherwise parks on that registration. A
+wake is allowed to be a false positive and only asks the caller to reread canonical records.
+Eviction discards registrations; reconnect/retry reconstructs the registration and repeats the
+authoritative read.
 
 ## 15. Requirements
 
@@ -348,3 +354,5 @@ cannot cause lost work because schedulers also scan the ledger.
 - **STORE-012**: Canonical records are retained indefinitely during private development.
 - **STORE-013**: Node/SQLite and Cloudflare Durable Object adapters implement the same Effect
   service contracts and conformance suite.
+- **STORE-014**: Public progress waits close subscribe/check and check/park races without making
+  in-memory notifications authoritative or adding a periodic polling/alarm loop.

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -41,7 +41,8 @@ Durable progress waits additionally force both lost-wakeup interleavings (notify
 but before the canonical check, and notify after the check but before park), count canonical reads
 over an advanced TestClock, broadcast to concurrent same-conversation waiters, isolate unrelated
 lanes, and verify cancellation cleanup. The Cloudflare suite repeats the public client/Object
-boundary with typed authorization/store failures and a real `ctx.abort()` reconstruction (#94).
+boundary with typed authorization/store failures, deterministic client cryptography, explicit
+waiter-registration latches, fiber interruption, and a real `ctx.abort()` reconstruction (#94).
 
 ### 1.4 Adapter conformance
 

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -37,6 +37,12 @@ Each Effect service is tested with deterministic TestClock, test providers, and
 scoped resources. Tests assert typed failures and interruption cleanup, not only
 returned values.
 
+Durable progress waits additionally force both lost-wakeup interleavings (notify after subscribe
+but before the canonical check, and notify after the check but before park), count canonical reads
+over an advanced TestClock, broadcast to concurrent same-conversation waiters, isolate unrelated
+lanes, and verify cancellation cleanup. The Cloudflare suite repeats the public client/Object
+boundary with typed authorization/store failures and a real `ctx.abort()` reconstruction (#94).
+
 ### 1.4 Adapter conformance
 
 Every implementation of a framework port runs the same behavioral suite. An

--- a/packages/platform-cloudflare/src/bindings.ts
+++ b/packages/platform-cloudflare/src/bindings.ts
@@ -31,6 +31,10 @@ export interface ConversationObjectRpc extends Rpc.DurableObjectBranded {
   submitEncoded(encoded: unknown): Promise<unknown>;
   /** Wake-hinted, poll-guaranteed settlement wait; answers an `AwaitSettlementResponse`. */
   awaitSettlementEncoded(encoded: unknown): Promise<unknown>;
+  /** Event-driven durable progress wait; answers a `ProgressObserved` host response. */
+  awaitProgressEncoded(encoded: unknown): Promise<unknown>;
+  /** Best-effort cancellation for one in-flight progress wait. */
+  cancelProgressEncoded(encoded: unknown): Promise<unknown>;
   /** One bounded page of canonical records; answers an `ObservePageResponse`. */
   observePage(encoded: unknown): Promise<unknown>;
   /** Durable abort intent; answers an `AbortResponse`. */

--- a/packages/platform-cloudflare/src/client.ts
+++ b/packages/platform-cloudflare/src/client.ts
@@ -18,6 +18,7 @@ import {
   IdempotencyKey,
   JoinedToHost,
   LedgerError,
+  OperationDenied,
   PersistedJson,
   Principal,
   Receipt,
@@ -29,7 +30,7 @@ import {
   type DurableSubmitAgent,
   type DurableSubmitOptions,
 } from "@effect-agent/session";
-import { Context, Effect, Layer, Schema } from "effect";
+import { Context, Duration, Effect, Layer, Schema } from "effect";
 
 import { DurableAlarmError } from "./alarm.ts";
 import { ConversationObjectNamespace, type ConversationObjectRpc } from "./bindings.ts";
@@ -73,6 +74,10 @@ export class ConversationClientError extends Schema.TaggedError<ConversationClie
     conversationId: Schema.String,
     message: Schema.String,
     cause: Schema.optionalKey(Schema.Defect()),
+    /** Cloudflare's own classification for a failure safe to retry with a fresh stub. */
+    retryable: Schema.optionalKey(Schema.Boolean),
+    /** Cloudflare overloads are surfaced immediately instead of adding retry pressure. */
+    overloaded: Schema.optionalKey(Schema.Boolean),
   },
 ) {}
 
@@ -104,6 +109,21 @@ export class ObservePageRequest extends Schema.Class<ObservePageRequest>(
   limit: Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(1_024)),
 }) {}
 
+/** One event-driven wait for canonical progress strictly after this sequence. */
+export class AwaitProgressRequest extends Schema.Class<AwaitProgressRequest>(
+  "@effect-agent/platform-cloudflare/AwaitProgressRequest",
+)({
+  afterSequence: CanonicalSequence,
+  waiterId: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(256)),
+}) {}
+
+/** Best-effort cancellation of one in-flight progress RPC. */
+export class CancelProgressRequest extends Schema.Class<CancelProgressRequest>(
+  "@effect-agent/platform-cloudflare/CancelProgressRequest",
+)({
+  waiterId: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(256)),
+}) {}
+
 // ---------------------------------------------------------------------------
 // Responses
 // ---------------------------------------------------------------------------
@@ -130,6 +150,7 @@ export const HostFailure = Schema.Union([
   DurableRuntimeFailpointError,
   AdmissionLimitExceeded,
   DurableAlarmError,
+  OperationDenied,
   HostProtocolError,
 ]);
 export type HostFailure = typeof HostFailure.Type;
@@ -151,6 +172,15 @@ export class ObservedPage extends Schema.TaggedClass<ObservedPage>(
 )("ObservedPage", {
   records: Schema.Array(CanonicalRecordEnvelope).check(Schema.isMaxLength(1_024)),
 }) {}
+
+/** A record was already committed or an incarnation-local hint says the caller should re-read. */
+export class ProgressObserved extends Schema.TaggedClass<ProgressObserved>(
+  "@effect-agent/platform-cloudflare/ProgressObserved",
+)("ProgressObserved", {}) {}
+
+export class ProgressCancelled extends Schema.TaggedClass<ProgressCancelled>(
+  "@effect-agent/platform-cloudflare/ProgressCancelled",
+)("ProgressCancelled", {}) {}
 
 export class AbortRecorded extends Schema.TaggedClass<AbortRecorded>(
   "@effect-agent/platform-cloudflare/AbortRecorded",
@@ -182,6 +212,8 @@ export const HostResponse = Schema.Union([
   SubmitSucceeded,
   SettlementReached,
   ObservedPage,
+  ProgressObserved,
+  ProgressCancelled,
   AbortRecorded,
   ApprovalRecorded,
   UnknownResolutionRecorded,
@@ -199,6 +231,10 @@ export const decodeReceipt = Schema.decodeUnknownEffect(Receipt);
 export const encodeReceipt = Schema.encodeEffect(Receipt);
 export const decodeObservePageRequest = Schema.decodeUnknownEffect(ObservePageRequest);
 export const encodeObservePageRequest = Schema.encodeEffect(ObservePageRequest);
+export const decodeAwaitProgressRequest = Schema.decodeUnknownEffect(AwaitProgressRequest);
+export const encodeAwaitProgressRequest = Schema.encodeEffect(AwaitProgressRequest);
+export const decodeCancelProgressRequest = Schema.decodeUnknownEffect(CancelProgressRequest);
+export const encodeCancelProgressRequest = Schema.encodeEffect(CancelProgressRequest);
 export const decodeAbortCommand = Schema.decodeUnknownEffect(AbortCommand);
 export const encodeAbortCommand = Schema.encodeEffect(AbortCommand);
 export const decodeApprovalDecisionCommand = Schema.decodeUnknownEffect(ApprovalDecisionCommand);
@@ -237,6 +273,14 @@ export type ClientAwaitFailure =
 export type ClientObserveFailure =
   | ConversationStoreError
   | ConversationNotMaterialized
+  | OperationDenied
+  | HostProtocolError
+  | ConversationClientError;
+
+export type ClientProgressFailure =
+  | ConversationStoreError
+  | ConversationNotMaterialized
+  | OperationDenied
   | HostProtocolError
   | ConversationClientError;
 
@@ -253,6 +297,7 @@ export type ClientApprovalFailure =
   | LedgerError
   | SettlementConflict
   | ApprovalConflict
+  | OperationDenied
   | DurableAlarmError
   | HostProtocolError
   | ConversationClientError;
@@ -263,6 +308,7 @@ export type ClientUnknownFailure =
   | UnknownResolutionConflict
   | JoinedToHost
   | DurableRuntimeFailpointError
+  | OperationDenied
   | DurableAlarmError
   | HostProtocolError
   | ConversationClientError;
@@ -289,8 +335,10 @@ const AWAIT_FAILURE_TAGS: ReadonlySet<string> = new Set([
 const OBSERVE_FAILURE_TAGS: ReadonlySet<string> = new Set([
   "ConversationStoreError",
   "ConversationNotMaterialized",
+  "OperationDenied",
   "HostProtocolError",
 ]);
+const PROGRESS_FAILURE_TAGS = OBSERVE_FAILURE_TAGS;
 const ABORT_FAILURE_TAGS: ReadonlySet<string> = new Set([
   "LedgerError",
   "SettlementConflict",
@@ -303,6 +351,7 @@ const APPROVAL_FAILURE_TAGS: ReadonlySet<string> = new Set([
   "LedgerError",
   "SettlementConflict",
   "ApprovalConflict",
+  "OperationDenied",
   "DurableAlarmError",
   "HostProtocolError",
 ]);
@@ -312,6 +361,7 @@ const UNKNOWN_FAILURE_TAGS: ReadonlySet<string> = new Set([
   "UnknownResolutionConflict",
   "JoinedToHost",
   "DurableRuntimeFailpointError",
+  "OperationDenied",
   "DurableAlarmError",
   "HostProtocolError",
 ]);
@@ -351,6 +401,14 @@ export class CloudflareConversationClient extends Context.Service<
     ) => Effect.Effect<Receipt, ClientSubmitFailure, InputSchema["EncodingServices"]>;
     /** Wake-hinted, poll-guaranteed settlement wait executed inside the owning Object. */
     readonly awaitSettlement: (receipt: Receipt) => Effect.Effect<Settlement, ClientAwaitFailure>;
+    /**
+     * Wait without polling until progress after `afterSequence` is already durable or hinted.
+     * The result is deliberately void: canonical records remain authoritative and must be read.
+     */
+    readonly awaitProgress: (
+      conversationId: ConversationId,
+      afterSequence: CanonicalSequence,
+    ) => Effect.Effect<void, ClientProgressFailure>;
     /** One bounded page of canonical records. */
     readonly readPage: (
       conversationId: ConversationId,
@@ -393,6 +451,34 @@ export class CloudflareConversationClient extends Context.Service<
   > = Layer.effect(CloudflareConversationClient)(
     Effect.gen(function* () {
       const { namespace } = yield* ConversationObjectNamespace;
+      const waiterPrefix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+      let nextWaiter = 0;
+
+      const platformSignals = (cause: unknown) => {
+        let retryable: boolean | undefined;
+        let overloaded: boolean | undefined;
+        if (typeof cause === "object" && cause !== null) {
+          if ("retryable" in cause && typeof cause.retryable === "boolean") {
+            retryable = cause.retryable;
+          }
+          if ("overloaded" in cause && typeof cause.overloaded === "boolean") {
+            overloaded = cause.overloaded;
+          }
+          // Miniflare's faithful `ctx.abort()` signal predates the public `retryable` field.
+          // Treat only its explicit reset marker as the same idempotent-retry classification.
+          if (
+            retryable === undefined &&
+            "durableObjectReset" in cause &&
+            cause.durableObjectReset === true
+          ) {
+            retryable = true;
+          }
+        }
+        return {
+          ...(retryable === undefined ? {} : { retryable }),
+          ...(overloaded === undefined ? {} : { overloaded }),
+        };
+      };
 
       const call = (
         conversationId: string,
@@ -410,6 +496,7 @@ export class CloudflareConversationClient extends Context.Service<
                 }`,
               ),
               cause,
+              ...platformSignals(cause),
             }),
         }).pipe(
           Effect.flatMap((raw) =>
@@ -488,6 +575,19 @@ export class CloudflareConversationClient extends Context.Service<
           return page.records;
         });
 
+      const cancelProgress = (
+        conversationId: ConversationId,
+        waiterId: string,
+      ): Effect.Effect<void> =>
+        encodeCancelProgressRequest(CancelProgressRequest.make({ waiterId })).pipe(
+          Effect.mapError(() => undefined),
+          Effect.flatMap((encoded) =>
+            call(conversationId, "cancelProgress", (stub) => stub.cancelProgressEncoded(encoded)),
+          ),
+          Effect.asVoid,
+          Effect.ignore,
+        );
+
       return CloudflareConversationClient.of({
         submit: <InputSchema extends Schema.Top>(
           agent: DurableSubmitAgent<InputSchema>,
@@ -556,6 +656,47 @@ export class CloudflareConversationClient extends Context.Service<
               AWAIT_FAILURE_TAGS,
             )(response);
             return settled.settlement;
+          }),
+
+        awaitProgress: (conversationId, afterSequence) =>
+          Effect.gen(function* () {
+            const waiterId = `${waiterPrefix}:${nextWaiter++}`;
+            const request = AwaitProgressRequest.make({ afterSequence, waiterId });
+            const encoded = yield* encodeAwaitProgressRequest(request).pipe(
+              Effect.mapError((error) =>
+                HostProtocolError.make({
+                  message: boundHostDiagnostic(
+                    `awaitProgress request encode failed: ${error.message}`,
+                  ),
+                }),
+              ),
+            );
+
+            const attempt = (retry: number): Effect.Effect<void, ClientProgressFailure> =>
+              call(conversationId, "awaitProgress", (stub) =>
+                stub.awaitProgressEncoded(encoded),
+              ).pipe(
+                Effect.flatMap(
+                  expect<ProgressObserved, ClientProgressFailure & HostFailure>(
+                    conversationId,
+                    "awaitProgress",
+                    "ProgressObserved",
+                    PROGRESS_FAILURE_TAGS,
+                  ),
+                ),
+                Effect.asVoid,
+                Effect.catchTag("ConversationClientError", (error) =>
+                  error.retryable === true && error.overloaded !== true && retry < 5
+                    ? Effect.sleep(Duration.millis(10 * 2 ** retry)).pipe(
+                        Effect.andThen(attempt(retry + 1)),
+                      )
+                    : Effect.fail(error),
+                ),
+              );
+
+            yield* attempt(0).pipe(
+              Effect.onInterrupt(() => cancelProgress(conversationId, waiterId)),
+            );
           }),
 
         readPage,

--- a/packages/platform-cloudflare/src/client.ts
+++ b/packages/platform-cloudflare/src/client.ts
@@ -30,7 +30,7 @@ import {
   type DurableSubmitAgent,
   type DurableSubmitOptions,
 } from "@effect-agent/session";
-import { Context, Duration, Effect, Layer, Schema } from "effect";
+import { Context, Crypto, Duration, Effect, Layer, Schema } from "effect";
 
 import { DurableAlarmError } from "./alarm.ts";
 import { ConversationObjectNamespace, type ConversationObjectRpc } from "./bindings.ts";
@@ -447,12 +447,11 @@ export class CloudflareConversationClient extends Context.Service<
   static readonly layer: Layer.Layer<
     CloudflareConversationClient,
     never,
-    ConversationObjectNamespace
+    ConversationObjectNamespace | Crypto.Crypto
   > = Layer.effect(CloudflareConversationClient)(
     Effect.gen(function* () {
       const { namespace } = yield* ConversationObjectNamespace;
-      const waiterPrefix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-      let nextWaiter = 0;
+      const crypto = yield* Crypto.Crypto;
 
       const platformSignals = (cause: unknown) => {
         let retryable: boolean | undefined;
@@ -660,7 +659,15 @@ export class CloudflareConversationClient extends Context.Service<
 
         awaitProgress: (conversationId, afterSequence) =>
           Effect.gen(function* () {
-            const waiterId = `${waiterPrefix}:${nextWaiter++}`;
+            const waiterId = yield* crypto.randomUUIDv4.pipe(
+              Effect.mapError((error) =>
+                HostProtocolError.make({
+                  message: boundHostDiagnostic(
+                    `awaitProgress cancellation identity generation failed: ${error.message}`,
+                  ),
+                }),
+              ),
+            );
             const request = AwaitProgressRequest.make({ afterSequence, waiterId });
             const encoded = yield* encodeAwaitProgressRequest(request).pipe(
               Effect.mapError((error) =>

--- a/packages/platform-cloudflare/src/conversation-object.ts
+++ b/packages/platform-cloudflare/src/conversation-object.ts
@@ -27,6 +27,7 @@ import {
   SettlementConflict,
   SubmissionLedger,
   SubmissionLookupByKey,
+  WakeScheduler,
   type DurableSubmitAgent,
 } from "@effect-agent/session";
 import type { DurableObject as CloudflareDurableObject } from "cloudflare:workers";
@@ -56,11 +57,15 @@ import {
   HostFailed,
   HostProtocolError,
   ObservedPage,
+  ProgressObserved,
+  ProgressCancelled,
   SettlementReached,
   SubmitSucceeded,
   UnknownResolutionRecorded,
   boundHostDiagnostic,
   decodeAbortCommand,
+  decodeAwaitProgressRequest,
+  decodeCancelProgressRequest,
   decodeApprovalDecisionCommand,
   decodeObservePageRequest,
   decodeReceipt,
@@ -78,6 +83,7 @@ import {
   type CloudflareDurableRuntimeOptions,
   type CloudflareDurableRuntimeServices,
 } from "./layers.ts";
+import { ProgressWaitRegistry } from "./progress-wait.ts";
 
 /**
  * `makeConversationObjectClass(options, observability?)` — the Conversation Durable Object
@@ -279,6 +285,46 @@ const awaitSettlementEndpoint = (
     Effect.flatMap(encodeResponse),
   );
 
+const awaitProgressEndpoint = (encoded: unknown): Effect.Effect<unknown, never, EndpointServices> =>
+  decodeAwaitProgressRequest(encoded).pipe(
+    Effect.mapError(protocolFailure("The progress request could not be decoded")),
+    Effect.flatMap((request) =>
+      Effect.gen(function* () {
+        const identity = yield* ConversationObjectIdentity;
+        const runtime = yield* DurableAgentRuntime;
+        const registry = yield* ProgressWaitRegistry;
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const cancelled = yield* registry.subscribe(request.waiterId);
+            yield* Effect.raceFirst(
+              runtime.awaitProgress(identity.conversationId, request.afterSequence),
+              cancelled,
+            );
+          }),
+        );
+        return ProgressObserved.make();
+      }),
+    ),
+    respond,
+    Effect.flatMap(encodeResponse),
+  );
+
+const cancelProgressEndpoint = (
+  encoded: unknown,
+): Effect.Effect<unknown, never, EndpointServices> =>
+  decodeCancelProgressRequest(encoded).pipe(
+    Effect.mapError(protocolFailure("The progress cancellation could not be decoded")),
+    Effect.flatMap((request) =>
+      Effect.gen(function* () {
+        const registry = yield* ProgressWaitRegistry;
+        yield* registry.cancel(request.waiterId);
+        return ProgressCancelled.make();
+      }),
+    ),
+    respond,
+    Effect.flatMap(encodeResponse),
+  );
+
 const observePageEndpoint = (encoded: unknown): Effect.Effect<unknown, never, EndpointServices> =>
   decodeObservePageRequest(encoded).pipe(
     Effect.mapError(protocolFailure("The observe request could not be decoded")),
@@ -289,14 +335,12 @@ const observePageEndpoint = (encoded: unknown): Effect.Effect<unknown, never, En
         // The same fail-closed authorization seam the runtime's `observe` consults (P7 WP1);
         // the default reference preserves the possession behavior.
         const authorizer = yield* OperationAuthorizer;
-        yield* authorizer
-          .authorize(
-            OperationAuthorizationRequest.make({
-              operation: "observe",
-              conversationId: identity.conversationId,
-            }),
-          )
-          .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure));
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "observe",
+            conversationId: identity.conversationId,
+          }),
+        );
         const records = yield* Stream.runCollect(
           store.read(
             ConversationRead.make({
@@ -330,24 +374,6 @@ const abortEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpoint
     Effect.flatMap(encodeResponse),
   );
 
-/**
- * The pre-P7 host protocol's failure union does not carry `OperationDenied` (the Worker client
- * predates the authorizer). This assembly always runs the default possession authorizer — no
- * `CloudflareDurableRuntimeOptions` authorizer lever exists yet — so a denial here is
- * unreachable today; if one ever surfaces it degrades to the protocol failure instead of an
- * out-of-contract throw. The four P7 admin entry points below carry `OperationDenied` typed.
- */
-const deniedToProtocolFailure = (
-  denied: OperationDenied,
-): Effect.Effect<never, HostProtocolError> =>
-  Effect.fail(
-    HostProtocolError.make({
-      message: boundHostDiagnostic(
-        `The ${denied.operation} operation was denied: ${denied.reason}`,
-      ),
-    }),
-  );
-
 const resolveApprovalEndpoint = (
   encoded: unknown,
 ): Effect.Effect<unknown, never, EndpointServices> =>
@@ -357,11 +383,7 @@ const resolveApprovalEndpoint = (
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        const intent = yield* maintenance.withMutation(
-          runtime
-            .resolveApproval(command)
-            .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure)),
-        );
+        const intent = yield* maintenance.withMutation(runtime.resolveApproval(command));
         return ApprovalRecorded.make({ intent });
       }),
     ),
@@ -378,11 +400,7 @@ const resolveUnknownEndpoint = (
       Effect.gen(function* () {
         const maintenance = yield* ConversationMaintenance;
         const runtime = yield* DurableAgentRuntime;
-        const intent = yield* maintenance.withMutation(
-          runtime
-            .resolveUnknown(command)
-            .pipe(Effect.catchTag("OperationDenied", deniedToProtocolFailure)),
-        );
+        const intent = yield* maintenance.withMutation(runtime.resolveUnknown(command));
         return UnknownResolutionRecorded.make({ intent });
       }),
     ),
@@ -599,12 +617,11 @@ const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpo
   });
 
 const wakeEndpoint: Effect.Effect<void, never, EndpointServices> = Effect.gen(function* () {
-  const alarm = yield* DurableAlarmService;
-  // Wake hints are droppable by contract: a failed alarm write is logged and swallowed; the
-  // sender's own alarm/scan pairing (or this Object's next entry point) restores liveness.
-  yield* alarm.scheduleNow.pipe(
-    Effect.catch((error) => Effect.logWarning("ConversationObject.wake dropped", error)),
-  );
+  const identity = yield* ConversationObjectIdentity;
+  const wake = yield* WakeScheduler;
+  // Route the remote hint through this incarnation's scheduler so scoped progress waiters and
+  // the alarm receive the same hint. Delivery remains droppable; canonical storage is authority.
+  yield* wake.notify(identity.conversationId);
 });
 
 const alarmEndpoint: Effect.Effect<void, MaintenancePassFailure, EndpointServices> = Effect.gen(
@@ -659,6 +676,8 @@ const effectCfPlatformLayer = (
 export interface ConversationObjectInstance extends CloudflareDurableObject {
   submitEncoded(encoded: unknown): Promise<unknown>;
   awaitSettlementEncoded(encoded: unknown): Promise<unknown>;
+  awaitProgressEncoded(encoded: unknown): Promise<unknown>;
+  cancelProgressEncoded(encoded: unknown): Promise<unknown>;
   observePage(encoded: unknown): Promise<unknown>;
   abortEncoded(encoded: unknown): Promise<unknown>;
   resolveApprovalEncoded(encoded: unknown): Promise<unknown>;
@@ -727,6 +746,8 @@ export const makeConversationObjectClass = <EventLayerError = never, EventServic
   const rpc = {
     submitEncoded: (encoded: unknown) => submitEndpoint(encoded),
     awaitSettlementEncoded: (encoded: unknown) => awaitSettlementEndpoint(encoded),
+    awaitProgressEncoded: (encoded: unknown) => awaitProgressEndpoint(encoded),
+    cancelProgressEncoded: (encoded: unknown) => cancelProgressEndpoint(encoded),
     observePage: (encoded: unknown) => observePageEndpoint(encoded),
     abortEncoded: (encoded: unknown) => abortEndpoint(encoded),
     resolveApprovalEncoded: (encoded: unknown) => resolveApprovalEndpoint(encoded),

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -17,6 +17,7 @@ export * from "./bindings.ts";
 export * from "./config.ts";
 export * from "./alarm.ts";
 export * from "./wake-scheduler.ts";
+export * from "./progress-wait.ts";
 export * from "./transport.ts";
 export * from "./layers.ts";
 export * from "./conversation-object.ts";

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -5,9 +5,11 @@ import {
   DurableRuntimeConfig,
   DurableRuntimeFailpoint,
   ProducerId,
+  operationAuthorizerLayer,
   ToolReconciler,
   type ConversationStore,
   type DurableRuntimeFailpointHandler,
+  type OperationAuthorizerService,
   type ResolvedBinding,
   type SubmissionLedger,
   type WakeScheduler,
@@ -45,6 +47,7 @@ import {
   CloudflareDurableRuntimeConfigValue,
   CloudflarePlatformConfigError,
 } from "./config.ts";
+import { ProgressWaitRegistry } from "./progress-wait.ts";
 import { conversationPortTransportLayer } from "./transport.ts";
 import { cloudflareWakeSchedulerLayer } from "./wake-scheduler.ts";
 
@@ -98,6 +101,8 @@ export interface CloudflareDurableRuntimeOptions {
   readonly maintenanceFailpoint?:
     | ((ctx: DurableObjectState) => ConversationMaintenanceFailpointHandler)
     | undefined;
+  /** Host-supplied fail-closed authorization policy; defaults to service possession. */
+  readonly operationAuthorizer?: OperationAuthorizerService | undefined;
   /**
    * Reconciliation policy consulted for open ordinary Tool Calls before an Unknown Outcome
    * is recorded (durability §10, DUR-009). Defaults to the fail-closed
@@ -152,7 +157,8 @@ export type CloudflareDurableRuntimeServices =
   | ConversationObjectIdentity
   | DurableAlarmService
   | ConversationMaintenance
-  | ConversationObjectPorts;
+  | ConversationObjectPorts
+  | ProgressWaitRegistry;
 
 /**
  * Owner-side endpoint body for the Conversation Object's `portCall` (plan §1.3): decode,
@@ -356,6 +362,10 @@ export class CloudflareDurableRuntime {
                 hit: options.maintenanceFailpoint(ctx),
               });
         const reconcilerLayer = options.toolReconciler ?? ToolReconciler.uncertain;
+        const authorizerLayer =
+          options.operationAuthorizer === undefined
+            ? Layer.empty
+            : operationAuthorizerLayer(options.operationAuthorizer);
         const bindingResolverLayer = Layer.effect(AgentBindingResolver)(
           Effect.map(
             resolveBindings(options.bindings, { ctx, env, conversationId, producerId }),
@@ -368,6 +378,7 @@ export class CloudflareDurableRuntime {
           cloudflareConfigLayer,
           DurableAlarmService.layer,
           maintenanceFailpointLayer,
+          ProgressWaitRegistry.layer,
         );
 
         const runtimeStack = DurableAgentRuntime.layer.pipe(
@@ -376,7 +387,12 @@ export class CloudflareDurableRuntime {
           Layer.provideMerge(runtimeConfigLayer),
           Layer.provideMerge(bindingResolverLayer),
           Layer.provide(
-            Layer.mergeAll(runtimeFailpointLayer, reconcilerLayer, BrowserCrypto.layer),
+            Layer.mergeAll(
+              runtimeFailpointLayer,
+              reconcilerLayer,
+              authorizerLayer,
+              BrowserCrypto.layer,
+            ),
           ),
           Layer.provideMerge(base),
         );

--- a/packages/platform-cloudflare/src/progress-wait.ts
+++ b/packages/platform-cloudflare/src/progress-wait.ts
@@ -1,0 +1,103 @@
+import { Context, Deferred, Effect, Layer, Ref, type Scope } from "effect";
+
+/** Cancellation tombstones are bounded hints, never durable authority. */
+const MAX_CANCELLATION_TOMBSTONES = 1_024;
+
+type ActiveRegistration = ReadonlySet<Deferred.Deferred<void>>;
+type Registration = ActiveRegistration | "cancelled";
+type Registrations = ReadonlyMap<string, Registration>;
+
+/**
+ * Per-incarnation cancellation registry for long-lived progress RPCs. The public runtime owns
+ * the actual wake registration; this host-only registry lets an interrupted Worker Effect ask
+ * the Object to interrupt its scoped wait before the Worker execution context itself ends.
+ */
+export class ProgressWaitRegistry extends Context.Service<
+  ProgressWaitRegistry,
+  {
+    /** Register a Scope-owned cancellation signal, observing any early cancel tombstone. */
+    readonly subscribe: (
+      waiterId: string,
+    ) => Effect.Effect<Effect.Effect<void>, never, Scope.Scope>;
+    /** Cancel a registered waiter, or remember a bounded early cancellation. */
+    readonly cancel: (waiterId: string) => Effect.Effect<void>;
+  }
+>()("@effect-agent/platform-cloudflare/ProgressWaitRegistry") {
+  static readonly layer: Layer.Layer<ProgressWaitRegistry> = Layer.effect(
+    ProgressWaitRegistry,
+    Effect.gen(function* () {
+      const registrations = yield* Ref.make<Registrations>(new Map());
+
+      const remove = (waiterId: string, deferred: Deferred.Deferred<void>) =>
+        Ref.update(registrations, (current) => {
+          const existing = current.get(waiterId);
+          if (existing === undefined || existing === "cancelled" || !existing.has(deferred)) {
+            return current;
+          }
+          const next = new Map(current);
+          const active = new Set(existing);
+          active.delete(deferred);
+          if (active.size === 0) {
+            next.delete(waiterId);
+          } else {
+            next.set(waiterId, active);
+          }
+          return next;
+        });
+
+      const subscribe = Effect.fn("ProgressWaitRegistry.subscribe")(
+        (waiterId: string): Effect.Effect<Effect.Effect<void>, never, Scope.Scope> =>
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<void>();
+            yield* Effect.addFinalizer(() => remove(waiterId, deferred));
+            const cancelled = yield* Ref.modify(registrations, (current) => {
+              const existing = current.get(waiterId);
+              const next = new Map(current);
+              if (existing === "cancelled") {
+                return [true, current] as const;
+              }
+              const active = new Set(existing ?? []);
+              active.add(deferred);
+              next.set(waiterId, active);
+              return [false, next] as const;
+            });
+            return { cancelled, deferred };
+          }).pipe(
+            Effect.map(({ cancelled, deferred }) =>
+              cancelled ? Effect.void : Deferred.await(deferred),
+            ),
+          ),
+      );
+
+      const cancel = Effect.fn("ProgressWaitRegistry.cancel")(function* (waiterId: string) {
+        const waiters = yield* Ref.modify(registrations, (current) => {
+          const existing = current.get(waiterId);
+          const next = new Map(current);
+          if (existing === undefined) {
+            next.set(waiterId, "cancelled");
+            let tombstones = 0;
+            for (const registration of next.values()) {
+              if (registration === "cancelled") tombstones += 1;
+            }
+            if (tombstones > MAX_CANCELLATION_TOMBSTONES) {
+              for (const [id, registration] of next) {
+                if (registration !== "cancelled") continue;
+                next.delete(id);
+                break;
+              }
+            }
+            return [[], next] as const;
+          }
+          if (existing === "cancelled") return [[], current] as const;
+          next.delete(waiterId);
+          return [[...existing], next] as const;
+        });
+        yield* Effect.forEach(waiters, (waiter) => Deferred.succeed(waiter, undefined), {
+          discard: true,
+        });
+      });
+
+      return ProgressWaitRegistry.of({ subscribe, cancel });
+    }),
+  );
+}

--- a/packages/platform-cloudflare/src/wake-scheduler.ts
+++ b/packages/platform-cloudflare/src/wake-scheduler.ts
@@ -1,5 +1,5 @@
 import type { ConversationId } from "@effect-agent/core";
-import { WakeScheduler } from "@effect-agent/session";
+import { makeWakeSubscriptionHub, WakeScheduler } from "@effect-agent/session";
 import { Effect, Layer, PubSub, Schema, Stream } from "effect";
 
 import { DurableAlarmService } from "./alarm.ts";
@@ -42,10 +42,12 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
     const identity = yield* ConversationObjectIdentity;
     const { namespace } = yield* ConversationObjectNamespace;
     const hints = yield* PubSub.sliding<ConversationId>(WAKE_BUFFER_CAPACITY);
+    const progress = yield* makeWakeSubscriptionHub;
     yield* Effect.addFinalizer(() => PubSub.shutdown(hints));
 
     const notifyLocal = (conversationId: ConversationId) =>
-      PubSub.publish(hints, conversationId).pipe(
+      progress.notify(conversationId).pipe(
+        Effect.andThen(PubSub.publish(hints, conversationId)),
         Effect.andThen(alarm.scheduleNow),
         Effect.catch((error) =>
           // `notify` never fails by contract; a failed alarm write degrades to "hint lost"
@@ -79,6 +81,7 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
         conversationId === identity.conversationId
           ? notifyLocal(conversationId)
           : notifyRemote(conversationId),
+      subscribe: progress.subscribe,
       wakes: Stream.fromPubSub(hints),
     });
   }),

--- a/packages/platform-cloudflare/test/eviction.test.ts
+++ b/packages/platform-cloudflare/test/eviction.test.ts
@@ -1047,7 +1047,13 @@ describe("DC eviction matrix — checkpoints and export", () => {
         }),
       ),
     );
-    await expect(stubFor(conversation).portCall(request)).rejects.toThrow();
+    const failure = await runInDurableObject(stubFor(conversation), (instance) =>
+      instance.portCall(request),
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(failure).toBeDefined();
     expect(armConsumed(conversation)).toBe(true);
     const after = await readCanonical(conversation);
     expect(after).toEqual(before);

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -19,6 +19,7 @@ import { decodeConversationId, supplierCountsFor, supplierValuesFor } from "./fi
 import type {
   ArrayBindingsConversationObject,
   DynamicBindingsConversationObject,
+  DeniedConversationObject,
   EffectBindingsConversationObject,
   LimitedConversationObject,
   SubagentConversationObject,
@@ -33,6 +34,7 @@ declare global {
       CONVERSATIONS: DurableObjectNamespace<TestConversationObject>;
       LIMITED: DurableObjectNamespace<LimitedConversationObject>;
       TINYDB: DurableObjectNamespace<TinyDatabaseConversationObject>;
+      DENIED: DurableObjectNamespace<DeniedConversationObject>;
       SUBAGENTS: DurableObjectNamespace<SubagentConversationObject>;
       DYNAMIC_BINDINGS: DurableObjectNamespace<DynamicBindingsConversationObject>;
       ARRAY_BINDINGS: DurableObjectNamespace<ArrayBindingsConversationObject>;
@@ -53,6 +55,7 @@ export type TestNamespace =
   | "CONVERSATIONS"
   | "LIMITED"
   | "TINYDB"
+  | "DENIED"
   | "SUBAGENTS"
   | "DYNAMIC_BINDINGS"
   | "ARRAY_BINDINGS"

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -109,6 +109,40 @@ export const runClientFiber = <A, E>(
   namespace: TestNamespace = "CONVERSATIONS",
 ) => Effect.runFork(effect.pipe(Effect.provide(clientLayer(namespace))));
 
+const isDurableObjectReset = (cause: unknown): boolean =>
+  typeof cause === "object" &&
+  cause !== null &&
+  (("retryable" in cause && cause.retryable === true) ||
+    ("durableObjectReset" in cause && cause.durableObjectReset === true));
+
+/**
+ * Follow an aborted Object to a fresh incarnation, then park on its exact waiter count.
+ * Attempts repeat only when the transport reports a reset or still reaches the prior
+ * incarnation; the count condition itself is an Object-side latch, never a timed poll.
+ */
+export const awaitReconstructedProgressWaiter = async (
+  conversation: string,
+  previousIncarnation: number,
+  expected: number,
+): Promise<number> => {
+  let lastReset: unknown;
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      const incarnation = await (
+        stubFor(conversation) as DurableObjectStub<TestConversationObject>
+      ).awaitProgressWaiterCountAfter(previousIncarnation, expected);
+      if (incarnation !== null) return incarnation;
+    } catch (cause) {
+      if (!isDurableObjectReset(cause)) throw cause;
+      lastReset = cause;
+    }
+    await Effect.runPromise(Effect.yieldNow);
+  }
+  throw new Error("#94 progress waiter did not reach a reconstructed Object", {
+    cause: lastReset,
+  });
+};
+
 /** Exit-capturing variant for rows whose client call is EXPECTED to die mid-eviction. */
 export const runClientExit = <A, E>(
   effect: Effect.Effect<A, E, CloudflareConversationClient>,

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -6,7 +6,7 @@ import {
 } from "@effect-agent/session";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
-import { Effect, Layer, Schema } from "effect";
+import { Crypto, Effect, Layer, Schema } from "effect";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
 import { expect } from "vite-plus/test";
 
@@ -68,24 +68,46 @@ export const stubFor = (conversation: string, namespace: TestNamespace = "CONVER
   return binding.get(binding.idFromName(conversation));
 };
 
+let nextProgressWaitIdentity = 0;
+const deterministicClientCrypto = Layer.succeed(
+  Crypto.Crypto,
+  Crypto.make({
+    randomBytes: (size) => {
+      let identity = ++nextProgressWaitIdentity;
+      const bytes = new Uint8Array(size);
+      for (let index = size - 1; index >= 0 && identity > 0; index--) {
+        bytes[index] = identity & 0xff;
+        identity = Math.floor(identity / 0x100);
+      }
+      return bytes;
+    },
+    digest: (_algorithm, data) => Effect.succeed(data),
+  }),
+);
+
+const clientLayer = (namespace: TestNamespace) =>
+  CloudflareConversationClient.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        ConversationObjectNamespace.layer(
+          env[namespace] as unknown as DurableObjectNamespace<ConversationObjectRpc>,
+        ),
+        deterministicClientCrypto,
+      ),
+    ),
+  );
+
 /** Run one client Effect against a namespace binding through the real Worker-side client. */
 export const runClient = <A, E>(
   effect: Effect.Effect<A, E, CloudflareConversationClient>,
   namespace: TestNamespace = "CONVERSATIONS",
-): Promise<A> =>
-  Effect.runPromise(
-    effect.pipe(
-      Effect.provide(
-        CloudflareConversationClient.layer.pipe(
-          Layer.provide(
-            ConversationObjectNamespace.layer(
-              env[namespace] as unknown as DurableObjectNamespace<ConversationObjectRpc>,
-            ),
-          ),
-        ),
-      ),
-    ),
-  );
+): Promise<A> => Effect.runPromise(effect.pipe(Effect.provide(clientLayer(namespace))));
+
+/** Fork one client Effect so tests can interrupt the real Worker-side caller deterministically. */
+export const runClientFiber = <A, E>(
+  effect: Effect.Effect<A, E, CloudflareConversationClient>,
+  namespace: TestNamespace = "CONVERSATIONS",
+) => Effect.runFork(effect.pipe(Effect.provide(clientLayer(namespace))));
 
 /** Exit-capturing variant for rows whose client call is EXPECTED to die mid-eviction. */
 export const runClientExit = <A, E>(

--- a/packages/platform-cloudflare/test/progress-wait.test.ts
+++ b/packages/platform-cloudflare/test/progress-wait.test.ts
@@ -1,0 +1,292 @@
+import { ApprovalDecisionCommand, CanonicalSequence, type Receipt } from "@effect-agent/session";
+import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { Cause, Effect, Option, Schema } from "effect";
+import { describe, expect, it } from "vite-plus/test";
+
+import { CloudflareConversationClient, ProgressWaitRegistry } from "../src/index.ts";
+import {
+  decodeConversationId,
+  BOOK_TOOL_CALL_ID,
+  approvalDefinition,
+  plannerDefinition,
+  submitOptions,
+} from "./fixtures.ts";
+import {
+  allSettled,
+  anyInState,
+  drainAlarmsUntil,
+  readCanonical,
+  runClient,
+  stubFor,
+} from "./harness.ts";
+import type { TestConversationObject } from "./worker.ts";
+
+const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
+let laneCounter = 0;
+const lane = (label: string): string => `cf-progress-${label}-${laneCounter++}`;
+
+const sleep = (millis: number) => new Promise((resolve) => setTimeout(resolve, millis));
+
+const progressStub = (conversation: string) =>
+  stubFor(conversation) as DurableObjectStub<TestConversationObject>;
+
+const withDeadline = async <A>(promise: Promise<A>, millis = 5_000): Promise<A> =>
+  Promise.race([
+    promise,
+    sleep(millis).then(() => {
+      throw new Error(`#94 progress wait exceeded ${millis}ms`);
+    }),
+  ]);
+
+const waitUntil = async (predicate: () => Promise<boolean>, millis = 5_000): Promise<void> => {
+  const deadline = Date.now() + millis;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      if (await predicate()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(5);
+  }
+  throw lastError ?? new Error(`#94 condition was not reached within ${millis}ms`);
+};
+
+const submitPlanner = (conversation: string) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareConversationClient;
+      return yield* client.submit(
+        { definition: plannerDefinition },
+        { question: "observe durable progress", ref: conversation },
+        submitOptions(conversation, `${conversation}-key`),
+      );
+    }),
+  );
+
+const submitApproval = (conversation: string) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareConversationClient;
+      return yield* client.submit(
+        { definition: approvalDefinition },
+        { question: "hold for approval", ref: conversation },
+        submitOptions(conversation, `${conversation}-key`),
+      );
+    }),
+  );
+
+const prepareApproval = async (
+  conversation: string,
+): Promise<{ readonly receipt: Receipt; readonly cursor: CanonicalSequence }> => {
+  const receipt = await submitApproval(conversation);
+  await drainAlarmsUntil(conversation, anyInState(conversation, "suspended"));
+  const cursor = (await readCanonical(conversation)).at(-1)?.sequence;
+  if (cursor === undefined) throw new Error("approval lane did not materialize canonical history");
+  return { receipt, cursor };
+};
+
+const approve = (conversation: string, receipt: Receipt) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareConversationClient;
+      return yield* client.resolveApproval(
+        decodeConversationId(conversation),
+        ApprovalDecisionCommand.make({
+          submissionId: receipt.submissionId,
+          toolCallId: BOOK_TOOL_CALL_ID,
+          decision: "approved",
+          resolver: "#94-test-approver",
+          reason: "release the durable progress test",
+        }),
+      );
+    }),
+  );
+
+const awaitProgress = (conversation: string, afterSequence: CanonicalSequence) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareConversationClient;
+      yield* client.awaitProgress(decodeConversationId(conversation), afterSequence);
+    }),
+  );
+
+const awaitCanonicalTag = (conversation: string, afterSequence: CanonicalSequence, tag: string) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareConversationClient;
+      const conversationId = decodeConversationId(conversation);
+      let cursor = afterSequence;
+      for (;;) {
+        const records = yield* client.readPage(conversationId, {
+          afterSequence: cursor,
+          limit: 1_024,
+        });
+        if (records.some((record) => record.record.payload._tag === tag)) return;
+        const last = records.at(-1);
+        if (last !== undefined) {
+          cursor = last.sequence;
+          continue;
+        }
+        yield* client.awaitProgress(conversationId, cursor);
+      }
+    }),
+  );
+
+describe("#94 Cloudflare durable progress wait", () => {
+  it("broadcasts cancellation across duplicate and late transport attempts", async () => {
+    const completed = await withDeadline(
+      Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const registry = yield* ProgressWaitRegistry;
+            const first = yield* registry.subscribe("duplicate-attempt");
+            const second = yield* registry.subscribe("duplicate-attempt");
+            yield* registry.cancel("duplicate-attempt");
+            yield* Effect.all([first, second], { concurrency: "unbounded" });
+
+            yield* registry.cancel("late-attempt");
+            const lateFirst = yield* registry.subscribe("late-attempt");
+            const lateSecond = yield* registry.subscribe("late-attempt");
+            yield* Effect.all([lateFirst, lateSecond], { concurrency: "unbounded" });
+            return true;
+          }),
+        ).pipe(Effect.provide(ProgressWaitRegistry.layer)),
+      ),
+    );
+    expect(completed).toBe(true);
+  });
+
+  it("returns for committed history and wakes promptly after a canonical append", async () => {
+    const conversation = lane("append");
+    await submitPlanner(conversation);
+
+    await withDeadline(awaitProgress(conversation, ZERO_SEQUENCE));
+    const before = await readCanonical(conversation);
+    const cursor = before.at(-1)?.sequence;
+    expect(cursor).toBeDefined();
+    if (cursor === undefined) return;
+
+    const waiting = awaitProgress(conversation, cursor);
+    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+    const alarm = runDurableObjectAlarm(stubFor(conversation));
+    await withDeadline(waiting);
+    await withDeadline(alarm);
+
+    const after = await readCanonical(conversation);
+    expect(after.some((record) => record.sequence > cursor)).toBe(true);
+  });
+
+  it("broadcasts to every waiter, isolates lanes, and cleans up a timed-out caller", async () => {
+    const conversation = lane("many");
+    const unrelated = lane("unrelated");
+    const main = await prepareApproval(conversation);
+    const other = await prepareApproval(unrelated);
+    const cursor = main.cursor;
+    const unrelatedCursor = other.cursor;
+
+    const first = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
+    const second = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
+    const timedUnrelated = runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        return yield* client
+          .awaitProgress(decodeConversationId(unrelated), unrelatedCursor)
+          .pipe(Effect.timeoutOption("1 second"));
+      }),
+    );
+    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 2);
+    await waitUntil(async () => (await progressStub(unrelated).progressWaiterCount()) === 1);
+
+    await approve(conversation, main.receipt);
+    await withDeadline(Promise.all([first, second]));
+    expect(await progressStub(unrelated).progressWaiterCount()).toBe(1);
+
+    expect(Option.isNone(await withDeadline(timedUnrelated))).toBe(true);
+    await waitUntil(async () => (await progressStub(unrelated).progressWaiterCount()) === 0);
+    await approve(unrelated, other.receipt);
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+    await drainAlarmsUntil(unrelated, allSettled(unrelated));
+  }, 20_000);
+
+  it("reconnects after eviction, reconstructs the wait, and rechecks durable authority", async () => {
+    const conversation = lane("eviction");
+    const approval = await prepareApproval(conversation);
+    const cursor = approval.cursor;
+
+    const waiting = awaitProgress(conversation, cursor);
+    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+    const priorIncarnation = await progressStub(conversation).progressIncarnation();
+    await runInDurableObject(stubFor(conversation), (_instance, state) => {
+      state.abort("#94 forced wait eviction");
+    }).catch(() => undefined);
+
+    await waitUntil(async () => {
+      const stub = progressStub(conversation);
+      return (
+        (await stub.progressIncarnation()) !== priorIncarnation &&
+        (await stub.progressWaiterCount()) === 1
+      );
+    });
+
+    await approve(conversation, approval.receipt);
+    await withDeadline(waiting);
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+    const after = await readCanonical(conversation);
+    expect(after.some((record) => record.sequence > cursor)).toBe(true);
+  }, 20_000);
+
+  it("delivers the remote wake seam used by child, parent, and host settlement", async () => {
+    const conversation = lane("remote");
+    const approval = await prepareApproval(conversation);
+    const waiting = awaitProgress(conversation, approval.cursor);
+    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+
+    await stubFor(conversation).wake();
+    await withDeadline(waiting);
+    expect(await progressStub(conversation).progressWaiterCount()).toBe(0);
+    await approve(conversation, approval.receipt);
+    await drainAlarmsUntil(conversation, allSettled(conversation));
+  });
+
+  it("preserves the typed non-materialized failure across the RPC client boundary", async () => {
+    const conversation = lane("missing");
+    const tag = await runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        const exit = yield* Effect.exit(
+          client.awaitProgress(decodeConversationId(conversation), ZERO_SEQUENCE),
+        );
+        if (exit._tag === "Success") return "success";
+        const error = Cause.findErrorOption(exit.cause);
+        if (Option.isNone(error)) return "defect";
+        const value: unknown = error.value;
+        return typeof value === "object" && value !== null && "_tag" in value
+          ? String(value._tag)
+          : "unknown";
+      }),
+    );
+    expect(tag).toBe("ConversationNotMaterialized");
+  });
+
+  it("preserves a typed authorization denial across the RPC client boundary", async () => {
+    const conversation = lane("denied");
+    const tag = await runClient(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        const exit = yield* Effect.exit(
+          client.awaitProgress(decodeConversationId(conversation), ZERO_SEQUENCE),
+        );
+        if (exit._tag === "Success") return "success";
+        const error = Cause.findErrorOption(exit.cause);
+        if (Option.isNone(error)) return "defect";
+        const value: unknown = error.value;
+        return typeof value === "object" && value !== null && "_tag" in value
+          ? String(value._tag)
+          : "unknown";
+      }),
+      "DENIED",
+    );
+    expect(tag).toBe("OperationDenied");
+  });
+});

--- a/packages/platform-cloudflare/test/progress-wait.test.ts
+++ b/packages/platform-cloudflare/test/progress-wait.test.ts
@@ -1,14 +1,13 @@
 import { ApprovalDecisionCommand, CanonicalSequence, type Receipt } from "@effect-agent/session";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { Cause, Effect, Fiber, Option, Schema } from "effect";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, onTestFinished } from "vite-plus/test";
 
 import { CloudflareConversationClient, ProgressWaitRegistry } from "../src/index.ts";
 import {
   decodeConversationId,
   BOOK_TOOL_CALL_ID,
   approvalDefinition,
-  plannerDefinition,
   submitOptions,
 } from "./fixtures.ts";
 import {
@@ -29,18 +28,6 @@ const lane = (label: string): string => `cf-progress-${label}-${laneCounter++}`;
 
 const progressStub = (conversation: string) =>
   stubFor(conversation) as DurableObjectStub<TestConversationObject>;
-
-const submitPlanner = (conversation: string) =>
-  runClient(
-    Effect.gen(function* () {
-      const client = yield* CloudflareConversationClient;
-      return yield* client.submit(
-        { definition: plannerDefinition },
-        { question: "observe durable progress", ref: conversation },
-        submitOptions(conversation, `${conversation}-key`),
-      );
-    }),
-  );
 
 const submitApproval = (conversation: string) =>
   runClient(
@@ -81,35 +68,41 @@ const approve = (conversation: string, receipt: Receipt) =>
     }),
   );
 
-const awaitProgress = (conversation: string, afterSequence: CanonicalSequence) =>
-  runClient(
-    Effect.gen(function* () {
-      const client = yield* CloudflareConversationClient;
-      yield* client.awaitProgress(decodeConversationId(conversation), afterSequence);
-    }),
-  );
+const awaitProgressEffect = (conversation: string, afterSequence: CanonicalSequence) =>
+  Effect.gen(function* () {
+    const client = yield* CloudflareConversationClient;
+    yield* client.awaitProgress(decodeConversationId(conversation), afterSequence);
+  });
 
-const awaitCanonicalTag = (conversation: string, afterSequence: CanonicalSequence, tag: string) =>
-  runClient(
-    Effect.gen(function* () {
-      const client = yield* CloudflareConversationClient;
-      const conversationId = decodeConversationId(conversation);
-      let cursor = afterSequence;
-      for (;;) {
-        const records = yield* client.readPage(conversationId, {
-          afterSequence: cursor,
-          limit: 1_024,
-        });
-        if (records.some((record) => record.record.payload._tag === tag)) return;
-        const last = records.at(-1);
-        if (last !== undefined) {
-          cursor = last.sequence;
-          continue;
-        }
-        yield* client.awaitProgress(conversationId, cursor);
+const awaitCanonicalTagEffect = (
+  conversation: string,
+  afterSequence: CanonicalSequence,
+  tag: string,
+) =>
+  Effect.gen(function* () {
+    const client = yield* CloudflareConversationClient;
+    const conversationId = decodeConversationId(conversation);
+    let cursor = afterSequence;
+    for (;;) {
+      const records = yield* client.readPage(conversationId, {
+        afterSequence: cursor,
+        limit: 1_024,
+      });
+      if (records.some((record) => record.record.payload._tag === tag)) return;
+      const last = records.at(-1);
+      if (last !== undefined) {
+        cursor = last.sequence;
+        continue;
       }
-    }),
-  );
+      yield* client.awaitProgress(conversationId, cursor);
+    }
+  });
+
+const runTrackedClientFiber = <A, E>(effect: Effect.Effect<A, E, CloudflareConversationClient>) => {
+  const fiber = runClientFiber(effect);
+  onTestFinished(() => Effect.runPromise(Fiber.interrupt(fiber)));
+  return fiber;
+};
 
 describe("#94 Cloudflare durable progress wait", () => {
   it("broadcasts cancellation across duplicate and late transport attempts", async () => {
@@ -135,23 +128,26 @@ describe("#94 Cloudflare durable progress wait", () => {
 
   it("returns for committed history and wakes promptly after a canonical append", async () => {
     const conversation = lane("append");
-    await submitPlanner(conversation);
+    const approval = await prepareApproval(conversation);
 
-    await awaitProgress(conversation, ZERO_SEQUENCE);
+    const committed = runTrackedClientFiber(awaitProgressEffect(conversation, ZERO_SEQUENCE));
+    await Effect.runPromise(Fiber.join(committed));
     const before = await readCanonical(conversation);
     const cursor = before.at(-1)?.sequence;
     expect(cursor).toBeDefined();
     if (cursor === undefined) return;
 
-    const waiting = awaitProgress(conversation, cursor);
+    const waiting = runTrackedClientFiber(
+      awaitCanonicalTagEffect(conversation, cursor, "ToolApprovalDecided"),
+    );
     await progressStub(conversation).awaitProgressWaiterCount(1);
-    const alarm = runDurableObjectAlarm(stubFor(conversation));
-    await waiting;
-    await alarm;
+    await approve(conversation, approval.receipt);
+    await runDurableObjectAlarm(stubFor(conversation));
+    await Effect.runPromise(Fiber.join(waiting));
 
     const after = await readCanonical(conversation);
     expect(after.some((record) => record.sequence > cursor)).toBe(true);
-  });
+  }, 20_000);
 
   it("broadcasts to every waiter, isolates lanes, and cleans up an interrupted caller", async () => {
     const conversation = lane("many");
@@ -161,20 +157,14 @@ describe("#94 Cloudflare durable progress wait", () => {
     const cursor = main.cursor;
     const unrelatedCursor = other.cursor;
 
-    const first = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
-    const second = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
-    const interruptedFiber = runClientFiber(
-      Effect.gen(function* () {
-        const client = yield* CloudflareConversationClient;
-        yield* client.awaitProgress(decodeConversationId(conversation), cursor);
-      }),
+    const first = runTrackedClientFiber(
+      awaitCanonicalTagEffect(conversation, cursor, "ToolApprovalDecided"),
     );
-    const unrelatedFiber = runClientFiber(
-      Effect.gen(function* () {
-        const client = yield* CloudflareConversationClient;
-        yield* client.awaitProgress(decodeConversationId(unrelated), unrelatedCursor);
-      }),
+    const second = runTrackedClientFiber(
+      awaitCanonicalTagEffect(conversation, cursor, "ToolApprovalDecided"),
     );
+    const interruptedFiber = runTrackedClientFiber(awaitProgressEffect(conversation, cursor));
+    const unrelatedFiber = runTrackedClientFiber(awaitProgressEffect(unrelated, unrelatedCursor));
     await progressStub(conversation).awaitProgressWaiterCount(3);
     await progressStub(unrelated).awaitProgressWaiterCount(1);
 
@@ -183,7 +173,7 @@ describe("#94 Cloudflare durable progress wait", () => {
     expect(await progressStub(unrelated).progressWaiterCount()).toBe(1);
 
     await approve(conversation, main.receipt);
-    await Promise.all([first, second]);
+    await Effect.runPromise(Effect.all([Fiber.join(first), Fiber.join(second)]));
     expect(await progressStub(unrelated).progressWaiterCount()).toBe(1);
 
     await Effect.runPromise(Fiber.interrupt(unrelatedFiber));
@@ -198,7 +188,7 @@ describe("#94 Cloudflare durable progress wait", () => {
     const approval = await prepareApproval(conversation);
     const cursor = approval.cursor;
 
-    const waiting = awaitProgress(conversation, cursor);
+    const waiting = runTrackedClientFiber(awaitProgressEffect(conversation, cursor));
     await progressStub(conversation).awaitProgressWaiterCount(1);
     const priorIncarnation = await progressStub(conversation).progressIncarnation();
     await runInDurableObject(stubFor(conversation), (_instance, state) => {
@@ -212,7 +202,7 @@ describe("#94 Cloudflare durable progress wait", () => {
     );
     expect(reconstructedIncarnation).not.toBe(priorIncarnation);
     await approve(conversation, approval.receipt);
-    await waiting;
+    await Effect.runPromise(Fiber.join(waiting));
     await drainAlarmsUntil(conversation, allSettled(conversation));
     const after = await readCanonical(conversation);
     expect(after.some((record) => record.sequence > cursor)).toBe(true);
@@ -221,11 +211,11 @@ describe("#94 Cloudflare durable progress wait", () => {
   it("delivers the remote wake seam used by child, parent, and host settlement", async () => {
     const conversation = lane("remote");
     const approval = await prepareApproval(conversation);
-    const waiting = awaitProgress(conversation, approval.cursor);
+    const waiting = runTrackedClientFiber(awaitProgressEffect(conversation, approval.cursor));
     await progressStub(conversation).awaitProgressWaiterCount(1);
 
     await stubFor(conversation).wake();
-    await waiting;
+    await Effect.runPromise(Fiber.join(waiting));
     await progressStub(conversation).awaitProgressWaiterCount(0);
     expect(await progressStub(conversation).progressWaiterCount()).toBe(0);
     await approve(conversation, approval.receipt);

--- a/packages/platform-cloudflare/test/progress-wait.test.ts
+++ b/packages/platform-cloudflare/test/progress-wait.test.ts
@@ -1,6 +1,6 @@
 import { ApprovalDecisionCommand, CanonicalSequence, type Receipt } from "@effect-agent/session";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
-import { Cause, Effect, Option, Schema } from "effect";
+import { Cause, Effect, Fiber, Option, Schema } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
 import { CloudflareConversationClient, ProgressWaitRegistry } from "../src/index.ts";
@@ -17,6 +17,7 @@ import {
   drainAlarmsUntil,
   readCanonical,
   runClient,
+  runClientFiber,
   stubFor,
 } from "./harness.ts";
 import type { TestConversationObject } from "./worker.ts";
@@ -25,32 +26,8 @@ const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
 let laneCounter = 0;
 const lane = (label: string): string => `cf-progress-${label}-${laneCounter++}`;
 
-const sleep = (millis: number) => new Promise((resolve) => setTimeout(resolve, millis));
-
 const progressStub = (conversation: string) =>
   stubFor(conversation) as DurableObjectStub<TestConversationObject>;
-
-const withDeadline = async <A>(promise: Promise<A>, millis = 5_000): Promise<A> =>
-  Promise.race([
-    promise,
-    sleep(millis).then(() => {
-      throw new Error(`#94 progress wait exceeded ${millis}ms`);
-    }),
-  ]);
-
-const waitUntil = async (predicate: () => Promise<boolean>, millis = 5_000): Promise<void> => {
-  const deadline = Date.now() + millis;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    try {
-      if (await predicate()) return;
-    } catch (error) {
-      lastError = error;
-    }
-    await sleep(5);
-  }
-  throw lastError ?? new Error(`#94 condition was not reached within ${millis}ms`);
-};
 
 const submitPlanner = (conversation: string) =>
   runClient(
@@ -135,24 +112,22 @@ const awaitCanonicalTag = (conversation: string, afterSequence: CanonicalSequenc
 
 describe("#94 Cloudflare durable progress wait", () => {
   it("broadcasts cancellation across duplicate and late transport attempts", async () => {
-    const completed = await withDeadline(
-      Effect.runPromise(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const registry = yield* ProgressWaitRegistry;
-            const first = yield* registry.subscribe("duplicate-attempt");
-            const second = yield* registry.subscribe("duplicate-attempt");
-            yield* registry.cancel("duplicate-attempt");
-            yield* Effect.all([first, second], { concurrency: "unbounded" });
+    const completed = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const registry = yield* ProgressWaitRegistry;
+          const first = yield* registry.subscribe("duplicate-attempt");
+          const second = yield* registry.subscribe("duplicate-attempt");
+          yield* registry.cancel("duplicate-attempt");
+          yield* Effect.all([first, second], { concurrency: "unbounded" });
 
-            yield* registry.cancel("late-attempt");
-            const lateFirst = yield* registry.subscribe("late-attempt");
-            const lateSecond = yield* registry.subscribe("late-attempt");
-            yield* Effect.all([lateFirst, lateSecond], { concurrency: "unbounded" });
-            return true;
-          }),
-        ).pipe(Effect.provide(ProgressWaitRegistry.layer)),
-      ),
+          yield* registry.cancel("late-attempt");
+          const lateFirst = yield* registry.subscribe("late-attempt");
+          const lateSecond = yield* registry.subscribe("late-attempt");
+          yield* Effect.all([lateFirst, lateSecond], { concurrency: "unbounded" });
+          return true;
+        }),
+      ).pipe(Effect.provide(ProgressWaitRegistry.layer)),
     );
     expect(completed).toBe(true);
   });
@@ -161,23 +136,23 @@ describe("#94 Cloudflare durable progress wait", () => {
     const conversation = lane("append");
     await submitPlanner(conversation);
 
-    await withDeadline(awaitProgress(conversation, ZERO_SEQUENCE));
+    await awaitProgress(conversation, ZERO_SEQUENCE);
     const before = await readCanonical(conversation);
     const cursor = before.at(-1)?.sequence;
     expect(cursor).toBeDefined();
     if (cursor === undefined) return;
 
     const waiting = awaitProgress(conversation, cursor);
-    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+    await progressStub(conversation).awaitProgressWaiterCount(1);
     const alarm = runDurableObjectAlarm(stubFor(conversation));
-    await withDeadline(waiting);
-    await withDeadline(alarm);
+    await waiting;
+    await alarm;
 
     const after = await readCanonical(conversation);
     expect(after.some((record) => record.sequence > cursor)).toBe(true);
   });
 
-  it("broadcasts to every waiter, isolates lanes, and cleans up a timed-out caller", async () => {
+  it("broadcasts to every waiter, isolates lanes, and cleans up an interrupted caller", async () => {
     const conversation = lane("many");
     const unrelated = lane("unrelated");
     const main = await prepareApproval(conversation);
@@ -187,23 +162,31 @@ describe("#94 Cloudflare durable progress wait", () => {
 
     const first = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
     const second = awaitCanonicalTag(conversation, cursor, "ToolApprovalDecided");
-    const timedUnrelated = runClient(
+    const interruptedFiber = runClientFiber(
       Effect.gen(function* () {
         const client = yield* CloudflareConversationClient;
-        return yield* client
-          .awaitProgress(decodeConversationId(unrelated), unrelatedCursor)
-          .pipe(Effect.timeoutOption("1 second"));
+        yield* client.awaitProgress(decodeConversationId(conversation), cursor);
       }),
     );
-    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 2);
-    await waitUntil(async () => (await progressStub(unrelated).progressWaiterCount()) === 1);
+    const unrelatedFiber = runClientFiber(
+      Effect.gen(function* () {
+        const client = yield* CloudflareConversationClient;
+        yield* client.awaitProgress(decodeConversationId(unrelated), unrelatedCursor);
+      }),
+    );
+    await progressStub(conversation).awaitProgressWaiterCount(3);
+    await progressStub(unrelated).awaitProgressWaiterCount(1);
 
-    await approve(conversation, main.receipt);
-    await withDeadline(Promise.all([first, second]));
+    await Effect.runPromise(Fiber.interrupt(interruptedFiber));
+    await progressStub(conversation).awaitProgressWaiterCount(2);
     expect(await progressStub(unrelated).progressWaiterCount()).toBe(1);
 
-    expect(Option.isNone(await withDeadline(timedUnrelated))).toBe(true);
-    await waitUntil(async () => (await progressStub(unrelated).progressWaiterCount()) === 0);
+    await approve(conversation, main.receipt);
+    await Promise.all([first, second]);
+    expect(await progressStub(unrelated).progressWaiterCount()).toBe(1);
+
+    await Effect.runPromise(Fiber.interrupt(unrelatedFiber));
+    await progressStub(unrelated).awaitProgressWaiterCount(0);
     await approve(unrelated, other.receipt);
     await drainAlarmsUntil(conversation, allSettled(conversation));
     await drainAlarmsUntil(unrelated, allSettled(unrelated));
@@ -215,23 +198,16 @@ describe("#94 Cloudflare durable progress wait", () => {
     const cursor = approval.cursor;
 
     const waiting = awaitProgress(conversation, cursor);
-    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+    await progressStub(conversation).awaitProgressWaiterCount(1);
     const priorIncarnation = await progressStub(conversation).progressIncarnation();
     await runInDurableObject(stubFor(conversation), (_instance, state) => {
       state.abort("#94 forced wait eviction");
     }).catch(() => undefined);
 
-    await waitUntil(async () => {
-      const stub = progressStub(conversation);
-      return (
-        (await stub.progressIncarnation()) !== priorIncarnation &&
-        (await stub.progressWaiterCount()) === 1
-      );
-    });
-
     await approve(conversation, approval.receipt);
-    await withDeadline(waiting);
+    await waiting;
     await drainAlarmsUntil(conversation, allSettled(conversation));
+    expect(await progressStub(conversation).progressIncarnation()).not.toBe(priorIncarnation);
     const after = await readCanonical(conversation);
     expect(after.some((record) => record.sequence > cursor)).toBe(true);
   }, 20_000);
@@ -240,10 +216,11 @@ describe("#94 Cloudflare durable progress wait", () => {
     const conversation = lane("remote");
     const approval = await prepareApproval(conversation);
     const waiting = awaitProgress(conversation, approval.cursor);
-    await waitUntil(async () => (await progressStub(conversation).progressWaiterCount()) === 1);
+    await progressStub(conversation).awaitProgressWaiterCount(1);
 
     await stubFor(conversation).wake();
-    await withDeadline(waiting);
+    await waiting;
+    await progressStub(conversation).awaitProgressWaiterCount(0);
     expect(await progressStub(conversation).progressWaiterCount()).toBe(0);
     await approve(conversation, approval.receipt);
     await drainAlarmsUntil(conversation, allSettled(conversation));

--- a/packages/platform-cloudflare/test/progress-wait.test.ts
+++ b/packages/platform-cloudflare/test/progress-wait.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   allSettled,
   anyInState,
+  awaitReconstructedProgressWaiter,
   drainAlarmsUntil,
   readCanonical,
   runClient,
@@ -204,10 +205,15 @@ describe("#94 Cloudflare durable progress wait", () => {
       state.abort("#94 forced wait eviction");
     }).catch(() => undefined);
 
+    const reconstructedIncarnation = await awaitReconstructedProgressWaiter(
+      conversation,
+      priorIncarnation,
+      1,
+    );
+    expect(reconstructedIncarnation).not.toBe(priorIncarnation);
     await approve(conversation, approval.receipt);
     await waiting;
     await drainAlarmsUntil(conversation, allSettled(conversation));
-    expect(await progressStub(conversation).progressIncarnation()).not.toBe(priorIncarnation);
     const after = await readCanonical(conversation);
     expect(after.some((record) => record.sequence > cursor)).toBe(true);
   }, 20_000);

--- a/packages/platform-cloudflare/test/restart/travel-planner-restart-worker.ts
+++ b/packages/platform-cloudflare/test/restart/travel-planner-restart-worker.ts
@@ -13,6 +13,7 @@ import {
   phase6TravelPlannerDeploymentId,
   phase6TravelPlannerProducerPrefix,
 } from "@effect-agent/testing";
+import { BrowserCrypto } from "@effect/platform-browser";
 import { Effect, Layer, Schema } from "effect";
 
 import {
@@ -140,8 +141,11 @@ const runClient = <A, E>(
       Effect.provide(
         CloudflareConversationClient.layer.pipe(
           Layer.provide(
-            ConversationObjectNamespace.layer(
-              env.CONVERSATIONS as unknown as DurableObjectNamespace<ConversationObjectRpc>,
+            Layer.mergeAll(
+              ConversationObjectNamespace.layer(
+                env.CONVERSATIONS as unknown as DurableObjectNamespace<ConversationObjectRpc>,
+              ),
+              BrowserCrypto.layer,
             ),
           ),
         ),

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -1,7 +1,11 @@
 import { OperationDenied } from "@effect-agent/session";
 import { Effect } from "effect";
 
-import { makeConversationObjectClass, type ConversationObjectOptions } from "../src/index.ts";
+import {
+  makeConversationObjectClass,
+  type ConversationObjectOptions,
+  type ConversationObjectRpc,
+} from "../src/index.ts";
 import {
   CONVERSATIONS_BINDING,
   DEPLOYMENT_ID,
@@ -246,27 +250,75 @@ export class TelemetryConversationObject extends makeConversationObjectClass(
 /**
  * The WP4 cross-Object subagent matrix's Conversation Object: parent and child Conversations
  * of one delegation are DIFFERENT Objects of this namespace by the identity rule. The
- * `portCall` override is the DO-unreachable lever — an armed transport fault makes the
- * incoming cross-Object RPC reject exactly like an unreachable Object's stub would, BEFORE
- * any owner-side execution, so the routed caller observes a `PortTransportError` (and
- * `AdmissionIndeterminate` on `resolveAdmission`, SUB-031). Unarmed, it is a passthrough.
+ * namespace wrapper is the DO-unreachable lever — an armed transport fault makes the
+ * caller-side stub throw BEFORE owner-side execution, so the routed caller observes a
+ * `PortTransportError` (and `AdmissionIndeterminate` on `resolveAdmission`, SUB-031). Wake
+ * hints fail at the same seam and remain droppable. Unarmed, every stub is a passthrough.
  */
-export class SubagentConversationObject extends makeConversationObjectClass({
+const SubagentConversationObjectBase = makeConversationObjectClass({
   ...baseOptions,
   namespaceBinding: "SUBAGENTS",
   bindings: makeSubagentTestBindings,
-}) {
-  override async portCall(encoded: unknown): Promise<unknown> {
-    const reason = transportFaultReason(this.ctx.id.name);
-    if (reason !== undefined) throw new Error(reason);
-    return super.portCall(encoded);
-  }
+});
 
-  /** An unreachable Object drops wake hints too — droppable by contract, so senders swallow. */
-  override async wake(): Promise<void> {
-    const reason = transportFaultReason(this.ctx.id.name);
-    if (reason !== undefined) throw new Error(reason);
-    return super.wake();
+const faultableStub = <RpcService extends ConversationObjectRpc>(
+  stub: DurableObjectStub<RpcService>,
+  name: string | undefined,
+): DurableObjectStub<RpcService> =>
+  new Proxy(stub, {
+    get(target, property, receiver) {
+      if (property === "portCall") {
+        return (encoded: unknown): Promise<unknown> => {
+          const reason = transportFaultReason(name);
+          if (reason !== undefined) throw new Error(reason);
+          return target.portCall(encoded);
+        };
+      }
+      if (property === "wake") {
+        return (): Promise<void> => {
+          const reason = transportFaultReason(name);
+          if (reason !== undefined) throw new Error(reason);
+          return target.wake();
+        };
+      }
+      const value: unknown = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+
+const faultableNamespace = <RpcService extends ConversationObjectRpc>(
+  namespace: DurableObjectNamespace<RpcService>,
+): DurableObjectNamespace<RpcService> =>
+  new Proxy(namespace, {
+    get(target, property, receiver) {
+      if (property === "get") {
+        return (
+          id: DurableObjectId,
+          options?: DurableObjectNamespaceGetDurableObjectOptions,
+        ): DurableObjectStub<RpcService> => faultableStub(target.get(id, options), id.name);
+      }
+      if (property === "getByName") {
+        return (
+          name: string,
+          options?: DurableObjectNamespaceGetDurableObjectOptions,
+        ): DurableObjectStub<RpcService> => faultableStub(target.getByName(name, options), name);
+      }
+      const value: unknown = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+
+const faultableEnvironment = (env: Cloudflare.Env): Cloudflare.Env =>
+  new Proxy(env, {
+    get(target, property, receiver) {
+      if (property === "SUBAGENTS") return faultableNamespace(target.SUBAGENTS);
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+export class SubagentConversationObject extends SubagentConversationObjectBase {
+  constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
+    super(ctx, faultableEnvironment(env));
   }
 }
 

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -1,3 +1,4 @@
+import { OperationDenied } from "@effect-agent/session";
 import { Effect } from "effect";
 
 import { makeConversationObjectClass, type ConversationObjectOptions } from "../src/index.ts";
@@ -73,7 +74,40 @@ const dynamicBindings: NonNullable<ConversationObjectOptions["bindings"]> = ({
   });
 
 /** The eviction/alarm/chaos suites' Conversation Object. */
-export class TestConversationObject extends makeConversationObjectClass(baseOptions) {}
+const progressWaiterCounts = new WeakMap<DurableObjectState, number>();
+const progressIncarnations = new WeakMap<DurableObjectState, number>();
+let nextProgressIncarnation = 0;
+
+const progressIncarnation = (ctx: DurableObjectState): number => {
+  const existing = progressIncarnations.get(ctx);
+  if (existing !== undefined) return existing;
+  const created = ++nextProgressIncarnation;
+  progressIncarnations.set(ctx, created);
+  return created;
+};
+
+export class TestConversationObject extends makeConversationObjectClass(baseOptions) {
+  override async awaitProgressEncoded(encoded: unknown): Promise<unknown> {
+    progressIncarnation(this.ctx);
+    progressWaiterCounts.set(this.ctx, (progressWaiterCounts.get(this.ctx) ?? 0) + 1);
+    try {
+      return await super.awaitProgressEncoded(encoded);
+    } finally {
+      progressWaiterCounts.set(
+        this.ctx,
+        Math.max(0, (progressWaiterCounts.get(this.ctx) ?? 1) - 1),
+      );
+    }
+  }
+
+  progressWaiterCount(): number {
+    return progressWaiterCounts.get(this.ctx) ?? 0;
+  }
+
+  progressIncarnation(): number {
+    return progressIncarnation(this.ctx);
+  }
+}
 
 /** Tight queue-depth and input-size quotas for the admission-limits gate rows. */
 export class LimitedConversationObject extends makeConversationObjectClass({
@@ -88,6 +122,25 @@ export class TinyDatabaseConversationObject extends makeConversationObjectClass(
   ...baseOptions,
   namespaceBinding: "TINYDB",
   maxDatabaseBytes: 1,
+}) {}
+
+/** Fail-closed authorization fixture for host-protocol error-tag fidelity. */
+export class DeniedConversationObject extends makeConversationObjectClass({
+  ...baseOptions,
+  namespaceBinding: "DENIED",
+  operationAuthorizer: {
+    authorize: (request) =>
+      Effect.fail(
+        OperationDenied.make({
+          operation: request.operation,
+          reason: "denied by the #94 Cloudflare fixture",
+          ...(request.conversationId === undefined
+            ? {}
+            : { conversationId: request.conversationId }),
+          ...(request.submissionId === undefined ? {} : { submissionId: request.submissionId }),
+        }),
+      ),
+  },
 }) {}
 
 /** Callback-form Binding capture probe. */

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -141,6 +141,16 @@ export class TestConversationObject extends makeConversationObjectClass(baseOpti
     return awaitProgressWaiterCount(this.ctx, expected);
   }
 
+  async awaitProgressWaiterCountAfter(
+    previousIncarnation: number,
+    expected: number,
+  ): Promise<number | null> {
+    const incarnation = progressIncarnation(this.ctx);
+    if (incarnation === previousIncarnation) return null;
+    await awaitProgressWaiterCount(this.ctx, expected);
+    return incarnation;
+  }
+
   progressIncarnation(): number {
     return progressIncarnation(this.ctx);
   }

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -75,8 +75,44 @@ const dynamicBindings: NonNullable<ConversationObjectOptions["bindings"]> = ({
 
 /** The eviction/alarm/chaos suites' Conversation Object. */
 const progressWaiterCounts = new WeakMap<DurableObjectState, number>();
+interface ProgressWaiterCountLatch {
+  readonly expected: number;
+  readonly resolve: () => void;
+}
+const progressWaiterCountLatches = new WeakMap<
+  DurableObjectState,
+  Array<ProgressWaiterCountLatch>
+>();
 const progressIncarnations = new WeakMap<DurableObjectState, number>();
 let nextProgressIncarnation = 0;
+
+const setProgressWaiterCount = (ctx: DurableObjectState, count: number): void => {
+  progressWaiterCounts.set(ctx, count);
+  const latches = progressWaiterCountLatches.get(ctx);
+  if (latches === undefined) return;
+  const pending: Array<ProgressWaiterCountLatch> = [];
+  for (const latch of latches) {
+    if (latch.expected === count) {
+      latch.resolve();
+    } else {
+      pending.push(latch);
+    }
+  }
+  if (pending.length === 0) {
+    progressWaiterCountLatches.delete(ctx);
+  } else {
+    progressWaiterCountLatches.set(ctx, pending);
+  }
+};
+
+const awaitProgressWaiterCount = (ctx: DurableObjectState, expected: number): Promise<void> => {
+  if ((progressWaiterCounts.get(ctx) ?? 0) === expected) return Promise.resolve();
+  return new Promise((resolve) => {
+    const latches = progressWaiterCountLatches.get(ctx) ?? [];
+    latches.push({ expected, resolve });
+    progressWaiterCountLatches.set(ctx, latches);
+  });
+};
 
 const progressIncarnation = (ctx: DurableObjectState): number => {
   const existing = progressIncarnations.get(ctx);
@@ -89,19 +125,20 @@ const progressIncarnation = (ctx: DurableObjectState): number => {
 export class TestConversationObject extends makeConversationObjectClass(baseOptions) {
   override async awaitProgressEncoded(encoded: unknown): Promise<unknown> {
     progressIncarnation(this.ctx);
-    progressWaiterCounts.set(this.ctx, (progressWaiterCounts.get(this.ctx) ?? 0) + 1);
+    setProgressWaiterCount(this.ctx, (progressWaiterCounts.get(this.ctx) ?? 0) + 1);
     try {
       return await super.awaitProgressEncoded(encoded);
     } finally {
-      progressWaiterCounts.set(
-        this.ctx,
-        Math.max(0, (progressWaiterCounts.get(this.ctx) ?? 1) - 1),
-      );
+      setProgressWaiterCount(this.ctx, Math.max(0, (progressWaiterCounts.get(this.ctx) ?? 1) - 1));
     }
   }
 
   progressWaiterCount(): number {
     return progressWaiterCounts.get(this.ctx) ?? 0;
+  }
+
+  awaitProgressWaiterCount(expected: number): Promise<void> {
+    return awaitProgressWaiterCount(this.ctx, expected);
   }
 
   progressIncarnation(): number {

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
                 CONVERSATIONS: { className: "TestConversationObject", useSQLite: true },
                 LIMITED: { className: "LimitedConversationObject", useSQLite: true },
                 TINYDB: { className: "TinyDatabaseConversationObject", useSQLite: true },
+                DENIED: { className: "DeniedConversationObject", useSQLite: true },
                 SUBAGENTS: { className: "SubagentConversationObject", useSQLite: true },
                 DYNAMIC_BINDINGS: {
                   className: "DynamicBindingsConversationObject",

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -20,11 +20,6 @@ export default defineConfig({
     sourcemap: true,
   },
   test: {
-    // The eviction harness ABORTS Durable Objects mid-flight by design; the pool surfaces
-    // each abort's orphaned in-flight promise as an "unhandled error" (durableObjectReset)
-    // even when every test passes. Convergence is asserted explicitly by every row, so
-    // these by-design rejections must not fail the run. Root-level only (non-project option).
-    dangerouslyIgnoreUnhandledErrors: true,
     projects: [
       {
         plugins: [

--- a/packages/platform-node/src/wake-scheduler.ts
+++ b/packages/platform-node/src/wake-scheduler.ts
@@ -1,5 +1,5 @@
 import type { ConversationId } from "@effect-agent/core";
-import { SubmissionLedger, WakeScheduler } from "@effect-agent/session";
+import { makeWakeSubscriptionHub, SubmissionLedger, WakeScheduler } from "@effect-agent/session";
 import { Context, Duration, Effect, Layer, PubSub, Stream } from "effect";
 
 /**
@@ -27,6 +27,7 @@ const makeWakeScheduler = Effect.gen(function* () {
   const ledger = yield* SubmissionLedger;
   const config = yield* NodeWakeSchedulerConfig;
   const hints = yield* PubSub.sliding<ConversationId>(WAKE_BUFFER_CAPACITY);
+  const progress = yield* makeWakeSubscriptionHub;
   yield* Effect.addFinalizer(() => PubSub.shutdown(hints));
 
   /**
@@ -61,7 +62,11 @@ const makeWakeScheduler = Effect.gen(function* () {
   );
 
   return WakeScheduler.of({
-    notify: (conversationId) => PubSub.publish(hints, conversationId).pipe(Effect.asVoid),
+    notify: (conversationId) =>
+      progress
+        .notify(conversationId)
+        .pipe(Effect.andThen(PubSub.publish(hints, conversationId)), Effect.asVoid),
+    subscribe: progress.subscribe,
     wakes: Stream.merge(Stream.fromPubSub(hints), fallbackScans),
   });
 });

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -499,6 +499,12 @@ export type DurableWorkerFailure =
 
 export type DurableAwaitFailure = LedgerError | SettlementConflict;
 
+/** Typed failures from the public canonical progress boundary. */
+export type DurableProgressFailure =
+  | ConversationStoreError
+  | ConversationNotMaterialized
+  | OperationDenied;
+
 export type DurableAbortFailure =
   | LedgerError
   | SettlementConflict
@@ -1207,6 +1213,7 @@ const make = Effect.gen(function* () {
                   )
               : Effect.fail(error),
           ),
+          Effect.andThen(wake.notify(conversationId)),
           Effect.asVoid,
         );
     },
@@ -1282,6 +1289,9 @@ const make = Effect.gen(function* () {
               sequence: result.lastSequence,
               digest: result.tailDigest,
             });
+            // Canonical storage is already committed. This hint may be lost or duplicated, but
+            // it lets scoped progress waiters re-read promptly without making memory authoritative.
+            yield* wake.notify(ctx.conversationId);
             return result;
           }
         }
@@ -2048,6 +2058,7 @@ const make = Effect.gen(function* () {
               )
             : Effect.fail(error),
         ),
+        Effect.andThen(wake.notify(request.childConversationId)),
         Effect.asVoid,
       );
   });
@@ -4800,6 +4811,7 @@ const make = Effect.gen(function* () {
           producerEpoch: tail.producerEpoch,
         }),
       );
+      yield* wake.notify(conversationId);
     }).pipe(Effect.ignore);
 
   const settleAbortedForRecovery = Effect.fn("DurableAgentRuntime.settleAbortedForRecovery")(
@@ -5709,6 +5721,38 @@ const make = Effect.gen(function* () {
     }
   });
 
+  const awaitProgress = Effect.fn("DurableAgentRuntime.awaitProgress")(function* (
+    conversationId: ConversationId,
+    afterSequence: CanonicalSequence,
+  ): Effect.fn.Return<void, DurableProgressFailure> {
+    yield* operationAuthorizer.authorize(
+      OperationAuthorizationRequest.make({
+        operation: "observe",
+        conversationId,
+      }),
+    );
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        // Registration MUST precede the authoritative read. A notify between this acquisition
+        // and parking completes the returned one-shot Effect, so neither subscribe/check nor
+        // check/park can lose progress.
+        const awaitHint = yield* wake.subscribe(conversationId);
+        const committed = yield* Stream.runHead(
+          store.read(
+            ConversationRead.make({
+              conversationId,
+              afterSequence,
+              limit: 1,
+            }),
+          ),
+        );
+        if (Option.isSome(committed)) return;
+        // A wake is only a hint. The caller re-reads canonical records after this returns.
+        yield* awaitHint;
+      }),
+    );
+  });
+
   const observe = (receipt: Receipt, options?: DurableObserveOptions) =>
     Stream.unwrap(
       operationAuthorizer
@@ -6250,6 +6294,7 @@ const make = Effect.gen(function* () {
   return DurableAgentRuntime.of({
     submit,
     awaitSettlement,
+    awaitProgress,
     observe,
     abort,
     resolveUnknown,
@@ -6338,6 +6383,14 @@ export class DurableAgentRuntime extends Context.Service<
       options: DurableSubmitOptions,
     ) => Effect.Effect<Receipt, DurableSubmitFailure, InputSchema["EncodingServices"]>;
     readonly awaitSettlement: (receipt: Receipt) => Effect.Effect<Settlement, DurableAwaitFailure>;
+    /**
+     * Wait for an already-committed record or one incarnation-local progress hint after
+     * `afterSequence`. Canonical records remain authoritative: callers re-read after return.
+     */
+    readonly awaitProgress: (
+      conversationId: ConversationId,
+      afterSequence: CanonicalSequence,
+    ) => Effect.Effect<void, DurableProgressFailure>;
     readonly observe: (
       receipt: Receipt,
       options?: DurableObserveOptions,

--- a/packages/session/src/wake.ts
+++ b/packages/session/src/wake.ts
@@ -1,15 +1,98 @@
 import { ConversationId } from "@effect-agent/core";
-import { Context, Effect, Layer, Stream } from "effect";
+import { Context, Deferred, Effect, Layer, Ref, Scope, Stream } from "effect";
+
+/**
+ * Incarnation-local, conversation-keyed wake registrations. A registration is installed before
+ * its returned Effect can be awaited, which lets a caller subscribe, check durable authority,
+ * and then park without a lost-wakeup window.
+ */
+export interface WakeSubscriptionHub {
+  /** Register one Scope-owned waiter and return its one-shot wake Effect. */
+  readonly subscribe: (
+    conversationId: ConversationId,
+  ) => Effect.Effect<Effect.Effect<void>, never, Scope.Scope>;
+  /** Wake every currently registered waiter for exactly this Conversation. */
+  readonly notify: (conversationId: ConversationId) => Effect.Effect<void>;
+}
+
+interface WakeRegistration {
+  readonly id: number;
+  readonly deferred: Deferred.Deferred<void>;
+}
+
+type WakeRegistrations = ReadonlyMap<ConversationId, ReadonlyMap<number, Deferred.Deferred<void>>>;
+
+/**
+ * Build the shared per-incarnation registration primitive used by host WakeSchedulers. The hub
+ * contains hints only: eviction may discard it, while a reconnecting caller re-subscribes and
+ * rechecks canonical storage. Scope finalizers remove cancelled waiters, and notify broadcasts
+ * instead of consuming a signal that belongs to another waiter.
+ */
+export const makeWakeSubscriptionHub: Effect.Effect<WakeSubscriptionHub> = Effect.gen(function* () {
+  const registrations = yield* Ref.make<WakeRegistrations>(new Map());
+  const nextId = yield* Ref.make(0);
+
+  const remove = (conversationId: ConversationId, id: number) =>
+    Ref.update(registrations, (current) => {
+      const existing = current.get(conversationId);
+      if (existing === undefined || !existing.has(id)) return current;
+      const next = new Map(current);
+      const conversation = new Map(existing);
+      conversation.delete(id);
+      if (conversation.size === 0) {
+        next.delete(conversationId);
+      } else {
+        next.set(conversationId, conversation);
+      }
+      return next;
+    });
+
+  const subscribe = Effect.fn("WakeSubscriptionHub.subscribe")(
+    (conversationId: ConversationId): Effect.Effect<Effect.Effect<void>, never, Scope.Scope> =>
+      Effect.gen(function* () {
+        const deferred = yield* Deferred.make<void>();
+        const id = yield* Ref.getAndUpdate(nextId, (current) => current + 1);
+        const registration: WakeRegistration = { id, deferred };
+        yield* Effect.addFinalizer(() => remove(conversationId, registration.id));
+        yield* Ref.update(registrations, (current) => {
+          const next = new Map(current);
+          const conversation = new Map(current.get(conversationId) ?? []);
+          conversation.set(registration.id, registration.deferred);
+          next.set(conversationId, conversation);
+          return next;
+        });
+        return registration.deferred;
+      }).pipe(Effect.map((deferred) => Deferred.await(deferred))),
+  );
+
+  const notify = Effect.fn("WakeSubscriptionHub.notify")(function* (
+    conversationId: ConversationId,
+  ) {
+    const waiters = yield* Ref.modify(registrations, (current) => {
+      const conversation = current.get(conversationId);
+      if (conversation === undefined) return [[], current] as const;
+      const next = new Map(current);
+      next.delete(conversationId);
+      return [[...conversation.values()], next] as const;
+    });
+    yield* Effect.forEach(waiters, (waiter) => Deferred.succeed(waiter, undefined), {
+      discard: true,
+    });
+  });
+
+  return { subscribe, notify };
+});
 
 /**
  * Liveness hint channel for durable schedulers. `notify` announces that a Conversation lane may
- * have claimable or settled work; `wakes` is the subscription surface for workers and
- * settlement waiters.
+ * have claimable, canonical, or settled work; `wakes` is the all-lanes subscription surface for
+ * workers, while `subscribe` installs an efficient one-Conversation wait registration.
  *
  * Correctness must NEVER depend on delivery: notifications may be dropped, coalesced, duplicated,
  * or observed by no subscriber (a notify before any subscription is simply lost). Every consumer
- * must pair a wake subscription with periodic SubmissionLedger scans so a dropped notification
- * cannot cause lost work (persistence §14).
+ * must pair a wake with durable authority: workers use periodic SubmissionLedger scans, while a
+ * public progress waiter subscribes before its canonical read and reconnects/rechecks after an
+ * incarnation loss (persistence §14).
  *
  * Each run of `wakes` creates its own subscription whose resources live in that run's Scope and
  * are released when the consuming stream ends or is interrupted. Implementations must not spawn
@@ -20,6 +103,10 @@ export class WakeScheduler extends Context.Service<
   {
     /** Best-effort hint that `conversationId` may have claimable or settled work. Never fails. */
     readonly notify: (conversationId: ConversationId) => Effect.Effect<void>;
+    /** Scope-owned one-shot registration for exactly one Conversation. */
+    readonly subscribe: (
+      conversationId: ConversationId,
+    ) => Effect.Effect<Effect.Effect<void>, never, Scope.Scope>;
     /** Scope-owned subscription to wake hints, starting at subscription time. */
     readonly wakes: Stream.Stream<ConversationId>;
   }
@@ -30,6 +117,7 @@ export class WakeScheduler extends Context.Service<
    */
   static readonly layerNoop: Layer.Layer<WakeScheduler> = Layer.succeed(WakeScheduler, {
     notify: () => Effect.void,
+    subscribe: () => Effect.succeed(Effect.never),
     wakes: Stream.never,
   });
 }

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -12,6 +12,7 @@ import { COMPACTION_SUMMARY_PREFIX, ToolExecutionClass } from "@effect-agent/eng
 import {
   AbortCommand,
   AdmissionConflict,
+  ApprovalDecisionCommand,
   BatchId,
   CanonicalRecordEnvelope,
   CanonicalSequence,
@@ -40,6 +41,7 @@ import {
   SubmissionLookupByKey,
   ToolReconciler,
   WakeScheduler,
+  makeWakeSubscriptionHub,
   modelResponseRecordId,
   projectRunJournal,
   promptFromCanonicalRecords,
@@ -61,6 +63,7 @@ import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, layer } from "@effect/vitest";
 import {
   Cause,
+  Context,
   DateTime,
   Deferred,
   Duration,
@@ -81,6 +84,7 @@ const PRINCIPAL = Schema.decodeSync(Principal)("principal-durable");
 const DIGESTS = DefinitionDigests.make({ agent: SHA_A, model: SHA_A, tools: SHA_A });
 const decodeConversationId = Schema.decodeSync(ConversationId);
 const decodeIdempotencyKey = Schema.decodeSync(IdempotencyKey);
+const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
 
 const submitOptions = (conversationId: string, idempotencyKey: string): DurableSubmitOptions => ({
   conversationId: decodeConversationId(conversationId),
@@ -104,6 +108,17 @@ const toolCallParts: ReadonlyArray<Response.StreamPartEncoded> = [
     id: "search-1",
     name: "search",
     params: { query: "sea" },
+    providerExecuted: false,
+  },
+  { type: "finish", reason: "tool-calls", usage },
+];
+
+const approvalCallParts: ReadonlyArray<Response.StreamPartEncoded> = [
+  {
+    type: "tool-call",
+    id: "book-progress-1",
+    name: "book_progress",
+    params: { ref: "#94" },
     providerExecuted: false,
   },
   { type: "finish", reason: "tool-calls", usage },
@@ -175,6 +190,28 @@ const searchToolLayer = searchTools.toLayer({
   search: () => Effect.succeed({ available: true }),
 });
 
+const BookProgress = Tool.make("book_progress", {
+  parameters: Schema.Struct({ ref: Schema.String }),
+  success: Schema.Struct({ confirmation: Schema.String }),
+  needsApproval: true,
+});
+const progressApprovalTools = Toolkit.make(BookProgress);
+const progressApprovalDefinition = Agent.define("durable-progress-approval", {
+  input: Schema.Struct({ question: Schema.String }),
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: "Book only after approval.",
+  toolkit: progressApprovalTools,
+  policy: AgentPolicy.make({
+    maxTurns: 3,
+    maxToolCalls: 2,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+});
+const progressApprovalToolLayer = progressApprovalTools.toLayer({
+  book_progress: () => Effect.succeed({ confirmation: "confirmed-#94" }),
+});
+
 const configLayer = DurableRuntimeConfig.layer({
   deploymentId: Schema.decodeSync(DeploymentId)("deployment-durable"),
   producerId: Schema.decodeSync(ProducerId)("producer-durable"),
@@ -193,6 +230,110 @@ const baseLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeCrypto.layer));
 
 const testLayer = DurableAgentRuntime.layer.pipe(Layer.provideMerge(baseLayer));
+
+class ProgressWaitTestControl extends Context.Service<
+  ProgressWaitTestControl,
+  {
+    readonly scheduler: WakeScheduler["Service"];
+    readonly active: Ref.Ref<number>;
+    readonly parking: Ref.Ref<number>;
+    readonly reads: Ref.Ref<ReadonlyMap<ConversationId, number>>;
+    readonly subscribeGate: Ref.Ref<Option.Option<Deferred.Deferred<void>>>;
+    readonly parkGate: Ref.Ref<Option.Option<Deferred.Deferred<void>>>;
+  }
+>()("@effect-agent/testing/ProgressWaitTestControl") {}
+
+const progressWaitControlLayer = Layer.effect(
+  ProgressWaitTestControl,
+  Effect.gen(function* () {
+    const hub = yield* makeWakeSubscriptionHub;
+    const active = yield* Ref.make(0);
+    const parking = yield* Ref.make(0);
+    const reads = yield* Ref.make<ReadonlyMap<ConversationId, number>>(new Map());
+    const subscribeGate = yield* Ref.make<Option.Option<Deferred.Deferred<void>>>(Option.none());
+    const parkGate = yield* Ref.make<Option.Option<Deferred.Deferred<void>>>(Option.none());
+
+    const scheduler = WakeScheduler.of({
+      notify: hub.notify,
+      wakes: Stream.never,
+      subscribe: (conversationId) =>
+        Effect.gen(function* () {
+          const wait = yield* hub.subscribe(conversationId);
+          yield* Ref.update(active, (count) => count + 1);
+          yield* Effect.addFinalizer(() => Ref.update(active, (count) => count - 1));
+          const beforeCheck = yield* Ref.get(subscribeGate);
+          if (Option.isSome(beforeCheck)) yield* Deferred.await(beforeCheck.value);
+          return wait;
+        }).pipe(
+          Effect.map((wait) =>
+            Effect.gen(function* () {
+              yield* Ref.update(parking, (count) => count + 1);
+              const beforePark = yield* Ref.get(parkGate);
+              if (Option.isSome(beforePark)) yield* Deferred.await(beforePark.value);
+              yield* wait;
+            }),
+          ),
+        ),
+    });
+
+    return ProgressWaitTestControl.of({
+      scheduler,
+      active,
+      parking,
+      reads,
+      subscribeGate,
+      parkGate,
+    });
+  }),
+);
+
+const progressWaitSchedulerLayer = Layer.effect(
+  WakeScheduler,
+  Effect.map(ProgressWaitTestControl, (control) => control.scheduler),
+);
+
+const progressWaitStoreLayer = Layer.effect(
+  ConversationStore,
+  Effect.gen(function* () {
+    const inner = yield* ConversationStore;
+    const control = yield* ProgressWaitTestControl;
+    return ConversationStore.of({
+      ...inner,
+      read: (request) =>
+        Stream.unwrap(
+          Ref.update(control.reads, (current) => {
+            const next = new Map(current);
+            next.set(request.conversationId, (current.get(request.conversationId) ?? 0) + 1);
+            return next;
+          }).pipe(Effect.as(inner.read(request))),
+        ),
+    });
+  }),
+).pipe(Layer.provide(MemoryConversationStoreLive));
+
+const progressWaitAdapters = Layer.merge(progressWaitSchedulerLayer, progressWaitStoreLayer).pipe(
+  Layer.provideMerge(progressWaitControlLayer),
+);
+
+const progressWaitBaseLayer = Layer.mergeAll(
+  MemorySubmissionLedgerLive,
+  progressWaitAdapters,
+  DurableRuntimeFailpoint.layerTest,
+  ToolReconciler.uncertain,
+  configLayer,
+).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const progressWaitTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(progressWaitBaseLayer),
+);
+
+const waitForAtLeast = (ref: Ref.Ref<number>, expected: number): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    while ((yield* Ref.get(ref)) < expected) yield* Effect.yieldNow;
+  });
+
+const readCount = (control: ProgressWaitTestControl["Service"], conversationId: ConversationId) =>
+  Ref.get(control.reads).pipe(Effect.map((counts) => counts.get(conversationId) ?? 0));
 
 const readLog = (conversationId: string) =>
   Effect.gen(function* () {
@@ -246,7 +387,302 @@ const failureTag = <A, E>(exit: Exit.Exit<A, E>): string => {
     : "unknown";
 };
 
+layer(progressWaitTestLayer)("#94 DurableAgentRuntime progress waits", (it) => {
+  it.effect("wakes promptly when the terminal settlement append commits", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const failpoints = yield* DurableRuntimeFailpointTestControl;
+      const control = yield* ProgressWaitTestControl;
+      const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"settled"}'));
+      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const conversationId = decodeConversationId("conversation-progress-settlement");
+      yield* runtime.submit(
+        agent,
+        { question: "wake on settlement" },
+        submitOptions(conversationId, "progress-settlement-1"),
+      );
+
+      const reserved = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      yield* failpoints.setHandler((location) =>
+        location === "terminalize:after-reserve"
+          ? Deferred.succeed(reserved, undefined).pipe(Effect.andThen(Deferred.await(release)))
+          : Effect.void,
+      );
+      yield* Effect.gen(function* () {
+        const processing = yield* Effect.forkChild(
+          runtime.processConversation(agent, conversationId),
+        );
+        yield* Deferred.await(reserved);
+
+        const beforeSettlement = yield* readLog(conversationId);
+        expect(logTags(beforeSettlement)).not.toContain("SubmissionSettled");
+        const cursor = beforeSettlement.at(-1)?.sequence;
+        expect(cursor).toBeDefined();
+        if (cursor === undefined) return;
+
+        const waiting = yield* Effect.forkChild(runtime.awaitProgress(conversationId, cursor));
+        yield* waitForAtLeast(control.active, 1);
+        yield* Deferred.succeed(release, undefined);
+        yield* Fiber.join(waiting);
+        yield* Fiber.join(processing);
+
+        const afterSettlement = yield* readLog(conversationId);
+        expect(afterSettlement.at(-1)?.record.payload._tag).toBe("SubmissionSettled");
+        expect(yield* Ref.get(control.active)).toBe(0);
+      }).pipe(Effect.ensuring(failpoints.clear));
+    }),
+  );
+
+  it.effect("wakes after approval request and decision records commit", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const control = yield* ProgressWaitTestControl;
+      const scripted = yield* makeScriptedModel((call) =>
+        call === 0 ? approvalCallParts : finalParts('{"answer":"approved"}'),
+      );
+      const agent = Agent.withModel(progressApprovalDefinition, scripted.model);
+      const conversationId = decodeConversationId("conversation-progress-approval");
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: "wake at both approval boundaries" },
+        submitOptions(conversationId, "progress-approval-1"),
+      );
+      const submitted = yield* readLog(conversationId);
+      const submittedCursor = submitted.at(-1)?.sequence;
+      expect(submittedCursor).toBeDefined();
+      if (submittedCursor === undefined) return;
+
+      const awaitingRequest = yield* Effect.forkChild(
+        runtime.awaitProgress(conversationId, submittedCursor),
+      );
+      yield* waitForAtLeast(control.active, 1);
+      yield* runtime
+        .processConversation(agent, conversationId)
+        .pipe(Effect.provide(progressApprovalToolLayer));
+      yield* Fiber.join(awaitingRequest);
+      const requested = yield* readLog(conversationId);
+      expect(
+        requested.some(
+          (record) =>
+            record.sequence > submittedCursor &&
+            record.record.payload._tag === "ToolApprovalRequested",
+        ),
+      ).toBe(true);
+      const requestCursor = requested.at(-1)?.sequence;
+      expect(requestCursor).toBeDefined();
+      if (requestCursor === undefined) return;
+
+      const parksBeforeDecision = yield* Ref.get(control.parking);
+      const awaitingDecision = yield* Effect.forkChild(
+        Effect.gen(function* () {
+          let cursor = requestCursor;
+          for (;;) {
+            const records = yield* readLog(conversationId);
+            if (
+              records.some(
+                (record) =>
+                  record.sequence > requestCursor &&
+                  record.record.payload._tag === "ToolApprovalDecided",
+              )
+            ) {
+              return;
+            }
+            const last = records.at(-1);
+            if (last !== undefined && last.sequence > cursor) cursor = last.sequence;
+            yield* runtime.awaitProgress(conversationId, cursor);
+          }
+        }),
+      );
+      yield* waitForAtLeast(control.parking, parksBeforeDecision + 1);
+      yield* runtime.resolveApproval(
+        ApprovalDecisionCommand.make({
+          submissionId: receipt.submissionId,
+          toolCallId: Schema.decodeSync(ToolCallId)("book-progress-1"),
+          decision: "approved",
+          resolver: "#94-runtime-test",
+          reason: "exercise the public approval progress edge",
+        }),
+      );
+      // Resolution first commits a ledger intent and emits a permitted false-positive hint.
+      // The caller re-reads, parks again, and the resumed Attempt appends the canonical decision.
+      yield* waitForAtLeast(control.parking, parksBeforeDecision + 2);
+      yield* runtime
+        .processConversation(agent, conversationId)
+        .pipe(Effect.provide(progressApprovalToolLayer));
+      yield* Fiber.join(awaitingDecision);
+      const decided = yield* readLog(conversationId);
+      expect(
+        decided.some(
+          (record) =>
+            record.sequence > requestCursor && record.record.payload._tag === "ToolApprovalDecided",
+        ),
+      ).toBe(true);
+      expect(yield* Ref.get(control.active)).toBe(0);
+    }),
+  );
+
+  it.effect("closes the subscribe/check and check/park lost-wakeup windows", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scheduler = yield* WakeScheduler;
+      const control = yield* ProgressWaitTestControl;
+      const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"never"}'));
+      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const conversationId = decodeConversationId("conversation-progress-races");
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: "race the wait" },
+        submitOptions(conversationId, "progress-races-1"),
+      );
+      const initial = yield* readLog(conversationId);
+      const initialCursor = initial.at(-1)?.sequence;
+      expect(initialCursor).toBeDefined();
+      if (initialCursor === undefined) return;
+
+      // Force append+notify after registration but before the authoritative check.
+      const beforeCheck = yield* Deferred.make<void>();
+      yield* Ref.set(control.subscribeGate, Option.some(beforeCheck));
+      const subscribedRace = yield* Effect.forkChild(
+        runtime.awaitProgress(conversationId, initialCursor),
+      );
+      yield* waitForAtLeast(control.active, 1);
+      yield* runtime.abort(
+        AbortCommand.make({
+          submissionId: receipt.submissionId,
+          author: "operator",
+          reason: "force #94 subscribe/check race",
+        }),
+      );
+      yield* Deferred.succeed(beforeCheck, undefined);
+      yield* Fiber.join(subscribedRace);
+      expect(yield* Ref.get(control.active)).toBe(0);
+
+      const afterAbort = yield* readLog(conversationId);
+      const abortCursor = afterAbort.at(-1)?.sequence;
+      expect(abortCursor).toBeDefined();
+      if (abortCursor === undefined) return;
+
+      // Force a hint after the empty canonical check but before the returned wait Effect parks.
+      yield* Ref.set(control.subscribeGate, Option.none());
+      const beforePark = yield* Deferred.make<void>();
+      yield* Ref.set(control.parkGate, Option.some(beforePark));
+      const readsBeforeParkRace = yield* readCount(control, conversationId);
+      const parksBeforeParkRace = yield* Ref.get(control.parking);
+      const parkedRace = yield* Effect.forkChild(
+        runtime.awaitProgress(conversationId, abortCursor),
+      );
+      yield* waitForAtLeast(control.parking, parksBeforeParkRace + 1);
+      yield* scheduler.notify(conversationId);
+      yield* Deferred.succeed(beforePark, undefined);
+      yield* Fiber.join(parkedRace);
+      expect(yield* readCount(control, conversationId)).toBe(readsBeforeParkRace + 1);
+      expect(yield* Ref.get(control.active)).toBe(0);
+
+      // The second wake was deliberately a false positive: storage, not the hint, is truth.
+      const final = yield* readLog(conversationId);
+      expect(final.at(-1)?.sequence).toBe(abortCursor);
+    }),
+  );
+
+  it.effect(
+    "broadcasts to concurrent waiters, stays O(1), and cleans up cancellation/timeout",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const scheduler = yield* WakeScheduler;
+        const control = yield* ProgressWaitTestControl;
+        const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"never"}'));
+        const agent = Agent.withModel(plannerDefinition, scripted.model);
+        const conversationId = decodeConversationId("conversation-progress-many");
+        const unrelatedId = decodeConversationId("conversation-progress-unrelated");
+
+        yield* runtime.submit(
+          agent,
+          { question: "many waiters" },
+          submitOptions(conversationId, "progress-many-1"),
+        );
+        yield* runtime.submit(
+          agent,
+          { question: "unrelated waiter" },
+          submitOptions(unrelatedId, "progress-unrelated-1"),
+        );
+        const records = yield* readLog(conversationId);
+        const unrelatedRecords = yield* readLog(unrelatedId);
+        const cursor = records.at(-1)?.sequence;
+        const unrelatedCursor = unrelatedRecords.at(-1)?.sequence;
+        expect(cursor).toBeDefined();
+        expect(unrelatedCursor).toBeDefined();
+        if (cursor === undefined || unrelatedCursor === undefined) return;
+
+        const readsBefore = yield* readCount(control, conversationId);
+        const unrelatedReadsBefore = yield* readCount(control, unrelatedId);
+        const first = yield* Effect.forkChild(runtime.awaitProgress(conversationId, cursor));
+        const second = yield* Effect.forkChild(runtime.awaitProgress(conversationId, cursor));
+        const unrelated = yield* Effect.forkChild(
+          runtime.awaitProgress(unrelatedId, unrelatedCursor),
+        );
+        yield* waitForAtLeast(control.active, 3);
+        yield* waitForAtLeast(control.parking, 3);
+        expect(yield* readCount(control, conversationId)).toBe(readsBefore + 2);
+        expect(yield* readCount(control, unrelatedId)).toBe(unrelatedReadsBefore + 1);
+
+        yield* TestClock.adjust(Duration.seconds(10));
+        expect(yield* readCount(control, conversationId)).toBe(readsBefore + 2);
+        expect(yield* readCount(control, unrelatedId)).toBe(unrelatedReadsBefore + 1);
+
+        yield* scheduler.notify(conversationId);
+        yield* Fiber.join(first);
+        yield* Fiber.join(second);
+        expect(unrelated.pollUnsafe()).toBeUndefined();
+        expect(yield* Ref.get(control.active)).toBe(1);
+
+        yield* Fiber.interrupt(unrelated);
+        expect(yield* Ref.get(control.active)).toBe(0);
+
+        const timed = yield* Effect.forkChild(
+          runtime
+            .awaitProgress(conversationId, cursor)
+            .pipe(Effect.timeoutOption(Duration.seconds(3))),
+        );
+        yield* waitForAtLeast(control.active, 1);
+        yield* TestClock.adjust(Duration.seconds(3));
+        const timedResult = yield* Fiber.join(timed);
+        expect(Option.isNone(timedResult)).toBe(true);
+        expect(yield* Ref.get(control.active)).toBe(0);
+      }),
+  );
+
+  it.effect("preserves the typed non-materialized failure and releases its registration", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const control = yield* ProgressWaitTestControl;
+      const missing = decodeConversationId("conversation-progress-missing");
+      const exit = yield* Effect.exit(runtime.awaitProgress(missing, ZERO_SEQUENCE));
+      expect(failureTag(exit)).toBe("ConversationNotMaterialized");
+      expect(yield* Ref.get(control.active)).toBe(0);
+    }),
+  );
+});
+
 layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
+  it.effect("#94 observes already-committed durable progress without polling", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"ok"}'));
+      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const conversationId = decodeConversationId("conversation-progress-committed");
+
+      yield* runtime.submit(
+        agent,
+        { question: "already committed?" },
+        submitOptions(conversationId, "progress-committed-1"),
+      );
+
+      yield* runtime.awaitProgress(conversationId, ZERO_SEQUENCE);
+    }),
+  );
+
   it.effect("submit returns a durable Receipt once admission and readiness commit", () =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;


### PR DESCRIPTION
## Summary\n\n- add a public Effect-native DurableAgentRuntime.awaitProgress boundary backed by conversation-keyed scoped wake registrations\n- carry the boundary through the Cloudflare Conversation Object RPC and CloudflareConversationClient, including explicit interruption cancellation and reset-safe reconstruction\n- emit best-effort hints only after authoritative durable mutations, while keeping canonical records authoritative\n- document the subscribe/read/park contract and add the required minor changeset\n\n## Correctness\n\nThe runtime installs a one-shot registration before its authoritative canonical read. A commit in either the subscribe/check or check/park seam completes the deferred hint, while already-committed history returns immediately. Hints may be dropped, duplicated, or false-positive; callers always re-read canonical storage.\n\nWake delivery broadcasts to every scoped waiter for one conversation only. Scope finalizers remove interrupted or timed-out registrations. The Cloudflare client generates one cancellation identity through its explicit Crypto.Crypto requirement, preserves it across reset retries, broadcasts cancellation across overlapping retry attempts, and reconstructs a wait with a fresh stub after platform-classified Durable Object resets.\n\nEvery canonical append notifies after commit. Approval and unknown-resolution ledger intents, abort, child/parent/host wakes, and terminal settlement paths retain their existing durable ordering and typed failures.\n\n## Red-green and lifecycle evidence\n\n- red: the first #94 public-runtime regression failed because DurableAgentRuntime.awaitProgress did not exist\n- green: forced notify-after-subscribe/before-read and notify-after-read/before-park interleavings both complete without polling\n- green: TestClock advances 10 seconds without increasing canonical reads\n- green: terminal settlement, approval request, approval resolution, abort, false-positive hints, concurrent waiters, interruption, timeout, and missing-conversation tags are covered\n- green: the workerd boundary covers committed history, canonical append, concurrent callers, cancellation, typed denial/non-materialization, remote wakes, and actual ctx.abort eviction/reconstruction\n- green: reconstruction is latched on a different Object incarnation before approval\n- green: all long-lived test client waits are owned Effect fibers with unconditional test-finalizer interruption\n- green: transport-fault injection now fails at the caller-side namespace/stub seam and direct export aborts are owned by runInDurableObject; the package no longer suppresses unhandled errors\n\n## Validation\n\n- vp check: zero errors across 501 files; repository warning baseline only\n- packages/platform-cloudflare focused progress suite: 7/7 passed with no Vitest unhandled-error section\n- packages/platform-cloudflare full suite: 13 files, 125/125 passed, zero unhandled errors\n- the same 125/125 full suite passes after removing dangerouslyIgnoreUnhandledErrors, so escaped promise failures fail the gate\n- unreachable-child transport-fault row: passed alone with zero unhandled errors\n- export reset row: passed alone with zero unhandled errors\n- vp run changeset status --since=origin/main: valid minor release plan including @effect-agent/session and @effect-agent/platform-cloudflare\n\nLocal vp run ready was attempted twice earlier. Vite+ failed before package checks with EINVAL while spawning different package TypeScript processes, although vp env doctor was clean and isolated checks and builds pass. Fresh CI Build, Static checks, Tests, and ready remain the authoritative clean-runner gates.\n\nCloses #94\n