### PR TITLE
perf(session): bound recovery history reads

### DIFF
--- a/.changeset/bounded-recovery-history.md
+++ b/.changeset/bounded-recovery-history.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/session": patch
+---
+
+Bound each recovery pass to one verified canonical-history prefix read per Conversation, with
+fail-closed pagination and pass-scoped memory.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -352,6 +352,23 @@ A recovery worker:
 Recovery policy is pure where possible and testable against a finite persisted
 snapshot.
 
+One `runRecovery` pass consumes the ledger's `(ConversationId, queue sequence)` order in
+contiguous Conversation groups. Before repairing any Submission in a group, it captures that
+Conversation's strongly consistent tail sequence `T` and reads exactly the canonical prefix
+`1..T` in pages of at most 1,024 records. Classification reads are therefore bounded to one tail
+inspection plus `ceil(T / 1024)` canonical-store page requests for the Conversation, independent
+of its nonterminal Submission count. Every page must exactly cover the requested contiguous
+sequence; a short page or gap fails as a typed `ConversationStoreError` before the group mutates.
+
+The prefix is a pass-scoped snapshot, not a second authority or a resident cache. The runtime's
+canonical-history working set is `O(T)` envelopes for at most one Conversation while processing
+its group. It releases that prefix before reading the next Conversation and retains nothing across
+interruption, restart, or the next pass. A concurrent append receives a sequence above `T` and is
+classified on the next pass. When a repair mutation must distinguish a racing append before it
+writes (for example canonical input apply), it reads only the newly committed suffix after the
+captured prefix rather than rereading history from sequence zero. Canonical storage remains
+authoritative for every repair and later pass.
+
 ## 15. Crash-point matrix
 
 | Crash point                                                   | Durable state                                                     | Recovery                                          |

--- a/docs/spec/persistence.md
+++ b/docs/spec/persistence.md
@@ -201,6 +201,14 @@ Reads that drive recovery must be strongly consistent with prior successful writ
 Eventually consistent replicas may serve UI/history views if their staleness is
 visible.
 
+Recovery-pass history reads first capture the strongly consistent tail and then request the exact
+bounded prefix through that sequence: one tail inspection plus `ceil(T / 1024)` page requests.
+Pagination is fail-closed: a short page or non-contiguous sequence is corruption, not
+end-of-history. The runtime shares that verified prefix across the Conversation's nonterminal
+recovery classifications, retains an `O(T)` working set for only one Conversation prefix at a
+time, and discards it after the group; concurrent append-only suffixes remain canonical and are
+read at an exact mutation seam or by the next pass.
+
 ## 8. Checkpoints
 
 A checkpoint contains a versioned encoded interpreter snapshot plus:
@@ -366,3 +374,6 @@ authoritative read.
   service contracts and conformance suite.
 - **STORE-014**: Public progress waits close subscribe/check and check/park races without making
   in-memory notifications authoritative or adding a periodic polling/alarm loop.
+- **STORE-015**: One recovery pass reads each Conversation's captured canonical prefix in bounded
+  pages once, rejects incomplete pagination, and retains no canonical-history cache across
+  Conversation groups or passes.

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -149,6 +149,13 @@ its alarm; a forced caught-up alarm performs no SQLite, ledger, recovery, or can
 work; mutations racing acknowledgement and mutations held after pre-arm remain dirty; and a child
 evicted after settlement finalization has already committed its parent marker/generation.
 
