### PR TITLE
fix(pr-review): spell the committable-suggestion contract out to fan-out discovery workers

### DIFF
--- a/.changeset/fan-out-suggestion-contract.md
+++ b/.changeset/fan-out-suggestion-contract.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Spell the finding shape and committable-suggestion rule out to fan-out discovery workers, and annotate `ReviewFinding.suggestion` with the same contract so the model-visible output schema carries it. Fan-out reviews no longer publish GitHub suggestion blocks containing prose advice instead of replacement code.

--- a/.changeset/fan-out-suggestion-contract.md
+++ b/.changeset/fan-out-suggestion-contract.md
@@ -2,4 +2,4 @@
 "@effect-agent/pr-review": patch
 ---
 
-Publish a fan-out finding's GitHub suggestion block only when the independent verifier settles it as "committable"; strip it from confirmed findings otherwise, and fail unit settlement when a carried suggestion is left unsettled. Also spell the finding shape and committable-suggestion rule out to discovery workers and annotate `ReviewFinding.suggestion` so the model-visible output schema carries the contract.
+Publish a fan-out finding's GitHub suggestion block only when independent verification settles its text as committable replacement source. A confirmed finding whose suggestion is not settled as committable is published without the suggestion block, and a verification pass that leaves a carried suggestion unsettled fails the unit's settlement.

--- a/.changeset/fan-out-suggestion-contract.md
+++ b/.changeset/fan-out-suggestion-contract.md
@@ -2,4 +2,4 @@
 "@effect-agent/pr-review": patch
 ---
 
-Spell the finding shape and committable-suggestion rule out to fan-out discovery workers, and annotate `ReviewFinding.suggestion` with the same contract so the model-visible output schema carries it. Fan-out reviews no longer publish GitHub suggestion blocks containing prose advice instead of replacement code.
+Publish a fan-out finding's GitHub suggestion block only when the independent verifier settles it as "committable"; strip it from confirmed findings otherwise, and fail unit settlement when a carried suggestion is left unsettled. Also spell the finding shape and committable-suggestion rule out to discovery workers and annotate `ReviewFinding.suggestion` so the model-visible output schema carries the contract.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -42598,7 +42598,9 @@ class ReviewFinding extends exports_Schema.Class("@effect-agent/pr-review/Review
   category: exports_Schema.optionalKey(FindingCategory),
   title: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(120)),
   body: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2000)),
-  suggestion: exports_Schema.optionalKey(exports_Schema.String.check(exports_Schema.isMaxLength(2000)))
+  suggestion: exports_Schema.optionalKey(exports_Schema.String.annotate({
+    description: "Committable replacement source code for exactly lines startLine..endLine: the full replacement for every line in the range and nothing else — never prose describing the change, which belongs in body."
+  }).check(exports_Schema.isMaxLength(2000)))
 }) {
 }
 var ReviewVerdict = exports_Schema.Literals(["approve", "comment", "request-changes"]);
@@ -43120,7 +43122,9 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => {
     focus,
     "The discovery evidence array contains every complete shard in the unit. Review every entry and every shard of a multi-shard path. A later independent verifier, not you, decides which candidates publish.",
     "When a non-anchored concern depends on one or more unit files, list 1-3 exact evidencePaths to bind the claim to scheduled evidence.",
-    `Return ONLY JSON with phase "discovery", the exact workId/unitId, up to ${MAX_CHILD_FINDINGS} findings, up to ${MAX_CHILD_CONCERNS} concerns shaped as {concern, evidencePaths}, one factual file summary per path (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars), and an empty assessments array. Empty candidate arrays are valid; do not invent defects.`
+    `Return ONLY JSON with phase "discovery", the exact workId/unitId, up to ${MAX_CHILD_FINDINGS} findings, up to ${MAX_CHILD_CONCERNS} concerns shaped as {concern, evidencePaths}, one factual file summary per path (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars), and an empty assessments array. Empty candidate arrays are valid; do not invent defects.`,
+    'Each finding is {"path": <a unit file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL problem-kind label>, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>}.',
+    'Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement source for every line in the range and nothing else — never prose describing the change, which belongs in "body".'
   ].join(`
 `);
 };

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -43006,9 +43006,20 @@ var reviewCandidateSubjectKey = (candidate) => candidate._tag === "FindingCandid
 class CandidateAssessment extends exports_Schema.Class("@effect-agent/pr-review/CandidateAssessment")({
   candidateId: ReviewCandidateId,
   disposition: exports_Schema.Literals(["confirmed", "rejected"]),
+  suggestion: exports_Schema.optionalKey(exports_Schema.Literals(["committable", "not-committable"]).annotate({
+    description: 'Required exactly when the candidate finding carries a suggestion: "committable" only when its text is the full replacement source for exactly lines startLine..endLine and nothing else. Forbidden for candidates without a suggestion.'
+  })),
   rationale: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(600))
 }) {
 }
