### PR TITLE
fix(pr-review): fail closed on incomplete coverage

### DIFF
--- a/.changeset/harden-pr-review-bot.md
+++ b/.changeset/harden-pr-review-bot.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/pr-review": minor
+---
+
+Harden full-diff review coverage, selection provenance, bounded fan-out retries, and policy-failure
+diagnostics so oversized reviews fail closed instead of silently reporting incomplete results.

--- a/.changeset/harden-pr-review-bot.md
+++ b/.changeset/harden-pr-review-bot.md
@@ -2,5 +2,7 @@
 "@effect-agent/pr-review": minor
 ---
 
-Harden full-diff review coverage, selection provenance, bounded fan-out retries, and policy-failure
-diagnostics so oversized reviews fail closed instead of silently reporting incomplete results.
+Harden full-diff review coverage, host-scoped selection provenance, bounded fan-out retries, and
+policy-failure diagnostics so oversized reviews fail closed instead of silently reporting
+incomplete results. Selection issuance and verification now require one explicit per-composition
+Effect service instead of process-wide mutable authority.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -36,10 +36,10 @@ jobs:
     # internally; this guard saves the runner spin-up).
     if: ${{ !github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name == 'pr-review:final-audit') }}
     runs-on: ubuntu-latest
-    # Above the configured 18-minute final-audit duration budget, so a run approaching
+    # Above the configured 50-minute final-audit duration budget, so a run approaching
     # its own budget ends gracefully instead of being killed by the runner
     # with nothing posted.
-    timeout-minutes: 20
+    timeout-minutes: 55 # FAN_OUT_WORKFLOW_TIMEOUT_MINUTES
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -52,16 +52,18 @@ jobs:
           # A dedicated secret is preferred. The provider credential is a
           # stable workflow-only fallback and is never sent to the reviewer as state.
           state-secret: ${{ secrets.PR_REVIEW_STATE_SECRET || secrets.OPENAI_API_KEY }}