+The exported durable runtime/store seam carries the active-pass regression from
+[issue #96](https://github.com/danieljvdm/effect-agent/issues/96): multiple nonterminal
+Submissions sharing one multi-page Conversation history receive mixed deterministic recovery
+decisions while the pass issues exactly the captured prefix's page count once, rather than once
+per Submission. The fixture uses the real reference `ConversationStore` and `SubmissionLedger`
+Layers, not the pure classifier or a fabricated recovery snapshot.
+
 The crash-point table in [durability.md](./durability.md) is a minimum coverage
 matrix and should be machine-linked to test names.
 

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -991,7 +991,15 @@ const make = Effect.gen(function* () {
     const after = records.at(-1)?.sequence ?? ZERO_SEQUENCE;
     const tail = yield* store.inspectTail(ConversationTailRequest.make({ conversationId }));
     if (tail.tailSequence <= after) return records;
-    const suffix = yield* readCanonicalRange(conversationId, after, tail.tailSequence);
+    const suffix = yield* readCanonicalRange(conversationId, after, tail.tailSequence).pipe(
+      Effect.catchTag("ConversationNotMaterialized", (error) =>
+        ConversationStoreError.make({
+          operation: "read recovery history",
+          message: `Conversation ${conversationId} disappeared after its recovery suffix tail was captured`,
+          cause: error,
+        }),
+      ),
+    );
     return [...records, ...suffix];
   });
 

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -290,9 +290,11 @@ type InstructionRequirementsOf<Instructions, Input> =
     : never;
 
 const decodeBatchId = Schema.decodeSync(BatchId);
+const decodeCanonicalSequence = Schema.decodeSync(CanonicalSequence);
 const decodeRecordId = Schema.decodeSync(RecordId);
 const decodeToolCallIdUnknown = Schema.decodeUnknownEffect(ToolCallId);
 const ZERO_EPOCH = Schema.decodeSync(ProducerEpoch)(0);
+const ZERO_SEQUENCE = decodeCanonicalSequence(0);
 const READ_PAGE = 1_024;
 /** Stale-tail append retries per batch before the conflict propagates (see `appendBatch`). */
 const MAX_APPEND_FENCE_REFRESHES = 8;
@@ -895,6 +897,103 @@ const make = Effect.gen(function* () {
         ),
       ),
   );
