### PR TITLE
fix(session): preserve durable run duration deadlines

### DIFF
--- a/.changeset/durable-run-duration.md
+++ b/.changeset/durable-run-duration.md
@@ -8,6 +8,7 @@ Preserve one wall-clock `maxDuration` deadline across durable Attempts. The coor
 derives the logical Run deadline from its first canonical input record, so recovery and
 `waitingForChild` suspension cannot reset the parent allowance; queue time remains excluded and
 the engine's deadline option is tightening-only. Already-settled child joins remain mandatory
-recovery cleanup before an expired parent records its typed duration failure.
+recovery cleanup before an expired parent records its typed duration failure; cleanup authority
+names the exact open delegation Calls and duration interruption resumes before continuation.
 Adapter certification fixtures now keep their Run duration above the deliberate multi-round
 virtual lease-expiry horizon instead of relying on replacement Attempts to reset it.

--- a/.changeset/durable-run-duration.md
+++ b/.changeset/durable-run-duration.md
@@ -1,0 +1,13 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/session": patch
+"@effect-agent/testing": patch
+---
+
+Preserve one wall-clock `maxDuration` deadline across durable Attempts. The coordinator now
+derives the logical Run deadline from its first canonical input record, so recovery and
+`waitingForChild` suspension cannot reset the parent allowance; queue time remains excluded and
+the engine's deadline option is tightening-only. Already-settled child joins remain mandatory
+recovery cleanup before an expired parent records its typed duration failure.
+Adapter certification fixtures now keep their Run duration above the deliberate multi-round
+virtual lease-expiry horizon instead of relying on replacement Attempts to reset it.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -35348,6 +35348,10 @@ function decodeRunDisposition(agent2, encoded) {
   })) : decodeRunDispositionCandidate(declaration, encoded);
 }
 var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => exports_Stream.unwrap(exports_Effect.gen(function* () {
+  const now3 = yield* exports_Clock.currentTimeMillis;
+  if (now3 >= context3.durationDeadlineMillis) {
+    return failRunEventStream(durationLimitError(agent2.definition.policy));
+  }
   const ids = yield* IdGenerator;
   const turnId = yield* ids.nextTurnId;
   const outputContract = outputSchemaContract(agent2.definition);
@@ -35837,10 +35841,18 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
   return started.pipe(exports_Stream.concat(toolResults), exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options)));
 }));
 var failRunEventStream = (error2) => exports_Stream.fail(error2);
+var durationLimitError = (policy2) => AgentPolicyError.make({
+  limit: "duration",
+  message: `Agent exceeded its ${exports_Duration.format(policy2.maxDuration)} duration limit`
+});
 var guardBudgetStream = (stream, budget) => budget === undefined ? stream : exports_Stream.transformPull(stream, (pull) => exports_Effect.succeed(budget.guard(pull)));
 var stream = (agent2, input, options = {}) => {
   const interpreted = exports_Stream.unwrap(exports_Effect.gen(function* () {
-    const startedAtMillis = yield* exports_Clock.currentTimeMillis;
+    const attemptStartedAtMillis = yield* exports_Clock.currentTimeMillis;
+    const maxDurationMillis = exports_Duration.toMillis(agent2.definition.policy.maxDuration);
+    const attemptDeadlineMillis = attemptStartedAtMillis + maxDurationMillis;
+    const durationDeadlineMillis = options.durationDeadline === undefined ? attemptDeadlineMillis : Math.min(attemptDeadlineMillis, exports_DateTime.toEpochMillis(options.durationDeadline));
+    const startedAtMillis = durationDeadlineMillis - maxDurationMillis;
     const ids = yield* IdGenerator;
     const conversationId = options.conversationId === undefined ? yield* ids.nextConversationId : options.conversationId;
     const runId = options.runId === undefined ? yield* ids.nextRunId : options.runId;
@@ -35850,6 +35862,7 @@ var stream = (agent2, input, options = {}) => {
       runId,
       pendingFollowUps: [],
       startedAtMillis,
+      durationDeadlineMillis,
       history: options.history ?? exports_Prompt.empty,
       modelCalls: options.resumeUsage?.modelCalls ?? 0,
       consecutiveToolFailures: 0,
@@ -35916,19 +35929,16 @@ var stream = (agent2, input, options = {}) => {
       const initialPrompt = yield* appendInputs(context3, prompt, steering, options);
       return makeTurn(agent2, context3, initialPrompt, 1, 0, options);
     }));
-    const durationLimit = AgentPolicyError.make({
-      limit: "duration",
-      message: `Agent exceeded its ${exports_Duration.format(agent2.definition.policy.maxDuration)} duration limit`
-    });
+    const durationLimit = durationLimitError(agent2.definition.policy);
     const deadlineEffect = exports_Effect.gen(function* () {
       const now3 = yield* exports_Clock.currentTimeMillis;
-      const remaining2 = startedAtMillis + exports_Duration.toMillis(agent2.definition.policy.maxDuration) - now3;
+      const remaining2 = durationDeadlineMillis - now3;
       if (remaining2 > 0) {
         yield* exports_Effect.sleep(remaining2);
       }
       return yield* durationLimit;
     });
-    const deadline = execution.pipe(exports_Stream.interruptWhen(deadlineEffect));
+    const deadline = options.resume?.completeSettledChildJoinsPastDeadline === true ? execution : execution.pipe(exports_Stream.interruptWhen(deadlineEffect));
     const engineToolServices = exports_Context.make(AgentSpawner, makeAgentSpawner({
       agentId: context3.agentId,
       conversationId: context3.conversationId,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -35783,6 +35783,16 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
       isFailure: settledCall.isFailure
     };
   }
+  const settledChildJoinCallIds = resume.settledChildJoinCallIdsPastDeadline;
+  if (settledChildJoinCallIds !== undefined) {
+    const cleanupIds = new Set(settledChildJoinCallIds);
+    const openCalls = resume.calls.filter((call) => !settledIds.has(call.id));
+    if (settledChildJoinCallIds.length === 0 || cleanupIds.size !== settledChildJoinCallIds.length || openCalls.length !== cleanupIds.size || openCalls.some((call) => !cleanupIds.has(call.id) || !isDelegationToolName(call.name))) {
+      return failRunEventStream(ModelProtocolError.make({
+        message: "Past-deadline cleanup authority must identify every and only still-open delegation Tool Call"
+      }));
+    }
+  }
   const policy2 = agent2.definition.policy;
   const bounds = effectiveRunBounds(policy2, options);
   const toolCalls = trace2.toolCalls.size;
@@ -35827,24 +35837,36 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
       })
     ];
   }).pipe(exports_Effect.withLogSpan("AgentRuntime.resume"))).pipe(exports_Stream.flatMap(exports_Stream.fromIterable));
+  const continueAfterBatch = () => {
+    const continuation = toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options);
+    return settledChildJoinCallIds === undefined ? continuation : enforceDurationDeadline(continuation, context3.durationDeadlineMillis, durationLimitError(policy2));
+  };
   if (overToolBudget) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
       limit: "tool-calls",
       message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
     }), settledIds);
