### PR TITLE
feat(session): persist typed run dispositions

### DIFF
--- a/.changeset/typed-run-disposition.md
+++ b/.changeset/typed-run-disposition.md
@@ -1,0 +1,9 @@
+---
+"@effect-agent/core": minor
+"@effect-agent/engine": minor
+"@effect-agent/session": minor
+---
+
+Add a Definition-owned Schema boundary for typed application run dispositions and persist valid
+ordinary-completion values on canonical `SubmissionSettled` records across crash recovery and
+replay.

--- a/.changeset/typed-run-disposition.md
+++ b/.changeset/typed-run-disposition.md
@@ -6,4 +6,4 @@
 
 Add a Definition-owned Schema boundary for typed application run dispositions and persist valid
 ordinary-completion values on canonical `SubmissionSettled` records across crash recovery and
-replay.
+replay, including materialization through the public durable Settlement API.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,7 +55,8 @@ capability.
 
 **Settlement**  
 The single durable terminal outcome owed to an accepted Submission: `completed`, `failed`, or
-`aborted`.
+`aborted`. An ordinary completed Settlement may materialize the Definition-validated,
+Schema-encoded application run disposition stored in its exact canonical record.
 
 ## Agent capabilities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,11 @@ the durable runtime admits a Submission and coordinates Attempts until Settlemen
 One logical request to execute an Agent Binding against a Conversation. In ephemeral mode the Run
 lives for one Scope. In durable mode the logical Run may span multiple process Attempts.
 
+**Run Disposition**<br>
+An optional application-defined value selected from decoded Agent output and validated by a
+Definition-owned Effect Schema. It is durable only for an ordinary completed Run and is never
+inferred from prose, Tool output, or successful side effects.
+
 **Attempt**  
 One ownership period in which a worker tries to advance a durable Submission. An interruption,
 lost ownership, eviction, or redeploy may end an Attempt without ending the Run.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -29384,11 +29384,15 @@ var EventOffset = identifier2("EventOffset");
 // packages/core/src/agent.ts
 var Agent;
 ((Agent) => {
-  Agent.define = (id2, options) => Object.freeze({
-    ...options,
-    id: exports_Schema.decodeSync(AgentId)(id2),
-    metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata })
-  });
+  function define(id2, options) {
+    return Object.freeze({
+      ...options,
+      id: exports_Schema.decodeSync(AgentId)(id2),
+      metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata }),
+      runDisposition: options.runDisposition === undefined ? undefined : Object.freeze({ ...options.runDisposition })
+    });
+  }
+  Agent.define = define;
   Agent.withModel = (definition, model) => Object.freeze({
     definition,
     model
@@ -29401,6 +29405,11 @@ class AgentInputError extends exports_Schema.TaggedError()("AgentInputError", {
 }
 
 class AgentOutputError extends exports_Schema.TaggedError()("AgentOutputError", {
+  message: exports_Schema.String
+}) {
+}
+
+class AgentRunDispositionError extends exports_Schema.TaggedError()("AgentRunDispositionError", {
   message: exports_Schema.String
 }) {
 }
@@ -29453,6 +29462,7 @@ class ContextOverflowError extends exports_Schema.TaggedError()("ContextOverflow
 var AgentError = exports_Schema.Union([
   AgentInputError,
   AgentOutputError,
+  AgentRunDispositionError,
   AgentPolicyError,
   AgentApprovalDenied,
   AgentApprovalPending,
@@ -29602,6 +29612,7 @@ var ExhaustedLimit = exports_Schema.Literals(["tokens", "tool-calls", "turns"]);
 class RunCompleted extends exports_Schema.TaggedClass()("RunCompleted", {
   ...RunEventBase,
   output: exports_Schema.Json,
+  runDisposition: exports_Schema.optionalKey(exports_Schema.Json),
   turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0)),
   finishReason: exports_Schema.Literals(["completed", "model-stop", "budget-exhausted"]),
   exhausted: exports_Schema.optionalKey(ExhaustedLimit)
@@ -35295,10 +35306,31 @@ var decodeFinalOutput = exports_Effect.fn("AgentRuntime.decodeFinalOutput")(func
     message: `Agent output is not valid JSON: ${cause.message}`
   })));
   const candidateOutput = eventJson;
-  yield* exports_Schema.decodeUnknownEffect(agent2.definition.output)(candidateOutput).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+  const decoded = yield* exports_Schema.decodeUnknownEffect(agent2.definition.output)(candidateOutput).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
     message: cause.message
   })));
-  return eventJson;
+  return { encoded: eventJson, decoded };
+});
+var encodeRunDisposition = exports_Effect.fn("AgentRuntime.encodeRunDisposition")(function* (declaration, output) {
+  const selected = yield* exports_Effect.try({
+    try: () => declaration.fromOutput(output),
+    catch: (cause) => AgentRunDispositionError.make({
+      message: `Run disposition selector failed: ${errorMessage(cause)}`
+    })
+  });
+  if (selected === undefined)
+    return;
+  const encoded = yield* exports_Schema.encodeUnknownEffect(declaration.schema)(selected).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    message: cause.message
+  })));
+  return yield* exports_Schema.decodeUnknownEffect(exports_Schema.Json)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    message: `Run disposition did not encode as durable JSON: ${cause.message}`
+  })));
+});
+var decodeRunDisposition = exports_Effect.fn("AgentRuntime.decodeRunDisposition")(function* (declaration, encoded) {
+  return yield* exports_Schema.decodeUnknownEffect(declaration.schema)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    message: cause.message
+  })));
 });
 var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => exports_Stream.unwrap(exports_Effect.gen(function* () {
   const ids = yield* IdGenerator;
@@ -35499,7 +35531,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
             yield* advanceHistory(context3, historyWithResponse(), options);
             return emitThen(exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
               ...base2,
-              output: output.value,
+              output: output.value.encoded,
               turns: turn,
               finishReason: "budget-exhausted",
               exhausted: "tokens"
@@ -35539,9 +35571,12 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         return makeTurn(agent2, context3, nextPrompt, turn + 1, toolCalls, options);
       }
       const output = yield* decodeFinalOutput(agent2, trace2.text.join(""));
+      const declaration = agent2.definition.runDisposition;
+      const runDisposition = finalAnswerOnly || declaration === undefined ? undefined : yield* encodeRunDisposition(declaration, output.decoded);
       return exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
         ...base2,
-        output,
+        output: output.encoded,
+        ...runDisposition === undefined ? {} : { runDisposition },
         turns: turn,
         finishReason: finalAnswerOnly ? "budget-exhausted" : "model-stop",
         ...finalAnswerOnly && context3.exhaustedDimension !== undefined ? { exhausted: context3.exhaustedDimension } : {}
@@ -35921,13 +35956,20 @@ var reduceRunEvents = (agent2, events2) => exports_Effect.gen(function* () {
   const output = yield* exports_Schema.decodeUnknownEffect(agent2.definition.output)(candidateOutput).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
     message: cause.message
   })));
+  const declaration = agent2.definition.runDisposition;
+  const runDisposition = completed.runDisposition === undefined ? undefined : completed.finishReason === "budget-exhausted" ? yield* ModelProtocolError.make({
+    message: "A budget-exhausted RunCompleted event cannot declare a run disposition"
+  }) : declaration === undefined ? yield* ModelProtocolError.make({
+    message: "RunCompleted declared a run disposition without a definition-owned Schema"
+  }) : yield* decodeRunDisposition(declaration, completed.runDisposition);
   return {
     output,
     conversationId: completed.conversationId,
     runId: completed.runId,
     turns: completed.turns,
     finishReason: completed.finishReason,
-    ...completed.exhausted !== undefined ? { exhausted: completed.exhausted } : {}
+    ...completed.exhausted !== undefined ? { exhausted: completed.exhausted } : {},
+    ...runDisposition === undefined ? {} : { runDisposition: completed.runDisposition }
   };
 });
 var run4 = exports_Effect.fn("AgentRuntime.run")(function* (agent2, input, options = {}) {

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -29410,6 +29410,7 @@ class AgentOutputError extends exports_Schema.TaggedError()("AgentOutputError", 
 }
 
 class AgentRunDispositionError extends exports_Schema.TaggedError()("AgentRunDispositionError", {
+  cause: exports_Schema.Defect(),
   message: exports_Schema.String
 }) {
 }
@@ -35315,15 +35316,18 @@ var encodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.encodeRunDis
   const selected = yield* exports_Effect.try({
     try: () => declaration.fromOutput(output),
     catch: (cause) => AgentRunDispositionError.make({
-      message: `Run disposition selector failed: ${errorMessage(cause)}`
+      cause,
+      message: "Run disposition selector failed"
     })
   });
   if (selected === undefined)
     return;
   const encoded = yield* exports_Schema.encodeUnknownEffect(declaration.schema)(selected).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    cause,
     message: cause.message
   })));
   return yield* exports_Schema.decodeUnknownEffect(exports_Schema.Json)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    cause,
     message: `Run disposition did not encode as durable JSON: ${cause.message}`
   })));
 });
@@ -35333,6 +35337,7 @@ function encodeRunDisposition(agent2, output) {
 }
 var decodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.decodeRunDisposition")(function* (declaration, encoded) {
   return yield* exports_Schema.decodeUnknownEffect(declaration.schema)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
+    cause,
     message: cause.message
   })));
 });

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -35324,11 +35324,11 @@ var encodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.encodeRunDis
     return;
   const encoded = yield* exports_Schema.encodeUnknownEffect(declaration.schema)(selected).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
     cause,
-    message: cause.message
+    message: "Run disposition failed Schema encoding"
   })));
   return yield* exports_Schema.decodeUnknownEffect(exports_Schema.Json)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
     cause,
-    message: `Run disposition did not encode as durable JSON: ${cause.message}`
+    message: "Run disposition did not encode as durable JSON"
   })));
 });
 function encodeRunDisposition(agent2, output) {

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -35311,7 +35311,7 @@ var decodeFinalOutput = exports_Effect.fn("AgentRuntime.decodeFinalOutput")(func
   })));
   return { encoded: eventJson, decoded };
 });