+
+  interface RecoveryHistorySnapshot {
+    readonly records: ReadonlyArray<CanonicalRecordEnvelope>;
+    readonly materialized: boolean;
+  }
+
+  /**
+   * Read one exact canonical prefix. The authoritative tail captured by the caller bounds both
+   * work and visibility: appends racing the read receive higher sequences and are deliberately
+   * left for a later snapshot, while a short page or sequence gap fails typed before recovery
+   * mutates anything. At most `ceil((through - after) / READ_PAGE)` store pages are requested.
+   */
+  const readCanonicalRange = Effect.fn("DurableAgentRuntime.readCanonicalRange")(function* (
+    conversationId: ConversationId,
+    afterSequence: CanonicalSequence,
+    throughSequence: CanonicalSequence,
+  ): Effect.fn.Return<
+    Array<CanonicalRecordEnvelope>,
+    ConversationStoreError | ConversationNotMaterialized
+  > {
+    const collected: Array<CanonicalRecordEnvelope> = [];
+    let after = afterSequence;
+    let expected = afterSequence + 1;
+    while (expected <= throughSequence) {
+      const limit = Math.min(READ_PAGE, throughSequence - expected + 1);
+      const request = ConversationRead.make({
+        conversationId,
+        limit,
+        ...(after === 0 ? {} : { afterSequence: after }),
+      });
+      const page: Array<CanonicalRecordEnvelope> = yield* Stream.runCollect(store.read(request));
+      if (page.length !== limit) {
+        return yield* ConversationStoreError.make({
+          operation: "read recovery history",
+          message: `Canonical history for ${conversationId} ended at ${after}; expected ${limit} records through sequence ${throughSequence}, received ${page.length}`,
+        });
+      }
+      for (const envelope of page) {
+        if (envelope.sequence !== expected) {
+          return yield* ConversationStoreError.make({
+            operation: "read recovery history",
+            message: `Canonical history for ${conversationId} is not contiguous: expected sequence ${expected}, received ${envelope.sequence}`,
+          });
+        }
+        expected += 1;
+        after = envelope.sequence;
+        collected.push(envelope);
+      }
+    }
+    return collected;
+  });
+
+  /**
+   * Capture one strongly-consistent pass-start tail and read exactly that prefix. This snapshot
+   * is disposable: `runRecovery` retains it only while processing the scan's contiguous group
+   * for this Conversation, so resident canonical history is bounded to one Conversation prefix
+   * and never survives the pass or an interruption/restart.
+   */
+  const readRecoveryHistory = Effect.fn("DurableAgentRuntime.readRecoveryHistory")(function* (
+    conversationId: ConversationId,
+  ): Effect.fn.Return<RecoveryHistorySnapshot, ConversationStoreError> {
+    const tail = yield* store.inspectTail(ConversationTailRequest.make({ conversationId })).pipe(
+      Effect.map(Option.some),
+      Effect.catchTag("ConversationNotMaterialized", () => Effect.succeed(Option.none())),
+    );
+    if (Option.isNone(tail)) return { records: [], materialized: false };
+    const records = yield* readCanonicalRange(
+      conversationId,
+      ZERO_SEQUENCE,
+      tail.value.tailSequence,
+    ).pipe(
+      Effect.catchTag("ConversationNotMaterialized", (error) =>
+        ConversationStoreError.make({
+          operation: "read recovery history",
+          message: `Conversation ${conversationId} disappeared after its recovery tail was captured`,
+          cause: error,
+        }),
+      ),
+    );
+    return { records, materialized: true };
+  });
+
+  /**
+   * A recovery mutation that must distinguish a racing canonical append reads only the suffix
+   * beyond its pass snapshot. The append-only prefix remains valid; no full-history retry is
+   * needed, and malformed suffix pagination fails through the same typed boundary.
+   */
+  const refreshRecoveryHistory = Effect.fn("DurableAgentRuntime.refreshRecoveryHistory")(function* (
+    conversationId: ConversationId,
+    records: ReadonlyArray<CanonicalRecordEnvelope>,
+  ): Effect.fn.Return<ReadonlyArray<CanonicalRecordEnvelope>, DurableWorkerFailure> {
+    const after = records.at(-1)?.sequence ?? ZERO_SEQUENCE;
+    const tail = yield* store.inspectTail(ConversationTailRequest.make({ conversationId }));
+    if (tail.tailSequence <= after) return records;
+    const suffix = yield* readCanonicalRange(conversationId, after, tail.tailSequence);
+    return [...records, ...suffix];
+  });
 
   const knownRecordIdsOf = (records: ReadonlyArray<CanonicalRecordEnvelope>): Set<string> =>
     new Set(records.map((envelope) => envelope.record.recordId));