-          # Routine incremental deltas use one flat reviewer. Reserve fan-out
-          # for the explicit full-diff audit instead of multiplying model calls
-          # across every corrective push.
-          fan-out: ${{ github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit' && 'true' || 'false' }}
+          # One flat reviewer has an honest 11-file diff+context envelope
+          # after its initial list call.
+          # Larger PRs use bounded fan-out even for routine incremental runs;
+          # the explicit full-diff audit always does so regardless of size.
+          fan-out: ${{ ((github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit') || github.event.pull_request.changed_files > 11) && 'true' || 'false' }}
           # Medium is the routine-review default. The deliberate full-diff
           # audit gets high effort together with fan-out.
           effort: ${{ github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit' && 'high' || 'medium' }}
-          # A 16-unit final audit needs four bounded waves at concurrency four;
-          # leave runner-cleanup headroom under the 20-minute job timeout.
-          max-duration-minutes: ${{ github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit' && '18' || '10' }}
+          # A 20-unit final audit plus one five-unit retry wave needs five
+          # 8-minute child waves, then a 10-minute coordinator merge window.
+          # Leave runner-cleanup headroom under the 55-minute job timeout.
+          max-duration-minutes: ${{ ((github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit') || github.event.pull_request.changed_files > 11) && '50' || '10' }}
           # The repository's deep Effect-architecture review profile —
           # distilled from the effect-architecture-audit skill and AGENTS.md's
           # non-negotiables. Fan-out injects it into every child reviewer.

--- a/action/README.md
+++ b/action/README.md
@@ -144,7 +144,7 @@ truncated source surface, or coordinator failure — is also non-success. The
 legacy `fail-on` input is accepted for compatibility but no longer weakens or
 changes this conservative gate.
 
-If you set `max-duration-minutes` (or rely on the defaults: 8 flat / 15
+If you set `max-duration-minutes` (or rely on the defaults: 8 flat / 50
 fan-out), keep the job's `timeout-minutes` above it — a runner-killed job
 posts nothing, while a budget-ended run fails typed with its forensics.
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   max-duration-minutes:
     description: >-
-      Run duration budget in minutes (defaults: 8 flat, 15 fan-out). Keep the
+      Run duration budget in minutes (defaults: 8 flat, 50 fan-out). Keep the
       job's timeout-minutes ABOVE this so the reviewer ends its run gracefully
       instead of being killed by the runner with nothing posted.
     required: false

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -52,6 +52,19 @@ __export(exports_Context, {
   Reference: () => Reference
 });
 
+// node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/Equal.js
+var exports_Equal = {};
+__export(exports_Equal, {
+  symbol: () => symbol2,
+  makeCompareSet: () => makeCompareSet,
+  makeCompareMap: () => makeCompareMap,
+  isEqual: () => isEqual,
+  equals: () => equals,
+  byReferenceUnsafe: () => byReferenceUnsafe,
+  byReference: () => byReference,
+  asEquivalence: () => asEquivalence
+});
+
 // node_modules/.bun/effect@4.0.0-beta.107/node_modules/effect/dist/Pipeable.js
 var pipeArguments = (self, args) => {
   switch (args.length) {
@@ -750,6 +763,7 @@ function makeCompareSet(equivalence) {
 var compareSets = /* @__PURE__ */ makeCompareSet(compareBoth);
 var isEqual = (u) => hasProperty(u, symbol2);
 var asEquivalence = () => equals;
+var byReference = (obj) => byReferenceUnsafe(new Proxy(obj, {}));
 var byReferenceUnsafe = (obj) => {
   byReferenceInstances.add(obj);
   return obj;
@@ -41626,7 +41640,7 @@ var PullRequestReviewer = Agent.define("pr-reviewer", {
 });
 
 // packages/pr-review/src/internal/review-units.ts
-var MAX_REVIEW_UNITS = 16;
+var MAX_REVIEW_UNITS = 20;
 var MAX_UNIT_FILES = 12;
 var UNIT_CHANGED_LINE_BUDGET = 1200;
 var FILE_OVERHEAD_LINES = 20;
@@ -41720,7 +41734,18 @@ var rankAndDedupeFindings = (findings) => {
 // packages/pr-review/src/internal/fan-out.ts
 var MAX_CHILD_FINDINGS = 8;
 var MAX_CHILD_CONCERNS = 3;
-var MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 2;
+var MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 4;
+var MAX_FILE_REVIEW_TURNS = MAX_FILE_REVIEW_TOOL_CALLS + 1;
+var FILE_REVIEW_TOKEN_BUDGET = 600000;
+var FILE_REVIEW_MAX_CONCURRENCY = 5;
+var MAX_FILE_REVIEW_RETRIES = FILE_REVIEW_MAX_CONCURRENCY;
+var MAX_FILE_REVIEW_ATTEMPTS = MAX_REVIEW_UNITS + MAX_FILE_REVIEW_RETRIES;
+var FILE_REVIEW_MAX_DURATION_MINUTES = 8;
+var MAX_FILE_REVIEW_WAVES = Math.ceil(MAX_FILE_REVIEW_ATTEMPTS / FILE_REVIEW_MAX_CONCURRENCY);
+var FILE_REVIEW_WAVE_DURATION_MINUTES = MAX_FILE_REVIEW_WAVES * FILE_REVIEW_MAX_DURATION_MINUTES;
+var FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES = 10;
+var FAN_OUT_MAX_DURATION_MINUTES = FILE_REVIEW_WAVE_DURATION_MINUTES + FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES;
+var FAN_OUT_WORKFLOW_TIMEOUT_MINUTES = FAN_OUT_MAX_DURATION_MINUTES + 5;
 var FileReviewToolkit = exports_Toolkit.make(ReadFileDiff, ReadFile);
 var FileReviewToolkitLayer = FileReviewToolkit.toLayer({
   read_file_diff: readFileDiffHandler,
@@ -41753,7 +41778,7 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => [
   ...staticGuidanceLines(options3.guidance),
   "Work in this order:",
   "1. Call read_file_diff for every file in your unit. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
-  "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
+  "2. Call read_file when you need surrounding context the diff does not show, at most three times per file. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
   "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
   "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
   "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
@@ -41764,12 +41789,12 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => [
 `);
 var fileReviewerInstructions = makeFileReviewerInstructions();
 var defaultFileReviewerPolicy = AgentPolicy.make({
-  maxTurns: 12,
+  maxTurns: MAX_FILE_REVIEW_TURNS,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "10 minutes",
+  maxDuration: `${FILE_REVIEW_MAX_DURATION_MINUTES} minutes`,
   toolConcurrency: 2,
   repeatedFailureLimit: 12,
-  tokenBudget: 200000,
+  tokenBudget: FILE_REVIEW_TOKEN_BUDGET,
   contextTokenLimit: 150000,
   toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   onExhaustion: "fail"
@@ -41791,19 +41816,21 @@ class FileReviewUnitResult extends exports_Schema.Class("@effect-agent/pr-review
 
 class FileReviewUnitFailed extends exports_Schema.TaggedError()("FileReviewUnitFailed", {
   childErrorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
+  childPolicyLimit: exports_Schema.optionalKey(PolicyLimit),
   message: exports_Schema.String.check(exports_Schema.isMaxLength(400))
 }) {
 }
 var fileReviewPolicy = SubagentPolicy.make({
-  maxChildren: MAX_REVIEW_UNITS,
-  maxConcurrency: 4,
-  maxTurns: 12,
+  maxChildren: MAX_FILE_REVIEW_ATTEMPTS,
+  maxConcurrency: FILE_REVIEW_MAX_CONCURRENCY,
+  maxTurns: MAX_FILE_REVIEW_TURNS,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "10 minutes"
+  maxDuration: `${FILE_REVIEW_MAX_DURATION_MINUTES} minutes`
 });
-var delegationDescription = "Delegate the review of one planned unit to a bounded file-reviewer child and return its line-anchored findings. Call it exactly once per unit from list_review_units; never retry a failed unit.";
+var delegationDescription = `Delegate one planned unit to a bounded read-only file reviewer. Call every unit once; after those settle, at most ${MAX_FILE_REVIEW_RETRIES} failed units may each be retried once with the exact same paths.`;
 var mapFileReviewChildFailure = (failure) => FileReviewUnitFailed.make({
   childErrorTag: failure._tag,
+  ...failure._tag === "AgentPolicyError" && failure.limit !== undefined ? { childPolicyLimit: failure.limit } : {},
   message: (failure.message ?? "").slice(0, 400)
 });
 
@@ -41837,12 +41864,13 @@ ${mission.body}` : "The author provided no description.",
     ...staticGuidanceLines(options3.guidance),
     "Work in this order:",
     "1. Call list_review_units once to get the planned review units.",
-    "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
-    `3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
-    `4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
-    `5. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
-    "6. Merge the units' fileSummaries into one walkthrough: copy each entry verbatim, one entry per file, dropping duplicate paths.",
-    '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "category": <string, OPTIONAL>, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>, "walkthrough": <array, OPTIONAL: [{"path": <string>, "summary": <string>}], the merged fileSummaries>}. Copy findings (including "category" and "suggestion" when present), concerns, and walkthrough entries verbatim from the delegation results; never invent or edit anchors.',
+    "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all initial delegation calls in one batch. Never review files yourself and never invent units.",
+    `3. After every initial call settles, you MUST retry the first ${MAX_FILE_REVIEW_RETRIES} FAILED units once, in unit order, with the exact same unitId and paths (or every failed unit when fewer than ${MAX_FILE_REVIEW_RETRIES} failed). Retrying is allowed only because this child surface is read-only. Never retry a successful unit or retry any unit more than once.`,
+    `4. A unit whose retry also returns an "_tag", or which was not eligible for the bounded retry wave, remains FAILED. Your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan's undiffablePaths and unassignedPaths must also be named as not reviewed when present.`,
+    `5. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
+    `6. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
+    "7. Merge the units' fileSummaries into one walkthrough: copy each entry verbatim, one entry per file, dropping duplicate paths.",
+    '8. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "category": <string, OPTIONAL>, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>, "walkthrough": <array, OPTIONAL: [{"path": <string>, "summary": <string>}], the merged fileSummaries>}. Copy findings (including "category" and "suggestion" when present), concerns, and walkthrough entries verbatim from the delegation results; never invent or edit anchors.',
     'Use verdict "request-changes" only when at least one finding or concern is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.'
   ].join(`
 `);
@@ -41850,9 +41878,9 @@ ${mission.body}` : "The author provided no description.",
 var fanOutReviewInstructions = makeFanOutReviewInstructions();
 var defaultFanOutPolicy = AgentPolicy.make({
   maxTurns: 6,
-  maxToolCalls: 1 + MAX_REVIEW_UNITS,
-  maxDuration: "20 minutes",
-  toolConcurrency: 4,
+  maxToolCalls: 1 + MAX_FILE_REVIEW_ATTEMPTS,
+  maxDuration: `${FAN_OUT_MAX_DURATION_MINUTES} minutes`,
+  toolConcurrency: FILE_REVIEW_MAX_CONCURRENCY,
   repeatedFailureLimit: 3,
   tokenBudget: 300000,
   contextTokenLimit: 150000,
@@ -42149,16 +42177,81 @@ class ReviewHeadComparison extends exports_Schema.Class("@effect-agent/pr-review
   truncated: exports_Schema.Boolean
 }) {
 }
-var fullSelection = (input) => ({
+var selectedRanges = new WeakMap;
+var selectionFingerprint = (selection) => {
+  try {
+    return JSON.stringify({
+      mode: selection.mode,
+      reason: selection.reason,
+      files: selection.files.map((file2) => exports_Schema.encodeSync(ChangedFile)(file2)),
+      affectedPaths: selection.affectedPaths,
+      totalFiles: selection.totalFiles,
+      baselineSha: selection.baselineSha,
+      priorState: selection.priorState === undefined ? undefined : exports_Schema.encodeSync(ReviewState)(selection.priorState),
+      profileFingerprint: selection.profileFingerprint
+    });
+  } catch {
+    return;
+  }
+};
+var freeze = (value4) => {
+  if (typeof value4 !== "object" || value4 === null)
+    return value4;
+  for (const nested2 of Object.values(value4))
+    freeze(nested2);
+  return Object.freeze(value4);
+};
+var selectionSnapshot = (selection) => freeze({
+  mode: selection.mode,
+  reason: selection.reason,
+  files: selection.files.map((file2) => exports_Schema.decodeUnknownSync(ChangedFile)(exports_Schema.encodeSync(ChangedFile)(file2))),
+  affectedPaths: [...selection.affectedPaths],
+  totalFiles: selection.totalFiles,
+  baselineSha: selection.baselineSha,
+  priorState: selection.priorState === undefined ? undefined : exports_Schema.decodeUnknownSync(ReviewState)(exports_Schema.encodeSync(ReviewState)(selection.priorState)),
+  profileFingerprint: selection.profileFingerprint
+});
+var sealReviewSelection = (selection, source) => {
+  const snapshot2 = selectionSnapshot(selection);
+  const fingerprint = selectionFingerprint(selection);
+  if (fingerprint === undefined)
+    throw new Error("Range selector produced an invalid selection");
+  selectedRanges.set(selection, {
+    source: {
+      repository: source.repository,
+      number: source.number,
+      baseRef: source.baseRef,
+      ...source.baseSha === undefined ? {} : { baseSha: source.baseSha },
+      headRef: source.headRef,
+      headSha: source.headSha,
+      totalChangedFiles: source.totalChangedFiles
+    },
+    fingerprint,
+    snapshot: snapshot2
+  });
+  return selection;
+};
+var sealedReviewSelection = (selection) => selectedRanges.get(selection)?.snapshot;
+var selectedReviewRangeFor = (selection, current) => {
+  const binding = selectedRanges.get(selection);
+  if (binding === undefined)
+    return;
+  const source = binding.source;
+  if (binding.fingerprint === selectionFingerprint(selection) && source.repository === current.repository && source.number === current.number && source.baseRef === current.baseRef && source.baseSha === current.baseSha && source.headRef === current.headRef && source.headSha === current.headSha && source.totalChangedFiles === current.totalChangedFiles) {
+    return binding.snapshot;
+  }
+  return;
+};
+var fullSelection = (input) => sealReviewSelection({
   mode: "full",
   reason: input.reason,
   files: input.files,
   affectedPaths: input.files.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]),
-  totalFiles: input.totalFiles,
+  totalFiles: input.current.totalChangedFiles,
   baselineSha: undefined,
   priorState: undefined,
   profileFingerprint: input.profileFingerprint
-});
+}, input.current);
 var validateReviewState = (state, current, profileFingerprint) => {
   if (state.repository !== current.repository || state.pullRequestNumber !== current.number) {
     return "stored state belongs to a different pull request";
@@ -42178,7 +42271,7 @@ var selectReviewRange = (input) => {
   const full = (reason) => fullSelection({
     reason,
     files: input.fullFiles,
-    totalFiles: input.current.totalChangedFiles,
+    current: input.current,
     profileFingerprint: input.profileFingerprint
   });
   if (input.requestedMode === "final")
@@ -42231,7 +42324,7 @@ var selectReviewRange = (input) => {
     }
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
-  return {
+  return sealReviewSelection({
     mode: "incremental",
     reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
     files: selectedFiles,
@@ -42240,7 +42333,7 @@ var selectReviewRange = (input) => {
     baselineSha: input.priorState.reviewedHeadSha,
     priorState: input.priorState,
     profileFingerprint: input.profileFingerprint
-  };
+  }, input.current);
 };
 var selectedPullRequestSourceLayer = (selection) => exports_Layer.effect(PullRequestSource)(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
@@ -42296,7 +42389,7 @@ class ReviewCoverage extends exports_Schema.Class("@effect-agent/pr-review/Revie
   requiredPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
   reviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
   unreviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  failedUnits: exports_Schema.Array(FailedReviewUnit).check(exports_Schema.isMaxLength(8)),
+  failedUnits: exports_Schema.Array(FailedReviewUnit).check(exports_Schema.isMaxLength(MAX_REVIEW_UNITS)),
   reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(20))
 }) {
 }
@@ -42381,9 +42474,32 @@ var fanOutCoverage = (files, totalFiles, trace3) => {
     if (exports_Option.isNone(request3))
       continue;
     const declarations = declarationsByUnit.get(request3.value.unitId) ?? [];
-    declarations.push({ id: toolCallId, paths: request3.value.paths });
+    declarations.push({
+      id: toolCallId,
+      paths: request3.value.paths,
+      sequence: declaration.sequence
+    });
     declarationsByUnit.set(request3.value.unitId, declarations);
   }
+  const plannedUnitIds = new Set(plan.units.map((unit) => unit.unitId));
+  const unknownUnitIds = [...declarationsByUnit.keys()].filter((unitId) => !plannedUnitIds.has(unitId));
+  const retryAttempts = plan.units.reduce((total, unit) => total + Math.max(0, (declarationsByUnit.get(unit.unitId)?.length ?? 0) - 1), 0);
+  const terminalSequence = (id2) => {
+    const success = trace3.succeeded.get(id2);
+    const failure = trace3.failed.get(id2);
+    if (success === undefined)
+      return failure?.sequence;
+    if (failure === undefined)
+      return success.sequence;
+    return Math.max(success.sequence, failure.sequence);
+  };
+  const initialUnitsSettledBefore = (retryDeclarationSequence) => plan.units.every((planned) => {
+    const initial = declarationsByUnit.get(planned.unitId)?.[0];
+    if (initial === undefined)
+      return false;
+    const terminal = terminalSequence(initial.id);
+    return terminal !== undefined && terminal < retryDeclarationSequence;
+  });
   const reviewed = new Set;
   const unreviewed = new Set([...plan.undiffablePaths, ...plan.unassignedPaths]);
   const failedUnits = [];
@@ -42399,18 +42515,28 @@ var fanOutCoverage = (files, totalFiles, trace3) => {
       const result4 = exports_Schema.decodeUnknownOption(FileReviewUnitResult)(event.result);
       return exports_Option.isSome(result4) && result4.value.unitId === unit.unitId;
     });
-    if (declarations.length === 1 && exact.length === 1 && successful.length === 1) {
+    const attemptFailed = (declaration) => {
+      if (trace3.failed.has(declaration.id))
+        return true;
+      const event = trace3.succeeded.get(declaration.id);
+      return event !== undefined && exports_Option.isSome(exports_Schema.decodeUnknownOption(FileReviewDelegationFailure)(event.result));
+    };
+    const initialSucceeded = declarations.length === 1 && exact.length === 1 && successful.length === 1;
+    const retry6 = exact[1];
+    const initialTerminal = exact[0] === undefined ? undefined : terminalSequence(exact[0].id);
+    const retryRecovered = declarations.length === 2 && exact.length === 2 && exact[0] !== undefined && retry6 !== undefined && attemptFailed(exact[0]) && successful.length === 1 && successful[0]?.id === retry6.id && initialTerminal !== undefined && initialTerminal < retry6.sequence && initialUnitsSettledBefore(retry6.sequence);
+    if (initialSucceeded || retryRecovered) {
       for (const path of unit.paths)
         reviewed.add(path);
       continue;
     }
     for (const path of unit.paths)
       unreviewed.add(path);
-    const failure = declarations.map((declaration) => trace3.failed.get(declaration.id)).find((event) => event !== undefined);
-    const returnedFailure = declarations.map((declaration) => trace3.succeeded.get(declaration.id)).filter((event) => event !== undefined).map((event) => exports_Schema.decodeUnknownOption(FileReviewDelegationFailure)(event.result)).find(exports_Option.isSome);
+    const failure = [...declarations].reverse().map((declaration) => trace3.failed.get(declaration.id)).find((event) => event !== undefined);
+    const returnedFailure = [...declarations].reverse().map((declaration) => trace3.succeeded.get(declaration.id)).filter((event) => event !== undefined).map((event) => exports_Schema.decodeUnknownOption(FileReviewDelegationFailure)(event.result)).find(exports_Option.isSome);
     failedUnits.push(FailedReviewUnit.make({
       unitId: unit.unitId,
-      errorTag: failure?.errorTag ?? (returnedFailure !== undefined ? returnedFailure.value._tag === "FileReviewUnitFailed" ? `${returnedFailure.value._tag}:${returnedFailure.value.childErrorTag}` : returnedFailure.value._tag : undefined) ?? (declarations.length === 0 ? "UnitNotAssigned" : declarations.length > 1 ? "UnitAssignedMultipleTimes" : exact.length === 0 ? "UnitAssignmentMismatch" : "UnitDidNotSettleSuccessfully")
+      errorTag: failure?.errorTag ?? (returnedFailure !== undefined ? returnedFailure.value._tag === "FileReviewUnitFailed" ? `${returnedFailure.value._tag}:${returnedFailure.value.childErrorTag}${returnedFailure.value.childPolicyLimit === undefined ? "" : `:${returnedFailure.value.childPolicyLimit}`}` : returnedFailure.value._tag : undefined) ?? (declarations.length === 0 ? "UnitNotAssigned" : declarations.length > 2 ? "UnitAssignedMultipleTimes" : exact.length !== declarations.length ? "UnitAssignmentMismatch" : declarations.length === 2 ? "UnitRetryDidNotSettleSuccessfully" : "UnitDidNotSettleSuccessfully")
     }));
   }
   if (plan.truncated) {
@@ -42421,6 +42547,12 @@ var fanOutCoverage = (files, totalFiles, trace3) => {
   }
   if (plan.unassignedPaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
+  }
+  if (unknownUnitIds.length > 0) {
+    reasons.push(boundedListReason("delegations targeted unknown review units", unknownUnitIds));
+  }
+  if (retryAttempts > MAX_FILE_REVIEW_RETRIES) {
+    reasons.push(`fan-out retry budget exceeded (${retryAttempts} of ${MAX_FILE_REVIEW_RETRIES} allowed)`);
   }
   if (failedUnits.length > 0) {
     reasons.push(boundedListReason("review units did not complete", failedUnits.map((unit) => `${unit.unitId} (${unit.errorTag})`)));
@@ -43444,9 +43576,9 @@ var reviewBudgetLimits = UsageBudgetLimits.make({
 var fanOutReviewBudgetLimits = UsageBudgetLimits.make({
   maxInputTokens: 400000,
   maxOutputTokens: 16000,
-  maxToolCalls: 24,
+  maxToolCalls: 1 + MAX_FILE_REVIEW_ATTEMPTS,
   maxCostMicrousd: 2000000,
-  maxDurationMillis: 900000
+  maxDurationMillis: FAN_OUT_MAX_DURATION_MINUTES * 60000
 });
 
 class ReviewRunOutcome extends exports_Schema.Class("@effect-agent/pr-review/ReviewRunOutcome")({
@@ -43464,6 +43596,51 @@ class ReviewRunOutcome extends exports_Schema.Class("@effect-agent/pr-review/Rev
   state: exports_Schema.optionalKey(ReviewState)
 }) {
 }
+
+class ReviewSelectionViolation extends exports_Schema.TaggedError()("ReviewSelectionViolation", { reason: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000)) }) {
+}
+var sameFiles = (left, right) => left.length === right.length && left.every((file2, index2) => exports_Equal.equals(file2, right[index2]));
+var sameSelectedFileIdentity = (left, right) => left.path === right.path && left.status === right.status && left.additions === right.additions && left.deletions === right.deletions && left.previousPath === right.previousPath && left.patch === right.patch;
+var sameSelectedFiles = (left, right) => left.length === right.length && left.every((file2, index2) => {
+  const candidate = right[index2];
+  return candidate !== undefined && sameSelectedFileIdentity(file2, candidate);
+});
+var validateSelection = (input) => {
+  const { selection, files, anchorFiles, metadata } = input;
+  const sealed = selectedReviewRangeFor(selection, metadata);
+  if (sealed === undefined) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "review selection was not created by the host range selector"
+    }));
+  }
+  if (!sameSelectedFiles(sealed.files, files)) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "review selection evidence does not match the model-visible source range"
+    }));
+  }
+  if (sealed.mode === "incremental" && sealed.totalFiles !== files.length) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "review selection total does not match the model-visible source range"
+    }));
+  }
+  const anchorPaths = new Set(anchorFiles.map((file2) => file2.path));
+  if (files.some((file2) => !anchorPaths.has(file2.path))) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "review selection contains a path outside the current pull-request source"
+    }));
+  }
+  if (sealed.mode === "full" && (sealed.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "full review selection does not cover the current pull-request source"
+    }));
+  }
+  if (sealed.mode === "incremental" && (sealed.priorState === undefined || sealed.baselineSha !== sealed.priorState.reviewedHeadSha || sealed.profileFingerprint !== sealed.priorState.profileFingerprint)) {
+    return exports_Effect.fail(ReviewSelectionViolation.make({
+      reason: "incremental review selection is not bound to its authenticated prior state"
+    }));
+  }
+  return exports_Effect.succeed(sealed);
+};
 var buildReviewMission = (metadata, files) => ReviewMission.make({
   repository: metadata.repository,
   number: metadata.number,
@@ -43503,7 +43680,7 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
   const metadata = yield* source.metadata;
   const files = yield* source.changedFiles;
   const anchorFiles = yield* source.anchorFiles;
-  const selection = options3.selection;
+  const selection = options3.selection === undefined ? undefined : yield* validateSelection({ selection: options3.selection, files, anchorFiles, metadata });
   const mission = buildReviewMission(metadata, files);
   const fullMission = buildReviewMission(metadata, anchorFiles);
   const fingerprint = options3.signature === undefined ? undefined : yield* computeChangesetFingerprint(anchorFiles, options3.signature(fullMission));
@@ -43648,6 +43825,7 @@ var requireReadonly = (tools) => {
   }
 };
 var provideIgnore = (effect2, ignore6) => ignore6 !== undefined && ignore6.length > 0 ? effect2.pipe(exports_Effect.provide(ignoringPullRequestSourceLayer(ignore6))) : effect2;
+var provideSelection = (effect2, selection) => selection === undefined ? effect2 : effect2.pipe(exports_Effect.provide(selectedPullRequestSourceLayer(sealedReviewSelection(selection) ?? selection)));
 var makeFingerprint = (signature, ignore6) => provideIgnore(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
   const metadata = yield* source.metadata;
@@ -43698,7 +43876,7 @@ var make58 = (options3) => {
     `applyVerdict=${String(options3.applyVerdict ?? false)}`,
     ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
   ].join("\x00");
-  const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
+  const run5 = (runOptions = {}) => provideSelection(provideIgnore(executeReview(binding, {
     post: runOptions.post ?? false,
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? reviewBudgetLimits,
@@ -43709,7 +43887,7 @@ var make58 = (options3) => {
     usageScope: "run",
     reviewShape: "flat",
     selection: runOptions.selection
-  }).pipe(exports_Effect.provide(exports_Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
+  }).pipe(exports_Effect.provide(exports_Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore), runOptions.selection);
   return {
     definition,
     binding,
@@ -43746,7 +43924,7 @@ var makeFanOut = (options3) => {
     ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
   ].join("\x00");
   const delegationLayer = fanOutHandlersLayerFor(suite.delegation)(childBinding).pipe(exports_Layer.provide(exports_Layer.mergeAll(FileReviewToolkitLayer, SubagentReservationsMemoryLive, IdGenerator.layer)));
-  const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
+  const run5 = (runOptions = {}) => provideSelection(provideIgnore(executeReview(binding, {
     post: runOptions.post ?? false,
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? fanOutReviewBudgetLimits,
@@ -43757,7 +43935,7 @@ var makeFanOut = (options3) => {
     usageScope: "coordinator",
     reviewShape: "fan-out",
     selection: runOptions.selection
-  }).pipe(exports_Effect.provide(exports_Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
+  }).pipe(exports_Effect.provide(exports_Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore), runOptions.selection);
   return {
     definition: suite.parent,
     binding,
@@ -54926,8 +55104,8 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
   const target = yield* resolveReviewTarget({});
   return yield* exports_Effect.gen(function* () {
     let selection;
-    const stateAuthenticator = yield* ReviewStateAuthenticator;
     if (reviewer.profileFingerprint !== undefined) {
+      const stateAuthenticator = yield* ReviewStateAuthenticator;
       const source = yield* PullRequestSource;
       const [snapshot2, profileFingerprint] = yield* exports_Effect.all([
         reviewer.snapshot ?? exports_Effect.all({ metadata: source.metadata, files: source.anchorFiles }),
@@ -55059,7 +55237,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       runUrl,
       modelLabel: options3.modelLabel
     }))) : runReview;
-    const outcome = yield* selection === undefined ? reviewEffect : reviewEffect.pipe(exports_Effect.provide(selectedPullRequestSourceLayer(selection)));
+    const outcome = yield* reviewEffect;
     yield* exports_Console.log(`Review finished in ${outcome.turns} turn(s): verdict ${outcome.review.verdict}, ` + `${outcome.plan.comments.length} inline comment(s), ${outcome.plan.demoted.length} demoted finding(s).`);
     if (outcome.published !== undefined) {
       yield* exports_Console.log(`Posted ${outcome.published.event} review: ${outcome.published.url}`);

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -42177,7 +42177,9 @@ class ReviewHeadComparison extends exports_Schema.Class("@effect-agent/pr-review
   truncated: exports_Schema.Boolean
 }) {
 }
-var selectedRanges = new WeakMap;
+
+class ReviewSelectionAuthority extends exports_Context.Service()("@effect-agent/pr-review/ReviewSelectionAuthority") {
+}
 var selectionFingerprint = (selection) => {
   try {
     return JSON.stringify({
@@ -42211,7 +42213,7 @@ var selectionSnapshot = (selection) => freeze({
   priorState: selection.priorState === undefined ? undefined : exports_Schema.decodeUnknownSync(ReviewState)(exports_Schema.encodeSync(ReviewState)(selection.priorState)),
   profileFingerprint: selection.profileFingerprint
 });
-var sealReviewSelection = (selection, source) => {
+var sealReviewSelection = (selectedRanges, selection, source) => {
   const snapshot2 = selectionSnapshot(selection);
   const fingerprint = selectionFingerprint(selection);
   if (fingerprint === undefined)
@@ -42231,18 +42233,15 @@ var sealReviewSelection = (selection, source) => {
   });
   return selection;
 };
-var sealedReviewSelection = (selection) => selectedRanges.get(selection)?.snapshot;
-var selectedReviewRangeFor = (selection, current) => {
-  const binding = selectedRanges.get(selection);
-  if (binding === undefined)
-    return;
-  const source = binding.source;
-  if (binding.fingerprint === selectionFingerprint(selection) && source.repository === current.repository && source.number === current.number && source.baseRef === current.baseRef && source.baseSha === current.baseSha && source.headRef === current.headRef && source.headSha === current.headSha && source.totalChangedFiles === current.totalChangedFiles) {
-    return binding.snapshot;
-  }
-  return;
-};
-var fullSelection = (input) => sealReviewSelection({
+var sealedReviewSelection = exports_Effect.fn("sealedReviewSelection")(function* (selection) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.snapshot(selection);
+});
+var selectedReviewRangeFor = exports_Effect.fn("selectedReviewRangeFor")(function* (selection, current) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.selectedFor(selection, current);
+});
+var fullSelection = (input) => ({
   mode: "full",
   reason: input.reason,
   files: input.files,
@@ -42251,7 +42250,7 @@ var fullSelection = (input) => sealReviewSelection({
   baselineSha: undefined,
   priorState: undefined,
   profileFingerprint: input.profileFingerprint
-}, input.current);
+});
 var validateReviewState = (state, current, profileFingerprint) => {
   if (state.repository !== current.repository || state.pullRequestNumber !== current.number) {
     return "stored state belongs to a different pull request";
@@ -42267,7 +42266,7 @@ var validateReviewState = (state, current, profileFingerprint) => {
   }
   return;
 };
-var selectReviewRange = (input) => {
+var selectReviewRangeValue = (input) => {
   const full = (reason) => fullSelection({
     reason,
     files: input.fullFiles,
@@ -42324,7 +42323,7 @@ var selectReviewRange = (input) => {
     }
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
-  return sealReviewSelection({
+  return {
     mode: "incremental",
     reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
     files: selectedFiles,
@@ -42333,8 +42332,26 @@ var selectReviewRange = (input) => {
     baselineSha: input.priorState.reviewedHeadSha,
     priorState: input.priorState,
     profileFingerprint: input.profileFingerprint
-  }, input.current);
+  };
 };
+var reviewSelectionAuthorityLayer = exports_Layer.fresh(exports_Layer.sync(ReviewSelectionAuthority, () => {
+  const selectedRanges = new WeakMap;
+  return ReviewSelectionAuthority.of({
+    select: (input) => exports_Effect.sync(() => sealReviewSelection(selectedRanges, selectReviewRangeValue(input), input.current)),
+    snapshot: (selection) => exports_Effect.sync(() => selectedRanges.get(selection)?.snapshot),
+    selectedFor: (selection, current) => exports_Effect.sync(() => {
+      const binding = selectedRanges.get(selection);
+      if (binding === undefined)
+        return;
+      const source = binding.source;
+      return binding.fingerprint === selectionFingerprint(selection) && source.repository === current.repository && source.number === current.number && source.baseRef === current.baseRef && source.baseSha === current.baseSha && source.headRef === current.headRef && source.headSha === current.headSha && source.totalChangedFiles === current.totalChangedFiles ? binding.snapshot : undefined;
+    })
+  });
+}));
+var selectReviewRange = exports_Effect.fn("selectReviewRange")(function* (input) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.select(input);
+});
 var selectedPullRequestSourceLayer = (selection) => exports_Layer.effect(PullRequestSource)(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
   const selectedPaths = new Set(selection.files.map((file2) => file2.path));
@@ -43605,42 +43622,42 @@ var sameSelectedFiles = (left, right) => left.length === right.length && left.ev
   const candidate = right[index2];
   return candidate !== undefined && sameSelectedFileIdentity(file2, candidate);
 });
-var validateSelection = (input) => {
+var validateSelection = exports_Effect.fn("validateSelection")(function* (input) {
   const { selection, files, anchorFiles, metadata } = input;
-  const sealed = selectedReviewRangeFor(selection, metadata);
-  if (sealed === undefined) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+  const verified = yield* selectedReviewRangeFor(selection, metadata);
+  if (verified === undefined) {
+    return yield* ReviewSelectionViolation.make({
       reason: "review selection was not created by the host range selector"
-    }));
+    });
   }
-  if (!sameSelectedFiles(sealed.files, files)) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+  if (!sameSelectedFiles(verified.files, files)) {
+    return yield* ReviewSelectionViolation.make({
       reason: "review selection evidence does not match the model-visible source range"
-    }));
+    });
   }
-  if (sealed.mode === "incremental" && sealed.totalFiles !== files.length) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+  if (verified.mode === "incremental" && verified.totalFiles !== files.length) {
+    return yield* ReviewSelectionViolation.make({
       reason: "review selection total does not match the model-visible source range"
-    }));
+    });
   }
   const anchorPaths = new Set(anchorFiles.map((file2) => file2.path));
   if (files.some((file2) => !anchorPaths.has(file2.path))) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+    return yield* ReviewSelectionViolation.make({
       reason: "review selection contains a path outside the current pull-request source"
-    }));
+    });
   }
-  if (sealed.mode === "full" && (sealed.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+  if (verified.mode === "full" && (verified.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))) {
+    return yield* ReviewSelectionViolation.make({
       reason: "full review selection does not cover the current pull-request source"
-    }));
+    });
   }
-  if (sealed.mode === "incremental" && (sealed.priorState === undefined || sealed.baselineSha !== sealed.priorState.reviewedHeadSha || sealed.profileFingerprint !== sealed.priorState.profileFingerprint)) {
-    return exports_Effect.fail(ReviewSelectionViolation.make({
+  if (verified.mode === "incremental" && (verified.priorState === undefined || verified.baselineSha !== verified.priorState.reviewedHeadSha || verified.profileFingerprint !== verified.priorState.profileFingerprint)) {
+    return yield* ReviewSelectionViolation.make({
       reason: "incremental review selection is not bound to its authenticated prior state"
-    }));
+    });
   }
-  return exports_Effect.succeed(sealed);
-};
+  return verified;
+});
 var buildReviewMission = (metadata, files) => ReviewMission.make({
   repository: metadata.repository,
   number: metadata.number,
@@ -43825,7 +43842,10 @@ var requireReadonly = (tools) => {
   }
 };
 var provideIgnore = (effect2, ignore6) => ignore6 !== undefined && ignore6.length > 0 ? effect2.pipe(exports_Effect.provide(ignoringPullRequestSourceLayer(ignore6))) : effect2;
-var provideSelection = (effect2, selection) => selection === undefined ? effect2 : effect2.pipe(exports_Effect.provide(selectedPullRequestSourceLayer(sealedReviewSelection(selection) ?? selection)));
+var provideSelection = (effect2, selection) => selection === undefined ? effect2 : exports_Effect.gen(function* () {
+  const sealed = yield* sealedReviewSelection(selection);
+  return yield* effect2.pipe(exports_Effect.provide(selectedPullRequestSourceLayer(sealed ?? selection)));
+});
 var makeFingerprint = (signature, ignore6) => provideIgnore(exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
   const metadata = yield* source.metadata;
@@ -55158,7 +55178,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           }
         }
       }
-      selection = selectReviewRange({
+      selection = yield* selectReviewRange({
         requestedMode: options3.reviewMode ?? "incremental",
         current: metadata,
         fullFiles,
@@ -55277,7 +55297,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       });
     }
     return { _tag: "Completed", outcome };
-  }).pipe(exports_Effect.provide(gitHubReviewLayers(target)));
+  }).pipe(exports_Effect.provide(exports_Layer.merge(gitHubReviewLayers(target), reviewSelectionAuthorityLayer)));
 });
 var reviewActionProgram = exports_Effect.gen(function* () {
   const inputs = yield* resolveActionInputs();

--- a/examples/pr-review/src/cli.ts
+++ b/examples/pr-review/src/cli.ts
@@ -2,6 +2,7 @@ import {
   gitHubReviewLayers,
   makeOpenAiReviewModel,
   openAiClientLayer,
+  reviewSelectionAuthorityLayer,
   resolveReviewTarget,
   ReviewPublicationPlan,
   unavailableReviewStateAuthenticatorLayer,
@@ -58,6 +59,7 @@ const command = CliCommand.make(
               gitHubReviewLayers(target),
               openAiClientLayer,
               ReadReviewConventionsLayer,
+              reviewSelectionAuthorityLayer,
               unavailableReviewStateAuthenticatorLayer(
                 "the example CLI has no configured review-state signing key",
               ),

--- a/examples/pr-review/test/example-reviewer.test.ts
+++ b/examples/pr-review/test/example-reviewer.test.ts
@@ -4,6 +4,7 @@ import {
   PullRequestMetadata,
   ReviewFinding,
   ReviewPublicationPlan,
+  reviewSelectionAuthorityLayer,
   unavailableReviewStateAuthenticatorLayer,
 } from "@effect-agent/pr-review";
 import {
@@ -113,6 +114,7 @@ describe("example reviewer", () => {
               collectingReviewPublisherLayer(published),
               ReadReviewConventionsLayer,
               NodeCrypto.layer,
+              reviewSelectionAuthorityLayer,
               unavailableReviewStateAuthenticatorLayer("offline example test"),
             ),
           ),

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -172,11 +172,18 @@ and with a bounded warning, so the next run safely performs a full review.
 `review-mode: final` is the explicit bounded merge-readiness audit. It reviews
 the full current PR diff and resets the incremental baseline; normal
 `synchronize` events use `incremental` and do not perform this audit.
-The packaged fan-out planner can assign up to 16 units of 12 files, with a
-1,200 changed-line soft budget per unit. Files beyond that finite capacity or
-children that fail their bounded policy remain explicitly unreviewed and make
-the review check incomplete; the workflow never converts partial coverage
-into an approval claim.
+The packaged fan-out planner can assign up to 20 units of 12 files, with a
+1,200 changed-line soft budget per unit. After all initial calls settle, the
+coordinator may retry up to five failed units once because their entire Tool
+surface is read-only. A unit that still fails, files beyond finite capacity,
+or any other coverage gap remains explicitly unreviewed and makes the review
+check incomplete; the workflow never converts partial coverage into an
+approval claim.
+
+The included repository workflow also selects fan-out for routine pull
+requests with more than 11 changed files. The flat reviewer's 24-Tool budget
+then remains an honest one-list plus two reads per file envelope instead of
+failing mid-review on a scope it cannot fully cover.
 
 ## Hosts
 

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -19,6 +19,8 @@ import {
   resolveReviewTarget,
   makeOpenAiReviewModel,
   openAiClientLayer,
+  reviewSelectionAuthorityLayer,
+  unavailableReviewStateAuthenticatorLayer,
 } from "@effect-agent/pr-review";
 
 const reviewer = PrReview.make({ model: makeOpenAiReviewModel() });
@@ -27,7 +29,16 @@ const program = Effect.gen(function* () {
   const target = yield* resolveReviewTarget({ repository: "acme/api", number: 123 });
   return yield* reviewer
     .run({ post: true })
-    .pipe(Effect.provide(Layer.merge(gitHubReviewLayers(target), openAiClientLayer)));
+    .pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          gitHubReviewLayers(target),
+          openAiClientLayer,
+          reviewSelectionAuthorityLayer,
+          unavailableReviewStateAuthenticatorLayer("incremental continuity is not configured"),
+        ),
+      ),
+    );
 });
 ```
 
@@ -168,6 +179,12 @@ WebCrypto import/sign/verify failures stay typed. The terminal marker is
 schema-branded and capped at 24,000 characters. If signing fails or state
 exceeds that bound, the completed review is posted without continuity state
 and with a bounded warning, so the next run safely performs a full review.
+
+Range selection is also explicit host authority. `reviewSelectionAuthorityLayer` is non-memoized,
+so each host composition receives a fresh issuer/verifier; the packaged Action installs one
+instance around authenticated state recovery, source decoration, and review execution. Selection
+validity is therefore scoped to that composition rather than process-wide mutable state, and a
+selection from another composition fails closed.
 
 `review-mode: final` is the explicit bounded merge-readiness audit. It reviews
 the full current PR diff and resets the incremental baseline; normal

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -25,7 +25,6 @@ import {
   type ReviewMode,
   type ReviewState,
   selectReviewRange,
-  selectedPullRequestSourceLayer,
   unavailableReviewStateAuthenticatorLayer,
   webCryptoReviewStateAuthenticatorLayer,
 } from "./internal/review-state.ts";
@@ -438,8 +437,11 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
     // the same cached pull-request snapshot.
     return yield* Effect.gen(function* () {
       let selection: ReturnType<typeof selectReviewRange> | undefined;
-      const stateAuthenticator = yield* ReviewStateAuthenticator;
       if (reviewer.profileFingerprint !== undefined) {
+        // Legacy/custom reviewers expose only the pre-state fingerprint seam.
+        // Do not acquire the packaged continuity authority unless this reviewer
+        // actually supports authenticated profile selection.
+        const stateAuthenticator = yield* ReviewStateAuthenticator;
         const source = yield* PullRequestSource;
         const [snapshot, profileFingerprint] = yield* Effect.all([
           reviewer.snapshot ?? Effect.all({ metadata: source.metadata, files: source.anchorFiles }),
@@ -606,9 +608,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
             ),
           )
         : runReview;
-      const outcome = yield* selection === undefined
-        ? reviewEffect
-        : reviewEffect.pipe(Effect.provide(selectedPullRequestSourceLayer(selection)));
+      const outcome = yield* reviewEffect;
       yield* Console.log(
         `Review finished in ${outcome.turns} turn(s): verdict ${outcome.review.verdict}, ` +
           `${outcome.plan.comments.length} inline comment(s), ${outcome.plan.demoted.length} demoted finding(s).`,

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -21,6 +21,8 @@ import {
 import { retireStaleReviews } from "./internal/retirement.ts";
 import {
   ReviewHeadComparison,
+  reviewSelectionAuthorityLayer,
+  type ReviewSelection,
   ReviewStateAuthenticator,
   type ReviewMode,
   type ReviewState,
@@ -436,7 +438,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
     // One layer build for state selection AND the run, so both observe
     // the same cached pull-request snapshot.
     return yield* Effect.gen(function* () {
-      let selection: ReturnType<typeof selectReviewRange> | undefined;
+      let selection: ReviewSelection | undefined;
       if (reviewer.profileFingerprint !== undefined) {
         // Legacy/custom reviewers expose only the pre-state fingerprint seam.
         // Do not acquire the packaged continuity authority unless this reviewer
@@ -504,7 +506,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
             }
           }
         }
-        selection = selectReviewRange({
+        selection = yield* selectReviewRange({
           requestedMode: options.reviewMode ?? "incremental",
           current: metadata,
           fullFiles,
@@ -658,7 +660,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
         });
       }
       return { _tag: "Completed", outcome } satisfies ReviewActionResult;
-    }).pipe(Effect.provide(gitHubReviewLayers(target)));
+    }).pipe(Effect.provide(Layer.merge(gitHubReviewLayers(target), reviewSelectionAuthorityLayer)));
   });
 
 /**

--- a/packages/pr-review/src/cli.ts
+++ b/packages/pr-review/src/cli.ts
@@ -19,7 +19,10 @@ import {
   type ReviewProvider,
 } from "./internal/providers.ts";
 import { ReviewPublicationPlan } from "./internal/render.ts";
-import { unavailableReviewStateAuthenticatorLayer } from "./internal/review-state.ts";
+import {
+  reviewSelectionAuthorityLayer,
+  unavailableReviewStateAuthenticatorLayer,
+} from "./internal/review-state.ts";
 import type { ReviewRunOutcome } from "./internal/run.ts";
 
 // ---------------------------------------------------------------------------
@@ -214,6 +217,7 @@ const program = CliCommand.run(command, { version: "0.0.0" }).pipe(
       NodeServices.layer,
       NodeCrypto.layer,
       FetchHttpClient.layer,
+      reviewSelectionAuthorityLayer,
       unavailableReviewStateAuthenticatorLayer(
         "the standalone CLI does not configure authenticated review continuity",
       ),

--- a/packages/pr-review/src/index.ts
+++ b/packages/pr-review/src/index.ts
@@ -17,11 +17,9 @@ export * from "./internal/providers.ts";
 export * from "./internal/render.ts";
 export * from "./internal/retirement.ts";
 export * from "./internal/review-agent.ts";
-// Continuity wire schemas and authenticator are public. Range selection is a
-// host-only authority: exposing its issuer would let an arbitrary consumer
-// mint a trusted narrowed scope before `PrReview.run` signs new continuity
-// state. The Action imports that internal selector after recovering the
-// authenticated GitHub state; generic consumers can only run a full source.
+// Continuity wire schemas and host capabilities are public. The packaged
+// Action installs one fresh selection authority around authenticated state
+// recovery, range selection, and the matching reviewer run.
 export {
   GitCommitSha,
   ReviewMode,
@@ -33,6 +31,8 @@ export {
   ReviewStateAuthenticationFailure,
   ReviewStateMarkerTooLarge,
   ReviewStateAuthenticator,
+  ReviewSelectionAuthority,
+  reviewSelectionAuthorityLayer,
   webCryptoReviewStateAuthenticatorLayer,
   unavailableReviewStateAuthenticatorLayer,
   ReviewHeadComparison,
@@ -44,6 +44,7 @@ export type {
   ReviewMode as ReviewModeType,
   ReviewScopeMode as ReviewScopeModeType,
   ReviewSelection,
+  SelectReviewRangeInput,
   ReviewStateMarker as ReviewStateMarkerType,
 } from "./internal/review-state.ts";
 export * from "./internal/review-units.ts";

--- a/packages/pr-review/src/index.ts
+++ b/packages/pr-review/src/index.ts
@@ -17,7 +17,35 @@ export * from "./internal/providers.ts";
 export * from "./internal/render.ts";
 export * from "./internal/retirement.ts";
 export * from "./internal/review-agent.ts";
-export * from "./internal/review-state.ts";
+// Continuity wire schemas and authenticator are public. Range selection is a
+// host-only authority: exposing its issuer would let an arbitrary consumer
+// mint a trusted narrowed scope before `PrReview.run` signs new continuity
+// state. The Action imports that internal selector after recovering the
+// authenticated GitHub state; generic consumers can only run a full source.
+export {
+  GitCommitSha,
+  ReviewMode,
+  ReviewScopeMode,
+  StoredReviewFinding,
+  StoredReviewConcern,
+  ReviewState,
+  ReviewStateMarker,
+  ReviewStateAuthenticationFailure,
+  ReviewStateMarkerTooLarge,
+  ReviewStateAuthenticator,
+  webCryptoReviewStateAuthenticatorLayer,
+  unavailableReviewStateAuthenticatorLayer,
+  ReviewHeadComparison,
+  computeProfileFingerprint,
+  validateReviewState,
+  buildProfileMission,
+} from "./internal/review-state.ts";
+export type {
+  ReviewMode as ReviewModeType,
+  ReviewScopeMode as ReviewScopeModeType,
+  ReviewSelection,
+  ReviewStateMarker as ReviewStateMarkerType,
+} from "./internal/review-state.ts";
 export * from "./internal/review-units.ts";
 export * from "./internal/run.ts";
 export * from "./internal/source.ts";

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -3,9 +3,14 @@ import type { RunEvent } from "effect-agent";
 
 import type { ChangedFile } from "./diff.ts";
 import { isReviewableFile } from "./diff.ts";
-import { FileReviewDelegationFailure, FileReviewRequest, FileReviewUnitResult } from "./fan-out.ts";
+import {
+  FileReviewDelegationFailure,
+  FileReviewRequest,
+  FileReviewUnitResult,
+  MAX_FILE_REVIEW_RETRIES,
+} from "./fan-out.ts";
 import { FileDiffQuery, type WalkthroughEntry } from "./review-agent.ts";
-import { planReviewUnits } from "./review-units.ts";
+import { MAX_REVIEW_UNITS, planReviewUnits } from "./review-units.ts";
 
 // ---------------------------------------------------------------------------
 // Host-owned coverage. Model summaries are untrusted prose; the check result
@@ -36,7 +41,7 @@ export class ReviewCoverage extends Schema.Class<ReviewCoverage>(
   unreviewedPaths: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(512))).check(
     Schema.isMaxLength(300),
   ),
-  failedUnits: Schema.Array(FailedReviewUnit).check(Schema.isMaxLength(8)),
+  failedUnits: Schema.Array(FailedReviewUnit).check(Schema.isMaxLength(MAX_REVIEW_UNITS)),
   reasons: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(1_000))).check(
     Schema.isMaxLength(20),
   ),
@@ -133,16 +138,42 @@ const fanOutCoverage = (
   const plan = planReviewUnits(files, { totalChangedFiles: totalFiles });
   const declarationsByUnit = new Map<
     string,
-    Array<{ readonly id: string; readonly paths: ReadonlyArray<string> }>
+    Array<{ readonly id: string; readonly paths: ReadonlyArray<string>; readonly sequence: number }>
   >();
   for (const [toolCallId, declaration] of trace.declared) {
     if (declaration.toolName !== "delegate_file_review") continue;
     const request = Schema.decodeUnknownOption(FileReviewRequest)(declaration.parameters);
     if (Option.isNone(request)) continue;
     const declarations = declarationsByUnit.get(request.value.unitId) ?? [];
-    declarations.push({ id: toolCallId, paths: request.value.paths });
+    declarations.push({
+      id: toolCallId,
+      paths: request.value.paths,
+      sequence: declaration.sequence,
+    });
     declarationsByUnit.set(request.value.unitId, declarations);
   }
+  const plannedUnitIds = new Set(plan.units.map((unit) => unit.unitId));
+  const unknownUnitIds = [...declarationsByUnit.keys()].filter(
+    (unitId) => !plannedUnitIds.has(unitId),
+  );
+  const retryAttempts = plan.units.reduce(
+    (total, unit) => total + Math.max(0, (declarationsByUnit.get(unit.unitId)?.length ?? 0) - 1),
+    0,
+  );
+  const terminalSequence = (id: string): number | undefined => {
+    const success = trace.succeeded.get(id);
+    const failure = trace.failed.get(id);
+    if (success === undefined) return failure?.sequence;
+    if (failure === undefined) return success.sequence;
+    return Math.max(success.sequence, failure.sequence);
+  };
+  const initialUnitsSettledBefore = (retryDeclarationSequence: number): boolean =>
+    plan.units.every((planned) => {
+      const initial = declarationsByUnit.get(planned.unitId)?.[0];
+      if (initial === undefined) return false;
+      const terminal = terminalSequence(initial.id);
+      return terminal !== undefined && terminal < retryDeclarationSequence;
+    });
 
   const reviewed = new Set<string>();
   const unreviewed = new Set<string>([...plan.undiffablePaths, ...plan.unassignedPaths]);
@@ -162,15 +193,40 @@ const fanOutCoverage = (
       const result = Schema.decodeUnknownOption(FileReviewUnitResult)(event.result);
       return Option.isSome(result) && result.value.unitId === unit.unitId;
     });
-    if (declarations.length === 1 && exact.length === 1 && successful.length === 1) {
+    const attemptFailed = (declaration: { readonly id: string }): boolean => {
+      if (trace.failed.has(declaration.id)) return true;
+      const event = trace.succeeded.get(declaration.id);
+      return (
+        event !== undefined &&
+        Option.isSome(Schema.decodeUnknownOption(FileReviewDelegationFailure)(event.result))
+      );
+    };
+    const initialSucceeded =
+      declarations.length === 1 && exact.length === 1 && successful.length === 1;
+    const retry = exact[1];
+    const initialTerminal = exact[0] === undefined ? undefined : terminalSequence(exact[0].id);
+    const retryRecovered =
+      declarations.length === 2 &&
+      exact.length === 2 &&
+      exact[0] !== undefined &&
+      retry !== undefined &&
+      attemptFailed(exact[0]) &&
+      successful.length === 1 &&
+      successful[0]?.id === retry.id &&
+      initialTerminal !== undefined &&
+      initialTerminal < retry.sequence &&
+      initialUnitsSettledBefore(retry.sequence);
+    if (initialSucceeded || retryRecovered) {
       for (const path of unit.paths) reviewed.add(path);
       continue;
     }
     for (const path of unit.paths) unreviewed.add(path);
-    const failure = declarations
+    const failure = [...declarations]
+      .reverse()
       .map((declaration) => trace.failed.get(declaration.id))
       .find((event) => event !== undefined);
-    const returnedFailure = declarations
+    const returnedFailure = [...declarations]
+      .reverse()
       .map((declaration) => trace.succeeded.get(declaration.id))
       .filter((event) => event !== undefined)
       .map((event) => Schema.decodeUnknownOption(FileReviewDelegationFailure)(event.result))
@@ -182,16 +238,22 @@ const fanOutCoverage = (
           failure?.errorTag ??
           (returnedFailure !== undefined
             ? returnedFailure.value._tag === "FileReviewUnitFailed"
-              ? `${returnedFailure.value._tag}:${returnedFailure.value.childErrorTag}`
+              ? `${returnedFailure.value._tag}:${returnedFailure.value.childErrorTag}${
+                  returnedFailure.value.childPolicyLimit === undefined
+                    ? ""
+                    : `:${returnedFailure.value.childPolicyLimit}`
+                }`
               : returnedFailure.value._tag
             : undefined) ??
           (declarations.length === 0
             ? "UnitNotAssigned"
-            : declarations.length > 1
+            : declarations.length > 2
               ? "UnitAssignedMultipleTimes"
-              : exact.length === 0
+              : exact.length !== declarations.length
                 ? "UnitAssignmentMismatch"
-                : "UnitDidNotSettleSuccessfully"),
+                : declarations.length === 2
+                  ? "UnitRetryDidNotSettleSuccessfully"
+                  : "UnitDidNotSettleSuccessfully"),
       }),
     );
   }
@@ -208,6 +270,14 @@ const fanOutCoverage = (
   }
   if (plan.unassignedPaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
+  }
+  if (unknownUnitIds.length > 0) {
+    reasons.push(boundedListReason("delegations targeted unknown review units", unknownUnitIds));
+  }
+  if (retryAttempts > MAX_FILE_REVIEW_RETRIES) {
+    reasons.push(
+      `fan-out retry budget exceeded (${retryAttempts} of ${MAX_FILE_REVIEW_RETRIES} allowed)`,
+    );
   }
   if (failedUnits.length > 0) {
     reasons.push(

--- a/packages/pr-review/src/internal/factory.ts
+++ b/packages/pr-review/src/internal/factory.ts
@@ -140,11 +140,12 @@ const provideSelection = <A, E, R>(
 ) =>
   selection === undefined
     ? effect
-    : effect.pipe(
-        Effect.provide(
-          selectedPullRequestSourceLayer(sealedReviewSelection(selection) ?? selection),
-        ),
-      );
+    : Effect.gen(function* () {
+        const sealed = yield* sealedReviewSelection(selection);
+        return yield* effect.pipe(
+          Effect.provide(selectedPullRequestSourceLayer(sealed ?? selection)),
+        );
+      });
 
 /**
  * The changeset fingerprint of what this reviewer WOULD review right now:

--- a/packages/pr-review/src/internal/factory.ts
+++ b/packages/pr-review/src/internal/factory.ts
@@ -34,6 +34,8 @@ import {
 import {
   buildProfileMission,
   computeProfileFingerprint,
+  sealedReviewSelection,
+  selectedPullRequestSourceLayer,
   type ReviewSelection,
 } from "./review-state.ts";
 import {
@@ -130,6 +132,19 @@ const provideIgnore = <A, E, R>(
   ignore !== undefined && ignore.length > 0
     ? effect.pipe(Effect.provide(ignoringPullRequestSourceLayer(ignore)))
     : effect;
+
+/** Keep the model's source surface identical to the continuity selection. */
+const provideSelection = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  selection: ReviewSelection | undefined,
+) =>
+  selection === undefined
+    ? effect
+    : effect.pipe(
+        Effect.provide(
+          selectedPullRequestSourceLayer(sealedReviewSelection(selection) ?? selection),
+        ),
+      );
 
 /**
  * The changeset fingerprint of what this reviewer WOULD review right now:
@@ -240,20 +255,26 @@ const make = <
     ].join("\u0000");
 
   const run = (runOptions: RunReviewOptions = {}) =>
-    provideIgnore(
-      executeReview(binding, {
-        post: runOptions.post ?? false,
-        applyVerdict: options.applyVerdict ?? false,
-        limits: options.budget ?? reviewBudgetLimits,
-        maxFindings: clampMaxFindings(options.maxFindings),
-        signature,
-        modelLabel: options.modelLabel,
-        runUrl: runOptions.runUrl,
-        usageScope: "run",
-        reviewShape: "flat",
-        selection: runOptions.selection,
-      }).pipe(Effect.provide(Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), Effect.scoped),
-      options.ignore,
+    provideSelection(
+      provideIgnore(
+        executeReview(binding, {
+          post: runOptions.post ?? false,
+          applyVerdict: options.applyVerdict ?? false,
+          limits: options.budget ?? reviewBudgetLimits,
+          maxFindings: clampMaxFindings(options.maxFindings),
+          signature,
+          modelLabel: options.modelLabel,
+          runUrl: runOptions.runUrl,
+          usageScope: "run",
+          reviewShape: "flat",
+          selection: runOptions.selection,
+        }).pipe(
+          Effect.provide(Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)),
+          Effect.scoped,
+        ),
+        options.ignore,
+      ),
+      runOptions.selection,
     );
 
   return {
@@ -337,25 +358,28 @@ const makeFanOut = <Provider, ModelProvides, ModelRequires>(
   );
 
   const run = (runOptions: RunReviewOptions = {}) =>
-    provideIgnore(
-      executeReview(binding, {
-        post: runOptions.post ?? false,
-        applyVerdict: options.applyVerdict ?? false,
-        limits: options.budget ?? fanOutReviewBudgetLimits,
-        maxFindings: clampMaxFindings(options.maxFindings),
-        signature,
-        modelLabel: options.modelLabel,
-        runUrl: runOptions.runUrl,
-        usageScope: "coordinator",
-        reviewShape: "fan-out",
-        selection: runOptions.selection,
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer),
+    provideSelection(
+      provideIgnore(
+        executeReview(binding, {
+          post: runOptions.post ?? false,
+          applyVerdict: options.applyVerdict ?? false,
+          limits: options.budget ?? fanOutReviewBudgetLimits,
+          maxFindings: clampMaxFindings(options.maxFindings),
+          signature,
+          modelLabel: options.modelLabel,
+          runUrl: runOptions.runUrl,
+          usageScope: "coordinator",
+          reviewShape: "fan-out",
+          selection: runOptions.selection,
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer),
+          ),
+          Effect.scoped,
         ),
-        Effect.scoped,
+        options.ignore,
       ),
-      options.ignore,
+      runOptions.selection,
     );
 
   return {

--- a/packages/pr-review/src/internal/fan-out-scripted.ts
+++ b/packages/pr-review/src/internal/fan-out-scripted.ts
@@ -18,6 +18,9 @@ export const OFFLINE_UNITS_CALL_ID = "units-1";
 /** The delegation Tool Call id the scripted coordinator uses for one unit. */
 export const offlineUnitCallId = (unitId: string): string => `delegate-${unitId}`;
 
+/** The retry Tool Call id the scripted coordinator uses for one failed unit. */
+export const offlineUnitRetryCallId = (unitId: string): string => `delegate-retry-${unitId}`;
+
 /** The diff Tool Call id the scripted child uses for one unit. */
 export const offlineChildDiffCallId = (unitId: string): string => `fanout-diff-${unitId}`;
 
@@ -35,11 +38,31 @@ export interface OfflineUnitCall {
  */
 export const makeOfflineFanOutCoordinatorModel = (script: {
   readonly unitCalls: ReadonlyArray<OfflineUnitCall>;
+  readonly retryUnitCalls?: ReadonlyArray<OfflineUnitCall> | undefined;
   readonly review: CodeReview;
 }) => {
   const firstUnitCallId = offlineUnitCallId(script.unitCalls[0]?.unitId ?? "unit-none");
+  const firstRetryCallId = offlineUnitRetryCallId(
+    script.retryUnitCalls?.[0]?.unitId ?? "unit-none",
+  );
   return makePromptKeyedModel("pr-fanout-coordinator-offline", (promptJson) => {
+    if ((script.retryUnitCalls?.length ?? 0) > 0 && promptJson.includes(firstRetryCallId)) {
+      return scriptedFinalParts(JSON.stringify(Schema.encodeSync(CodeReview)(script.review)));
+    }
     if (promptJson.includes(firstUnitCallId)) {
+      if ((script.retryUnitCalls?.length ?? 0) > 0) {
+        return scriptedToolTurn(
+          ...(script.retryUnitCalls ?? []).map(
+            (unit): Response.StreamPartEncoded => ({
+              type: "tool-call",
+              id: offlineUnitRetryCallId(unit.unitId),
+              name: "delegate_file_review",
+              params: { unitId: unit.unitId, paths: unit.paths },
+              providerExecuted: false,
+            }),
+          ),
+        );
+      }
       return scriptedFinalParts(JSON.stringify(Schema.encodeSync(CodeReview)(script.review)));
     }
     if (promptJson.includes(OFFLINE_UNITS_CALL_ID)) {
@@ -71,6 +94,8 @@ export type OfflineUnitOutcome =
   | { readonly _tag: "findings"; readonly report: FileReviewReport }
   /** Read one diff, then return non-JSON — the child fails typed (AgentOutputError). */
   | { readonly _tag: "malformed-output" }
+  /** First child fails output decoding; one explicit retry returns the report. */
+  | { readonly _tag: "malformed-once-then-findings"; readonly report: FileReviewReport }
   /**
    * Declare more Tool Calls than the child's AgentPolicy allows in one turn —
    * none executes and the child fails typed (AgentPolicyError "tool-calls",
@@ -98,7 +123,11 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
   Effect.gen(function* () {
     const calls = yield* Ref.make(0);
     const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
-    const decide = (promptJson: string): ReadonlyArray<Response.StreamPartEncoded> | undefined => {
+    const completedAttempts = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
+    const decide = (
+      promptJson: string,
+      completedAttempt: number | undefined,
+    ): ReadonlyArray<Response.StreamPartEncoded> | undefined => {
       const script = scripts.find((candidate) => promptJson.includes(candidate.unitId));
       if (script === undefined) return undefined;
       switch (script.outcome._tag) {
@@ -133,6 +162,22 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
             providerExecuted: false,
           });
         }
+        case "malformed-once-then-findings": {
+          if (promptJson.includes(offlineChildDiffCallId(script.unitId))) {
+            return scriptedFinalParts(
+              completedAttempt === 0
+                ? "this is not the JSON you are looking for"
+                : JSON.stringify(Schema.encodeSync(FileReviewReport)(script.outcome.report)),
+            );
+          }
+          return scriptedToolTurn({
+            type: "tool-call",
+            id: offlineChildDiffCallId(script.unitId),
+            name: "read_file_diff",
+            params: { path: script.diffPath },
+            providerExecuted: false,
+          });
+        }
       }
     };
     const model = Model.make(
@@ -148,7 +193,18 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
                 yield* Ref.update(calls, (value) => value + 1);
                 const promptJson = JSON.stringify(request.prompt);
                 yield* Ref.update(prompts, (previous) => [...previous, promptJson]);
-                const parts = decide(promptJson);
+                const script = scripts.find((candidate) => promptJson.includes(candidate.unitId));
+                const completedAttempt =
+                  script?.outcome._tag === "malformed-once-then-findings" &&
+                  promptJson.includes(offlineChildDiffCallId(script.unitId))
+                    ? yield* Ref.modify(completedAttempts, (attempts) => {
+                        const current = attempts.get(script.unitId) ?? 0;
+                        const next = new Map(attempts);
+                        next.set(script.unitId, current + 1);
+                        return [current, next] as const;
+                      })
+                    : undefined;
+                const parts = decide(promptJson, completedAttempt);
                 if (parts === undefined) {
                   return yield* Effect.die(
                     new Error("The child prompt names no scripted review unit"),

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect";
 import {
   Agent,
   AgentPolicy,
+  PolicyLimit,
   Subagent,
   SubagentPolicy,
   SubagentRuntime,
@@ -42,10 +43,11 @@ import { PullRequestSource, PullRequestSourceFailure } from "./source.ts";
 // the diff reading happens in bounded delegated children (S1 attached
 // ephemeral delegation) so no single context window has to hold every diff.
 // A coordinator lists the changeset as deterministic review units, delegates
-// one `delegate_file_review` call per unit, then merges the children's
-// bounded findings into one `CodeReview`. Publication and anchor validation
-// are unchanged: child output is untrusted input like everything else and
-// crosses to the host only through the same fail-closed planPublication path.
+// one initial `delegate_file_review` call per unit, optionally retries one
+// bounded wave of failed read-only units, then merges the children's bounded
+// findings into one `CodeReview`. Publication and anchor validation are
+// unchanged: child output is untrusted input like everything else and crosses
+// to the host only through the same fail-closed planPublication path.
 // ---------------------------------------------------------------------------
 
 /** One child returns at most this many findings; the merge caps the total. */
@@ -55,10 +57,58 @@ export const MAX_CHILD_FINDINGS = 8;
 export const MAX_CHILD_CONCERNS = 3;
 
 /**
- * One mandatory diff read plus one bounded context read for every path in a
- * maximum-size unit. Keep the child and delegation reservation aligned.
+ * One mandatory diff read plus at most three bounded context reads for every
+ * path in a maximum-size unit. The reviewer can need distinct focused reads
+ * for the producer and consumer sides of a changed contract; keep the child
+ * and delegation reservation aligned rather than making that ordinary work
+ * look like a policy failure.
  */
-export const MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 2;
+export const MAX_FILE_REVIEW_TOOL_CALLS = MAX_UNIT_FILES * 4;
+
+/**
+ * A child may serialize every permitted read across model turns, then needs
+ * one final turn to return its structured report. Keep this independent bound
+ * aligned with the full read budget: a valid maximum-size review must not
+ * fail merely because the provider did not batch calls.
+ */
+export const MAX_FILE_REVIEW_TURNS = MAX_FILE_REVIEW_TOOL_CALLS + 1;
+
+/**
+ * Each maximum-size unit may read 12 annotated diffs and then inspect up to
+ * three bounded contexts per file. The live 172-file audit demonstrated that
+ * 200k cumulative tokens is below that ordinary, permitted read envelope.
+ * 600k remains finite while leaving the 150k live-context cap as the prompt
+ * safety boundary.
+ */
+export const FILE_REVIEW_TOKEN_BUDGET = 600_000;
+
+/** Parent-side concurrent child permits. */
+export const FILE_REVIEW_MAX_CONCURRENCY = 5;
+
+/** One bounded retry wave for failed read-only review units. */
+export const MAX_FILE_REVIEW_RETRIES = FILE_REVIEW_MAX_CONCURRENCY;
+
+/** Initial unit attempts plus the single bounded retry wave. */
+export const MAX_FILE_REVIEW_ATTEMPTS = MAX_REVIEW_UNITS + MAX_FILE_REVIEW_RETRIES;
+
+/** Maximum wall-clock allowance for one attached file-review child. */
+export const FILE_REVIEW_MAX_DURATION_MINUTES = 8;
+
+/**
+ * A maximum-size audit schedules every initial unit plus one bounded retry
+ * wave. The coordinator must remain alive for all waves, then have time to
+ * merge the reports into its terminal review.
+ */
+export const MAX_FILE_REVIEW_WAVES = Math.ceil(
+  MAX_FILE_REVIEW_ATTEMPTS / FILE_REVIEW_MAX_CONCURRENCY,
+);
+export const FILE_REVIEW_WAVE_DURATION_MINUTES =
+  MAX_FILE_REVIEW_WAVES * FILE_REVIEW_MAX_DURATION_MINUTES;
+export const FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES = 10;
+export const FAN_OUT_MAX_DURATION_MINUTES =
+  FILE_REVIEW_WAVE_DURATION_MINUTES + FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES;
+/** GitHub Actions job timeout, including a bounded runner-cleanup allowance. */
+export const FAN_OUT_WORKFLOW_TIMEOUT_MINUTES = FAN_OUT_MAX_DURATION_MINUTES + 5;
 
 // ---------------------------------------------------------------------------
 // The child: a file reviewer over one unit. Its toolkit is intentionally
@@ -130,7 +180,7 @@ export const makeFileReviewerInstructions =
       ...staticGuidanceLines(options.guidance),
       "Work in this order:",
       "1. Call read_file_diff for every file in your unit. A normal diff marks new-version anchors as R<number>; only those numbers are valid startLine/endLine values. When GitHub omitted a diff, the tool may return bounded base/head content marked B/H instead. Review that content, but report its defects as non-anchored concerns because B/H lines cannot anchor GitHub comments. Never anchor a finding to a removed (-), B, or H line.",
-      "2. Call read_file when you need surrounding context the diff does not show. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
+      "2. Call read_file when you need surrounding context the diff does not show, at most three times per file. ONLY files in the changeset are readable: a request for any other path (an import, a neighbor, a config) returns a failed result — do not retry it; reason from the diff instead and note the gap in your report when it matters.",
       "3. Review for real defects first: correctness, security, concurrency, resource leaks, error handling, API misuse. Style nits are least important. Do not praise; do not restate the diff.",
       "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
       "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
@@ -143,15 +193,15 @@ export const fileReviewerInstructions = makeFileReviewerInstructions();
 
 /** The default per-unit child execution bounds. */
 export const defaultFileReviewerPolicy = AgentPolicy.make({
-  maxTurns: 12,
+  maxTurns: MAX_FILE_REVIEW_TURNS,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "10 minutes",
+  maxDuration: `${FILE_REVIEW_MAX_DURATION_MINUTES} minutes`,
   toolConcurrency: 2,
   // Same rationale as the flat reviewer's bound: read refusals are
   // model-visible results, and one parallel batch of out-of-unit probes must
   // not kill the child before it has seen a single refusal.
   repeatedFailureLimit: 12,
-  tokenBudget: 200_000,
+  tokenBudget: FILE_REVIEW_TOKEN_BUDGET,
   // Bound one live prompt independently from cumulative usage. The engine
   // prunes old diff/file results before paying for a summary.
   contextTokenLimit: 150_000,
@@ -200,12 +250,15 @@ export class FileReviewUnitResult extends Schema.Class<FileReviewUnitResult>(
 /**
  * One unit's review failed: the child Run ended in a typed failure (policy
  * bound, output violation, model fault). The marker is bounded and carries no
- * child transcript content beyond the failure tag and message.
+ * child transcript content beyond the failure tag, its finite policy dimension
+ * when applicable, and a bounded message.
  */
 export class FileReviewUnitFailed extends Schema.TaggedError<FileReviewUnitFailed>()(
   "FileReviewUnitFailed",
   {
     childErrorTag: Schema.NonEmptyString.check(Schema.isMaxLength(256)),
+    /** A finite, non-sensitive exhaustion dimension when the child hit policy. */
+    childPolicyLimit: Schema.optionalKey(PolicyLimit),
     message: Schema.String.check(Schema.isMaxLength(400)),
   },
 ) {}
@@ -216,26 +269,30 @@ export class FileReviewUnitFailed extends Schema.TaggedError<FileReviewUnitFaile
  * reservation mirrors it so parent-side accounting stays honest.
  */
 export const fileReviewPolicy = SubagentPolicy.make({
-  maxChildren: MAX_REVIEW_UNITS,
-  maxConcurrency: 4,
-  maxTurns: 12,
+  maxChildren: MAX_FILE_REVIEW_ATTEMPTS,
+  maxConcurrency: FILE_REVIEW_MAX_CONCURRENCY,
+  maxTurns: MAX_FILE_REVIEW_TURNS,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "10 minutes",
+  maxDuration: `${FILE_REVIEW_MAX_DURATION_MINUTES} minutes`,
 });
 
-const delegationDescription =
-  "Delegate the review of one planned unit to a bounded file-reviewer child and return its line-anchored findings. Call it exactly once per unit from list_review_units; never retry a failed unit.";
+const delegationDescription = `Delegate one planned unit to a bounded read-only file reviewer. Call every unit once; after those settle, at most ${MAX_FILE_REVIEW_RETRIES} failed units may each be retried once with the exact same paths.`;
 
 /**
  * Total mapping from every expected child Run failure to the declared unit
- * failure (SUB-028): the tag plus a bounded message, nothing else crosses.
+ * failure (SUB-028): the tag plus a bounded message cross. Policy exhaustion
+ * additionally retains only its finite dimension, never child trace data.
  */
 export const mapFileReviewChildFailure = (failure: {
   readonly _tag: string;
+  readonly limit?: PolicyLimit;
   readonly message?: string;
 }): FileReviewUnitFailed =>
   FileReviewUnitFailed.make({
     childErrorTag: failure._tag,
+    ...(failure._tag === "AgentPolicyError" && failure.limit !== undefined
+      ? { childPolicyLimit: failure.limit }
+      : {}),
     message: (failure.message ?? "").slice(0, 400),
   });
 
@@ -299,12 +356,13 @@ export const makeFanOutReviewInstructions =
       ...staticGuidanceLines(options.guidance),
       "Work in this order:",
       "1. Call list_review_units once to get the planned review units.",
-      "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all delegation calls in one batch. Never review files yourself and never invent units.",
-      '3. A delegation result with "_tag" is a FAILED unit. Never retry it; instead your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan\'s undiffablePaths and unassignedPaths must also be named as not reviewed when present.',
-      `4. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
-      `5. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
-      "6. Merge the units' fileSummaries into one walkthrough: copy each entry verbatim, one entry per file, dropping duplicate paths.",
-      '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "category": <string, OPTIONAL>, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>, "walkthrough": <array, OPTIONAL: [{"path": <string>, "summary": <string>}], the merged fileSummaries>}. Copy findings (including "category" and "suggestion" when present), concerns, and walkthrough entries verbatim from the delegation results; never invent or edit anchors.',
+      "2. Call delegate_file_review EXACTLY once per unit, passing each unit's unitId and paths verbatim. Prefer declaring all initial delegation calls in one batch. Never review files yourself and never invent units.",
+      `3. After every initial call settles, you MUST retry the first ${MAX_FILE_REVIEW_RETRIES} FAILED units once, in unit order, with the exact same unitId and paths (or every failed unit when fewer than ${MAX_FILE_REVIEW_RETRIES} failed). Retrying is allowed only because this child surface is read-only. Never retry a successful unit or retry any unit more than once.`,
+      '4. A unit whose retry also returns an "_tag", or which was not eligible for the bounded retry wave, remains FAILED. Your summary MUST name it honestly, e.g. "unit-002 unreviewed: AgentPolicyError". The plan\'s undiffablePaths and unassignedPaths must also be named as not reviewed when present.',
+      `5. Merge the successful units' findings: drop duplicates sharing the same path and line range keeping the most severe, rank blocking > important > nit, and keep at most ${maxFindings} findings. Drop bloat-shaped findings during the merge — defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies; children bias toward recommending changes, and a finding must be sound, correct, and worth acting on to survive.`,
+      `6. Merge the units' concerns the same way: drop duplicates keeping the most severe, and keep at most ${MAX_CONCERNS}.`,
+      "7. Merge the units' fileSummaries into one walkthrough: copy each entry verbatim, one entry per file, dropping duplicate paths.",
+      '8. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment, including every unreviewed unit or file>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string>, "startLine": <integer>, "endLine": <integer>, "severity": <"blocking" | "important" | "nit">, "category": <string, OPTIONAL>, "title": <string, <= 120 chars>, "body": <string>, "suggestion": <string, OPTIONAL>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], the merged unit concerns>, "walkthrough": <array, OPTIONAL: [{"path": <string>, "summary": <string>}], the merged fileSummaries>}. Copy findings (including "category" and "suggestion" when present), concerns, and walkthrough entries verbatim from the delegation results; never invent or edit anchors.',
       'Use verdict "request-changes" only when at least one finding or concern is "blocking". An empty findings array with verdict "approve" is a valid review when every unit succeeded and found nothing.',
     ].join("\n");
   };
@@ -314,9 +372,11 @@ export const fanOutReviewInstructions = makeFanOutReviewInstructions();
 /** The default fan-out coordinator execution bounds. */
 export const defaultFanOutPolicy = AgentPolicy.make({
   maxTurns: 6,
-  maxToolCalls: 1 + MAX_REVIEW_UNITS,
-  maxDuration: "20 minutes",
-  toolConcurrency: 4,
+  maxToolCalls: 1 + MAX_FILE_REVIEW_ATTEMPTS,
+  // 20 initial units plus one five-unit retry wave, followed by the
+  // coordinator's bounded merge and final response window.
+  maxDuration: `${FAN_OUT_MAX_DURATION_MINUTES} minutes`,
+  toolConcurrency: FILE_REVIEW_MAX_CONCURRENCY,
   // Contained unit failures (SUB-033) are ordinary successful Tool results,
   // so they no longer fold into the repeated-failure counter; the default
   // bound suffices.

--- a/packages/pr-review/src/internal/profiles.ts
+++ b/packages/pr-review/src/internal/profiles.ts
@@ -48,8 +48,8 @@ export class FanOutReviewerProfile extends Schema.Class<FanOutReviewerProfile>(
   anchorsValidatedBeforePublication: Schema.Literal(true),
   /** S1 attached ephemeral delegation at depth 1; nested delegation is rejected. */
   attachedEphemeralDelegation: Schema.Literal(true),
-  /** A failed unit surfaces to the coordinator as a typed failed result, never retried. */
-  failedUnitsReportedNotRetried: Schema.Literal(true),
+  /** Failed read-only units may be retried once within one bounded retry wave. */
+  boundedReadOnlyUnitRetry: Schema.Literal(true),
   /** The live profile is env-gated out of every ordinary test gate. */
   liveProfileOptIn: Schema.Literal(true),
   /** Never claimed at any phase (DUR-003). */
@@ -62,7 +62,7 @@ export const fanOutReviewerProfile = FanOutReviewerProfile.make({
   publicationOutsideAgentLoop: true,
   anchorsValidatedBeforePublication: true,
   attachedEphemeralDelegation: true,
-  failedUnitsReportedNotRetried: true,
+  boundedReadOnlyUnitRetry: true,
   liveProfileOptIn: true,
   exactlyOnceExternalEffects: false,
 });

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -282,23 +282,145 @@ export interface ReviewSelection {
   readonly profileFingerprint: string;
 }
 
+/**
+ * A selection is an internal capability, not caller-supplied accounting data.
+ * The range selector records the object it produced so a structural lookalike
+ * cannot shrink a current full review and mint continuity state for it.
+ */
+interface SelectionSource {
+  readonly repository: string;
+  readonly number: number;
+  readonly baseRef: string;
+  readonly baseSha?: string | undefined;
+  readonly headRef: string;
+  readonly headSha: string;
+  readonly totalChangedFiles: number;
+}
+
+interface SelectionBinding {
+  readonly source: SelectionSource;
+  readonly fingerprint: string;
+  readonly snapshot: ReviewSelection;
+}
+
+const selectedRanges = new WeakMap<object, SelectionBinding>();
+
+const selectionFingerprint = (selection: ReviewSelection): string | undefined => {
+  try {
+    return JSON.stringify({
+      mode: selection.mode,
+      reason: selection.reason,
+      files: selection.files.map((file) => Schema.encodeSync(ChangedFile)(file)),
+      affectedPaths: selection.affectedPaths,
+      totalFiles: selection.totalFiles,
+      baselineSha: selection.baselineSha,
+      priorState:
+        selection.priorState === undefined
+          ? undefined
+          : Schema.encodeSync(ReviewState)(selection.priorState),
+      profileFingerprint: selection.profileFingerprint,
+    });
+  } catch {
+    return undefined;
+  }
+};
+
+const freeze = <Value>(value: Value): Value => {
+  if (typeof value !== "object" || value === null) return value;
+  for (const nested of Object.values(value)) freeze(nested);
+  return Object.freeze(value);
+};
+
+const selectionSnapshot = (selection: ReviewSelection): ReviewSelection =>
+  freeze({
+    mode: selection.mode,
+    reason: selection.reason,
+    files: selection.files.map((file) =>
+      Schema.decodeUnknownSync(ChangedFile)(Schema.encodeSync(ChangedFile)(file)),
+    ),
+    affectedPaths: [...selection.affectedPaths],
+    totalFiles: selection.totalFiles,
+    baselineSha: selection.baselineSha,
+    priorState:
+      selection.priorState === undefined
+        ? undefined
+        : Schema.decodeUnknownSync(ReviewState)(
+            Schema.encodeSync(ReviewState)(selection.priorState),
+          ),
+    profileFingerprint: selection.profileFingerprint,
+  });
+
+const sealReviewSelection = (
+  selection: ReviewSelection,
+  source: PullRequestMetadata,
+): ReviewSelection => {
+  const snapshot = selectionSnapshot(selection);
+  const fingerprint = selectionFingerprint(selection);
+  if (fingerprint === undefined) throw new Error("Range selector produced an invalid selection");
+  selectedRanges.set(selection, {
+    source: {
+      repository: source.repository,
+      number: source.number,
+      baseRef: source.baseRef,
+      ...(source.baseSha === undefined ? {} : { baseSha: source.baseSha }),
+      headRef: source.headRef,
+      headSha: source.headSha,
+      totalChangedFiles: source.totalChangedFiles,
+    },
+    fingerprint,
+    snapshot,
+  });
+  return selection;
+};
+
+/** The immutable selection snapshot, if this object originated at the host range selector. */
+export const sealedReviewSelection = (selection: ReviewSelection): ReviewSelection | undefined =>
+  selectedRanges.get(selection)?.snapshot;
+
+/** Resolve an unmodified range-selector selection for this exact source snapshot. */
+export const selectedReviewRangeFor = (
+  selection: ReviewSelection,
+  current: PullRequestMetadata,
+): ReviewSelection | undefined => {
+  const binding = selectedRanges.get(selection);
+  if (binding === undefined) return undefined;
+  const source = binding.source;
+  if (
+    binding.fingerprint === selectionFingerprint(selection) &&
+    source.repository === current.repository &&
+    source.number === current.number &&
+    source.baseRef === current.baseRef &&
+    source.baseSha === current.baseSha &&
+    source.headRef === current.headRef &&
+    source.headSha === current.headSha &&
+    source.totalChangedFiles === current.totalChangedFiles
+  ) {
+    return binding.snapshot;
+  }
+  return undefined;
+};
+
 const fullSelection = (input: {
   readonly reason: string;
   readonly files: ReadonlyArray<ChangedFile>;
-  readonly totalFiles: number;
+  readonly current: PullRequestMetadata;
   readonly profileFingerprint: string;
-}): ReviewSelection => ({
-  mode: "full",
-  reason: input.reason,
-  files: input.files,
-  affectedPaths: input.files.flatMap((file) =>
-    file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
-  ),
-  totalFiles: input.totalFiles,
-  baselineSha: undefined,
-  priorState: undefined,
-  profileFingerprint: input.profileFingerprint,
-});
+}): ReviewSelection =>
+  sealReviewSelection(
+    {
+      mode: "full",
+      reason: input.reason,
+      files: input.files,
+      affectedPaths: input.files.flatMap((file) =>
+        file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
+      ),
+      totalFiles: input.current.totalChangedFiles,
+      baselineSha: undefined,
+      priorState: undefined,
+      profileFingerprint: input.profileFingerprint,
+    },
+    input.current,
+  );
 
 /**
  * Validate that persisted state belongs to this exact PR/base lineage and the
@@ -337,7 +459,7 @@ export const selectReviewRange = (input: {
     fullSelection({
       reason,
       files: input.fullFiles,
-      totalFiles: input.current.totalChangedFiles,
+      current: input.current,
       profileFingerprint: input.profileFingerprint,
     });
   if (input.requestedMode === "final") return full("explicit final full-diff audit requested");
@@ -411,16 +533,19 @@ export const selectReviewRange = (input: {
   const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
     left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
   );
-  return {
-    mode: "incremental",
-    reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
-    files: selectedFiles,
-    affectedPaths: [...affectedPaths].sort(),
-    totalFiles: selectedFiles.length,
-    baselineSha: input.priorState.reviewedHeadSha,
-    priorState: input.priorState,
-    profileFingerprint: input.profileFingerprint,
-  };
+  return sealReviewSelection(
+    {
+      mode: "incremental",
+      reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
+      files: selectedFiles,
+      affectedPaths: [...affectedPaths].sort(),
+      totalFiles: selectedFiles.length,
+      baselineSha: input.priorState.reviewedHeadSha,
+      priorState: input.priorState,
+      profileFingerprint: input.profileFingerprint,
+    },
+    input.current,
+  );
 };
 
 /**

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -303,7 +303,29 @@ interface SelectionBinding {
   readonly snapshot: ReviewSelection;
 }
 
-const selectedRanges = new WeakMap<object, SelectionBinding>();
+export interface SelectReviewRangeInput {
+  readonly requestedMode: ReviewMode;
+  readonly current: PullRequestMetadata;
+  readonly fullFiles: ReadonlyArray<ChangedFile>;
+  readonly profileFingerprint: string;
+  readonly priorState: ReviewState | undefined;
+  readonly comparison: ReviewHeadComparison | undefined;
+  readonly baseComparison?: ReviewHeadComparison | undefined;
+  readonly lookupFailure?: string | undefined;
+}
+
+/** Host-owned authority for issuing and verifying narrowed review scope. */
+export class ReviewSelectionAuthority extends Context.Service<
+  ReviewSelectionAuthority,
+  {
+    readonly select: (input: SelectReviewRangeInput) => Effect.Effect<ReviewSelection>;
+    readonly snapshot: (selection: ReviewSelection) => Effect.Effect<ReviewSelection | undefined>;
+    readonly selectedFor: (
+      selection: ReviewSelection,
+      current: PullRequestMetadata,
+    ) => Effect.Effect<ReviewSelection | undefined>;
+  }
+>()("@effect-agent/pr-review/ReviewSelectionAuthority") {}
 
 const selectionFingerprint = (selection: ReviewSelection): string | undefined => {
   try {
@@ -351,6 +373,7 @@ const selectionSnapshot = (selection: ReviewSelection): ReviewSelection =>
   });
 
 const sealReviewSelection = (
+  selectedRanges: WeakMap<object, SelectionBinding>,
   selection: ReviewSelection,
   source: PullRequestMetadata,
 ): ReviewSelection => {
@@ -374,53 +397,39 @@ const sealReviewSelection = (
 };
 
 /** The immutable selection snapshot, if this object originated at the host range selector. */
-export const sealedReviewSelection = (selection: ReviewSelection): ReviewSelection | undefined =>
-  selectedRanges.get(selection)?.snapshot;
+export const sealedReviewSelection = Effect.fn("sealedReviewSelection")(function* (
+  selection: ReviewSelection,
+) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.snapshot(selection);
+});
 
 /** Resolve an unmodified range-selector selection for this exact source snapshot. */
-export const selectedReviewRangeFor = (
+export const selectedReviewRangeFor = Effect.fn("selectedReviewRangeFor")(function* (
   selection: ReviewSelection,
   current: PullRequestMetadata,
-): ReviewSelection | undefined => {
-  const binding = selectedRanges.get(selection);
-  if (binding === undefined) return undefined;
-  const source = binding.source;
-  if (
-    binding.fingerprint === selectionFingerprint(selection) &&
-    source.repository === current.repository &&
-    source.number === current.number &&
-    source.baseRef === current.baseRef &&
-    source.baseSha === current.baseSha &&
-    source.headRef === current.headRef &&
-    source.headSha === current.headSha &&
-    source.totalChangedFiles === current.totalChangedFiles
-  ) {
-    return binding.snapshot;
-  }
-  return undefined;
-};
+) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.selectedFor(selection, current);
+});
 
 const fullSelection = (input: {
   readonly reason: string;
   readonly files: ReadonlyArray<ChangedFile>;
   readonly current: PullRequestMetadata;
   readonly profileFingerprint: string;
-}): ReviewSelection =>
-  sealReviewSelection(
-    {
-      mode: "full",
-      reason: input.reason,
-      files: input.files,
-      affectedPaths: input.files.flatMap((file) =>
-        file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
-      ),
-      totalFiles: input.current.totalChangedFiles,
-      baselineSha: undefined,
-      priorState: undefined,
-      profileFingerprint: input.profileFingerprint,
-    },
-    input.current,
-  );
+}): ReviewSelection => ({
+  mode: "full",
+  reason: input.reason,
+  files: input.files,
+  affectedPaths: input.files.flatMap((file) =>
+    file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
+  ),
+  totalFiles: input.current.totalChangedFiles,
+  baselineSha: undefined,
+  priorState: undefined,
+  profileFingerprint: input.profileFingerprint,
+});
 
 /**
  * Validate that persisted state belongs to this exact PR/base lineage and the
@@ -444,17 +453,8 @@ export const validateReviewState = (
   return undefined;
 };
 
-/** Pure, deterministic range selection with conservative full-review fallbacks. */
-export const selectReviewRange = (input: {
-  readonly requestedMode: ReviewMode;
-  readonly current: PullRequestMetadata;
-  readonly fullFiles: ReadonlyArray<ChangedFile>;
-  readonly profileFingerprint: string;
-  readonly priorState: ReviewState | undefined;
-  readonly comparison: ReviewHeadComparison | undefined;
-  readonly baseComparison?: ReviewHeadComparison | undefined;
-  readonly lookupFailure?: string | undefined;
-}): ReviewSelection => {
+/** Pure, deterministic range policy with conservative full-review fallbacks. */
+const selectReviewRangeValue = (input: SelectReviewRangeInput): ReviewSelection => {
   const full = (reason: string) =>
     fullSelection({
       reason,
@@ -533,20 +533,55 @@ export const selectReviewRange = (input: {
   const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
     left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
   );
-  return sealReviewSelection(
-    {
-      mode: "incremental",
-      reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
-      files: selectedFiles,
-      affectedPaths: [...affectedPaths].sort(),
-      totalFiles: selectedFiles.length,
-      baselineSha: input.priorState.reviewedHeadSha,
-      priorState: input.priorState,
-      profileFingerprint: input.profileFingerprint,
-    },
-    input.current,
-  );
+  return {
+    mode: "incremental",
+    reason: `changes since successfully reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
+    files: selectedFiles,
+    affectedPaths: [...affectedPaths].sort(),
+    totalFiles: selectedFiles.length,
+    baselineSha: input.priorState.reviewedHeadSha,
+    priorState: input.priorState,
+    profileFingerprint: input.profileFingerprint,
+  };
 };
+
+/** A non-memoized selection registry scoped to each host composition. */
+export const reviewSelectionAuthorityLayer: Layer.Layer<ReviewSelectionAuthority> = Layer.fresh(
+  Layer.sync(ReviewSelectionAuthority, () => {
+    const selectedRanges = new WeakMap<object, SelectionBinding>();
+    return ReviewSelectionAuthority.of({
+      select: (input) =>
+        Effect.sync(() =>
+          sealReviewSelection(selectedRanges, selectReviewRangeValue(input), input.current),
+        ),
+      snapshot: (selection) => Effect.sync(() => selectedRanges.get(selection)?.snapshot),
+      selectedFor: (selection, current) =>
+        Effect.sync(() => {
+          const binding = selectedRanges.get(selection);
+          if (binding === undefined) return undefined;
+          const source = binding.source;
+          return binding.fingerprint === selectionFingerprint(selection) &&
+            source.repository === current.repository &&
+            source.number === current.number &&
+            source.baseRef === current.baseRef &&
+            source.baseSha === current.baseSha &&
+            source.headRef === current.headRef &&
+            source.headSha === current.headSha &&
+            source.totalChangedFiles === current.totalChangedFiles
+            ? binding.snapshot
+            : undefined;
+        }),
+    });
+  }),
+);
+
+/** Issue one selection through the authority installed by the review host. */
+export const selectReviewRange = Effect.fn("selectReviewRange")(function* (
+  input: SelectReviewRangeInput,
+) {
+  const authority = yield* ReviewSelectionAuthority;
+  return yield* authority.select(input);
+});
 
 /**
  * Decorate the full source with the selected review range. Full anchor files

--- a/packages/pr-review/src/internal/review-units.ts
+++ b/packages/pr-review/src/internal/review-units.ts
@@ -14,7 +14,7 @@ import { ReviewFinding } from "./review-agent.ts";
 // ---------------------------------------------------------------------------
 
 /** The delegation fan-out bound: one parent Run spawns at most this many children. */
-export const MAX_REVIEW_UNITS = 16;
+export const MAX_REVIEW_UNITS = 20;
 
 /** A unit never carries more files than this, regardless of their size. */
 export const MAX_UNIT_FILES = 12;

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -181,67 +181,55 @@ const sameSelectedFiles = (
     return candidate !== undefined && sameSelectedFileIdentity(file, candidate);
   });
 
-const validateSelection = (input: {
+const validateSelection = Effect.fn("validateSelection")(function* (input: {
   readonly selection: ReviewSelection;
   readonly files: ReadonlyArray<ChangedFile>;
   readonly anchorFiles: ReadonlyArray<ChangedFile>;
   readonly metadata: PullRequestMetadata;
-}): Effect.Effect<ReviewSelection, ReviewSelectionViolation> => {
+}) {
   const { selection, files, anchorFiles, metadata } = input;
-  const sealed = selectedReviewRangeFor(selection, metadata);
-  if (sealed === undefined) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "review selection was not created by the host range selector",
-      }),
-    );
+  const verified = yield* selectedReviewRangeFor(selection, metadata);
+  if (verified === undefined) {
+    return yield* ReviewSelectionViolation.make({
+      reason: "review selection was not created by the host range selector",
+    });
   }
-  if (!sameSelectedFiles(sealed.files, files)) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "review selection evidence does not match the model-visible source range",
-      }),
-    );
+  if (!sameSelectedFiles(verified.files, files)) {
+    return yield* ReviewSelectionViolation.make({
+      reason: "review selection evidence does not match the model-visible source range",
+    });
   }
-  if (sealed.mode === "incremental" && sealed.totalFiles !== files.length) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "review selection total does not match the model-visible source range",
-      }),
-    );
+  if (verified.mode === "incremental" && verified.totalFiles !== files.length) {
+    return yield* ReviewSelectionViolation.make({
+      reason: "review selection total does not match the model-visible source range",
+    });
   }
   const anchorPaths = new Set(anchorFiles.map((file) => file.path));
   if (files.some((file) => !anchorPaths.has(file.path))) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "review selection contains a path outside the current pull-request source",
-      }),
-    );
+    return yield* ReviewSelectionViolation.make({
+      reason: "review selection contains a path outside the current pull-request source",
+    });
   }
   if (
-    sealed.mode === "full" &&
-    (sealed.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))
+    verified.mode === "full" &&
+    (verified.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))
   ) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "full review selection does not cover the current pull-request source",
-      }),
-    );
+    return yield* ReviewSelectionViolation.make({
+      reason: "full review selection does not cover the current pull-request source",
+    });
   }
   if (
-    sealed.mode === "incremental" &&
-    (sealed.priorState === undefined ||
-      sealed.baselineSha !== sealed.priorState.reviewedHeadSha ||
-      sealed.profileFingerprint !== sealed.priorState.profileFingerprint)
+    verified.mode === "incremental" &&
+    (verified.priorState === undefined ||
+      verified.baselineSha !== verified.priorState.reviewedHeadSha ||
+      verified.profileFingerprint !== verified.priorState.profileFingerprint)
   ) {
-    return Effect.fail(
-      ReviewSelectionViolation.make({
-        reason: "incremental review selection is not bound to its authenticated prior state",
-      }),
-    );
+    return yield* ReviewSelectionViolation.make({
+      reason: "incremental review selection is not bound to its authenticated prior state",
+    });
   }
-  return Effect.succeed(sealed);
-};
+  return verified;
+});
 
 /** Build the mission one review run frames from the source's snapshot. */
 export const buildReviewMission = (

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect";
+import { Effect, Equal, Schema } from "effect";
 import {
   makeUsageBudget,
   toRunBudgetHook,
@@ -16,6 +16,7 @@ import {
   type ReviewShape,
 } from "./coverage.ts";
 import type { ChangedFile } from "./diff.ts";
+import { FAN_OUT_MAX_DURATION_MINUTES, MAX_FILE_REVIEW_ATTEMPTS } from "./fan-out.ts";
 import { computeChangesetFingerprint } from "./fingerprint.ts";
 import { PublishedReview, ReviewPublisher } from "./github.ts";
 import { planPublication, ReviewPublicationPlan } from "./render.ts";
@@ -31,6 +32,7 @@ import {
   fromStoredConcern,
   fromStoredFinding,
   ReviewState,
+  selectedReviewRangeFor,
   type ReviewSelection,
   ReviewStateAuthenticator,
   toStoredConcern,
@@ -70,9 +72,9 @@ export const reviewBudgetLimits = UsageBudgetLimits.make({
 export const fanOutReviewBudgetLimits = UsageBudgetLimits.make({
   maxInputTokens: 400_000,
   maxOutputTokens: 16_000,
-  maxToolCalls: 24,
+  maxToolCalls: 1 + MAX_FILE_REVIEW_ATTEMPTS,
   maxCostMicrousd: 2_000_000,
-  maxDurationMillis: 900_000,
+  maxDurationMillis: FAN_OUT_MAX_DURATION_MINUTES * 60_000,
 });
 
 /** Everything one review run produced, publication receipt included. */
@@ -139,12 +141,107 @@ export interface ExecuteReviewOptions {
   /** Host-owned coverage shape; defaults to the flat reviewer. */
   readonly reviewShape?: ReviewShape | undefined;
   /**
-   * Explicit host-selected review range. Callers that provide a selection
-   * also decorate `PullRequestSource` with `selectedPullRequestSourceLayer` so
-   * the model sees exactly this range while publication retains full anchors.
+   * Explicit host-selected review range. `PrReview.run` applies the matching
+   * source decorator itself, so its model-visible range cannot diverge from
+   * the selection used for continuity and publication.
    */
   readonly selection?: ReviewSelection | undefined;
 }
+
+/** A caller attempted to supply review-accounting scope not selected by the host. */
+export class ReviewSelectionViolation extends Schema.TaggedError<ReviewSelectionViolation>()(
+  "ReviewSelectionViolation",
+  { reason: Schema.NonEmptyString.check(Schema.isMaxLength(1_000)) },
+) {}
+
+const sameFiles = (left: ReadonlyArray<ChangedFile>, right: ReadonlyArray<ChangedFile>): boolean =>
+  left.length === right.length && left.every((file, index) => Equal.equals(file, right[index]));
+
+/**
+ * The selected-source decorator may add bounded base/head evidence to a
+ * patchless selected file. That is host-side enrichment of the exact same
+ * changed-file identity, not a second selection. Keep every selection field
+ * stable while deliberately excluding only those two evidence fields.
+ */
+const sameSelectedFileIdentity = (left: ChangedFile, right: ChangedFile): boolean =>
+  left.path === right.path &&
+  left.status === right.status &&
+  left.additions === right.additions &&
+  left.deletions === right.deletions &&
+  left.previousPath === right.previousPath &&
+  left.patch === right.patch;
+
+const sameSelectedFiles = (
+  left: ReadonlyArray<ChangedFile>,
+  right: ReadonlyArray<ChangedFile>,
+): boolean =>
+  left.length === right.length &&
+  left.every((file, index) => {
+    const candidate = right[index];
+    return candidate !== undefined && sameSelectedFileIdentity(file, candidate);
+  });
+
+const validateSelection = (input: {
+  readonly selection: ReviewSelection;
+  readonly files: ReadonlyArray<ChangedFile>;
+  readonly anchorFiles: ReadonlyArray<ChangedFile>;
+  readonly metadata: PullRequestMetadata;
+}): Effect.Effect<ReviewSelection, ReviewSelectionViolation> => {
+  const { selection, files, anchorFiles, metadata } = input;
+  const sealed = selectedReviewRangeFor(selection, metadata);
+  if (sealed === undefined) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "review selection was not created by the host range selector",
+      }),
+    );
+  }
+  if (!sameSelectedFiles(sealed.files, files)) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "review selection evidence does not match the model-visible source range",
+      }),
+    );
+  }
+  if (sealed.mode === "incremental" && sealed.totalFiles !== files.length) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "review selection total does not match the model-visible source range",
+      }),
+    );
+  }
+  const anchorPaths = new Set(anchorFiles.map((file) => file.path));
+  if (files.some((file) => !anchorPaths.has(file.path))) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "review selection contains a path outside the current pull-request source",
+      }),
+    );
+  }
+  if (
+    sealed.mode === "full" &&
+    (sealed.totalFiles !== metadata.totalChangedFiles || !sameFiles(files, anchorFiles))
+  ) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "full review selection does not cover the current pull-request source",
+      }),
+    );
+  }
+  if (
+    sealed.mode === "incremental" &&
+    (sealed.priorState === undefined ||
+      sealed.baselineSha !== sealed.priorState.reviewedHeadSha ||
+      sealed.profileFingerprint !== sealed.priorState.profileFingerprint)
+  ) {
+    return Effect.fail(
+      ReviewSelectionViolation.make({
+        reason: "incremental review selection is not bound to its authenticated prior state",
+      }),
+    );
+  }
+  return Effect.succeed(sealed);
+};
 
 /** Build the mission one review run frames from the source's snapshot. */
 export const buildReviewMission = (
@@ -233,7 +330,10 @@ export const executeReview = <
     const metadata = yield* source.metadata;
     const files = yield* source.changedFiles;
     const anchorFiles = yield* source.anchorFiles;
-    const selection = options.selection;
+    const selection =
+      options.selection === undefined
+        ? undefined
+        : yield* validateSelection({ selection: options.selection, files, anchorFiles, metadata });
     const mission = buildReviewMission(metadata, files);
     const fullMission = buildReviewMission(metadata, anchorFiles);
     const fingerprint =

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -35,6 +35,7 @@ import {
   ReviewFinding,
   ReviewRunOutcome,
   ReviewState,
+  ReviewStateAuthenticator,
   StoredReviewFinding,
   webCryptoReviewStateAuthenticatorLayer,
   type ReviewVerdict,
@@ -316,6 +317,36 @@ describe("runReviewAction", () => {
       expect(outputs).toContain("inline-comments=0");
       expect(outputs).toContain("conclusion=success");
       expect(outputs).toContain("coverage=complete");
+    }),
+  );
+
+  it.effect("does not access authenticated-state support for a legacy fingerprint reviewer", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const unsupportedState = ReviewStateAuthenticator.of({
+        status: "available",
+        unavailableReason: undefined,
+        render: () => Effect.die("legacy reviewer must not render state"),
+        extract: () => Effect.die("legacy reviewer must not extract state"),
+      });
+      const result = yield* runReviewAction(
+        {
+          run: () => Effect.succeed(fakeOutcome("comment")),
+          fingerprint: Effect.succeed("f".repeat(64)),
+        },
+        { post: false, priorReviews: staticPriorReviews(Option.none()) },
+      ).pipe(
+        Effect.provideService(ReviewStateAuthenticator, unsupportedState),
+        Effect.provide(harness.layer),
+      );
+
+      expect(result._tag).toBe("Completed");
+      expect(yield* Ref.get(harness.written)).toContain("conclusion=success");
     }),
   );
 

--- a/packages/pr-review/test/factory.test.ts
+++ b/packages/pr-review/test/factory.test.ts
@@ -16,6 +16,8 @@ import {
   ReviewFinding,
   ReviewPublicationPlan,
   ReviewPublisher,
+  type ReviewSelectionAuthority,
+  reviewSelectionAuthorityLayer,
   type RunReviewOptions,
   type ReviewSelection,
   ReviewState,
@@ -170,6 +172,7 @@ const runFactoryReviewer = <E, R>(
         Layer.mergeAll(
           fixturePullRequestSourceLayer(fixture),
           collectingReviewPublisherLayer(published),
+          reviewSelectionAuthorityLayer,
           unavailableReviewStateAuthenticatorLayer("offline factory test"),
         ),
       ),
@@ -293,6 +296,7 @@ describe("PrReview.make", () => {
             Layer.mergeAll(
               fixturePullRequestSourceLayer(fixture),
               collectingReviewPublisherLayer(ignoredPublished),
+              reviewSelectionAuthorityLayer,
               unavailableReviewStateAuthenticatorLayer("offline factory test"),
               NodeCrypto.layer,
             ),
@@ -391,6 +395,7 @@ describe("PrReview.make", () => {
               fixturePullRequestSourceLayer(fixture),
               collectingReviewPublisherLayer(published),
               guidelinesLayer,
+              reviewSelectionAuthorityLayer,
               unavailableReviewStateAuthenticatorLayer("offline factory test"),
             ),
           ),
@@ -458,6 +463,9 @@ type ExplicitSelectionProof = Assert<
 type StateAuthenticatorVisibleProof = Assert<
   Equal<Extract<PlainServices, ReviewStateAuthenticator>, ReviewStateAuthenticator>
 >;
+type SelectionAuthorityVisibleProof = Assert<
+  Equal<Extract<PlainServices, ReviewSelectionAuthority>, ReviewSelectionAuthority>
+>;
 // An extra tool's handler is the caller's dependency, visible in `R` — and
 // absent when no extra tool is configured.
 type ExtraHandlerProof = Assert<
@@ -481,6 +489,7 @@ describe("factory type proofs", () => {
     const fanOutCryptoVisibleProof: FanOutCryptoVisibleProof = true;
     const explicitSelectionProof: ExplicitSelectionProof = true;
     const stateAuthenticatorVisibleProof: StateAuthenticatorVisibleProof = true;
+    const selectionAuthorityVisibleProof: SelectionAuthorityVisibleProof = true;
     const extraHandlerProof: ExtraHandlerProof = true;
     const plainHandlerExcludedProof: PlainHandlerExcludedProof = true;
     expect([
@@ -493,9 +502,10 @@ describe("factory type proofs", () => {
       fanOutCryptoVisibleProof,
       explicitSelectionProof,
       stateAuthenticatorVisibleProof,
+      selectionAuthorityVisibleProof,
       extraHandlerProof,
       plainHandlerExcludedProof,
-    ]).toEqual([true, true, true, true, true, true, true, true, true, true, true]);
+    ]).toEqual([true, true, true, true, true, true, true, true, true, true, true, true]);
   });
 });
 

--- a/packages/pr-review/test/factory.test.ts
+++ b/packages/pr-review/test/factory.test.ts
@@ -16,7 +16,9 @@ import {
   ReviewFinding,
   ReviewPublicationPlan,
   ReviewPublisher,
+  type RunReviewOptions,
   type ReviewSelection,
+  ReviewState,
   ReviewStateAuthenticator,
   unavailableReviewStateAuthenticatorLayer,
 } from "../src/index.ts";
@@ -159,7 +161,7 @@ describe("enforceFindingsBound", () => {
 // ---------------------------------------------------------------------------
 
 const runFactoryReviewer = <E, R>(
-  run: (options?: { readonly post?: boolean }) => Effect.Effect<unknown, E, R>,
+  run: (options?: RunReviewOptions) => Effect.Effect<unknown, E, R>,
 ) =>
   Effect.gen(function* () {
     const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
@@ -242,6 +244,67 @@ describe("PrReview.make", () => {
       expect(plan?.comments.map((comment) => comment.path)).toEqual(["src/hello.ts"]);
       expect(plan?.demoted.map((finding) => finding.path)).toEqual(["deps/bun.lock"]);
       expect(outcome).toBeDefined();
+    }),
+  );
+
+  it.effect("rejects a caller-forged selection before it can narrow continuity accounting", () =>
+    Effect.gen(function* () {
+      const scripted = yield* makeOfflineReviewerModel({
+        diffPath: "src/hello.ts",
+        readPath: "src/hello.ts",
+        review: singleFindingReview,
+      });
+      const reviewer = PrReview.make({ model: scripted.model });
+      const [selectedFile] = fixture.files;
+      if (selectedFile === undefined) {
+        throw new Error("Expected the factory fixture to include src/hello.ts");
+      }
+      const selection: ReviewSelection = {
+        mode: "incremental",
+        reason: "test selected delta",
+        files: [selectedFile.file],
+        affectedPaths: [selectedFile.file.path],
+        totalFiles: 1,
+        baselineSha: "0".repeat(40),
+        priorState: ReviewState.make({
+          version: 1,
+          repository: fixture.metadata.repository,
+          pullRequestNumber: fixture.metadata.number,
+          baseRef: fixture.metadata.baseRef,
+          baseSha: "1".repeat(40),
+          headRef: fixture.metadata.headRef,
+          reviewedHeadSha: "0".repeat(40),
+          profileFingerprint: "a".repeat(64),
+          acceptedScopeFingerprint: "b".repeat(64),
+          reviewedPathCount: 1,
+          unresolvedFindings: [],
+          unresolvedConcerns: [],
+          lastReviewMode: "full",
+        }),
+        profileFingerprint: "a".repeat(64),
+      };
+      const ignoredPublished = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
+
+      const error = yield* reviewer
+        .run({ post: false, selection })
+        .pipe(
+          Effect.flip,
+          Effect.provide(
+            Layer.mergeAll(
+              fixturePullRequestSourceLayer(fixture),
+              collectingReviewPublisherLayer(ignoredPublished),
+              unavailableReviewStateAuthenticatorLayer("offline factory test"),
+              NodeCrypto.layer,
+            ),
+          ),
+        );
+
+      const prompts = yield* scripted.prompts;
+      expect(error._tag).toBe("ReviewSelectionViolation");
+      if (error._tag === "ReviewSelectionViolation") {
+        expect(error.reason).toBe("review selection was not created by the host range selector");
+      }
+      expect(prompts).toEqual([]);
     }),
   );
 

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1,5 +1,5 @@
 import { NodeCrypto } from "@effect/platform-node";
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, layer } from "@effect/vitest";
 import { Duration, Effect, Layer, Ref, Schema, Stream } from "effect";
 import {
   Agent,
@@ -59,6 +59,7 @@ import {
   ReviewFinding,
   ReviewMission,
   ReviewPublicationPlan,
+  reviewSelectionAuthorityLayer,
   ReviewStateAuthenticator,
   WalkthroughEntry,
   defaultFanOutPolicy,
@@ -240,6 +241,7 @@ const runOfflineFanOut = (script: {
           FanOutCoordinatorToolkitLayer.pipe(Layer.provideMerge(sourceLayer)),
           fanOutHandlersLayer(childBinding).pipe(Layer.provide(childSupportLayer)),
           collectingReviewPublisherLayer(published),
+          reviewSelectionAuthorityLayer,
           testIdGeneratorLayer,
           unavailableReviewStateAuthenticatorLayer("offline fan-out test"),
         ),
@@ -534,7 +536,7 @@ describe("rankAndDedupeFindings", () => {
 // the real S1 delegation, toolkits, source port, and publication path.
 // ---------------------------------------------------------------------------
 
-describe("offline fan-out review run", () => {
+layer(reviewSelectionAuthorityLayer)("offline fan-out review run", (it) => {
   const happyChildren: ReadonlyArray<OfflineUnitScript> = [
     {
       unitId: "unit-001",

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -23,6 +23,13 @@ import {
   DelegateFileReview,
   executeReview,
   FanOutCoordinatorToolkitLayer,
+  FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES,
+  FAN_OUT_MAX_DURATION_MINUTES,
+  FAN_OUT_WORKFLOW_TIMEOUT_MINUTES,
+  FILE_REVIEW_MAX_CONCURRENCY,
+  FILE_REVIEW_MAX_DURATION_MINUTES,
+  FILE_REVIEW_TOKEN_BUDGET,
+  FILE_REVIEW_WAVE_DURATION_MINUTES,
   fanOutHandlersLayer,
   FanOutReviewer,
   fanOutReviewBudgetLimits,
@@ -37,8 +44,12 @@ import {
   ListReviewUnits,
   makeFanOutReviewInstructions,
   makeFanOutReviewSuite,
+  MAX_FILE_REVIEW_ATTEMPTS,
+  MAX_FILE_REVIEW_RETRIES,
   MAX_FILE_REVIEW_TOOL_CALLS,
+  MAX_FILE_REVIEW_TURNS,
   MAX_REVIEW_UNITS,
+  MAX_FILE_REVIEW_WAVES,
   MAX_UNIT_FILES,
   planReviewUnits,
   PullRequestMetadata,
@@ -50,6 +61,7 @@ import {
   ReviewPublicationPlan,
   ReviewStateAuthenticator,
   WalkthroughEntry,
+  defaultFanOutPolicy,
   defaultFileReviewerPolicy,
   fileReviewPolicy,
   unavailableReviewStateAuthenticatorLayer,
@@ -198,11 +210,13 @@ const runOfflineFanOut = (script: {
   readonly children: ReadonlyArray<OfflineUnitScript>;
   readonly review: CodeReview;
   readonly unitCalls?: ReadonlyArray<OfflineUnitCall> | undefined;
+  readonly retryUnitCalls?: ReadonlyArray<OfflineUnitCall> | undefined;
   readonly sourceFixture?: FixturePullRequest | undefined;
 }) =>
   Effect.gen(function* () {
     const coordinator = yield* makeOfflineFanOutCoordinatorModel({
       unitCalls: script.unitCalls ?? [UNIT_ONE, UNIT_TWO],
+      retryUnitCalls: script.retryUnitCalls,
       review: script.review,
     });
     const children = yield* makeOfflineFileReviewerModel(script.children);
@@ -283,15 +297,48 @@ describe("coordinator instructions", () => {
 });
 
 describe("file-reviewer policy", () => {
-  it("budgets one diff and one context read for every path in a maximum-size unit", () => {
-    expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(MAX_UNIT_FILES * 2);
-    expect(defaultFileReviewerPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
-    expect(fileReviewPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 2);
+  it("budgets one diff and three context reads for every path in a maximum-size unit", () => {
+    expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(MAX_UNIT_FILES * 4);
+    // A provider may issue those valid reads serially, followed by one terminal response.
+    expect(MAX_FILE_REVIEW_TURNS).toBe(MAX_FILE_REVIEW_TOOL_CALLS + 1);
+    expect(defaultFileReviewerPolicy.maxTurns).toBe(MAX_FILE_REVIEW_TURNS);
+    expect(fileReviewPolicy.maxTurns).toBe(MAX_FILE_REVIEW_TURNS);
+    expect(defaultFileReviewerPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 4);
+    expect(fileReviewPolicy.maxToolCalls).toBe(MAX_UNIT_FILES * 4);
+    // The complete permitted read envelope for a 12-file unit is deliberately
+    // larger than the former 200k cumulative budget; it must not fail as an
+    // ordinary `AgentPolicyError:tokens` after all valid reads were allowed.
+    expect(defaultFileReviewerPolicy.tokenBudget).toBe(FILE_REVIEW_TOKEN_BUDGET);
+    expect(FILE_REVIEW_TOKEN_BUDGET).toBe(600_000);
   });
 
   it("keeps the child and delegation deadlines aligned with reasoning-model headroom", () => {
-    expect(Duration.toMillis(defaultFileReviewerPolicy.maxDuration)).toBe(10 * 60_000);
-    expect(Duration.toMillis(fileReviewPolicy.maxDuration)).toBe(10 * 60_000);
+    expect(Duration.toMillis(defaultFileReviewerPolicy.maxDuration)).toBe(
+      FILE_REVIEW_MAX_DURATION_MINUTES * 60_000,
+    );
+    expect(Duration.toMillis(fileReviewPolicy.maxDuration)).toBe(
+      FILE_REVIEW_MAX_DURATION_MINUTES * 60_000,
+    );
+  });
+
+  it("aligns a maximum-size full audit's child waves, coordinator, run budget, and job timeout", () => {
+    expect(MAX_REVIEW_UNITS).toBe(20);
+    expect(FILE_REVIEW_MAX_CONCURRENCY).toBe(5);
+    expect(fileReviewPolicy.maxConcurrency).toBe(FILE_REVIEW_MAX_CONCURRENCY);
+    expect(defaultFanOutPolicy.toolConcurrency).toBe(FILE_REVIEW_MAX_CONCURRENCY);
+    expect(MAX_FILE_REVIEW_RETRIES).toBe(5);
+    expect(MAX_FILE_REVIEW_ATTEMPTS).toBe(25);
+    expect(fileReviewPolicy.maxChildren).toBe(MAX_FILE_REVIEW_ATTEMPTS);
+    expect(defaultFanOutPolicy.maxToolCalls).toBe(1 + MAX_FILE_REVIEW_ATTEMPTS);
+    expect(MAX_FILE_REVIEW_WAVES).toBe(5);
+    expect(FILE_REVIEW_WAVE_DURATION_MINUTES).toBe(40);
+    expect(FAN_OUT_COORDINATOR_MERGE_HEADROOM_MINUTES).toBe(10);
+    expect(FAN_OUT_MAX_DURATION_MINUTES).toBe(50);
+    expect(Duration.toMillis(defaultFanOutPolicy.maxDuration)).toBe(
+      FAN_OUT_MAX_DURATION_MINUTES * 60_000,
+    );
+    expect(fanOutReviewBudgetLimits.maxDurationMillis).toBe(FAN_OUT_MAX_DURATION_MINUTES * 60_000);
+    expect(FAN_OUT_WORKFLOW_TIMEOUT_MINUTES).toBe(FAN_OUT_MAX_DURATION_MINUTES + 5);
   });
 });
 
@@ -311,7 +358,7 @@ describe("fan-out profile", () => {
       publicationOutsideAgentLoop: true,
       anchorsValidatedBeforePublication: true,
       attachedEphemeralDelegation: true,
-      failedUnitsReportedNotRetried: true,
+      boundedReadOnlyUnitRetry: true,
       liveProfileOptIn: true,
       exactlyOnceExternalEffects: false,
     });
@@ -439,7 +486,9 @@ describe("planReviewUnits", () => {
     );
 
     const plan = planReviewUnits(files, { totalChangedFiles: files.length });
-    expect(plan.units.flatMap((unit) => unit.paths)).toHaveLength(files.length);
+    expect([...new Set(plan.units.flatMap((unit) => unit.paths))].sort()).toEqual(
+      files.map((file) => file.path).sort(),
+    );
     expect(plan.unassignedPaths).toEqual([]);
   });
 });
@@ -782,6 +831,76 @@ describe("offline fan-out review run", () => {
     }),
   );
 
+  it.effect("recovers one failed read-only unit through the bounded retry wave", () =>
+    Effect.gen(function* () {
+      const retryingChildren: ReadonlyArray<OfflineUnitScript> = [
+        {
+          unitId: "unit-001",
+          diffPath: "src/api/alpha.ts",
+          outcome: { _tag: "malformed-once-then-findings", report: unitOneReport },
+        },
+        happyChildren[1] as OfflineUnitScript,
+      ];
+
+      const result = yield* runOfflineFanOut({
+        children: retryingChildren,
+        retryUnitCalls: [UNIT_ONE],
+        review: happyReview,
+      });
+
+      // list -> initial delegation batch -> one retry -> final merge.
+      expect(result.coordinatorCalls).toBe(4);
+      // The failed child and its retry each read then answer; unit-002 runs once.
+      expect(result.childCalls).toBe(6);
+      expect(result.outcome.coverage.failedUnits).toEqual([]);
+      expect(result.outcome.coverage.reviewedPaths).toEqual([
+        "src/api/alpha.ts",
+        "src/api/beta.ts",
+        "src/core/delta.ts",
+        "src/core/gamma.ts",
+      ]);
+      expect(result.outcome.coverage.unreviewedPaths).toEqual(["assets/logo.png"]);
+      expect(result.coordinatorPrompts[3]).toContain(alphaFinding.title);
+    }),
+  );
+
+  it.effect("keeps a unit incomplete when its one bounded retry also fails", () =>
+    Effect.gen(function* () {
+      const persistentlyFailingChildren: ReadonlyArray<OfflineUnitScript> = [
+        {
+          unitId: "unit-001",
+          diffPath: "src/api/alpha.ts",
+          outcome: { _tag: "malformed-output" },
+        },
+        happyChildren[1] as OfflineUnitScript,
+      ];
+      const honestReview = CodeReview.make({
+        summary: "unit-001 remained unreviewed after its AgentOutputError retry failed.",
+        verdict: "comment",
+        findings: [...unitTwoReport.findings],
+      });
+
+      const result = yield* runOfflineFanOut({
+        children: persistentlyFailingChildren,
+        retryUnitCalls: [UNIT_ONE],
+        review: honestReview,
+      });
+
+      expect(result.coordinatorCalls).toBe(4);
+      expect(result.childCalls).toBe(6);
+      expect(result.outcome.coverage.status).toBe("incomplete");
+      expect(result.outcome.coverage.failedUnits).toContainEqual({
+        unitId: "unit-001",
+        errorTag: "FileReviewUnitFailed:AgentOutputError",
+      });
+      expect(result.outcome.coverage.unreviewedPaths).toEqual([
+        "assets/logo.png",
+        "src/api/alpha.ts",
+        "src/api/beta.ts",
+      ]);
+    }),
+  );
+
   it.effect("reports a whole batch of failed units before the repeated-failure stop", () =>
     Effect.gen(function* () {
       const failedUnits: ReadonlyArray<OfflineUnitScript> = [
@@ -828,7 +947,7 @@ describe("offline fan-out review run", () => {
   );
 
   it.effect(
-    "SUB-033 a runaway child fails typed and its unit is reported honestly, never retried",
+    "SUB-033 a runaway child fails typed and stays incomplete without a bounded retry",
     () =>
       Effect.gen(function* () {
         const runawayChildren: ReadonlyArray<OfflineUnitScript> = [
@@ -869,12 +988,13 @@ describe("offline fan-out review run", () => {
         const finalPrompt = result.coordinatorPrompts[2] ?? "";
         expect(finalPrompt).toContain("FileReviewUnitFailed");
         expect(finalPrompt).toContain("AgentPolicyError");
+        expect(finalPrompt).toContain("tool-calls");
         expect(result.outcome.review.summary).toContain("unit-002 unreviewed: AgentPolicyError");
         expect(result.published).toHaveLength(1);
         expect(result.outcome.coverage.status).toBe("incomplete");
         expect(result.outcome.coverage.failedUnits).toContainEqual({
           unitId: "unit-002",
-          errorTag: "FileReviewUnitFailed:AgentPolicyError",
+          errorTag: "FileReviewUnitFailed:AgentPolicyError:tool-calls",
         });
       }),
   );

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -1,5 +1,5 @@
 import { NodeCrypto } from "@effect/platform-node";
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, layer } from "@effect/vitest";
 import { Effect, Exit, Layer, Ref, Schema } from "effect";
 import { Agent, IdGenerator, RunEvent } from "effect-agent";
 import { Tool } from "effect/unstable/ai";
@@ -34,6 +34,7 @@ import {
   ReviewFinding,
   ReviewHeadComparison,
   ReviewPublicationPlan,
+  reviewSelectionAuthorityLayer,
   ReviewState,
   ReviewToolkitLayer,
   StoredReviewFinding,
@@ -1051,7 +1052,7 @@ describe("concerns, metadata, and footer", () => {
 // live model.
 // ---------------------------------------------------------------------------
 
-describe("offline review run", () => {
+layer(reviewSelectionAuthorityLayer)("offline review run", (it) => {
   it.effect("reviews the fixture pull request end-to-end and publishes the validated plan", () =>
     Effect.gen(function* () {
       const scripted = yield* makeOfflineReviewerModel({
@@ -1067,6 +1068,7 @@ describe("offline review run", () => {
           Layer.mergeAll(
             ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
             collectingReviewPublisherLayer(published),
+            reviewSelectionAuthorityLayer,
             testIdGeneratorLayer,
             unavailableReviewStateAuthenticatorLayer("offline review test"),
           ),
@@ -1255,7 +1257,7 @@ describe("offline review run", () => {
         unresolvedConcerns: [],
         lastReviewMode: "full",
       });
-      const selection = selectReviewRange({
+      const selection = yield* selectReviewRange({
         requestedMode: "incremental",
         current: metadata,
         fullFiles: [unchangedFile, correctiveFile],
@@ -1343,7 +1345,7 @@ describe("offline review run", () => {
           // The adapter's visible list is bounded below GitHub's total.
           totalChangedFiles: 2,
         });
-        const selection = selectReviewRange({
+        const selection = yield* selectReviewRange({
           requestedMode: "final",
           current: metadata,
           fullFiles: [file],
@@ -1418,7 +1420,7 @@ describe("offline review run", () => {
           headSha,
           totalChangedFiles: 1,
         });
-        const selection = selectReviewRange({
+        const selection = yield* selectReviewRange({
           requestedMode: "final",
           current: metadata,
           fullFiles: [stale],
@@ -1490,6 +1492,7 @@ describe.skipIf(!liveEnabled)("pr-review live profile (opt-in)", () => {
               ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
               collectingReviewPublisherLayer(published),
               openAiClientLayer,
+              reviewSelectionAuthorityLayer,
               testIdGeneratorLayer,
               unavailableReviewStateAuthenticatorLayer("live review test"),
             ),

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -1,7 +1,7 @@
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Ref, Schema } from "effect";
-import { Agent, IdGenerator } from "effect-agent";
+import { Agent, IdGenerator, RunEvent } from "effect-agent";
 import { Tool } from "effect/unstable/ai";
 import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 
@@ -36,12 +36,11 @@ import {
   ReviewPublicationPlan,
   ReviewState,
   ReviewToolkitLayer,
-  selectReviewRange,
-  selectedPullRequestSourceLayer,
   StoredReviewFinding,
   WalkthroughEntry,
   unavailableReviewStateAuthenticatorLayer,
 } from "../src/index.ts";
+import { selectReviewRange, selectedPullRequestSourceLayer } from "../src/internal/review-state.ts";
 import {
   collectingReviewPublisherLayer,
   FixtureFile,
@@ -89,6 +88,70 @@ describe("host coverage diagnostics", () => {
     expect(coverage.status).toBe("incomplete");
     expect(coverage.reasons.every((reason) => reason.length <= 1_000)).toBe(true);
     expect(coverage.reasons.join("\n")).toContain("(+2 more)");
+  });
+
+  it("rejects a speculative fan-out duplicate that was declared before the initial wave settled", () => {
+    const file = ChangedFile.make({
+      path: "src/hello.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      patch: "@@ -0,0 +1 @@\n+export {};",
+    });
+    const event = (encoded: unknown) => Schema.decodeUnknownSync(RunEvent)(encoded);
+    const common = {
+      eventVersion: 1,
+      runId: "run-1",
+      conversationId: "conversation-1",
+      agentId: "reviewer",
+      timestamp: "2026-08-17T00:00:00.000Z",
+      turnId: "turn-1",
+      toolName: "delegate_file_review",
+      providerExecuted: false,
+    };
+    const events = [
+      event({
+        ...common,
+        _tag: "ToolCallDeclared",
+        sequence: 1,
+        toolCallId: "initial",
+        parameters: { unitId: "unit-001", paths: [file.path] },
+      }),
+      event({
+        ...common,
+        _tag: "ToolCallDeclared",
+        sequence: 2,
+        toolCallId: "speculative-retry",
+        parameters: { unitId: "unit-001", paths: [file.path] },
+      }),
+      event({
+        ...common,
+        _tag: "ToolCallSucceeded",
+        sequence: 3,
+        toolCallId: "speculative-retry",
+        result: { unitId: "unit-001", findings: [] },
+      }),
+      event({
+        ...common,
+        _tag: "ToolCallFailed",
+        sequence: 4,
+        toolCallId: "initial",
+        errorTag: "AgentOutputError",
+        message: "invalid child output",
+      }),
+    ];
+
+    const coverage = assessReviewCoverage({
+      shape: "fan-out",
+      files: [file],
+      totalFiles: 1,
+      anchorFiles: [file],
+      totalAnchorFiles: 1,
+      events,
+    });
+
+    expect(coverage.status).toBe("incomplete");
+    expect(coverage.unreviewedPaths).toContain(file.path);
   });
 });
 
@@ -1149,7 +1212,14 @@ describe("offline review run", () => {
         status: "modified",
         additions: 1,
         deletions: 1,
-        patch: "@@ -1 +1 @@\n-before\n+after",
+      });
+      // The compare payload has no patch. The selected-source decorator must
+      // enrich it from the current full source without invalidating the
+      // authenticated incremental selection's stable identity.
+      const enrichedCorrectiveFile = ChangedFile.make({
+        ...correctiveFile,
+        reviewBaseContent: "before",
+        reviewHeadContent: "after",
       });
       const metadata = PullRequestMetadata.make({
         repository: "acme/widgets",
@@ -1217,7 +1287,7 @@ describe("offline review run", () => {
           metadata,
           files: [
             FixtureFile.make({ file: unchangedFile, headContent: "unchanged" }),
-            FixtureFile.make({ file: correctiveFile, headContent: "after" }),
+            FixtureFile.make({ file: enrichedCorrectiveFile, headContent: "after" }),
           ],
         }),
       );
@@ -1248,6 +1318,151 @@ describe("offline review run", () => {
       expect(outcome.plan.body).toContain(priorFinding.title);
       expect((yield* scripted.prompts).join("\n")).not.toContain("src/unchanged.ts");
     }),
+  );
+
+  it.effect(
+    "reports a full source truncated by the host bound as incomplete instead of rejecting it",
+    () =>
+      Effect.gen(function* () {
+        const file = ChangedFile.make({
+          path: "src/visible.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+          patch: "@@ -1 +1 @@\n-old\n+new",
+        });
+        const metadata = PullRequestMetadata.make({
+          repository: "acme/widgets",
+          number: 32,
+          title: "Bounded source",
+          body: "",
+          baseRef: "main",
+          baseSha: "1".repeat(40),
+          headRef: "fix/bounded-source",
+          headSha: "2".repeat(40),
+          // The adapter's visible list is bounded below GitHub's total.
+          totalChangedFiles: 2,
+        });
+        const selection = selectReviewRange({
+          requestedMode: "final",
+          current: metadata,
+          fullFiles: [file],
+          profileFingerprint: "a".repeat(64),
+          priorState: undefined,
+          comparison: undefined,
+        });
+        const scripted = yield* makeOfflineReviewerModel({
+          diffPath: file.path,
+          readPath: file.path,
+          review: CodeReview.make({
+            summary: "one visible file",
+            verdict: "approve",
+            findings: [],
+          }),
+        });
+        const outcome = yield* executeReview(Agent.withModel(PullRequestReviewer, scripted.model), {
+          post: false,
+          applyVerdict: false,
+          selection,
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              ReviewToolkitLayer.pipe(
+                Layer.provideMerge(
+                  fixturePullRequestSourceLayer(
+                    FixturePullRequest.make({
+                      metadata,
+                      files: [FixtureFile.make({ file, headContent: "new" })],
+                    }),
+                  ),
+                ),
+              ),
+              collectingReviewPublisherLayer(
+                yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]),
+              ),
+              testIdGeneratorLayer,
+              unavailableReviewStateAuthenticatorLayer("bounded source test"),
+            ),
+          ),
+          Effect.scoped,
+        );
+
+        expect(outcome.coverage.status).toBe("incomplete");
+        expect(outcome.plan.body).toContain("Reviewed 1 of 2 changed files");
+      }),
+  );
+
+  it.effect(
+    "rejects a sealed selection when a current rename has the same path but different ancestry",
+    () =>
+      Effect.gen(function* () {
+        const baseSha = "1".repeat(40);
+        const headSha = "2".repeat(40);
+        const stale = ChangedFile.make({
+          path: "src/new.ts",
+          previousPath: "src/old-a.ts",
+          status: "renamed",
+          additions: 1,
+          deletions: 1,
+          patch: "@@ -1 +1 @@\n-old\n+new",
+        });
+        const current = ChangedFile.make({ ...stale, previousPath: "src/old-b.ts" });
+        const metadata = PullRequestMetadata.make({
+          repository: "acme/widgets",
+          number: 31,
+          title: "Rename source",
+          body: "",
+          baseRef: "main",
+          baseSha,
+          headRef: "fix/rename",
+          headSha,
+          totalChangedFiles: 1,
+        });
+        const selection = selectReviewRange({
+          requestedMode: "final",
+          current: metadata,
+          fullFiles: [stale],
+          profileFingerprint: "a".repeat(64),
+          priorState: undefined,
+          comparison: undefined,
+        });
+        const scripted = yield* makeOfflineReviewerModel({
+          diffPath: current.path,
+          readPath: current.path,
+          review: CodeReview.make({ summary: "unused", verdict: "approve", findings: [] }),
+        });
+        const error = yield* executeReview(Agent.withModel(PullRequestReviewer, scripted.model), {
+          post: false,
+          applyVerdict: false,
+          selection,
+        }).pipe(
+          Effect.flip,
+          Effect.provide(
+            Layer.mergeAll(
+              ReviewToolkitLayer.pipe(
+                Layer.provideMerge(
+                  fixturePullRequestSourceLayer(
+                    FixturePullRequest.make({
+                      metadata,
+                      files: [FixtureFile.make({ file: current, headContent: "new" })],
+                    }),
+                  ),
+                ),
+              ),
+              collectingReviewPublisherLayer(
+                yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]),
+              ),
+              testIdGeneratorLayer,
+              unavailableReviewStateAuthenticatorLayer("rename test"),
+            ),
+          ),
+        );
+        expect(error).toMatchObject({
+          _tag: "ReviewSelectionViolation",
+          reason: "review selection evidence does not match the model-visible source range",
+        });
+        expect(yield* scripted.prompts).toEqual([]);
+      }),
   );
 });
 

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Option, Redacted } from "effect";
 
+import * as publicApi from "../src/index.ts";
 import {
   ChangedFile,
   PullRequestMetadata,
   ReviewHeadComparison,
   ReviewState,
   ReviewStateAuthenticator,
-  selectReviewRange,
   StoredReviewFinding,
   webCryptoReviewStateAuthenticatorLayer,
 } from "../src/index.ts";
+import { selectedReviewRangeFor, selectReviewRange } from "../src/internal/review-state.ts";
 
 const BASE_SHA = "1".repeat(40);
 const REVIEWED_HEAD_SHA = "2".repeat(40);
@@ -92,6 +93,32 @@ const select = (overrides: Partial<Parameters<typeof selectReviewRange>[0]> = {}
   });
 
 describe("review state", () => {
+  it("does not export the host-only range-selection issuer", () => {
+    expect("selectReviewRange" in publicApi).toBe(false);
+    expect("selectedReviewRangeFor" in publicApi).toBe(false);
+    expect("sealedReviewSelection" in publicApi).toBe(false);
+  });
+
+  it("invalidates a sealed selection when an aliased source array changes after selection", () => {
+    const fullFiles = [acceptedFile, correctiveFile];
+    const selection = selectReviewRange({
+      requestedMode: "final",
+      current: metadata,
+      fullFiles,
+      profileFingerprint: PROFILE_FINGERPRINT,
+      priorState: undefined,
+      comparison: undefined,
+    });
+
+    expect(selectedReviewRangeFor(selection, metadata)?.files.map((file) => file.path)).toEqual([
+      "src/accepted.ts",
+      "src/corrective.ts",
+    ]);
+    fullFiles[0] = correctiveFile;
+
+    expect(selectedReviewRangeFor(selection, metadata)).toBeUndefined();
+  });
+
   it.effect("authenticates only a terminal schema-validated review-body marker", () =>
     Effect.gen(function* () {
       const secret = Redacted.make("stable-state-secret");

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest";
+import { expect, layer } from "@effect/vitest";
 import { Effect, Option, Redacted } from "effect";
 
 import * as publicApi from "../src/index.ts";
@@ -6,6 +6,7 @@ import {
   ChangedFile,
   PullRequestMetadata,
   ReviewHeadComparison,
+  reviewSelectionAuthorityLayer,
   ReviewState,
   ReviewStateAuthenticator,
   StoredReviewFinding,
@@ -92,32 +93,55 @@ const select = (overrides: Partial<Parameters<typeof selectReviewRange>[0]> = {}
     ...overrides,
   });
 
-describe("review state", () => {
-  it("does not export the host-only range-selection issuer", () => {
+layer(reviewSelectionAuthorityLayer)("review state", (it) => {
+  it("exposes selection issuance only through explicit host authority", () => {
     expect("selectReviewRange" in publicApi).toBe(false);
     expect("selectedReviewRangeFor" in publicApi).toBe(false);
     expect("sealedReviewSelection" in publicApi).toBe(false);
+    expect("ReviewSelectionAuthority" in publicApi).toBe(true);
+    expect("reviewSelectionAuthorityLayer" in publicApi).toBe(true);
   });
 
-  it("invalidates a sealed selection when an aliased source array changes after selection", () => {
-    const fullFiles = [acceptedFile, correctiveFile];
-    const selection = selectReviewRange({
-      requestedMode: "final",
-      current: metadata,
-      fullFiles,
-      profileFingerprint: PROFILE_FINGERPRINT,
-      priorState: undefined,
-      comparison: undefined,
-    });
+  it.effect(
+    "invalidates a sealed selection when an aliased source array changes after selection",
+    () =>
+      Effect.gen(function* () {
+        const fullFiles = [acceptedFile, correctiveFile];
+        const selection = yield* selectReviewRange({
+          requestedMode: "final",
+          current: metadata,
+          fullFiles,
+          profileFingerprint: PROFILE_FINGERPRINT,
+          priorState: undefined,
+          comparison: undefined,
+        });
 
-    expect(selectedReviewRangeFor(selection, metadata)?.files.map((file) => file.path)).toEqual([
-      "src/accepted.ts",
-      "src/corrective.ts",
-    ]);
-    fullFiles[0] = correctiveFile;
+        expect(
+          (yield* selectedReviewRangeFor(selection, metadata))?.files.map((file) => file.path),
+        ).toEqual(["src/accepted.ts", "src/corrective.ts"]);
+        fullFiles[0] = correctiveFile;
 
-    expect(selectedReviewRangeFor(selection, metadata)).toBeUndefined();
-  });
+        expect(yield* selectedReviewRangeFor(selection, metadata)).toBeUndefined();
+      }),
+  );
+
+  it.effect("does not share selection authority across host compositions", () =>
+    Effect.gen(function* () {
+      const selection = yield* selectReviewRange({
+        requestedMode: "final",
+        current: metadata,
+        fullFiles: [acceptedFile, correctiveFile],
+        profileFingerprint: PROFILE_FINGERPRINT,
+        priorState: undefined,
+        comparison: undefined,
+      }).pipe(Effect.provide(reviewSelectionAuthorityLayer));
+
+      const resolved = yield* selectedReviewRangeFor(selection, metadata).pipe(
+        Effect.provide(reviewSelectionAuthorityLayer),
+      );
+      expect(resolved).toBeUndefined();
+    }),
+  );
 
   it.effect("authenticates only a terminal schema-validated review-body marker", () =>
     Effect.gen(function* () {
@@ -181,91 +205,101 @@ describe("review state", () => {
     }),
   );
 
-  it("reviews only the corrective delta and preserves unchanged prior scope", () => {
-    const selection = select();
-    expect(selection.mode).toBe("incremental");
-    expect(selection.baselineSha).toBe(REVIEWED_HEAD_SHA);
-    expect(selection.files.map((file) => file.path)).toEqual(["src/corrective.ts"]);
-    expect(selection.files.map((file) => file.path)).not.toContain("src/accepted.ts");
-    expect(selection.priorState?.unresolvedFindings).toEqual([unresolvedFinding]);
-    expect(selection.reason).toContain(REVIEWED_HEAD_SHA.slice(0, 7));
-  });
+  it.effect("reviews only the corrective delta and preserves unchanged prior scope", () =>
+    Effect.gen(function* () {
+      const selection = yield* select();
+      expect(selection.mode).toBe("incremental");
+      expect(selection.baselineSha).toBe(REVIEWED_HEAD_SHA);
+      expect(selection.files.map((file) => file.path)).toEqual(["src/corrective.ts"]);
+      expect(selection.files.map((file) => file.path)).not.toContain("src/accepted.ts");
+      expect(selection.priorState?.unresolvedFindings).toEqual([unresolvedFinding]);
+      expect(selection.reason).toContain(REVIEWED_HEAD_SHA.slice(0, 7));
+    }),
+  );
 
-  it("falls back to the full diff when state is missing or incompatible", () => {
-    const missing = select({ priorState: undefined, comparison: undefined });
-    expect(missing.mode).toBe("full");
-    expect(missing.reason).toContain("no compatible stored review state");
+  it.effect("falls back to the full diff when state is missing or incompatible", () =>
+    Effect.gen(function* () {
+      const missing = yield* select({ priorState: undefined, comparison: undefined });
+      expect(missing.mode).toBe("full");
+      expect(missing.reason).toContain("no compatible stored review state");
 
-    const wrongProfile = select({ profileFingerprint: "c".repeat(64) });
-    expect(wrongProfile.mode).toBe("full");
-    expect(wrongProfile.reason).toContain("profile or model configuration changed");
+      const wrongProfile = yield* select({ profileFingerprint: "c".repeat(64) });
+      expect(wrongProfile.mode).toBe("full");
+      expect(wrongProfile.reason).toContain("profile or model configuration changed");
 
-    const changedBase = select({
-      current: PullRequestMetadata.make({ ...metadata, baseSha: "4".repeat(40) }),
-    });
-    expect(changedBase.mode).toBe("full");
-    expect(changedBase.reason).toContain("base changed");
-  });
+      const changedBase = yield* select({
+        current: PullRequestMetadata.make({ ...metadata, baseSha: "4".repeat(40) }),
+      });
+      expect(changedBase.mode).toBe("full");
+      expect(changedBase.reason).toContain("base changed");
+    }),
+  );
 
-  it("falls back to the full diff for unsafe or incomplete head comparisons", () => {
-    const diverged = select({
-      comparison: ReviewHeadComparison.make({ ...comparison, status: "diverged" }),
-    });
-    expect(diverged.mode).toBe("full");
-    expect(diverged.reason).toContain("not an ancestor");
+  it.effect("falls back to the full diff for unsafe or incomplete head comparisons", () =>
+    Effect.gen(function* () {
+      const diverged = yield* select({
+        comparison: ReviewHeadComparison.make({ ...comparison, status: "diverged" }),
+      });
+      expect(diverged.mode).toBe("full");
+      expect(diverged.reason).toContain("not an ancestor");
 
-    const truncated = select({
-      comparison: ReviewHeadComparison.make({ ...comparison, truncated: true }),
-    });
-    expect(truncated.mode).toBe("full");
-    expect(truncated.reason).toContain("file bound");
+      const truncated = yield* select({
+        comparison: ReviewHeadComparison.make({ ...comparison, truncated: true }),
+      });
+      expect(truncated.mode).toBe("full");
+      expect(truncated.reason).toContain("file bound");
 
-    const unavailable = select({ comparison: undefined });
-    expect(unavailable.mode).toBe("full");
-    expect(unavailable.reason).toContain("comparison was unavailable");
-  });
+      const unavailable = yield* select({ comparison: undefined });
+      expect(unavailable.mode).toBe("full");
+      expect(unavailable.reason).toContain("comparison was unavailable");
+    }),
+  );
 
-  it("keeps an ancestor base advance incremental and includes overlapping PR context", () => {
-    const nextBase = "4".repeat(40);
-    const baseComparison = ReviewHeadComparison.make({
-      status: "ahead",
-      baseSha: BASE_SHA,
-      headSha: nextBase,
-      mergeBaseSha: BASE_SHA,
-      files: [acceptedFile],
-      truncated: false,
-    });
-    const selection = select({
-      current: PullRequestMetadata.make({ ...metadata, baseSha: nextBase }),
-      baseComparison,
-    });
-    expect(selection.mode).toBe("incremental");
-    expect(selection.files.map((file) => file.path)).toEqual([
-      "src/accepted.ts",
-      "src/corrective.ts",
-    ]);
-    expect(selection.reason).toContain("base advanced");
+  it.effect("keeps an ancestor base advance incremental and includes overlapping PR context", () =>
+    Effect.gen(function* () {
+      const nextBase = "4".repeat(40);
+      const baseComparison = ReviewHeadComparison.make({
+        status: "ahead",
+        baseSha: BASE_SHA,
+        headSha: nextBase,
+        mergeBaseSha: BASE_SHA,
+        files: [acceptedFile],
+        truncated: false,
+      });
+      const selection = yield* select({
+        current: PullRequestMetadata.make({ ...metadata, baseSha: nextBase }),
+        baseComparison,
+      });
+      expect(selection.mode).toBe("incremental");
+      expect(selection.files.map((file) => file.path)).toEqual([
+        "src/accepted.ts",
+        "src/corrective.ts",
+      ]);
+      expect(selection.reason).toContain("base advanced");
 
-    const rewrittenBase = select({
-      current: PullRequestMetadata.make({ ...metadata, baseSha: nextBase }),
-      baseComparison: ReviewHeadComparison.make({
-        ...baseComparison,
-        status: "diverged",
-        mergeBaseSha: "5".repeat(40),
-      }),
-    });
-    expect(rewrittenBase.mode).toBe("full");
-    expect(rewrittenBase.reason).toContain("changed materially");
-  });
+      const rewrittenBase = yield* select({
+        current: PullRequestMetadata.make({ ...metadata, baseSha: nextBase }),
+        baseComparison: ReviewHeadComparison.make({
+          ...baseComparison,
+          status: "diverged",
+          mergeBaseSha: "5".repeat(40),
+        }),
+      });
+      expect(rewrittenBase.mode).toBe("full");
+      expect(rewrittenBase.reason).toContain("changed materially");
+    }),
+  );
 
-  it("performs a bounded full-diff audit only when final mode is explicit", () => {
-    const selection = select({ requestedMode: "final" });
-    expect(selection.mode).toBe("full");
-    expect(selection.files.map((file) => file.path)).toEqual([
-      "src/accepted.ts",
-      "src/corrective.ts",
-    ]);
-    expect(selection.reason).toBe("explicit final full-diff audit requested");
-    expect(selection.priorState).toBe(undefined);
-  });
+  it.effect("performs a bounded full-diff audit only when final mode is explicit", () =>
+    Effect.gen(function* () {
+      const selection = yield* select({ requestedMode: "final" });
+      expect(selection.mode).toBe("full");
+      expect(selection.files.map((file) => file.path)).toEqual([
+        "src/accepted.ts",
+        "src/corrective.ts",
+      ]);
+      expect(selection.reason).toBe("explicit final full-diff audit requested");
+      expect(selection.priorState).toBe(undefined);
+    }),
+  );
 });


### PR DESCRIPTION
## Outcome

Makes the PR review bot fail closed when a large review is incomplete instead of posting a misleading zero-finding result.

This is intentionally stacked on #92 because the bot package consumes the runtime contracts introduced there. After #92 merges, this PR can be retargeted to `main` without changing its bot-only diff.

## What changed

- binds narrowed review selections to authenticated PR metadata, exact file evidence, and recovered review state;
- fans out oversized routine and final-audit reviews with bounded concurrency, retry, duration, call, turn, and token budgets;
- requires exact path coverage and ordered terminal evidence before publishing findings or retrying failed units;
- preserves bounded policy-failure diagnostics and rejects incomplete coverage;
- updates the Action bundle, workflow profile, and package documentation.

## Evidence

- `vp check packages/pr-review` — 0 errors;
- `vp run -F @effect-agent/pr-review test` — 144 passed, 1 intentional skip;
- `vp run action:build -- --check` — bundle current;
- scoped formatting and `git diff --check` — clean.

Key implementation: `packages/pr-review/src/internal/run.ts`, `packages/pr-review/src/internal/fan-out.ts`, `packages/pr-review/src/internal/review-state.ts`, and `.github/workflows/pr-review.yml`.