-var encodeRunDisposition = exports_Effect.fn("AgentRuntime.encodeRunDisposition")(function* (declaration, output) {
+var encodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.encodeRunDisposition")(function* (declaration, output) {
   const selected = yield* exports_Effect.try({
     try: () => declaration.fromOutput(output),
     catch: (cause) => AgentRunDispositionError.make({
@@ -35327,11 +35327,21 @@ var encodeRunDisposition = exports_Effect.fn("AgentRuntime.encodeRunDisposition"
     message: `Run disposition did not encode as durable JSON: ${cause.message}`
   })));
 });
-var decodeRunDisposition = exports_Effect.fn("AgentRuntime.decodeRunDisposition")(function* (declaration, encoded) {
+function encodeRunDisposition(agent2, output) {
+  const declaration = agent2.definition.runDisposition;
+  return declaration === undefined ? exports_Effect.void : encodeRunDispositionCandidate(declaration, output);
+}
+var decodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.decodeRunDisposition")(function* (declaration, encoded) {
   return yield* exports_Schema.decodeUnknownEffect(declaration.schema)(encoded).pipe(exports_Effect.mapError((cause) => AgentRunDispositionError.make({
     message: cause.message
   })));
 });
+function decodeRunDisposition(agent2, encoded) {
+  const declaration = agent2.definition.runDisposition;
+  return declaration === undefined ? exports_Effect.fail(ModelProtocolError.make({
+    message: "RunCompleted declared a run disposition without a definition-owned Schema"
+  })) : decodeRunDispositionCandidate(declaration, encoded);
+}
 var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => exports_Stream.unwrap(exports_Effect.gen(function* () {
   const ids = yield* IdGenerator;
   const turnId = yield* ids.nextTurnId;
@@ -35572,7 +35582,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
       }
       const output = yield* decodeFinalOutput(agent2, trace2.text.join(""));
       const declaration = agent2.definition.runDisposition;
-      const runDisposition = finalAnswerOnly || declaration === undefined ? undefined : yield* encodeRunDisposition(declaration, output.decoded);
+      const runDisposition = finalAnswerOnly || declaration === undefined ? undefined : yield* encodeRunDisposition(agent2, output.decoded);
       return exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
         ...base2,
         output: output.encoded,
@@ -35961,7 +35971,7 @@ var reduceRunEvents = (agent2, events2) => exports_Effect.gen(function* () {
     message: "A budget-exhausted RunCompleted event cannot declare a run disposition"
   }) : declaration === undefined ? yield* ModelProtocolError.make({
     message: "RunCompleted declared a run disposition without a definition-owned Schema"
-  }) : yield* decodeRunDisposition(declaration, completed.runDisposition);
+  }) : yield* decodeRunDisposition(agent2, completed.runDisposition);
   return {
     output,
     conversationId: completed.conversationId,

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -27,13 +27,17 @@ making Model selection explicit.
 ## Definition contract
 
 ```ts
-interface Definition<InputSchema, OutputSchema, Instructions, Toolkit> {
+interface Definition<InputSchema, OutputSchema, Instructions, Toolkit, RunDisposition> {
   readonly id: AgentId;
   readonly input: InputSchema;
   readonly output: OutputSchema;
   readonly instructions: Instructions;
   readonly toolkit: Toolkit;
   readonly policy: AgentPolicy;
+  readonly runDisposition?: {
+    readonly schema: RunDisposition;
+    readonly fromOutput: (output: OutputSchema["Type"]) => unknown;
+  };
   readonly description?: string;
   readonly metadata?: Readonly<Record<string, string>>;
 }
@@ -56,6 +60,34 @@ type Failure = Agent.Failure<typeof agent>;
 
 The repository protects these projections with compile-time tests. An unbound Definition is
 rejected by `AgentRuntime`.
+
+## Declare application completion explicitly
+
+Use an optional run-disposition boundary when a record reader needs an application-owned durable
+classification beyond the framework's `completed | failed | aborted` settlement outcome.
+
+```ts
+const RunDisposition = Schema.Literal("answered-without-cloud-task");
+
+const definition = Agent.define("support-triage", {
+  input: SupportRequest,
+  output: Resolution,
+  instructions,
+  toolkit: SupportToolkit,
+  policy,
+  runDisposition: {
+    schema: RunDisposition,
+    fromOutput: (resolution) => resolution.runDisposition,
+  },
+});
+```
+
+The selector sees decoded output and may return `undefined`. Its candidate is untrusted until the
+Schema validates and encodes it; invalid selection fails with `AgentRunDispositionError`. An
+ordinary completed durable Run persists the encoded value on `SubmissionSettled.runDisposition`,
+where readers decode it with the same application Schema. Budget exhaustion, failure, abort, and
+incomplete recovery never receive one. Do not parse summary prose or infer finality from successful
+Tool Calls.
 
 ## Stable identity
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -67,7 +67,7 @@ Use an optional run-disposition boundary when a record reader needs an applicati
 classification beyond the framework's `completed | failed | aborted` settlement outcome.
 
 ```ts
-const RunDisposition = Schema.Literal("answered-without-cloud-task");
+const RunDisposition = Schema.Literal("application-complete");
 
 const definition = Agent.define("support-triage", {
   input: SupportRequest,
@@ -83,11 +83,11 @@ const definition = Agent.define("support-triage", {
 ```
 
 The selector sees decoded output and may return `undefined`. Its candidate is untrusted until the
-Schema validates and encodes it; invalid selection fails with `AgentRunDispositionError`. An
-ordinary completed durable Run persists the encoded value on `SubmissionSettled.runDisposition`,
-where readers decode it with the same application Schema. Budget exhaustion, failure, abort, and
-incomplete recovery never receive one. Do not parse summary prose or infer finality from successful
-Tool Calls.
+Schema validates and encodes it; invalid selection fails with `AgentRunDispositionError`, which
+joins `Agent.Failure` only for Definitions that declare this boundary. An ordinary completed
+durable Run persists the encoded value on `SubmissionSettled.runDisposition`, where readers decode
+it with the same application Schema. Budget exhaustion, failure, abort, and incomplete recovery
+never receive one. Do not parse summary prose or infer finality from successful Tool Calls.
 
 ## Stable identity
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -87,7 +87,9 @@ Schema validates and encodes it; invalid selection fails with `AgentRunDispositi
 joins `Agent.Failure` only for Definitions that declare this boundary. An ordinary completed
 durable Run persists the encoded value on `SubmissionSettled.runDisposition`, where readers decode
 it with the same application Schema. Budget exhaustion, failure, abort, and incomplete recovery
-never receive one. Do not parse summary prose or infer finality from successful Tool Calls.
+never receive one. A selector exception remains available as the typed error's diagnostic `cause`;
+only a fixed, non-sensitive message enters the Run event stream. Do not parse summary prose or
+infer finality from successful Tool Calls.
 
 ## Stable identity
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -27,17 +27,25 @@ making Model selection explicit.
 ## Definition contract
 
 ```ts
-interface Definition<InputSchema, OutputSchema, Instructions, Toolkit, RunDisposition> {
+interface RunDispositionDeclaration<Output, DispositionSchema> {
+  readonly schema: DispositionSchema;
+  readonly fromOutput: (output: Output) => unknown;
+}
+
+interface Definition<
+  InputSchema,
+  OutputSchema,
+  Instructions,
+  Toolkit,
+  RunDispositionValue = undefined,
+> {
   readonly id: AgentId;
   readonly input: InputSchema;
   readonly output: OutputSchema;
   readonly instructions: Instructions;
   readonly toolkit: Toolkit;
   readonly policy: AgentPolicy;
-  readonly runDisposition?: {
-    readonly schema: RunDisposition;
-    readonly fromOutput: (output: OutputSchema["Type"]) => unknown;
-  };
+  readonly runDisposition?: RunDispositionValue;
   readonly description?: string;
   readonly metadata?: Readonly<Record<string, string>>;
 }

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -29,9 +29,10 @@ interface AgentResult<Output> {
 
 `runDisposition` is present only when the Definition declares a disposition Schema, its selector
 returns a value, and the Run completes ordinarily. It is the Schema-encoded JSON value; durable
-callers read the same value from the canonical `SubmissionSettled` record and decode it with the
-application Schema. The exported `AgentResultSchema` enforces the same boundary and rejects a
-`runDisposition` paired with `finishReason: "budget-exhausted"`.
+callers receive the same value from `DurableAgentRuntime.awaitSettlement` and canonical
+`SubmissionSettled` record readers, then decode it with the application Schema. The exported
+`AgentResultSchema` enforces the same boundary and rejects a `runDisposition` paired with
+`finishReason: "budget-exhausted"`.
 
 Under the default `onExhaustion: "final-answer"` policy, a Run that exhausts its Turn or Tool
 Call budget settles with one constrained final-answer Turn and reports it honestly as

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -30,7 +30,8 @@ interface AgentResult<Output> {
 `runDisposition` is present only when the Definition declares a disposition Schema, its selector
 returns a value, and the Run completes ordinarily. It is the Schema-encoded JSON value; durable
 callers read the same value from the canonical `SubmissionSettled` record and decode it with the
-application Schema.
+application Schema. The exported `AgentResultSchema` enforces the same boundary and rejects a
+`runDisposition` paired with `finishReason: "budget-exhausted"`.
 
 Under the default `onExhaustion: "final-answer"` policy, a Run that exhausts its Turn or Tool
 Call budget settles with one constrained final-answer Turn and reports it honestly as

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -19,12 +19,18 @@ const result = yield * AgentRuntime.run(agent, input);
 ```ts
 interface AgentResult<Output> {
   readonly output: Output;
+  readonly runDisposition?: Json;
   readonly conversationId: ConversationId;
   readonly runId: RunId;
   readonly turns: number;
   readonly finishReason: "completed" | "model-stop" | "budget-exhausted";
 }
 ```
+
+`runDisposition` is present only when the Definition declares a disposition Schema, its selector
+returns a value, and the Run completes ordinarily. It is the Schema-encoded JSON value; durable
+callers read the same value from the canonical `SubmissionSettled` record and decode it with the
+application Schema.
 
 Under the default `onExhaustion: "final-answer"` policy, a Run that exhausts its Turn or Tool
 Call budget settles with one constrained final-answer Turn and reports it honestly as

--- a/docs/spec/authoring.md
+++ b/docs/spec/authoring.md
@@ -63,12 +63,48 @@ An Agent Binding additionally requires one Effect AI Model. An unbound Definitio
 ### Optional fields
 
 - description and metadata;
+- an application run-disposition Schema and decoded-output selector;
 - context transforms;
 - response acceptance policy;
 - compaction policy;
 - content persistence policy;
 - capability requirements;
 - application version label.
+
+### Application run disposition
+
+An application that needs a durable completion classification declares a vocabulary-neutral
+Schema boundary on the Definition. The application owns the vocabulary; the framework owns
+validation and persistence.
+
+```ts
+const TaskRunDisposition = Schema.Literal("answered-without-cloud-task");
+
+const TaskAgent = Agent.define("task-agent", {
+  input: TaskInput,
+  output: TaskReport,
+  instructions,
+  toolkit,
+  policy,
+  runDisposition: {
+    schema: TaskRunDisposition,
+    fromOutput: (report) => report.runDisposition,
+  },
+});
+
+type TaskDisposition = Agent.RunDisposition<typeof TaskAgent>;
+// "answered-without-cloud-task"
+```
+
+`fromOutput` receives the decoded output and returns an untrusted candidate or `undefined`. The
+runtime Schema-encodes the candidate before it emits `RunCompleted`; validation failure is the
+typed `AgentRunDispositionError`. The disposition Schema's decoding and encoding services remain
+visible in the Definition and runtime requirement projections.
+
+The selector runs only at ordinary completion. Final-answer budget exhaustion, failure,
+interruption, abort, unresolved recovery, and run-less joined settlement never acquire a run
+disposition. Applications must not derive one from summary prose or arbitrary successful Tool
+Calls.
 
 ## 3. Instructions
 

--- a/docs/spec/authoring.md
+++ b/docs/spec/authoring.md
@@ -100,7 +100,9 @@ type TaskDisposition = Agent.RunDisposition<typeof TaskAgent>;
 runtime Schema-encodes the candidate before it emits `RunCompleted`; validation failure is the
 typed `AgentRunDispositionError`. The disposition Schema's decoding and encoding services remain
 visible in the Definition and runtime requirement projections. `Agent.Failure` admits
-`AgentRunDispositionError` only for a Definition that declares this boundary.
+`AgentRunDispositionError` only for a Definition that declares this boundary. A thrown selector
+value is retained on that typed error as a Schema-safe diagnostic `cause`, while the canonical
+`RunFailed` message is fixed and does not expose application exception text.
 
 The selector runs only at ordinary completion. Final-answer budget exhaustion, failure,
 interruption, abort, unresolved recovery, and run-less joined settlement never acquire a run

--- a/docs/spec/authoring.md
+++ b/docs/spec/authoring.md
@@ -78,7 +78,7 @@ Schema boundary on the Definition. The application owns the vocabulary; the fram
 validation and persistence.
 
 ```ts
-const TaskRunDisposition = Schema.Literal("answered-without-cloud-task");
+const TaskRunDisposition = Schema.Literal("application-complete");
 
 const TaskAgent = Agent.define("task-agent", {
   input: TaskInput,
@@ -93,13 +93,14 @@ const TaskAgent = Agent.define("task-agent", {
 });
 
 type TaskDisposition = Agent.RunDisposition<typeof TaskAgent>;
-// "answered-without-cloud-task"
+// "application-complete"
 ```
 
 `fromOutput` receives the decoded output and returns an untrusted candidate or `undefined`. The
 runtime Schema-encodes the candidate before it emits `RunCompleted`; validation failure is the
 typed `AgentRunDispositionError`. The disposition Schema's decoding and encoding services remain
-visible in the Definition and runtime requirement projections.
+visible in the Definition and runtime requirement projections. `Agent.Failure` admits
+`AgentRunDispositionError` only for a Definition that declares this boundary.
 
 The selector runs only at ordinary completion. Final-answer budget exhaustion, failure,
 interruption, abort, unresolved recovery, and run-less joined settlement never acquire a run

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -293,6 +293,14 @@ wrong settlement family — or a `policyLimit` whose `result` does not carry the
 and records persisted before the metadata existed decode with it absent (additive,
 schemaVersion 1).
 
+An ordinary completed Run may additionally carry the application-defined, Schema-encoded
+`runDisposition` from `RunCompleted` (RUN-029). It is part of the same exact reserved settlement
+record, so reservation replay, canonical append, ledger-finalization recovery, record reads, and
+projection rebuilds preserve it byte-for-byte. Decode is fail-closed: the field is valid only on a
+`completed` settlement with a `runId` and without `finishReason: "budget-exhausted"`. Failed,
+aborted, budget-exhausted, run-less joined, incomplete, and recovery-only outcomes cannot acquire
+one. The durable runtime never reconstructs this value from result prose or Tool records.
+
 ## 13. Abort
 
 Abort is a durable command with identity, author, reason, and target.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -296,10 +296,13 @@ schemaVersion 1).
 An ordinary completed Run may additionally carry the application-defined, Schema-encoded
 `runDisposition` from `RunCompleted` (RUN-029). It is part of the same exact reserved settlement
 record, so reservation replay, canonical append, ledger-finalization recovery, record reads, and
-projection rebuilds preserve it byte-for-byte. Decode is fail-closed: the field is valid only on a
-`completed` settlement with a `runId` and without `finishReason: "budget-exhausted"`. Failed,
-aborted, budget-exhausted, run-less joined, incomplete, and recovery-only outcomes cannot acquire
-one. The durable runtime never reconstructs this value from result prose or Tool records.
+projection rebuilds preserve it byte-for-byte. The public `Settlement` returned by
+`awaitSettlement` materializes the encoded value from that exact reservation, including after
+recovery; it does not derive it from cached outcome metadata. Decode is fail-closed: the field is
+valid only on a `completed` settlement with a `runId` and without
+`finishReason: "budget-exhausted"`. Failed, aborted, budget-exhausted, run-less joined,
+incomplete, and recovery-only outcomes cannot acquire one. The durable runtime never reconstructs
+this value from result prose or Tool records.
 
 ## 13. Abort
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -357,6 +357,14 @@ Terminal events are exactly one of:
 - `RunInterrupted`;
 - `RunSuspended`.
 
+An Agent Definition may declare an application run-disposition Schema plus a pure selector from
+decoded output. At an ordinary completion seam the engine selects, Schema-encodes, and JSON-checks
+that value before adding it to `RunCompleted.runDisposition`; `undefined` means absent. Invalid
+selection fails typed with `AgentRunDispositionError`. A final-answer budget completion never
+evaluates or carries the selector result. Reducers fail closed if a budget-completed event carries
+a disposition or if an event carries one without a Definition-owned Schema. No runtime path parses
+output prose or infers disposition from Tool events.
+
 Raw provider chunks are never mixed into the stable event union.
 
 `RunFailed` covers expected failures. The engine keeps defects as defects: a defect fails the
@@ -557,3 +565,8 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   derivation, applied after context preparation and never entered into official history; a
   Definition whose output Schema cannot be derived runs with the documented fallback and a
   diagnostic, never a silent difference.
+- **RUN-029:** An Agent Definition may declare an application-owned run-disposition Schema and
+  decoded-output selector. Only an ordinary completed Run may Schema-validate, emit, and durably
+  persist the selected value. Failed, interrupted, aborted, incomplete, run-less, and
+  budget-exhausted Runs carry none; invalid values fail typed, and consumers never infer a
+  disposition from prose or Tool output.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -363,7 +363,9 @@ that value before adding it to `RunCompleted.runDisposition`; `undefined` means 
 selection fails typed with `AgentRunDispositionError`. A final-answer budget completion never
 evaluates or carries the selector result. Reducers fail closed if a budget-completed event carries
 a disposition or if an event carries one without a Definition-owned Schema. No runtime path parses
-output prose or infers disposition from Tool events.
+output prose or infers disposition from Tool events. When the application selector throws, the
+typed error retains the original value in its Schema-safe diagnostic `cause`; the terminal event
+uses a fixed non-sensitive message and never serializes that foreign cause.
 
 Raw provider chunks are never mixed into the stable event union.
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -365,7 +365,9 @@ evaluates or carries the selector result. Reducers fail closed if a budget-compl
 a disposition or if an event carries one without a Definition-owned Schema. No runtime path parses
 output prose or infers disposition from Tool events. When the application selector throws, the
 typed error retains the original value in its Schema-safe diagnostic `cause`; the terminal event
-uses a fixed non-sensitive message and never serializes that foreign cause.
+uses a fixed non-sensitive message and never serializes that foreign cause. The public
+`AgentResultSchema` independently rejects a disposition on `finishReason: "budget-exhausted"`, so
+untrusted serialized results cannot bypass the event-reducer invariant.
 
 Raw provider chunks are never mixed into the stable event union.
 

--- a/examples/demo/src/demo/general-chat.test.ts
+++ b/examples/demo/src/demo/general-chat.test.ts
@@ -1,4 +1,5 @@
 import {
+  AgentRunDispositionError,
   AgentApprovalDenied,
   AgentApprovalPending,
   AgentInputError,
@@ -51,6 +52,7 @@ type ExpectedFailure =
   | AiError.AiError
   | AgentInputError
   | AgentOutputError
+  | AgentRunDispositionError
   | AgentPolicyError
   | ContextOverflowError
   | ModelProtocolError

--- a/examples/demo/src/demo/general-chat.test.ts
+++ b/examples/demo/src/demo/general-chat.test.ts
@@ -1,5 +1,4 @@
 import {
-  AgentRunDispositionError,
   AgentApprovalDenied,
   AgentApprovalPending,
   AgentInputError,
@@ -52,7 +51,6 @@ type ExpectedFailure =
   | AiError.AiError
   | AgentInputError
   | AgentOutputError
-  | AgentRunDispositionError
   | AgentPolicyError
   | ContextOverflowError
   | ModelProtocolError

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -2,7 +2,7 @@ import type { Effect, Schema } from "effect";
 import { Schema as S } from "effect";
 import type { AiError, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
 
-import type { AgentInputError, AgentOutputError } from "./errors.ts";
+import type { AgentInputError, AgentOutputError, AgentRunDispositionError } from "./errors.ts";
 import { AgentId } from "./identifiers.ts";
 import type { AgentPolicy } from "./policy.ts";
 
@@ -22,12 +22,21 @@ export type NativeModel<ModelValue> =
     ? ModelValue
     : never;
 
+/** Definition-owned boundary for selecting and validating an application run disposition. */
+export interface RunDispositionDeclaration<Output, DispositionSchema extends Schema.Top> {
+  /** Canonical Schema used to validate and encode the selected disposition. */
+  readonly schema: DispositionSchema;
+  /** Pure selection from decoded output; `undefined` means this ordinary Run declares none. */
+  readonly fromOutput: (output: Output) => unknown;
+}
+
 /** Immutable, model-agnostic schemas, behavior, tools, and bounds for an agent. */
 export interface Definition<
   InputSchema extends Schema.Top,
   OutputSchema extends Schema.Top,
   Instructions,
   ToolkitValue extends Toolkit.Any,
+  RunDispositionValue = undefined,
 > {
   /** Stable agent identity; changing it creates a distinct definition identity. */
   readonly id: AgentId;
@@ -41,6 +50,7 @@ export interface Definition<
   readonly toolkit: ToolkitValue;
   /** Finite execution bounds enforced by the runtime. */
   readonly policy: AgentPolicy;
+  readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
 }
@@ -51,17 +61,27 @@ export interface DefinitionOptions<
   OutputSchema extends Schema.Top,
   Instructions extends InstructionSource<InputSchema["Type"], unknown, unknown>,
   ToolkitValue extends Toolkit.Any,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 > {
   readonly input: InputSchema;
   readonly output: OutputSchema;
   readonly instructions: Instructions;
   readonly toolkit: ToolkitValue;
   readonly policy: AgentPolicy;
+  readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
 }
 
-type AnyDefinitionShape = Definition<Schema.Top, Schema.Top, unknown, Toolkit.Any>;
+type AnyDefinitionShape = Definition<
+  Schema.Top,
+  Schema.Top,
+  unknown,
+  Toolkit.Any,
+  RunDispositionDeclaration<never, Schema.Top> | undefined
+>;
 
 /** Immutable pairing of an agent definition with the explicit Effect AI Model used to run it. */
 export interface Binding<DefinitionValue extends AnyDefinitionShape, ModelValue> {
@@ -99,6 +119,17 @@ export namespace Agent {
     ? DefinitionValue
     : AgentValue;
 
+  type RunDispositionSchemaOf<DefinitionValue extends AnyDefinition> = [
+    Exclude<DefinitionValue["runDisposition"], undefined>,
+  ] extends [never]
+    ? never
+    : Exclude<DefinitionValue["runDisposition"], undefined> extends RunDispositionDeclaration<
+          never,
+          infer DispositionSchema
+        >
+      ? DispositionSchema
+      : never;
+
   /** Decoded input type of a definition or binding. */
   export type Input<AgentValue extends AnyDefinition | Any> =
     DefinitionOf<AgentValue>["input"]["Type"];
@@ -115,6 +146,18 @@ export namespace Agent {
   export type OutputSchema<AgentValue extends AnyDefinition | Any> =
     DefinitionOf<AgentValue>["output"];
 
+  /** Application run-disposition Schema carried by a definition or binding, or `never`. */
+  export type RunDispositionSchema<AgentValue extends AnyDefinition | Any> = RunDispositionSchemaOf<
+    DefinitionOf<AgentValue>
+  >;
+
+  /** Decoded application run disposition declared by a definition or binding. */
+  export type RunDisposition<AgentValue extends AnyDefinition | Any> = [
+    RunDispositionSchema<AgentValue>,
+  ] extends [never]
+    ? never
+    : RunDispositionSchema<AgentValue>["Type"];
+
   /** Effect AI tool map carried by a definition or binding. */
   export type Tools<AgentValue extends AnyDefinition | Any> = Toolkit.Tools<
     DefinitionOf<AgentValue>["toolkit"]
@@ -130,7 +173,9 @@ export namespace Agent {
     | Tool.HandlerServices<Tools<DefinitionValue>[keyof Tools<DefinitionValue>]>
     | DefinitionValue["input"]["DecodingServices"]
     | DefinitionValue["input"]["EncodingServices"]
-    | DefinitionValue["output"]["DecodingServices"];
+    | DefinitionValue["output"]["DecodingServices"]
+    | RunDispositionSchemaOf<DefinitionValue>["DecodingServices"]
+    | RunDispositionSchemaOf<DefinitionValue>["EncodingServices"];
 
   /** All services required by a runnable binding, including its Model Layer requirements. */
   export type Requirements<AgentValue extends Any> =
@@ -143,10 +188,35 @@ export namespace Agent {
     | Tool.HandlerError<Tools<AgentValue>[keyof Tools<AgentValue>]>
     | AiError.AiError
     | AgentInputError
-    | AgentOutputError;
+    | AgentOutputError
+    | AgentRunDispositionError;
 
   /** Validate an agent ID and return a shallowly frozen, model-agnostic definition. */
-  export const define = <
+  export function define<
+    InputSchema extends Schema.Top,
+    OutputSchema extends Schema.Top,
+    Instructions extends InstructionSource<InputSchema["Type"], unknown, unknown>,
+    ToolkitValue extends Toolkit.Any,
+    DispositionSchema extends Schema.Top,
+  >(
+    id: string,
+    options: DefinitionOptions<
+      InputSchema,
+      OutputSchema,
+      Instructions,
+      ToolkitValue,
+      RunDispositionDeclaration<OutputSchema["Type"], DispositionSchema>
+    > & {
+      readonly runDisposition: RunDispositionDeclaration<OutputSchema["Type"], DispositionSchema>;
+    },
+  ): Definition<
+    InputSchema,
+    OutputSchema,
+    Instructions,
+    ToolkitValue,
+    RunDispositionDeclaration<OutputSchema["Type"], DispositionSchema>
+  >;
+  export function define<
     InputSchema extends Schema.Top,
     OutputSchema extends Schema.Top,
     Instructions extends InstructionSource<InputSchema["Type"], unknown, unknown>,
@@ -154,12 +224,30 @@ export namespace Agent {
   >(
     id: string,
     options: DefinitionOptions<InputSchema, OutputSchema, Instructions, ToolkitValue>,
-  ): Definition<InputSchema, OutputSchema, Instructions, ToolkitValue> =>
-    Object.freeze({
+  ): Definition<InputSchema, OutputSchema, Instructions, ToolkitValue>;
+  export function define(
+    id: string,
+    options: {
+      readonly input: Schema.Top;
+      readonly output: Schema.Top;
+      readonly instructions: unknown;
+      readonly toolkit: Toolkit.Any;
+      readonly policy: AgentPolicy;
+      readonly runDisposition?: RunDispositionDeclaration<never, Schema.Top> | undefined;
+      readonly description?: string | undefined;
+      readonly metadata?: Readonly<Record<string, string>> | undefined;
+    },
+  ): AnyDefinition {
+    return Object.freeze({
       ...options,
       id: S.decodeSync(AgentId)(id),
       metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata }),
+      runDisposition:
+        options.runDisposition === undefined
+          ? undefined
+          : Object.freeze({ ...options.runDisposition }),
     });
+  }
 
   /** Bind a definition to a Model without acquiring or hiding the Model Layer's requirements. */
   export const withModel = <DefinitionValue extends AnyDefinition, ModelValue>(

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -158,6 +158,13 @@ export namespace Agent {
     ? never
     : RunDispositionSchema<AgentValue>["Type"];
 
+  /** Validation failure admitted only by definitions that declare a run disposition. */
+  export type RunDispositionFailure<AgentValue extends AnyDefinition | Any> = [
+    RunDispositionSchemaOf<DefinitionOf<AgentValue>>,
+  ] extends [never]
+    ? never
+    : AgentRunDispositionError;
+
   /** Effect AI tool map carried by a definition or binding. */
   export type Tools<AgentValue extends AnyDefinition | Any> = Toolkit.Tools<
     DefinitionOf<AgentValue>["toolkit"]
@@ -189,7 +196,7 @@ export namespace Agent {
     | AiError.AiError
     | AgentInputError
     | AgentOutputError
-    | AgentRunDispositionError;
+    | RunDispositionFailure<AgentValue>;
 
   /** Validate an agent ID and return a shallowly frozen, model-agnostic definition. */
   export function define<

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -10,6 +10,14 @@ export class AgentOutputError extends Schema.TaggedError<AgentOutputError>()("Ag
   message: Schema.String,
 }) {}
 
+/** An application-selected run disposition failed its definition-owned Schema boundary. */
+export class AgentRunDispositionError extends Schema.TaggedError<AgentRunDispositionError>()(
+  "AgentRunDispositionError",
+  {
+    message: Schema.String,
+  },
+) {}
+
 /** The finite policy dimension a run exhausted; shared with durable settlement metadata. */
 export const PolicyLimit = Schema.Literals([
   "turns",
@@ -80,6 +88,7 @@ export class ContextOverflowError extends Schema.TaggedError<ContextOverflowErro
 export const AgentError = Schema.Union([
   AgentInputError,
   AgentOutputError,
+  AgentRunDispositionError,
   AgentPolicyError,
   AgentApprovalDenied,
   AgentApprovalPending,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -14,6 +14,7 @@ export class AgentOutputError extends Schema.TaggedError<AgentOutputError>()("Ag
 export class AgentRunDispositionError extends Schema.TaggedError<AgentRunDispositionError>()(
   "AgentRunDispositionError",
   {
+    cause: Schema.Defect(),
     message: Schema.String,
   },
 ) {}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -160,6 +160,8 @@ export type ExhaustedLimit = typeof ExhaustedLimit.Type;
 export class RunCompleted extends Schema.TaggedClass<RunCompleted>()("RunCompleted", {
   ...RunEventBase,
   output: Schema.Json,
+  /** Schema-encoded application disposition, present only for an ordinary completed Run. */
+  runDisposition: Schema.optionalKey(Schema.Json),
   turns: Schema.Int.check(Schema.isGreaterThan(0)),
   finishReason: Schema.Literals(["completed", "model-stop", "budget-exhausted"]),
   exhausted: Schema.optionalKey(ExhaustedLimit),

--- a/packages/core/test/agent-types.test.ts
+++ b/packages/core/test/agent-types.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentError,
   type AgentInputError,
   type AgentOutputError,
+  type AgentRunDispositionError,
   AgentPolicy,
   type CompactionPolicy,
   type ContextOverflowError,
@@ -87,6 +88,27 @@ const definition = Agent.define("type-proof", {
 });
 const agent = Agent.withModel(definition, model);
 
+const RunDisposition = Schema.Literal("answered-without-cloud-task");
+const dispositionDefinition = Agent.define("disposition-type-proof", {
+  input: Schema.Struct({ destination: Schema.String }),
+  output: Schema.Struct({
+    summary: Schema.String,
+    runDisposition: Schema.optionalKey(RunDisposition),
+  }),
+  instructions: "Answer with a typed disposition when the run completed the application work.",
+  toolkit: Toolkit.empty,
+  policy: AgentPolicy.make({
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+  runDisposition: {
+    schema: RunDisposition,
+    fromOutput: (output) => output.runDisposition,
+  },
+});
+
 type ExpectedRequirements =
   | InstructionContext
   | ModelConfig
@@ -101,7 +123,8 @@ type ExpectedFailure =
   | AvailabilityFailure
   | AiError.AiError
   | AgentInputError
-  | AgentOutputError;
+  | AgentOutputError
+  | AgentRunDispositionError;
 
 type RequirementsProof = Assert<Equal<Agent.Requirements<typeof agent>, ExpectedRequirements>>;
 type DefinitionRequirementsProof = Assert<
@@ -117,6 +140,18 @@ type InputProjectionProof = Assert<
 >;
 type OutputProjectionProof = Assert<
   Equal<Agent.Output<typeof agent>, { readonly summary: string }>
+>;
+type RunDispositionProjectionProof = Assert<
+  Equal<Agent.RunDisposition<typeof dispositionDefinition>, "answered-without-cloud-task">
+>;
+type RunDispositionRequirementsProof = Assert<
+  Equal<Agent.DefinitionRequirements<typeof dispositionDefinition>, never>
+>;
+type RunDispositionFailureProof = Assert<
+  Equal<
+    Extract<Agent.Failure<typeof dispositionDefinition>, { _tag: "AgentRunDispositionError" }>,
+    AgentRunDispositionError
+  >
 >;
 type PolicyExhaustionModeProof = Assert<
   Equal<AgentPolicy["onExhaustion"], "final-answer" | "fail">
@@ -142,6 +177,9 @@ describe("Agent type inference", () => {
     const bindingRetainsNativeModelProof: BindingRetainsNativeModelProof = true;
     const inputProjectionProof: InputProjectionProof = true;
     const outputProjectionProof: OutputProjectionProof = true;
+    const runDispositionProjectionProof: RunDispositionProjectionProof = true;
+    const runDispositionRequirementsProof: RunDispositionRequirementsProof = true;
+    const runDispositionFailureProof: RunDispositionFailureProof = true;
     const policyExhaustionModeProof: PolicyExhaustionModeProof = true;
     const policyRunStatusProof: PolicyRunStatusProof = true;
     const policyContextLimitOptionalityProof: PolicyContextLimitOptionalityProof = true;
@@ -162,6 +200,10 @@ describe("Agent type inference", () => {
     expect(bindingRetainsNativeModelProof).toBe(true);
     expect(inputProjectionProof).toBe(true);
     expect(outputProjectionProof).toBe(true);
+    expect(runDispositionProjectionProof).toBe(true);
+    expect(runDispositionRequirementsProof).toBe(true);
+    expect(runDispositionFailureProof).toBe(true);
+    expect(Object.isFrozen(dispositionDefinition.runDisposition)).toBe(true);
     expect(agent.definition).toBe(definition);
     expect(agent.model).toBe(model);
     expect(Object.isFrozen(definition)).toBe(true);

--- a/packages/core/test/agent-types.test.ts
+++ b/packages/core/test/agent-types.test.ts
@@ -88,7 +88,7 @@ const definition = Agent.define("type-proof", {
 });
 const agent = Agent.withModel(definition, model);
 
-const RunDisposition = Schema.Literal("answered-without-cloud-task");
+const RunDisposition = Schema.Literal("application-complete");
 const dispositionDefinition = Agent.define("disposition-type-proof", {
   input: Schema.Struct({ destination: Schema.String }),
   output: Schema.Struct({
@@ -123,8 +123,7 @@ type ExpectedFailure =
   | AvailabilityFailure
   | AiError.AiError
   | AgentInputError
-  | AgentOutputError
-  | AgentRunDispositionError;
+  | AgentOutputError;
 
 type RequirementsProof = Assert<Equal<Agent.Requirements<typeof agent>, ExpectedRequirements>>;
 type DefinitionRequirementsProof = Assert<
@@ -142,10 +141,16 @@ type OutputProjectionProof = Assert<
   Equal<Agent.Output<typeof agent>, { readonly summary: string }>
 >;
 type RunDispositionProjectionProof = Assert<
-  Equal<Agent.RunDisposition<typeof dispositionDefinition>, "answered-without-cloud-task">
+  Equal<Agent.RunDisposition<typeof dispositionDefinition>, "application-complete">
 >;
 type RunDispositionRequirementsProof = Assert<
   Equal<Agent.DefinitionRequirements<typeof dispositionDefinition>, never>
+>;
+type PlainRunDispositionFailureProof = Assert<
+  Equal<Agent.RunDispositionFailure<typeof definition>, never>
+>;
+type DeclaredRunDispositionFailureProof = Assert<
+  Equal<Agent.RunDispositionFailure<typeof dispositionDefinition>, AgentRunDispositionError>
 >;
 type RunDispositionFailureProof = Assert<
   Equal<
@@ -179,6 +184,8 @@ describe("Agent type inference", () => {
     const outputProjectionProof: OutputProjectionProof = true;
     const runDispositionProjectionProof: RunDispositionProjectionProof = true;
     const runDispositionRequirementsProof: RunDispositionRequirementsProof = true;
+    const plainRunDispositionFailureProof: PlainRunDispositionFailureProof = true;
+    const declaredRunDispositionFailureProof: DeclaredRunDispositionFailureProof = true;
     const runDispositionFailureProof: RunDispositionFailureProof = true;
     const policyExhaustionModeProof: PolicyExhaustionModeProof = true;
     const policyRunStatusProof: PolicyRunStatusProof = true;
@@ -202,6 +209,8 @@ describe("Agent type inference", () => {
     expect(outputProjectionProof).toBe(true);
     expect(runDispositionProjectionProof).toBe(true);
     expect(runDispositionRequirementsProof).toBe(true);
+    expect(plainRunDispositionFailureProof).toBe(true);
+    expect(declaredRunDispositionFailureProof).toBe(true);
     expect(runDispositionFailureProof).toBe(true);
     expect(Object.isFrozen(dispositionDefinition.runDisposition)).toBe(true);
     expect(agent.definition).toBe(definition);

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -119,7 +119,10 @@ describe("core schemas", () => {
     const failures = [
       AgentInputError.make({ message: "invalid trip input" }),
       AgentOutputError.make({ message: "invalid itinerary output" }),
-      AgentRunDispositionError.make({ message: "invalid application run disposition" }),
+      AgentRunDispositionError.make({
+        cause: new Error("invalid application run disposition"),
+        message: "invalid application run disposition",
+      }),
       AgentPolicyError.make({ limit: "turns", message: "turn limit reached" }),
       AgentPolicyError.make({
         limit: "repeated-failures",

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -19,6 +19,7 @@ import {
   AgentInputError,
   AgentInterrupted,
   AgentOutputError,
+  AgentRunDispositionError,
   AgentPolicy,
   AgentPolicyError,
   applyToolResultBounds,
@@ -118,6 +119,7 @@ describe("core schemas", () => {
     const failures = [
       AgentInputError.make({ message: "invalid trip input" }),
       AgentOutputError.make({ message: "invalid itinerary output" }),
+      AgentRunDispositionError.make({ message: "invalid application run disposition" }),
       AgentPolicyError.make({ limit: "turns", message: "turn limit reached" }),
       AgentPolicyError.make({
         limit: "repeated-failures",
@@ -163,6 +165,29 @@ describe("core schemas", () => {
       eventVersion: 2,
     };
     expect(() => Schema.decodeUnknownSync(RunEvent)(invalidEncodedEvent)).toThrow();
+  });
+
+  it("round-trips a Schema-encoded application run disposition on ordinary completion", () => {
+    const encodedEvent = {
+      _tag: "RunCompleted",
+      eventVersion: 1,
+      runId: "run-1",
+      conversationId: "conversation-1",
+      agentId: "travel-planner",
+      sequence: 5,
+      timestamp: "2026-07-29T12:00:00.000Z",
+      output: { itinerary: "Kyoto" },
+      turns: 1,
+      finishReason: "model-stop",
+      runDisposition: "answered-without-cloud-task",
+    } satisfies typeof RunCompleted.Encoded;
+
+    const event = Schema.decodeSync(RunEvent)(encodedEvent);
+    expect(event).toMatchObject({
+      _tag: "RunCompleted",
+      runDisposition: "answered-without-cloud-task",
+    });
+    expect(Schema.encodeSync(RunEvent)(event)).toEqual(encodedEvent);
   });
 
   it("preserves Tool Call parameters and provider execution provenance", () => {

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -179,13 +179,13 @@ describe("core schemas", () => {
       output: { itinerary: "Kyoto" },
       turns: 1,
       finishReason: "model-stop",
-      runDisposition: "answered-without-cloud-task",
+      runDisposition: "application-complete",
     } satisfies typeof RunCompleted.Encoded;
 
     const event = Schema.decodeSync(RunEvent)(encodedEvent);
     expect(event).toMatchObject({
       _tag: "RunCompleted",
-      runDisposition: "answered-without-cloud-task",
+      runDisposition: "application-complete",
     });
     expect(Schema.encodeSync(RunEvent)(event)).toEqual(encodedEvent);
   });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2810,7 +2810,7 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
   return { encoded: eventJson, decoded };
 });
 
-const encodeRunDisposition = Effect.fn("AgentRuntime.encodeRunDisposition")(function* <
+const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDisposition")(function* <
   Output,
   DispositionSchema extends Schema.Top,
 >(
@@ -2845,7 +2845,33 @@ const encodeRunDisposition = Effect.fn("AgentRuntime.encodeRunDisposition")(func
   );
 });
 
-const decodeRunDisposition = Effect.fn("AgentRuntime.decodeRunDisposition")(function* <
+function encodeRunDisposition<AgentValue extends Agent.Any>(
+  agent: AgentValue,
+  output: Agent.Output<AgentValue>,
+): Effect.Effect<
+  Schema.Json | undefined,
+  Agent.RunDispositionFailure<AgentValue>,
+  Agent.RunDispositionSchema<AgentValue>["EncodingServices"]
+>;
+function encodeRunDisposition<Output, DispositionSchema extends Schema.Top>(
+  agent: {
+    readonly definition: {
+      readonly runDisposition?: RunDispositionDeclaration<Output, DispositionSchema> | undefined;
+    };
+  },
+  output: Output,
+): Effect.Effect<
+  Schema.Json | void,
+  AgentRunDispositionError,
+  DispositionSchema["EncodingServices"]
+> {
+  const declaration = agent.definition.runDisposition;
+  return declaration === undefined
+    ? Effect.void
+    : encodeRunDispositionCandidate(declaration, output);
+}
+
+const decodeRunDispositionCandidate = Effect.fn("AgentRuntime.decodeRunDisposition")(function* <
   Output,
   DispositionSchema extends Schema.Top,
 >(
@@ -2864,6 +2890,36 @@ const decodeRunDisposition = Effect.fn("AgentRuntime.decodeRunDisposition")(func
     ),
   );
 });
+
+function decodeRunDisposition<AgentValue extends Agent.Any>(
+  agent: AgentValue,
+  encoded: Schema.Json,
+): Effect.Effect<
+  Agent.RunDisposition<AgentValue>,
+  Agent.RunDispositionFailure<AgentValue> | ModelProtocolError,
+  Agent.RunDispositionSchema<AgentValue>["DecodingServices"]
+>;
+function decodeRunDisposition<DispositionSchema extends Schema.Top>(
+  agent: {
+    readonly definition: {
+      readonly runDisposition?: RunDispositionDeclaration<never, DispositionSchema> | undefined;
+    };
+  },
+  encoded: Schema.Json,
+): Effect.Effect<
+  DispositionSchema["Type"],
+  AgentRunDispositionError | ModelProtocolError,
+  DispositionSchema["DecodingServices"]
+> {
+  const declaration = agent.definition.runDisposition;
+  return declaration === undefined
+    ? Effect.fail(
+        ModelProtocolError.make({
+          message: "RunCompleted declared a run disposition without a definition-owned Schema",
+        }),
+      )
+    : decodeRunDispositionCandidate(declaration, encoded);
+}
 
 const makeTurn = <
   InputSchema extends Schema.Top,
@@ -3444,7 +3500,7 @@ const makeTurn = <
               const runDisposition =
                 finalAnswerOnly || declaration === undefined
                   ? undefined
-                  : yield* encodeRunDisposition(declaration, output.decoded);
+                  : yield* encodeRunDisposition(agent, output.decoded);
               return Stream.fromEffect(
                 Effect.map(eventBase(context), (base) =>
                   RunCompleted.make({
@@ -4237,7 +4293,7 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
   events: Stream.Stream<RunEvent, Error, Requirements>,
 ): Effect.Effect<
   AgentResult<Agent.Output<AgentValue>>,
-  Error | ModelProtocolError | AgentOutputError | AgentRunDispositionError,
+  Error | ModelProtocolError | AgentOutputError | Agent.RunDispositionFailure<AgentValue>,
   | Requirements
   | AgentValue["definition"]["output"]["DecodingServices"]
   | Agent.RunDispositionSchema<AgentValue>["DecodingServices"]
@@ -4275,7 +4331,7 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
                 message:
                   "RunCompleted declared a run disposition without a definition-owned Schema",
               })
-            : yield* decodeRunDisposition(declaration, completed.runDisposition);
+            : yield* decodeRunDisposition(agent, completed.runDisposition);
     return {
       output,
       conversationId: completed.conversationId,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -232,7 +232,18 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
     exhausted: Schema.optionalKey(Schema.Literals(["tokens", "tool-calls", "turns"])),
     /** Schema-encoded application disposition declared for an ordinary completed Run. */
     runDisposition: Schema.optionalKey(Schema.Json),
-  });
+  }).check(
+    Schema.makeFilter(
+      (result) =>
+        !("runDisposition" in result) ||
+        result.runDisposition === undefined ||
+        !("finishReason" in result) ||
+        result.finishReason !== "budget-exhausted",
+      {
+        expected: "runDisposition only when finishReason is not budget-exhausted",
+      },
+    ),
+  );
 
 /** Decoded terminal value produced by reducing a completed agent event stream. */
 export type AgentResult<Output> = ReturnType<

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2825,13 +2825,15 @@ const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDispositi
     try: () => declaration.fromOutput(output),
     catch: (cause) =>
       AgentRunDispositionError.make({
-        message: `Run disposition selector failed: ${errorMessage(cause)}`,
+        cause,
+        message: "Run disposition selector failed",
       }),
   });
   if (selected === undefined) return undefined;
   const encoded = yield* Schema.encodeUnknownEffect(declaration.schema)(selected).pipe(
     Effect.mapError((cause) =>
       AgentRunDispositionError.make({
+        cause,
         message: cause.message,
       }),
     ),
@@ -2839,6 +2841,7 @@ const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDispositi
   return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
     Effect.mapError((cause) =>
       AgentRunDispositionError.make({
+        cause,
         message: `Run disposition did not encode as durable JSON: ${cause.message}`,
       }),
     ),
@@ -2885,6 +2888,7 @@ const decodeRunDispositionCandidate = Effect.fn("AgentRuntime.decodeRunDispositi
   return yield* Schema.decodeUnknownEffect(declaration.schema)(encoded).pipe(
     Effect.mapError((cause) =>
       AgentRunDispositionError.make({
+        cause,
         message: cause.message,
       }),
     ),

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,6 +4,7 @@ import {
   AgentApprovalPending,
   AgentInputError,
   AgentOutputError,
+  AgentRunDispositionError,
   type AgentPolicy,
   AgentPolicyError,
   type AgentId,
@@ -19,6 +20,7 @@ import {
   type DelegationId,
   IdGenerator,
   type InstructionSource,
+  type RunDispositionDeclaration,
   ModelStarted,
   ModelProtocolError,
   ReasoningDelta,
@@ -111,12 +113,16 @@ export type RuntimeBinding<
   ModelRequires,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 > = {
   readonly definition: Definition<
     InputSchema,
     OutputSchema,
     Instructions,
-    Toolkit.Toolkit<Tools>
+    Toolkit.Toolkit<Tools>,
+    RunDispositionValue
   > & {
     readonly instructions: InstructionSource<
       InputSchema["Type"],
@@ -224,6 +230,8 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
     finishReason: Schema.Literals(["completed", "model-stop", "budget-exhausted"]),
     /** Dimension that bound when the Run settled budget-exhausted (RUN-025; the grant-flow marker). */
     exhausted: Schema.optionalKey(Schema.Literals(["tokens", "tool-calls", "turns"])),
+    /** Schema-encoded application disposition declared for an ordinary completed Run. */
+    runDisposition: Schema.optionalKey(Schema.Json),
   });
 
 /** Decoded terminal value produced by reducing a completed agent event stream. */
@@ -2778,7 +2786,7 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
   agent: AgentValue,
   text: string,
 ): Effect.fn.Return<
-  Schema.Json,
+  { readonly encoded: Schema.Json; readonly decoded: Agent.Output<AgentValue> },
   AgentOutputError,
   AgentValue["definition"]["output"]["DecodingServices"]
 > {
@@ -2792,14 +2800,69 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
     ),
   );
   const candidateOutput: unknown = eventJson;
-  yield* Schema.decodeUnknownEffect(agent.definition.output)(candidateOutput).pipe(
+  const decoded = yield* Schema.decodeUnknownEffect(agent.definition.output)(candidateOutput).pipe(
     Effect.mapError((cause) =>
       AgentOutputError.make({
         message: cause.message,
       }),
     ),
   );
-  return eventJson;
+  return { encoded: eventJson, decoded };
+});
+
+const encodeRunDisposition = Effect.fn("AgentRuntime.encodeRunDisposition")(function* <
+  Output,
+  DispositionSchema extends Schema.Top,
+>(
+  declaration: RunDispositionDeclaration<Output, DispositionSchema>,
+  output: Output,
+): Effect.fn.Return<
+  Schema.Json | undefined,
+  AgentRunDispositionError,
+  DispositionSchema["EncodingServices"]
+> {
+  const selected = yield* Effect.try({
+    try: () => declaration.fromOutput(output),
+    catch: (cause) =>
+      AgentRunDispositionError.make({
+        message: `Run disposition selector failed: ${errorMessage(cause)}`,
+      }),
+  });
+  if (selected === undefined) return undefined;
+  const encoded = yield* Schema.encodeUnknownEffect(declaration.schema)(selected).pipe(
+    Effect.mapError((cause) =>
+      AgentRunDispositionError.make({
+        message: cause.message,
+      }),
+    ),
+  );
+  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
+    Effect.mapError((cause) =>
+      AgentRunDispositionError.make({
+        message: `Run disposition did not encode as durable JSON: ${cause.message}`,
+      }),
+    ),
+  );
+});
+
+const decodeRunDisposition = Effect.fn("AgentRuntime.decodeRunDisposition")(function* <
+  Output,
+  DispositionSchema extends Schema.Top,
+>(
+  declaration: RunDispositionDeclaration<Output, DispositionSchema>,
+  encoded: Schema.Json,
+): Effect.fn.Return<
+  DispositionSchema["Type"],
+  AgentRunDispositionError,
+  DispositionSchema["DecodingServices"]
+> {
+  return yield* Schema.decodeUnknownEffect(declaration.schema)(encoded).pipe(
+    Effect.mapError((cause) =>
+      AgentRunDispositionError.make({
+        message: cause.message,
+      }),
+    ),
+  );
 });
 
 const makeTurn = <
@@ -2814,6 +2877,9 @@ const makeTurn = <
   HookRequirements,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -2824,7 +2890,8 @@ const makeTurn = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   context: RunContext,
   prompt: Prompt.Prompt,
@@ -3272,7 +3339,7 @@ const makeTurn = <
                               Effect.map(eventBase(context), (base) =>
                                 RunCompleted.make({
                                   ...base,
-                                  output: output.value,
+                                  output: output.value.encoded,
                                   turns: turn,
                                   finishReason: "budget-exhausted",
                                   exhausted: "tokens",
@@ -3373,11 +3440,17 @@ const makeTurn = <
                 return makeTurn(agent, context, nextPrompt, turn + 1, toolCalls, options);
               }
               const output = yield* decodeFinalOutput(agent, trace.text.join(""));
+              const declaration = agent.definition.runDisposition;
+              const runDisposition =
+                finalAnswerOnly || declaration === undefined
+                  ? undefined
+                  : yield* encodeRunDisposition(declaration, output.decoded);
               return Stream.fromEffect(
                 Effect.map(eventBase(context), (base) =>
                   RunCompleted.make({
                     ...base,
-                    output,
+                    output: output.encoded,
+                    ...(runDisposition === undefined ? {} : { runDisposition }),
                     turns: turn,
                     // A Run settled under the final-answer constraint reports
                     // the exhaustion honestly (RUN-011), never a plain model
@@ -3546,6 +3619,9 @@ const toolBatchContinuation = <
   HookRequirements,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -3556,7 +3632,8 @@ const toolBatchContinuation = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   context: RunContext,
   trace: TurnTrace,
@@ -3641,6 +3718,9 @@ const makeResumeTurn = <
   HookRequirements,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -3651,7 +3731,8 @@ const makeResumeTurn = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   context: RunContext,
   prompt: Prompt.Prompt,
@@ -3923,6 +4004,9 @@ const stream = <
   HookRequirements = never,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -3933,7 +4017,8 @@ const stream = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   input: unknown,
   options: RunOptions<HookError, HookRequirements> = {},
@@ -4152,8 +4237,10 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
   events: Stream.Stream<RunEvent, Error, Requirements>,
 ): Effect.Effect<
   AgentResult<Agent.Output<AgentValue>>,
-  Error | ModelProtocolError | AgentOutputError,
-  Requirements | AgentValue["definition"]["output"]["DecodingServices"]
+  Error | ModelProtocolError | AgentOutputError | AgentRunDispositionError,
+  | Requirements
+  | AgentValue["definition"]["output"]["DecodingServices"]
+  | Agent.RunDispositionSchema<AgentValue>["DecodingServices"]
 > =>
   Effect.gen(function* () {
     const reduction = yield* Stream.runFold(
@@ -4175,6 +4262,20 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
         }),
       ),
     );
+    const declaration = agent.definition.runDisposition;
+    const runDisposition =
+      completed.runDisposition === undefined
+        ? undefined
+        : completed.finishReason === "budget-exhausted"
+          ? yield* ModelProtocolError.make({
+              message: "A budget-exhausted RunCompleted event cannot declare a run disposition",
+            })
+          : declaration === undefined
+            ? yield* ModelProtocolError.make({
+                message:
+                  "RunCompleted declared a run disposition without a definition-owned Schema",
+              })
+            : yield* decodeRunDisposition(declaration, completed.runDisposition);
     return {
       output,
       conversationId: completed.conversationId,
@@ -4182,6 +4283,7 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
       turns: completed.turns,
       finishReason: completed.finishReason,
       ...(completed.exhausted !== undefined ? { exhausted: completed.exhausted } : {}),
+      ...(runDisposition === undefined ? {} : { runDisposition: completed.runDisposition }),
     };
   });
 
@@ -4198,6 +4300,9 @@ const run = Effect.fn("AgentRuntime.run")(function* <
   HookRequirements = never,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -4208,7 +4313,8 @@ const run = Effect.fn("AgentRuntime.run")(function* <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   input: unknown,
   options: RunOptions<HookError, HookRequirements> = {},
@@ -4250,6 +4356,9 @@ const start = Effect.fn("AgentRuntime.start")(function* <
   HookRequirements = never,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -4260,7 +4369,8 @@ const start = Effect.fn("AgentRuntime.start")(function* <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   input: unknown,
   options: RunOptions<HookError, HookRequirements> = {},

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2845,7 +2845,7 @@ const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDispositi
     Effect.mapError((cause) =>
       AgentRunDispositionError.make({
         cause,
-        message: cause.message,
+        message: "Run disposition failed Schema encoding",
       }),
     ),
   );
@@ -2853,7 +2853,7 @@ const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDispositi
     Effect.mapError((cause) =>
       AgentRunDispositionError.make({
         cause,
-        message: `Run disposition did not encode as durable JSON: ${cause.message}`,
+        message: "Run disposition did not encode as durable JSON",
       }),
     ),
   );

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -46,6 +46,7 @@ import {
 } from "effect/unstable/ai";
 
 import {
+  AgentResultSchema,
   AgentRuntime,
   ToolExecutionClass,
   withTerminalDefectEvent,
@@ -2527,6 +2528,39 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(reduced?.runId).toBe(runResult.runId);
       expect(reduced?.turns).toBe(runResult.turns);
     });
+  });
+
+  it("AgentResultSchema rejects a disposition on budget exhaustion", () => {
+    const Result = AgentResultSchema(Schema.Struct({ answer: Schema.String }));
+    const ordinary = {
+      output: { answer: "done" },
+      conversationId: "conversation-1",
+      runId: "run-1",
+      turns: 1,
+      finishReason: "completed",
+      runDisposition: "application-complete",
+    } as const;
+    const budgetExhausted = {
+      ...ordinary,
+      finishReason: "budget-exhausted",
+      exhausted: "turns",
+    } as const;
+    const budgetWithoutDisposition = {
+      output: ordinary.output,
+      conversationId: ordinary.conversationId,
+      runId: ordinary.runId,
+      turns: ordinary.turns,
+      finishReason: budgetExhausted.finishReason,
+      exhausted: budgetExhausted.exhausted,
+    } as const;
+
+    expect(Schema.decodeUnknownSync(Result)(ordinary).runDisposition).toBe("application-complete");
+    expect(Schema.decodeUnknownSync(Result)(budgetWithoutDisposition).finishReason).toBe(
+      "budget-exhausted",
+    );
+    expect(() => Schema.decodeUnknownSync(Result)(budgetExhausted)).toThrow(
+      /runDisposition only when finishReason is not budget-exhausted/,
+    );
   });
 
   it.effect("RUN-029 validates and exposes an application run disposition", () => {

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -2576,6 +2576,72 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
     });
   });
 
+  it.effect("keeps a thrown run-disposition selector cause out of canonical events", () => {
+    const RunDisposition = Schema.Literal("application-complete");
+    const secret = "selector-secret-must-not-enter-events";
+    const structuredCause = {
+      _tag: "SelectorDependencyFailure",
+      code: "E_SELECTOR",
+      detail: secret,
+    } as const;
+    const selectorFailure = new Error(`selector failed with ${secret}`, {
+      cause: structuredCause,
+    });
+    selectorFailure.name = "SelectorFailure";
+    const definition = Agent.define("throwing-run-disposition", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Answer as JSON.",
+      toolkit: Toolkit.empty,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+      runDisposition: {
+        schema: RunDisposition,
+        fromOutput: () => {
+          throw selectorFailure;
+        },
+      },
+    });
+    const agent = Agent.withModel(definition, modelFromParts(finalParts('{"answer":"done"}')));
+
+    return Effect.gen(function* () {
+      const observed: Array<RunEvent> = [];
+      const exit = yield* AgentRuntime.stream(agent, { question: "done?" }).pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            observed.push(event);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+
+      const isRunDispositionError = Schema.is(AgentRunDispositionError)(failure);
+      expect(isRunDispositionError).toBe(true);
+      if (!isRunDispositionError) {
+        throw new Error("Expected AgentRunDispositionError");
+      }
+      expect(failure.message).toBe("Run disposition selector failed");
+      expect(failure.message).not.toContain(secret);
+      expect(failure.cause).toBe(selectorFailure);
+      expect(selectorFailure.name).toBe("SelectorFailure");
+      expect(selectorFailure.stack).toContain("SelectorFailure");
+      expect(selectorFailure.cause).toBe(structuredCause);
+      expect(observed.at(-1)).toMatchObject({
+        _tag: "RunFailed",
+        errorTag: "AgentRunDispositionError",
+        message: "Run disposition selector failed",
+      });
+      expect(observed.some((event) => event._tag === "RunCompleted")).toBe(false);
+      expect(JSON.stringify(observed)).not.toContain(secret);
+    });
+  });
+
   it.effect("keeps input and output decode failures typed", () => {
     const agent = makeAgent(finalParts('{"answer":42}'));
 

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -2564,7 +2564,11 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
   });
 
   it.effect("RUN-029 validates and exposes an application run disposition", () => {
-    const RunDisposition = Schema.Literal("application-complete");
+    const RunDisposition = Schema.String.check(
+      Schema.makeFilter((value) =>
+        value === "application-complete" ? undefined : `Rejected disposition: ${value}`,
+      ),
+    );
     const definition = Agent.define("run-disposition", {
       input: Schema.Struct({ question: Schema.String }),
       output: Schema.Struct({
@@ -2601,12 +2605,52 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       });
       expect(result.runDisposition).toBe("application-complete");
 
+      const secret = "sensitive-run-disposition-must-not-enter-events";
+      const invalidDefinition = Agent.define("invalid-run-disposition", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Answer as JSON.",
+        toolkit: Toolkit.empty,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+        runDisposition: {
+          schema: RunDisposition,
+          fromOutput: () => secret,
+        },
+      });
       const invalid = Agent.withModel(
-        definition,
-        modelFromParts(finalParts('{"answer":"done","runDisposition":"invented"}')),
+        invalidDefinition,
+        modelFromParts(finalParts('{"answer":"done"}')),
       );
-      const invalidExit = yield* AgentRuntime.run(invalid, { question: "done?" }).pipe(Effect.exit);
-      expect(failureFrom(invalidExit)).toBeInstanceOf(AgentRunDispositionError);
+      const observed: Array<RunEvent> = [];
+      const invalidExit = yield* AgentRuntime.stream(invalid, { question: "done?" }).pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            observed.push(event);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.exit,
+      );
+      const failure = failureFrom(invalidExit);
+      const isRunDispositionError = Schema.is(AgentRunDispositionError)(failure);
+      expect(isRunDispositionError).toBe(true);
+      if (!isRunDispositionError) {
+        throw new Error("Expected AgentRunDispositionError");
+      }
+      expect(failure.message).toBe("Run disposition failed Schema encoding");
+      expect(failure.message).not.toContain(secret);
+      expect(String(failure.cause)).toContain(secret);
+      expect(observed.at(-1)).toMatchObject({
+        _tag: "RunFailed",
+        errorTag: "AgentRunDispositionError",
+        message: "Run disposition failed Schema encoding",
+      });
+      expect(JSON.stringify(observed)).not.toContain(secret);
     });
   });
 

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -2530,7 +2530,7 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
   });
 
   it.effect("RUN-029 validates and exposes an application run disposition", () => {
-    const RunDisposition = Schema.Literal("answered-without-cloud-task");
+    const RunDisposition = Schema.Literal("application-complete");
     const definition = Agent.define("run-disposition", {
       input: Schema.Struct({ question: Schema.String }),
       output: Schema.Struct({
@@ -2554,9 +2554,7 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
     return Effect.gen(function* () {
       const valid = Agent.withModel(
         definition,
-        modelFromParts(
-          finalParts('{"answer":"done","runDisposition":"answered-without-cloud-task"}'),
-        ),
+        modelFromParts(finalParts('{"answer":"done","runDisposition":"application-complete"}')),
       );
       const events = yield* AgentRuntime.stream(valid, { question: "done?" }).pipe(
         Stream.runCollect,
@@ -2565,9 +2563,9 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
 
       expect(events.at(-1)).toMatchObject({
         _tag: "RunCompleted",
-        runDisposition: "answered-without-cloud-task",
+        runDisposition: "application-complete",
       });
-      expect(result.runDisposition).toBe("answered-without-cloud-task");
+      expect(result.runDisposition).toBe("application-complete");
 
       const invalid = Agent.withModel(
         definition,

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   AgentApprovalPending,
   AgentInputError,
   AgentOutputError,
+  AgentRunDispositionError,
   AgentPolicy,
   AgentPolicyError,
   ConversationId,
@@ -2525,6 +2526,55 @@ layer(identifiers)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(reduced?.conversationId).toBe(runResult.conversationId);
       expect(reduced?.runId).toBe(runResult.runId);
       expect(reduced?.turns).toBe(runResult.turns);
+    });
+  });
+
+  it.effect("RUN-029 validates and exposes an application run disposition", () => {
+    const RunDisposition = Schema.Literal("answered-without-cloud-task");
+    const definition = Agent.define("run-disposition", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({
+        answer: Schema.String,
+        runDisposition: Schema.optionalKey(Schema.String),
+      }),
+      instructions: "Answer as JSON.",
+      toolkit: Toolkit.empty,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+      runDisposition: {
+        schema: RunDisposition,
+        fromOutput: (output) => output.runDisposition,
+      },
+    });
+
+    return Effect.gen(function* () {
+      const valid = Agent.withModel(
+        definition,
+        modelFromParts(
+          finalParts('{"answer":"done","runDisposition":"answered-without-cloud-task"}'),
+        ),
+      );
+      const events = yield* AgentRuntime.stream(valid, { question: "done?" }).pipe(
+        Stream.runCollect,
+      );
+      const result = yield* AgentRuntime.run(valid, { question: "done?" });
+
+      expect(events.at(-1)).toMatchObject({
+        _tag: "RunCompleted",
+        runDisposition: "answered-without-cloud-task",
+      });
+      expect(result.runDisposition).toBe("answered-without-cloud-task");
+
+      const invalid = Agent.withModel(
+        definition,
+        modelFromParts(finalParts('{"answer":"done","runDisposition":"invented"}')),
+      );
+      const invalidExit = yield* AgentRuntime.run(invalid, { question: "done?" }).pipe(Effect.exit);
+      expect(failureFrom(invalidExit)).toBeInstanceOf(AgentRunDispositionError);
     });
   });
 

--- a/packages/session/src/binding-resolver.ts
+++ b/packages/session/src/binding-resolver.ts
@@ -1,4 +1,4 @@
-import { AgentId, ConversationId } from "@effect-agent/core";
+import { AgentId, ConversationId, type RunDispositionDeclaration } from "@effect-agent/core";
 import type { RuntimeBinding } from "@effect-agent/engine";
 import { Context, Effect, Layer, Option, Schema } from "effect";
 import type { Tool } from "effect/unstable/ai";
@@ -87,6 +87,9 @@ export type ResolvedAttemptDriver = <
   ModelRequires,
   InstructionError,
   InstructionRequirements,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -97,7 +100,8 @@ export type ResolvedAttemptDriver = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   conversationId: ConversationId,
   claim: Claim,
@@ -114,7 +118,8 @@ export type ResolvedAttemptDriver = <
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
     InstructionRequirements
   >
@@ -151,6 +156,9 @@ const capture = <
   ModelRequires,
   InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
   InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+  RunDispositionValue extends
+    | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+    | undefined = undefined,
 >(
   agent: RuntimeBinding<
     InputSchema,
@@ -161,7 +169,8 @@ const capture = <
     ModelProvides,
     ModelRequires,
     InstructionError,
-    InstructionRequirements
+    InstructionRequirements,
+    RunDispositionValue
   >,
   digests: DefinitionDigests | undefined,
 ): Effect.Effect<
@@ -213,6 +222,9 @@ export const DurableWorkerBinding = {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -223,7 +235,8 @@ export const DurableWorkerBinding = {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
     digests: DefinitionDigests,
   ): Effect.Effect<
@@ -241,6 +254,9 @@ export const DurableWorkerBinding = {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -251,7 +267,8 @@ export const DurableWorkerBinding = {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
   ): Effect.Effect<
     ResolvedBinding,

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -821,6 +821,33 @@ const make = Effect.gen(function* () {
       }),
     );
 
+  const materializeSettlement = (
+    settlement: Settlement,
+    record: RecordEnvelope | undefined,
+  ): Settlement => {
+    const payload = record?.payload;
+    if (
+      payload === undefined ||
+      payload._tag !== "SubmissionSettled" ||
+      payload.submissionId !== settlement.submissionId ||
+      payload.settlementId !== settlement.settlementId ||
+      payload.receiptId !== settlement.receiptId ||
+      payload.outcome !== settlement.outcome ||
+      settlement.outcome !== "completed" ||
+      payload.runDisposition === undefined
+    ) {
+      return settlement;
+    }
+    return Settlement.make({
+      submissionId: settlement.submissionId,
+      settlementId: settlement.settlementId,
+      receiptId: settlement.receiptId,
+      outcome: settlement.outcome,
+      runDisposition: payload.runDisposition,
+      settledAt: settlement.settledAt,
+    });
+  };
+
   const readAll = Effect.fn("DurableAgentRuntime.readAll")(function* (
     conversationId: ConversationId,
   ): Effect.fn.Return<
@@ -1908,7 +1935,7 @@ const make = Effect.gen(function* () {
     yield* wake.notify(submission.conversationId);
     yield* notifyParentOfChildSettlement(submission);
     yield* settleJoinedSubmissions(ctx, submissionId, outcome._tag);
-    return settlement;
+    return materializeSettlement(settlement, reserved.record);
   });
 
   /** Complete a previously reserved settlement: append the EXACT reserved record, then finalize. */
@@ -1944,7 +1971,7 @@ const make = Effect.gen(function* () {
     yield* wake.notify(submission.conversationId);
     yield* notifyParentOfChildSettlement(submission);
     yield* settleJoinedSubmissions(ctx, submission.submissionId, settlement.outcome);
-    return settlement;
+    return materializeSettlement(settlement, reservation.record);
   });
 
   /** Canonical settlement exists: rebuild the ledger from history, never the reverse (DUR-015). */
@@ -1956,9 +1983,12 @@ const make = Effect.gen(function* () {
     const settlement = yield* ledger.finalizeSettlement(
       SettlementFinalization.make({ submissionId: submission.submissionId, settlementId }),
     );
+    const snapshot = yield* ledger.loadRecoverySnapshot(
+      RecoverySnapshotRequest.make({ submissionId: submission.submissionId }),
+    );
     yield* wake.notify(submission.conversationId);
     yield* notifyParentOfChildSettlement(submission);
-    return settlement;
+    return materializeSettlement(settlement, snapshot.reservation?.record);
   });
 
   /**
@@ -5755,12 +5785,16 @@ const make = Effect.gen(function* () {
       }
       if (snapshot.value.state === "settled") {
         // The idempotent finalization replay returns the recorded Settlement (settledAt intact).
-        return yield* ledger.finalizeSettlement(
+        const settlement = yield* ledger.finalizeSettlement(
           SettlementFinalization.make({
             submissionId: receipt.submissionId,
             settlementId: submissionSettlementId(receipt.submissionId),
           }),
         );
+        const recovery = yield* ledger.loadRecoverySnapshot(
+          RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+        );
+        return materializeSettlement(settlement, recovery.reservation?.record);
       }
       // Wake delivery is a pure liveness hint; the ledger poll below guarantees progress.
       yield* Effect.raceFirst(

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -836,7 +836,13 @@ const make = Effect.gen(function* () {
       settlement.outcome !== "completed" ||
       payload.runDisposition === undefined
     ) {
-      return settlement;
+      return Settlement.make({
+        submissionId: settlement.submissionId,
+        settlementId: settlement.settlementId,
+        receiptId: settlement.receiptId,
+        outcome: settlement.outcome,
+        settledAt: settlement.settledAt,
+      });
     }
     return Settlement.make({
       submissionId: settlement.submissionId,

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -16,6 +16,7 @@ import {
   type ExhaustedLimit,
   type RunEvent,
   type RunId,
+  type RunDispositionDeclaration,
   type TurnId,
 } from "@effect-agent/core";
 import {
@@ -630,6 +631,8 @@ type AttemptOutcome =
   | {
       readonly _tag: "completed";
       readonly result: PersistedJson;
+      /** Schema-encoded application disposition, only for an ordinary completed Run. */
+      readonly runDisposition?: PersistedJson;
       /** Set when the Run settled through the final-answer exhaustion resolution (RUN-018). */
       readonly finishReason?: "budget-exhausted";
       /** The dimension that bound; set exactly alongside `finishReason` (RUN-011). */
@@ -1854,6 +1857,12 @@ const make = Effect.gen(function* () {
       outcome: outcome._tag,
       ...(includeRunId ? { runId: runIdForSubmission(submissionId) } : {}),
       ...(outcome._tag === "aborted" ? {} : { result: outcome.result }),
+      ...(includeRunId &&
+      outcome._tag === "completed" &&
+      outcome.finishReason === undefined &&
+      outcome.runDisposition !== undefined
+        ? { runDisposition: outcome.runDisposition }
+        : {}),
       ...(outcome._tag === "completed" && outcome.finishReason !== undefined
         ? { finishReason: outcome.finishReason }
         : {}),
@@ -2726,6 +2735,9 @@ const make = Effect.gen(function* () {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -2736,7 +2748,8 @@ const make = Effect.gen(function* () {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
     ctx: AttemptAppendContext,
     submission: SubmissionSnapshot,
@@ -2921,6 +2934,7 @@ const make = Effect.gen(function* () {
         readonly history: Prompt.Prompt | undefined;
         readonly pendingTurn: { readonly turn: number; readonly turnId: TurnId } | undefined;
         readonly completedOutput: PersistedJson | undefined;
+        readonly completedRunDisposition: PersistedJson | undefined;
         readonly completedFinishReason: "budget-exhausted" | undefined;
         readonly completedExhausted: ExhaustedLimit | undefined;
       }
@@ -2930,6 +2944,7 @@ const make = Effect.gen(function* () {
         history: undefined,
         pendingTurn: undefined,
         completedOutput: undefined,
+        completedRunDisposition: undefined,
         completedFinishReason: undefined,
         completedExhausted: undefined,
       });
@@ -3991,27 +4006,48 @@ const make = Effect.gen(function* () {
         output: unknown,
         finishReason: "completed" | "model-stop" | "budget-exhausted",
         exhausted: ExhaustedLimit | undefined,
+        runDisposition: unknown,
       ): Effect.Effect<void, DurableWorkerFailure> =>
-        Schema.decodeUnknownEffect(PersistedJson)(output).pipe(
-          Effect.mapError(
-            (cause): DurableWorkerFailure =>
-              LedgerError.make({
-                operation: "recordCompleted",
-                message: "Run output exceeds canonical persistence bounds",
-                cause,
-              }),
-          ),
-          Effect.flatMap((result) =>
-            Ref.update(stateRef, (state) => ({
-              ...state,
-              completedOutput: result,
-              completedFinishReason: finishReason === "budget-exhausted" ? finishReason : undefined,
-              // The pair travels together or not at all (RUN-011 fail-safe): a
-              // divergent event never persists a lone dimension.
-              completedExhausted: finishReason === "budget-exhausted" ? exhausted : undefined,
-            })),
-          ),
-        );
+        Effect.gen(function* () {
+          const result = yield* Schema.decodeUnknownEffect(PersistedJson)(output).pipe(
+            Effect.mapError(
+              (cause): DurableWorkerFailure =>
+                LedgerError.make({
+                  operation: "recordCompleted",
+                  message: "Run output exceeds canonical persistence bounds",
+                  cause,
+                }),
+            ),
+          );
+          if (finishReason === "budget-exhausted" && runDisposition !== undefined) {
+            return yield* LedgerError.make({
+              operation: "recordCompleted",
+              message: "A budget-exhausted Run cannot declare an application run disposition",
+            });
+          }
+          const persistedRunDisposition =
+            runDisposition === undefined
+              ? undefined
+              : yield* Schema.decodeUnknownEffect(PersistedJson)(runDisposition).pipe(
+                  Effect.mapError(
+                    (cause): DurableWorkerFailure =>
+                      LedgerError.make({
+                        operation: "recordCompleted",
+                        message: "Run disposition exceeds canonical persistence bounds",
+                        cause,
+                      }),
+                  ),
+                );
+          yield* Ref.update(stateRef, (state) => ({
+            ...state,
+            completedOutput: result,
+            completedRunDisposition: persistedRunDisposition,
+            completedFinishReason: finishReason === "budget-exhausted" ? finishReason : undefined,
+            // The pair travels together or not at all (RUN-011 fail-safe): a
+            // divergent event never persists a lone dimension.
+            completedExhausted: finishReason === "budget-exhausted" ? exhausted : undefined,
+          }));
+        });
 
       const handleEvent = (event: RunEvent): Effect.Effect<void, DurableWorkerFailure> => {
         switch (event._tag) {
@@ -4027,7 +4063,14 @@ const make = Effect.gen(function* () {
           }
           case "RunCompleted": {
             return commitPendingTurn.pipe(
-              Effect.andThen(recordCompleted(event.output, event.finishReason, event.exhausted)),
+              Effect.andThen(
+                recordCompleted(
+                  event.output,
+                  event.finishReason,
+                  event.exhausted,
+                  event.runDisposition,
+                ),
+              ),
             );
           }
           case "RunFailed": {
@@ -4262,6 +4305,9 @@ const make = Effect.gen(function* () {
       return {
         _tag: "completed",
         result: state.completedOutput,
+        ...(state.completedRunDisposition === undefined
+          ? {}
+          : { runDisposition: state.completedRunDisposition }),
         ...(state.completedFinishReason === undefined
           ? {}
           : { finishReason: state.completedFinishReason }),
@@ -4288,6 +4334,9 @@ const make = Effect.gen(function* () {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -4298,7 +4347,8 @@ const make = Effect.gen(function* () {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
     conversationId: ConversationId,
     claim: Claim,
@@ -4703,6 +4753,9 @@ const make = Effect.gen(function* () {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -4713,7 +4766,8 @@ const make = Effect.gen(function* () {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
     conversationId: ConversationId,
   ) =>
@@ -6244,6 +6298,9 @@ const make = Effect.gen(function* () {
     ModelRequires,
     InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
     InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+    RunDispositionValue extends
+      | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+      | undefined = undefined,
   >(
     agent: RuntimeBinding<
       InputSchema,
@@ -6254,7 +6311,8 @@ const make = Effect.gen(function* () {
       ModelProvides,
       ModelRequires,
       InstructionError,
-      InstructionRequirements
+      InstructionRequirements,
+      RunDispositionValue
     >,
   ) =>
     Effect.gen(function* () {
@@ -6458,6 +6516,9 @@ export class DurableAgentRuntime extends Context.Service<
       ModelRequires,
       InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
       InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+      RunDispositionValue extends
+        | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+        | undefined = undefined,
     >(
       agent: RuntimeBinding<
         InputSchema,
@@ -6468,7 +6529,8 @@ export class DurableAgentRuntime extends Context.Service<
         ModelProvides,
         ModelRequires,
         InstructionError,
-        InstructionRequirements
+        InstructionRequirements,
+        RunDispositionValue
       >,
       conversationId: ConversationId,
     ) => Effect.Effect<
@@ -6484,7 +6546,8 @@ export class DurableAgentRuntime extends Context.Service<
           ModelProvides,
           ModelRequires,
           InstructionError,
-          InstructionRequirements
+          InstructionRequirements,
+          RunDispositionValue
         >,
         InstructionRequirements
       >
@@ -6506,6 +6569,9 @@ export class DurableAgentRuntime extends Context.Service<
       ModelRequires,
       InstructionError = InstructionErrorOf<Instructions, InputSchema["Type"]>,
       InstructionRequirements = InstructionRequirementsOf<Instructions, InputSchema["Type"]>,
+      RunDispositionValue extends
+        | RunDispositionDeclaration<OutputSchema["Type"], Schema.Top>
+        | undefined = undefined,
     >(
       agent: RuntimeBinding<
         InputSchema,
@@ -6516,7 +6582,8 @@ export class DurableAgentRuntime extends Context.Service<
         ModelProvides,
         ModelRequires,
         InstructionError,
-        InstructionRequirements
+        InstructionRequirements,
+        RunDispositionValue
       >,
     ) => Effect.Effect<
       void,
@@ -6531,7 +6598,8 @@ export class DurableAgentRuntime extends Context.Service<
           ModelProvides,
           ModelRequires,
           InstructionError,
-          InstructionRequirements
+          InstructionRequirements,
+          RunDispositionValue
         >,
         InstructionRequirements
       >

--- a/packages/session/src/ledger.ts
+++ b/packages/session/src/ledger.ts
@@ -346,6 +346,8 @@ export class Settlement extends Schema.Class<Settlement>("@effect-agent/session/
   settlementId: SettlementId,
   receiptId: ReceiptId,
   outcome: SettlementOutcome,
+  /** Schema-encoded application disposition materialized from the exact canonical reservation. */
+  runDisposition: Schema.optionalKey(PersistedJson),
   settledAt: Schema.DateTimeUtcFromString,
 }) {}
 

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -416,6 +416,12 @@ export class SubmissionSettled extends Schema.TaggedClass<SubmissionSettled>(
   runId: Schema.optionalKey(RunId),
   result: Schema.optionalKey(PersistedJson),
   /**
+   * Application-defined, Schema-encoded disposition for an ordinary completed
+   * Run. Absent for budget exhaustion and every non-completed or run-less
+   * settlement; consumers decode it with the application definition's Schema.
+   */
+  runDisposition: Schema.optionalKey(PersistedJson),
+  /**
    * Present only when a `completed` Run settled through the final-answer
    * exhaustion resolution (RUN-011, RUN-018): the durable log must be able to
    * distinguish honest-exhaustion completion from ordinary completion without
@@ -449,7 +455,8 @@ const isPolicyFailureProjection = Schema.is(
  * Canonical-boundary view of `SubmissionSettled`: `finishReason` is valid
  * only on a `completed` outcome, `exhausted` only alongside
  * `finishReason: "budget-exhausted"`, and `policyLimit` only on a `failed`
- * outcome whose `result` carries the `AgentPolicyError` failure projection —
+ * outcome whose `result` carries the `AgentPolicyError` failure projection,
+ * and `runDisposition` only on an ordinary completed settlement with a Run —
  * so a malformed persisted combination such as
  * `{ outcome: "failed", finishReason: "budget-exhausted" }` or a
  * `policyLimit` contradicting `result.errorTag` fails closed at decode
@@ -460,11 +467,16 @@ const SubmissionSettledRecord = SubmissionSettled.pipe(
     (settled): settled is SubmissionSettled =>
       (settled.finishReason === undefined || settled.outcome === "completed") &&
       (settled.exhausted === undefined || settled.finishReason === "budget-exhausted") &&
+      (settled.runDisposition === undefined ||
+        (settled.outcome === "completed" &&
+          settled.finishReason === undefined &&
+          settled.runId !== undefined &&
+          settled.result !== undefined)) &&
       (settled.policyLimit === undefined ||
         (settled.outcome === "failed" && isPolicyFailureProjection(settled.result))),
     {
       expected:
-        "finishReason only on a completed settlement, exhausted only with finishReason budget-exhausted, policyLimit only on a failed AgentPolicyError settlement",
+        "finishReason only on a completed settlement, exhausted only with finishReason budget-exhausted, runDisposition only on an ordinary completed settlement with a Run result, policyLimit only on a failed AgentPolicyError settlement",
     },
   ),
 );

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -446,21 +446,29 @@ describe("phase 4 durable canonical payloads", () => {
       payload,
     });
     const failures: ReadonlyArray<unknown> = [
-      { ...encodedSubmissionSettled, outcome: "failed", runDisposition: "not-final" },
-      { ...encodedSubmissionSettled, outcome: "aborted", runDisposition: "not-final" },
+      {
+        ...encodedSubmissionSettled,
+        outcome: "failed",
+        runDisposition: "application-complete",
+      },
+      {
+        ...encodedSubmissionSettled,
+        outcome: "aborted",
+        runDisposition: "application-complete",
+      },
       {
         ...encodedSubmissionSettled,
         finishReason: "budget-exhausted",
         exhausted: "turns",
-        runDisposition: "not-final",
+        runDisposition: "application-complete",
       },
       (() => {
         const { runId: _runId, ...withoutRun } = encodedSubmissionSettled;
-        return { ...withoutRun, runDisposition: "not-final" };
+        return { ...withoutRun, runDisposition: "application-complete" };
       })(),
       (() => {
         const { result: _result, ...withoutResult } = encodedSubmissionSettled;
-        return { ...withoutResult, runDisposition: "not-final" };
+        return { ...withoutResult, runDisposition: "application-complete" };
       })(),
     ];
 

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -743,9 +743,11 @@ describe("SubmissionLedger port schemas", () => {
       settlementId: "settlement:submission-1",
       receiptId: "receipt-1",
       outcome: "completed",
+      runDisposition: "application-complete",
       settledAt: "2026-08-12T00:01:00.000Z",
     });
     expect(settlement.outcome).toBe("completed");
+    expect(settlement.runDisposition).toBe("application-complete");
     expect(
       Schema.decodeUnknownExit(SettlementReservation)({
         ...encodedReservation,

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -423,6 +423,52 @@ describe("phase 4 durable canonical payloads", () => {
     }
   });
 
+  it("RUN-029: round-trips an application run disposition on ordinary completion", () => {
+    const payload = {
+      ...encodedSubmissionSettled,
+      runDisposition: "answered-without-cloud-task",
+    } as const;
+    const record = decodeRecord("record-run029", payload);
+
+    expect(Schema.encodeSync(RecordEnvelope)(record).payload).toEqual(payload);
+    expect(
+      Schema.decodeUnknownSync(RecordEnvelope)(Schema.encodeSync(RecordEnvelope)(record)),
+    ).toEqual(record);
+  });
+
+  it("RUN-029: rejects run disposition outside an ordinary completed Run", () => {
+    const envelope = (payload: unknown): unknown => ({
+      recordId: "record-run029-invalid",
+      family: "conversation",
+      schemaVersion: 1,
+      createdAt: "2026-07-29T12:00:00.000Z",
+      deploymentId: "test-deployment",
+      payload,
+    });
+    const failures: ReadonlyArray<unknown> = [
+      { ...encodedSubmissionSettled, outcome: "failed", runDisposition: "not-final" },
+      { ...encodedSubmissionSettled, outcome: "aborted", runDisposition: "not-final" },
+      {
+        ...encodedSubmissionSettled,
+        finishReason: "budget-exhausted",
+        exhausted: "turns",
+        runDisposition: "not-final",
+      },
+      (() => {
+        const { runId: _runId, ...withoutRun } = encodedSubmissionSettled;
+        return { ...withoutRun, runDisposition: "not-final" };
+      })(),
+      (() => {
+        const { result: _result, ...withoutResult } = encodedSubmissionSettled;
+        return { ...withoutResult, runDisposition: "not-final" };
+      })(),
+    ];
+
+    for (const payload of failures) {
+      expect(Schema.decodeUnknownExit(RecordEnvelope)(envelope(payload))._tag).toBe("Failure");
+    }
+  });
+
   it("reduces settlements and abort requests while model responses only advance the sequence", () => {
     const created = decodeEnvelope(
       1,

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -426,7 +426,7 @@ describe("phase 4 durable canonical payloads", () => {
   it("RUN-029: round-trips an application run disposition on ordinary completion", () => {
     const payload = {
       ...encodedSubmissionSettled,
-      runDisposition: "answered-without-cloud-task",
+      runDisposition: "application-complete",
     } as const;
     const record = decodeRecord("record-run029", payload);
 

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -253,6 +253,42 @@ const baseLayer = Layer.mergeAll(
 
 const testLayer = DurableAgentRuntime.layer.pipe(Layer.provideMerge(baseLayer));
 
+const untrustedSettlementLedgerLayer = Layer.effect(
+  SubmissionLedger,
+  Effect.gen(function* () {
+    const inner = yield* SubmissionLedger;
+    return SubmissionLedger.of({
+      ...inner,
+      finalizeSettlement: (request) =>
+        inner.finalizeSettlement(request).pipe(
+          Effect.map((settlement) =>
+            Settlement.make({
+              submissionId: settlement.submissionId,
+              settlementId: settlement.settlementId,
+              receiptId: settlement.receiptId,
+              outcome: settlement.outcome,
+              runDisposition: "unverified-ledger-disposition",
+              settledAt: settlement.settledAt,
+            }),
+          ),
+        ),
+    });
+  }),
+).pipe(Layer.provide(MemorySubmissionLedgerLive));
+
+const untrustedSettlementBaseLayer = Layer.mergeAll(
+  untrustedSettlementLedgerLayer,
+  MemoryConversationStoreLive,
+  WakeScheduler.layerNoop,
+  DurableRuntimeFailpoint.layerTest,
+  ToolReconciler.uncertain,
+  configLayer,
+).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const untrustedSettlementTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(untrustedSettlementBaseLayer),
+);
+
 class ProgressWaitTestControl extends Context.Service<
   ProgressWaitTestControl,
   {
@@ -683,6 +719,41 @@ layer(progressWaitTestLayer)("#94 DurableAgentRuntime progress waits", (it) => {
       const exit = yield* Effect.exit(runtime.awaitProgress(missing, ZERO_SEQUENCE));
       expect(failureTag(exit)).toBe("ConversationNotMaterialized");
       expect(yield* Ref.get(control.active)).toBe(0);
+    }),
+  );
+});
+
+layer(untrustedSettlementTestLayer)("RUN-029 canonical settlement authority", (it) => {
+  it.effect("drops a ledger-only disposition when canonical proof fails", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel(() =>
+        finalParts('{"answer":"done","runDisposition":"invalid-disposition"}'),
+      );
+      const agent = Agent.withModel(dispositionDefinition, scripted.model);
+      const conversation = "conversation-unverified-ledger-disposition";
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: "done?" },
+        submitOptions(conversation, "unverified-ledger-disposition-1"),
+      );
+
+      const processed = yield* runtime.processConversation(
+        agent,
+        decodeConversationId(conversation),
+      );
+      expect(processed[0]?.outcome).toBe("failed");
+      expect(processed[0]?.runDisposition).toBeUndefined();
+
+      const settlement = yield* runtime.awaitSettlement(receipt);
+      expect(settlement.outcome).toBe("failed");
+      expect(settlement.runDisposition).toBeUndefined();
+
+      const settled = (yield* readLog(conversation)).at(-1)?.record.payload;
+      expect(settled?._tag).toBe("SubmissionSettled");
+      if (settled?._tag === "SubmissionSettled") {
+        expect(settled.runDisposition).toBeUndefined();
+      }
     }),
   );
 });

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -45,6 +45,7 @@ import {
   modelResponseRecordId,
   projectRunJournal,
   promptFromCanonicalRecords,
+  replayConversation,
   recoveryRepairRecordId,
   runIdForSubmission,
   submissionInputRecordId,
@@ -165,6 +166,27 @@ const plannerDefinition = Agent.define("durable-planner", {
     maxDuration: "30 seconds",
     toolConcurrency: 1,
   }),
+});
+
+const RunDisposition = Schema.Literal("answered-without-cloud-task");
+const dispositionDefinition = Agent.define("durable-run-disposition", {
+  input: Schema.Struct({ question: Schema.String }),
+  output: Schema.Struct({
+    answer: Schema.String,
+    runDisposition: Schema.optionalKey(Schema.String),
+  }),
+  instructions: "Answer as JSON and declare application completion explicitly.",
+  toolkit: Toolkit.empty,
+  policy: AgentPolicy.make({
+    maxTurns: 3,
+    maxToolCalls: 2,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+  runDisposition: {
+    schema: RunDisposition,
+    fromOutput: (output) => output.runDisposition,
+  },
 });
 
 // `readonly` keeps the P4 canonical record shape byte-stable (plan §4.3): an unannotated tool
@@ -788,6 +810,92 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
   );
 
   it.effect(
+    "RUN-029 persists and replays an ordinary application run disposition across terminalization crashes",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const scenarios = [
+          {
+            location: undefined,
+            conversation: "conversation-run-disposition",
+            key: "run-disposition-1",
+          },
+          {
+            location: "terminalize:after-reserve" as const,
+            conversation: "conversation-run-disposition-reserve",
+            key: "run-disposition-reserve-1",
+          },
+          {
+            location: "terminalize:after-canonical-append" as const,
+            conversation: "conversation-run-disposition-append",
+            key: "run-disposition-append-1",
+          },
+        ];
+
+        for (const scenario of scenarios) {
+          const scripted = yield* makeScriptedModel(() =>
+            finalParts('{"answer":"done","runDisposition":"answered-without-cloud-task"}'),
+          );
+          const agent = Agent.withModel(dispositionDefinition, scripted.model);
+          const conversationId = decodeConversationId(scenario.conversation);
+          const receipt = yield* runtime.submit(
+            agent,
+            { question: "done?" },
+            submitOptions(scenario.conversation, scenario.key),
+          );
+
+          if (scenario.location === undefined) {
+            yield* runtime.processConversation(agent, conversationId);
+          } else {
+            yield* armFailpoint(scenario.location);
+            const killed = yield* Effect.exit(runtime.processConversation(agent, conversationId));
+            expect(failureTag(killed)).toBe("DurableRuntimeFailpointError");
+            yield* clearFailpoint;
+            yield* runtime.runRecovery;
+          }
+
+          expect((yield* runtime.awaitSettlement(receipt)).outcome).toBe("completed");
+          const records = yield* readLog(scenario.conversation);
+          const projection = replayConversation(conversationId, records);
+          expect(projection.settlements).toHaveLength(1);
+          const disposition = projection.settlements[0]?.runDisposition;
+          const decodedDisposition = yield* Schema.decodeUnknownEffect(RunDisposition)(disposition);
+          expect(decodedDisposition).toBe("answered-without-cloud-task");
+        }
+      }),
+  );
+
+  it.effect("RUN-029 invalid disposition selection settles failed without disposition", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel(() =>
+        finalParts('{"answer":"done","runDisposition":"invented"}'),
+      );
+      const agent = Agent.withModel(dispositionDefinition, scripted.model);
+      const conversation = "conversation-run-disposition-invalid";
+
+      yield* runtime.submit(
+        agent,
+        { question: "done?" },
+        submitOptions(conversation, "run-disposition-invalid-1"),
+      );
+      const settlements = yield* runtime.processConversation(
+        agent,
+        decodeConversationId(conversation),
+      );
+
+      expect(settlements[0]?.outcome).toBe("failed");
+      const settled = (yield* readLog(conversation)).at(-1)?.record.payload;
+      expect(settled?._tag).toBe("SubmissionSettled");
+      if (settled?._tag === "SubmissionSettled") {
+        expect(settled.outcome).toBe("failed");
+        expect(settled.result).toMatchObject({ errorTag: "AgentRunDispositionError" });
+        expect(settled.runDisposition).toBeUndefined();
+      }
+    }),
+  );
+
+  it.effect(
     "RUN-018 a budget-exhausted Run settles the Submission completed with canonical synthetic Tool settlements",
     () =>
       Effect.gen(function* () {
@@ -802,7 +910,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
         const probeTools = Toolkit.make(Probe);
         const definition = Agent.define("durable-soft-landing", {
           input: Schema.Struct({ question: Schema.String }),
-          output: Schema.Struct({ answer: Schema.String }),
+          output: Schema.Struct({
+            answer: Schema.String,
+            runDisposition: Schema.optionalKey(Schema.String),
+          }),
           instructions: "Probe before answering.",
           toolkit: probeTools,
           policy: AgentPolicy.make({
@@ -811,6 +922,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
             maxDuration: "30 seconds",
             toolConcurrency: 1,
           }),
+          runDisposition: {
+            schema: RunDisposition,
+            fromOutput: (output) => output.runDisposition,
+          },
         });
         const handlerStarts = yield* Ref.make(0);
         const probeToolLayer = probeTools.toLayer({
@@ -836,7 +951,9 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
                 },
                 { type: "finish", reason: "tool-calls", usage },
               ]
-            : finalParts('{"answer":"partial, budget exhausted"}'),
+            : finalParts(
+                '{"answer":"partial, budget exhausted","runDisposition":"answered-without-cloud-task"}',
+              ),
         );
         const agent = Agent.withModel(definition, scripted.model);
         const conversation = "conversation-soft-landing";
@@ -904,7 +1021,11 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(settled.finishReason).toBe("budget-exhausted");
           expect(settled.exhausted).toBe("tool-calls");
           expect(settled.policyLimit).toBeUndefined();
-          expect(settled.result).toEqual({ answer: "partial, budget exhausted" });
+          expect(settled.runDisposition).toBeUndefined();
+          expect(settled.result).toEqual({
+            answer: "partial, budget exhausted",
+            runDisposition: "answered-without-cloud-task",
+          });
         }
 
         // The canonical journal alone rebuilds the exact model-visible prompt,
@@ -954,7 +1075,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           const probeTools = Toolkit.make(Probe);
           const definition = Agent.define("durable-soft-landing-recovery", {
             input: Schema.Struct({ question: Schema.String }),
-            output: Schema.Struct({ answer: Schema.String }),
+            output: Schema.Struct({
+              answer: Schema.String,
+              runDisposition: Schema.optionalKey(Schema.String),
+            }),
             instructions: "Probe before answering.",
             toolkit: probeTools,
             policy: AgentPolicy.make({
@@ -963,6 +1087,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
               maxDuration: "30 seconds",
               toolConcurrency: 1,
             }),
+            runDisposition: {
+              schema: RunDisposition,
+              fromOutput: (output) => output.runDisposition,
+            },
           });
           const probeToolLayer = probeTools.toLayer({
             probe: () => Effect.succeed({ available: true }),
@@ -986,7 +1114,9 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
                   },
                   { type: "finish", reason: "tool-calls", usage },
                 ]
-              : finalParts('{"answer":"recovered partial"}'),
+              : finalParts(
+                  '{"answer":"recovered partial","runDisposition":"answered-without-cloud-task"}',
+                ),
           );
           const agent = Agent.withModel(definition, scripted.model);
 
@@ -1017,6 +1147,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
             finishReason: "budget-exhausted",
             exhausted: "tool-calls",
           });
+          expect(settledRecords[0]?.runDisposition).toBeUndefined();
         }
       }),
   );
@@ -1099,7 +1230,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
       const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"never"}'));
-      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const agent = Agent.withModel(dispositionDefinition, scripted.model);
       const conversation = "conversation-abort-ready";
 
       const receipt = yield* runtime.submit(
@@ -1128,6 +1259,13 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
       const tags = logTags(records);
       expect(tags).toContain("AbortRequested");
       expect(tags.indexOf("AbortRequested")).toBeLessThan(tags.indexOf("SubmissionSettled"));
+      const settled = records.find(
+        (envelope) => envelope.record.payload._tag === "SubmissionSettled",
+      )?.record.payload;
+      expect(settled?._tag).toBe("SubmissionSettled");
+      if (settled?._tag === "SubmissionSettled") {
+        expect(settled.runDisposition).toBeUndefined();
+      }
       // No model ran and no input became canonical for the aborted, never-claimed head.
       expect(tags).not.toContain("ModelResponseRecorded");
       // DUR-013: the executed decision left a deterministic audit record.

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -854,7 +854,9 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
             yield* runtime.runRecovery;
           }
 
-          expect((yield* runtime.awaitSettlement(receipt)).outcome).toBe("completed");
+          const settlement = yield* runtime.awaitSettlement(receipt);
+          expect(settlement.outcome).toBe("completed");
+          expect(settlement.runDisposition).toBe("application-complete");
           const records = yield* readLog(scenario.conversation);
           const projection = replayConversation(conversationId, records);
           expect(projection.settlements).toHaveLength(1);
@@ -868,13 +870,16 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
   it.effect("RUN-029 invalid disposition selection settles failed without disposition", () =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
+      const secret = "sensitive-run-disposition-must-not-enter-history";
       const scripted = yield* makeScriptedModel(() =>
-        finalParts('{"answer":"done","runDisposition":"invented"}'),
+        finalParts(
+          '{"answer":"done","runDisposition":"sensitive-run-disposition-must-not-enter-history"}',
+        ),
       );
       const agent = Agent.withModel(dispositionDefinition, scripted.model);
       const conversation = "conversation-run-disposition-invalid";
 
-      yield* runtime.submit(
+      const receipt = yield* runtime.submit(
         agent,
         { question: "done?" },
         submitOptions(conversation, "run-disposition-invalid-1"),
@@ -885,12 +890,20 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
       );
 
       expect(settlements[0]?.outcome).toBe("failed");
+      expect(settlements[0]?.runDisposition).toBeUndefined();
+      const settlement = yield* runtime.awaitSettlement(receipt);
+      expect(settlement.outcome).toBe("failed");
+      expect(settlement.runDisposition).toBeUndefined();
       const settled = (yield* readLog(conversation)).at(-1)?.record.payload;
       expect(settled?._tag).toBe("SubmissionSettled");
       if (settled?._tag === "SubmissionSettled") {
         expect(settled.outcome).toBe("failed");
-        expect(settled.result).toMatchObject({ errorTag: "AgentRunDispositionError" });
+        expect(settled.result).toMatchObject({
+          errorTag: "AgentRunDispositionError",
+          message: "Run disposition failed Schema encoding",
+        });
         expect(settled.runDisposition).toBeUndefined();
+        expect(JSON.stringify(settled)).not.toContain(secret);
       }
     }),
   );
@@ -969,6 +982,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
 
         expect(settlements).toHaveLength(1);
         expect(settlements[0]?.outcome).toBe("completed");
+        expect(settlements[0]?.runDisposition).toBeUndefined();
+        const settlement = yield* runtime.awaitSettlement(receipt);
+        expect(settlement.outcome).toBe("completed");
+        expect(settlement.runDisposition).toBeUndefined();
         expect(yield* Ref.get(handlerStarts)).toBe(0);
 
         const submissionId = receipt.submissionId;
@@ -1137,6 +1154,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           yield* runtime.runRecovery;
           const settlement = yield* runtime.awaitSettlement(receipt);
           expect(settlement.outcome).toBe("completed");
+          expect(settlement.runDisposition).toBeUndefined();
           const records = yield* readLog(scenario.conversation);
           const settledRecords = records
             .map((envelope) => envelope.record.payload)
@@ -1254,6 +1272,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
 
       const settlement = yield* runtime.awaitSettlement(receipt);
       expect(settlement.outcome).toBe("aborted");
+      expect(settlement.runDisposition).toBeUndefined();
 
       const records = yield* readLog(conversation);
       const tags = logTags(records);

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -168,7 +168,7 @@ const plannerDefinition = Agent.define("durable-planner", {
   }),
 });
 
-const RunDisposition = Schema.Literal("answered-without-cloud-task");
+const RunDisposition = Schema.Literal("application-complete");
 const dispositionDefinition = Agent.define("durable-run-disposition", {
   input: Schema.Struct({ question: Schema.String }),
   output: Schema.Struct({
@@ -834,7 +834,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
 
         for (const scenario of scenarios) {
           const scripted = yield* makeScriptedModel(() =>
-            finalParts('{"answer":"done","runDisposition":"answered-without-cloud-task"}'),
+            finalParts('{"answer":"done","runDisposition":"application-complete"}'),
           );
           const agent = Agent.withModel(dispositionDefinition, scripted.model);
           const conversationId = decodeConversationId(scenario.conversation);
@@ -860,7 +860,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(projection.settlements).toHaveLength(1);
           const disposition = projection.settlements[0]?.runDisposition;
           const decodedDisposition = yield* Schema.decodeUnknownEffect(RunDisposition)(disposition);
-          expect(decodedDisposition).toBe("answered-without-cloud-task");
+          expect(decodedDisposition).toBe("application-complete");
         }
       }),
   );
@@ -952,7 +952,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
                 { type: "finish", reason: "tool-calls", usage },
               ]
             : finalParts(
-                '{"answer":"partial, budget exhausted","runDisposition":"answered-without-cloud-task"}',
+                '{"answer":"partial, budget exhausted","runDisposition":"application-complete"}',
               ),
         );
         const agent = Agent.withModel(definition, scripted.model);
@@ -1024,7 +1024,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(settled.runDisposition).toBeUndefined();
           expect(settled.result).toEqual({
             answer: "partial, budget exhausted",
-            runDisposition: "answered-without-cloud-task",
+            runDisposition: "application-complete",
           });
         }
 
@@ -1115,7 +1115,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
                   { type: "finish", reason: "tool-calls", usage },
                 ]
               : finalParts(
-                  '{"answer":"recovered partial","runDisposition":"answered-without-cloud-task"}',
+                  '{"answer":"recovered partial","runDisposition":"application-complete"}',
                 ),
           );
           const agent = Agent.withModel(definition, scripted.model);

--- a/packages/testing/test/travel-planner.compile.test.ts
+++ b/packages/testing/test/travel-planner.compile.test.ts
@@ -1,4 +1,5 @@
 import {
+  AgentRunDispositionError,
   Agent,
   AgentApprovalDenied,
   AgentApprovalPending,
@@ -62,6 +63,7 @@ type ExpectedFailure =
   | AiError.AiError
   | AgentInputError
   | AgentOutputError
+  | AgentRunDispositionError
   | AgentPolicyError
   | ContextOverflowError
   | ModelProtocolError

--- a/packages/testing/test/travel-planner.compile.test.ts
+++ b/packages/testing/test/travel-planner.compile.test.ts
@@ -1,5 +1,4 @@
 import {
-  AgentRunDispositionError,
   Agent,
   AgentApprovalDenied,
   AgentApprovalPending,
@@ -63,7 +62,6 @@ type ExpectedFailure =
   | AiError.AiError
   | AgentInputError
   | AgentOutputError
-  | AgentRunDispositionError
   | AgentPolicyError
   | ContextOverflowError
   | ModelProtocolError


### PR DESCRIPTION
## Summary

- add a Definition-owned, generic Effect Schema boundary for application run dispositions
- validate and encode a declared disposition only at ordinary completion, then persist it on the exact canonical `SubmissionSettled` reservation
- fail closed for invalid declarations and exclude failed, aborted, budget-exhausted, run-less, and incomplete/recovered settlements

This supplies the upstream boundary required by [reve-ai/kommunikasie#545](https://github.com/reve-ai/kommunikasie/issues/545). It deliberately does not encode downstream application vocabulary or infer finality from output prose or Tool success.

## Problem and contract

`SubmissionSettled` already persisted framework outcome/result/budget metadata, but applications had no typed durable completion classification. A consumer therefore could not safely distinguish one ordinary completion class from other successful activity without inventing a heuristic.

The additive API lets the application own a literal or richer Schema:

```ts
const RunDisposition = Schema.Literal("application-complete");

const definition = Agent.define("task-agent", {
  input: TaskInput,
  output: TaskReport,
  instructions,
  toolkit,
  policy,
  runDisposition: {
    schema: RunDisposition,
    fromOutput: (report) => report.runDisposition,
  },
});

type Disposition = Agent.RunDisposition<typeof definition>;
// "application-complete"
```

`fromOutput` receives decoded output and yields an untrusted candidate or `undefined`. The engine Schema-encodes and JSON-validates it; invalid selection fails as `AgentRunDispositionError`. That error joins `Agent.Failure` only when the Definition declares the boundary. Selector and Schema failures retain their exact diagnostic cause through `Schema.Defect()`, while `RunFailed` and canonical settlements receive only fixed non-sensitive messages.

The semantic `RunCompleted` event, `AgentResult`, canonical `SubmissionSettled`, and public durable `Settlement` retain the encoded JSON value for application Schema decoding. `Settlement` materializes it from the exact validated reservation in ordinary execution and recovery; a ledger projection can never supply or preserve an unverified value. The exported `AgentResultSchema` rejects `finishReason: "budget-exhausted"` together with `runDisposition`, so public decoding enforces the runtime and persistence invariant.

## Reviewer map

| Concern | Vital code |
| --- | --- |
| Public generic, conditional failure, inferred type/requirements | [`packages/core/src/agent.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/core/src/agent.ts) |
| Typed validation failure and diagnostic cause | [`packages/core/src/errors.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/core/src/errors.ts) |
| Ordinary-completion selection, sanitized failures, public result invariant, and replay validation | [`packages/engine/src/index.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/engine/src/index.ts) |
| Canonical settlement invariant | [`packages/session/src/records.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/session/src/records.ts) |
| Public Settlement projection | [`packages/session/src/ledger.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/session/src/ledger.ts) |
| Exact reservation/append terminalization and fail-closed materialization | [`packages/session/src/durable-runtime.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/session/src/durable-runtime.ts) |
| Crash/replay, corrupt-ledger, public Settlement, and negative boundary regressions | [`packages/testing/test/durable-runtime.test.ts`](https://github.com/danieljvdm/effect-agent/blob/fbedb087f0fb7976377420ba50fde0d92fbec69b/packages/testing/test/durable-runtime.test.ts) |

The existing terminalization failpoints bracket the exact new durable mutation. Tests cover uninterrupted persistence plus crashes after reservation and after canonical append, public `awaitSettlement` materialization across those paths, invalid Schema selection without diagnostic leakage, thrown selector diagnostics without event leakage, corrupt ledger projections without canonical authority, public budget/disposition schema exclusion, budget completion and recovery, and abort/recovery without a disposition.

## Release note

`.changeset/typed-run-disposition.md` gives minor changesets to the three behavior-owning published packages:

- `@effect-agent/core`
- `@effect-agent/engine`
- `@effect-agent/session`

The repository fixed group will advance the remaining public packages automatically; no unrelated package is named in the changeset.

## Verification

- `vp fmt --check` — 502 files formatted
- `vp run --no-cache --log grouped build` — 20/20 Build tasks passed
- `vp run --no-cache --log grouped check` — 23/23 Static tasks passed; action bundle current
- `vp run --no-cache --log grouped test` — 20/20 Tests tasks passed, including testing 225/225 and the real-process crash and Cloudflare eviction suites
- `vp run --no-cache --log grouped ready` — passed the repository handoff gate

The earlier `11 errors / 329 warnings` output came from invoking the root `check` task while attempting to filter packages and placing Vite+ options after the task specifier. The 11 errors were intentional negative compile fixtures selected by that malformed command. Correct task-qualified focused checks and the full repository commands above are clean.