@@ -5489,7 +5588,7 @@ const make = Effect.gen(function* () {
           );
           const ctx = yield* attemptContextFor(submission.conversationId, claim.producerEpoch);
           const tokenRef = yield* Ref.make(claim.ownershipToken);
-          const currentRecords = yield* readAll(submission.conversationId);
+          const currentRecords = yield* refreshRecoveryHistory(submission.conversationId, records);
           yield* applyCanonicalInput(
             ctx,
             submission,
@@ -5812,19 +5911,24 @@ const make = Effect.gen(function* () {
 
   const recoverSubmission = Effect.fn("DurableAgentRuntime.recoverSubmission")(function* (
     submission: SubmissionSnapshot,
+    history: RecoveryHistorySnapshot,
   ): Effect.fn.Return<RecoveryReport, DurableWorkerFailure> {
     const snapshot = yield* ledger.loadRecoverySnapshot(
       RecoverySnapshotRequest.make({ submissionId: submission.submissionId }),
     );
-    const read = yield* readAllTolerant(submission.conversationId);
     const evidence = yield* evidenceFor(
-      read.records,
+      history.records,
       submission.submissionId,
-      read.materialized,
+      history.materialized,
       snapshot.hostSubmissionId,
     );
     const decision = classifyRecovery(snapshot, evidence);
-    const disposition = yield* executeRecoveryDecision(snapshot, evidence, decision, read.records);
+    const disposition = yield* executeRecoveryDecision(
+      snapshot,
+      evidence,
+      decision,
+      history.records,
+    );
     if (disposition === "repaired") {
       yield* annotateRepair(submission.conversationId, submission.submissionId, decision);
     }
@@ -5840,8 +5944,24 @@ const make = Effect.gen(function* () {
     function* (): Effect.fn.Return<ReadonlyArray<RecoveryReport>, DurableWorkerFailure> {
       const nonterminal = yield* Stream.runCollect(ledger.scanNonterminal);
       const reports: Array<RecoveryReport> = [];
-      for (const submission of nonterminal) {
-        reports.push(yield* recoverSubmission(submission));
+      // SubmissionLedger guarantees `(conversationId, queueSequence)` order. Capture and retain
+      // one verified canonical prefix only for the current contiguous Conversation group: read
+      // work is one tail inspection plus `ceil(passStartTail / READ_PAGE)` pages per Conversation
+      // rather than multiplied by its nonterminal Submission count, and the prefix becomes
+      // unreachable before the next Conversation is read.
+      let index = 0;
+      while (index < nonterminal.length) {
+        const first = nonterminal[index];
+        if (first === undefined) break;
+        const history = yield* readRecoveryHistory(first.conversationId);
+        while (index < nonterminal.length) {
+          const submission = nonterminal[index];
+          if (submission === undefined || submission.conversationId !== first.conversationId) {
+            break;
+          }
+          reports.push(yield* recoverSubmission(submission, history));
+          index += 1;
+        }
       }
       return reports;
     },

--- a/packages/storage-memory/test/recovery-history.test.ts
+++ b/packages/storage-memory/test/recovery-history.test.ts
@@ -7,6 +7,7 @@ import {
   CanonicalSequence,
   ConversationCreated,
   ConversationMaterialization,
+  ConversationNotMaterialized,
   ConversationRead,
   ConversationStore,
   DefinitionDigests,
@@ -31,13 +32,14 @@ import {
 } from "@effect-agent/session";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Context, DateTime, Effect, Layer, Ref, Schema, Stream } from "effect";
+import { Context, DateTime, Effect, Layer, Option, Ref, Schema, Stream } from "effect";
 
 import { MemoryConversationStoreLive, MemorySubmissionLedgerLive } from "../src/index.ts";
 
 class RecoveryReadProbe extends Context.Service<
   RecoveryReadProbe,
   {
+    readonly failReadAfter: (sequence: CanonicalSequence) => Effect.Effect<void>;
     readonly requests: Effect.Effect<ReadonlyArray<ConversationRead>>;
     readonly reset: Effect.Effect<void>;
   }
@@ -47,14 +49,23 @@ const countingConversationStoreLayer = Layer.effectContext(
   Effect.gen(function* () {
     const store = yield* ConversationStore;
     const requests = yield* Ref.make<ReadonlyArray<ConversationRead>>([]);
+    const failingAfter = yield* Ref.make<Option.Option<CanonicalSequence>>(Option.none());
     const counted = ConversationStore.of({
       materialize: store.materialize,
       append: store.append,
       read: (request) =>
         Stream.unwrap(
-          Ref.update(requests, (current) => [...current, request]).pipe(
-            Effect.as(store.read(request)),
-          ),
+          Effect.gen(function* () {
+            yield* Ref.update(requests, (current) => [...current, request]);
+            const failure = yield* Ref.get(failingAfter);
+            if (Option.isSome(failure) && request.afterSequence === failure.value) {
+              yield* Ref.set(failingAfter, Option.none());
+              return Stream.fail(
+                ConversationNotMaterialized.make({ conversationId: request.conversationId }),
+              );
+            }
+            return store.read(request);
+          }),
         ),
       observe: store.observe,
       export: store.export,
@@ -66,6 +77,7 @@ const countingConversationStoreLayer = Layer.effectContext(
       Context.add(
         RecoveryReadProbe,
         RecoveryReadProbe.of({
+          failReadAfter: (sequence) => Ref.set(failingAfter, Option.some(sequence)),
           requests: Ref.get(requests),
           reset: Ref.set(requests, []),
         }),
@@ -95,6 +107,7 @@ const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
 const DIGEST = decodeDigest("a".repeat(64));
 const DEFINITIONS = DefinitionDigests.make({ agent: DIGEST, model: DIGEST, tools: DIGEST });
 const HISTORY_RECORDS = 2_050;
+const HISTORY_TAIL = Schema.decodeSync(CanonicalSequence)(HISTORY_RECORDS);
 
 const runtimeLayer = DurableAgentRuntime.layer.pipe(
   Layer.provideMerge(
@@ -230,6 +243,61 @@ describe("DurableAgentRuntime recovery history", () => {
         { afterSequence: 1_024, limit: 1_024 },
         { afterSequence: 2_048, limit: 2 },
       ]);
+    }).pipe(Effect.provide(runtimeLayer)),
+  );
+
+  it.effect("STORE-015 issue #96: normalizes disappearance during suffix refresh", () =>
+    Effect.gen(function* () {
+      yield* seedHistory();
+      const ledger = yield* SubmissionLedger;
+      const runtime = yield* DurableAgentRuntime;
+      const probe = yield* RecoveryReadProbe;
+      for (let index = 0; index < 2; index++) {
+        const input = { work: `suffix-race-${index}` };
+        const inputDigest = yield* digestJson(input);
+        const admitted = yield* ledger.admit(
+          AdmissionRequest.make({
+            conversationId: CONVERSATION_ID,
+            principal: PRINCIPAL,
+            idempotencyKey: decodeIdempotencyKey(`recovery-suffix-race-${index}`),
+            agentId: AGENT_ID,
+            agentDigests: DEFINITIONS,
+            deploymentId: DEPLOYMENT_ID,
+            inputPayload: input,
+            inputDigest,
+          }),
+        );
+        yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+        if (index === 0) {
+          yield* ledger.requestAbort(
+            AbortCommand.make({
+              submissionId: admitted.submissionId,
+              author: "issue-96-test",
+              reason: "exercise suffix refresh after a repaired predecessor",
+            }),
+          );
+        }
+      }
+
+      yield* probe.reset;
+      yield* probe.failReadAfter(HISTORY_TAIL);
+      const failure = yield* runtime.runRecovery.pipe(Effect.flip);
+      expect(failure).toMatchObject({
+        _tag: "ConversationStoreError",
+        operation: "read recovery history",
+      });
+      const requests = (yield* probe.requests).map((request) => ({
+        afterSequence: request.afterSequence,
+        limit: request.limit,
+      }));
+      expect(requests.slice(0, 3)).toEqual([
+        { afterSequence: undefined, limit: 1_024 },
+        { afterSequence: 1_024, limit: 1_024 },
+        { afterSequence: 2_048, limit: 2 },
+      ]);
+      expect(requests.at(-1)).toMatchObject({
+        afterSequence: HISTORY_TAIL,
+      });
     }).pipe(Effect.provide(runtimeLayer)),
   );
 });

--- a/packages/storage-memory/test/recovery-history.test.ts
+++ b/packages/storage-memory/test/recovery-history.test.ts
@@ -1,0 +1,235 @@
+import { AgentId, ConversationId } from "@effect-agent/core";
+import {
+  AbortCommand,
+  AdmissionRequest,
+  CanonicalBatch,
+  CanonicalRecord,
+  CanonicalSequence,
+  ConversationCreated,
+  ConversationMaterialization,
+  ConversationRead,
+  ConversationStore,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+  DurableRuntimeFailpoint,
+  EMPTY_TAIL_DIGEST,
+  FencedAppendRequest,
+  IdempotencyKey,
+  MarkReadyRequest,
+  Principal,
+  ProducerEpoch,
+  ProducerId,
+  RecoveryDecision,
+  RepairAnnotated,
+  SubmissionLedger,
+  ToolReconciler,
+  WakeScheduler,
+  digestJson,
+} from "@effect-agent/session";
+import { NodeCrypto } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Context, DateTime, Effect, Layer, Ref, Schema, Stream } from "effect";
+
+import { MemoryConversationStoreLive, MemorySubmissionLedgerLive } from "../src/index.ts";
+
+class RecoveryReadProbe extends Context.Service<
+  RecoveryReadProbe,
+  {
+    readonly requests: Effect.Effect<ReadonlyArray<ConversationRead>>;
+    readonly reset: Effect.Effect<void>;
+  }
+>()("@effect-agent/storage-memory/test/RecoveryReadProbe") {}
+
+const countingConversationStoreLayer = Layer.effectContext(
+  Effect.gen(function* () {
+    const store = yield* ConversationStore;
+    const requests = yield* Ref.make<ReadonlyArray<ConversationRead>>([]);
+    const counted = ConversationStore.of({
+      materialize: store.materialize,
+      append: store.append,
+      read: (request) =>
+        Stream.unwrap(
+          Ref.update(requests, (current) => [...current, request]).pipe(
+            Effect.as(store.read(request)),
+          ),
+        ),
+      observe: store.observe,
+      export: store.export,
+      inspectTail: store.inspectTail,
+      saveCheckpoint: store.saveCheckpoint,
+      loadCheckpoint: store.loadCheckpoint,
+    });
+    return Context.make(ConversationStore, counted).pipe(
+      Context.add(
+        RecoveryReadProbe,
+        RecoveryReadProbe.of({
+          requests: Ref.get(requests),
+          reset: Ref.set(requests, []),
+        }),
+      ),
+    );
+  }),
+).pipe(Layer.provide(MemoryConversationStoreLive));
+
+const decodeConversationId = Schema.decodeSync(ConversationId);
+const decodeAgentId = Schema.decodeSync(AgentId);
+const decodeDeploymentId = Schema.decodeSync(DeploymentId);
+const decodeDigest = Schema.decodeSync(Digest);
+const decodeIdempotencyKey = Schema.decodeSync(IdempotencyKey);
+const decodePrincipal = Schema.decodeSync(Principal);
+const decodeProducerEpoch = Schema.decodeSync(ProducerEpoch);
+const decodeProducerId = Schema.decodeSync(ProducerId);
+const decodeBatchId = Schema.decodeSync(CanonicalBatch.fields.batchId);
+const decodeRecordId = Schema.decodeSync(CanonicalRecord.fields.recordId);
+
+const CONVERSATION_ID = decodeConversationId("conversation-recovery-history-bound");
+const AGENT_ID = decodeAgentId("agent-recovery-history-bound");
+const DEPLOYMENT_ID = decodeDeploymentId("deployment-recovery-history-bound");
+const PRODUCER_ID = decodeProducerId("producer-recovery-history-bound");
+const PRINCIPAL = decodePrincipal("principal-recovery-history-bound");
+const FIRST_EPOCH = decodeProducerEpoch(1);
+const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
+const DIGEST = decodeDigest("a".repeat(64));
+const DEFINITIONS = DefinitionDigests.make({ agent: DIGEST, model: DIGEST, tools: DIGEST });
+const HISTORY_RECORDS = 2_050;
+
+const runtimeLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      countingConversationStoreLayer,
+      MemorySubmissionLedgerLive,
+      WakeScheduler.layerNoop,
+      DurableRuntimeFailpoint.layer,
+      DurableRuntimeConfig.layer({
+        deploymentId: DEPLOYMENT_ID,
+        producerId: PRODUCER_ID,
+      }),
+      ToolReconciler.uncertain,
+    ).pipe(Layer.provideMerge(NodeCrypto.layer)),
+  ),
+);
+
+const seedHistory = Effect.fn("RecoveryHistoryTest.seedHistory")(function* () {
+  const store = yield* ConversationStore;
+  yield* store.materialize(
+    ConversationMaterialization.make({
+      conversationId: CONVERSATION_ID,
+      producerEpoch: FIRST_EPOCH,
+    }),
+  );
+
+  let tailSequence = ZERO_SEQUENCE;
+  let tailDigest = EMPTY_TAIL_DIGEST;
+  for (let start = 0; start < HISTORY_RECORDS; start += 256) {
+    const size = Math.min(256, HISTORY_RECORDS - start);
+    const records = Array.from({ length: size }, (_, offset) => {
+      const sequence = start + offset;
+      return CanonicalRecord.make({
+        recordId: decodeRecordId(`history-seed:${sequence}`),
+        family: "conversation",
+        schemaVersion: 1,
+        createdAt: DateTime.toUtc(DateTime.makeUnsafe(sequence + 1)),
+        deploymentId: DEPLOYMENT_ID,
+        payload:
+          sequence === 0
+            ? ConversationCreated.make({ agentId: AGENT_ID, definitions: DEFINITIONS })
+            : RepairAnnotated.make({ reason: "history seed", details: { sequence } }),
+      });
+    });
+    const [first, ...rest] = records;
+    if (first === undefined) {
+      return yield* Effect.die(new Error("The history seed must produce a non-empty batch"));
+    }
+    const appended = yield* store.append(
+      FencedAppendRequest.make({
+        conversationId: CONVERSATION_ID,
+        batch: CanonicalBatch.make({
+          batchId: decodeBatchId(`history-seed:${start}`),
+          producerId: PRODUCER_ID,
+          records: [first, ...rest],
+        }),
+        expectedTailSequence: tailSequence,
+        expectedTailDigest: tailDigest,
+        producerEpoch: FIRST_EPOCH,
+      }),
+    );
+    tailSequence = appended.lastSequence;
+    tailDigest = appended.tailDigest;
+  }
+});
+
+describe("DurableAgentRuntime recovery history", () => {
+  it.effect("STORE-015 issue #96: reads canonical pages once for mixed recovery decisions", () =>
+    Effect.gen(function* () {
+      yield* seedHistory();
+      const ledger = yield* SubmissionLedger;
+      const runtime = yield* DurableAgentRuntime;
+      const probe = yield* RecoveryReadProbe;
+      const admitted = [];
+      for (let index = 0; index < 4; index++) {
+        const input = { work: `submission-${index}` };
+        const inputDigest = yield* digestJson(input);
+        admitted.push(
+          yield* ledger.admit(
+            AdmissionRequest.make({
+              conversationId: CONVERSATION_ID,
+              principal: PRINCIPAL,
+              idempotencyKey: decodeIdempotencyKey(`recovery-history-${index}`),
+              agentId: AGENT_ID,
+              agentDigests: DEFINITIONS,
+              deploymentId: DEPLOYMENT_ID,
+              inputPayload: input,
+              inputDigest,
+            }),
+          ),
+        );
+      }
+      const second = admitted[1];
+      const third = admitted[2];
+      const fourth = admitted[3];
+      if (second === undefined || third === undefined || fourth === undefined) {
+        return yield* Effect.die(new Error("The recovery fixture must admit four Submissions"));
+      }
+      yield* ledger.markReady(MarkReadyRequest.make({ submissionId: second.submissionId }));
+      yield* ledger.markReady(MarkReadyRequest.make({ submissionId: third.submissionId }));
+      yield* ledger.requestAbort(
+        AbortCommand.make({
+          submissionId: third.submissionId,
+          author: "issue-96-test",
+          reason: "exercise a mixed queued-abort recovery decision",
+        }),
+      );
+      yield* ledger.markReady(MarkReadyRequest.make({ submissionId: fourth.submissionId }));
+
+      yield* probe.reset;
+      const reports = yield* runtime.runRecovery;
+      expect(reports.map((report) => report.decision._tag)).toEqual([
+        "RepairReadiness",
+        "ApplyInput",
+        "SettleAborted",
+        "ApplyInput",
+      ] satisfies ReadonlyArray<RecoveryDecision["_tag"]>);
+      expect(reports.map((report) => report.disposition)).toEqual([
+        "repaired",
+        "deferred",
+        "repaired",
+        "deferred",
+      ]);
+
+      const requests = yield* probe.requests;
+      expect(
+        requests.map((request) => ({
+          afterSequence: request.afterSequence,
+          limit: request.limit,
+        })),
+      ).toEqual([
+        { afterSequence: undefined, limit: 1_024 },
+        { afterSequence: 1_024, limit: 1_024 },
+        { afterSequence: 2_048, limit: 2 },
+      ]);
+    }).pipe(Effect.provide(runtimeLayer)),
+  );
+});


### PR DESCRIPTION
## What went wrong

A recovery pass paginated the same canonical Conversation history independently for every nonterminal Submission. After quiescent maintenance, the exported runtime/store reproduction still observed 12 page reads for four mixed recovery decisions over a 2,050-record history: the same three pages were read four times.

## What changed

- Capture one strongly consistent canonical tail and read the exact verified prefix once per contiguous Conversation group in ledger scan order.
- Share that pass-scoped prefix across deterministic recovery classification while keeping canonical storage authoritative.
- Refresh only the append-only suffix at input mutation seams that must observe racing canonical appends.
- Fail closed with typed `ConversationStoreError` values on short pages, gaps, or disappearance after tail capture.
- Bound read work to one tail inspection plus `ceil(T / 1024)` pages per Conversation group and memory to one transient `O(T)` Conversation prefix.
- Add STORE-015 specification coverage and a patch changeset for `@effect-agent/session`.

Vital code:

- [bounded recovery history read and grouping](https://github.com/danieljvdm/effect-agent/blob/9702cef35c67fc3c07808db97902e7bd6cd709f4/packages/session/src/durable-runtime.ts#L881)
- [public runtime/store regression](https://github.com/danieljvdm/effect-agent/blob/9702cef35c67fc3c07808db97902e7bd6cd709f4/packages/storage-memory/test/recovery-history.test.ts)
- [durability contract](https://github.com/danieljvdm/effect-agent/blob/9702cef35c67fc3c07808db97902e7bd6cd709f4/docs/spec/durability.md)

## Verification

- Red evidence on corrected main: 12 canonical page reads; expected 3.
- Green on this head: exact requests `{ afterSequence: undefined, limit: 1024 }`, `{ afterSequence: 1024, limit: 1024 }`, `{ afterSequence: 2048, limit: 2 }` across `RepairReadiness`, `ApplyInput`, `SettleAborted`, and `ApplyInput`.
- `vp test packages/storage-memory/test/recovery-history.test.ts` — pass.
- `vp run -F @effect-agent/session check` — pass.
- `vp run -F @effect-agent/storage-memory check` — pass.
- `vp run check` — pass.
- `vp run build` — pass before the latest main rebase; the focused and static gates were rerun after rebase.
- Relevant session, memory, SQLite, Node crash/restart, Cloudflare eviction/restart, and certification suites passed locally.

Local `vp run ready` remains unavailable on this macOS host because unchanged nested Vite+ test processes intermittently fail to spawn with OS error 22, and the unchanged release reporter fixture independently exceeds its hard-coded 15-second timeout. The affected fixture and workflow are byte-identical to main. Per owner direction, this PR relies on fresh required CI Build, Static checks, Tests, and ready before merge.

Fixes #96.