+var assessmentSettlesSuggestionExactly = (assessment, candidate) => candidate._tag === "FindingCandidate" && candidate.finding.suggestion !== undefined ? assessment.suggestion !== undefined : assessment.suggestion === undefined;
+var confirmedFindingForPublication = (assessment, candidate) => {
+  if (candidate.finding.suggestion === undefined || assessment.suggestion === "committable") {
+    return candidate.finding;
+  }
+  const { suggestion: _stripped, ...finding } = candidate.finding;
+  return ReviewFinding.make(finding);
+};
 
 class DiscoveredConcern extends exports_Schema.Class("@effect-agent/pr-review/DiscoveredConcern")({
   concern: ReviewConcern,
@@ -43112,7 +43123,8 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => {
       "Independently verify every candidate in the input. You did not receive another reviewer's transcript or reasoning; use only the candidate claim and bounded evidence.",
       "The evidence array contains the complete bounded unit, including neighboring changed code that may confirm or falsify a locally plausible claim.",
       "For each candidate, try to falsify it first. Confirm only when the cited behavior is supported and actionable. Reject unsupported, speculative, duplicate, or non-actionable candidates.",
-      'Return ONLY JSON with phase "verification", the exact workId/unitId, empty findings/concerns/fileSummaries arrays, and exactly one assessment per candidateId. Each assessment is {"candidateId": <exact id>, "disposition": <"confirmed" | "rejected">, "rationale": <bounded evidence-based reason>}. Never add or omit an id.'
+      'Return ONLY JSON with phase "verification", the exact workId/unitId, empty findings/concerns/fileSummaries arrays, and exactly one assessment per candidateId. Each assessment is {"candidateId": <exact id>, "disposition": <"confirmed" | "rejected">, "suggestion": <"committable" | "not-committable", present exactly when the candidate finding carries a suggestion>, "rationale": <bounded evidence-based reason>}. Never add or omit an id.',
+      `Settle every carried suggestion independently of the claim: answer "committable" only when its text is the full replacement source for exactly lines startLine..endLine and nothing else — it compiles in context and preserves the finding's intent, never prose describing a change. Otherwise answer "not-committable"; the host then publishes the confirmed finding without its suggestion. Omit the assessment "suggestion" field for candidates without one.`
     ].join(`
 `);
   }
@@ -43223,15 +43235,19 @@ var projectReviewResult = (report2, context4, request3) => {
     if (report2.findings.length > 0 || report2.concerns.length > 0 || report2.fileSummaries.length > 0) {
       return exports_Effect.fail(rejectWork(report2.workId, "verification output contained discovery-only fields"));
     }
-    const expectedIds = new Set(request3.candidates.map((candidate) => candidate.candidateId));
+    const expectedById = new Map(request3.candidates.map((candidate) => [candidate.candidateId, candidate]));
     const assessedIds = new Set;
     for (const assessment of report2.assessments) {
-      if (!expectedIds.has(assessment.candidateId) || assessedIds.has(assessment.candidateId)) {
+      const candidate = expectedById.get(assessment.candidateId);
+      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
         return exports_Effect.fail(rejectWork(report2.workId, "verification output did not assess the exact candidate set"));
+      }
+      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+        return exports_Effect.fail(rejectWork(report2.workId, "verification output did not settle suggestion publication exactly"));
       }
       assessedIds.add(assessment.candidateId);
     }
-    if (assessedIds.size !== expectedIds.size) {
+    if (assessedIds.size !== expectedById.size) {
       return exports_Effect.fail(rejectWork(report2.workId, "verification output did not assess the exact candidate set"));
     }
     return exports_Effect.succeed(FileReviewUnitResult.make({
@@ -44107,31 +44123,35 @@ var fanOutAssurance = (files, totalFiles, anchorFiles, trace3) => {
       }));
       continue;
     }
-    const expectedIds = new Set(candidates.map((candidate) => candidate.candidateId));
+    const byId = new Map(candidates.map((candidate) => [candidate.candidateId, candidate]));
     const assessedIds = new Set;
+    let suggestionSettlementExact = true;
     const exactAssessments = result4.value.assessments.every((assessment) => {
-      if (!expectedIds.has(assessment.candidateId) || assessedIds.has(assessment.candidateId)) {
+      const candidate = byId.get(assessment.candidateId);
+      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
         return false;
       }
       assessedIds.add(assessment.candidateId);
+      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+        suggestionSettlementExact = false;
+      }
       return true;
     });
-    if (expectedIds.size !== candidates.length || !exactAssessments || assessedIds.size !== expectedIds.size) {
+    if (byId.size !== candidates.length || !exactAssessments || assessedIds.size !== byId.size || !suggestionSettlementExact) {
       unsettledCandidates += candidates.length;
       failedPasses.push(FailedReviewPass.make({
         workId,
         stage: "verification",
-        errorTag: "VerificationAssessmentMismatch"
+        errorTag: exactAssessments && !suggestionSettlementExact ? "SuggestionSettlementMismatch" : "VerificationAssessmentMismatch"
       }));
       continue;
     }
     completedVerificationPasses += 1;
-    const byId = new Map(candidates.map((candidate) => [candidate.candidateId, candidate]));
     for (const assessment of result4.value.assessments) {
       if (assessment.disposition === "confirmed") {
         const candidate = byId.get(assessment.candidateId);
         if (candidate !== undefined)
-          confirmedCandidates.push(candidate);
+          confirmedCandidates.push({ assessment, candidate });
       } else {
         rejectedCandidates += 1;
       }
@@ -44171,8 +44191,8 @@ var fanOutAssurance = (files, totalFiles, anchorFiles, trace3) => {
       failedPasses,
       reasons
     }),
-    confirmedFindings: confirmedCandidates.flatMap((candidate) => candidate._tag === "FindingCandidate" ? [candidate.finding] : []),
-    confirmedConcerns: confirmedCandidates.flatMap((candidate) => candidate._tag === "ConcernCandidate" ? [candidate.concern] : []),
+    confirmedFindings: confirmedCandidates.flatMap(({ assessment, candidate }) => candidate._tag === "FindingCandidate" ? [confirmedFindingForPublication(assessment, candidate)] : []),
+    confirmedConcerns: confirmedCandidates.flatMap(({ candidate }) => candidate._tag === "ConcernCandidate" ? [candidate.concern] : []),
     walkthrough
   };
 };

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -5,6 +5,9 @@ import { anchorViolation } from "./anchors.ts";
 import type { ChangedFile } from "./diff.ts";
 import { isReviewableFile } from "./diff.ts";
 import {
+  assessmentSettlesSuggestionExactly,
+  type CandidateAssessment,
+  confirmedFindingForPublication,
   FileReviewDelegationFailure,
   FileReviewRequest,
   FileReviewUnitResult,
@@ -473,7 +476,10 @@ const fanOutAssurance = (
     }
   }
 
