### PR TITLE
fix(ci): require exact generated release commits

### DIFF
--- a/.changeset/stable-testing-release-artifacts.md
+++ b/.changeset/stable-testing-release-artifacts.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/testing": patch
+---
+
+Stabilize the encoded Travel Planner persistence fixture's declaration so repeated package builds
+produce the same release artifact.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       release-pr-number: ${{ steps.changesets.outputs.pullRequestNumber }}
       has-changesets: ${{ steps.changesets.outputs.hasChangesets }}
+      is-release-commit: ${{ steps.classify-release.outputs.is-release-commit }}
     env:
       CI: "true"
       VITE_GIT_HOOKS: "0"
@@ -79,6 +80,18 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Classify exact generated release commit
+        id: classify-release
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          BASE_SHA="$(git rev-parse "${GITHUB_SHA}^")"
+          ./node_modules/.bin/vp run --no-cache verify:changesets-release -- \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$GITHUB_SHA" \
+            --classification-output "$GITHUB_OUTPUT"
 
   verify-release:
     name: Verify generated release tree
@@ -229,7 +242,7 @@ jobs:
   prepare-publish:
     name: Build immutable release artifacts
     needs: version-release
-    if: ${{ needs.version-release.outputs.has-changesets == 'false' }}
+    if: ${{ needs.version-release.outputs.is-release-commit == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -292,7 +305,7 @@ jobs:
   publish-packages:
     name: Publish packages with npm OIDC
     needs: [version-release, prepare-publish]
-    if: ${{ needs.version-release.outputs.has-changesets == 'false' && needs.prepare-publish.outputs.publish-count != '0' }}
+    if: ${{ needs.version-release.outputs.is-release-commit == 'true' && needs.prepare-publish.outputs.publish-count != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -484,7 +497,7 @@ jobs:
   tag-release:
     name: Tag published packages
     needs: [version-release, prepare-publish, publish-packages]
-    if: ${{ always() && needs.version-release.outputs.has-changesets == 'false' && needs.prepare-publish.result == 'success' && (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') }}
+    if: ${{ always() && needs.version-release.outputs.is-release-commit == 'true' && needs.prepare-publish.result == 'success' && (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -160,8 +160,10 @@ the fixed group in `.changeset/config.json`; the toolchain test fails if the wor
 diverge.
 
 Releases are automated: on every push to `main`, `.github/workflows/release.yml`
-maintains a "Version Packages (beta)" PR from the pending changesets, and
-merging that PR publishes via npm **trusted publishing** — the workflow's OIDC
+maintains a "Version Packages (beta)" PR from the pending changesets. When no pending changeset
+remains, the workflow classifies the pushed tree against a clean Changesets regeneration from its
+first parent; only that exact generated tree may enter the publish jobs. An ordinary no-changeset
+push is not release authority. Merging the version PR publishes via npm **trusted publishing** — the workflow's OIDC
 identity is exchanged for short-lived credentials (no npm token, no OTP), with
 provenance attached. The generated PR is release metadata over code that
 already passed the ordinary PR gates: its Static checks, Tests, Build, and
@@ -192,8 +194,8 @@ not complete, or that rule is absent, it posts a failing `ready` conclusion. Ope
 the ruleset's `strict_required_status_checks_policy` setting: it invalidates the head-bound success
 for merge purposes whenever `main` later advances, until Changesets regenerates from the new base.
 
-After a version PR merge, an unprivileged preparation job frozen-installs and rebuilds the exact
-versioned tree, packs every public workspace with Bun into a scope-owned staging directory, and
+After the version PR merge passes that exact-tree classification, an unprivileged preparation job
+frozen-installs and rebuilds the exact versioned tree, packs every public workspace with Bun into a scope-owned staging directory, and
 atomically renames that directory into place only after every tarball and the manifest are
 complete. Failure or interruption removes the partial staging tree, so a retry never inherits an
 incomplete release artifact. The atomic rename itself is uninterruptible, and a failed preparation,

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -377,6 +377,9 @@ Current platform references:
 
 - framework and platform code live in owner-gated `packages/*`; private runnable benches may live
   in leaf `examples/*`, and there is no deployable `apps/` workspace;
+- a `main` push may enter package publication only when its complete tree is the exact Changesets
+  version regeneration from its first parent; the absence of pending changesets alone grants no
+  release authority;
 - the root Bun catalog pins the exact Effect v4 version before 1.0;
 - workspace manifests consume that version through `catalog:` and may not introduce another copy;
 - `platform-cloudflare` publishes `effect-cf` as a compatible caret peer while the root catalog

--- a/packages/testing/src/fixtures/travel-planner/phase3.ts
+++ b/packages/testing/src/fixtures/travel-planner/phase3.ts
@@ -115,9 +115,8 @@ export const phase3TravelPlannerBatches = [
 ] as const;
 
 /** Portable current-version fixture; it contains no passenger identity or credentials. */
-export const phase3TravelPlannerEncodedFixture = Schema.encodeSync(Schema.Array(CanonicalBatch))(
-  phase3TravelPlannerBatches,
-);
+export const phase3TravelPlannerEncodedFixture: ReadonlyArray<typeof CanonicalBatch.Encoded> =
+  Schema.encodeSync(Schema.Array(CanonicalBatch))(phase3TravelPlannerBatches);
 
 export class TravelPlannerProjectionError extends Schema.TaggedError<TravelPlannerProjectionError>()(
   "TravelPlannerProjectionError",

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -13,6 +13,7 @@ import {
   withTemporaryManifest,
 } from "../../../scripts/release-publish.ts";
 import {
+  classifyChangesetsRelease,
   InvalidCommitSha,
   ReleaseTreeMismatch,
   verifyChangesetsRelease,
@@ -931,6 +932,22 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
         publish: "true",
         version: "./node_modules/.bin/vp run ci:version",
       });
+      expect(versionJob?.outputs?.["is-release-commit"]).toBe(
+        "${{ steps.classify-release.outputs.is-release-commit }}",
+      );
+      const classifyReleaseStep = workflowStep(
+        releaseWorkflow,
+        "version-release",
+        "Classify exact generated release commit",
+      );
+      expect(classifyReleaseStep?.id).toBe("classify-release");
+      expect(classifyReleaseStep?.if).toBe(
+        "${{ steps.changesets.outputs.hasChangesets == 'false' }}",
+      );
+      expect(classifyReleaseStep?.env).toEqual({ GITHUB_TOKEN: "${{ github.token }}" });
+      expect(classifyReleaseStep?.run).toContain('git rev-parse "${GITHUB_SHA}^"');
+      expect(classifyReleaseStep?.run).toContain("vp run --no-cache verify:changesets-release");
+      expect(classifyReleaseStep?.run).toContain('--classification-output "$GITHUB_OUTPUT"');
 
       const verifyJob = releaseWorkflow.jobs["verify-release"];
       expect(verifyJob?.needs).toBe("version-release");
@@ -983,7 +1000,9 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
 
       const prepareJob = releaseWorkflow.jobs["prepare-publish"];
       expect(prepareJob?.needs).toBe("version-release");
-      expect(prepareJob?.if).toBe("${{ needs.version-release.outputs.has-changesets == 'false' }}");
+      expect(prepareJob?.if).toBe(
+        "${{ needs.version-release.outputs.is-release-commit == 'true' }}",
+      );
       expect(prepareJob?.permissions).toEqual({ contents: "read" });
       const prepareStep = workflowStep(
         releaseWorkflow,
@@ -994,6 +1013,9 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(prepareStep?.run).toContain("sha256sum --check --strict");
 
       const publishJob = releaseWorkflow.jobs["publish-packages"];
+      expect(publishJob?.if).toBe(
+        "${{ needs.version-release.outputs.is-release-commit == 'true' && needs.prepare-publish.outputs.publish-count != '0' }}",
+      );
       expect(publishJob?.permissions).toEqual({
         actions: "read",
         contents: "read",
@@ -1030,6 +1052,9 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(publishStep?.run).not.toContain("vp run");
 
       const tagJob = releaseWorkflow.jobs["tag-release"];
+      expect(tagJob?.if).toBe(
+        "${{ always() && needs.version-release.outputs.is-release-commit == 'true' && needs.prepare-publish.result == 'success' && (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped') }}",
+      );
       expect(tagJob?.permissions).toEqual({ actions: "read", contents: "write" });
       expect(tagJob?.steps?.every((step) => step.uses === undefined)).toBe(true);
       const tagStep = workflowStep(
@@ -1529,6 +1554,14 @@ Exercise the generated release verifier.
           headSha: generatedHead,
           repositoryRoot: fixtureRoot,
         });
+        expect(
+          yield* classifyChangesetsRelease({
+            baseSha,
+            changesetBinary,
+            headSha: generatedHead,
+            repositoryRoot: fixtureRoot,
+          }),
+        ).toBe(true);
         const worktreesAfterSuccess = yield* runFixtureCommand(fixtureRoot, "git", [
           "worktree",
           "list",
@@ -1601,7 +1634,7 @@ Exercise the generated release verifier.
         yield* runFixtureCommand(fixtureRoot, "git", ["commit", "-m", "alter generated output"]);
         const alteredHead = yield* runFixtureCommand(fixtureRoot, "git", ["rev-parse", "HEAD"]);
         const alteredFailure = yield* Effect.flip(
-          verifyChangesetsRelease({
+          classifyChangesetsRelease({
             baseSha,
             changesetBinary,
             headSha: alteredHead,
@@ -1628,6 +1661,14 @@ Exercise the generated release verifier.
         expect(
           Schema.decodeUnknownSync(ReleaseTreeMismatch)(unexpectedFailure).changedPaths,
         ).toContain("unexpected.txt");
+        expect(
+          yield* classifyChangesetsRelease({
+            baseSha,
+            changesetBinary: path.join(temporaryRoot, "must-not-run"),
+            headSha: unexpectedHead,
+            repositoryRoot: fixtureRoot,
+          }),
+        ).toBe(false);
 
         const invalidShaFailure = yield* Effect.flip(
           verifyChangesetsRelease({

--- a/scripts/verify-changesets-release.ts
+++ b/scripts/verify-changesets-release.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Cause, Console, Effect, Exit, FileSystem, Path, Schema, Stream } from "effect";
+import { Cause, Console, Effect, Exit, FileSystem, Option, Path, Schema, Stream } from "effect";
 import { Command as CliCommand, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 
@@ -105,6 +105,14 @@ const findRepositoryRoot = Effect.fn("verifyChangesetsRelease.findRepositoryRoot
   const scriptPath = yield* path.fromFileUrl(new URL(import.meta.url));
   return path.resolve(path.dirname(scriptPath), "..");
 });
+
+const isReleaseMetadataPath = (path: string): boolean =>
+  path === ".changeset/pre.json" || /^\.changeset\/[A-Za-z0-9._-]+[.]md$/.test(path);
+
+const isGeneratedReleasePath = (path: string): boolean =>
+  path === "bun.lock" ||
+  isReleaseMetadataPath(path) ||
+  /^packages\/[^/]+\/(?:CHANGELOG[.]md|package[.]json)$/.test(path);
 
 const cleanupError = (operation: string) => (cause: unknown) =>
   VerificationCleanupError.make({
@@ -244,22 +252,83 @@ export const verifyChangesetsRelease = Effect.fn("verifyChangesetsRelease")(func
   );
 });
 
+/**
+ * Classify one pushed commit without treating the absence of pending changesets as release
+ * authority. Commits outside the generated Changesets surface are ordinary pushes; commits that
+ * look like release output must pass the same exact-tree verifier used for the generated PR.
+ */
+export const classifyChangesetsRelease = Effect.fn("classifyChangesetsRelease")(
+  function* (options: {
+    readonly baseSha: string;
+    readonly headSha: string;
+    readonly repositoryRoot?: string;
+    readonly changesetBinary?: string;
+    readonly bunBinary?: string;
+  }) {
+    const baseSha = yield* decodeCommitSha("--base-sha", options.baseSha);
+    const headSha = yield* decodeCommitSha("--head-sha", options.headSha);
+    const root = options.repositoryRoot ?? (yield* findRepositoryRoot());
+
+    yield* runCommand(root, "git", ["cat-file", "-e", `${baseSha}^{commit}`]);
+    yield* runCommand(root, "git", ["cat-file", "-e", `${headSha}^{commit}`]);
+    const changedPathOutput = yield* runCommand(root, "git", [
+      "diff",
+      "--name-only",
+      baseSha,
+      headSha,
+    ]);
+    const changedPaths = changedPathOutput.length === 0 ? [] : changedPathOutput.split("\n");
+    const isReleaseCandidate =
+      changedPaths.some(isReleaseMetadataPath) && changedPaths.every(isGeneratedReleasePath);
+
+    if (!isReleaseCandidate) return false;
+
+    yield* verifyChangesetsRelease(options);
+    return true;
+  },
+);
+
 const baseSha = Flag.string("base-sha").pipe(
   Flag.withDescription("Trusted pull-request base commit SHA."),
 );
 const headSha = Flag.string("head-sha").pipe(
   Flag.withDescription("Generated Changesets pull-request head commit SHA."),
 );
+const classificationOutput = Flag.string("classification-output").pipe(
+  Flag.optional,
+  Flag.withDescription(
+    "Append an is-release-commit result for GitHub Actions after classifying the candidate commit.",
+  ),
+);
 
 const command = CliCommand.make(
   "verify-changesets-release",
-  { baseSha, headSha },
-  Effect.fn("verifyChangesetsRelease.command")(function* ({ baseSha, headSha }) {
-    yield* verifyChangesetsRelease({ baseSha, headSha });
+  { baseSha, classificationOutput, headSha },
+  Effect.fn("verifyChangesetsRelease.command")(function* ({
+    baseSha,
+    classificationOutput,
+    headSha,
+  }) {
+    if (Option.isNone(classificationOutput)) {
+      return yield* verifyChangesetsRelease({ baseSha, headSha });
+    }
+
+    const isReleaseCommit = yield* classifyChangesetsRelease({ baseSha, headSha });
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.writeFileString(
+      classificationOutput.value,
+      `is-release-commit=${String(isReleaseCommit)}\n`,
+      { flag: "a" },
+    );
+    yield* Console.log(
+      isReleaseCommit
+        ? `Classified ${headSha} as an exact generated Changesets release commit.`
+        : `Classified ${headSha} as an ordinary non-release commit.`,
+    );
   }),
 ).pipe(
   CliCommand.withDescription(
-    "Regenerate Changesets output from a trusted base and require the PR head tree to match exactly.",
+    "Regenerate Changesets output from a trusted base and verify or classify a candidate release tree.",
   ),
 );
 


### PR DESCRIPTION
## Summary

- Prevent ordinary no-changeset pushes from entering package publication by requiring the [version job classifier](https://github.com/danieljvdm/effect-agent/blob/d5217034/.github/workflows/release.yml#L84-L95) to prove that the pushed tree is exact Changesets-generated release output.
- Keep candidate classification fail-closed through the [existing exact-tree verifier](https://github.com/danieljvdm/effect-agent/blob/d5217034/scripts/verify-changesets-release.ts#L260-L291), while allowing unrelated main pushes to skip release jobs normally.
- Stabilize the [encoded Travel Planner fixture declaration](https://github.com/danieljvdm/effect-agent/blob/d5217034/packages/testing/src/fixtures/travel-planner/phase3.ts#L117-L119) so repeated package builds produce identical declaration output and release artifacts.

## What went wrong

The release workflow treated `hasChangesets == false` as proof that every push to `main` was a merged Changesets version PR. After beta.21 was published, the ordinary #119 merge also had no pending changesets, so the workflow rebuilt the already-published beta.21 packages.

That rebuild exposed nondeterministic inferred declaration output in `@effect-agent/testing`: TypeScript reordered members of the expanded encoded `CanonicalBatch` union even though the source, runtime JavaScript, source map, package metadata, lockfile, and toolchain were unchanged. The resulting tarball checksum differed from the package already on npm, so the immutable-artifact guard correctly rejected publication.

The workflow now distinguishes release authority from changeset absence. A commit is a candidate only when its changed paths fit the generated Changesets surface and include release metadata; candidates must then match a clean Changesets regeneration from their first parent exactly. Prepare, publish, and tag jobs require that positive classification. The explicit fixture annotation also prevents declaration bundling from inferring and reordering the expanded union.

## Architecture

- The version job owns release classification and exports `is-release-commit`.
- The Effect CLI classifies ordinary commits without invoking Changesets, but routes candidate release commits through the exact-tree verifier and preserves its typed failures.
- Publish preparation, npm OIDC publication, and tag creation consume only the positive classification.

## Evidence

- Replaying the affected history classified `a1166f37..dd455442` (the failed ordinary push) as `false` and `27618dc0..a1166f37` (the genuine beta.21 release) as `true`.
- Two consecutive uncached package builds produced the same `packages/testing/dist/index.d.mts` SHA-256: `056d4ce5e1b54efd0e32333a300570cdf9202b0432f97ef7c65c147e9a85d0ce`.
- [Regression coverage](https://github.com/danieljvdm/effect-agent/blob/d5217034/packages/testing/test/toolchain.test.ts#L1554-L1672) exercises exact generated output, altered candidates, and ordinary pushes that must not execute the verifier.