-    return started.pipe(exports_Stream.concat(exports_Stream.fromIterable(rejection)), exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options)));
+    return started.pipe(exports_Stream.concat(exports_Stream.fromIterable(rejection)), exports_Stream.concat(continueAfterBatch()));
   }
   const toolResults = guardBudgetStream(executeToolBatch(context3, turnId, toolkit, trace2.applicationToolCalls, trace2, concurrency, options, {
     maxToolCalls: bounds.maxToolCalls,
     declaredToolCalls: toolCalls
   }, agent2.definition.policy.toolResultBounds, settledIds), options.budget);
-  return started.pipe(exports_Stream.concat(toolResults), exports_Stream.concat(toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options)));
+  return started.pipe(exports_Stream.concat(toolResults), exports_Stream.concat(continueAfterBatch()));
 }));
 var failRunEventStream = (error2) => exports_Stream.fail(error2);
 var durationLimitError = (policy2) => AgentPolicyError.make({
   limit: "duration",
   message: `Agent exceeded its ${exports_Duration.format(policy2.maxDuration)} duration limit`
 });
+var enforceDurationDeadline = (execution, durationDeadlineMillis, durationLimit) => exports_Stream.unwrap(exports_Effect.gen(function* () {
+  const now3 = yield* exports_Clock.currentTimeMillis;
+  const remaining2 = durationDeadlineMillis - now3;
+  if (remaining2 <= 0) {
+    return exports_Stream.fail(durationLimit);
+  }
+  return execution.pipe(exports_Stream.interruptWhen(exports_Effect.sleep(remaining2).pipe(exports_Effect.andThen(exports_Effect.fail(durationLimit)))));
+}));
 var guardBudgetStream = (stream, budget) => budget === undefined ? stream : exports_Stream.transformPull(stream, (pull) => exports_Effect.succeed(budget.guard(pull)));
 var stream = (agent2, input, options = {}) => {
   const interpreted = exports_Stream.unwrap(exports_Effect.gen(function* () {
@@ -35930,16 +35952,7 @@ var stream = (agent2, input, options = {}) => {
       return makeTurn(agent2, context3, initialPrompt, 1, 0, options);
     }));
     const durationLimit = durationLimitError(agent2.definition.policy);
-    const deadlineExpired = (yield* exports_Clock.currentTimeMillis) >= durationDeadlineMillis;
-    const deadlineEffect = exports_Effect.gen(function* () {
-      const now3 = yield* exports_Clock.currentTimeMillis;
-      const remaining2 = durationDeadlineMillis - now3;
-      if (remaining2 > 0) {
-        yield* exports_Effect.sleep(remaining2);
-      }
-      return yield* durationLimit;
-    });
-    const deadline = options.resume?.completeSettledChildJoinsPastDeadline === true ? execution : deadlineExpired ? failRunEventStream(durationLimit) : execution.pipe(exports_Stream.interruptWhen(deadlineEffect));
+    const deadline = options.resume?.settledChildJoinCallIdsPastDeadline !== undefined ? execution : enforceDurationDeadline(execution, durationDeadlineMillis, durationLimit);
     const engineToolServices = exports_Context.make(AgentSpawner, makeAgentSpawner({
       agentId: context3.agentId,
       conversationId: context3.conversationId,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -35930,6 +35930,7 @@ var stream = (agent2, input, options = {}) => {
       return makeTurn(agent2, context3, initialPrompt, 1, 0, options);
     }));
     const durationLimit = durationLimitError(agent2.definition.policy);
+    const deadlineExpired = (yield* exports_Clock.currentTimeMillis) >= durationDeadlineMillis;
     const deadlineEffect = exports_Effect.gen(function* () {
       const now3 = yield* exports_Clock.currentTimeMillis;
       const remaining2 = durationDeadlineMillis - now3;
@@ -35938,7 +35939,7 @@ var stream = (agent2, input, options = {}) => {
       }
       return yield* durationLimit;
     });
-    const deadline = options.resume?.completeSettledChildJoinsPastDeadline === true ? execution : execution.pipe(exports_Stream.interruptWhen(deadlineEffect));
+    const deadline = options.resume?.completeSettledChildJoinsPastDeadline === true ? execution : deadlineExpired ? failRunEventStream(durationLimit) : execution.pipe(exports_Stream.interruptWhen(deadlineEffect));
     const engineToolServices = exports_Context.make(AgentSpawner, makeAgentSpawner({
       agentId: context3.agentId,
       conversationId: context3.conversationId,

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -33,15 +33,15 @@ AgentPolicy.make({
 });
 ```
 
-| Bound                  | What it limits                                      | On exhaustion                     |
-| ---------------------- | --------------------------------------------------- | --------------------------------- |
-| `maxTurns`             | model requests per Run                              | `onExhaustion` resolves           |
-| `maxToolCalls`         | declared Tool Calls per Run (programmatic included) | `onExhaustion` resolves           |
-| `maxDuration`          | wall clock per Run                                  | always fails typed                |
-| `tokenBudget`          | input + output tokens per Run                       | `onExhaustion` resolves (RUN-025) |
-| `costBudgetMicrousd`   | estimated cost per Run (needs a cost estimator)     | always fails typed                |
-| `repeatedFailureLimit` | consecutive terminal Tool failures                  | always fails typed                |
-| `toolConcurrency`      | parallel Tool Handlers per batch                    | not a failure — a gate            |
+| Bound                  | What it limits                                       | On exhaustion                     |
+| ---------------------- | ---------------------------------------------------- | --------------------------------- |
+| `maxTurns`             | model requests per Run                               | `onExhaustion` resolves           |
+| `maxToolCalls`         | declared Tool Calls per Run (programmatic included)  | `onExhaustion` resolves           |
+| `maxDuration`          | logical-Run wall clock, including durable suspension | always fails typed                |
+| `tokenBudget`          | input + output tokens per Run                        | `onExhaustion` resolves (RUN-025) |
+| `costBudgetMicrousd`   | estimated cost per Run (needs a cost estimator)      | always fails typed                |
+| `repeatedFailureLimit` | consecutive terminal Tool failures                   | always fails typed                |
+| `toolConcurrency`      | parallel Tool Handlers per batch                     | not a failure — a gate            |
 
 A typed exhaustion failure is `AgentPolicyError` with a `limit` literal naming which bound bound.
 In the DN and DC assemblies a Run failed this way settles with that literal preserved as the

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -103,8 +103,11 @@ An ordinary replacement Attempt whose deadline is already expired fails before s
 unresolved Tool or model execution; deadline interruption then handles only future expiry.
 If the deadline expires while attached children are suspended, the coordinator still completes
 the mandatory joins of children whose Settlements are already canonical before failing the
-parent. That recovery cleanup authorizes no new child, ordinary Tool, or model execution and
-cannot turn the expired Run into success (SUB-019).
+parent. The coordinator supplies the exact still-open child Call IDs, the engine verifies they
+are every and only the resumed delegation calls, and duration interruption is restored around
+the continuation after those joins. That recovery cleanup authorizes no new child, ordinary
+Tool, or model execution and cannot turn the expired Run into success, including when the
+deadline expires during the post-join continuation (SUB-019).
 
 Note on durable Attempts: the batch-resume seam counts Tool Calls from the resumed batch onward,
 so `maxToolCalls` is enforced per Attempt under the durable coordinator. This is existing,
@@ -592,5 +595,6 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   absolute deadline from the first canonical input record and preserve that deadline across
   Attempt replacement and every durable suspension; admission and queue delay are excluded, and
   no Run option may widen the Definition's fresh duration allowance. Already-settled attached
-  children still join as mandatory recovery cleanup before the expired parent fails, without
-  authorizing a new model, ordinary Tool, or child execution.
+  children still join as mandatory recovery cleanup before the expired parent fails. The engine
+  verifies the coordinator's exact open delegation Call IDs and restores duration interruption
+  before continuation, without authorizing a new model, ordinary Tool, or child execution.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -92,6 +92,18 @@ Call success resets it, and reaching `repeatedFailureLimit` fails the Run with t
 failure (`limit: "repeated-failures"`). A `repeatedFailureLimit` of `0` disables the bound.
 Budget-rejected synthetic settlements neither advance nor reset that counter.
 
+`maxDuration` bounds wall clock for one logical Run, not one process Attempt and not cumulative
+worker-active time. In the durable assemblies the clock starts when the Submission's initial
+`UserInputRecorded` record becomes canonical: admission and queue delay precede the Run clock,
+while process loss, recovery gaps, approval suspension, unknown-outcome suspension, and
+`waitingForChild` suspension do not reset or pause it. The coordinator derives one absolute
+deadline from that canonical timestamp and supplies it to every replacement Attempt; the engine
+accepts only a deadline that preserves or tightens its fresh policy allowance (RUN-030).
+If the deadline expires while attached children are suspended, the coordinator still completes
+the mandatory joins of children whose Settlements are already canonical before failing the
+parent. That recovery cleanup authorizes no new child, ordinary Tool, or model execution and
+cannot turn the expired Run into success (SUB-019).
+
 Note on durable Attempts: the batch-resume seam counts Tool Calls from the resumed batch onward,
 so `maxToolCalls` is enforced per Attempt under the durable coordinator. This is existing,
 documented behavior; cumulative cross-Attempt accounting would require persisted counters and is
@@ -574,3 +586,9 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   persist the selected value. Failed, interrupted, aborted, incomplete, run-less, and
   budget-exhausted Runs carry none; invalid values fail typed, and consumers never infer a
   disposition from prose or Tool output.
+- **RUN-030:** `maxDuration` is one wall-clock allowance per logical Run. DN and DC derive its
+  absolute deadline from the first canonical input record and preserve that deadline across
+  Attempt replacement and every durable suspension; admission and queue delay are excluded, and
+  no Run option may widen the Definition's fresh duration allowance. Already-settled attached
+  children still join as mandatory recovery cleanup before the expired parent fails, without
+  authorizing a new model, ordinary Tool, or child execution.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -99,6 +99,8 @@ while process loss, recovery gaps, approval suspension, unknown-outcome suspensi
 `waitingForChild` suspension do not reset or pause it. The coordinator derives one absolute
 deadline from that canonical timestamp and supplies it to every replacement Attempt; the engine
 accepts only a deadline that preserves or tightens its fresh policy allowance (RUN-030).
+An ordinary replacement Attempt whose deadline is already expired fails before subscribing to
+unresolved Tool or model execution; deadline interruption then handles only future expiry.
 If the deadline expires while attached children are suspended, the coordinator still completes
 the mandatory joins of children whose Settlements are already canonical before failing the
 parent. That recovery cleanup authorizes no new child, ordinary Tool, or model execution and

--- a/docs/spec/subagents.md
+++ b/docs/spec/subagents.md
@@ -599,8 +599,12 @@ another child.
 
 `waitingForChild` retains the parent Conversation lane, ownership of the join obligation, and its
 open budget reservation, but holds no worker, provider, model, Tool, or child-concurrency permit.
-Child Settlement durably wakes the parent. The child uses its separate Conversation lane. S2 MUST
-prove this suspension/wakeup path at the smallest worker-pool size.
+It does not pause the parent logical Run's wall-clock `maxDuration` (RUN-030). Child Settlement
+durably wakes the parent. The child uses its separate Conversation lane. S2 MUST prove this
+suspension/wakeup path at the smallest worker-pool size. If the parent deadline has expired by
+then, its replacement Attempt may complete only the already-settled child join and reservation
+release before recording the typed duration failure; it may not invoke another model, ordinary
+Tool, or child.
 
 Joining is also recoverable:
 
@@ -906,7 +910,8 @@ Require separate proposals:
 - **SUB-029**: S1 and S2 reject every nested delegation at preflight; depth above one requires a
   separately accepted scheduling, cycle, authority, and budget contract.
 - **SUB-030**: A durable parent waiting for a child retains its lane and join obligation but
-  releases worker, provider, model, Tool, and child-concurrency permits.
+  releases worker, provider, model, Tool, and child-concurrency permits without pausing its
+  logical Run's wall-clock duration allowance.
 - **SUB-031**: Durable admission recovery uses an authoritative idempotency-key query with
   `notAdmitted`, `admitted`, and `indeterminate` results; projection absence never proves absence.
 - **SUB-032**: Child-binding and parent-declaration compatibility failures have distinct,

--- a/docs/spec/subagents.md
+++ b/docs/spec/subagents.md
@@ -603,8 +603,10 @@ It does not pause the parent logical Run's wall-clock `maxDuration` (RUN-030). C
 durably wakes the parent. The child uses its separate Conversation lane. S2 MUST prove this
 suspension/wakeup path at the smallest worker-pool size. If the parent deadline has expired by
 then, its replacement Attempt may complete only the already-settled child join and reservation
-release before recording the typed duration failure; it may not invoke another model, ordinary
-Tool, or child.
+release before recording the typed duration failure. The coordinator names the exact open child
+Call IDs, the engine rejects a cleanup claim covering any ordinary or non-open call, and duration
+interruption resumes around the post-join continuation; it may not invoke another model,
+ordinary Tool, or child.
 
 Joining is also recoverable:
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -20,6 +20,7 @@ import {
   type DelegationId,
   IdGenerator,
   type InstructionSource,
+  isDelegationToolName,
   type RunDispositionDeclaration,
   ModelStarted,
   ModelProtocolError,
@@ -3934,6 +3935,24 @@ const makeResumeTurn = <
           isFailure: settledCall.isFailure,
         };
       }
+      const settledChildJoinCallIds = resume.settledChildJoinCallIdsPastDeadline;
+      if (settledChildJoinCallIds !== undefined) {
+        const cleanupIds = new Set<string>(settledChildJoinCallIds);
+        const openCalls = resume.calls.filter((call) => !settledIds.has(call.id));
+        if (
+          settledChildJoinCallIds.length === 0 ||
+          cleanupIds.size !== settledChildJoinCallIds.length ||
+          openCalls.length !== cleanupIds.size ||
+          openCalls.some((call) => !cleanupIds.has(call.id) || !isDelegationToolName(call.name))
+        ) {
+          return failRunEventStream(
+            ModelProtocolError.make({
+              message:
+                "Past-deadline cleanup authority must identify every and only still-open delegation Tool Call",
+            }),
+          );
+        }
+      }
       const policy = agent.definition.policy;
       const bounds = effectiveRunBounds(policy, options);
       const toolCalls = trace.toolCalls.size;
@@ -4006,6 +4025,24 @@ const makeResumeTurn = <
           ] satisfies ReadonlyArray<RunEvent>;
         }).pipe(Effect.withLogSpan("AgentRuntime.resume")),
       ).pipe(Stream.flatMap(Stream.fromIterable));
+      const continueAfterBatch = () => {
+        const continuation = toolBatchContinuation(
+          agent,
+          context,
+          trace,
+          resumedPrompt,
+          turn,
+          toolCalls,
+          options,
+        );
+        return settledChildJoinCallIds === undefined
+          ? continuation
+          : enforceDurationDeadline(
+              continuation,
+              context.durationDeadlineMillis,
+              durationLimitError(policy),
+            );
+      };
 
       // RUN-018 on the resume path: a canonically declared over-budget batch
       // settles synthetically under final-answer mode — recorded settled
@@ -4025,9 +4062,7 @@ const makeResumeTurn = <
         );
         return started.pipe(
           Stream.concat(Stream.fromIterable(rejection)),
-          Stream.concat(
-            toolBatchContinuation(agent, context, trace, resumedPrompt, turn, toolCalls, options),
-          ),
+          Stream.concat(continueAfterBatch()),
         );
       }
       const toolResults = guardBudgetStream(
@@ -4048,12 +4083,7 @@ const makeResumeTurn = <
         ),
         options.budget,
       );
-      return started.pipe(
-        Stream.concat(toolResults),
-        Stream.concat(
-          toolBatchContinuation(agent, context, trace, resumedPrompt, turn, toolCalls, options),
-        ),
-      );
+      return started.pipe(Stream.concat(toolResults), Stream.concat(continueAfterBatch()));
     }),
   );
 
@@ -4065,6 +4095,26 @@ const durationLimitError = (policy: AgentPolicy): AgentPolicyError =>
     limit: "duration",
     message: `Agent exceeded its ${Duration.format(policy.maxDuration)} duration limit`,
   });
+
+const enforceDurationDeadline = <A, E, R>(
+  execution: Stream.Stream<A, E, R>,
+  durationDeadlineMillis: number,
+  durationLimit: AgentPolicyError,
+): Stream.Stream<A, E | AgentPolicyError, R> =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const remaining = durationDeadlineMillis - now;
+      if (remaining <= 0) {
+        return Stream.fail(durationLimit);
+      }
+      return execution.pipe(
+        Stream.interruptWhen(
+          Effect.sleep(remaining).pipe(Effect.andThen(Effect.fail(durationLimit))),
+        ),
+      );
+    }),
+  );
 
 const guardBudgetStream = <A, E, R, HookError, HookRequirements>(
   stream: Stream.Stream<A, E, R>,
@@ -4241,28 +4291,14 @@ const stream = <
       );
 
       const durationLimit = durationLimitError(agent.definition.policy);
-      // Fail an already-expired ordinary Attempt synchronously before
-      // subscribing to the lazy resume/execution stream. The ongoing
-      // interrupter below remains responsible only for future expiry.
-      const deadlineExpired = (yield* Clock.currentTimeMillis) >= durationDeadlineMillis;
-      const deadlineEffect = Effect.gen(function* () {
-        const now = yield* Clock.currentTimeMillis;
-        const remaining = durationDeadlineMillis - now;
-        if (remaining > 0) {
-          yield* Effect.sleep(remaining);
-        }
-        return yield* durationLimit;
-      });
-      // A coordinator-proven resume of already-settled attached children is
-      // mandatory accepted-work cleanup. Let those joins commit, then the
-      // `makeTurn` pre-model check observes the same expired deadline; no
-      // model call or new child/external work receives an extension.
+      // A coordinator-proven resume of exact already-settled attached-child
+      // Calls is mandatory accepted-work cleanup. `makeResumeTurn` validates
+      // and runs only that join batch past expiry, then restores this same
+      // deadline guard around its continuation.
       const deadline =
-        options.resume?.completeSettledChildJoinsPastDeadline === true
+        options.resume?.settledChildJoinCallIdsPastDeadline !== undefined
           ? execution
-          : deadlineExpired
-            ? failRunEventStream(durationLimit)
-            : execution.pipe(Stream.interruptWhen(deadlineEffect));
+          : enforceDurationDeadline(execution, durationDeadlineMillis, durationLimit);
 
       // Engine-provided Tool services for this Run: a real `AgentSpawner`
       // bound to the Run's immutable identity and delegation depth, plus the

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4241,6 +4241,10 @@ const stream = <
       );
 
       const durationLimit = durationLimitError(agent.definition.policy);
+      // Fail an already-expired ordinary Attempt synchronously before
+      // subscribing to the lazy resume/execution stream. The ongoing
+      // interrupter below remains responsible only for future expiry.
+      const deadlineExpired = (yield* Clock.currentTimeMillis) >= durationDeadlineMillis;
       const deadlineEffect = Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis;
         const remaining = durationDeadlineMillis - now;
@@ -4256,7 +4260,9 @@ const stream = <
       const deadline =
         options.resume?.completeSettledChildJoinsPastDeadline === true
           ? execution
-          : execution.pipe(Stream.interruptWhen(deadlineEffect));
+          : deadlineExpired
+            ? failRunEventStream(durationLimit)
+            : execution.pipe(Stream.interruptWhen(deadlineEffect));
 
       // Engine-provided Tool services for this Run: a real `AgentSpawner`
       // bound to the Run's immutable identity and delegation depth, plus the

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -317,6 +317,8 @@ interface RunContext {
   readonly pendingFollowUps: Array<Prompt.RawInput>;
   /** Wall-clock Run start, the base of the run-status elapsed rendering (RUN-024). */
   readonly startedAtMillis: number;
+  /** Absolute `maxDuration` rail shared by every durable Attempt (RUN-030). */
+  readonly durationDeadlineMillis: number;
   history: Prompt.Prompt;
   modelCalls: number;
   consecutiveToolFailures: number;
@@ -2976,6 +2978,10 @@ const makeTurn = <
 > =>
   Stream.unwrap(
     Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      if (now >= context.durationDeadlineMillis) {
+        return failRunEventStream(durationLimitError(agent.definition.policy));
+      }
       const ids = yield* IdGenerator;
       const turnId = yield* ids.nextTurnId;
       // Model-visible final-output contract (RUN-028):
@@ -4054,6 +4060,12 @@ const makeResumeTurn = <
 const failRunEventStream = <Error>(error: Error): Stream.Stream<RunEvent, Error> =>
   Stream.fail(error);
 
+const durationLimitError = (policy: AgentPolicy): AgentPolicyError =>
+  AgentPolicyError.make({
+    limit: "duration",
+    message: `Agent exceeded its ${Duration.format(policy.maxDuration)} duration limit`,
+  });
+
 const guardBudgetStream = <A, E, R, HookError, HookRequirements>(
   stream: Stream.Stream<A, E, R>,
   budget: RunOptions<HookError, HookRequirements>["budget"],
@@ -4100,7 +4112,17 @@ const stream = <
 > => {
   const interpreted = Stream.unwrap(
     Effect.gen(function* () {
-      const startedAtMillis = yield* Clock.currentTimeMillis;
+      const attemptStartedAtMillis = yield* Clock.currentTimeMillis;
+      const maxDurationMillis = Duration.toMillis(agent.definition.policy.maxDuration);
+      const attemptDeadlineMillis = attemptStartedAtMillis + maxDurationMillis;
+      // RUN-030: a durable coordinator supplies the logical Run deadline from
+      // canonical Run-start evidence. Taking the earlier deadline keeps this
+      // public option tightening-only for every other caller.
+      const durationDeadlineMillis =
+        options.durationDeadline === undefined
+          ? attemptDeadlineMillis
+          : Math.min(attemptDeadlineMillis, DateTime.toEpochMillis(options.durationDeadline));
+      const startedAtMillis = durationDeadlineMillis - maxDurationMillis;
       const ids = yield* IdGenerator;
       const conversationId =
         options.conversationId === undefined
@@ -4113,6 +4135,7 @@ const stream = <
         runId,
         pendingFollowUps: [],
         startedAtMillis,
+        durationDeadlineMillis,
         history: options.history ?? Prompt.empty,
         // RUN-019: a resumed Attempt re-seeds cumulative usage from the
         // canonical response records so token budgets and the compaction
@@ -4217,20 +4240,23 @@ const stream = <
         }),
       );
 
-      const durationLimit = AgentPolicyError.make({
-        limit: "duration",
-        message: `Agent exceeded its ${Duration.format(agent.definition.policy.maxDuration)} duration limit`,
-      });
+      const durationLimit = durationLimitError(agent.definition.policy);
       const deadlineEffect = Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis;
-        const remaining =
-          startedAtMillis + Duration.toMillis(agent.definition.policy.maxDuration) - now;
+        const remaining = durationDeadlineMillis - now;
         if (remaining > 0) {
           yield* Effect.sleep(remaining);
         }
         return yield* durationLimit;
       });
-      const deadline = execution.pipe(Stream.interruptWhen(deadlineEffect));
+      // A coordinator-proven resume of already-settled attached children is
+      // mandatory accepted-work cleanup. Let those joins commit, then the
+      // `makeTurn` pre-model check observes the same expired deadline; no
+      // model call or new child/external work receives an extension.
+      const deadline =
+        options.resume?.completeSettledChildJoinsPastDeadline === true
+          ? execution
+          : execution.pipe(Stream.interruptWhen(deadlineEffect));
 
       // Engine-provided Tool services for this Run: a real `AgentSpawner`
       // bound to the Run's immutable identity and delegation depth, plus the

--- a/packages/engine/src/run-options.ts
+++ b/packages/engine/src/run-options.ts
@@ -395,13 +395,13 @@ export interface RunTurnResume {
   readonly calls: ReadonlyArray<RunTurnResumeCall>;
   readonly settled: ReadonlyArray<RunTurnResumeSettledCall>;
   /**
-   * The durable coordinator proved that every still-open call is an attached
-   * child whose Settlement is already canonical. Those mandatory joins may
+   * Exact still-open delegation Call IDs whose attached child Settlements the
+   * durable coordinator proved canonical. Only this resumed join batch may
    * finish after the logical Run deadline so accepted-work cleanup cannot be
-   * stranded; the next Turn still observes the expired deadline before any
-   * model call or new Tool work starts (RUN-030/SUB-019).
+   * stranded; duration enforcement resumes before the continuation can start
+   * model, ordinary Tool, or new-child work (RUN-030/SUB-019).
    */
-  readonly completeSettledChildJoinsPastDeadline?: true | undefined;
+  readonly settledChildJoinCallIdsPastDeadline?: ReadonlyArray<ToolCallId> | undefined;
   /**
    * The pending Turn's committed LEADING messages — the messages the durable
    * coordinator committed inside the pending Turn's canonical response record

--- a/packages/engine/src/run-options.ts
+++ b/packages/engine/src/run-options.ts
@@ -10,7 +10,7 @@ import type {
   ToolCallId,
   TurnId,
 } from "@effect-agent/core";
-import type { Effect } from "effect";
+import type { DateTime, Effect } from "effect";
 import type { Prompt, Response } from "effect/unstable/ai";
 
 import type { RunStepHook, ToolExecutionClassValue } from "./durable-step.ts";
@@ -395,6 +395,14 @@ export interface RunTurnResume {
   readonly calls: ReadonlyArray<RunTurnResumeCall>;
   readonly settled: ReadonlyArray<RunTurnResumeSettledCall>;
   /**
+   * The durable coordinator proved that every still-open call is an attached
+   * child whose Settlement is already canonical. Those mandatory joins may
+   * finish after the logical Run deadline so accepted-work cleanup cannot be
+   * stranded; the next Turn still observes the expired deadline before any
+   * model call or new Tool work starts (RUN-030/SUB-019).
+   */
+  readonly completeSettledChildJoinsPastDeadline?: true | undefined;
+  /**
    * The pending Turn's committed LEADING messages — the messages the durable
    * coordinator committed inside the pending Turn's canonical response record
    * BEFORE the assistant tool-call message (Turn-1 evaluated instructions +
@@ -456,6 +464,14 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
   readonly approval?: RunApprovalHook<HookError, HookRequirements> | undefined;
   readonly context?: RunContextHook<HookError, HookRequirements> | undefined;
   readonly budget?: RunBudgetHook<HookError, HookRequirements> | undefined;
+  /**
+   * Optional absolute deadline for the Run's `maxDuration` rail. The engine
+   * uses the earlier of this value and the fresh policy deadline, so callers
+   * may preserve or tighten an existing Run allowance but can never widen it.
+   * Durable coordinators derive this value from canonical Run-start evidence
+   * so replacement Attempts share one wall-clock allowance (RUN-030).
+   */
+  readonly durationDeadline?: DateTime.Utc | undefined;
   /**
    * Durable turn-commit seam (P5). When absent the engine behaves exactly as
    * the ephemeral runtime: no response/prepared commits, and `DurableStep`

--- a/packages/engine/test/durable-tool-seam.test.ts
+++ b/packages/engine/test/durable-tool-seam.test.ts
@@ -2,6 +2,7 @@ import {
   Agent,
   AgentApprovalDenied,
   AgentPolicy,
+  AgentPolicyError,
   ConversationId,
   IdGenerator,
   ModelProtocolError,
@@ -10,7 +11,19 @@ import {
   type RunEvent,
 } from "@effect-agent/core";
 import { expect, layer } from "@effect/vitest";
-import { Cause, Context, DateTime, Effect, Exit, Layer, Option, Ref, Schema, Stream } from "effect";
+import {
+  Cause,
+  Clock,
+  Context,
+  DateTime,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Ref,
+  Schema,
+  Stream,
+} from "effect";
 import { LanguageModel, Model, Prompt, type Response, Tool, Toolkit } from "effect/unstable/ai";
 
 import {
@@ -671,6 +684,71 @@ layer(identifiers)("P5 WP1 durable Tool seams", (it) => {
           ["call-b", "handled-b"],
         ]);
       }),
+  );
+
+  it.effect("an expired resumed batch fails before subscribing to unresolved Tool execution", () =>
+    Effect.gen(function* () {
+      const handlerStarts = yield* Ref.make(0);
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      let modelCalls = 0;
+      const Lookup = Tool.make("lookup", {
+        parameters: Schema.Struct({ key: Schema.String }),
+        success: Schema.String,
+      });
+      const tools = Toolkit.make(Lookup);
+      const definition = Agent.define("expired-resume", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Look everything up.",
+        toolkit: tools,
+        policy: policy(),
+      });
+      const model = Model.make(
+        "scripted",
+        "expired-resume",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () => {
+              modelCalls += 1;
+              return Stream.fromIterable(finalParts('{"answer":"unreachable"}'));
+            },
+          }),
+        ),
+      );
+      const toolLayer = tools.toLayer({
+        lookup: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("unexpected")),
+      });
+      const resume: RunTurnResume = {
+        turn: 1,
+        turnId: resumeTurnId,
+        calls: [{ id: "call-open", name: "lookup", params: { key: "a" } }],
+        settled: [],
+      };
+      const now = yield* Clock.currentTimeMillis;
+      const durationDeadline = DateTime.toUtc(DateTime.makeUnsafe(now - 1));
+
+      const exit = yield* AgentRuntime.stream(
+        Agent.withModel(definition, model),
+        { question: "resume" },
+        { durationDeadline, resume },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.exit,
+      );
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect(failure).toMatchObject({ limit: "duration" });
+      expect(yield* Ref.get(handlerStarts)).toBe(0);
+      expect(modelCalls).toBe(0);
+      expect(observed.filter((event) => event._tag === "ToolCallStarted")).toHaveLength(0);
+      expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+    }),
   );
 
   it.effect("truncated tool arguments never execute after resume", () =>

--- a/packages/engine/test/durable-tool-seam.test.ts
+++ b/packages/engine/test/durable-tool-seam.test.ts
@@ -7,6 +7,7 @@ import {
   IdGenerator,
   ModelProtocolError,
   RunId,
+  ToolCallId,
   TurnId,
   type RunEvent,
 } from "@effect-agent/core";
@@ -16,14 +17,17 @@ import {
   Clock,
   Context,
   DateTime,
+  Deferred,
   Effect,
   Exit,
+  Fiber,
   Layer,
   Option,
   Ref,
   Schema,
   Stream,
 } from "effect";
+import { TestClock } from "effect/testing";
 import { LanguageModel, Model, Prompt, type Response, Tool, Toolkit } from "effect/unstable/ai";
 
 import {
@@ -748,6 +752,107 @@ layer(identifiers)("P5 WP1 durable Tool seams", (it) => {
       expect(modelCalls).toBe(0);
       expect(observed.filter((event) => event._tag === "ToolCallStarted")).toHaveLength(0);
       expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+
+      const forgedCleanupExit = yield* AgentRuntime.stream(
+        Agent.withModel(definition, model),
+        { question: "resume" },
+        {
+          durationDeadline,
+          resume: {
+            ...resume,
+            settledChildJoinCallIdsPastDeadline: [Schema.decodeSync(ToolCallId)("call-open")],
+          },
+        },
+      ).pipe(Stream.runDrain, Effect.provide(toolLayer), Effect.exit);
+      const forgedCleanupFailure = failureFrom(forgedCleanupExit);
+
+      expect(forgedCleanupFailure).toBeInstanceOf(ModelProtocolError);
+      expect((forgedCleanupFailure as ModelProtocolError).message).toContain(
+        "still-open delegation Tool Call",
+      );
+      expect(yield* Ref.get(handlerStarts)).toBe(0);
+      expect(modelCalls).toBe(0);
+    }),
+  );
+
+  it.effect("restores duration interruption after settled-child resume cleanup", () =>
+    Effect.gen(function* () {
+      const modelStarted = yield* Deferred.make<void>();
+      const handlerStarts = yield* Ref.make(0);
+      const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+      let modelCalls = 0;
+      const DelegateLookup = Tool.make("delegate_lookup", {
+        parameters: Schema.Struct({ key: Schema.String }),
+        success: Schema.String,
+      });
+      const tools = Toolkit.make(DelegateLookup);
+      const definition = Agent.define("cleanup-deadline", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Join, then answer.",
+        toolkit: tools,
+        policy: policy({ maxDuration: "5 seconds" }),
+      });
+      const model = Model.make(
+        "scripted",
+        "cleanup-deadline",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () => {
+              modelCalls += 1;
+              return Stream.fromEffect(
+                Deferred.succeed(modelStarted, undefined).pipe(
+                  Effect.andThen(Effect.sleep("10 seconds")),
+                ),
+              ).pipe(
+                Stream.drain,
+                Stream.concat(Stream.fromIterable(finalParts('{"answer":"too late"}'))),
+              );
+            },
+          }),
+        ),
+      );
+      const toolLayer = tools.toLayer({
+        delegate_lookup: () =>
+          Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("joined")),
+      });
+      const resume: RunTurnResume = {
+        turn: 1,
+        turnId: resumeTurnId,
+        calls: [{ id: "call-child", name: "delegate_lookup", params: { key: "a" } }],
+        settled: [],
+        settledChildJoinCallIdsPastDeadline: [Schema.decodeSync(ToolCallId)("call-child")],
+      };
+      const now = yield* Clock.currentTimeMillis;
+      const durationDeadline = DateTime.addDuration(
+        DateTime.toUtc(DateTime.makeUnsafe(now)),
+        "5 seconds",
+      );
+
+      const fiber = yield* AgentRuntime.stream(
+        Agent.withModel(definition, model),
+        { question: "resume" },
+        { durationDeadline, resume },
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (all) => [...all, event])),
+        Stream.runDrain,
+        Effect.provide(toolLayer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(modelStarted);
+      yield* TestClock.adjust("10 seconds");
+      const exit = yield* Fiber.await(fiber);
+      const failure = failureFrom(exit);
+      const observed = yield* Ref.get(events);
+
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect(failure).toMatchObject({ limit: "duration" });
+      expect(yield* Ref.get(handlerStarts)).toBe(1);
+      expect(modelCalls).toBe(1);
+      expect(observed.filter((event) => event._tag === "RunFailed")).toHaveLength(1);
+      expect(observed.filter((event) => event._tag === "RunCompleted")).toHaveLength(0);
     }),
   );
 

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -2935,23 +2935,32 @@ const make = Effect.gen(function* () {
           declaredNamesByCallId.set(call.id, call.name);
         }
       }
-      const resumedSettledChildCleanup =
-        pending !== undefined &&
-        pending.calls.every((call) => {
-          if (pending.settled.some((settled) => settled.id === call.id)) return true;
+      let settledChildJoinCallIdsPastDeadline: ReadonlyArray<ToolCallId> | undefined;
+      if (pending !== undefined) {
+        const joinCallIds: Array<ToolCallId> = [];
+        let everyOpenCallIsSettledChild = true;
+        for (const call of pending.calls) {
+          if (pending.settled.some((settled) => settled.id === call.id)) continue;
           const started = [...subagentState.started.values()].find(
             (candidate) => candidate.toolCallId === call.id,
           );
-          return (
-            started !== undefined &&
-            childAttachments.some(
-              (child) =>
-                child.toolCallId === started.toolCallId &&
-                child.childSubmissionId === started.childSubmissionId &&
-                child.childState === "settled",
-            )
+          const settledChild = childAttachments.find(
+            (child) =>
+              started !== undefined &&
+              child.toolCallId === started.toolCallId &&
+              child.childSubmissionId === started.childSubmissionId &&
+              child.childState === "settled",
           );
-        });
+          if (started === undefined || settledChild === undefined) {
+            everyOpenCallIsSettledChild = false;
+            break;
+          }
+          joinCallIds.push(settledChild.toolCallId);
+        }
+        if (everyOpenCallIsSettledChild && joinCallIds.length > 0) {
+          settledChildJoinCallIdsPastDeadline = joinCallIds;
+        }
+      }
       // Task #12 (WP1 `resume.leadingMessages`): the pending canonical response's messages
       // BEFORE its first assistant message — Turn-1 evaluated instructions + input, or steering
       // committed inside the pending record — re-enter official history through the engine so
@@ -3983,9 +3992,9 @@ const make = Effect.gen(function* () {
                 turnId: pending.turnId,
                 calls: pending.calls,
                 settled: pending.settled,
-                ...(resumedSettledChildCleanup
-                  ? { completeSettledChildJoinsPastDeadline: true as const }
-                  : {}),
+                ...(settledChildJoinCallIdsPastDeadline === undefined
+                  ? {}
+                  : { settledChildJoinCallIdsPastDeadline }),
                 ...(resumeLeadingMessages === undefined
                   ? {}
                   : { leadingMessages: resumeLeadingMessages }),

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -2793,10 +2793,26 @@ const make = Effect.gen(function* () {
     records: ReadonlyArray<CanonicalRecordEnvelope>,
     lineage: AttemptLineage,
     approvalDecisions: ReadonlyArray<ApprovalDecisionIntent>,
+    childAttachments: RecoverySnapshot["childAttachments"],
   ) =>
     Effect.gen(function* () {
       const submissionId = submission.submissionId;
       const runId = runIdForSubmission(submissionId);
+      const inputRecord = records.find(
+        (envelope) => envelope.record.recordId === submissionInputRecordId(submissionId),
+      );
+      if (inputRecord === undefined) {
+        return yield* RunJournalError.make({
+          message: `Run ${runId} has no canonical input record for its duration deadline`,
+        });
+      }
+      // RUN-030: the first canonical input append is the logical Run-start
+      // authority. Queue/admission time precedes it; every later Attempt uses
+      // this same absolute deadline, including after durable suspension.
+      const durationDeadline = DateTime.addDuration(
+        inputRecord.record.createdAt,
+        agent.definition.policy.maxDuration,
+      );
       const journal = yield* projectRunJournal(records, runId);
       const pending = yield* pendingToolBatchFor(records, runId);
       const resumeProjection =
@@ -2919,6 +2935,23 @@ const make = Effect.gen(function* () {
           declaredNamesByCallId.set(call.id, call.name);
         }
       }
+      const resumedSettledChildCleanup =
+        pending !== undefined &&
+        pending.calls.every((call) => {
+          if (pending.settled.some((settled) => settled.id === call.id)) return true;
+          const started = [...subagentState.started.values()].find(
+            (candidate) => candidate.toolCallId === call.id,
+          );
+          return (
+            started !== undefined &&
+            childAttachments.some(
+              (child) =>
+                child.toolCallId === started.toolCallId &&
+                child.childSubmissionId === started.childSubmissionId &&
+                child.childState === "settled",
+            )
+          );
+        });
       // Task #12 (WP1 `resume.leadingMessages`): the pending canonical response's messages
       // BEFORE its first assistant message — Turn-1 evaluated instructions + input, or steering
       // committed inside the pending record — re-enter official history through the engine so
@@ -3941,6 +3974,7 @@ const make = Effect.gen(function* () {
         approval,
         durability,
         subagent,
+        durationDeadline,
         ...(pending === undefined
           ? {}
           : {
@@ -3949,6 +3983,9 @@ const make = Effect.gen(function* () {
                 turnId: pending.turnId,
                 calls: pending.calls,
                 settled: pending.settled,
+                ...(resumedSettledChildCleanup
+                  ? { completeSettledChildJoinsPastDeadline: true as const }
+                  : {}),
                 ...(resumeLeadingMessages === undefined
                   ? {}
                   : { leadingMessages: resumeLeadingMessages }),
@@ -4495,6 +4532,9 @@ const make = Effect.gen(function* () {
       let approvalDecisionIntents = snapshot.approvalDecisions;
       while (true) {
         const currentRecords = yield* readAll(conversationId);
+        const currentSnapshot = yield* ledger.loadRecoverySnapshot(
+          RecoverySnapshotRequest.make({ submissionId }),
+        );
         const outcome = yield* runModel(
           agent,
           ctx,
@@ -4503,6 +4543,7 @@ const make = Effect.gen(function* () {
           currentRecords,
           lineage,
           approvalDecisionIntents,
+          currentSnapshot.childAttachments,
         );
         if (outcome._tag === "suspendedChild") {
           // Durable waitingForChild suspension (spec §12 step 10, SUB-030): the sibling

--- a/packages/testing/src/certification.ts
+++ b/packages/testing/src/certification.ts
@@ -261,10 +261,16 @@ const promptShapeModel = (
     ),
   );
 
+// Tier-2 intentionally advances virtual time past a 30-second ownership lease on every
+// re-drive round. Keep its business-policy duration above the full eight-round sweep so this
+// fixture certifies crash convergence rather than accidentally relying on a fresh duration
+// allowance per replacement Attempt. RUN-030 owns the dedicated duration-expiry coverage.
+const CERTIFICATION_MAX_DURATION = "10 minutes" as const;
+
 const policy = AgentPolicy.make({
   maxTurns: 4,
   maxToolCalls: 4,
-  maxDuration: "30 seconds",
+  maxDuration: CERTIFICATION_MAX_DURATION,
   toolConcurrency: 2,
 });
 
@@ -334,7 +340,7 @@ const childDefinition = Agent.define("certify-child", {
   policy: AgentPolicy.make({
     maxTurns: 2,
     maxToolCalls: 1,
-    maxDuration: "30 seconds",
+    maxDuration: CERTIFICATION_MAX_DURATION,
     toolConcurrency: 1,
   }),
 });
@@ -357,7 +363,7 @@ const researchDelegation = Subagent.define("delegate_research", {
     maxConcurrency: 2,
     maxTurns: 4,
     maxToolCalls: 4,
-    maxDuration: "10 seconds",
+    maxDuration: CERTIFICATION_MAX_DURATION,
   }),
 });
 
@@ -374,7 +380,7 @@ const coordinatorDefinition = Agent.define("certify-coordinator", {
   policy: AgentPolicy.make({
     maxTurns: 4,
     maxToolCalls: 3,
-    maxDuration: "30 seconds",
+    maxDuration: CERTIFICATION_MAX_DURATION,
     toolConcurrency: 2,
   }),
 });

--- a/packages/testing/test/durable-subagents.test.ts
+++ b/packages/testing/test/durable-subagents.test.ts
@@ -55,6 +55,7 @@ import {
 import { NodeCrypto } from "@effect/platform-node";
 import { expect, layer } from "@effect/vitest";
 import { Cause, Duration, Effect, Exit, Layer, Option, Ref, Schema, Stream } from "effect";
+import { TestClock } from "effect/testing";
 import { LanguageModel, Model, Prompt, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 const SHA_A = Schema.decodeSync(Digest)("a".repeat(64));
@@ -545,6 +546,45 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         expect(roles.indexOf("user")).toBeGreaterThanOrEqual(0);
         expect(roles.indexOf("user")).toBeLessThan(roles.indexOf("assistant"));
       }),
+  );
+
+  it.effect("RUN-030: counts waitingForChild wall clock against parent maxDuration", () =>
+    Effect.gen(function* () {
+      yield* clearFailpoint;
+      const harness = yield* makeHarness();
+      const run = drive(harness);
+      const conversation = "conversation-s2-parent-duration";
+      const parent = yield* harness.submitParent(conversation, "parent-duration-1");
+      const childConversationId = childConversationIdFor(parent.submissionId, DELEGATE_CALL);
+
+      const first = yield* run(parent.conversationId);
+      expect(first).toHaveLength(0);
+      expect((yield* parentState(parent.submissionId)).state).toBe("suspended");
+
+      // `maxDuration` is wall clock for the logical Run, not a fresh allowance per Attempt.
+      // Advancing deterministic time while no parent worker is held must therefore exhaust the
+      // same parent Run before its replacement Attempt can continue after the child join.
+      yield* TestClock.adjust(Duration.seconds(31));
+
+      const childSettlements = yield* run(childConversationId);
+      expect(childSettlements.map((settlement) => settlement.outcome)).toEqual(["completed"]);
+      expect((yield* parentState(parent.submissionId)).state).toBe("input-applied");
+
+      const parentSettlements = yield* run(parent.conversationId);
+      expect(parentSettlements.map((settlement) => settlement.outcome)).toEqual(["failed"]);
+      expect(yield* harness.childInvocations).toBe(1);
+      expect(harness.parentPrompts).toHaveLength(1);
+
+      const log = yield* readLog(parent.conversationId);
+      expect(payloadsOf(log, "SubagentJoined")).toHaveLength(1);
+      expect((yield* parentReservations(parent.submissionId)).map((row) => row.status)).toEqual([
+        "released",
+      ]);
+      const settled = payloadsOf(log, "SubmissionSettled")[0]?.record.payload;
+      if (settled?._tag !== "SubmissionSettled") throw new Error("Expected SubmissionSettled");
+      expect(settled.policyLimit).toBe("duration");
+      expect(settled.result).toMatchObject({ errorTag: "AgentPolicyError" });
+    }),
   );
 
   it.effect("every establishment failpoint converges on one child Receipt and Conversation", () =>


### PR DESCRIPTION
## Summary

- define `maxDuration` as one wall-clock allowance for a logical Run, including process loss, recovery gaps, approvals, unknown-outcome suspension, and `waitingForChild`
- derive one absolute deadline from the first canonical `UserInputRecorded` record and pass it to every replacement Attempt through a tightening-only engine option
- allow only coordinator-proven, already-settled child joins to finish after expiry, then fail the parent typed before another model or ordinary Tool call
- update the runtime/subagent contracts, correct certification fixtures that had relied on the accidental per-Attempt reset, rebuild the Action bundle, and add a patch changeset

## What was wrong

The engine sampled `Clock.currentTimeMillis` whenever `AgentRuntime.stream` was instantiated. The durable coordinator creates a new stream for every Attempt, so a parent resumed after `waitingForChild` received a fresh `maxDuration` allowance.

A deterministic public-seam reproduction through `DurableAgentRuntime.processConversationResolved` demonstrated the defect: after the parent suspended, advancing `TestClock` by 31 seconds and settling the child still let the parent complete. The new RUN-030 regression initially failed with actual `completed` versus expected `failed`.

The architectural contract is wall clock per logical Run—not per Attempt and not cumulative worker-active time. The initial canonical input is the durable Run-start authority, so queue/admission time is excluded while every later suspension and recovery gap is included.

## Implementation

- [Engine deadline seam](packages/engine/src/run-options.ts) and [enforcement](packages/engine/src/index.ts)
- [Durable deadline derivation and settled-child cleanup proof](packages/session/src/durable-runtime.ts)
- [RUN-030 public durable regression](packages/testing/test/durable-subagents.test.ts)
- [Runtime contract](docs/spec/runtime.md) and [subagent suspension contract](docs/spec/subagents.md)
- [Changeset](.changeset/durable-run-duration.md)

The expired-parent path still verifies and commits the canonical child join and releases its reservation before recording the typed duration failure. The test proves one child invocation, one join, a released reservation, no second parent model prompt, and `SubmissionSettled.policyLimit === "duration"`.

## Evidence

Green on latest `main` base:

- `vp test run packages/testing/test/durable-subagents.test.ts -t "RUN-030"` — 1 passed
- `vp test run packages/testing/test/certification-memory.test.ts packages/testing/test/certification-sqlite.test.ts` — 9 passed
- `vp test run packages/testing/test/durable-subagents.test.ts packages/testing/test/durable-runtime.test.ts packages/engine/test/agent-runtime.test.ts` — 153 passed
- `vp run check`
- `vp run build`
- serialized Vite+ package graph: every runtime, storage, process-kill, certification, chaos, and soak suite passed; 28/29 testing files passed (224 tests)
- `vp run --concurrency-limit 1 -F './examples/*' test` — all example suites passed

Local gate note: the exact `vp run ready` wrapper is blocked on this macOS host by Vite+ concurrent spawn error 22. Serialized execution reaches only two unchanged release-workflow shell-fixture timeouts (`toolchain.test.ts`, 15s and 90s); all product/runtime tests pass. The required clean-Linux Static checks, Tests, Build, and `ready` jobs remain mandatory before merge.

Closes #47