-  const confirmedCandidates: Array<ReviewCandidate> = [];
+  const confirmedCandidates: Array<{
+    readonly assessment: CandidateAssessment;
+    readonly candidate: ReviewCandidate;
+  }> = [];
   let rejectedCandidates = 0;
   let unsettledCandidates = 0;
   let requiredVerificationPasses = 0;
@@ -549,38 +555,46 @@ const fanOutAssurance = (
       );
       continue;
     }
-    const expectedIds = new Set(candidates.map((candidate) => candidate.candidateId));
+    const byId = new Map(
+      candidates.map((candidate) => [candidate.candidateId, candidate] as const),
+    );
     const assessedIds = new Set<string>();
+    let suggestionSettlementExact = true;
     const exactAssessments = result.value.assessments.every((assessment) => {
-      if (!expectedIds.has(assessment.candidateId) || assessedIds.has(assessment.candidateId)) {
+      const candidate = byId.get(assessment.candidateId);
+      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
         return false;
       }
       assessedIds.add(assessment.candidateId);
+      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+        suggestionSettlementExact = false;
+      }
       return true;
     });
     if (
-      expectedIds.size !== candidates.length ||
+      byId.size !== candidates.length ||
       !exactAssessments ||
-      assessedIds.size !== expectedIds.size
+      assessedIds.size !== byId.size ||
+      !suggestionSettlementExact
     ) {
       unsettledCandidates += candidates.length;
       failedPasses.push(
         FailedReviewPass.make({
           workId,
           stage: "verification",
-          errorTag: "VerificationAssessmentMismatch",
+          errorTag:
+            exactAssessments && !suggestionSettlementExact
+              ? "SuggestionSettlementMismatch"
+              : "VerificationAssessmentMismatch",
         }),
       );
       continue;
     }
     completedVerificationPasses += 1;
-    const byId = new Map(
-      candidates.map((candidate) => [candidate.candidateId, candidate] as const),
-    );
     for (const assessment of result.value.assessments) {
       if (assessment.disposition === "confirmed") {
         const candidate = byId.get(assessment.candidateId);
-        if (candidate !== undefined) confirmedCandidates.push(candidate);
+        if (candidate !== undefined) confirmedCandidates.push({ assessment, candidate });
       } else {
         rejectedCandidates += 1;
       }
@@ -641,10 +655,12 @@ const fanOutAssurance = (
       failedPasses,
       reasons,
     }),
