### PR TITLE
fix(ci): keep pull-request review fan-out stable

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -52,12 +52,13 @@ jobs:
           # A dedicated secret is preferred. The provider credential is a
           # stable workflow-only fallback and is never sent to the reviewer as state.
           state-secret: ${{ secrets.PR_REVIEW_STATE_SECRET || secrets.OPENAI_API_KEY }}
-          # Routine incremental deltas use one flat reviewer. Reserve fan-out
-          # for the explicit full-diff audit instead of multiplying model calls
-          # across every corrective push.
-          fan-out: ${{ github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit' && 'true' || 'false' }}
+          # Keep one fan-out review profile across initial, incremental, and
+          # final runs. A flat review cannot completely cover a large initial
+          # scope within its tool-call bound, and switching topology later
+          # invalidates the authenticated incremental-review baseline.
+          fan-out: "true"
           # Medium is the routine-review default. The deliberate full-diff
-          # audit gets high effort together with fan-out.
+          # audit gets high effort without changing the review topology.
           effort: ${{ github.event.action == 'labeled' && github.event.label.name == 'pr-review:final-audit' && 'high' || 'medium' }}
           # Bound pathological fan-out runs below the package's 15-minute
           # ceiling while leaving headroom under the 20-minute runner timeout.


### PR DESCRIPTION
## Summary

- Run the repository pull-request reviewer with [bounded fan-out for every review mode](https://github.com/danieljvdm/effect-agent/blob/90ec912ddcebb74769a3ad413498e6c35d092032/.github/workflows/pr-review.yml#L55-L64), while retaining medium effort for routine pushes and high effort for explicit final audits.
- This lets large initial scopes establish authenticated review state and keeps the review profile stable for later incremental runs.

## What went wrong

Routine reviews used the flat reviewer, whose policy permits at most 24 tool calls. PR #110 exposed 41 required files, while complete coverage requires a successful diff read for every required path. The run therefore could not produce complete coverage, and continuity state is intentionally emitted only after complete coverage. Every corrective push consequently fell back to another stochastic full-diff review and surfaced unrelated pre-existing findings.

Using fan-out only for a labeled final audit was not a durable bootstrap either: flat and fan-out reviewers have different profile fingerprints, so returning to flat mode invalidated the fan-out baseline. Keeping fan-out enabled across initial, incremental, and final runs fixes both halves of the loop.

## Evidence

- [PR #110 review at `11e0c48`](https://github.com/danieljvdm/effect-agent/pull/110#pullrequestreview-4954430115) reported a full-diff fallback with 20 required paths unreviewed.
- [PR #110 review at `05ca56b`](https://github.com/danieljvdm/effect-agent/pull/110#pullrequestreview-4955134385) again reported no compatible state and 21 required paths unreviewed after two corrective pushes.
