### PR TITLE
test(platform-cloudflare): poll for the retained retry alarm instead of one instant probe

### DIFF
--- a/packages/platform-cloudflare/test/subagents-cross-do.test.ts
+++ b/packages/platform-cloudflare/test/subagents-cross-do.test.ts
@@ -541,10 +541,14 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
     const duringFault = await readCanonical(ref, SUBAGENTS);
     expect(payloadsOf(duringFault, "SubagentStarted")).toHaveLength(0);
     expect(childModelInvocations(ref)).toBe(0);
-    expect(
-      await scheduledAlarm(ref, SUBAGENTS),
-      "indeterminate establishment is autonomous retry state and must retain an alarm (#93)",
-    ).not.toBeNull();
+    // Each recovery pass re-arms the alarm inside its own delivery, and workerd auto-retries
+    // a rejected delivery on its own timers — an instant probe can land mid-delivery, after
+    // the alarm slot was consumed but before the pass re-arms it. The durable SUB-031 claim
+    // is that autonomous retry state keeps an alarm armed, so poll for it.
+    await waitFor(
+      async () => (await scheduledAlarm(ref, SUBAGENTS)) !== null,
+      "indeterminate establishment to retain its autonomous retry alarm (#93)",
+    );
 
     // Heal the transport: the next alarm passes resolve the admission (fresh), establish the
     // ONE child, and the delegation completes — no duplicate was ever possible.


### PR DESCRIPTION
## Summary

- Fixes the flaky assertion in the cross-Object indeterminate-establishment test: CI failed on `expected null not to be null` for the retained retry alarm (run 32167826255), then passed on rerun with zero code change.

## What went wrong

The test asserts that after establishment retries against an unreachable child Object, the parent retains a durable retry alarm (SUB-031, #93). But the assertion probed `storage.getAlarm()` at one instant, and alarm state is legitimately null mid-delivery: workerd consumes the scheduled slot when a delivery starts, auto-retries a rejected delivery on its own timers, and the recovery pass only re-arms the slot inside the handler. When the instant probe interleaved with one of those in-flight deliveries, it read null even though retry state was healthy — the same alarm cancel/reschedule machinery is visible in workerd's `requestScheduledAlarm` log lines during the suite.

The durable claim is "autonomous retry state keeps an alarm armed", not "the slot is non-null at every instant", so the assertion now polls for it with the file's existing `waitFor` idiom (condition polling, no wall-clock stabilization). A genuinely lost alarm still fails the test via the poll timeout.

## Evidence

The suite passes 4/4 consecutive local runs with the fix (18 tests each). The failure mode was observed once in CI on an unrelated PR (#121's first push) and vanished on rerun, matching the in-flight-delivery race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