-    confirmedFindings: confirmedCandidates.flatMap((candidate) =>
-      candidate._tag === "FindingCandidate" ? [candidate.finding] : [],
+    confirmedFindings: confirmedCandidates.flatMap(({ assessment, candidate }) =>
+      candidate._tag === "FindingCandidate"
+        ? [confirmedFindingForPublication(assessment, candidate)]
+        : [],
     ),
-    confirmedConcerns: confirmedCandidates.flatMap((candidate) =>
+    confirmedConcerns: confirmedCandidates.flatMap(({ candidate }) =>
       candidate._tag === "ConcernCandidate" ? [candidate.concern] : [],
     ),
     walkthrough,

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -275,6 +275,8 @@ export const makeFileReviewerInstructions =
       "The discovery evidence array contains every complete shard in the unit. Review every entry and every shard of a multi-shard path. A later independent verifier, not you, decides which candidates publish.",
       "When a non-anchored concern depends on one or more unit files, list 1-3 exact evidencePaths to bind the claim to scheduled evidence.",
       `Return ONLY JSON with phase "discovery", the exact workId/unitId, up to ${MAX_CHILD_FINDINGS} findings, up to ${MAX_CHILD_CONCERNS} concerns shaped as {concern, evidencePaths}, one factual file summary per path (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars), and an empty assessments array. Empty candidate arrays are valid; do not invent defects.`,
+      'Each finding is {"path": <a unit file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL problem-kind label>, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>}.',
+      'Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement source for every line in the range and nothing else — never prose describing the change, which belongs in "body".',
     ].join("\n");
   };
 

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -111,8 +111,50 @@ export class CandidateAssessment extends Schema.Class<CandidateAssessment>(
 )({
   candidateId: ReviewCandidateId,
   disposition: Schema.Literals(["confirmed", "rejected"]),
+  /**
+   * Exact suggestion settlement: required when the candidate finding carries
+   * a suggestion, forbidden otherwise. Untrusted child output cannot publish
+   * a GitHub replacement block by prompt compliance alone — the host keeps a
+   * confirmed finding's suggestion only on an exact "committable" settlement.
+   */
+  suggestion: Schema.optionalKey(
+    Schema.Literals(["committable", "not-committable"]).annotate({
+      description:
+        'Required exactly when the candidate finding carries a suggestion: "committable" only when its text is the full replacement source for exactly lines startLine..endLine and nothing else. Forbidden for candidates without a suggestion.',
+    }),
+  ),
   rationale: Schema.NonEmptyString.check(Schema.isMaxLength(600)),
 }) {}
+
+/**
+ * Exact suggestion settlement shape: a carried suggestion must be settled and
+ * nothing else may be. Enforced identically by the live delegation projection
+ * and the independent host coverage fold.
+ */
+export const assessmentSettlesSuggestionExactly = (
+  assessment: CandidateAssessment,
+  candidate: ReviewCandidate,
+): boolean =>
+  candidate._tag === "FindingCandidate" && candidate.finding.suggestion !== undefined
+    ? assessment.suggestion !== undefined
+    : assessment.suggestion === undefined;
+
+/**
+ * Fail-closed publication of a confirmed finding: only an exact "committable"
+ * settlement keeps the suggestion; anything else publishes the finding with
+ * the suggestion stripped so unverified text can never become a one-click
+ * GitHub replacement block.
+ */
+export const confirmedFindingForPublication = (
+  assessment: CandidateAssessment,
+  candidate: FindingCandidate,
+): ReviewFinding => {
+  if (candidate.finding.suggestion === undefined || assessment.suggestion === "committable") {
+    return candidate.finding;
+  }
+  const { suggestion: _stripped, ...finding } = candidate.finding;
+  return ReviewFinding.make(finding);
+};
 
 /**
  * Concern candidates need explicit paths internally to bind the claim to
@@ -260,7 +302,8 @@ export const makeFileReviewerInstructions =
         "Independently verify every candidate in the input. You did not receive another reviewer's transcript or reasoning; use only the candidate claim and bounded evidence.",
         "The evidence array contains the complete bounded unit, including neighboring changed code that may confirm or falsify a locally plausible claim.",
         "For each candidate, try to falsify it first. Confirm only when the cited behavior is supported and actionable. Reject unsupported, speculative, duplicate, or non-actionable candidates.",
-        'Return ONLY JSON with phase "verification", the exact workId/unitId, empty findings/concerns/fileSummaries arrays, and exactly one assessment per candidateId. Each assessment is {"candidateId": <exact id>, "disposition": <"confirmed" | "rejected">, "rationale": <bounded evidence-based reason>}. Never add or omit an id.',
+        'Return ONLY JSON with phase "verification", the exact workId/unitId, empty findings/concerns/fileSummaries arrays, and exactly one assessment per candidateId. Each assessment is {"candidateId": <exact id>, "disposition": <"confirmed" | "rejected">, "suggestion": <"committable" | "not-committable", present exactly when the candidate finding carries a suggestion>, "rationale": <bounded evidence-based reason>}. Never add or omit an id.',
+        'Settle every carried suggestion independently of the claim: answer "committable" only when its text is the full replacement source for exactly lines startLine..endLine and nothing else — it compiles in context and preserves the finding\'s intent, never prose describing a change. Otherwise answer "not-committable"; the host then publishes the confirmed finding without its suggestion. Omit the assessment "suggestion" field for candidates without one.',
       ].join("\n");
     }
     const focus =
@@ -464,17 +507,28 @@ const projectReviewResult = (
         rejectWork(report.workId, "verification output contained discovery-only fields"),
       );
     }
-    const expectedIds = new Set(request.candidates.map((candidate) => candidate.candidateId));
+    const expectedById = new Map(
+      request.candidates.map((candidate) => [candidate.candidateId, candidate] as const),
+    );
     const assessedIds = new Set<string>();
     for (const assessment of report.assessments) {
-      if (!expectedIds.has(assessment.candidateId) || assessedIds.has(assessment.candidateId)) {
+      const candidate = expectedById.get(assessment.candidateId);
+      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
         return Effect.fail(
           rejectWork(report.workId, "verification output did not assess the exact candidate set"),
         );
       }
+      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+        return Effect.fail(
+          rejectWork(
+            report.workId,
+            "verification output did not settle suggestion publication exactly",
+          ),
+        );
+      }
       assessedIds.add(assessment.candidateId);
     }
-    if (assessedIds.size !== expectedIds.size) {
+    if (assessedIds.size !== expectedById.size) {
       return Effect.fail(
         rejectWork(report.workId, "verification output did not assess the exact candidate set"),
       );

--- a/packages/pr-review/src/internal/review-agent.ts
+++ b/packages/pr-review/src/internal/review-agent.ts
@@ -346,7 +346,12 @@ export class ReviewFinding extends Schema.Class<ReviewFinding>(
   title: Schema.NonEmptyString.check(Schema.isMaxLength(120)),
   body: Schema.NonEmptyString.check(Schema.isMaxLength(2_000)),
   /** Replacement for exactly lines startLine..endLine; omit when unsure. */
-  suggestion: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(2_000))),
+  suggestion: Schema.optionalKey(
+    Schema.String.annotate({
+      description:
+        "Committable replacement source code for exactly lines startLine..endLine: the full replacement for every line in the range and nothing else — never prose describing the change, which belongs in body.",
+    }).check(Schema.isMaxLength(2_000)),
+  ),
 }) {}
 
 export const ReviewVerdict = Schema.Literals(["approve", "comment", "request-changes"]);

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -366,6 +366,21 @@ describe("fan-out review contract", () => {
     expect(outputSchema).toContain("never prose describing the change");
   });
 
+  it("requires verifiers to settle every carried suggestion exactly", () => {
+    const instructions = FileReviewer.instructions({
+      ...verificationRequest,
+      evidence: [],
+    });
+    expect(instructions).toContain('"suggestion": <"committable" | "not-committable"');
+    expect(instructions).toContain(
+      "full replacement source for exactly lines startLine..endLine and nothing else",
+    );
+    const outputSchema = JSON.stringify(Tool.getJsonSchemaFromSchema(FileReviewReport));
+    expect(outputSchema).toContain(
+      "Required exactly when the candidate finding carries a suggestion",
+    );
+  });
+
   it("configures evidence-only children with the framework's bounded concurrency policy", () => {
     expect(Object.keys(FileReviewToolkit.tools)).toEqual([]);
     expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(1);
@@ -998,6 +1013,150 @@ describe("offline discovery and verification pipeline", () => {
     }),
   );
 
+  const committableSuggestionFinding = ReviewFinding.make({
+    ...supportedFinding,
+    suggestion: 'export const authenticateMode = "verified";',
+  });
+  const proseSuggestionFinding = ReviewFinding.make({
+    path: supportedFinding.path,
+    startLine: 3,
+    endLine: 3,
+    severity: "important",
+    category: "correctness",
+    title: "The enable flag ships without a rollout guard",
+    body: "The new flag enables the mode unconditionally in every environment.",
+    suggestion: "Move the flag behind the environment rollout guard before enabling it.",
+  });
+  const committableCandidate = candidateFor(committableSuggestionFinding, 1);
+  const proseCandidate = candidateFor(proseSuggestionFinding, 2);
+  const suggestionDiscovery: ReadonlyArray<OfflineUnitScript> = [
+    successfulDiscovery[0]!,
+    {
+      workId: specialistPass.passId,
+      outcome: {
+        _tag: "report",
+        report: discoveryReport(specialistPass, [
+          committableSuggestionFinding,
+          proseSuggestionFinding,
+        ]),
+      },
+    },
+  ];
+  const suggestionVerificationRequest = FileReviewRequest.make({
+    ...verificationRequest,
+    candidates: [committableCandidate, proseCandidate],
+  });
+
+  it.effect("publishes a suggestion only on an exact committable settlement", () =>
+    Effect.gen(function* () {
+      const result = yield* runOfflineFanOut({
+        discoveryReports: suggestionDiscovery,
+        verificationCalls: [suggestionVerificationRequest],
+        verificationReports: [
+          {
+            workId: suggestionVerificationRequest.workId,
+            outcome: {
+              _tag: "report",
+              report: FileReviewReport.make({
+                phase: "verification",
+                workId: suggestionVerificationRequest.workId,
+                unitId: suggestionVerificationRequest.unitId,
+                findings: [],
+                concerns: [],
+                fileSummaries: [],
+                assessments: [
+                  CandidateAssessment.make({
+                    candidateId: committableCandidate.candidateId,
+                    disposition: "confirmed",
+                    suggestion: "committable",
+                    rationale: "The replacement is the exact committable source for line 2.",
+                  }),
+                  CandidateAssessment.make({
+                    candidateId: proseCandidate.candidateId,
+                    disposition: "confirmed",
+                    suggestion: "not-committable",
+                    rationale: "The suggestion text is advice prose, not replacement source.",
+                  }),
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+      const { suggestion: _prose, ...strippedProse } = proseSuggestionFinding;
+      expect(result.outcome.assurance).toMatchObject({
+        status: "settled",
+        confirmedCandidates: 2,
+        rejectedCandidates: 0,
+        unsettledCandidates: 0,
+      });
+      expect(result.outcome.review.findings).toEqual([
+        committableSuggestionFinding,
+        ReviewFinding.make(strippedProse),
+      ]);
+      const committableComment = result.outcome.plan.comments.find((comment) =>
+        comment.body.includes(committableSuggestionFinding.title),
+      );
+      const strippedComment = result.outcome.plan.comments.find((comment) =>
+        comment.body.includes(proseSuggestionFinding.title),
+      );
+      expect(committableComment?.body).toContain("```suggestion");
+      expect(strippedComment?.body).toBeDefined();
+      expect(strippedComment?.body).not.toContain("```suggestion");
+    }),
+  );
+
+  it.effect("leaves the unit unsettled when a carried suggestion is not settled", () =>
+    Effect.gen(function* () {
+      const result = yield* runOfflineFanOut({
+        discoveryReports: suggestionDiscovery,
+        verificationCalls: [suggestionVerificationRequest],
+        verificationReports: [
+          {
+            workId: suggestionVerificationRequest.workId,
+            outcome: {
+              _tag: "report",
+              report: FileReviewReport.make({
+                phase: "verification",
+                workId: suggestionVerificationRequest.workId,
+                unitId: suggestionVerificationRequest.unitId,
+                findings: [],
+                concerns: [],
+                fileSummaries: [],
+                assessments: [
+                  CandidateAssessment.make({
+                    candidateId: committableCandidate.candidateId,
+                    disposition: "confirmed",
+                    rationale: "Confirmed without settling the carried suggestion.",
+                  }),
+                  CandidateAssessment.make({
+                    candidateId: proseCandidate.candidateId,
+                    disposition: "confirmed",
+                    suggestion: "not-committable",
+                    rationale: "The suggestion text is advice prose, not replacement source.",
+                  }),
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+      expect(result.outcome.assurance.status).toBe("incomplete");
+      expect(result.outcome.assurance.failedPasses).toContainEqual(
+        expect.objectContaining({
+          workId: suggestionVerificationRequest.workId,
+          stage: "verification",
+          errorTag: "FileReviewWorkRejected",
+        }),
+      );
+      expect(result.outcome.review.findings).toEqual([]);
+      expect(result.outcome.plan.comments).toEqual([]);
+      expect(result.outcome.state).toBeUndefined();
+    }),
+  );
+
   it("surfaces typed policy exhaustion as a failed specialist pass", () => {
     const generalRequest = discoveryRequest(generalPass);
     const specialistRequest = discoveryRequest(specialistPass);
@@ -1076,6 +1235,113 @@ describe("offline discovery and verification pipeline", () => {
       }),
     );
     expect(assessment.coverage.status).toBe("incomplete");
+  });
+
+  // The independent fold must re-enforce suggestion settlement itself: a
+  // recorded trace can carry verification results the live projection never
+  // vetted, e.g. runs recorded before this contract existed.
+  it("independently rejects a recorded settlement that settles a suggestion nothing carried", () => {
+    const generalRequest = discoveryRequest(generalPass);
+    const specialistRequest = discoveryRequest(specialistPass);
+    const discoveredCandidate = candidateFor(supportedFinding, 1, generalPass);
+    const recordedVerificationRequest = FileReviewRequest.make({
+      ...verificationRequest,
+      candidates: [discoveredCandidate],
+    });
+    const base = {
+      eventVersion: 1,
+      runId: "run-suggestion-settlement",
+      conversationId: "conversation-suggestion-settlement",
+      agentId: "pr-fanout-reviewer",
+      timestamp: "2026-08-18T20:00:00.000Z",
+      providerExecuted: false,
+    } as const;
+    const declared = (sequence: number, toolCallId: string, request: FileReviewRequest) =>
+      Schema.decodeUnknownSync(RunEvent)({
+        ...base,
+        _tag: "ToolCallDeclared",
+        sequence,
+        toolCallId,
+        toolName: "delegate_file_review",
+        parameters: Schema.encodeSync(FileReviewRequest)(request),
+      });
+    const succeeded = (sequence: number, toolCallId: string, result: FileReviewUnitResult) =>
+      Schema.decodeUnknownSync(RunEvent)({
+        ...base,
+        _tag: "ToolCallSucceeded",
+        sequence,
+        toolCallId,
+        toolName: "delegate_file_review",
+        result: Schema.encodeSync(FileReviewUnitResult)(result),
+      });
+    const events = [
+      declared(1, "general-call", generalRequest),
+      succeeded(
+        2,
+        "general-call",
+        FileReviewUnitResult.make({
+          phase: "discovery",
+          workId: generalPass.passId,
+          unitId: generalPass.unitId,
+          candidates: [discoveredCandidate],
+          fileSummaries: [],
+          assessments: [],
+        }),
+      ),
+      declared(3, "specialist-call", specialistRequest),
+      succeeded(
+        4,
+        "specialist-call",
+        FileReviewUnitResult.make({
+          phase: "discovery",
+          workId: specialistPass.passId,
+          unitId: specialistPass.unitId,
+          candidates: [],
+          fileSummaries: [],
+          assessments: [],
+        }),
+      ),
+      declared(5, "verification-call", recordedVerificationRequest),
+      succeeded(
+        6,
+        "verification-call",
+        FileReviewUnitResult.make({
+          phase: "verification",
+          workId: recordedVerificationRequest.workId,
+          unitId: recordedVerificationRequest.unitId,
+          candidates: [],
+          fileSummaries: [],
+          assessments: [
+            CandidateAssessment.make({
+              candidateId: discoveredCandidate.candidateId,
+              disposition: "confirmed",
+              // supportedFinding carries no suggestion, so settling one is
+              // an inexact recorded settlement the fold must reject.
+              suggestion: "committable",
+              rationale: "The recorded settlement names a suggestion the candidate never carried.",
+            }),
+          ],
+        }),
+      ),
+    ];
+    const assessment = assessReviewPipeline({
+      shape: "fan-out",
+      files: highRiskFiles,
+      totalFiles: 2,
+      anchorFiles: highRiskFiles,
+      totalAnchorFiles: 2,
+      events,
+    });
+
+    expect(assessment.assurance.status).toBe("incomplete");
+    expect(assessment.assurance.failedPasses).toContainEqual(
+      expect.objectContaining({
+        workId: recordedVerificationRequest.workId,
+        stage: "verification",
+        errorTag: "SuggestionSettlementMismatch",
+      }),
+    );
+    expect(assessment.confirmedFindings).toEqual([]);
   });
 });
 

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -349,6 +349,23 @@ describe("fan-out review contract", () => {
     expect(instructions).toContain("publication cap is 7");
   });
 
+  it("spells the finding shape and committable-suggestion rule out to discovery workers", () => {
+    const instructions = FileReviewer.instructions({
+      ...discoveryRequest(generalPass),
+      evidence: [],
+    });
+    expect(instructions).toContain(
+      '"suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>',
+    );
+    expect(instructions).toContain(
+      "full replacement source for every line in the range and nothing else",
+    );
+    // The rendered final-output contract carries the same rule with the schema,
+    // so every consumer of ReviewFinding shows it to the model.
+    const outputSchema = JSON.stringify(Tool.getJsonSchemaFromSchema(FileReviewReport));
+    expect(outputSchema).toContain("never prose describing the change");
+  });
+
   it("configures evidence-only children with the framework's bounded concurrency policy", () => {
     expect(Object.keys(FileReviewToolkit.tools)).toEqual([]);
     expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(1);


### PR DESCRIPTION
## Summary

- Fan-out (assured multi-pass) reviews were publishing GitHub suggestion blocks containing prose advice ("Move `state.storage.setAlarm(...)` before …") instead of committable replacement code.
- The contract is now both **stated and enforced**. Discovery workers get the [finding shape and suggestion rule spelled out](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/fan-out.ts#L321-L322), and `ReviewFinding.suggestion` carries the rule as a [schema description](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/review-agent.ts#L349-L355) so the rendered final-output contract shows it to the model wherever the schema travels. Because that alone cannot bound untrusted model output, the independent verifier must now settle every carried suggestion, and the host publishes a suggestion block only on an exact `"committable"` settlement.
- The committed Action bundle is rebuilt.

## What went wrong

#117 moved Action reviews to the fan-out pipeline by default (`PR_REVIEW_FAN_OUT=true`). In that pipeline, findings are produced by `pr-review-worker` discovery children — but their instructions only said "up to 6 findings" without ever stating the finding contract. The only model-visible definition of `suggestion` was the JSON schema of `FileReviewReport`, where it was a bare optional string: the "Replacement for exactly lines startLine..endLine" text above the field is a TypeScript doc comment, which never reaches the model. Faced with an undescribed field named `suggestion`, live models fill it with advice prose, and nothing downstream corrected it — the verifier assessed only the claim, host projection validated only anchors, and the renderer fenced whatever the field held as a ```suggestion``` block that GitHub offers as a one-click commit.

The single-pass reviewer never regressed because its prompt spells the rule out explicitly — and the comment above it states the principle the fan-out path violated: "Live models diverge wherever the contract is implicit, so the exact JSON shape, the anchor rule, and the suggestion rule are all spelled out with types."

## Architecture

Suggestion publication is now a verified settlement, mirroring #117's candidate settlement:

- [`CandidateAssessment`](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/fan-out.ts#L109-L127) gains an exact suggestion channel: required (`"committable" | "not-committable"`) when the candidate finding carries a suggestion, forbidden otherwise. The [verifier instructions](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/fan-out.ts#L306) require settling the suggestion text independently of the claim.
- The [live delegation projection](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/fan-out.ts#L525) rejects a verification report that leaves a carried suggestion unsettled or settles one nothing carried — the unit becomes unsettled work, consistent with exact assurance settlement.
- The [independent coverage fold](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/coverage.ts#L660) re-enforces the same rule from the recorded trace (`SuggestionSettlementMismatch`) and reconstructs published findings through [`confirmedFindingForPublication`](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/src/internal/fan-out.ts#L148-L157): only an exact `"committable"` settlement keeps the suggestion; a confirmed finding with a `"not-committable"` settlement publishes without the block, so a malformed suggestion never suppresses a true finding.
- Traces recorded before this contract (assessments without the settlement field) fail settlement clearly rather than publishing unverified suggestions.

A model-side judgment is still a model claim — no host can prove replacement source compiles — but publication is now fail-closed on an explicit, independently produced settlement rather than on prompt compliance, and the single-pass (non-assured) path is unchanged: it has no verifier, which is exactly the assurance gap #117 exists to close.

## Evidence

The model-visible output contract (rendered into every discovery child's prompt) now carries the rule on the property node:

```json
"suggestion": {
  "type": "string",
  "description": "Committable replacement source code for exactly lines startLine..endLine: the full replacement for every line in the range and nothing else — never prose describing the change, which belongs in body.",
  "allOf": [{ "maxLength": 2000 }]
}
```

Deterministic tests cover every new settlement transition: [publish on committable / strip on not-committable](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/test/pr-review-fanout.test.ts#L1050) (asserts the rendered comment keeps/drops the ```suggestion``` fence), [unit left unsettled when a carried suggestion is not settled](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/test/pr-review-fanout.test.ts#L1110), and the [fold independently rejecting a recorded spurious settlement](https://github.com/danieljvdm/effect-agent/blob/77754f89ca05812b5234e6ad34b08d533519ac0c/packages/pr-review/test/pr-review-fanout.test.ts#L1243), plus instruction-contract assertions for discovery and verification workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
