### PR TITLE
fix(pr-review): converge incremental reviews with host-scheduled fan-out and monotone continuity

### DIFF
--- a/.changeset/monotone-review-continuity.md
+++ b/.changeset/monotone-review-continuity.md
@@ -2,18 +2,13 @@
 "@effect-agent/pr-review": minor
 ---
 
-Schedule the fan-out review pipeline entirely from host code — no coordinator model, no
-delegation tool — retrying each failed pass once, discarding invalid-anchor findings instead of
-rejecting their pass, and advancing the authenticated incremental baseline on every completed
-run with unsettled scope carried forward as retryable `unreviewedPaths`.
-
-BEHAVIOR CHANGE: incremental reviews now converge instead of looping — a remediation push is
-reviewed against its immediate predecessor plus carried leftovers, never the whole
-post-baseline scope; blocking findings outrank machinery gaps in the check conclusion, and an
-`incomplete` conclusion explicitly names a reviewer-side gap retried automatically, not a
-request to change code. Stored review state moved to `state-v2`, so the first run after
-upgrading performs one full review. Removed exports: the coordinator agent
-(`FanOutReviewer`, `makeFanOutReviewSuite`, `fanOutHandlersLayer`, `DelegateFileReview`,
-`FileReviewRequest`, `FileReviewUnitResult`, `FileReviewWorkRejected`, `FileReviewUnitFailed`,
-`ListReviewUnits`) and the `usageScope`/`reviewShape` options — fan-out runs now report
-whole-run usage via `executeFanOutReview`.
+Make incremental reviews converge: the authenticated baseline now advances on every completed
+run, carrying unsettled or unreviewable scope forward for automatic retry, and fan-out passes
+are host-scheduled with one retry each so a flaky pass can no longer reopen the whole
+post-baseline scope. BEHAVIOR CHANGE: stored review state moved to `state-v2` (the first run
+after upgrading performs one full review), blocking findings now outrank machinery gaps in the
+check conclusion, and the coordinator-model exports (`FanOutReviewer`, `makeFanOutReviewSuite`,
+`fanOutHandlersLayer`, `DelegateFileReview`, `FileReviewRequest`, `FileReviewUnitResult`,
+`FileReviewWorkRejected`, `FileReviewUnitFailed`, `ListReviewUnits`) and the
+`usageScope`/`reviewShape` options are removed — fan-out runs report whole-run usage via
+`executeFanOutReview`.

--- a/.changeset/monotone-review-continuity.md
+++ b/.changeset/monotone-review-continuity.md
@@ -1,0 +1,19 @@
+---
+"@effect-agent/pr-review": minor
+---
+
+Schedule the fan-out review pipeline entirely from host code — no coordinator model, no
+delegation tool — retrying each failed pass once, discarding invalid-anchor findings instead of
+rejecting their pass, and advancing the authenticated incremental baseline on every completed
+run with unsettled scope carried forward as retryable `unreviewedPaths`.
+
+BEHAVIOR CHANGE: incremental reviews now converge instead of looping — a remediation push is
+reviewed against its immediate predecessor plus carried leftovers, never the whole
+post-baseline scope; blocking findings outrank machinery gaps in the check conclusion, and an
+`incomplete` conclusion explicitly names a reviewer-side gap retried automatically, not a
+request to change code. Stored review state moved to `state-v2`, so the first run after
+upgrading performs one full review. Removed exports: the coordinator agent
+(`FanOutReviewer`, `makeFanOutReviewSuite`, `fanOutHandlersLayer`, `DelegateFileReview`,
+`FileReviewRequest`, `FileReviewUnitResult`, `FileReviewWorkRejected`, `FileReviewUnitFailed`,
+`ListReviewUnits`) and the `usageScope`/`reviewShape` options — fan-out runs now report
+whole-run usage via `executeFanOutReview`.

--- a/action/README.md
+++ b/action/README.md
@@ -49,18 +49,21 @@ must not combine `guidance-file` with `pull_request_target`.)
 
 ## Incremental reviews and authenticated continuity state
 
-Every review with complete host-derived input coverage and settled discovery/
-verification assurance embeds a bounded, schema-validated, terminal state
-marker in its review body. `state-secret`
+Every completed review that can be signed embeds a bounded, schema-validated,
+terminal state marker in its review body — the baseline advances on every
+run, monotonically. `state-secret`
 HMAC-authenticates the marker so model text or another workflow cannot forge
 scope-narrowing authority. The marker records the PR
 identity, base/head lineage, reviewer-profile fingerprint, settled-scope
-fingerprint, and unresolved findings/concerns. On the next `synchronize`, the
+fingerprint, unresolved findings/concerns, any retryable unreviewed paths,
+and whether the run fully settled. On the next `synchronize`, the
 action validates that state and asks GitHub for the previous-head...current-head
-comparison. Only changed paths still present in the current PR diff are sent
-to the model; prior unresolved findings in unchanged paths remain active, and
-paths changed or reverted since the baseline receive fresh discovery and
-verification. A compatible
+comparison. Only changed paths still present in the current PR diff — plus
+carried unreviewed paths — are sent to the model; prior unresolved findings
+in unchanged paths remain active, and paths changed or reverted since the
+baseline receive fresh discovery and verification. A pass that failed on the
+reviewer's side costs exactly its own scope on the next run; it can never
+freeze the baseline and reopen everything reviewed since. A compatible
 ancestor advance of the base includes overlapping PR paths as affected
 context.
 
@@ -73,7 +76,8 @@ patchless base/head evidence, pull-request framing, and reviewer profile. It
 does not hash commit IDs or base ancestry. An equivalent rebase therefore
 creates the new head-bound workflow check but skips model execution and posts
 no duplicate review or findings; the stored blocking/success conclusion is
-preserved. A changed diff, PR framing, model, guidance, bounds, or ignore
+preserved. The skip requires a FULLY SETTLED stored state — one carrying
+unreviewed scope is always retried instead. A changed diff, PR framing, model, guidance, bounds, or ignore
 configuration reviews again.
 
 The action visibly falls back to the full current PR diff when state is
@@ -164,12 +168,16 @@ also writes a step summary and `conclusion`, `input-coverage`,
 `coverage` output remains as a deprecated compatibility aggregate.
 
 The check conclusion does not trust the model verdict. Any active blocking
-finding or concern fails the job. Incomplete or partial input evidence, a failed or
-exhausted discovery/specialist/verification pass, a mismatched candidate
-batch, or unsettled candidates is also non-success. Reading every path is not
-semantic completeness, and settled assurance never claims that every defect
-was found. Fan-out is enabled by default because the flat compatibility shape
-has no independent verifier and cannot produce settled assurance. Large textual
+finding or concern fails the job as `blocking` — code findings outrank
+machinery gaps. A failed or exhausted discovery/specialist/verification pass
+(after its bounded retry) or partial input evidence concludes `incomplete`,
+with reasons that explicitly name a reviewer-side gap whose paths are carried
+forward and retried automatically — never an invitation to change code. A
+finding whose anchor falls outside its assigned evidence is discarded and
+counted, not a failed pass. Reading every path is not semantic completeness,
+and settled assurance never claims that every defect was found. Fan-out is
+enabled by default because the flat compatibility shape has no independent
+verifier and cannot produce settled assurance. Large textual
 diffs are deterministically split into complete bounded
 evidence shards; a path is partial only if finite plan capacity leaves one or
 more shards unassigned. Overflow reports every affected path and the exact
@@ -191,6 +199,7 @@ posts nothing, while a budget-ended run fails typed with its forensics.
 Inputs, outputs, and defaults are documented in [`action.yml`](action.yml).
 Honest limits: execution remains deployment class E and posting is never
 exactly-once. Review progress survives across runs only through the bounded
-state in complete-input, settled-assurance GitHub reviews. A runtime failure posts
-nothing; a settled run with incomplete input or assurance is posted honestly
-and fails the check. A draft or non-PR event is a typed skip (`skipped=true`).
+authenticated state in posted GitHub reviews. A runtime failure posts
+nothing; a completed run with incomplete input or unsettled passes is posted
+honestly, fails the check as `incomplete`, and carries the gap forward for
+the next run. A draft or non-PR event is a typed skip (`skipped=true`).

--- a/action/action.yml
+++ b/action/action.yml
@@ -61,9 +61,10 @@ inputs:
   fan-out:
     description: >-
       Use deterministic evidence sharding, independent general and specialist
-      discovery, and candidate verification with bounded subagent children.
-      Enabled by default because the flat shape has no independent verifier
-      and therefore cannot produce settled review assurance.
+      discovery, and candidate verification as host-scheduled child passes
+      (each retried once on failure). Enabled by default because the flat
+      shape has no independent verifier and therefore cannot produce settled
+      review assurance.
     required: false
     default: "true"
   guidance:
@@ -91,9 +92,10 @@ inputs:
   skip-unchanged:
     description: >-
       Skip model execution when the current effective patch matches the last
-      patch with settled stored assurance ('true', default), including commit-ID-only
-      rebases, while preserving the stored blocking/success conclusion. Set
-      'false' to force execution.
+      FULLY SETTLED stored review ('true', default), including commit-ID-only
+      rebases, while preserving the stored blocking/success conclusion. A
+      stored state carrying unreviewed scope is never skipped over — the next
+      run retries exactly that scope. Set 'false' to force execution.
     required: false
     default: "true"
   retire-stale-reviews:
@@ -105,9 +107,10 @@ inputs:
     default: "true"
   review-mode:
     description: >-
-      "incremental" (default) reviews changes since the last compatible,
-      complete-input, settled-assurance head. "final" deliberately performs
-      fresh discovery over the full current pull-request diff.
+      "incremental" (default) reviews changes since the last reviewed head
+      plus any carried unreviewed scope; the baseline advances on every
+      completed run. "final" deliberately performs fresh discovery over the
+      full current pull-request diff.
     required: false
     default: "incremental"
   progress-comment:
@@ -138,7 +141,9 @@ outputs:
   fingerprint:
     description: "Deprecated changeset-fingerprint output."
   conclusion:
-    description: "Host-derived check conclusion: success, blocking, or incomplete."
+    description: >-
+      Host-derived check conclusion: success, blocking (code findings), or
+      incomplete (reviewer-side gap carried forward and retried next run).
   input-coverage:
     description: "Host-derived path/evidence assignment: complete or incomplete."
   review-assurance:
@@ -157,10 +162,12 @@ outputs:
     description: "Number of findings whose anchors failed diff validation."
   concerns:
     description: "Number of non-anchored concerns rendered into the review body."
+  unreviewed-paths:
+    description: "Number of retryable unreviewed paths carried to the next run."
   input-tokens:
-    description: "Input tokens the run budget observed (coordinator only under fan-out)."
+    description: "Input tokens the run budget observed across the whole run."
   output-tokens:
-    description: "Output tokens the run budget observed (coordinator only under fan-out)."
+    description: "Output tokens the run budget observed across the whole run."
   review-url:
     description: "URL of the posted review (empty on dry runs)."
 runs:

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -42406,6 +42406,9 @@ var assessFlatReview = (input) => {
   if (input.files.length < input.totalFiles) {
     reasons.push(`review range exposed ${input.files.length} of ${input.totalFiles} required files`);
   }
+  if (undiffable.size > 0) {
+    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", undiffable));
+  }
   if (failedPaths.size > 0)
     reasons.push(boundedListReason("diff reads failed", failedPaths));
   if (partial.size > 0) {
@@ -42426,7 +42429,7 @@ var assessFlatReview = (input) => {
   return {
     inputCoverage,
     assurance: flatAssurance(),
-    unreviewedPaths: unassigned
+    unreviewedPaths: sortedUnique([...unassigned, ...undiffable])
   };
 };
 var fanOutInputCoverage = (input) => {
@@ -42436,6 +42439,9 @@ var fanOutInputCoverage = (input) => {
   const reasons = [];
   if (plan.truncated) {
     reasons.push(`review range exposed ${input.files.length} of ${input.totalFiles} required files`);
+  }
+  if (plan.undiffablePaths.length > 0) {
+    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", plan.undiffablePaths));
   }
   if (plan.partialEvidencePaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left some deterministic evidence shards unassigned", plan.partialEvidencePaths));
@@ -43160,7 +43166,7 @@ var composeSummary = (plan, assurance) => {
     parts2.push(`${countNoun(assurance.discardedInvalidFindings, "candidate")} discarded for anchors or paths outside the assigned evidence.`);
   }
   if (plan.undiffablePaths.length > 0) {
-    parts2.push(`${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence.`);
+    parts2.push(`${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence and keep input coverage incomplete; exclude such paths with ignore globs when that is intended.`);
   }
   if (plan.unassignedPaths.length > 0 || plan.unassignedEvidenceShardCount > 0) {
     parts2.push("The changeset exceeded the bounded fan-out capacity; unassigned scope is reported under input coverage.");
@@ -43223,7 +43229,8 @@ var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
       ...new Set([
         ...outcomes.flatMap((outcome) => outcome.unreviewedPaths),
         ...plan.unassignedPaths,
-        ...plan.partialEvidencePaths
+        ...plan.partialEvidencePaths,
+        ...plan.undiffablePaths
       ])
     ].sort(),
     turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0)
@@ -44468,9 +44475,6 @@ var planPublication = (review, files, options3) => {
     parts2.push("", renderReviewStats(files, options3.totalChangedFiles, counts));
     if (options3.inputCoverage !== undefined && options3.assurance !== undefined) {
       parts2.push("", `**Input coverage:** ${options3.inputCoverage.status} (${options3.inputCoverage.assignedPaths.length}/${options3.inputCoverage.requiredPaths.length} paths assigned, ${options3.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options3.assurance.status} (${options3.assurance.completedGeneralDiscoveryPasses}/${options3.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options3.assurance.completedSpecialistPasses}/${options3.assurance.requiredSpecialistPasses} specialist, ${options3.assurance.completedVerificationPasses}/${options3.assurance.requiredVerificationPasses} verification; ${options3.assurance.confirmedCandidates} confirmed / ${options3.assurance.rejectedCandidates} rejected / ${options3.assurance.unsettledCandidates} unsettled${options3.assurance.discardedInvalidFindings > 0 ? ` / ${options3.assurance.discardedInvalidFindings} discarded` : ""} candidates)`);
-      if (options3.inputCoverage.undiffablePaths.length > 0) {
-        parts2.push("", `ℹ️ ${countNoun2(options3.inputCoverage.undiffablePaths.length, "path")} had no reviewable textual evidence (binary or oversized) and ${options3.inputCoverage.undiffablePaths.length === 1 ? "is" : "are"} outside the review surface.`);
-      }
     }
     parts2.push("", review.summary);
     if (walkthroughKept2 && walkthrough.length > 0) {
@@ -44864,8 +44868,9 @@ var makeFanOut = (options3) => {
   const child = makeFileReviewerDefinition({ guidance: options3.guidance });
   const childBinding = Object.freeze({ definition: child, model: options3.model });
   const guidanceLines = options3.guidance === undefined ? [] : typeof options3.guidance === "string" ? [options3.guidance] : options3.guidance;
-  const signature = (_mission) => [
+  const signature = (mission) => [
     "pr-review-fan-out-host-scheduled-v1",
+    JSON.stringify(exports_Schema.encodeSync(ReviewMission)(mission)),
     `childGuidance=${JSON.stringify(guidanceLines)}`,
     `maxFindings=${clampMaxFindings(options3.maxFindings)}`,
     `applyVerdict=${String(options3.applyVerdict ?? false)}`,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -39850,82 +39850,6 @@ class SubagentExecutionFailure extends exports_Schema.TaggedError()("SubagentExe
 var DelegationToolName = exports_Schema.String.pipe(exports_Schema.refine((name) => name.startsWith(delegationToolPrefix) && name.length > delegationToolPrefix.length, { expected: `a delegation Tool name of the form "${delegationToolPrefix}<target>"` }));
 var decodeDelegationToolName = exports_Schema.decodeSync(DelegationToolName);
 var decodeDelegationId = exports_Schema.decodeSync(DelegationId);
-var define = (name, options) => {
-  decodeDelegationToolName(name);
-  for (const childToolName of Object.keys(options.target.toolkit.tools)) {
-    if (isDelegationToolName(childToolName)) {
-      throw new Error(`Subagent.define(${JSON.stringify(name)}): target Agent ${options.target.id} exposes delegation Tool ${childToolName}; S1 rejects every nested delegation (SUB-029)`);
-    }
-  }
-  const delegationId = decodeDelegationId(name);
-  const grant = options.grant ?? SubagentGrant.make({
-    allowedToolNames: Object.keys(options.target.toolkit.tools),
-    maxDepth: 1
-  });
-  const failureMode = options.failureMode ?? "error";
-  const containedFailure = exports_Schema.Union([
-    options.failure,
-    SubagentPrestartDenied,
-    SubagentBudgetExhausted,
-    SubagentProjectionFailure,
-    SubagentExecutionFailure
-  ]);
-  const returnModeTool = exports_Tool.make(name, {
-    description: options.description,
-    parameters: options.parameters,
-    success: exports_Schema.Union([options.success, containedFailure]),
-    failure: exports_Schema.Union([ToolCallWaiting, SubagentDurabilityError]),
-    needsApproval: options.needsApproval
-  });
-  const errorModeTool = exports_Tool.make(name, {
-    description: options.description,
-    parameters: options.parameters,
-    success: options.success,
-    failure: exports_Schema.Union([
-      options.failure,
-      SubagentPrestartDenied,
-      SubagentBudgetExhausted,
-      SubagentProjectionFailure,
-      SubagentExecutionFailure,
-      ToolCallWaiting,
-      SubagentDurabilityError
-    ]),
-    needsApproval: options.needsApproval
-  });
-  const tool = (failureMode === "return" ? returnModeTool : errorModeTool).addDependency(AgentSpawner).addDependency(RunEventSink).addDependency(SubagentDurability).addDependency(IdGenerator);
-  return Object.freeze({
-    ...options,
-    name,
-    delegationId,
-    grant,
-    failureMode,
-    containedFailure,
-    tool
-  });
-};
-var Subagent = { define };
-var millisOfMaxDuration = (policy2) => Math.max(1, Math.ceil(exports_Duration.toMillis(policy2.maxDuration)));
-var delegationCapsFromPolicy = (policy2) => SubagentDelegationCaps.make({
-  maxTotalChildInvocations: policy2.maxChildren,
-  maxConcurrentChildren: policy2.maxConcurrency,
-  maxTurns: policy2.maxChildren * policy2.maxTurns,
-  maxToolCalls: policy2.maxChildren * policy2.maxToolCalls,
-  maxDurationMillis: policy2.maxChildren * millisOfMaxDuration(policy2),
-  ...policy2.maxInputTokens === undefined ? {} : { maxInputTokens: policy2.maxChildren * policy2.maxInputTokens },
-  ...policy2.maxOutputTokens === undefined ? {} : { maxOutputTokens: policy2.maxChildren * policy2.maxOutputTokens },
-  ...policy2.maxCostMicrousd === undefined ? {} : { maxCostMicrousd: policy2.maxChildren * policy2.maxCostMicrousd },
-  ...policy2.maxResultBytes === undefined ? {} : { maxResultBytes: policy2.maxChildren * policy2.maxResultBytes }
-});
-var delegationAllocationFromPolicy = (policy2) => SubagentReservationAmounts.make({
-  turns: policy2.maxTurns,
-  toolCalls: policy2.maxToolCalls,
-  durationMillis: millisOfMaxDuration(policy2),
-  inputTokens: policy2.maxInputTokens ?? 0,
-  outputTokens: policy2.maxOutputTokens ?? 0,
-  costMicrousd: policy2.maxCostMicrousd ?? 0,
-  resultBytes: policy2.maxResultBytes ?? 0
-});
-
 class SubagentDurableAccounting extends exports_Schema.Class("@effect-agent/capabilities/SubagentDurableAccounting")({
   allocation: SubagentReservationAmounts,
   consumed: SubagentReservationAmounts,
@@ -39934,31 +39858,11 @@ class SubagentDurableAccounting extends exports_Schema.Class("@effect-agent/capa
 }) {
 }
 var maxEventTextLength = 4 * 1024;
-var boundedEventText = (text) => text.length <= maxEventTextLength ? text : `${text.slice(0, maxEventTextLength - 1)}…`;
 var ErrorMessage2 = exports_Schema.Struct({ message: exports_Schema.String });
 var ErrorTag2 = exports_Schema.Struct({ _tag: exports_Schema.NonEmptyString });
-var errorMessageOf = (error2) => exports_Option.match(exports_Schema.decodeUnknownOption(ErrorMessage2)(error2), {
-  onNone: () => String(error2),
-  onSome: ({ message }) => message
-});
-var errorTagOf = (error2) => exports_Option.match(exports_Schema.decodeUnknownOption(ErrorTag2)(error2), {
-  onNone: () => "UnknownError",
-  onSome: ({ _tag }) => _tag
-});
-var boundedErrorTag = (tag2) => {
-  const nonEmpty = tag2.length === 0 ? "UnknownError" : tag2;
-  return nonEmpty.length <= maxErrorTagLength ? nonEmpty : nonEmpty.slice(0, maxErrorTagLength);
-};
 var ChildFailureProjection = exports_Schema.Struct({
   errorTag: exports_Schema.NonEmptyString,
   message: exports_Schema.String
-});
-var childFailureProjectionOf = (encodedResult) => exports_Option.match(exports_Schema.decodeUnknownOption(ChildFailureProjection)(encodedResult), {
-  onNone: () => ({
-    errorTag: errorTagOf(encodedResult),
-    message: errorMessageOf(encodedResult)
-  }),
-  onSome: (projection) => projection
 });
 var zeroReservationAmounts = SubagentReservationAmounts.make({
   turns: 0,
@@ -39975,22 +39879,6 @@ var encodeBudgetFailure = exports_Schema.encodeEffect(SubagentBudgetExhausted);
 var encodeExecutionFailure = exports_Schema.encodeEffect(SubagentExecutionFailure);
 var encodeGrant = exports_Schema.encodeEffect(SubagentGrant);
 var encodeAllocationAmounts = exports_Schema.encodeEffect(SubagentReservationAmounts);
-var utf8ByteLength2 = (value4) => {
-  let total = 0;
-  for (const character of value4) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    total += codePoint <= 127 ? 1 : codePoint <= 2047 ? 2 : codePoint <= 65535 ? 3 : 4;
-  }
-  return total;
-};
-var toNatural = (value4) => Number.isFinite(value4) && value4 > 0 ? Math.floor(value4) : 0;
-var observedUsageFromDelta = (delta) => SubagentObservedUsage.make({
-  turns: delta.modelCalls,
-  toolCalls: toNatural(delta.toolCalls),
-  inputTokens: toNatural(delta.inputTokens),
-  outputTokens: toNatural(delta.outputTokens),
-  costMicrousd: toNatural(delta.costMicrousd)
-});
 var neverStartedUsage = SubagentObservedUsage.make({
   turns: 0,
   toolCalls: 0,
@@ -40000,344 +39888,10 @@ var neverStartedUsage = SubagentObservedUsage.make({
   costMicrousd: 0,
   resultBytes: 0
 });
-var settleReservation = (reservations, reservationId, startedAt) => exports_Effect.gen(function* () {
-  const started = yield* exports_Ref.get(startedAt);
-  if (started === undefined) {
-    yield* reservations.observe(reservationId, neverStartedUsage);
-  } else {
-    const now3 = yield* exports_Clock.currentTimeMillis;
-    yield* reservations.observe(reservationId, SubagentObservedUsage.make({ durationMillis: Math.max(0, Math.floor(now3 - started)) }));
-  }
-  yield* reservations.release(reservationId);
-}).pipe(exports_Effect.orDie);
-
-class GenuineEngineSignal {
-  signal;
-  _tag = "GenuineEngineSignal";
-  constructor(signal) {
-    this.signal = signal;
-  }
-}
-var wrapEngineSignal = (signal) => new GenuineEngineSignal(signal);
-var layer15 = (delegation, childBinding, options) => {
-  const caps = options.parentCaps ?? delegationCapsFromPolicy(delegation.policy);
-  const allocation = delegationAllocationFromPolicy(delegation.policy);
-  const toolkit = exports_Toolkit.make(delegation.tool);
-  const contained = delegation.failureMode === "return";
-  const encodeChildInput = exports_Schema.encodeEffect(delegation.target.input);
-  const encodeSuccess = exports_Schema.encodeEffect(delegation.success);
-  const decodeChildOutput = exports_Schema.decodeUnknownEffect(delegation.target.output);
-  const encodeDeclaredFailure = exports_Schema.encodeEffect(delegation.failure);
-  const childToolNames = Object.keys(delegation.target.toolkit.tools);
-  const durableDeclaration = options.durable === undefined ? undefined : {
-    targetDigests: {
-      agent: options.durable.targetDigests.agent,
-      model: options.durable.targetDigests.model,
-      tools: options.durable.targetDigests.tools
-    }
-  };
-  const executionFailure = (classification, errorTag2, message, child) => SubagentExecutionFailure.make({
-    delegationId: delegation.delegationId,
-    targetAgentId: delegation.target.id,
-    classification,
-    errorTag: boundedErrorTag(errorTag2),
-    message: boundedEventText(message),
-    ...child === undefined ? {} : {
-      childConversationId: child.childConversationId,
-      childSubmissionId: child.childSubmissionId,
-      childRunId: child.childRunId
-    }
-  });
-  const prestartDenied = (reason, message) => SubagentPrestartDenied.make({
-    delegationId: delegation.delegationId,
-    targetAgentId: delegation.target.id,
-    reason,
-    message: boundedEventText(message)
-  });
-  const build2 = exports_Effect.gen(function* () {
-    const captured = yield* exports_Effect.context();
-    const encodedGrant = yield* encodeGrant(delegation.grant).pipe(exports_Effect.orDie);
-    const encodedAllocation = yield* encodeAllocationAmounts(allocation).pipe(exports_Effect.orDie);
-    const conservativeAccounting = yield* encodeDurableAccounting(SubagentDurableAccounting.make({
-      allocation,
-      consumed: allocation,
-      released: zeroReservationAmounts,
-      basis: "reserved-conservative"
-    })).pipe(exports_Effect.orDie);
-    const invoke = exports_Effect.fn(`SubagentRuntime.${delegation.name}`)(function* (parameters, handlerContext) {
-      const spawner = yield* AgentSpawner;
-      const sink = yield* RunEventSink;
-      const reservations = yield* SubagentReservations;
-      const toolCallId = yield* exports_Schema.decodeUnknownEffect(ToolCallId)(handlerContext.toolCallId).pipe(exports_Effect.orDie);
-      if (spawner.depth + 1 > delegation.grant.maxDepth) {
-        return yield* prestartDenied("nested-delegation", `Delegation ${delegation.name} was requested at depth ${spawner.depth}; S1 rejects every nested delegation`);
-      }
-      for (const childToolName of childToolNames) {
-        if (isDelegationToolName(childToolName)) {
-          return yield* prestartDenied("nested-delegation", `Child Toolkit exposes delegation Tool ${childToolName}; S1 rejects every nested delegation`);
-        }
-        if (!delegation.grant.allowedToolNames.includes(childToolName)) {
-          return yield* prestartDenied("grant-violation", `Child Tool ${childToolName} is outside the delegation grant ceiling`);
-        }
-      }
-      const prepared = yield* delegation.prepareInput(parameters, {
-        delegationId: delegation.delegationId,
-        toolCallId,
-        parent: spawner.parent
-      });
-      const encodedInput = yield* encodeChildInput(prepared).pipe(exports_Effect.mapError(() => SubagentProjectionFailure.make({
-        delegationId: delegation.delegationId,
-        stage: "input",
-        message: "Prepared child input did not satisfy the target Agent input Schema"
-      })));
-      const parentRunId = spawner.parent.runId;
-      yield* reservations.registerParent(parentRunId, caps).pipe(exports_Effect.catchTag("SubagentParentBudgetConflict", () => exports_Effect.fail(prestartDenied("budget-conflict", "The parent Run is already registered with different delegation caps; supply shared parentCaps explicitly"))));
-      const reservationId = makeBudgetReservationId(parentRunId, toolCallId);
-      const startedAt = yield* exports_Ref.make(undefined);
-      yield* exports_Effect.acquireRelease(reservations.reserve(SubagentReservationRequest.make({
-        parentRunId,
-        parentToolCallId: toolCallId,
-        allocation
-      })).pipe(exports_Effect.catchTags({
-        SubagentReservationConflict: (conflict) => exports_Effect.die(conflict),
-        SubagentParentBudgetUnknown: (unknown2) => exports_Effect.die(unknown2)
-      })), () => settleReservation(reservations, reservationId, startedAt));
-      yield* reservations.acquireChildSlot(parentRunId).pipe(exports_Effect.catchTag("SubagentParentBudgetUnknown", (unknown2) => exports_Effect.die(unknown2)));
-      const seededChild = options.child;
-      const seededBudget = seededChild?.budget;
-      const budget = {
-        guard: seededBudget === undefined ? (effect2) => effect2 : (effect2) => seededBudget.guard(effect2),
-        consume: (delta) => reservations.observe(reservationId, observedUsageFromDelta(delta)).pipe(exports_Effect.orDie, exports_Effect.andThen(seededBudget === undefined ? exports_Effect.void : seededBudget.consume(delta)))
-      };
-      const allowanceOption = delegation.toolCallAllowance;
-      const extracted = allowanceOption?.fromParameters?.(parameters);
-      const requestedAllowance = allowanceOption === undefined ? undefined : extracted !== undefined && Number.isFinite(extracted) ? extracted : Number.isFinite(allowanceOption.default) ? allowanceOption.default : delegation.policy.maxToolCalls;
-      const toolCallAllowance = requestedAllowance === undefined ? undefined : Math.min(Math.max(1, Math.floor(requestedAllowance)), delegation.policy.maxToolCalls);
-      const childOptions = {
-        ...seededChild,
-        budget,
-        ...toolCallAllowance === undefined ? {} : { toolCallAllowance }
-      };
-      yield* exports_Ref.set(startedAt, yield* exports_Clock.currentTimeMillis);
-      const child = yield* spawner.spawn(childBinding, encodedInput, { delegationId: delegation.delegationId, parentToolCallId: toolCallId }, childOptions);
-      const payload = {
-        toolCallId,
-        delegationId: delegation.delegationId,
-        childConversationId: child.conversationId,
-        childRunId: child.runId,
-        targetAgentId: delegation.target.id,
-        depth: child.parentLink.depth
-      };
-      const emit = (event) => sink.emit(event).pipe(exports_Effect.orDie);
-      yield* emit({ _tag: "SubagentRequested", ...payload });
-      yield* emit({ _tag: "SubagentStarted", ...payload });
-      const joined = exports_Effect.gen(function* () {
-        const result4 = yield* child.await.pipe(exports_Effect.catch((childFailure) => emit({
-          _tag: "SubagentFailed",
-          ...payload,
-          errorTag: errorTagOf(childFailure),
-          message: boundedEventText(errorMessageOf(childFailure))
-        }).pipe(exports_Effect.andThen(exports_Effect.fail(options.mapChildFailure(childFailure))))), exports_Effect.timeoutOrElse({
-          duration: exports_Duration.millis(allocation.durationMillis),
-          orElse: () => emit({
-            _tag: "SubagentFailed",
-            ...payload,
-            errorTag: "SubagentBudgetExhausted",
-            message: `Attached child exceeded its ${allocation.durationMillis}ms delegation duration budget`
-          }).pipe(exports_Effect.andThen(exports_Effect.fail(SubagentBudgetExhausted.make({
-            parentRunId,
-            dimension: "duration",
-            limitValue: allocation.durationMillis,
-            observedValue: allocation.durationMillis
-          }))))
-        }));
-        yield* emit({
-          _tag: "SubagentCompleted",
-          ...payload,
-          turns: result4.turns,
-          finishReason: result4.finishReason,
-          ...result4.exhausted !== undefined ? { exhausted: result4.exhausted } : {}
-        });
-        const projected = yield* delegation.projectResult(result4.output, {
-          budgetExhausted: result4.finishReason === "budget-exhausted"
-        }, parameters);
-        const encodedResult = yield* encodeSuccess(projected).pipe(exports_Effect.mapError(() => SubagentProjectionFailure.make({
-          delegationId: delegation.delegationId,
-          stage: "result",
-          message: "Projected child result did not satisfy the delegation success Schema"
-        })));
-        const resultBytes = utf8ByteLength2(JSON.stringify(encodedResult) ?? "");
-        yield* reservations.observe(reservationId, SubagentObservedUsage.make({ resultBytes })).pipe(exports_Effect.orDie);
-        if (delegation.policy.maxResultBytes !== undefined && resultBytes > delegation.policy.maxResultBytes) {
-          yield* emit({
-            _tag: "SubagentFailed",
-            ...payload,
-            errorTag: "SubagentBudgetExhausted",
-            message: `Projected child result of ${resultBytes} bytes exceeds the ${delegation.policy.maxResultBytes}-byte delegation budget`
-          });
-          return yield* SubagentBudgetExhausted.make({
-            parentRunId,
-            dimension: "result-bytes",
-            limitValue: delegation.policy.maxResultBytes,
-            observedValue: resultBytes
-          });
-        }
-        yield* emit({ _tag: "SubagentJoined", ...payload });
-        return projected;
-      });
-      return yield* joined.pipe(exports_Effect.onInterrupt(() => sink.emit({
-        _tag: "SubagentInterrupted",
-        ...payload,
-        reason: "Parent Run interrupted the attached child before it settled"
-      }).pipe(exports_Effect.ignore)));
-    });
-    const invokeDurable = exports_Effect.fn(`SubagentRuntime.${delegation.name}.durable`)(function* (parameters, handlerContext, durability) {
-      const spawner = yield* AgentSpawner;
-      const sink = yield* RunEventSink;
-      const toolCallId = yield* exports_Schema.decodeUnknownEffect(ToolCallId)(handlerContext.toolCallId).pipe(exports_Effect.orDie);
-      const emit = (event) => sink.emit(event).pipe(exports_Effect.orDie);
-      if (durableDeclaration === undefined) {
-        return yield* executionFailure("declaration-unavailable", "SubagentDeclarationUnavailable", `Delegation ${delegation.name} runs under a durable coordinator but its handler Layer was constructed without SubagentRuntimeOptions.durable`);
-      }
-      const depth = spawner.depth + 1;
-      if (depth > delegation.grant.maxDepth) {
-        return yield* prestartDenied("nested-delegation", `Delegation ${delegation.name} was requested at depth ${spawner.depth}; S2 rejects every nested delegation`);
-      }
-      for (const childToolName of childToolNames) {
-        if (isDelegationToolName(childToolName)) {
-          return yield* prestartDenied("nested-delegation", `Child Toolkit exposes delegation Tool ${childToolName}; S2 rejects every nested delegation`);
-        }
-        if (!delegation.grant.allowedToolNames.includes(childToolName)) {
-          return yield* prestartDenied("grant-violation", `Child Tool ${childToolName} is outside the delegation grant ceiling`);
-        }
-      }
-      const prepared = yield* delegation.prepareInput(parameters, {
-        delegationId: delegation.delegationId,
-        toolCallId,
-        parent: spawner.parent
-      });
-      const encodedInput = yield* encodeChildInput(prepared).pipe(exports_Effect.mapError(() => SubagentProjectionFailure.make({
-        delegationId: delegation.delegationId,
-        stage: "input",
-        message: "Prepared child input did not satisfy the target Agent input Schema"
-      })));
-      const status = yield* exports_Effect.mapError(wrapEngineSignal)(durability.establish({
-        toolCallId,
-        delegationId: delegation.delegationId,
-        targetAgentId: delegation.target.id,
-        depth,
-        targetDigests: durableDeclaration.targetDigests,
-        encodedChildInput: encodedInput,
-        encodedGrant,
-        encodedAllocation
-      }));
-      switch (status._tag) {
-        case "denied": {
-          return yield* executionFailure("establishment-denied", status.errorTag, status.message);
-        }
-        case "waiting": {
-          const payload = {
-            toolCallId,
-            delegationId: delegation.delegationId,
-            childConversationId: status.childConversationId,
-            childRunId: status.childRunId,
-            targetAgentId: delegation.target.id,
-            depth
-          };
-          yield* emit({ _tag: "SubagentRequested", ...payload });
-          yield* emit({ _tag: "SubagentStarted", ...payload });
-          return yield* exports_Effect.mapError(wrapEngineSignal)(durability.waiting(toolCallId, status));
-        }
-        case "settled": {
-          const payload = {
-            toolCallId,
-            delegationId: delegation.delegationId,
-            childConversationId: status.childConversationId,
-            childRunId: status.childRunId,
-            targetAgentId: delegation.target.id,
-            depth
-          };
-          const settleFailure = (failure, encodedFailure) => emit({
-            _tag: "SubagentFailed",
-            ...payload,
-            errorTag: errorTagOf(failure),
-            message: boundedEventText(errorMessageOf(failure))
-          }).pipe(exports_Effect.andThen(exports_Effect.mapError(wrapEngineSignal)(durability.join({
-            toolCallId,
-            encodedResult: encodedFailure,
-            isFailure: !contained,
-            encodedAccounting: conservativeAccounting
-          }))), exports_Effect.andThen(exports_Effect.fail(failure)));
-          if (status.outcome !== "completed") {
-            const projection = childFailureProjectionOf(status.encodedResult);
-            const failure = executionFailure(status.outcome === "aborted" ? "child-aborted" : projection.errorTag === "ChildCompatibilityFailure" ? "child-compatibility" : "child-failed", projection.errorTag, projection.message, status);
-            const encodedFailure = yield* encodeExecutionFailure(failure).pipe(exports_Effect.orDie);
-            return yield* settleFailure(failure, encodedFailure);
-          }
-          const decoded = yield* decodeChildOutput(status.encodedResult).pipe(exports_Effect.catch(() => {
-            const failure = SubagentProjectionFailure.make({
-              delegationId: delegation.delegationId,
-              stage: "result",
-              message: "Settled child output did not satisfy the target Agent output Schema"
-            });
-            return encodeProjectionFailure(failure).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(failure, encodedFailure)));
-          }));
-          const projected = yield* delegation.projectResult(decoded, {
-            budgetExhausted: status.finishReason === "budget-exhausted"
-          }, parameters).pipe(exports_Effect.catch((declared) => encodeDeclaredFailure(declared).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)))));
-          const encodedResult = yield* encodeSuccess(projected).pipe(exports_Effect.catch(() => {
-            const failure = SubagentProjectionFailure.make({
-              delegationId: delegation.delegationId,
-              stage: "result",
-              message: "Projected child result did not satisfy the delegation success Schema"
-            });
-            return encodeProjectionFailure(failure).pipe(exports_Effect.orDie, exports_Effect.flatMap((encodedFailure) => settleFailure(failure, encodedFailure)));
-          }));
-          const resultBytes = utf8ByteLength2(JSON.stringify(encodedResult) ?? "");
-          if (delegation.policy.maxResultBytes !== undefined && resultBytes > delegation.policy.maxResultBytes) {
-            const failure = SubagentBudgetExhausted.make({
-              parentRunId: spawner.parent.runId,
-              dimension: "result-bytes",
-              limitValue: delegation.policy.maxResultBytes,
-              observedValue: resultBytes
-            });
-            const encodedFailure = yield* encodeBudgetFailure(failure).pipe(exports_Effect.orDie);
-            return yield* settleFailure(failure, encodedFailure);
-          }
-          yield* exports_Effect.mapError(wrapEngineSignal)(durability.join({
-            toolCallId,
-            encodedResult,
-            isFailure: false,
-            encodedAccounting: conservativeAccounting
-          }));
-          yield* emit({ _tag: "SubagentJoined", ...payload });
-          return projected;
-        }
-      }
-    });
-    const containSignals = (failure) => failure instanceof GenuineEngineSignal ? exports_Effect.fail(failure.signal) : exports_Effect.succeed(failure);
-    const unwrapSignals = (failure) => failure instanceof GenuineEngineSignal ? failure.signal : failure;
-    const handlerImpl = (parameters, handlerContext) => exports_Effect.gen(function* () {
-      const spawner = yield* AgentSpawner;
-      const sink = yield* RunEventSink;
-      const durability = yield* SubagentDurability;
-      if (durability.mode === "durable") {
-        const durable = invokeDurable(parameters, handlerContext, durability).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
-        return yield* contained ? durable.pipe(exports_Effect.catch(containSignals)) : durable.pipe(exports_Effect.mapError(unwrapSignals));
-      }
-      const ephemeral = invoke(parameters, handlerContext).pipe(exports_Effect.scoped, exports_Effect.provideService(AgentSpawner, spawner), exports_Effect.provideService(RunEventSink, sink), exports_Effect.provideService(SubagentDurability, durability), exports_Effect.provide(captured));
-      return yield* contained ? ephemeral.pipe(exports_Effect.catch(containSignals)) : ephemeral.pipe(exports_Effect.mapError(unwrapSignals));
-    });
-    const handler = handlerImpl;
-    return { [delegation.name]: handler };
-  });
-  return toolkit.toLayer(build2);
-};
-var SubagentRuntime = { layer: layer15 };
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/FetchHttpClient.js
 var exports_FetchHttpClient = {};
 __export(exports_FetchHttpClient, {
-  layer: () => layer16,
+  layer: () => layer15,
   RequestInit: () => RequestInit,
   Fetch: () => Fetch
 });
@@ -42149,7 +41703,7 @@ var fetch = /* @__PURE__ */ make58((request3, url2, signal, fiber3) => {
   }
   return send(undefined);
 });
-var layer16 = /* @__PURE__ */ layerMergedContext(/* @__PURE__ */ succeed6(fetch));
+var layer15 = /* @__PURE__ */ layerMergedContext(/* @__PURE__ */ succeed6(fetch));
 // packages/pr-review/src/internal/effort.ts
 var EFFORT_ALIASES = {
   low: 0,
@@ -42714,6 +42268,217 @@ var PullRequestReviewer = Agent.define("pr-reviewer", {
   metadata: { deploymentClass: "E", surface: "read-only" }
 });
 
+// packages/pr-review/src/internal/coverage.ts
+class FailedReviewUnit extends exports_Schema.Class("@effect-agent/pr-review/FailedReviewUnit")({
+  unitId: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(32)),
+  errorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256))
+}) {
+}
+
+class ReviewCoverage extends exports_Schema.Class("@effect-agent/pr-review/ReviewCoverage")({
+  status: exports_Schema.Literals(["complete", "incomplete"]),
+  requiredPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  reviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  unreviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  failedUnits: exports_Schema.Array(FailedReviewUnit).check(exports_Schema.isMaxLength(8)),
+  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(32))
+}) {
+}
+
+class ReviewInputCoverage extends exports_Schema.Class("@effect-agent/pr-review/ReviewInputCoverage")({
+  status: exports_Schema.Literals(["complete", "incomplete"]),
+  requiredPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  assignedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  partialPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  unassignedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  undiffablePaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
+  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(20))
+}) {
+}
+
+class FailedReviewPass extends exports_Schema.Class("@effect-agent/pr-review/FailedReviewPass")({
+  workId: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(96)),
+  stage: exports_Schema.Literals(["discovery", "specialist", "verification"]),
+  errorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256))
+}) {
+}
+
+class ReviewAssurance extends exports_Schema.Class("@effect-agent/pr-review/ReviewAssurance")({
+  status: exports_Schema.Literals(["settled", "incomplete", "unverified"]),
+  requiredGeneralDiscoveryPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  completedGeneralDiscoveryPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  requiredSpecialistPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  completedSpecialistPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  requiredVerificationPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  completedVerificationPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  discoveredCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  confirmedCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  rejectedCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  unsettledCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  discardedInvalidFindings: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
+  failedPasses: exports_Schema.Array(FailedReviewPass).check(exports_Schema.isMaxLength(64)),
+  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(32))
+}) {
+}
+var toolTrace = (events2) => {
+  const declared = new Map;
+  const succeeded = new Map;
+  const failed = new Map;
+  for (const event of events2) {
+    if (event._tag === "ToolCallDeclared")
+      declared.set(event.toolCallId, event);
+    if (event._tag === "ToolCallSucceeded")
+      succeeded.set(event.toolCallId, event);
+    if (event._tag === "ToolCallFailed")
+      failed.set(event.toolCallId, event);
+  }
+  return { declared, succeeded, failed };
+};
+var sortedUnique = (values3) => [...new Set(values3)].sort((left, right) => left < right ? -1 : left > right ? 1 : 0);
+var boundedListReason = (label, values3) => {
+  const items = sortedUnique(values3);
+  const prefix = `${label} (${items.length}): `;
+  let rendered = prefix;
+  for (let index2 = 0;index2 < items.length; index2 += 1) {
+    const item = items[index2] ?? "";
+    const separator = index2 === 0 ? "" : ", ";
+    const omitted = items.length - index2 - 1;
+    const suffix = omitted === 0 ? "" : ` … (+${omitted} more)`;
+    if (`${rendered}${separator}${item}${suffix}`.length > 1000) {
+      const omission = `… (+${items.length - index2} more)`;
+      return `${rendered.slice(0, 1000 - omission.length)}${omission}`;
+    }
+    rendered = `${rendered}${separator}${item}`;
+  }
+  return rendered;
+};
+var anchorSurfaceAdjusted = (inputCoverage, anchorFiles, totalAnchorFiles) => anchorFiles.length >= totalAnchorFiles ? inputCoverage : ReviewInputCoverage.make({
+  ...inputCoverage,
+  status: "incomplete",
+  reasons: [
+    ...inputCoverage.reasons,
+    `full pull-request anchor surface exposed ${anchorFiles.length} of ${totalAnchorFiles} required files`
+  ]
+});
+var flatAssurance = () => ReviewAssurance.make({
+  status: "unverified",
+  requiredGeneralDiscoveryPasses: 1,
+  completedGeneralDiscoveryPasses: 1,
+  requiredSpecialistPasses: 0,
+  completedSpecialistPasses: 0,
+  requiredVerificationPasses: 0,
+  completedVerificationPasses: 0,
+  discoveredCandidates: 0,
+  confirmedCandidates: 0,
+  rejectedCandidates: 0,
+  unsettledCandidates: 0,
+  discardedInvalidFindings: 0,
+  failedPasses: [],
+  reasons: [
+    "flat review has no independent candidate-verification pass; use the fan-out pipeline for a settled assurance result"
+  ]
+});
+var assessFlatReview = (input) => {
+  const trace3 = toolTrace(input.events);
+  const requiredPaths = sortedUnique(input.files.map((file2) => file2.path));
+  const assigned = new Set;
+  const partial = new Set;
+  const failedPaths = new Set;
+  for (const [toolCallId, declaration] of trace3.declared) {
+    if (declaration.toolName !== "read_file_diff")
+      continue;
+    const query = exports_Schema.decodeUnknownOption(FileDiffQuery)(declaration.parameters);
+    if (exports_Option.isNone(query))
+      continue;
+    const success = trace3.succeeded.get(toolCallId);
+    if (success !== undefined) {
+      assigned.add(query.value.path);
+      const view = exports_Schema.decodeUnknownOption(FileDiffView)(success.result);
+      if (exports_Option.isSome(view) && view.value.truncated)
+        partial.add(query.value.path);
+    }
+    if (trace3.failed.has(toolCallId))
+      failedPaths.add(query.value.path);
+  }
+  const undiffable = new Set(input.files.filter((file2) => !isReviewableFile(file2)).map((file2) => file2.path));
+  const unassigned = requiredPaths.filter((path) => !undiffable.has(path) && (!assigned.has(path) || failedPaths.has(path)));
+  const reasons = [];
+  if (input.files.length < input.totalFiles) {
+    reasons.push(`review range exposed ${input.files.length} of ${input.totalFiles} required files`);
+  }
+  if (failedPaths.size > 0)
+    reasons.push(boundedListReason("diff reads failed", failedPaths));
+  if (partial.size > 0) {
+    reasons.push(boundedListReason("model-visible diff evidence was truncated", partial));
+  }
+  if (unassigned.length > 0) {
+    reasons.push(boundedListReason("required paths received no successful diff input", unassigned));
+  }
+  const inputCoverage = anchorSurfaceAdjusted(ReviewInputCoverage.make({
+    status: reasons.length === 0 ? "complete" : "incomplete",
+    requiredPaths,
+    assignedPaths: sortedUnique(assigned),
+    partialPaths: sortedUnique(partial),
+    unassignedPaths: sortedUnique(unassigned),
+    undiffablePaths: sortedUnique(undiffable),
+    reasons
+  }), input.anchorFiles, input.totalAnchorFiles);
+  return {
+    inputCoverage,
+    assurance: flatAssurance(),
+    unreviewedPaths: unassigned
+  };
+};
+var fanOutInputCoverage = (input) => {
+  const plan = input.plan;
+  const assignedPaths = sortedUnique(plan.units.flatMap((unit) => unit.paths));
+  const unassignedPaths = sortedUnique(plan.unassignedPaths);
+  const reasons = [];
+  if (plan.truncated) {
+    reasons.push(`review range exposed ${input.files.length} of ${input.totalFiles} required files`);
+  }
+  if (plan.partialEvidencePaths.length > 0) {
+    reasons.push(boundedListReason("fan-out capacity left some deterministic evidence shards unassigned", plan.partialEvidencePaths));
+  }
+  if (plan.unassignedEvidenceShardCount > 0) {
+    reasons.push(`${plan.unassignedEvidenceShardCount} deterministic evidence shard(s) exceeded fan-out capacity`);
+    reasons.push(boundedListReason(`unassigned evidence shard identifier sample (${plan.unassignedEvidenceShardIds.length} of ${plan.unassignedEvidenceShardCount})`, plan.unassignedEvidenceShardIds));
+  }
+  if (plan.unassignedPaths.length > 0) {
+    reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
+  }
+  return anchorSurfaceAdjusted(ReviewInputCoverage.make({
+    status: reasons.length === 0 ? "complete" : "incomplete",
+    requiredPaths: sortedUnique(input.files.map((file2) => file2.path)),
+    assignedPaths,
+    partialPaths: plan.partialEvidencePaths,
+    unassignedPaths,
+    undiffablePaths: sortedUnique(plan.undiffablePaths),
+    reasons
+  }), input.anchorFiles, input.totalAnchorFiles);
+};
+var compatibilityCoverage = (inputCoverage, assurance) => {
+  const assuranceIncomplete = assurance.status === "incomplete";
+  const failedUnits = new Map;
+  for (const pass of assurance.failedPasses) {
+    const unitId = pass.workId.slice(0, "unit-000".length);
+    if (!failedUnits.has(unitId)) {
+      failedUnits.set(unitId, FailedReviewUnit.make({ unitId, errorTag: `${pass.stage}:${pass.errorTag}` }));
+    }
+  }
+  return ReviewCoverage.make({
+    status: inputCoverage.status === "complete" && !assuranceIncomplete ? "complete" : "incomplete",
+    requiredPaths: inputCoverage.requiredPaths,
+    reviewedPaths: inputCoverage.assignedPaths,
+    unreviewedPaths: sortedUnique([
+      ...inputCoverage.partialPaths,
+      ...inputCoverage.unassignedPaths
+    ]),
+    failedUnits: [...failedUnits.values()].slice(0, 8),
+    reasons: [...inputCoverage.reasons, ...assuranceIncomplete ? assurance.reasons : []]
+  });
+};
+
 // packages/pr-review/src/internal/review-units.ts
 var MAX_REVIEW_UNITS = 8;
 var MAX_UNIT_FILES = 12;
@@ -43001,12 +42766,24 @@ var rankAndDedupeFindings = (findings) => {
     return left.startLine - right.startLine;
   }).slice(0, MAX_MERGED_FINDINGS);
 };
+var rankAndDedupeConcerns = (concerns) => {
+  const byContent = new Map;
+  for (const concern of concerns) {
+    const key = `${concern.title}\x00${concern.body}`;
+    const previous = byContent.get(key);
+    if (previous === undefined || severityRank[concern.severity] < severityRank[previous.severity]) {
+      byContent.set(key, concern);
+    }
+  }
+  return [...byContent.values()].sort((left, right) => severityRank[left.severity] - severityRank[right.severity]).slice(0, 10);
+};
 
 // packages/pr-review/src/internal/fan-out.ts
 var MAX_CHILD_FINDINGS = 6;
 var MAX_CHILD_CONCERNS = 3;
 var MAX_UNIT_CANDIDATES = (MAX_CHILD_FINDINGS + MAX_CHILD_CONCERNS) * 2;
 var MAX_REVIEW_CHILDREN = MAX_REVIEW_UNITS * 3;
+var REVIEW_UNIT_CONCURRENCY = 4;
 var MAX_FILE_REVIEW_TOOL_CALLS = 1;
 var ReviewWorkPhase = exports_Schema.Literals(["discovery", "verification"]);
 var ReviewWorkPerspective = exports_Schema.Literals([
@@ -43064,18 +42841,6 @@ var RiskCategories = exports_Schema.Array(ReviewRiskCategory).check(exports_Sche
 var Candidates = exports_Schema.Array(ReviewCandidate).check(exports_Schema.isMaxLength(MAX_UNIT_CANDIDATES));
 var EvidenceShardIds2 = exports_Schema.Array(ReviewEvidenceShardId).check(exports_Schema.isMinLength(1)).check(exports_Schema.isMaxLength(MAX_UNIT_EVIDENCE_SHARDS));
 
-class FileReviewRequest extends exports_Schema.Class("@effect-agent/pr-review/FileReviewRequest")({
-  phase: ReviewWorkPhase,
-  workId: ReviewPassId,
-  unitId: ReviewUnitId,
-  paths: UnitPaths,
-  evidenceShardIds: EvidenceShardIds2,
-  perspective: ReviewWorkPerspective,
-  riskCategories: RiskCategories,
-  candidates: Candidates
-}) {
-}
-
 class FileReviewEvidence extends exports_Schema.Class("@effect-agent/pr-review/FileReviewEvidence")({
   shardId: ReviewEvidenceShardId,
   path: ChangedPath,
@@ -43111,28 +42876,11 @@ class FileReviewReport extends exports_Schema.Class("@effect-agent/pr-review/Fil
 }) {
 }
 
-class FileReviewUnitResult extends exports_Schema.Class("@effect-agent/pr-review/FileReviewUnitResult")({
-  phase: ReviewWorkPhase,
-  workId: ReviewPassId,
-  unitId: ReviewUnitId,
-  candidates: Candidates,
-  fileSummaries: exports_Schema.Array(WalkthroughEntry).check(exports_Schema.isMaxLength(MAX_UNIT_FILES)),
-  assessments: exports_Schema.Array(CandidateAssessment).check(exports_Schema.isMaxLength(MAX_UNIT_CANDIDATES))
-}) {
-}
-
-class FileReviewUnitFailed extends exports_Schema.TaggedError()("FileReviewUnitFailed", {
-  childErrorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
-  message: exports_Schema.String.check(exports_Schema.isMaxLength(400))
-}) {
-}
-
-class FileReviewWorkRejected extends exports_Schema.TaggedError()("FileReviewWorkRejected", {
+class ReviewPassMisbehaved extends exports_Schema.TaggedError()("ReviewPassMisbehaved", {
   workId: ReviewPassId,
   reason: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(600))
 }) {
 }
-var FileReviewFailure = exports_Schema.Union([FileReviewUnitFailed, FileReviewWorkRejected]);
 var staticGuidanceLines = (guidance) => {
   if (guidance === undefined)
     return [];
@@ -43175,7 +42923,6 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => {
 };
 var fileReviewerInstructions = makeFileReviewerInstructions();
 var FileReviewToolkit = exports_Toolkit.empty;
-var FileReviewToolkitLayer = exports_Layer.empty;
 var defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 6,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
@@ -43187,62 +42934,25 @@ var defaultFileReviewerPolicy = AgentPolicy.make({
   toolResultBounds: ToolResultBounds.make({ maxBytes: REVIEW_TOOL_RESULT_MAX_BYTES }),
   onExhaustion: "fail"
 });
-var fileReviewPolicy = SubagentPolicy.make({
-  maxChildren: MAX_REVIEW_CHILDREN,
-  maxConcurrency: 4,
-  maxTurns: 6,
-  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "6 minutes",
-  maxResultBytes: 256 * 1024
+var makeFileReviewerDefinition = (options3 = {}) => Agent.define("pr-review-worker", {
+  input: FileReviewBrief,
+  output: FileReviewReport,
+  instructions: makeFileReviewerInstructions(options3),
+  toolkit: FileReviewToolkit,
+  policy: defaultFileReviewerPolicy,
+  description: "Perform one bounded discovery or independent candidate-verification pass over host-supplied pull-request evidence.",
+  metadata: { deploymentClass: "E", surface: "read-only", stage: "discovery-verification" }
 });
-var mapFileReviewChildFailure = (failure) => FileReviewUnitFailed.make({
-  childErrorTag: failure._tag,
-  message: (failure.message ?? "").slice(0, 400)
-});
-var sameStrings = (left, right) => left.length === right.length && left.every((value4, index2) => value4 === right[index2]);
-var rejectWork = (workId, reason) => FileReviewWorkRejected.make({ workId, reason });
-var prepareReviewBrief = (request3) => exports_Effect.gen(function* () {
-  const source = yield* PullRequestSource;
-  const mapSourceFailure = (failure) => rejectWork(request3.workId, `pull-request source ${failure.operation} failed: ${failure.reason}`.slice(0, 600));
-  const files = yield* source.changedFiles.pipe(exports_Effect.mapError(mapSourceFailure));
-  const metadata = yield* source.metadata.pipe(exports_Effect.mapError(mapSourceFailure));
-  const plan = planReviewUnits(files, { totalChangedFiles: metadata.totalChangedFiles });
-  const unit = plan.units.find((candidate) => candidate.unitId === request3.unitId);
-  if (unit === undefined || !sameStrings(request3.paths, unit.paths) || !sameStrings(request3.evidenceShardIds, unit.evidenceShards.map((shard) => shard.shardId))) {
-    return yield* rejectWork(request3.workId, "request does not match a host-planned unit");
-  }
-  if (request3.phase === "discovery") {
-    const pass = plan.discoveryPasses.find((candidate) => candidate.passId === request3.workId);
-    if (pass === undefined || pass.unitId !== request3.unitId || !sameStrings(pass.paths, request3.paths) || !sameStrings(pass.evidenceShardIds, request3.evidenceShardIds) || pass.perspective !== request3.perspective || !sameStrings(pass.riskCategories, request3.riskCategories) || request3.candidates.length !== 0) {
-      return yield* rejectWork(request3.workId, "discovery request does not match the host plan");
-    }
-  } else {
-    if (request3.workId !== `${request3.unitId}-verification` || request3.perspective !== "candidate-verification" || !sameStrings(request3.riskCategories, unit.riskCategories) || request3.candidates.length === 0) {
-      return yield* rejectWork(request3.workId, "verification request does not match the host-planned unit");
-    }
-    const candidateIds = new Set;
-    const candidateSubjects = new Set;
-    const allowed = new Set(unit.paths);
-    for (const candidate of request3.candidates) {
-      const subjectKey = reviewCandidateSubjectKey(candidate);
-      if (candidateIds.has(candidate.candidateId) || candidateSubjects.has(subjectKey) || candidate.unitId !== unit.unitId || candidate.evidencePaths.some((path) => !allowed.has(path)) || candidate._tag === "FindingCandidate" && !allowed.has(candidate.finding.path)) {
-        return yield* rejectWork(request3.workId, "verification candidates are duplicated or outside the planned unit");
-      }
-      candidateIds.add(candidate.candidateId);
-      candidateSubjects.add(subjectKey);
-    }
-  }
+var FileReviewer = makeFileReviewerDefinition();
+var candidateOrdinal = (index2) => String(index2 + 1).padStart(3, "0");
+var unitEvidence = (unit, files) => exports_Effect.gen(function* () {
   const byPath = new Map(files.map((file2) => [file2.path, file2]));
   const evidence = [];
   for (const shard of unit.evidenceShards) {
     const file2 = byPath.get(shard.path);
-    if (file2 === undefined) {
-      return yield* rejectWork(request3.workId, `planned evidence path is unavailable: ${shard.path}`);
-    }
-    const chunks2 = fileReviewEvidenceChunks(file2);
-    const chunk = chunks2[shard.ordinal - 1];
-    if (chunk === undefined || chunks2.length !== shard.total || chunk.annotatedPatch.length !== shard.evidenceChars) {
-      return yield* rejectWork(request3.workId, `planned evidence shard no longer matches source: ${shard.shardId}`);
+    const chunk = file2 === undefined ? undefined : fileReviewEvidenceChunks(file2)[shard.ordinal - 1];
+    if (file2 === undefined || chunk === undefined) {
+      return yield* exports_Effect.die(new Error(`planned evidence shard has no source: ${shard.shardId} (${shard.path})`));
     }
     evidence.push(FileReviewEvidence.make({
       shardId: shard.shardId,
@@ -43254,198 +42964,271 @@ var prepareReviewBrief = (request3) => exports_Effect.gen(function* () {
       annotatedPatch: chunk.annotatedPatch
     }));
   }
-  return FileReviewBrief.make({ ...request3, evidence });
+  return evidence;
 });
-var candidateOrdinal = (index2) => String(index2 + 1).padStart(3, "0");
-var projectReviewResult = (report2, context4, request3) => {
-  if (context4.budgetExhausted) {
-    return exports_Effect.fail(rejectWork(report2.workId, "review work exhausted its budget before exact settlement"));
+var misbehaved = (workId, reason) => ReviewPassMisbehaved.make({ workId, reason: reason.slice(0, 600) });
+var validateVerificationReport = (brief, report2) => {
+  if (report2.findings.length > 0 || report2.concerns.length > 0 || report2.fileSummaries.length > 0) {
+    return misbehaved(brief.workId, "verification output contained discovery-only fields");
   }
-  if (report2.phase !== request3.phase || report2.workId !== request3.workId || report2.unitId !== request3.unitId) {
-    return exports_Effect.fail(rejectWork(request3.workId, "review output identity does not match the scheduled request"));
+  const expectedById = new Map(brief.candidates.map((candidate) => [candidate.candidateId, candidate]));
+  const assessedIds = new Set;
+  for (const assessment of report2.assessments) {
+    const candidate = expectedById.get(assessment.candidateId);
+    if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
+      return misbehaved(brief.workId, "verification output did not assess the exact candidate set");
+    }
+    if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+      return misbehaved(brief.workId, "verification output did not settle suggestion publication exactly");
+    }
+    assessedIds.add(assessment.candidateId);
   }
-  if (report2.phase === "verification") {
-    if (report2.findings.length > 0 || report2.concerns.length > 0 || report2.fileSummaries.length > 0) {
-      return exports_Effect.fail(rejectWork(report2.workId, "verification output contained discovery-only fields"));
-    }
-    const expectedById = new Map(request3.candidates.map((candidate) => [candidate.candidateId, candidate]));
-    const assessedIds = new Set;
-    for (const assessment of report2.assessments) {
-      const candidate = expectedById.get(assessment.candidateId);
-      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
-        return exports_Effect.fail(rejectWork(report2.workId, "verification output did not assess the exact candidate set"));
-      }
-      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
-        return exports_Effect.fail(rejectWork(report2.workId, "verification output did not settle suggestion publication exactly"));
-      }
-      assessedIds.add(assessment.candidateId);
-    }
-    if (assessedIds.size !== expectedById.size) {
-      return exports_Effect.fail(rejectWork(report2.workId, "verification output did not assess the exact candidate set"));
-    }
-    return exports_Effect.succeed(FileReviewUnitResult.make({
-      phase: report2.phase,
-      workId: report2.workId,
-      unitId: report2.unitId,
-      candidates: [],
-      fileSummaries: [],
-      assessments: report2.assessments
-    }));
+  if (assessedIds.size !== expectedById.size) {
+    return misbehaved(brief.workId, "verification output did not assess the exact candidate set");
   }
-  if (report2.assessments.length > 0) {
-    return exports_Effect.fail(rejectWork(report2.workId, "discovery output contained verification-only assessments"));
-  }
-  const allowed = new Set(request3.paths);
-  if (report2.findings.some((finding) => !allowed.has(finding.path)) || report2.concerns.some((candidate) => candidate.evidencePaths.some((path) => !allowed.has(path))) || report2.fileSummaries.some((entry) => !allowed.has(entry.path))) {
-    return exports_Effect.fail(rejectWork(report2.workId, "discovery output referenced evidence outside the scheduled unit"));
-  }
-  return exports_Effect.gen(function* () {
-    const source = yield* PullRequestSource;
-    const mapSourceFailure = (failure) => rejectWork(request3.workId, `pull-request source ${failure.operation} failed: ${failure.reason}`.slice(0, 600));
-    const files = yield* source.changedFiles.pipe(exports_Effect.mapError(mapSourceFailure));
-    const metadata = yield* source.metadata.pipe(exports_Effect.mapError(mapSourceFailure));
-    const anchorFiles = yield* source.anchorFiles.pipe(exports_Effect.mapError(mapSourceFailure));
-    const unit = planReviewUnits(files, {
-      totalChangedFiles: metadata.totalChangedFiles
-    }).units.find((candidate) => candidate.unitId === request3.unitId);
-    if (unit === undefined) {
-      return yield* rejectWork(request3.workId, "scheduled review unit is no longer available");
-    }
-    for (const finding of report2.findings) {
-      const violation = anchorViolation(finding, anchorFiles);
-      if (violation !== undefined || !findingAnchorInUnitEvidence(finding, unit, files)) {
-        return yield* rejectWork(request3.workId, `discovery finding has no valid anchor in its assigned evidence: ${violation ?? finding.path}`);
-      }
-    }
-    const findingCandidates = report2.findings.map((finding, index2) => FindingCandidate.make({
-      candidateId: `${request3.workId}:finding:${candidateOrdinal(index2)}`,
-      workId: request3.workId,
-      unitId: request3.unitId,
-      finding,
-      evidencePaths: [finding.path]
-    }));
-    const concernCandidates = report2.concerns.map((candidate, index2) => ConcernCandidate.make({
-      candidateId: `${request3.workId}:concern:${candidateOrdinal(index2)}`,
-      workId: request3.workId,
-      unitId: request3.unitId,
-      concern: candidate.concern,
-      evidencePaths: candidate.evidencePaths
-    }));
-    return FileReviewUnitResult.make({
-      phase: report2.phase,
-      workId: report2.workId,
-      unitId: report2.unitId,
-      candidates: [...findingCandidates, ...concernCandidates],
-      fileSummaries: report2.fileSummaries,
-      assessments: []
-    });
+  return;
+};
+var runReviewPass = (binding, brief, budget2) => exports_Effect.gen(function* () {
+  const result4 = yield* AgentRuntime.run(binding, brief, {
+    ...budget2 === undefined ? {} : { budget: budget2 },
+    estimateCostMicrousd: () => exports_Effect.succeed(500)
   });
-};
-var delegationDescription = "Run exactly one host-planned discovery or candidate-verification child. Copy every plan field and candidate verbatim; never retry failed work.";
-var makeFileReviewDelegation = (child) => Subagent.define("delegate_file_review", {
-  description: delegationDescription,
-  target: child,
-  parameters: FileReviewRequest,
-  success: FileReviewUnitResult,
-  failure: FileReviewFailure,
-  failureMode: "return",
-  prepareInput: prepareReviewBrief,
-  projectResult: projectReviewResult,
-  policy: fileReviewPolicy
-});
-
-class ListReviewUnitsQuery extends exports_Schema.Class("@effect-agent/pr-review/ListReviewUnitsQuery")({
-  scope: exports_Schema.Literal("all")
-}) {
-}
-var ListReviewUnits = exports_Tool.make("list_review_units", {
-  description: "List deterministic bounded review units, explicit risk categories, every required discovery pass, and paths the pipeline cannot cover.",
-  parameters: ListReviewUnitsQuery,
-  success: ReviewUnitPlan,
-  failure: PullRequestSourceFailure,
-  failureMode: "error",
-  dependencies: [PullRequestSource]
-}).annotate(ToolExecutionClass, "readonly");
-var FanOutCoordinatorToolkit = exports_Toolkit.make(ListReviewUnits);
-var FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
-  list_review_units: () => exports_Effect.gen(function* () {
-    const source = yield* PullRequestSource;
-    const files = yield* source.changedFiles;
-    const metadata = yield* source.metadata;
-    return planReviewUnits(files, { totalChangedFiles: metadata.totalChangedFiles });
-  })
-});
-var makeFanOutReviewInstructions = (options3 = {}) => (mission) => {
-  const maxFindings = clampMaxFindings(options3.maxFindings);
-  return [
-    `You coordinate the bounded multi-pass review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}.`,
-    mission.body.length > 0 ? `Author description:
-${mission.body}` : "No author description.",
-    ...staticGuidanceLines(options3.guidance),
-    "1. Call list_review_units exactly once.",
-    '2. For EVERY discoveryPass, call delegate_file_review exactly once with phase "discovery", workId=passId, and the pass unitId/paths/evidenceShardIds/perspective/riskCategories verbatim; candidates must be []. Prefer one bounded parallel batch. Never retry.',
-    '3. Group candidates returned by all successful discovery passes by unit. Deterministically deduplicate byte-identical finding or concern payloads, retaining the first candidate in discoveryPass plan order. For every unit with at least one retained candidate, call delegate_file_review exactly once with phase "verification", workId "<unitId>-verification", perspective "candidate-verification", the unit paths/evidenceShardIds/riskCategories, and EVERY retained candidate copied byte-for-byte. Prefer one bounded parallel batch. Never retry.',
-    "4. Verification is authoritative: rejected candidates must not be reported. The host independently reconstructs publishable findings from exact confirmed assessments, so do not select, rewrite, downgrade, or invent findings.",
-    `5. Return ONLY CodeReview JSON. Write a concise summary of completed and failed stages. Set findings=[] and concerns=[]; the host injects exact confirmed candidates. Copy factual fileSummaries into walkthrough without invention. The host publication cap is ${maxFindings}.`,
-    "No configured pipeline can prove absence of defects. Describe settled work, never an exhaustive or defect-free review."
-  ].join(`
-`);
-};
-var fanOutReviewInstructions = makeFanOutReviewInstructions();
-var defaultFanOutPolicy = AgentPolicy.make({
-  maxTurns: 7,
-  maxToolCalls: 1 + MAX_REVIEW_CHILDREN,
-  maxDuration: "20 minutes",
-  toolConcurrency: 4,
-  repeatedFailureLimit: 3,
-  tokenBudget: 400000,
-  contextTokenLimit: 150000,
-  onExhaustion: "final-answer"
-});
-var makeFileReviewerDefinition = (options3 = {}) => Agent.define("pr-review-worker", {
-  input: FileReviewBrief,
-  output: FileReviewReport,
-  instructions: makeFileReviewerInstructions(options3),
-  toolkit: FileReviewToolkit,
-  policy: defaultFileReviewerPolicy,
-  description: "Perform one bounded discovery or independent candidate-verification pass over host-supplied pull-request evidence.",
-  metadata: { deploymentClass: "E", surface: "read-only", stage: "discovery-verification" }
-});
-var delegationToolFor = (delegation) => delegation.tool.annotate(ToolExecutionClass, "readonly");
-var makeFanOutReviewerDefinition = (options3, delegation) => Agent.define("pr-fanout-reviewer", {
-  input: ReviewMission,
-  output: CodeReview,
-  instructions: makeFanOutReviewInstructions(options3),
-  toolkit: exports_Toolkit.make(ListReviewUnits, delegationToolFor(delegation)),
-  policy: defaultFanOutPolicy,
-  description: "Coordinate deterministic general/specialist discovery and independent candidate verification over bounded review units.",
-  metadata: {
-    deploymentClass: "E",
-    surface: "read-only",
-    delegation: "S1-attached",
-    assurance: "multi-pass"
+  const report2 = yield* exports_Schema.decodeUnknownEffect(FileReviewReport)(result4.output).pipe(exports_Effect.mapError((error2) => misbehaved(brief.workId, `child report failed to decode: ${error2.message}`)));
+  if (report2.phase !== brief.phase || report2.workId !== brief.workId || report2.unitId !== brief.unitId) {
+    return yield* misbehaved(brief.workId, "child report identity does not match the scheduled pass");
   }
-});
-var makeFanOutReviewSuite = (options3 = {}) => {
-  const child = makeFileReviewerDefinition({ guidance: options3.guidance });
-  const delegation = makeFileReviewDelegation(child);
+  if (brief.phase === "verification") {
+    const violation = validateVerificationReport(brief, report2);
+    if (violation !== undefined)
+      return yield* violation;
+  } else if (report2.assessments.length > 0) {
+    return yield* misbehaved(brief.workId, "discovery output contained verification-only assessments");
+  }
+  return { report: report2, turns: result4.turns };
+}).pipe(exports_Effect.scoped, exports_Effect.retry({ times: 1, while: (error2) => error2._tag !== "BudgetExceeded" }), exports_Effect.map((settled) => ({ _tag: "settled", ...settled })), exports_Effect.catch((error2) => exports_Effect.succeed({ _tag: "failed", errorTag: String(error2._tag).slice(0, 256) })));
+var harvestDiscovery = (pass, unit, files, anchorFiles, report2) => {
+  const allowed = new Set(pass.paths);
+  let discarded = 0;
+  const keptFindings = [];
+  for (const finding of report2.findings) {
+    if (!allowed.has(finding.path) || anchorViolation(finding, anchorFiles) !== undefined || !findingAnchorInUnitEvidence(finding, unit, files)) {
+      discarded += 1;
+      continue;
+    }
+    keptFindings.push(finding);
+  }
+  const keptConcerns = [];
+  for (const candidate of report2.concerns) {
+    if (candidate.evidencePaths.some((path) => !allowed.has(path))) {
+      discarded += 1;
+      continue;
+    }
+    keptConcerns.push(candidate);
+  }
   return {
-    child,
-    parent: makeFanOutReviewerDefinition(options3, delegation),
-    delegation
+    candidates: [
+      ...keptFindings.map((finding, index2) => FindingCandidate.make({
+        candidateId: `${pass.passId}:finding:${candidateOrdinal(index2)}`,
+        workId: pass.passId,
+        unitId: pass.unitId,
+        finding,
+        evidencePaths: [finding.path]
+      })),
+      ...keptConcerns.map((candidate, index2) => ConcernCandidate.make({
+        candidateId: `${pass.passId}:concern:${candidateOrdinal(index2)}`,
+        workId: pass.passId,
+        unitId: pass.unitId,
+        concern: candidate.concern,
+        evidencePaths: candidate.evidencePaths
+      }))
+    ],
+    fileSummaries: report2.fileSummaries.filter((entry) => allowed.has(entry.path)),
+    discarded
   };
 };
-var defaultSuite = makeFanOutReviewSuite();
-var FileReviewer = defaultSuite.child;
-var FanOutReviewer = defaultSuite.parent;
-var fileReviewDelegation = defaultSuite.delegation;
-var DelegateFileReview = delegationToolFor(fileReviewDelegation);
-var FanOutReviewToolkit = FanOutReviewer.toolkit;
-var FileReviewDelegationFailure = fileReviewDelegation.containedFailure;
-var fanOutHandlersLayerFor = (delegation) => (childBinding) => SubagentRuntime.layer(delegation, childBinding, {
-  mapChildFailure: mapFileReviewChildFailure
+var reviewUnit = (binding, unit, passes, input) => exports_Effect.gen(function* () {
+  const evidence = yield* unitEvidence(unit, input.files);
+  const failedPasses = [];
+  const candidates = [];
+  const subjects = new Set;
+  const walkthrough = [];
+  let discardedFindings = 0;
+  let turns = 0;
+  let completedGeneralPasses = 0;
+  let completedSpecialistPasses = 0;
+  for (const pass of passes) {
+    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+    const brief = FileReviewBrief.make({
+      phase: "discovery",
+      workId: pass.passId,
+      unitId: pass.unitId,
+      paths: pass.paths,
+      evidenceShardIds: pass.evidenceShardIds,
+      perspective: pass.perspective,
+      riskCategories: pass.riskCategories,
+      candidates: [],
+      evidence
+    });
+    const outcome = yield* runReviewPass(binding, brief, input.budget);
+    if (outcome._tag === "failed") {
+      failedPasses.push(FailedReviewPass.make({ workId: pass.passId, stage, errorTag: outcome.errorTag }));
+      continue;
+    }
+    turns += outcome.turns;
+    if (stage === "specialist") {
+      completedSpecialistPasses += 1;
+    } else {
+      completedGeneralPasses += 1;
+    }
+    const harvest = harvestDiscovery(pass, unit, input.files, input.anchorFiles, outcome.report);
+    discardedFindings += harvest.discarded;
+    if (pass.perspective === "general")
+      walkthrough.push(...harvest.fileSummaries);
+    for (const candidate of harvest.candidates) {
+      const subject = reviewCandidateSubjectKey(candidate);
+      if (subjects.has(subject))
+        continue;
+      subjects.add(subject);
+      candidates.push(candidate);
+    }
+  }
+  const confirmed = [];
+  let rejectedCandidates = 0;
+  let unsettledCandidates = 0;
+  let completedVerificationPasses = 0;
+  const requiredVerificationPasses = candidates.length > 0 ? 1 : 0;
+  if (candidates.length > 0) {
+    const workId = `${unit.unitId}-verification`;
+    const brief = FileReviewBrief.make({
+      phase: "verification",
+      workId,
+      unitId: unit.unitId,
+      paths: unit.paths,
+      evidenceShardIds: unit.evidenceShards.map((shard) => shard.shardId),
+      perspective: "candidate-verification",
+      riskCategories: unit.riskCategories,
+      candidates,
+      evidence
+    });
+    const outcome = yield* runReviewPass(binding, brief, input.budget);
+    if (outcome._tag === "failed") {
+      unsettledCandidates = candidates.length;
+      failedPasses.push(FailedReviewPass.make({ workId, stage: "verification", errorTag: outcome.errorTag }));
+    } else {
+      turns += outcome.turns;
+      completedVerificationPasses = 1;
+      const byId = new Map(candidates.map((candidate) => [candidate.candidateId, candidate]));
+      for (const assessment of outcome.report.assessments) {
+        const candidate = byId.get(assessment.candidateId);
+        if (candidate === undefined)
+          continue;
+        if (assessment.disposition === "confirmed") {
+          confirmed.push({ assessment, candidate });
+        } else {
+          rejectedCandidates += 1;
+        }
+      }
+    }
+  }
+  return {
+    failedPasses,
+    discoveredCandidates: candidates.length,
+    confirmed,
+    rejectedCandidates,
+    unsettledCandidates,
+    discardedFindings,
+    walkthrough,
+    turns,
+    completedGeneralPasses,
+    completedSpecialistPasses,
+    requiredVerificationPasses,
+    completedVerificationPasses,
+    unreviewedPaths: failedPasses.length > 0 ? unit.paths : []
+  };
 });
-var fanOutHandlersLayer = fanOutHandlersLayerFor(fileReviewDelegation);
+var countNoun = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
+var composeSummary = (plan, assurance) => {
+  const requiredDiscovery = assurance.requiredGeneralDiscoveryPasses + assurance.requiredSpecialistPasses;
+  const completedDiscovery = assurance.completedGeneralDiscoveryPasses + assurance.completedSpecialistPasses;
+  const parts2 = [
+    `Reviewed ${countNoun(plan.totalFiles, "changed file")} across ${countNoun(plan.units.length, "bounded unit")}: ${completedDiscovery}/${requiredDiscovery} discovery and ${assurance.completedVerificationPasses}/${assurance.requiredVerificationPasses} verification pass(es) settled; ${assurance.confirmedCandidates} of ${countNoun(assurance.discoveredCandidates, "discovered candidate")} confirmed by independent verification.`
+  ];
+  if (assurance.failedPasses.length > 0) {
+    parts2.push(`${countNoun(assurance.failedPasses.length, "pass")} did not settle; the affected paths are carried forward and retried on the next run. This is a reviewer-side gap, not a code defect.`);
+  }
+  if (assurance.discardedInvalidFindings > 0) {
+    parts2.push(`${countNoun(assurance.discardedInvalidFindings, "candidate")} discarded for anchors or paths outside the assigned evidence.`);
+  }
+  if (plan.undiffablePaths.length > 0) {
+    parts2.push(`${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence.`);
+  }
+  if (plan.unassignedPaths.length > 0 || plan.unassignedEvidenceShardCount > 0) {
+    parts2.push("The changeset exceeded the bounded fan-out capacity; unassigned scope is reported under input coverage.");
+  }
+  parts2.push("No configured pipeline can prove absence of defects; this describes settled work only.");
+  return parts2.join(" ").slice(0, 4000);
+};
+var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
+  const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
+  const passesByUnit = new Map;
+  for (const pass of plan.discoveryPasses) {
+    const passes = passesByUnit.get(pass.unitId) ?? [];
+    passes.push(pass);
+    passesByUnit.set(pass.unitId, passes);
+  }
+  const outcomes = yield* exports_Effect.forEach(plan.units, (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input), { concurrency: REVIEW_UNIT_CONCURRENCY });
+  const failedPasses = outcomes.flatMap((outcome) => outcome.failedPasses);
+  const unsettledCandidates = outcomes.reduce((total, outcome) => total + outcome.unsettledCandidates, 0);
+  const reasons = [];
+  if (failedPasses.length > 0) {
+    reasons.push(boundedListReason("configured review passes did not settle", failedPasses.map((pass) => `${pass.workId} (${pass.errorTag})`)));
+  }
+  if (unsettledCandidates > 0) {
+    reasons.push(`${unsettledCandidates} discovered candidate(s) did not receive exact verification`);
+  }
+  const requiredSpecialistPasses = plan.discoveryPasses.filter((pass) => pass.perspective === "risk-specialist").length;
+  const confirmed = outcomes.flatMap((outcome) => outcome.confirmed);
+  const assurance = ReviewAssurance.make({
+    status: reasons.length === 0 ? "settled" : "incomplete",
+    requiredGeneralDiscoveryPasses: plan.discoveryPasses.length - requiredSpecialistPasses,
+    completedGeneralDiscoveryPasses: outcomes.reduce((total, outcome) => total + outcome.completedGeneralPasses, 0),
+    requiredSpecialistPasses,
+    completedSpecialistPasses: outcomes.reduce((total, outcome) => total + outcome.completedSpecialistPasses, 0),
+    requiredVerificationPasses: outcomes.reduce((total, outcome) => total + outcome.requiredVerificationPasses, 0),
+    completedVerificationPasses: outcomes.reduce((total, outcome) => total + outcome.completedVerificationPasses, 0),
+    discoveredCandidates: outcomes.reduce((total, outcome) => total + outcome.discoveredCandidates, 0),
+    confirmedCandidates: confirmed.length,
+    rejectedCandidates: outcomes.reduce((total, outcome) => total + outcome.rejectedCandidates, 0),
+    unsettledCandidates,
+    discardedInvalidFindings: outcomes.reduce((total, outcome) => total + outcome.discardedFindings, 0),
+    failedPasses,
+    reasons
+  });
+  const findings = rankAndDedupeFindings(confirmed.flatMap(({ assessment, candidate }) => candidate._tag === "FindingCandidate" ? [confirmedFindingForPublication(assessment, candidate)] : []));
+  const concerns = rankAndDedupeConcerns(confirmed.flatMap(({ candidate }) => candidate._tag === "ConcernCandidate" ? [candidate.concern] : []));
+  const walkthrough = outcomes.flatMap((outcome) => outcome.walkthrough);
+  const blocking = findings.some((finding) => finding.severity === "blocking") || concerns.some((concern) => concern.severity === "blocking");
+  const review = CodeReview.make({
+    summary: composeSummary(plan, assurance),
+    verdict: blocking ? "request-changes" : findings.length > 0 || concerns.length > 0 ? "comment" : "approve",
+    findings,
+    ...concerns.length === 0 ? {} : { concerns },
+    ...walkthrough.length === 0 ? {} : { walkthrough }
+  });
+  return {
+    review,
+    assurance,
+    plan,
+    unreviewedPaths: [
+      ...new Set([
+        ...outcomes.flatMap((outcome) => outcome.unreviewedPaths),
+        ...plan.unassignedPaths,
+        ...plan.partialEvidencePaths
+      ])
+    ].sort(),
+    turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0)
+  };
+});
 
 // packages/pr-review/src/internal/fingerprint.ts
 var MARKER_PREFIX = "<!-- effect-agent-pr-review fingerprint=sha256:";
@@ -43529,9 +43312,10 @@ class StoredReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/
   body: StoredText
 }) {
 }
+var MAX_STORED_UNREVIEWED_PATHS = 100;
 
 class ReviewState extends exports_Schema.Class("@effect-agent/pr-review/ReviewState")({
-  version: exports_Schema.Literal(1),
+  version: exports_Schema.Literal(2),
   repository: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(200)),
   pullRequestNumber: exports_Schema.Int.check(exports_Schema.isGreaterThan(0)),
   baseRef: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(300)),
@@ -43543,6 +43327,8 @@ class ReviewState extends exports_Schema.Class("@effect-agent/pr-review/ReviewSt
   reviewedPathCount: exports_Schema.Int.check(exports_Schema.isBetween({ minimum: 0, maximum: 300 })),
   unresolvedFindings: exports_Schema.Array(StoredReviewFinding).check(exports_Schema.isMaxLength(20)),
   unresolvedConcerns: exports_Schema.Array(StoredReviewConcern).check(exports_Schema.isMaxLength(10)),
+  unreviewedPaths: exports_Schema.Array(ChangedPath).check(exports_Schema.isMaxLength(MAX_STORED_UNREVIEWED_PATHS)),
+  settled: exports_Schema.Boolean,
   lastReviewMode: ReviewScopeMode
 }) {
 }
@@ -43568,12 +43354,12 @@ var toStoredConcern = (concern) => StoredReviewConcern.make({
   body: concern.body.slice(0, 800)
 });
 var fromStoredConcern = (concern) => ReviewConcern.make({ severity: concern.severity, title: concern.title, body: concern.body });
-var STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v1:";
+var STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v2:";
 var STATE_MARKER_SUFFIX = " -->";
-var STATE_MARKER_PATTERN = /(?:^|\n)<!-- effect-agent-pr-review state-v1:([A-Za-z0-9+/]+={0,2})\.([0-9a-f]{64}) -->$/;
-var STATE_SIGNATURE_DOMAIN = "effect-agent-pr-review/state-v1\x00";
+var STATE_MARKER_PATTERN = /(?:^|\n)<!-- effect-agent-pr-review state-v2:([A-Za-z0-9+/]+={0,2})\.([0-9a-f]{64}) -->$/;
+var STATE_SIGNATURE_DOMAIN = "effect-agent-pr-review/state-v2\x00";
 var MAX_REVIEW_STATE_MARKER_CHARS = 24000;
-var ReviewStateMarker = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(MAX_REVIEW_STATE_MARKER_CHARS), exports_Schema.isPattern(/^<!-- effect-agent-pr-review state-v1:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->$/)).pipe(exports_Schema.brand("@effect-agent/pr-review/ReviewStateMarker"));
+var ReviewStateMarker = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(MAX_REVIEW_STATE_MARKER_CHARS), exports_Schema.isPattern(/^<!-- effect-agent-pr-review state-v2:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->$/)).pipe(exports_Schema.brand("@effect-agent/pr-review/ReviewStateMarker"));
 
 class ReviewStateAuthenticationFailure extends exports_Schema.TaggedError()("ReviewStateAuthenticationFailure", {
   operation: exports_Schema.Literals(["sign", "verify"]),
@@ -43752,17 +43538,22 @@ var selectReviewRange = (input) => {
       selectedByPath.set(file2.path, file2);
     }
   }
-  if (input.priorState.baseSha !== input.current.baseSha) {
+  const carriedPaths = new Set(input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path)));
+  for (const path of carriedPaths)
+    affectedPaths.add(path);
+  const rescuePaths = input.priorState.baseSha !== input.current.baseSha;
+  if (rescuePaths || carriedPaths.size > 0) {
     for (const file2 of input.fullFiles) {
-      if (affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath)) {
+      const affected = rescuePaths && (affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath)) || carriedPaths.has(file2.path) || file2.previousPath !== undefined && carriedPaths.has(file2.previousPath);
+      if (affected)
         selectedByPath.set(file2.path, file2);
-      }
     }
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  const carriedReason = carriedPaths.size === 0 ? "" : `; retrying ${carriedPaths.size} carried unreviewed path(s)`;
   return {
     mode: "incremental",
-    reason: `changes since settled review head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
+    reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}${carriedReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
     totalFiles: selectedFiles.length,
@@ -43814,466 +43605,6 @@ var buildProfileMission = (metadata, files) => ReviewMission.make({
   changedFileCount: files.length
 });
 
-// packages/pr-review/src/internal/coverage.ts
-var ReviewShape = exports_Schema.Literals(["flat", "fan-out"]);
-
-class FailedReviewUnit extends exports_Schema.Class("@effect-agent/pr-review/FailedReviewUnit")({
-  unitId: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(32)),
-  errorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256))
-}) {
-}
-
-class ReviewCoverage extends exports_Schema.Class("@effect-agent/pr-review/ReviewCoverage")({
-  status: exports_Schema.Literals(["complete", "incomplete"]),
-  requiredPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  reviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  unreviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  failedUnits: exports_Schema.Array(FailedReviewUnit).check(exports_Schema.isMaxLength(8)),
-  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(32))
-}) {
-}
-
-class ReviewInputCoverage extends exports_Schema.Class("@effect-agent/pr-review/ReviewInputCoverage")({
-  status: exports_Schema.Literals(["complete", "incomplete"]),
-  requiredPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  assignedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  partialPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  unassignedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
-  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(20))
-}) {
-}
-
-class FailedReviewPass extends exports_Schema.Class("@effect-agent/pr-review/FailedReviewPass")({
-  workId: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(96)),
-  stage: exports_Schema.Literals(["discovery", "specialist", "verification"]),
-  errorTag: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256))
-}) {
-}
-
-class ReviewAssurance extends exports_Schema.Class("@effect-agent/pr-review/ReviewAssurance")({
-  status: exports_Schema.Literals(["settled", "incomplete", "unverified"]),
-  requiredGeneralDiscoveryPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  completedGeneralDiscoveryPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  requiredSpecialistPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  completedSpecialistPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  requiredVerificationPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  completedVerificationPasses: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  discoveredCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  confirmedCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  rejectedCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  unsettledCandidates: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
-  failedPasses: exports_Schema.Array(FailedReviewPass).check(exports_Schema.isMaxLength(64)),
-  reasons: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1000))).check(exports_Schema.isMaxLength(32))
-}) {
-}
-var toolTrace = (events2) => {
-  const declared = new Map;
-  const succeeded = new Map;
-  const failed = new Map;
-  for (const event of events2) {
-    if (event._tag === "ToolCallDeclared")
-      declared.set(event.toolCallId, event);
-    if (event._tag === "ToolCallSucceeded")
-      succeeded.set(event.toolCallId, event);
-    if (event._tag === "ToolCallFailed")
-      failed.set(event.toolCallId, event);
-  }
-  return { declared, succeeded, failed };
-};
-var sortedUnique = (values3) => [...new Set(values3)].sort((left, right) => left < right ? -1 : left > right ? 1 : 0);
-var boundedListReason = (label, values3) => {
-  const items = sortedUnique(values3);
-  const prefix = `${label} (${items.length}): `;
-  let rendered = prefix;
-  for (let index2 = 0;index2 < items.length; index2 += 1) {
-    const item = items[index2] ?? "";
-    const separator = index2 === 0 ? "" : ", ";
-    const omitted = items.length - index2 - 1;
-    const suffix = omitted === 0 ? "" : ` … (+${omitted} more)`;
-    if (`${rendered}${separator}${item}${suffix}`.length > 1000) {
-      const omission = `… (+${items.length - index2} more)`;
-      return `${rendered.slice(0, 1000 - omission.length)}${omission}`;
-    }
-    rendered = `${rendered}${separator}${item}`;
-  }
-  return rendered;
-};
-var flatInputCoverage = (files, totalFiles, trace3) => {
-  const requiredPaths = sortedUnique(files.map((file2) => file2.path));
-  const assigned = new Set;
-  const partial = new Set;
-  const failedPaths = new Set;
-  for (const [toolCallId, declaration] of trace3.declared) {
-    if (declaration.toolName !== "read_file_diff")
-      continue;
-    const query = exports_Schema.decodeUnknownOption(FileDiffQuery)(declaration.parameters);
-    if (exports_Option.isNone(query))
-      continue;
-    const success = trace3.succeeded.get(toolCallId);
-    if (success !== undefined) {
-      assigned.add(query.value.path);
-      const view = exports_Schema.decodeUnknownOption(FileDiffView)(success.result);
-      if (exports_Option.isSome(view) && view.value.truncated)
-        partial.add(query.value.path);
-    }
-    if (trace3.failed.has(toolCallId))
-      failedPaths.add(query.value.path);
-  }
-  const undiffable = files.filter((file2) => !isReviewableFile(file2)).map((file2) => file2.path);
-  const unassigned = requiredPaths.filter((path) => !assigned.has(path) || undiffable.includes(path) || failedPaths.has(path));
-  const reasons = [];
-  if (files.length < totalFiles) {
-    reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
-  }
-  if (undiffable.length > 0) {
-    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", undiffable));
-  }
-  if (failedPaths.size > 0)
-    reasons.push(boundedListReason("diff reads failed", failedPaths));
-  if (partial.size > 0) {
-    reasons.push(boundedListReason("model-visible diff evidence was truncated", partial));
-  }
-  if (unassigned.length > 0) {
-    reasons.push(boundedListReason("required paths received no successful diff input", unassigned));
-  }
-  return ReviewInputCoverage.make({
-    status: reasons.length === 0 ? "complete" : "incomplete",
-    requiredPaths,
-    assignedPaths: sortedUnique(assigned),
-    partialPaths: sortedUnique(partial),
-    unassignedPaths: sortedUnique(unassigned),
-    reasons
-  });
-};
-var fanOutInputCoverage = (files, totalFiles) => {
-  const plan = planReviewUnits(files, { totalChangedFiles: totalFiles });
-  const assignedPaths = sortedUnique(plan.units.flatMap((unit) => unit.paths));
-  const unassignedPaths = sortedUnique([...plan.undiffablePaths, ...plan.unassignedPaths]);
-  const reasons = [];
-  if (plan.truncated) {
-    reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
-  }
-  if (plan.undiffablePaths.length > 0) {
-    reasons.push(boundedListReason("required paths have no reviewable diff or bounded text", plan.undiffablePaths));
-  }
-  if (plan.partialEvidencePaths.length > 0) {
-    reasons.push(boundedListReason("fan-out capacity left some deterministic evidence shards unassigned", plan.partialEvidencePaths));
-  }
-  if (plan.unassignedEvidenceShardCount > 0) {
-    reasons.push(`${plan.unassignedEvidenceShardCount} deterministic evidence shard(s) exceeded fan-out capacity`);
-    reasons.push(boundedListReason(`unassigned evidence shard identifier sample (${plan.unassignedEvidenceShardIds.length} of ${plan.unassignedEvidenceShardCount})`, plan.unassignedEvidenceShardIds));
-  }
-  if (plan.unassignedPaths.length > 0) {
-    reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
-  }
-  return ReviewInputCoverage.make({
-    status: reasons.length === 0 ? "complete" : "incomplete",
-    requiredPaths: sortedUnique(files.map((file2) => file2.path)),
-    assignedPaths,
-    partialPaths: plan.partialEvidencePaths,
-    unassignedPaths,
-    reasons
-  });
-};
-var sameStrings2 = (left, right) => left.length === right.length && left.every((value4, index2) => value4 === right[index2]);
-var candidateKey = (candidate) => JSON.stringify(exports_Schema.encodeSync(ReviewCandidate)(candidate));
-var sameCandidates = (left, right) => left.length === right.length && left.every((candidate, index2) => {
-  const corresponding = right[index2];
-  return corresponding !== undefined && candidateKey(candidate) === candidateKey(corresponding);
-});
-var delegationDeclarations = (trace3) => [...trace3.declared].flatMap(([id2, declaration]) => {
-  if (declaration.toolName !== "delegate_file_review")
-    return [];
-  const request3 = exports_Schema.decodeUnknownOption(FileReviewRequest)(declaration.parameters);
-  return exports_Option.isNone(request3) ? [] : [{ id: id2, request: request3.value }];
-});
-var failureTag2 = (trace3, id2) => {
-  const failed = trace3.failed.get(id2);
-  if (failed !== undefined)
-    return failed.errorTag;
-  const succeeded = trace3.succeeded.get(id2);
-  if (succeeded === undefined)
-    return;
-  const returned = exports_Schema.decodeUnknownOption(FileReviewDelegationFailure)(succeeded.result);
-  if (exports_Option.isNone(returned))
-    return;
-  return returned.value._tag === "FileReviewUnitFailed" ? `${returned.value._tag}:${returned.value.childErrorTag}` : returned.value._tag;
-};
-var exactDiscoveryRequest = (request3, pass) => request3.phase === "discovery" && request3.workId === pass.passId && request3.unitId === pass.unitId && request3.perspective === pass.perspective && sameStrings2(request3.paths, pass.paths) && sameStrings2(request3.evidenceShardIds, pass.evidenceShardIds) && sameStrings2(request3.riskCategories, pass.riskCategories) && request3.candidates.length === 0;
-var validCandidate = (candidate, pass, unit, files, anchorFiles) => {
-  const allowed = new Set(pass.paths);
-  const kind = candidate._tag === "FindingCandidate" ? "finding" : "concern";
-  const idPrefix = `${pass.passId}:${kind}:`;
-  return candidate.candidateId.startsWith(idPrefix) && /^\d{3}$/.test(candidate.candidateId.slice(idPrefix.length)) && candidate.workId === pass.passId && candidate.unitId === pass.unitId && candidate.evidencePaths.length > 0 && candidate.evidencePaths.every((path) => allowed.has(path)) && (candidate._tag !== "FindingCandidate" || allowed.has(candidate.finding.path) && anchorViolation(candidate.finding, anchorFiles) === undefined && findingAnchorInUnitEvidence(candidate.finding, unit, files));
-};
-var flatAssurance = () => ({
-  assurance: ReviewAssurance.make({
-    status: "unverified",
-    requiredGeneralDiscoveryPasses: 1,
-    completedGeneralDiscoveryPasses: 1,
-    requiredSpecialistPasses: 0,
-    completedSpecialistPasses: 0,
-    requiredVerificationPasses: 1,
-    completedVerificationPasses: 0,
-    discoveredCandidates: 0,
-    confirmedCandidates: 0,
-    rejectedCandidates: 0,
-    unsettledCandidates: 0,
-    failedPasses: [],
-    reasons: [
-      "flat review has no independent candidate-verification pass; use the fan-out pipeline for a settled assurance result"
-    ]
-  }),
-  confirmedFindings: [],
-  confirmedConcerns: [],
-  walkthrough: []
-});
-var fanOutAssurance = (files, totalFiles, anchorFiles, trace3) => {
-  const plan = planReviewUnits(files, { totalChangedFiles: totalFiles });
-  const declarations = delegationDeclarations(trace3);
-  const consumedDeclarationIds = new Set;
-  const failedPasses = [];
-  const reasons = [];
-  const candidatesByUnit = new Map;
-  const walkthrough = [];
-  let completedGeneralDiscoveryPasses = 0;
-  let completedSpecialistPasses = 0;
-  for (const pass of plan.discoveryPasses) {
-    const unit = plan.units.find((candidate) => candidate.unitId === pass.unitId);
-    const matching = declarations.filter(({ request: request3 }) => exactDiscoveryRequest(request3, pass));
-    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
-    if (matching.length !== 1) {
-      failedPasses.push(FailedReviewPass.make({
-        workId: pass.passId,
-        stage,
-        errorTag: matching.length === 0 ? "PassNotAssigned" : "PassAssignedMultipleTimes"
-      }));
-      continue;
-    }
-    const call = matching[0];
-    if (call === undefined) {
-      failedPasses.push(FailedReviewPass.make({
-        workId: pass.passId,
-        stage,
-        errorTag: "PassLookupInvariantFailed"
-      }));
-      continue;
-    }
-    consumedDeclarationIds.add(call.id);
-    const failure = failureTag2(trace3, call.id);
-    const succeeded = trace3.succeeded.get(call.id);
-    const result4 = succeeded === undefined ? exports_Option.none() : exports_Schema.decodeUnknownOption(FileReviewUnitResult)(succeeded.result);
-    if (failure !== undefined || exports_Option.isNone(result4) || result4.value.phase !== "discovery" || result4.value.workId !== pass.passId || result4.value.unitId !== pass.unitId || result4.value.assessments.length !== 0) {
-      failedPasses.push(FailedReviewPass.make({
-        workId: pass.passId,
-        stage,
-        errorTag: failure ?? "DiscoveryDidNotSettleExactly"
-      }));
-      continue;
-    }
-    const ids = new Set;
-    let candidatesValid = true;
-    for (const candidate of result4.value.candidates) {
-      if (unit === undefined || ids.has(candidate.candidateId) || !validCandidate(candidate, pass, unit, files, anchorFiles)) {
-        candidatesValid = false;
-        break;
-      }
-      ids.add(candidate.candidateId);
-    }
-    const unitCandidates = candidatesByUnit.get(pass.unitId) ?? [];
-    const unitIds = new Set(unitCandidates.map((candidate) => candidate.candidateId));
-    if (result4.value.candidates.some((candidate) => unitIds.has(candidate.candidateId))) {
-      candidatesValid = false;
-    }
-    if (!candidatesValid) {
-      failedPasses.push(FailedReviewPass.make({
-        workId: pass.passId,
-        stage,
-        errorTag: "DiscoveryCandidateMismatch"
-      }));
-      continue;
-    }
-    if (stage === "specialist") {
-      completedSpecialistPasses += 1;
-    } else {
-      completedGeneralDiscoveryPasses += 1;
-    }
-    const subjectKeys = new Set(unitCandidates.map(reviewCandidateSubjectKey));
-    for (const candidate of result4.value.candidates) {
-      const subjectKey = reviewCandidateSubjectKey(candidate);
-      if (subjectKeys.has(subjectKey))
-        continue;
-      subjectKeys.add(subjectKey);
-      unitCandidates.push(candidate);
-    }
-    candidatesByUnit.set(pass.unitId, unitCandidates);
-    if (pass.perspective === "general") {
-      const allowed = new Set(pass.paths);
-      walkthrough.push(...result4.value.fileSummaries.filter((entry) => allowed.has(entry.path)));
-    }
-  }
-  const confirmedCandidates = [];
-  let rejectedCandidates = 0;
-  let unsettledCandidates = 0;
-  let requiredVerificationPasses = 0;
-  let completedVerificationPasses = 0;
-  for (const unit of plan.units) {
-    const candidates = candidatesByUnit.get(unit.unitId) ?? [];
-    if (candidates.length === 0)
-      continue;
-    requiredVerificationPasses += 1;
-    const workId = `${unit.unitId}-verification`;
-    const matching = declarations.filter(({ request: request3 }) => request3.phase === "verification" && request3.workId === workId && request3.unitId === unit.unitId && request3.perspective === "candidate-verification" && sameStrings2(request3.paths, unit.paths) && sameStrings2(request3.evidenceShardIds, unit.evidenceShards.map((shard) => shard.shardId)) && sameStrings2(request3.riskCategories, unit.riskCategories) && sameCandidates(request3.candidates, candidates));
-    if (matching.length !== 1) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(FailedReviewPass.make({
-        workId,
-        stage: "verification",
-        errorTag: matching.length === 0 ? "VerificationNotAssignedOrCandidateMismatch" : "VerificationAssignedMultipleTimes"
-      }));
-      continue;
-    }
-    const call = matching[0];
-    if (call === undefined) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(FailedReviewPass.make({
-        workId,
-        stage: "verification",
-        errorTag: "PassLookupInvariantFailed"
-      }));
-      continue;
-    }
-    consumedDeclarationIds.add(call.id);
-    const failure = failureTag2(trace3, call.id);
-    const succeeded = trace3.succeeded.get(call.id);
-    const result4 = succeeded === undefined ? exports_Option.none() : exports_Schema.decodeUnknownOption(FileReviewUnitResult)(succeeded.result);
-    if (failure !== undefined || exports_Option.isNone(result4) || result4.value.phase !== "verification" || result4.value.workId !== workId || result4.value.unitId !== unit.unitId || result4.value.candidates.length !== 0 || result4.value.fileSummaries.length !== 0) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(FailedReviewPass.make({
-        workId,
-        stage: "verification",
-        errorTag: failure ?? "VerificationDidNotSettleExactly"
-      }));
-      continue;
-    }
-    const byId = new Map(candidates.map((candidate) => [candidate.candidateId, candidate]));
-    const assessedIds = new Set;
-    let suggestionSettlementExact = true;
-    const exactAssessments = result4.value.assessments.every((assessment) => {
-      const candidate = byId.get(assessment.candidateId);
-      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
-        return false;
-      }
-      assessedIds.add(assessment.candidateId);
-      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
-        suggestionSettlementExact = false;
-      }
-      return true;
-    });
-    if (byId.size !== candidates.length || !exactAssessments || assessedIds.size !== byId.size || !suggestionSettlementExact) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(FailedReviewPass.make({
-        workId,
-        stage: "verification",
-        errorTag: exactAssessments && !suggestionSettlementExact ? "SuggestionSettlementMismatch" : "VerificationAssessmentMismatch"
-      }));
-      continue;
-    }
-    completedVerificationPasses += 1;
-    for (const assessment of result4.value.assessments) {
-      if (assessment.disposition === "confirmed") {
-        const candidate = byId.get(assessment.candidateId);
-        if (candidate !== undefined)
-          confirmedCandidates.push({ assessment, candidate });
-      } else {
-        rejectedCandidates += 1;
-      }
-    }
-  }
-  const unexpected = [...trace3.declared].filter(([id2, declaration]) => declaration.toolName === "delegate_file_review" && !consumedDeclarationIds.has(id2));
-  for (const [, declaration] of unexpected) {
-    const request3 = exports_Schema.decodeUnknownOption(FileReviewRequest)(declaration.parameters);
-    failedPasses.push(FailedReviewPass.make({
-      workId: exports_Option.isSome(request3) ? request3.value.workId : "invalid-delegation-request",
-      stage: exports_Option.isSome(request3) && request3.value.phase === "verification" ? "verification" : "discovery",
-      errorTag: "UnexpectedPass"
-    }));
-  }
-  if (failedPasses.length > 0) {
-    reasons.push(boundedListReason("configured review passes did not settle", failedPasses.map((pass) => `${pass.workId} (${pass.errorTag})`)));
-  }
-  if (unsettledCandidates > 0) {
-    reasons.push(`${unsettledCandidates} discovered candidate(s) did not receive exact verification`);
-  }
-  const requiredSpecialistPasses = plan.discoveryPasses.filter((pass) => pass.perspective === "risk-specialist").length;
-  const requiredGeneralDiscoveryPasses = plan.discoveryPasses.length - requiredSpecialistPasses;
-  const discoveredCandidates = [...candidatesByUnit.values()].reduce((total, candidates) => total + candidates.length, 0);
-  return {
-    assurance: ReviewAssurance.make({
-      status: reasons.length === 0 ? "settled" : "incomplete",
-      requiredGeneralDiscoveryPasses,
-      completedGeneralDiscoveryPasses,
-      requiredSpecialistPasses,
-      completedSpecialistPasses,
-      requiredVerificationPasses,
-      completedVerificationPasses,
-      discoveredCandidates,
-      confirmedCandidates: confirmedCandidates.length,
-      rejectedCandidates,
-      unsettledCandidates,
-      failedPasses,
-      reasons
-    }),
-    confirmedFindings: confirmedCandidates.flatMap(({ assessment, candidate }) => candidate._tag === "FindingCandidate" ? [confirmedFindingForPublication(assessment, candidate)] : []),
-    confirmedConcerns: confirmedCandidates.flatMap(({ candidate }) => candidate._tag === "ConcernCandidate" ? [candidate.concern] : []),
-    walkthrough
-  };
-};
-var compatibilityCoverage = (inputCoverage, assurance) => {
-  const assuranceIncomplete = assurance.status === "incomplete";
-  const failedUnits = new Map;
-  for (const pass of assurance.failedPasses) {
-    const unitId = pass.workId.slice(0, "unit-000".length);
-    if (!failedUnits.has(unitId)) {
-      failedUnits.set(unitId, FailedReviewUnit.make({ unitId, errorTag: `${pass.stage}:${pass.errorTag}` }));
-    }
-  }
-  return ReviewCoverage.make({
-    status: inputCoverage.status === "complete" && !assuranceIncomplete ? "complete" : "incomplete",
-    requiredPaths: inputCoverage.requiredPaths,
-    reviewedPaths: inputCoverage.assignedPaths,
-    unreviewedPaths: sortedUnique([
-      ...inputCoverage.partialPaths,
-      ...inputCoverage.unassignedPaths
-    ]),
-    failedUnits: [...failedUnits.values()].slice(0, 8),
-    reasons: [...inputCoverage.reasons, ...assuranceIncomplete ? assurance.reasons : []]
-  });
-};
-var assessReviewPipeline = (input) => {
-  const trace3 = toolTrace(input.events);
-  let inputCoverage = input.shape === "fan-out" ? fanOutInputCoverage(input.files, input.totalFiles) : flatInputCoverage(input.files, input.totalFiles, trace3);
-  if (input.anchorFiles.length < input.totalAnchorFiles) {
-    inputCoverage = ReviewInputCoverage.make({
-      ...inputCoverage,
-      status: "incomplete",
-      reasons: [
-        ...inputCoverage.reasons,
-        `full pull-request anchor surface exposed ${input.anchorFiles.length} of ${input.totalAnchorFiles} required files`
-      ]
-    });
-  }
-  const assessed = input.shape === "fan-out" ? fanOutAssurance(input.files, input.totalFiles, input.anchorFiles, trace3) : flatAssurance();
-  return {
-    inputCoverage,
-    assurance: assessed.assurance,
-    coverage: compatibilityCoverage(inputCoverage, assessed.assurance),
-    confirmedFindings: assessed.confirmedFindings,
-    confirmedConcerns: assessed.confirmedConcerns,
-    walkthrough: assessed.walkthrough
-  };
-};
-
 // packages/pr-review/src/internal/retirement.ts
 var PositiveLine = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 
@@ -44317,7 +43648,7 @@ class ReviewRetirementReport extends exports_Schema.Class("@effect-agent/pr-revi
 var findingIdentity = (finding) => `${finding.path}\x00${finding.startLine}\x00${finding.endLine}\x00${finding.title}`;
 var REVIEW_METADATA_PATTERN = /<!-- effect-agent-pr-review metadata\n[\s\S]*?\n-->/g;
 var FINGERPRINT_PATTERN = /<!-- effect-agent-pr-review fingerprint=sha256:[0-9a-f]{64} -->/g;
-var STATE_PATTERN = /<!-- effect-agent-pr-review state-v1:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g;
+var STATE_PATTERN = /<!-- effect-agent-pr-review state-v\d+:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g;
 var RETIRED_ORIGINAL_PATTERN = /<!-- effect-agent-pr-review retired-original:start -->\n([\s\S]*?)\n<!-- effect-agent-pr-review retired-original:end -->/;
 var MACHINE_COMMENT_PATTERN = new RegExp(`${REVIEW_METADATA_PATTERN.source}|${FINGERPRINT_PATTERN.source}|${STATE_PATTERN.source}`, "g");
 var VERDICT_CALLOUT_PATTERN = /^(?:> \[!(?:CAUTION|IMPORTANT)\]\n> [^\n]*(?:\n> [^\n]*)*|> (?:ℹ️|✅)[^\n]*)\n*/;
@@ -44963,7 +44294,7 @@ var agentPromptDetails = (summary2, prompt) => {
 var renderAgentPromptBlock = (finding, headSha) => agentPromptDetails("Prompt for AI agents", `${AGENT_PROMPT_PREAMBLE}
 
 ${renderAgentPrompt(finding, headSha)}`);
-var renderConsolidatedAgentPrompt = (entries3) => agentPromptDetails(`Prompt for all ${countNoun(entries3.length, "finding")} with AI agents`, [
+var renderConsolidatedAgentPrompt = (entries3) => agentPromptDetails(`Prompt for all ${countNoun2(entries3.length, "finding")} with AI agents`, [
   AGENT_PROMPT_PREAMBLE,
   ...entries3.map(({ finding, writtenAtSha }) => renderAgentPrompt(finding, writtenAtSha))
 ].join(`
@@ -44985,7 +44316,7 @@ var renderDemoted = (finding, reason) => {
   const location2 = `\`${finding.path}:${finding.startLine}${finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}\``;
   return `- ${location2} **[${findingLabel(finding)}] ${finding.title}** — ${finding.body} _(demoted: ${reason})_`;
 };
-var countNoun = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
+var countNoun2 = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
 var severityCounts = (review, carriedFindings = [], carriedConcerns = []) => {
   const severities = [
     ...review.findings.map((finding) => finding.severity),
@@ -45001,23 +44332,19 @@ var severityCounts = (review, carriedFindings = [], carriedConcerns = []) => {
 };
 var renderVerdictCallout = (review, options3) => {
   const counts = severityCounts(review, options3.carriedFindings, options3.carriedConcerns);
-  if (options3.inputCoverage?.status === "incomplete" || options3.inputCoverage === undefined && options3.coverage?.status === "incomplete") {
-    const suffix = counts.blocking > 0 ? ` It also has ${countNoun(counts.blocking, "blocking finding")}.` : "";
-    return `> [!CAUTION]
-> Input coverage is incomplete — the check must not pass.${suffix}`;
-  }
-  if (options3.assurance !== undefined && options3.assurance.status !== "settled") {
-    const suffix = counts.blocking > 0 ? ` It also has ${countNoun(counts.blocking, "blocking finding")}.` : "";
-    return `> [!CAUTION]
-> Configured review assurance did not settle — the check must not pass.${suffix}`;
-  }
   if (counts.blocking > 0) {
     return `> [!CAUTION]
-> ${countNoun(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+> ${countNoun2(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+  }
+  const carried = options3.unreviewedPaths?.length ?? 0;
+  if (options3.inputCoverage?.status === "incomplete" || options3.assurance?.status === "incomplete") {
+    const carriedNote = carried > 0 ? ` ${countNoun2(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.` : "";
+    return `> [!WARNING]
+> Review infrastructure did not settle — a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
   }
   if (counts.important > 0) {
     return `> [!IMPORTANT]
-> ${countNoun(counts.important, "important finding")} to address before merging.`;
+> ${countNoun2(counts.important, "important finding")} to address before merging.`;
   }
   if (counts.total > 0) {
     return "> ℹ️ Minor suggestions only — mergeable as-is.";
@@ -45041,7 +44368,7 @@ var planWalkthrough = (entries3, files) => {
 var tableCell = (value4) => value4.replaceAll(/\r?\n/g, " ").replaceAll("|", "\\|");
 var renderWalkthrough = (entries3) => [
   "<details>",
-  `<summary>\uD83D\uDCDD Walkthrough (${countNoun(entries3.length, "file")})</summary>`,
+  `<summary>\uD83D\uDCDD Walkthrough (${countNoun2(entries3.length, "file")})</summary>`,
   "",
   "| File | Summary |",
   "| --- | --- |",
@@ -45060,7 +44387,7 @@ var estimateReviewEffort = (files) => {
 var renderReviewStats = (files, totalChangedFiles, counts) => {
   const additions = files.reduce((total, file2) => total + file2.additions, 0);
   const deletions = files.reduce((total, file2) => total + file2.deletions, 0);
-  const fileCount = files.length < totalChangedFiles ? `${files.length} of ${totalChangedFiles} files` : countNoun(files.length, "file");
+  const fileCount = files.length < totalChangedFiles ? `${files.length} of ${totalChangedFiles} files` : countNoun2(files.length, "file");
   const nits = counts.total - counts.blocking - counts.important;
   const tally = counts.total === 0 ? "none" : [
     ...counts.blocking > 0 ? [`${counts.blocking} blocking`] : [],
@@ -45105,9 +44432,8 @@ var planPublication = (review, files, options3) => {
   const footerParts = ["Automated review by @effect-agent/pr-review"];
   if (options3.modelLabel !== undefined)
     footerParts.push(options3.modelLabel);
-  if (options3.usage !== undefined && options3.usageScope !== undefined) {
-    const scope3 = options3.usageScope === "coordinator" ? " (coordinator)" : "";
-    footerParts.push(`${options3.usage.inputTokens} in / ${options3.usage.outputTokens} out tokens${scope3}`);
+  if (options3.usage !== undefined) {
+    footerParts.push(`${options3.usage.inputTokens} in / ${options3.usage.outputTokens} out tokens`);
   }
   if (options3.runUrl !== undefined)
     footerParts.push(`[run](${options3.runUrl})`);
@@ -45128,9 +44454,9 @@ var planPublication = (review, files, options3) => {
       renderVerdictCallout(review, {
         carriedFindings,
         carriedConcerns,
-        coverage: options3.coverage,
         inputCoverage: options3.inputCoverage,
-        assurance: options3.assurance
+        assurance: options3.assurance,
+        unreviewedPaths: options3.unreviewedPaths
       })
     ];
     if (options3.reviewMode !== undefined && options3.reviewReason !== undefined) {
@@ -45141,7 +44467,10 @@ var planPublication = (review, files, options3) => {
     }
     parts2.push("", renderReviewStats(files, options3.totalChangedFiles, counts));
     if (options3.inputCoverage !== undefined && options3.assurance !== undefined) {
-      parts2.push("", `**Input coverage:** ${options3.inputCoverage.status} (${options3.inputCoverage.assignedPaths.length}/${options3.inputCoverage.requiredPaths.length} paths assigned, ${options3.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options3.assurance.status} (${options3.assurance.completedGeneralDiscoveryPasses}/${options3.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options3.assurance.completedSpecialistPasses}/${options3.assurance.requiredSpecialistPasses} specialist, ${options3.assurance.completedVerificationPasses}/${options3.assurance.requiredVerificationPasses} verification; ${options3.assurance.confirmedCandidates} confirmed / ${options3.assurance.rejectedCandidates} rejected / ${options3.assurance.unsettledCandidates} unsettled candidates)`);
+      parts2.push("", `**Input coverage:** ${options3.inputCoverage.status} (${options3.inputCoverage.assignedPaths.length}/${options3.inputCoverage.requiredPaths.length} paths assigned, ${options3.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options3.assurance.status} (${options3.assurance.completedGeneralDiscoveryPasses}/${options3.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options3.assurance.completedSpecialistPasses}/${options3.assurance.requiredSpecialistPasses} specialist, ${options3.assurance.completedVerificationPasses}/${options3.assurance.requiredVerificationPasses} verification; ${options3.assurance.confirmedCandidates} confirmed / ${options3.assurance.rejectedCandidates} rejected / ${options3.assurance.unsettledCandidates} unsettled${options3.assurance.discardedInvalidFindings > 0 ? ` / ${options3.assurance.discardedInvalidFindings} discarded` : ""} candidates)`);
+      if (options3.inputCoverage.undiffablePaths.length > 0) {
+        parts2.push("", `ℹ️ ${countNoun2(options3.inputCoverage.undiffablePaths.length, "path")} had no reviewable textual evidence (binary or oversized) and ${options3.inputCoverage.undiffablePaths.length === 1 ? "is" : "are"} outside the review surface.`);
+      }
     }
     parts2.push("", review.summary);
     if (walkthroughKept2 && walkthrough.length > 0) {
@@ -45150,12 +44479,10 @@ var planPublication = (review, files, options3) => {
       parts2.push("", "⚠️ Walkthrough omitted — the body exceeded GitHub's review size cap.");
     }
     if (options3.inputCoverage?.status === "incomplete") {
-      parts2.push("", "### \uD83D\uDED1 Incomplete input coverage", "", ...options3.inputCoverage.reasons.map((reason) => `- ${reason}`));
-    } else if (options3.inputCoverage === undefined && options3.coverage?.status === "incomplete") {
-      parts2.push("", "### \uD83D\uDED1 Incomplete coverage", "", ...options3.coverage.reasons.map((reason) => `- ${reason}`));
+      parts2.push("", "### ⚠️ Incomplete input coverage", "", ...options3.inputCoverage.reasons.map((reason) => `- ${reason}`));
     }
-    if (options3.assurance !== undefined && options3.assurance.status !== "settled") {
-      parts2.push("", "### \uD83D\uDED1 Incomplete review assurance", "", ...options3.assurance.reasons.map((reason) => `- ${reason}`));
+    if (options3.assurance?.status === "incomplete") {
+      parts2.push("", "### ⚠️ Unsettled review passes", "", "The passes below failed on the reviewer's side after a bounded retry. Their paths are carried forward and re-reviewed automatically on the next run — do not change code to satisfy this section.", "", ...options3.assurance.reasons.map((reason) => `- ${reason}`));
     }
     if (carriedFindings.length > 0) {
       parts2.push("", "<details>", `<summary>Unresolved findings carried from unchanged scope (${carriedFindings.length})</summary>`, "", ...carriedFindings.map(renderCarriedFinding), "", "</details>");
@@ -45178,14 +44505,15 @@ var planPublication = (review, files, options3) => {
       parts2.push("", promptsKept2 ? renderConsolidatedAgentPrompt(promptEntries) : "⚠️ Consolidated agent prompt omitted — the body exceeded GitHub's review size cap.");
     }
     if (omitted2 > 0) {
-      parts2.push("", `⚠️ ${countNoun(omitted2, "review item")} omitted — the body exceeded GitHub's review size cap.`);
+      parts2.push("", `⚠️ ${countNoun2(omitted2, "review item")} omitted — the body exceeded GitHub's review size cap.`);
     }
     parts2.push("", footer);
     return parts2.join(`
 `);
   };
   const counts = severityCounts(review, options3.carriedFindings ?? [], options3.carriedConcerns ?? []);
-  const event = !options3.applyVerdict ? "COMMENT" : options3.inputCoverage?.status === "incomplete" || options3.inputCoverage === undefined && options3.coverage?.status === "incomplete" || options3.assurance !== undefined && options3.assurance.status !== "settled" || counts.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.important === 0 ? "APPROVE" : "COMMENT";
+  const unclean = options3.inputCoverage?.status === "incomplete" || options3.assurance?.status === "incomplete";
+  const event = !options3.applyVerdict ? "COMMENT" : counts.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.important === 0 && !unclean ? "APPROVE" : "COMMENT";
   const tail = [
     renderReviewMetadata({
       headSha: options3.headSha,
@@ -45255,11 +44583,11 @@ class ReviewRunOutcome extends exports_Schema.Class("@effect-agent/pr-review/Rev
   coverage: ReviewCoverage,
   inputCoverage: ReviewInputCoverage,
   assurance: ReviewAssurance,
+  unreviewedPaths: exports_Schema.Array(exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512))).check(exports_Schema.isMaxLength(300)),
   plan: ReviewPublicationPlan,
   published: exports_Schema.optionalKey(PublishedReview),
-  turns: exports_Schema.Int.check(exports_Schema.isGreaterThan(0)),
+  turns: exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(0)),
   usage: exports_Schema.optionalKey(UsageTotals),
-  usageScope: exports_Schema.optionalKey(exports_Schema.Literals(["run", "coordinator"])),
   reviewMode: exports_Schema.optionalKey(exports_Schema.Literals(["incremental", "full"])),
   reviewReason: exports_Schema.optionalKey(exports_Schema.String.check(exports_Schema.isMaxLength(1000))),
   state: exports_Schema.optionalKey(ReviewState)
@@ -45282,57 +44610,13 @@ var enforceFindingsBound = (review, maxFindings) => review.findings.length <= ma
   ...review.walkthrough !== undefined ? { walkthrough: review.walkthrough } : {}
 });
 var findingKey = (finding) => `${finding.path}\x00${finding.startLine}\x00${finding.endLine}\x00${finding.severity}\x00${finding.title}`;
-var severityRank3 = {
-  blocking: 0,
-  important: 1,
-  nit: 2
-};
-var rankAndDedupeConcerns = (concerns) => {
-  const byContent = new Map;
-  for (const concern of concerns) {
-    const key = `${concern.title}\x00${concern.body}`;
-    const previous = byContent.get(key);
-    if (previous === undefined || severityRank3[concern.severity] < severityRank3[previous.severity]) {
-      byContent.set(key, concern);
-    }
-  }
-  return [...byContent.values()].sort((left, right) => severityRank3[left.severity] - severityRank3[right.severity]).slice(0, 10);
-};
-var executeReview = (binding, options3) => exports_Effect.gen(function* () {
-  const source = yield* PullRequestSource;
-  const metadata = yield* source.metadata;
-  const files = yield* source.changedFiles;
-  const anchorFiles = yield* source.anchorFiles;
+var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function* () {
+  const { metadata, files, anchorFiles, fingerprint, usage } = context4;
   const executionContext = exports_Option.getOrUndefined(yield* exports_Effect.serviceOption(ReviewExecutionContext));
-  const mission = buildReviewMission(metadata, files);
-  const fullMission = buildReviewMission(metadata, anchorFiles);
-  const fingerprint = options3.signature === undefined ? undefined : yield* computeChangesetFingerprint(anchorFiles, options3.signature(fullMission));
-  const budget2 = yield* makeUsageBudget(options3.limits ?? reviewBudgetLimits);
-  const detached = yield* AgentRuntime.start(binding, mission, {
-    budget: toRunBudgetHook(budget2),
-    estimateCostMicrousd: () => exports_Effect.succeed(500)
-  });
-  const result4 = yield* detached.await;
-  const events2 = yield* detached.events;
-  const decoded = yield* exports_Schema.decodeUnknownEffect(CodeReview)(result4.output);
+  const review = enforceFindingsBound(core2.review, clampMaxFindings(options3.maxFindings));
+  const { inputCoverage, assurance } = core2;
+  const unreviewedPaths = [...new Set(core2.unreviewedPaths)].sort();
   const reviewTotalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
-  const pipeline = assessReviewPipeline({
-    shape: options3.reviewShape ?? "flat",
-    files,
-    totalFiles: reviewTotalFiles,
-    anchorFiles,
-    totalAnchorFiles: metadata.totalChangedFiles,
-    events: events2
-  });
-  const verifiedReview = options3.reviewShape !== "fan-out" ? decoded : CodeReview.make({
-    summary: decoded.summary,
-    verdict: decoded.verdict,
-    findings: rankAndDedupeFindings(pipeline.confirmedFindings),
-    ...pipeline.confirmedConcerns.length === 0 ? {} : { concerns: rankAndDedupeConcerns(pipeline.confirmedConcerns) },
-    ...pipeline.walkthrough.length === 0 ? {} : { walkthrough: pipeline.walkthrough }
-  });
-  const review = enforceFindingsBound(verifiedReview, clampMaxFindings(options3.maxFindings));
-  const usage = yield* budget2.snapshot;
   const affectedPaths = new Set(executionContext?.affectedPaths ?? files.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]));
   const priorState = executionContext?.mode === "incremental" ? executionContext.priorState : undefined;
   const carriedCandidates = priorState?.unresolvedFindings.filter((finding) => !affectedPaths.has(finding.path)).map(fromStoredFinding) ?? [];
@@ -45351,9 +44635,11 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
     const key = `${concern.title}\x00${concern.body}`;
     return activeConcernKeys.has(key) && !currentConcernKeys.has(key);
   });
-  const { assurance, coverage, inputCoverage } = pipeline;
-  const stateCandidate = executionContext !== undefined && inputCoverage.status === "complete" && assurance.status === "settled" && fingerprint !== undefined && metadata.baseSha !== undefined && executionContext.stateAuthenticator?.status === "available" ? ReviewState.make({
-    version: 1,
+  const settled = inputCoverage.status === "complete" && assurance.status !== "incomplete" && unreviewedPaths.length === 0;
+  const skipFingerprint = settled ? fingerprint : undefined;
+  const carriedScopeFits = unreviewedPaths.length <= MAX_STORED_UNREVIEWED_PATHS;
+  const stateCandidate = executionContext !== undefined && fingerprint !== undefined && metadata.baseSha !== undefined && anchorFiles.length >= metadata.totalChangedFiles && carriedScopeFits && executionContext.stateAuthenticator?.status === "available" ? ReviewState.make({
+    version: 2,
     repository: metadata.repository,
     pullRequestNumber: metadata.number,
     baseRef: metadata.baseRef,
@@ -45365,12 +44651,14 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
     reviewedPathCount: anchorFiles.length,
     unresolvedFindings: activeFindings.map(toStoredFinding),
     unresolvedConcerns: activeConcerns.map(toStoredConcern),
+    unreviewedPaths,
+    settled,
     lastReviewMode: executionContext.mode
   }) : undefined;
   const continuity = stateCandidate === undefined || executionContext?.stateAuthenticator === undefined ? {
     state: undefined,
     marker: undefined,
-    notice: executionContext?.stateAuthenticator?.status === "unavailable" && inputCoverage.status === "complete" && assurance.status === "settled" ? executionContext.stateAuthenticator.unavailableReason ?? "authenticated continuity state is unavailable" : undefined
+    notice: executionContext !== undefined && !carriedScopeFits ? `carried unreviewed scope (${unreviewedPaths.length} paths) exceeded the ${MAX_STORED_UNREVIEWED_PATHS}-path continuity bound` : executionContext?.stateAuthenticator?.status === "unavailable" ? executionContext.stateAuthenticator.unavailableReason ?? "authenticated continuity state is unavailable" : undefined
   } : yield* executionContext.stateAuthenticator.render(stateCandidate).pipe(exports_Effect.match({
     onFailure: (error2) => ({
       state: undefined,
@@ -45388,11 +44676,10 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
     modelLabel: options3.modelLabel,
     runUrl: options3.runUrl,
     usage,
-    usageScope: options3.usageScope,
-    fingerprint: inputCoverage.status === "complete" && assurance.status === "settled" ? fingerprint : undefined,
-    coverage,
+    fingerprint: skipFingerprint,
     inputCoverage,
     assurance,
+    unreviewedPaths,
     carriedFindings,
     carriedConcerns,
     reviewMode: executionContext?.mode,
@@ -45403,40 +44690,91 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
     stateMarker: continuity.marker,
     stateNotice: continuity.notice
   });
-  const scope3 = options3.usageScope === undefined ? {} : { usageScope: options3.usageScope };
-  if (!options3.post) {
-    return ReviewRunOutcome.make({
-      review,
-      activeFindings,
-      activeConcerns,
-      coverage,
-      inputCoverage,
-      assurance,
-      plan,
-      turns: result4.turns,
-      usage,
-      ...scope3,
-      ...executionContext === undefined ? {} : { reviewMode: executionContext.mode, reviewReason: executionContext.reason },
-      ...continuity.state === undefined ? {} : { state: continuity.state }
-    });
-  }
-  const publisher = yield* ReviewPublisher;
-  const published = yield* publisher.publish(plan);
-  return ReviewRunOutcome.make({
+  const shared = {
     review,
     activeFindings,
     activeConcerns,
-    coverage,
+    coverage: compatibilityCoverage(inputCoverage, assurance),
     inputCoverage,
     assurance,
+    unreviewedPaths,
     plan,
-    published,
-    turns: result4.turns,
-    usage,
-    ...scope3,
+    turns: core2.turns,
+    ...usage === undefined ? {} : { usage },
     ...executionContext === undefined ? {} : { reviewMode: executionContext.mode, reviewReason: executionContext.reason },
     ...continuity.state === undefined ? {} : { state: continuity.state }
+  };
+  if (!options3.post)
+    return ReviewRunOutcome.make(shared);
+  const publisher = yield* ReviewPublisher;
+  const published = yield* publisher.publish(plan);
+  return ReviewRunOutcome.make({ ...shared, published });
+});
+var executeReview = (binding, options3) => exports_Effect.gen(function* () {
+  const source = yield* PullRequestSource;
+  const metadata = yield* source.metadata;
+  const files = yield* source.changedFiles;
+  const anchorFiles = yield* source.anchorFiles;
+  const executionContext = exports_Option.getOrUndefined(yield* exports_Effect.serviceOption(ReviewExecutionContext));
+  const mission = buildReviewMission(metadata, files);
+  const fullMission = buildReviewMission(metadata, anchorFiles);
+  const fingerprint = options3.signature === undefined ? undefined : yield* computeChangesetFingerprint(anchorFiles, options3.signature(fullMission));
+  const budget2 = yield* makeUsageBudget(options3.limits ?? reviewBudgetLimits);
+  const detached = yield* AgentRuntime.start(binding, mission, {
+    budget: toRunBudgetHook(budget2),
+    estimateCostMicrousd: () => exports_Effect.succeed(500)
   });
+  const result4 = yield* detached.await;
+  const events2 = yield* detached.events;
+  const review = yield* exports_Schema.decodeUnknownEffect(CodeReview)(result4.output);
+  const assessment = assessFlatReview({
+    files,
+    totalFiles: executionContext?.totalFiles ?? metadata.totalChangedFiles,
+    anchorFiles,
+    totalAnchorFiles: metadata.totalChangedFiles,
+    events: events2
+  });
+  const usage = yield* budget2.snapshot;
+  return yield* settleReviewRun({
+    review,
+    inputCoverage: assessment.inputCoverage,
+    assurance: assessment.assurance,
+    unreviewedPaths: assessment.unreviewedPaths,
+    turns: result4.turns
+  }, { metadata, files, anchorFiles, fingerprint, usage }, options3);
+});
+var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* () {
+  const source = yield* PullRequestSource;
+  const metadata = yield* source.metadata;
+  const files = yield* source.changedFiles;
+  const anchorFiles = yield* source.anchorFiles;
+  const executionContext = exports_Option.getOrUndefined(yield* exports_Effect.serviceOption(ReviewExecutionContext));
+  const fullMission = buildReviewMission(metadata, anchorFiles);
+  const fingerprint = options3.signature === undefined ? undefined : yield* computeChangesetFingerprint(anchorFiles, options3.signature(fullMission));
+  const budget2 = yield* makeUsageBudget(options3.limits ?? fanOutReviewBudgetLimits);
+  const totalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
+  const pipeline = yield* runFanOutReview(binding, {
+    files,
+    anchorFiles,
+    totalChangedFiles: totalFiles,
+    maxFindings: options3.maxFindings,
+    budget: toRunBudgetHook(budget2)
+  });
+  const inputCoverage = fanOutInputCoverage({
+    plan: pipeline.plan,
+    files,
+    totalFiles,
+    anchorFiles,
+    totalAnchorFiles: metadata.totalChangedFiles
+  });
+  const usage = yield* budget2.snapshot;
+  return yield* settleReviewRun({
+    review: pipeline.review,
+    inputCoverage,
+    assurance: pipeline.assurance,
+    unreviewedPaths: pipeline.unreviewedPaths,
+    turns: pipeline.turns
+  }, { metadata, files, anchorFiles, fingerprint, usage }, options3);
 });
 
 // packages/pr-review/src/internal/factory.ts
@@ -45507,9 +44845,7 @@ var make59 = (options3) => {
     maxFindings: clampMaxFindings(options3.maxFindings),
     signature,
     modelLabel: options3.modelLabel,
-    runUrl: runOptions.runUrl,
-    usageScope: "run",
-    reviewShape: "flat"
+    runUrl: runOptions.runUrl
   }).pipe(exports_Effect.provide(exports_Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
   return {
     definition,
@@ -45525,42 +44861,35 @@ var make59 = (options3) => {
   };
 };
 var makeFanOut = (options3) => {
-  const suite = makeFanOutReviewSuite({
-    guidance: options3.guidance,
-    maxFindings: options3.maxFindings
-  });
-  const binding = Object.freeze({ definition: suite.parent, model: options3.model });
-  const childBinding = Object.freeze({ definition: suite.child, model: options3.model });
+  const child = makeFileReviewerDefinition({ guidance: options3.guidance });
+  const childBinding = Object.freeze({ definition: child, model: options3.model });
   const guidanceLines = options3.guidance === undefined ? [] : typeof options3.guidance === "string" ? [options3.guidance] : options3.guidance;
-  const signature = (mission) => [
-    suite.parent.instructions(mission),
+  const signature = (_mission) => [
+    "pr-review-fan-out-host-scheduled-v1",
     `childGuidance=${JSON.stringify(guidanceLines)}`,
+    `maxFindings=${clampMaxFindings(options3.maxFindings)}`,
     `applyVerdict=${String(options3.applyVerdict ?? false)}`,
     ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
   ].join(" ");
   const profileSignature = (_mission) => [
-    "pr-review-profile-v3-sharded-request-bound-assurance",
+    "pr-review-profile-v4-host-scheduled",
     JSON.stringify(guidanceLines),
     JSON.stringify(options3.ignore ?? []),
     `maxFindings=${clampMaxFindings(options3.maxFindings)}`,
     `applyVerdict=${String(options3.applyVerdict ?? false)}`,
     ...options3.modelLabel === undefined ? [] : [`model=${options3.modelLabel}`]
-  ].join("\x00");
-  const delegationLayer = fanOutHandlersLayerFor(suite.delegation)(childBinding).pipe(exports_Layer.provide(exports_Layer.mergeAll(FileReviewToolkitLayer, SubagentReservationsMemoryLive, IdGenerator.layer)));
-  const run5 = (runOptions = {}) => provideIgnore(executeReview(binding, {
+  ].join(" ");
+  const run5 = (runOptions = {}) => provideIgnore(executeFanOutReview(childBinding, {
     post: runOptions.post ?? false,
     applyVerdict: options3.applyVerdict ?? false,
     limits: options3.budget ?? fanOutReviewBudgetLimits,
     maxFindings: clampMaxFindings(options3.maxFindings),
     signature,
     modelLabel: options3.modelLabel,
-    runUrl: runOptions.runUrl,
-    usageScope: "coordinator",
-    reviewShape: "fan-out"
-  }).pipe(exports_Effect.provide(exports_Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer)), exports_Effect.scoped), options3.ignore);
+    runUrl: runOptions.runUrl
+  }).pipe(exports_Effect.provide(IdGenerator.layer), exports_Effect.scoped), options3.ignore);
   return {
-    definition: suite.parent,
-    binding,
+    definition: child,
     childBinding,
     run: run5,
     fingerprint: makeFingerprint(signature, options3.ignore),
@@ -45892,7 +45221,7 @@ var exports_AnthropicClient = {};
 __export(exports_AnthropicClient, {
   make: () => make61,
   layerConfig: () => layerConfig,
-  layer: () => layer17,
+  layer: () => layer16,
   AnthropicClient: () => AnthropicClient
 });
 
@@ -50537,7 +49866,7 @@ var make61 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createMessageStream
   });
 }, withRedactedHeaders);
-var layer17 = (options3) => effect(AnthropicClient, make61(options3));
+var layer16 = (options3) => effect(AnthropicClient, make61(options3));
 var layerConfig = (options3) => effect(AnthropicClient, gen4(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
@@ -50555,7 +49884,7 @@ __export(exports_AnthropicLanguageModel, {
   withConfigOverride: () => withConfigOverride,
   model: () => model,
   make: () => make63,
-  layer: () => layer18,
+  layer: () => layer17,
   Config: () => Config
 });
 
@@ -51220,9 +50549,9 @@ var Proto19 = {
     };
   }
 };
-var make62 = (provider, modelName, layer18) => Object.assign(Object.create(Proto19), {
+var make62 = (provider, modelName, layer17) => Object.assign(Object.create(Proto19), {
   provider
-}, merge3(layer18, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
+}, merge3(layer17, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
 
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/AnthropicTelemetry.js
 var addAnthropicRequestAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.request", camelToSnake);
@@ -51264,7 +50593,7 @@ var formatIssue2 = /* @__PURE__ */ makeFormatterDefault();
 
 class Config extends (/* @__PURE__ */ Service()("@effect/ai-anthropic/AnthropicLanguageModel/Config")) {
 }
-var model = (model2, config) => make62("anthropic", model2, layer18({
+var model = (model2, config) => make62("anthropic", model2, layer17({
   model: model2,
   config
 }));
@@ -51391,7 +50720,7 @@ var make63 = /* @__PURE__ */ fnUntraced2(function* ({
     })))
   });
 });
-var layer18 = (options3) => effect(LanguageModel, make63(options3));
+var layer17 = (options3) => effect(LanguageModel, make63(options3));
 var withConfigOverride = /* @__PURE__ */ dual(2, (self, overrides) => flatMap5(serviceOption2(Config), (config) => provideService2(self, Config, {
   ...config._tag === "Some" ? config.value : {},
   ...overrides
@@ -53182,7 +52511,7 @@ __export(exports_OpenAiClient, {
   make: () => make65,
   layerWebSocketMode: () => layerWebSocketMode,
   layerConfig: () => layerConfig2,
-  layer: () => layer19,
+  layer: () => layer18,
   OpenAiSocket: () => OpenAiSocket,
   OpenAiClient: () => OpenAiClient
 });
@@ -54089,7 +53418,7 @@ var make65 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createEmbedding
   });
 }, withRedactedHeaders2);
-var layer19 = (options3) => effect(OpenAiClient, make65(options3));
+var layer18 = (options3) => effect(OpenAiClient, make65(options3));
 var layerConfig2 = (options3) => effect(OpenAiClient, gen4(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
@@ -54256,7 +53585,7 @@ __export(exports_OpenAiLanguageModel, {
   withConfigOverride: () => withConfigOverride2,
   model: () => model2,
   make: () => make66,
-  layer: () => layer20,
+  layer: () => layer19,
   Config: () => Config2
 });
 
@@ -54306,7 +53635,7 @@ var SharedModelIds = ModelIdsShared.members[1];
 
 class Config2 extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiLanguageModel/Config")) {
 }
-var model2 = (model3, config) => make62("openai", model3, layer20({
+var model2 = (model3, config) => make62("openai", model3, layer19({
   model: model3,
   config
 }));
@@ -54414,7 +53743,7 @@ var make66 = /* @__PURE__ */ fnUntraced2(function* ({
     })))
   });
 });
-var layer20 = (options3) => effect(LanguageModel, make66(options3));
+var layer19 = (options3) => effect(LanguageModel, make66(options3));
 var withConfigOverride2 = /* @__PURE__ */ dual(2, (self, overrides) => flatMap5(serviceOption2(Config2), (config) => provideService2(self, Config2, {
   ...config._tag === "Some" ? config.value : {},
   ...overrides
@@ -56659,6 +55988,7 @@ var outcomeOutputs = (outcome, conclusion) => [
   ["inline-comments", String(outcome.plan.comments.length)],
   ["demoted-findings", String(outcome.plan.demoted.length)],
   ["concerns", String(outcome.review.concerns?.length ?? 0)],
+  ["unreviewed-paths", String(outcome.unreviewedPaths.length)],
   ...outcome.usage === undefined ? [] : [
     ["input-tokens", String(outcome.usage.inputTokens)],
     ["output-tokens", String(outcome.usage.outputTokens)]
@@ -56672,10 +56002,11 @@ var outcomeSummary = (outcome, modelLabel, conclusion) => [
   `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
   `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
   `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
-  ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
-  ...outcome.usage === undefined ? [] : [
-    `- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out${outcome.usageScope === "coordinator" ? " (coordinator)" : ""}`
+  ...outcome.unreviewedPaths.length === 0 ? [] : [
+    `- Carried forward: ${outcome.unreviewedPaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`
   ],
+  ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
+  ...outcome.usage === undefined ? [] : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`],
   ...outcome.published === undefined ? ["- Dry run: nothing posted"] : [`- Posted: ${outcome.published.url}`]
 ];
 var skip = (reason) => exports_Effect.gen(function* () {
@@ -56700,20 +56031,26 @@ var blockingReasons = (input) => [
   ...input.concerns.filter((concern) => concern.severity === "blocking").map((concern) => `blocking concern: ${concern.title}`)
 ];
 var concludeReviewOutcome = (outcome) => {
-  if (outcome.inputCoverage.status === "incomplete") {
-    return { conclusion: "incomplete", reasons: outcome.inputCoverage.reasons };
+  const machinery = [];
+  if (outcome.inputCoverage.status === "incomplete" || outcome.assurance.status === "incomplete") {
+    machinery.push(outcome.unreviewedPaths.length > 0 ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${outcome.unreviewedPaths.length} path(s) are carried forward and retried automatically on the next run` : "review infrastructure did not settle — a reviewer-side gap, not a code defect");
+    if (outcome.inputCoverage.status === "incomplete") {
+      machinery.push(...outcome.inputCoverage.reasons);
+    }
+    if (outcome.assurance.status === "incomplete") {
+      machinery.push(...outcome.assurance.reasons);
+    }
   }
-  if (outcome.assurance.status !== "settled") {
-    return {
-      conclusion: "incomplete",
-      reasons: outcome.assurance.reasons.length > 0 ? outcome.assurance.reasons : ["configured discovery and verification work did not settle"]
-    };
-  }
-  const reasons = blockingReasons({
+  const blocking = blockingReasons({
     findings: outcome.activeFindings,
     concerns: outcome.activeConcerns
   });
-  return reasons.length > 0 ? { conclusion: "blocking", reasons } : { conclusion: "success", reasons };
+  if (blocking.length > 0) {
+    return { conclusion: "blocking", reasons: [...blocking, ...machinery] };
+  }
+  if (machinery.length > 0)
+    return { conclusion: "incomplete", reasons: machinery };
+  return { conclusion: "success", reasons: [] };
 };
 var concludeReviewState = (state) => {
   const reasons = blockingReasons({
@@ -56783,7 +56120,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           failure: undefined
         })
       }));
-      const equivalentPatchState = (options3.reviewMode ?? "incremental") === "incremental" && options3.skipUnchanged !== false && recovered.state !== undefined && currentFingerprint !== undefined && validateReviewState(recovered.state, metadata, profileFingerprint) === undefined && recovered.state.acceptedScopeFingerprint === currentFingerprint ? recovered.state : undefined;
+      const equivalentPatchState = (options3.reviewMode ?? "incremental") === "incremental" && options3.skipUnchanged !== false && recovered.state !== undefined && recovered.state.settled && currentFingerprint !== undefined && validateReviewState(recovered.state, metadata, profileFingerprint) === undefined && recovered.state.acceptedScopeFingerprint === currentFingerprint ? recovered.state : undefined;
       if (equivalentPatchState !== undefined) {
         return yield* skipCoveredReview({
           repository: target.repository,
@@ -56841,7 +56178,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
         }),
         stateAuthenticator
       };
-      if (options3.skipUnchanged !== false && selection.mode === "incremental" && selection.files.length === 0 && selection.priorState !== undefined) {
+      if (options3.skipUnchanged !== false && selection.mode === "incremental" && selection.files.length === 0 && selection.priorState !== undefined && selection.priorState.settled) {
         const reason = "no changed review scope since the last settled review head";
         return yield* skipCoveredReview({
           repository: target.repository,

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -119,13 +119,15 @@ The packaged GitHub pull-request reviewer: schema-first review contracts, the
 `PullRequestSource`/`ReviewPublisher` ports with GitHub REST adapters, fail-closed anchor
 validation and publication planning, a fail-open sticky progress comment
 (`ReviewProgressReporter`), flat and fan-out reviewer shapes, and the `PrReview`
-configuration factory. Fan-out uses deterministic host-owned evidence units and risk
-classification labels, complete bounded evidence sharding, redundant specialist discovery for
-every unit, fresh candidate verification over the complete bounded unit, and host-only publication
-of exactly confirmed candidates. Its public
-result separates path/input coverage from discovery and verification settlement; neither claim
-means exhaustive defect detection. Only complete input plus settled assurance can emit
-authenticated incremental state or a green Action conclusion. Subpath entries: `./testing`
+configuration factory. Fan-out is scheduled entirely by host code from the deterministic
+unit plan — no coordinator model, no delegation tool: independent general and specialist
+discovery plus fresh candidate verification run as bounded child passes with one retry each,
+and only exactly confirmed candidates publish. Its public result separates path/input
+coverage from pass settlement; neither claim means exhaustive defect detection. Every
+completed run that can be signed advances the authenticated incremental baseline; a pass
+that stays failed carries its paths forward as retryable scope inside the state instead of
+freezing the baseline, and only a fully settled state authorizes skip-unchanged. Subpath
+entries: `./testing`
 (fixture source, collecting publisher,
 prompt-keyed scripted models), `./action` and `./cli` (platform-node host entrypoints). Consumes
 the `effect-agent` umbrella — the first package-level consumer of that edge. Deployment class E
@@ -150,9 +152,11 @@ publication proof; `examples/repo-ops`
 is an internal repository-operations auditor. None is a framework
 or deployment package. The repository root also carries `action/`, the prebuilt
 node-runtime GitHub Action over `@effect-agent/pr-review` with its committed bundle.
-Its normal synchronize path recovers authenticated review state and reviews only affected scope;
-explicit final mode performs fresh discovery over the bounded full diff, and blocking,
-input-incomplete, or assurance-incomplete results fail the check host-side.
+Its normal synchronize path recovers authenticated review state and reviews only the new delta
+plus carried unreviewed scope; explicit final mode performs fresh discovery over the bounded
+full diff. Blocking findings fail the check first; a machinery-incomplete result fails it with
+reasons that explicitly name a reviewer-side gap carried forward for retry, never a request to
+change code.
 
 ## Dependency direction
 

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -87,9 +87,10 @@ base, and other changes require both. Reviewers receive that content through
 the ordinary diff-read tool with non-anchorable `B`/`H` line labels and must
 report defects as review-body concerns. Invalid UTF-8, binary NUL content,
 missing sides, and files beyond the per-side read bound leave a path with no
-reviewable textual evidence; such paths are reported informationally — they
-can never be reviewed by re-running, so they are not incompleteness and are
-not carried as retryable scope.
+reviewable textual evidence. Such paths keep input coverage incomplete and are
+carried for as long as they are part of the pull request — an unreviewable
+change must never authorize a green check; exclude them deliberately with
+ignore globs when that is intended.
 
 ## Assurance model
 
@@ -98,11 +99,10 @@ The public result deliberately separates two claims:
 - **Input coverage** says every reviewable required path in the selected
   scope was assigned every deterministic bounded evidence shard and
   separately names partially assigned and over-capacity paths, the exact
-  unassigned-shard count with a bounded identifier sample, and source
-  truncation. Undiffable paths are listed informationally. A large textual
-  diff is split across shards and units instead of being called partial
-  merely for exceeding one prompt chunk. Input coverage does not say the
-  model understood the evidence.
+  unassigned-shard count with a bounded identifier sample, undiffable paths,
+  and source truncation. A large textual diff is split across shards and
+  units instead of being called partial merely for exceeding one prompt
+  chunk. Input coverage does not say the model understood the evidence.
 - **Review assurance** says every scheduled general discovery pass, required
   independent specialist pass, and candidate-verification pass settled after
   at most one retry. It reports discovered, confirmed, rejected, unsettled,
@@ -193,8 +193,10 @@ to the current head plus the carried unreviewed paths, not the complete
 base...HEAD diff. Unchanged settled scope is not sent back to the model;
 unchanged unresolved findings remain active; changed or reverted paths
 invalidate their prior findings and receive fresh discovery and verification.
-An over-capacity changeset is reviewed in bounded installments across pushes
-through the same carry. Non-anchored concerns are carried conservatively
+Whole overflow files are reviewed in bounded installments across pushes
+through the same carry; a single file beyond total plan capacity and
+undiffable paths stay explicitly incomplete instead — an unreviewable tail
+never moves behind a green check. Non-anchored concerns are carried conservatively
 until a full audit because they cannot be mapped safely to one path.
 
 The state marker must be terminal, signed with the configured stable

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -59,21 +59,26 @@ re-validated against the parsed unified diff (invalid ones are demoted into
 the review body with the reason named, never trusted), the findings bound is
 enforced host-side, and publication happens only through the
 `ReviewPublisher` port after the run settles. `PrReview.makeFanOut` builds the
-assured delegating variant. The host deterministically partitions bounded
+assured host-scheduled variant. The host deterministically partitions bounded
 evidence, classifies high-risk units, requires a general discovery pass for
 every unit, adds a fresh specialist discovery pass for every unit, and uses
 deterministic host-classified risk categories as explicit focus labels. A
-fresh verifier must confirm or reject every discovered candidate. These are
-S1 attached ephemeral children using Effect structured concurrency. Verifiers
-receive the exact candidate claims and the complete bounded unit, including
-neighboring evidence that can falsify a locally plausible claim; they do not
-receive discovery reasoning.
-The host reconstructs publishable findings and concerns from exact confirmed
-candidate IDs, deduplicates byte-identical cross-pass claims in deterministic
-plan order, and requires every delegation declaration to be consumed by one
-exact planned request. Neither a discovery child nor the coordinator can publish
-an unsupported or invented finding. Shared `guidance` reaches both discovery
-and verification; `maxFindings` remains a host-enforced publication cap.
+fresh verifier must confirm or reject every discovered candidate. Every pass
+runs as a bounded evidence-only child dispatched directly by host code with
+Effect structured concurrency — there is no coordinator model and no
+delegation tool, so nothing depends on a model copying the plan correctly. A
+pass that fails (child fault, malformed or misdirected output) is retried
+once; a pass that stays failed is reported and its unit's paths carry forward
+as retryable scope. Verifiers receive the exact candidate claims and the
+complete bounded unit, including neighboring evidence that can falsify a
+locally plausible claim; they do not receive discovery reasoning.
+The host builds publishable findings and concerns from exact confirmed
+candidate IDs and deduplicates byte-identical cross-pass claims in
+deterministic plan order; a discovery claim anchored outside its assigned
+evidence is discarded and counted, never published and never pass-fatal. The
+summary and verdict are composed deterministically from the confirmed
+severities. Shared `guidance` reaches both discovery and verification;
+`maxFindings` remains a host-enforced publication cap.
 
 GitHub may omit the `patch` field for large textual files as well as binary
 files. The GitHub source recovers a missing patch by reading bounded, strict
@@ -81,24 +86,29 @@ UTF-8 base/head content: additions require the head, deletions require the
 base, and other changes require both. Reviewers receive that content through
 the ordinary diff-read tool with non-anchorable `B`/`H` line labels and must
 report defects as review-body concerns. Invalid UTF-8, binary NUL content,
-missing sides, files beyond the per-side read bound, and complete B/H evidence
-beyond the model-facing render bound remain explicit coverage gaps.
+missing sides, and files beyond the per-side read bound leave a path with no
+reviewable textual evidence; such paths are reported informationally — they
+can never be reviewed by re-running, so they are not incompleteness and are
+not carried as retryable scope.
 
 ## Assurance model
 
 The public result deliberately separates two claims:
 
-- **Input coverage** says every required path in the selected scope was
-  assigned every deterministic bounded evidence shard and separately names
-  partially assigned and unassigned paths, the exact unassigned-shard count
-  with a bounded identifier sample, undiffable paths, source truncation, or
-  over-capacity paths. A large textual diff is split across
-  shards and units instead of being called partial merely for exceeding one
-  prompt chunk. Input coverage does not say the model understood the evidence.
-- **Review assurance** says every configured general discovery pass, required
-  independent specialist pass, and candidate-verification batch settled
-  exactly. It reports discovered, confirmed, rejected, and unsettled
-  candidate counts plus failed pass IDs.
+- **Input coverage** says every reviewable required path in the selected
+  scope was assigned every deterministic bounded evidence shard and
+  separately names partially assigned and over-capacity paths, the exact
+  unassigned-shard count with a bounded identifier sample, and source
+  truncation. Undiffable paths are listed informationally. A large textual
+  diff is split across shards and units instead of being called partial
+  merely for exceeding one prompt chunk. Input coverage does not say the
+  model understood the evidence.
+- **Review assurance** says every scheduled general discovery pass, required
+  independent specialist pass, and candidate-verification pass settled after
+  at most one retry. It reports discovered, confirmed, rejected, unsettled,
+  and discarded (invalid-anchor) candidate counts plus failed pass IDs. A
+  failed pass is a reviewer-side gap: its unit's paths carry forward as
+  retryable scope and the next incremental run re-reviews exactly them.
 
 `settled` assurance means the configured work completed; it never means the
 review is exhaustive or the pull request is defect-free. Risk classification
@@ -126,10 +136,9 @@ discovery/specialist/verification settlement, and candidate dispositions.
 Below the summary, a collapsed **📝 Walkthrough** table carries the
 model's one-sentence per-file change summaries — walkthrough paths are
 validated like finding anchors, so entries naming files outside the changeset
-are dropped. Under fan-out the walkthrough is additionally host-verified
-against the delegation Tool events: only summaries a successfully settled
-child actually reported for its own unit's paths survive, so neither a child
-nor the coordinator can smuggle or invent entries. Non-anchored `concerns`
+are dropped. Under fan-out only summaries a
+successfully settled general pass actually reported for its own unit's paths
+survive, so a child cannot smuggle or invent entries. Non-anchored `concerns`
 (deletion plans, rollout sequencing,
 coverage gaps, scope questions — things with no diff line to point at) render
 as severity-tagged sections; demoted findings and findings carried from
@@ -172,17 +181,21 @@ ordinary gate.
 
 ## Incremental Action reviews
 
-A posted Action review with complete input coverage and settled review
-assurance carries bounded, versioned, HMAC-authenticated continuity state:
-the exact PR/base/head lineage, profile and settled-scope fingerprints, and
-the still-unresolved findings and concerns. A later Action run validates the
-state and reviews the GitHub comparison from that reviewed head to the
-current head, not the complete base...HEAD diff. Unchanged settled scope is
-not sent back to the model; unchanged unresolved findings remain active;
-changed or reverted paths invalidate their prior findings and receive fresh
-discovery and verification. Non-anchored
-concerns are carried conservatively until a full audit because they cannot be
-mapped safely to one path.
+Every completed Action review that can be signed carries bounded, versioned,
+HMAC-authenticated continuity state: the exact PR/base/head lineage, profile
+and settled-scope fingerprints, the still-unresolved findings and concerns,
+any retryable unreviewed paths, and whether the run fully settled. The
+baseline is monotone by design — a flaky or failed pass carries exactly its
+own scope forward instead of freezing the baseline and reopening everything
+reviewed since (the non-converging loop of issue #131). A later Action run
+validates the state and reviews the GitHub comparison from that reviewed head
+to the current head plus the carried unreviewed paths, not the complete
+base...HEAD diff. Unchanged settled scope is not sent back to the model;
+unchanged unresolved findings remain active; changed or reverted paths
+invalidate their prior findings and receive fresh discovery and verification.
+An over-capacity changeset is reviewed in bounded installments across pushes
+through the same carry. Non-anchored concerns are carried conservatively
+until a full audit because they cannot be mapped safely to one path.
 
 The state marker must be terminal, signed with the configured stable
 `PR_REVIEW_STATE_SECRET`, authored by the configured review-posting bot, and
@@ -198,11 +211,12 @@ full unless the authenticated settled-scope fingerprint still matches. The
 schema field retains the compatibility name `acceptedScopeFingerprint`. That
 fingerprint hashes the ignore-filtered effective diff, patchless base/head
 evidence, PR framing, and review-shaping profile while excluding commit IDs,
-base ancestry, and unified-diff hunk coordinates. Re-running the same settled
-head or a patch-equivalent rebase skips model execution by default while
-preserving its stored blocking/success conclusion and posting no duplicate
-review comments. Missing/corrupt state and any fingerprint or profile mismatch
-review conservatively.
+base ancestry, and unified-diff hunk coordinates. Re-running the same head or a
+patch-equivalent rebase skips model execution by default ONLY when the stored
+state fully settled — a state carrying unreviewed scope is always retried.
+The preserved skip keeps its stored blocking/success conclusion and posts no
+duplicate review comments. Missing/corrupt state and any fingerprint or
+profile mismatch review conservatively.
 
 After a new state-bearing Action review posts, prior marker-bearing bot reviews
 are retired by default: their bodies become collapsed, superseded history,

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -266,6 +266,7 @@ const outcomeOutputs = (
   ["inline-comments", String(outcome.plan.comments.length)],
   ["demoted-findings", String(outcome.plan.demoted.length)],
   ["concerns", String(outcome.review.concerns?.length ?? 0)],
+  ["unreviewed-paths", String(outcome.unreviewedPaths.length)],
   ...(outcome.usage === undefined
     ? []
     : ([
@@ -286,14 +287,15 @@ const outcomeSummary = (
   `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
   `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
   `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
+  ...(outcome.unreviewedPaths.length === 0
+    ? []
+    : [
+        `- Carried forward: ${outcome.unreviewedPaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`,
+      ]),
   ...(modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``]),
   ...(outcome.usage === undefined
     ? []
-    : [
-        `- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out${
-          outcome.usageScope === "coordinator" ? " (coordinator)" : ""
-        }`,
-      ]),
+    : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`]),
   ...(outcome.published === undefined
     ? ["- Dry run: nothing posted"]
     : [`- Posted: ${outcome.published.url}`]),
@@ -366,32 +368,44 @@ const blockingReasons = (input: {
     .map((concern) => `blocking concern: ${concern.title}`),
 ];
 
-/** Host-derived check conclusion; model verdict prose cannot weaken it. */
+/**
+ * Host-derived check conclusion; model verdict prose cannot weaken it.
+ *
+ * Blocking code findings outrank machinery gaps — they are the actionable
+ * signal. A machinery gap (incomplete input, unsettled passes) concludes
+ * `incomplete` with reasons that explicitly say the failure is reviewer-side
+ * uncertainty carried forward for retry, never an invitation to change code.
+ * The flat reviewer's constant `unverified` assurance is not a gap.
+ */
 export const concludeReviewOutcome = (
   outcome: ReviewRunOutcome,
 ): {
   readonly conclusion: ReviewCheckConclusion;
   readonly reasons: ReadonlyArray<string>;
 } => {
-  if (outcome.inputCoverage.status === "incomplete") {
-    return { conclusion: "incomplete", reasons: outcome.inputCoverage.reasons };
+  const machinery: Array<string> = [];
+  if (outcome.inputCoverage.status === "incomplete" || outcome.assurance.status === "incomplete") {
+    machinery.push(
+      outcome.unreviewedPaths.length > 0
+        ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${outcome.unreviewedPaths.length} path(s) are carried forward and retried automatically on the next run`
+        : "review infrastructure did not settle — a reviewer-side gap, not a code defect",
+    );
+    if (outcome.inputCoverage.status === "incomplete") {
+      machinery.push(...outcome.inputCoverage.reasons);
+    }
+    if (outcome.assurance.status === "incomplete") {
+      machinery.push(...outcome.assurance.reasons);
+    }
   }
-  if (outcome.assurance.status !== "settled") {
-    return {
-      conclusion: "incomplete",
-      reasons:
-        outcome.assurance.reasons.length > 0
-          ? outcome.assurance.reasons
-          : ["configured discovery and verification work did not settle"],
-    };
-  }
-  const reasons = blockingReasons({
+  const blocking = blockingReasons({
     findings: outcome.activeFindings,
     concerns: outcome.activeConcerns,
   });
-  return reasons.length > 0
-    ? { conclusion: "blocking", reasons }
-    : { conclusion: "success", reasons };
+  if (blocking.length > 0) {
+    return { conclusion: "blocking", reasons: [...blocking, ...machinery] };
+  }
+  if (machinery.length > 0) return { conclusion: "incomplete", reasons: machinery };
+  return { conclusion: "success", reasons: [] };
 };
 
 const concludeReviewState = (state: ReviewState) => {
@@ -522,6 +536,9 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
           (options.reviewMode ?? "incremental") === "incremental" &&
           options.skipUnchanged !== false &&
           recovered.state !== undefined &&
+          // Only a fully settled run may be skipped over: an unsettled state
+          // carries retryable scope the next run must actually retry.
+          recovered.state.settled &&
           currentFingerprint !== undefined &&
           validateReviewState(recovered.state, metadata, profileFingerprint) === undefined &&
           recovered.state.acceptedScopeFingerprint === currentFingerprint
@@ -594,7 +611,8 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
           options.skipUnchanged !== false &&
           selection.mode === "incremental" &&
           selection.files.length === 0 &&
-          selection.priorState !== undefined
+          selection.priorState !== undefined &&
+          selection.priorState.settled
         ) {
           const reason = "no changed review scope since the last settled review head";
           return yield* skipCoveredReview({

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -69,9 +69,10 @@ export class ReviewInputCoverage extends Schema.Class<ReviewInputCoverage>(
   ),
   /**
    * Paths with neither a textual diff nor bounded base/head text (binaries,
-   * oversized files). A permanent property of the changeset: reported for
-   * honesty, but never a reason the status is incomplete — re-running can
-   * never review them, so treating them as gaps would fail every run forever.
+   * oversized files). Fail-closed: they keep the status incomplete for as
+   * long as they are part of the pull request — an unreviewable change must
+   * never authorize a green check. Exclude them deliberately with ignore
+   * globs when that is intended.
    */
   undiffablePaths: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(512))).check(
     Schema.isMaxLength(300),
@@ -243,6 +244,11 @@ export const assessFlatReview = (input: {
       `review range exposed ${input.files.length} of ${input.totalFiles} required files`,
     );
   }
+  if (undiffable.size > 0) {
+    reasons.push(
+      boundedListReason("required paths have no reviewable diff or bounded text", undiffable),
+    );
+  }
   if (failedPaths.size > 0) reasons.push(boundedListReason("diff reads failed", failedPaths));
   if (partial.size > 0) {
     reasons.push(boundedListReason("model-visible diff evidence was truncated", partial));
@@ -266,15 +272,18 @@ export const assessFlatReview = (input: {
   return {
     inputCoverage,
     assurance: flatAssurance(),
-    unreviewedPaths: unassigned,
+    // Everything still unreviewed and still part of the pull request carries
+    // forward — undiffable paths included, so the check stays fail-closed
+    // even after they leave the incremental delta.
+    unreviewedPaths: sortedUnique([...unassigned, ...undiffable]),
   };
 };
 
 /**
  * Input coverage of one host-scheduled fan-out plan: which required paths the
- * bounded plan actually assigned complete evidence for. Capacity overflow is
- * a real gap and is carried by the pipeline as retryable scope; undiffable
- * paths are reported informationally only.
+ * bounded plan actually assigned complete evidence for. Capacity overflow and
+ * undiffable paths are both real gaps; the pipeline carries them so the check
+ * stays fail-closed until they are reviewed, removed, or explicitly ignored.
  */
 export const fanOutInputCoverage = (input: {
   readonly plan: ReviewUnitPlan;
@@ -290,6 +299,14 @@ export const fanOutInputCoverage = (input: {
   if (plan.truncated) {
     reasons.push(
       `review range exposed ${input.files.length} of ${input.totalFiles} required files`,
+    );
+  }
+  if (plan.undiffablePaths.length > 0) {
+    reasons.push(
+      boundedListReason(
+        "required paths have no reviewable diff or bounded text",
+        plan.undiffablePaths,
+      ),
     );
   }
   if (plan.partialEvidencePaths.length > 0) {

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -1,46 +1,23 @@
 import { Option, Schema } from "effect";
 import type { RunEvent } from "effect-agent";
 
-import { anchorViolation } from "./anchors.ts";
 import type { ChangedFile } from "./diff.ts";
 import { isReviewableFile } from "./diff.ts";
-import {
-  assessmentSettlesSuggestionExactly,
-  type CandidateAssessment,
-  confirmedFindingForPublication,
-  FileReviewDelegationFailure,
-  FileReviewRequest,
-  FileReviewUnitResult,
-  ReviewCandidate,
-  reviewCandidateSubjectKey,
-} from "./fan-out.ts";
-import {
-  FileDiffView,
-  FileDiffQuery,
-  type ReviewConcern,
-  type ReviewFinding,
-  type WalkthroughEntry,
-} from "./review-agent.ts";
-import {
-  findingAnchorInUnitEvidence,
-  planReviewUnits,
-  type ReviewDiscoveryPass,
-  type ReviewUnit,
-} from "./review-units.ts";
+import { FileDiffView, FileDiffQuery } from "./review-agent.ts";
+import type { ReviewUnitPlan } from "./review-units.ts";
 
 // ---------------------------------------------------------------------------
 // Two different claims are deliberately modeled:
 //
 // - input coverage: every required path was assigned bounded evidence or was
 //   explicitly reported outside the pipeline's capacity;
-// - review assurance: every configured discovery/specialist pass and every
-//   candidate-verification batch settled exactly.
+// - review assurance: every scheduled discovery/specialist pass and every
+//   candidate-verification pass settled.
 //
-// Neither claims that the model found every defect.
+// Neither claims that the model found every defect. The fan-out pipeline is
+// host-scheduled (fan-out.ts), so its assurance is computed from direct pass
+// results; only the flat reviewer is assessed from its Run event trace here.
 // ---------------------------------------------------------------------------
-
-export const ReviewShape = Schema.Literals(["flat", "fan-out"]);
-export type ReviewShape = typeof ReviewShape.Type;
 
 export class FailedReviewUnit extends Schema.Class<FailedReviewUnit>(
   "@effect-agent/pr-review/FailedReviewUnit",
@@ -90,6 +67,15 @@ export class ReviewInputCoverage extends Schema.Class<ReviewInputCoverage>(
   unassignedPaths: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(512))).check(
     Schema.isMaxLength(300),
   ),
+  /**
+   * Paths with neither a textual diff nor bounded base/head text (binaries,
+   * oversized files). A permanent property of the changeset: reported for
+   * honesty, but never a reason the status is incomplete — re-running can
+   * never review them, so treating them as gaps would fail every run forever.
+   */
+  undiffablePaths: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(512))).check(
+    Schema.isMaxLength(300),
+  ),
   reasons: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(1_000))).check(
     Schema.isMaxLength(20),
   ),
@@ -103,6 +89,13 @@ export class FailedReviewPass extends Schema.Class<FailedReviewPass>(
   errorTag: Schema.NonEmptyString.check(Schema.isMaxLength(256)),
 }) {}
 
+/**
+ * Settlement of scheduled review work. `incomplete` means reviewer-side work
+ * failed after its bounded retry — a machinery gap that is carried forward and
+ * retried on the next run, never a statement about the code under review.
+ * `unverified` is the flat reviewer's honest constant: one pass with no
+ * independent verifier is neither settled assurance nor a failure.
+ */
 export class ReviewAssurance extends Schema.Class<ReviewAssurance>(
   "@effect-agent/pr-review/ReviewAssurance",
 )({
@@ -117,7 +110,8 @@ export class ReviewAssurance extends Schema.Class<ReviewAssurance>(
   confirmedCandidates: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   rejectedCandidates: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   unsettledCandidates: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
-  /** Every failure remains visible within the coordinator's 32-call hard bound. */
+  /** Discovery claims discarded for anchors/paths outside their assigned evidence. */
+  discardedInvalidFindings: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   failedPasses: Schema.Array(FailedReviewPass).check(Schema.isMaxLength(64)),
   reasons: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(1_000))).check(
     Schema.isMaxLength(32),
@@ -145,7 +139,8 @@ const toolTrace = (events: ReadonlyArray<RunEvent>): ToolTrace => {
 const sortedUnique = (values: Iterable<string>): ReadonlyArray<string> =>
   [...new Set(values)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
 
-const boundedListReason = (label: string, values: Iterable<string>): string => {
+/** Render a bounded, deterministic "label (n): a, b, … (+k more)" reason line. */
+export const boundedListReason = (label: string, values: Iterable<string>): string => {
   const items = sortedUnique(values);
   const prefix = `${label} (${items.length}): `;
   let rendered = prefix;
@@ -163,12 +158,64 @@ const boundedListReason = (label: string, values: Iterable<string>): string => {
   return rendered;
 };
 
-const flatInputCoverage = (
-  files: ReadonlyArray<ChangedFile>,
-  totalFiles: number,
-  trace: ToolTrace,
-): ReviewInputCoverage => {
-  const requiredPaths = sortedUnique(files.map((file) => file.path));
+const anchorSurfaceAdjusted = (
+  inputCoverage: ReviewInputCoverage,
+  anchorFiles: ReadonlyArray<ChangedFile>,
+  totalAnchorFiles: number,
+): ReviewInputCoverage =>
+  anchorFiles.length >= totalAnchorFiles
+    ? inputCoverage
+    : ReviewInputCoverage.make({
+        ...inputCoverage,
+        status: "incomplete",
+        reasons: [
+          ...inputCoverage.reasons,
+          `full pull-request anchor surface exposed ${anchorFiles.length} of ${totalAnchorFiles} required files`,
+        ],
+      });
+
+/** The flat reviewer's honest constant assurance: one pass, no verifier. */
+export const flatAssurance = (): ReviewAssurance =>
+  ReviewAssurance.make({
+    status: "unverified",
+    requiredGeneralDiscoveryPasses: 1,
+    completedGeneralDiscoveryPasses: 1,
+    requiredSpecialistPasses: 0,
+    completedSpecialistPasses: 0,
+    requiredVerificationPasses: 0,
+    completedVerificationPasses: 0,
+    discoveredCandidates: 0,
+    confirmedCandidates: 0,
+    rejectedCandidates: 0,
+    unsettledCandidates: 0,
+    discardedInvalidFindings: 0,
+    failedPasses: [],
+    reasons: [
+      "flat review has no independent candidate-verification pass; use the fan-out pipeline for a settled assurance result",
+    ],
+  });
+
+export interface FlatReviewAssessment {
+  readonly inputCoverage: ReviewInputCoverage;
+  readonly assurance: ReviewAssurance;
+  /** Retryable evidence gaps (failed or missing diff reads), never undiffable paths. */
+  readonly unreviewedPaths: ReadonlyArray<string>;
+}
+
+/**
+ * Assess one settled flat run from its Run event trace: which required paths
+ * received successful bounded diff evidence. This observes tool INPUT
+ * assignment only — the host cannot know which evidence the model weighed.
+ */
+export const assessFlatReview = (input: {
+  readonly files: ReadonlyArray<ChangedFile>;
+  readonly totalFiles: number;
+  readonly anchorFiles: ReadonlyArray<ChangedFile>;
+  readonly totalAnchorFiles: number;
+  readonly events: ReadonlyArray<RunEvent>;
+}): FlatReviewAssessment => {
+  const trace = toolTrace(input.events);
+  const requiredPaths = sortedUnique(input.files.map((file) => file.path));
   const assigned = new Set<string>();
   const partial = new Set<string>();
   const failedPaths = new Set<string>();
@@ -184,17 +231,16 @@ const flatInputCoverage = (
     }
     if (trace.failed.has(toolCallId)) failedPaths.add(query.value.path);
   }
-  const undiffable = files.filter((file) => !isReviewableFile(file)).map((file) => file.path);
+  const undiffable = new Set(
+    input.files.filter((file) => !isReviewableFile(file)).map((file) => file.path),
+  );
   const unassigned = requiredPaths.filter(
-    (path) => !assigned.has(path) || undiffable.includes(path) || failedPaths.has(path),
+    (path) => !undiffable.has(path) && (!assigned.has(path) || failedPaths.has(path)),
   );
   const reasons: Array<string> = [];
-  if (files.length < totalFiles) {
-    reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
-  }
-  if (undiffable.length > 0) {
+  if (input.files.length < input.totalFiles) {
     reasons.push(
-      boundedListReason("required paths have no reviewable diff or bounded text", undiffable),
+      `review range exposed ${input.files.length} of ${input.totalFiles} required files`,
     );
   }
   if (failedPaths.size > 0) reasons.push(boundedListReason("diff reads failed", failedPaths));
@@ -204,33 +250,46 @@ const flatInputCoverage = (
   if (unassigned.length > 0) {
     reasons.push(boundedListReason("required paths received no successful diff input", unassigned));
   }
-  return ReviewInputCoverage.make({
-    status: reasons.length === 0 ? "complete" : "incomplete",
-    requiredPaths,
-    assignedPaths: sortedUnique(assigned),
-    partialPaths: sortedUnique(partial),
-    unassignedPaths: sortedUnique(unassigned),
-    reasons,
-  });
+  const inputCoverage = anchorSurfaceAdjusted(
+    ReviewInputCoverage.make({
+      status: reasons.length === 0 ? "complete" : "incomplete",
+      requiredPaths,
+      assignedPaths: sortedUnique(assigned),
+      partialPaths: sortedUnique(partial),
+      unassignedPaths: sortedUnique(unassigned),
+      undiffablePaths: sortedUnique(undiffable),
+      reasons,
+    }),
+    input.anchorFiles,
+    input.totalAnchorFiles,
+  );
+  return {
+    inputCoverage,
+    assurance: flatAssurance(),
+    unreviewedPaths: unassigned,
+  };
 };
 
-const fanOutInputCoverage = (
-  files: ReadonlyArray<ChangedFile>,
-  totalFiles: number,
-): ReviewInputCoverage => {
-  const plan = planReviewUnits(files, { totalChangedFiles: totalFiles });
+/**
+ * Input coverage of one host-scheduled fan-out plan: which required paths the
+ * bounded plan actually assigned complete evidence for. Capacity overflow is
+ * a real gap and is carried by the pipeline as retryable scope; undiffable
+ * paths are reported informationally only.
+ */
+export const fanOutInputCoverage = (input: {
+  readonly plan: ReviewUnitPlan;
+  readonly files: ReadonlyArray<ChangedFile>;
+  readonly totalFiles: number;
+  readonly anchorFiles: ReadonlyArray<ChangedFile>;
+  readonly totalAnchorFiles: number;
+}): ReviewInputCoverage => {
+  const plan = input.plan;
   const assignedPaths = sortedUnique(plan.units.flatMap((unit) => unit.paths));
-  const unassignedPaths = sortedUnique([...plan.undiffablePaths, ...plan.unassignedPaths]);
+  const unassignedPaths = sortedUnique(plan.unassignedPaths);
   const reasons: Array<string> = [];
   if (plan.truncated) {
-    reasons.push(`review range exposed ${files.length} of ${totalFiles} required files`);
-  }
-  if (plan.undiffablePaths.length > 0) {
     reasons.push(
-      boundedListReason(
-        "required paths have no reviewable diff or bounded text",
-        plan.undiffablePaths,
-      ),
+      `review range exposed ${input.files.length} of ${input.totalFiles} required files`,
     );
   }
   if (plan.partialEvidencePaths.length > 0) {
@@ -255,419 +314,23 @@ const fanOutInputCoverage = (
   if (plan.unassignedPaths.length > 0) {
     reasons.push(boundedListReason("fan-out capacity left paths unassigned", plan.unassignedPaths));
   }
-  return ReviewInputCoverage.make({
-    status: reasons.length === 0 ? "complete" : "incomplete",
-    requiredPaths: sortedUnique(files.map((file) => file.path)),
-    assignedPaths,
-    partialPaths: plan.partialEvidencePaths,
-    unassignedPaths,
-    reasons,
-  });
-};
-
-const sameStrings = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
-  left.length === right.length && left.every((value, index) => value === right[index]);
-
-const candidateKey = (candidate: ReviewCandidate): string =>
-  JSON.stringify(Schema.encodeSync(ReviewCandidate)(candidate));
-
-const sameCandidates = (
-  left: ReadonlyArray<ReviewCandidate>,
-  right: ReadonlyArray<ReviewCandidate>,
-): boolean =>
-  left.length === right.length &&
-  left.every((candidate, index) => {
-    const corresponding = right[index];
-    return corresponding !== undefined && candidateKey(candidate) === candidateKey(corresponding);
-  });
-
-const delegationDeclarations = (trace: ToolTrace) =>
-  [...trace.declared].flatMap(([id, declaration]) => {
-    if (declaration.toolName !== "delegate_file_review") return [];
-    const request = Schema.decodeUnknownOption(FileReviewRequest)(declaration.parameters);
-    return Option.isNone(request) ? [] : [{ id, request: request.value }];
-  });
-
-const failureTag = (trace: ToolTrace, id: string): string | undefined => {
-  const failed = trace.failed.get(id);
-  if (failed !== undefined) return failed.errorTag;
-  const succeeded = trace.succeeded.get(id);
-  if (succeeded === undefined) return undefined;
-  const returned = Schema.decodeUnknownOption(FileReviewDelegationFailure)(succeeded.result);
-  if (Option.isNone(returned)) return undefined;
-  return returned.value._tag === "FileReviewUnitFailed"
-    ? `${returned.value._tag}:${returned.value.childErrorTag}`
-    : returned.value._tag;
-};
-
-const exactDiscoveryRequest = (request: FileReviewRequest, pass: ReviewDiscoveryPass): boolean =>
-  request.phase === "discovery" &&
-  request.workId === pass.passId &&
-  request.unitId === pass.unitId &&
-  request.perspective === pass.perspective &&
-  sameStrings(request.paths, pass.paths) &&
-  sameStrings(request.evidenceShardIds, pass.evidenceShardIds) &&
-  sameStrings(request.riskCategories, pass.riskCategories) &&
-  request.candidates.length === 0;
-
-const validCandidate = (
-  candidate: ReviewCandidate,
-  pass: ReviewDiscoveryPass,
-  unit: ReviewUnit,
-  files: ReadonlyArray<ChangedFile>,
-  anchorFiles: ReadonlyArray<ChangedFile>,
-): boolean => {
-  const allowed = new Set(pass.paths);
-  const kind = candidate._tag === "FindingCandidate" ? "finding" : "concern";
-  const idPrefix = `${pass.passId}:${kind}:`;
-  return (
-    candidate.candidateId.startsWith(idPrefix) &&
-    /^\d{3}$/.test(candidate.candidateId.slice(idPrefix.length)) &&
-    candidate.workId === pass.passId &&
-    candidate.unitId === pass.unitId &&
-    candidate.evidencePaths.length > 0 &&
-    candidate.evidencePaths.every((path) => allowed.has(path)) &&
-    (candidate._tag !== "FindingCandidate" ||
-      (allowed.has(candidate.finding.path) &&
-        anchorViolation(candidate.finding, anchorFiles) === undefined &&
-        findingAnchorInUnitEvidence(candidate.finding, unit, files)))
-  );
-};
-
-interface AssuranceAssessment {
-  readonly assurance: ReviewAssurance;
-  readonly confirmedFindings: ReadonlyArray<ReviewFinding>;
-  readonly confirmedConcerns: ReadonlyArray<ReviewConcern>;
-  readonly walkthrough: ReadonlyArray<WalkthroughEntry>;
-}
-
-const flatAssurance = (): AssuranceAssessment => ({
-  assurance: ReviewAssurance.make({
-    status: "unverified",
-    requiredGeneralDiscoveryPasses: 1,
-    completedGeneralDiscoveryPasses: 1,
-    requiredSpecialistPasses: 0,
-    completedSpecialistPasses: 0,
-    requiredVerificationPasses: 1,
-    completedVerificationPasses: 0,
-    discoveredCandidates: 0,
-    confirmedCandidates: 0,
-    rejectedCandidates: 0,
-    unsettledCandidates: 0,
-    failedPasses: [],
-    reasons: [
-      "flat review has no independent candidate-verification pass; use the fan-out pipeline for a settled assurance result",
-    ],
-  }),
-  confirmedFindings: [],
-  confirmedConcerns: [],
-  walkthrough: [],
-});
-
-const fanOutAssurance = (
-  files: ReadonlyArray<ChangedFile>,
-  totalFiles: number,
-  anchorFiles: ReadonlyArray<ChangedFile>,
-  trace: ToolTrace,
-): AssuranceAssessment => {
-  const plan = planReviewUnits(files, { totalChangedFiles: totalFiles });
-  const declarations = delegationDeclarations(trace);
-  const consumedDeclarationIds = new Set<string>();
-  const failedPasses: Array<FailedReviewPass> = [];
-  const reasons: Array<string> = [];
-  const candidatesByUnit = new Map<string, Array<ReviewCandidate>>();
-  const walkthrough: Array<WalkthroughEntry> = [];
-  let completedGeneralDiscoveryPasses = 0;
-  let completedSpecialistPasses = 0;
-
-  for (const pass of plan.discoveryPasses) {
-    const unit = plan.units.find((candidate) => candidate.unitId === pass.unitId);
-    const matching = declarations.filter(({ request }) => exactDiscoveryRequest(request, pass));
-    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
-    if (matching.length !== 1) {
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId: pass.passId,
-          stage,
-          errorTag: matching.length === 0 ? "PassNotAssigned" : "PassAssignedMultipleTimes",
-        }),
-      );
-      continue;
-    }
-    const call = matching[0];
-    if (call === undefined) {
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId: pass.passId,
-          stage,
-          errorTag: "PassLookupInvariantFailed",
-        }),
-      );
-      continue;
-    }
-    consumedDeclarationIds.add(call.id);
-    const failure = failureTag(trace, call.id);
-    const succeeded = trace.succeeded.get(call.id);
-    const result =
-      succeeded === undefined
-        ? Option.none()
-        : Schema.decodeUnknownOption(FileReviewUnitResult)(succeeded.result);
-    if (
-      failure !== undefined ||
-      Option.isNone(result) ||
-      result.value.phase !== "discovery" ||
-      result.value.workId !== pass.passId ||
-      result.value.unitId !== pass.unitId ||
-      result.value.assessments.length !== 0
-    ) {
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId: pass.passId,
-          stage,
-          errorTag: failure ?? "DiscoveryDidNotSettleExactly",
-        }),
-      );
-      continue;
-    }
-    const ids = new Set<string>();
-    let candidatesValid = true;
-    for (const candidate of result.value.candidates) {
-      if (
-        unit === undefined ||
-        ids.has(candidate.candidateId) ||
-        !validCandidate(candidate, pass, unit, files, anchorFiles)
-      ) {
-        candidatesValid = false;
-        break;
-      }
-      ids.add(candidate.candidateId);
-    }
-    const unitCandidates = candidatesByUnit.get(pass.unitId) ?? [];
-    const unitIds = new Set(unitCandidates.map((candidate) => candidate.candidateId));
-    if (result.value.candidates.some((candidate) => unitIds.has(candidate.candidateId))) {
-      candidatesValid = false;
-    }
-    if (!candidatesValid) {
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId: pass.passId,
-          stage,
-          errorTag: "DiscoveryCandidateMismatch",
-        }),
-      );
-      continue;
-    }
-    if (stage === "specialist") {
-      completedSpecialistPasses += 1;
-    } else {
-      completedGeneralDiscoveryPasses += 1;
-    }
-    const subjectKeys = new Set(unitCandidates.map(reviewCandidateSubjectKey));
-    for (const candidate of result.value.candidates) {
-      const subjectKey = reviewCandidateSubjectKey(candidate);
-      if (subjectKeys.has(subjectKey)) continue;
-      subjectKeys.add(subjectKey);
-      unitCandidates.push(candidate);
-    }
-    candidatesByUnit.set(pass.unitId, unitCandidates);
-    if (pass.perspective === "general") {
-      const allowed = new Set(pass.paths);
-      walkthrough.push(...result.value.fileSummaries.filter((entry) => allowed.has(entry.path)));
-    }
-  }
-
-  const confirmedCandidates: Array<{
-    readonly assessment: CandidateAssessment;
-    readonly candidate: ReviewCandidate;
-  }> = [];
-  let rejectedCandidates = 0;
-  let unsettledCandidates = 0;
-  let requiredVerificationPasses = 0;
-  let completedVerificationPasses = 0;
-  for (const unit of plan.units) {
-    const candidates = candidatesByUnit.get(unit.unitId) ?? [];
-    if (candidates.length === 0) continue;
-    requiredVerificationPasses += 1;
-    const workId = `${unit.unitId}-verification`;
-    const matching = declarations.filter(
-      ({ request }) =>
-        request.phase === "verification" &&
-        request.workId === workId &&
-        request.unitId === unit.unitId &&
-        request.perspective === "candidate-verification" &&
-        sameStrings(request.paths, unit.paths) &&
-        sameStrings(
-          request.evidenceShardIds,
-          unit.evidenceShards.map((shard) => shard.shardId),
-        ) &&
-        sameStrings(request.riskCategories, unit.riskCategories) &&
-        sameCandidates(request.candidates, candidates),
-    );
-    if (matching.length !== 1) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId,
-          stage: "verification",
-          errorTag:
-            matching.length === 0
-              ? "VerificationNotAssignedOrCandidateMismatch"
-              : "VerificationAssignedMultipleTimes",
-        }),
-      );
-      continue;
-    }
-    const call = matching[0];
-    if (call === undefined) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId,
-          stage: "verification",
-          errorTag: "PassLookupInvariantFailed",
-        }),
-      );
-      continue;
-    }
-    consumedDeclarationIds.add(call.id);
-    const failure = failureTag(trace, call.id);
-    const succeeded = trace.succeeded.get(call.id);
-    const result =
-      succeeded === undefined
-        ? Option.none()
-        : Schema.decodeUnknownOption(FileReviewUnitResult)(succeeded.result);
-    if (
-      failure !== undefined ||
-      Option.isNone(result) ||
-      result.value.phase !== "verification" ||
-      result.value.workId !== workId ||
-      result.value.unitId !== unit.unitId ||
-      result.value.candidates.length !== 0 ||
-      result.value.fileSummaries.length !== 0
-    ) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId,
-          stage: "verification",
-          errorTag: failure ?? "VerificationDidNotSettleExactly",
-        }),
-      );
-      continue;
-    }
-    const byId = new Map(
-      candidates.map((candidate) => [candidate.candidateId, candidate] as const),
-    );
-    const assessedIds = new Set<string>();
-    let suggestionSettlementExact = true;
-    const exactAssessments = result.value.assessments.every((assessment) => {
-      const candidate = byId.get(assessment.candidateId);
-      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
-        return false;
-      }
-      assessedIds.add(assessment.candidateId);
-      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
-        suggestionSettlementExact = false;
-      }
-      return true;
-    });
-    if (
-      byId.size !== candidates.length ||
-      !exactAssessments ||
-      assessedIds.size !== byId.size ||
-      !suggestionSettlementExact
-    ) {
-      unsettledCandidates += candidates.length;
-      failedPasses.push(
-        FailedReviewPass.make({
-          workId,
-          stage: "verification",
-          errorTag:
-            exactAssessments && !suggestionSettlementExact
-              ? "SuggestionSettlementMismatch"
-              : "VerificationAssessmentMismatch",
-        }),
-      );
-      continue;
-    }
-    completedVerificationPasses += 1;
-    for (const assessment of result.value.assessments) {
-      if (assessment.disposition === "confirmed") {
-        const candidate = byId.get(assessment.candidateId);
-        if (candidate !== undefined) confirmedCandidates.push({ assessment, candidate });
-      } else {
-        rejectedCandidates += 1;
-      }
-    }
-  }
-
-  const unexpected = [...trace.declared].filter(
-    ([id, declaration]) =>
-      declaration.toolName === "delegate_file_review" && !consumedDeclarationIds.has(id),
-  );
-  for (const [, declaration] of unexpected) {
-    const request = Schema.decodeUnknownOption(FileReviewRequest)(declaration.parameters);
-    failedPasses.push(
-      FailedReviewPass.make({
-        workId: Option.isSome(request) ? request.value.workId : "invalid-delegation-request",
-        stage:
-          Option.isSome(request) && request.value.phase === "verification"
-            ? "verification"
-            : "discovery",
-        errorTag: "UnexpectedPass",
-      }),
-    );
-  }
-  if (failedPasses.length > 0) {
-    reasons.push(
-      boundedListReason(
-        "configured review passes did not settle",
-        failedPasses.map((pass) => `${pass.workId} (${pass.errorTag})`),
-      ),
-    );
-  }
-  if (unsettledCandidates > 0) {
-    reasons.push(
-      `${unsettledCandidates} discovered candidate(s) did not receive exact verification`,
-    );
-  }
-  const requiredSpecialistPasses = plan.discoveryPasses.filter(
-    (pass) => pass.perspective === "risk-specialist",
-  ).length;
-  const requiredGeneralDiscoveryPasses = plan.discoveryPasses.length - requiredSpecialistPasses;
-  const discoveredCandidates = [...candidatesByUnit.values()].reduce(
-    (total, candidates) => total + candidates.length,
-    0,
-  );
-  return {
-    assurance: ReviewAssurance.make({
-      status: reasons.length === 0 ? "settled" : "incomplete",
-      requiredGeneralDiscoveryPasses,
-      completedGeneralDiscoveryPasses,
-      requiredSpecialistPasses,
-      completedSpecialistPasses,
-      requiredVerificationPasses,
-      completedVerificationPasses,
-      discoveredCandidates,
-      confirmedCandidates: confirmedCandidates.length,
-      rejectedCandidates,
-      unsettledCandidates,
-      failedPasses,
+  return anchorSurfaceAdjusted(
+    ReviewInputCoverage.make({
+      status: reasons.length === 0 ? "complete" : "incomplete",
+      requiredPaths: sortedUnique(input.files.map((file) => file.path)),
+      assignedPaths,
+      partialPaths: plan.partialEvidencePaths,
+      unassignedPaths,
+      undiffablePaths: sortedUnique(plan.undiffablePaths),
       reasons,
     }),
-    confirmedFindings: confirmedCandidates.flatMap(({ assessment, candidate }) =>
-      candidate._tag === "FindingCandidate"
-        ? [confirmedFindingForPublication(assessment, candidate)]
-        : [],
-    ),
-    confirmedConcerns: confirmedCandidates.flatMap(({ candidate }) =>
-      candidate._tag === "ConcernCandidate" ? [candidate.concern] : [],
-    ),
-    walkthrough,
-  };
+    input.anchorFiles,
+    input.totalAnchorFiles,
+  );
 };
 
-const compatibilityCoverage = (
+/** Compatibility aggregate over the two precise claims. */
+export const compatibilityCoverage = (
   inputCoverage: ReviewInputCoverage,
   assurance: ReviewAssurance,
 ): ReviewCoverage => {
@@ -692,86 +355,5 @@ const compatibilityCoverage = (
     ]),
     failedUnits: [...failedUnits.values()].slice(0, 8),
     reasons: [...inputCoverage.reasons, ...(assuranceIncomplete ? assurance.reasons : [])],
-  });
-};
-
-export interface ReviewPipelineAssessment {
-  readonly inputCoverage: ReviewInputCoverage;
-  readonly assurance: ReviewAssurance;
-  /** Deprecated compatibility aggregate. */
-  readonly coverage: ReviewCoverage;
-  readonly confirmedFindings: ReadonlyArray<ReviewFinding>;
-  readonly confirmedConcerns: ReadonlyArray<ReviewConcern>;
-  readonly walkthrough: ReadonlyArray<WalkthroughEntry>;
-}
-
-/** Assess one settled run without trusting coordinator prose or findings. */
-export const assessReviewPipeline = (input: {
-  readonly shape: ReviewShape;
-  readonly files: ReadonlyArray<ChangedFile>;
-  readonly totalFiles: number;
-  readonly anchorFiles: ReadonlyArray<ChangedFile>;
-  readonly totalAnchorFiles: number;
-  readonly events: ReadonlyArray<RunEvent>;
-}): ReviewPipelineAssessment => {
-  const trace = toolTrace(input.events);
-  let inputCoverage =
-    input.shape === "fan-out"
-      ? fanOutInputCoverage(input.files, input.totalFiles)
-      : flatInputCoverage(input.files, input.totalFiles, trace);
-  if (input.anchorFiles.length < input.totalAnchorFiles) {
-    inputCoverage = ReviewInputCoverage.make({
-      ...inputCoverage,
-      status: "incomplete",
-      reasons: [
-        ...inputCoverage.reasons,
-        `full pull-request anchor surface exposed ${input.anchorFiles.length} of ${input.totalAnchorFiles} required files`,
-      ],
-    });
-  }
-  const assessed =
-    input.shape === "fan-out"
-      ? fanOutAssurance(input.files, input.totalFiles, input.anchorFiles, trace)
-      : flatAssurance();
-  return {
-    inputCoverage,
-    assurance: assessed.assurance,
-    coverage: compatibilityCoverage(inputCoverage, assessed.assurance),
-    confirmedFindings: assessed.confirmedFindings,
-    confirmedConcerns: assessed.confirmedConcerns,
-    walkthrough: assessed.walkthrough,
-  };
-};
-
-/** Compatibility helper; prefer assessReviewPipeline for precise claims. */
-export const assessReviewCoverage = (input: {
-  readonly shape: ReviewShape;
-  readonly files: ReadonlyArray<ChangedFile>;
-  readonly totalFiles: number;
-  readonly anchorFiles: ReadonlyArray<ChangedFile>;
-  readonly totalAnchorFiles: number;
-  readonly events: ReadonlyArray<RunEvent>;
-}): ReviewCoverage => assessReviewPipeline(input).coverage;
-
-/** Host-verified summaries from successful general discovery passes only. */
-export const collectUnitFileSummaries = (
-  events: ReadonlyArray<RunEvent>,
-): ReadonlyArray<WalkthroughEntry> => {
-  const trace = toolTrace(events);
-  return delegationDeclarations(trace).flatMap(({ id, request }) => {
-    if (request.phase !== "discovery" || request.perspective !== "general") return [];
-    const success = trace.succeeded.get(id);
-    if (success === undefined || trace.failed.has(id)) return [];
-    const result = Schema.decodeUnknownOption(FileReviewUnitResult)(success.result);
-    if (
-      Option.isNone(result) ||
-      result.value.phase !== "discovery" ||
-      result.value.workId !== request.workId ||
-      result.value.unitId !== request.unitId
-    ) {
-      return [];
-    }
-    const assigned = new Set(request.paths);
-    return result.value.fileSummaries.filter((entry) => assigned.has(entry.path));
   });
 };

--- a/packages/pr-review/src/internal/factory.ts
+++ b/packages/pr-review/src/internal/factory.ts
@@ -4,19 +4,13 @@ import {
   AgentPolicy,
   getToolExecutionClass,
   IdGenerator,
-  SubagentReservationsMemoryLive,
   type AgentPolicyInput,
   type UsageBudgetLimits,
 } from "effect-agent";
 import { Toolkit, type LanguageModel, type Model, type Tool } from "effect/unstable/ai";
 
 import type { ChangedFile } from "./diff.ts";
-import {
-  fanOutHandlersLayerFor,
-  FanOutCoordinatorToolkitLayer,
-  FileReviewToolkitLayer,
-  makeFanOutReviewSuite,
-} from "./fan-out.ts";
+import { makeFileReviewerDefinition } from "./fan-out.ts";
 import { computeChangesetFingerprint } from "./fingerprint.ts";
 import { compileIgnoreGlobs, ignoringPullRequestSourceLayer } from "./ignore.ts";
 import {
@@ -35,6 +29,7 @@ import {
 import { buildProfileMission, computeProfileFingerprint } from "./review-state.ts";
 import {
   buildReviewMission,
+  executeFanOutReview,
   executeReview,
   fanOutReviewBudgetLimits,
   reviewBudgetLimits,
@@ -244,8 +239,6 @@ const make = <
         signature,
         modelLabel: options.modelLabel,
         runUrl: runOptions.runUrl,
-        usageScope: "run",
-        reviewShape: "flat",
       }).pipe(Effect.provide(Layer.mergeAll(ReviewToolkitLayer, IdGenerator.layer)), Effect.scoped),
       options.ignore,
     );
@@ -264,77 +257,68 @@ const make = <
   } as const;
 };
 
-/** Options accepted by `PrReview.makeFanOut` (the delegating reviewer). */
+/** Options accepted by `PrReview.makeFanOut` (the host-scheduled pipeline). */
 export interface PrReviewFanOutOptions<
   Provider,
   ModelProvides,
   ModelRequires,
 > extends PrReviewSharedOptions {
-  /** The Effect AI Model bound to both the coordinator and its children. */
+  /** The Effect AI Model bound to every child review pass. */
   readonly model: Model.Model<Provider, LanguageModel.LanguageModel | ModelProvides, ModelRequires>;
   /**
    * Static guidance injected into every child reviewer's instructions. The
-   * coordinator's mission never crosses the delegation boundary, so
+   * pipeline schedules children from the deterministic plan, so
    * mission-dependent guidance cannot exist for children.
    */
   readonly guidance?: string | ReadonlyArray<string> | undefined;
 }
 
 /**
- * Build the fan-out reviewer: a coordinator schedules host-planned general
- * and specialist discovery plus independent candidate verification through
- * attached ephemeral children. Host code reconstructs publication only from
- * exactly confirmed candidates. Child and coordinator execution bounds are
- * packaged and not configurable here — the delegation reservation mirrors
- * the child policy, and letting the two drift apart is a published-API hazard.
+ * Build the fan-out reviewer: host code schedules host-planned general and
+ * specialist discovery plus independent candidate verification directly as
+ * bounded child runs — there is no coordinator model and no delegation tool,
+ * so review assurance cannot fail on scheduling compliance. Host code
+ * composes publication only from exactly confirmed candidates. Child
+ * execution bounds are packaged and not configurable here.
  */
 const makeFanOut = <Provider, ModelProvides, ModelRequires>(
   options: PrReviewFanOutOptions<Provider, ModelProvides, ModelRequires>,
 ) => {
-  const suite = makeFanOutReviewSuite({
-    guidance: options.guidance,
-    maxFindings: options.maxFindings,
-  });
-  // Structural bindings for the same reason as in `make` above.
-  const binding = Object.freeze({ definition: suite.parent, model: options.model });
-  const childBinding = Object.freeze({ definition: suite.child, model: options.model });
+  const child = makeFileReviewerDefinition({ guidance: options.guidance });
+  // Structural binding for the same reason as in `make` above.
+  const childBinding = Object.freeze({ definition: child, model: options.model });
 
-  // The coordinator's rendered instructions (mission, guidance, findings
-  // bound, contract) plus the review-shaping options they do not carry: the
-  // child guidance, the host knobs, and the model binding descriptor.
+  // Everything that shapes this pipeline's output: the child instructions
+  // (guidance included) plus the host knobs the children do not carry.
   const guidanceLines =
     options.guidance === undefined
       ? []
       : typeof options.guidance === "string"
         ? [options.guidance]
         : options.guidance;
-  const signature = (mission: ReviewMission): string =>
+  const signature = (_mission: ReviewMission): string =>
     [
-      suite.parent.instructions(mission),
+      "pr-review-fan-out-host-scheduled-v1",
       `childGuidance=${JSON.stringify(guidanceLines)}`,
+      `maxFindings=${clampMaxFindings(options.maxFindings)}`,
       `applyVerdict=${String(options.applyVerdict ?? false)}`,
       ...(options.modelLabel === undefined ? [] : [`model=${options.modelLabel}`]),
     ].join(" ");
   const profileSignature = (_mission: ReviewMission): string =>
     [
-      // v3 invalidates continuity produced before complete evidence sharding,
-      // universal specialist scrutiny, and request-bound result projection.
-      "pr-review-profile-v3-sharded-request-bound-assurance",
+      // v4 invalidates continuity produced by the coordinator-scheduled
+      // pipeline; the host now schedules every pass and retries failures.
+      "pr-review-profile-v4-host-scheduled",
       JSON.stringify(guidanceLines),
       JSON.stringify(options.ignore ?? []),
       `maxFindings=${clampMaxFindings(options.maxFindings)}`,
       `applyVerdict=${String(options.applyVerdict ?? false)}`,
       ...(options.modelLabel === undefined ? [] : [`model=${options.modelLabel}`]),
-    ].join("\u0000");
-  const delegationLayer = fanOutHandlersLayerFor(suite.delegation)(childBinding).pipe(
-    Layer.provide(
-      Layer.mergeAll(FileReviewToolkitLayer, SubagentReservationsMemoryLive, IdGenerator.layer),
-    ),
-  );
+    ].join(" ");
 
   const run = (runOptions: RunReviewOptions = {}) =>
     provideIgnore(
-      executeReview(binding, {
+      executeFanOutReview(childBinding, {
         post: runOptions.post ?? false,
         applyVerdict: options.applyVerdict ?? false,
         limits: options.budget ?? fanOutReviewBudgetLimits,
@@ -342,20 +326,12 @@ const makeFanOut = <Provider, ModelProvides, ModelRequires>(
         signature,
         modelLabel: options.modelLabel,
         runUrl: runOptions.runUrl,
-        usageScope: "coordinator",
-        reviewShape: "fan-out",
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(FanOutCoordinatorToolkitLayer, delegationLayer, IdGenerator.layer),
-        ),
-        Effect.scoped,
-      ),
+      }).pipe(Effect.provide(IdGenerator.layer), Effect.scoped),
       options.ignore,
     );
 
   return {
-    definition: suite.parent,
-    binding,
+    definition: child,
     childBinding,
     run,
     fingerprint: makeFingerprint(signature, options.ignore),

--- a/packages/pr-review/src/internal/factory.ts
+++ b/packages/pr-review/src/internal/factory.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schema } from "effect";
 import {
   Agent,
   AgentPolicy,
@@ -296,9 +296,12 @@ const makeFanOut = <Provider, ModelProvides, ModelRequires>(
       : typeof options.guidance === "string"
         ? [options.guidance]
         : options.guidance;
-  const signature = (_mission: ReviewMission): string =>
+  const signature = (mission: ReviewMission): string =>
     [
       "pr-review-fan-out-host-scheduled-v1",
+      // Children never see the mission, but the documented skip-unchanged
+      // contract includes pull-request framing, so the fingerprint keeps it.
+      JSON.stringify(Schema.encodeSync(ReviewMission)(mission)),
       `childGuidance=${JSON.stringify(guidanceLines)}`,
       `maxFindings=${clampMaxFindings(options.maxFindings)}`,
       `applyVerdict=${String(options.applyVerdict ?? false)}`,

--- a/packages/pr-review/src/internal/fan-out-scripted.ts
+++ b/packages/pr-review/src/internal/fan-out-scripted.ts
@@ -1,83 +1,14 @@
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
-import { LanguageModel, Model, type Response } from "effect/unstable/ai";
+import { LanguageModel, Model } from "effect/unstable/ai";
 
-import { FileReviewReport, FileReviewRequest } from "./fan-out.ts";
-import { CodeReview } from "./review-agent.ts";
-import { makePromptKeyedModel, scriptedFinalParts, scriptedToolTurn } from "./scripted.ts";
+import { FileReviewReport } from "./fan-out.ts";
+import { scriptedFinalParts } from "./scripted.ts";
 
-// Deterministic offline models for the complete fan-out protocol. Decisions
-// key on committed Tool Call IDs or work IDs in each prompt, never call order,
-// so bounded child concurrency cannot make the fixtures flaky.
-
-export const OFFLINE_UNITS_CALL_ID = "units-1";
-
-export const offlineUnitCallId = (workId: string): string => `delegate-${workId}`;
-
-export type OfflineUnitCall = FileReviewRequest;
-
-const scriptedUnitCallId = (calls: ReadonlyArray<OfflineUnitCall>, index: number): string => {
-  const call = calls[index];
-  if (call === undefined) return "delegate-none";
-  const occurrence = calls
-    .slice(0, index + 1)
-    .filter((candidate) => candidate.workId === call.workId).length;
-  const base = offlineUnitCallId(call.workId);
-  return occurrence === 1 ? base : `${base}-${occurrence}`;
-};
-
-export const makeOfflineFanOutCoordinatorModel = (script: {
-  readonly discoveryCalls: ReadonlyArray<OfflineUnitCall>;
-  readonly verificationCalls: ReadonlyArray<OfflineUnitCall>;
-  readonly review: CodeReview;
-}) => {
-  const firstDiscovery = scriptedUnitCallId(script.discoveryCalls, 0);
-  const firstVerification = scriptedUnitCallId(script.verificationCalls, 0);
-  return makePromptKeyedModel("pr-fanout-coordinator-offline", (promptJson) => {
-    if (script.discoveryCalls.length === 0 && promptJson.includes(OFFLINE_UNITS_CALL_ID)) {
-      return scriptedFinalParts(JSON.stringify(Schema.encodeSync(CodeReview)(script.review)));
-    }
-    if (
-      script.verificationCalls.length === 0
-        ? promptJson.includes(firstDiscovery)
-        : promptJson.includes(firstVerification)
-    ) {
-      return scriptedFinalParts(JSON.stringify(Schema.encodeSync(CodeReview)(script.review)));
-    }
-    if (promptJson.includes(firstDiscovery)) {
-      return scriptedToolTurn(
-        ...script.verificationCalls.map(
-          (call, index): Response.StreamPartEncoded => ({
-            type: "tool-call",
-            id: scriptedUnitCallId(script.verificationCalls, index),
-            name: "delegate_file_review",
-            params: Schema.encodeSync(FileReviewRequest)(call),
-            providerExecuted: false,
-          }),
-        ),
-      );
-    }
-    if (promptJson.includes(OFFLINE_UNITS_CALL_ID)) {
-      return scriptedToolTurn(
-        ...script.discoveryCalls.map(
-          (call, index): Response.StreamPartEncoded => ({
-            type: "tool-call",
-            id: scriptedUnitCallId(script.discoveryCalls, index),
-            name: "delegate_file_review",
-            params: Schema.encodeSync(FileReviewRequest)(call),
-            providerExecuted: false,
-          }),
-        ),
-      );
-    }
-    return scriptedToolTurn({
-      type: "tool-call",
-      id: OFFLINE_UNITS_CALL_ID,
-      name: "list_review_units",
-      params: { scope: "all" },
-      providerExecuted: false,
-    });
-  });
-};
+// Deterministic offline child models for the host-scheduled fan-out pipeline.
+// Decisions key on the work ID committed into each child's instructions,
+// never call order, so bounded pass concurrency cannot make fixtures flaky.
+// Each work ID carries a SEQUENCE of outcomes consumed per call, so tests can
+// script "fail once, then settle" and pin the pipeline's bounded retry.
 
 export type OfflineUnitOutcome =
   | { readonly _tag: "report"; readonly report: FileReviewReport }
@@ -85,13 +16,15 @@ export type OfflineUnitOutcome =
 
 export interface OfflineUnitScript {
   readonly workId: string;
-  readonly outcome: OfflineUnitOutcome;
+  /** Consumed one per child call for this work ID; the last outcome repeats. */
+  readonly outcomes: ReadonlyArray<OfflineUnitOutcome>;
 }
 
 export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitScript>) =>
   Effect.gen(function* () {
     const calls = yield* Ref.make(0);
     const prompts = yield* Ref.make<ReadonlyArray<string>>([]);
+    const callsByWorkId = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
     const model = Model.make(
       "scripted",
       "pr-fanout-file-reviewer-offline",
@@ -115,10 +48,23 @@ export const makeOfflineFileReviewerModel = (scripts: ReadonlyArray<OfflineUnitS
                 }
                 const [selected] = script;
                 if (selected === undefined) return yield* Effect.die("unreachable scripted match");
+                const occurrence = yield* Ref.modify(callsByWorkId, (byWorkId) => {
+                  const count = byWorkId.get(selected.workId) ?? 0;
+                  const next = new Map(byWorkId);
+                  next.set(selected.workId, count + 1);
+                  return [count, next] as const;
+                });
+                const outcome =
+                  selected.outcomes[Math.min(occurrence, selected.outcomes.length - 1)];
+                if (outcome === undefined) {
+                  return yield* Effect.die(
+                    new Error(`Work ID ${selected.workId} scripts no outcomes`),
+                  );
+                }
                 return Stream.fromIterable(
                   scriptedFinalParts(
-                    selected.outcome._tag === "report"
-                      ? JSON.stringify(Schema.encodeSync(FileReviewReport)(selected.outcome.report))
+                    outcome._tag === "report"
+                      ? JSON.stringify(Schema.encodeSync(FileReviewReport)(outcome.report))
                       : "this is not valid review JSON",
                   ),
                 );

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -723,7 +723,7 @@ const composeSummary = (plan: ReviewUnitPlan, assurance: ReviewAssurance): strin
   }
   if (plan.undiffablePaths.length > 0) {
     parts.push(
-      `${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence.`,
+      `${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence and keep input coverage incomplete; exclude such paths with ignore globs when that is intended.`,
     );
   }
   if (plan.unassignedPaths.length > 0 || plan.unassignedEvidenceShardCount > 0) {
@@ -851,14 +851,18 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
       review,
       assurance,
       plan,
-      // Retryable scope: unsettled units plus reviewable paths the bounded
-      // plan could not fit this run — the next run reviews them in
-      // installments instead of losing them behind an advancing baseline.
+      // Everything not fully reviewed this run and still part of the pull
+      // request carries forward, so the baseline can advance without ever
+      // moving unreviewed scope behind a green check: failed units retry,
+      // whole overflow files review in later installments, and partial or
+      // undiffable files keep the check fail-closed until they are reviewed,
+      // removed, or explicitly ignored.
       unreviewedPaths: [
         ...new Set([
           ...outcomes.flatMap((outcome) => outcome.unreviewedPaths),
           ...plan.unassignedPaths,
           ...plan.partialEvidencePaths,
+          ...plan.undiffablePaths,
         ]),
       ].sort(),
       turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0),

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -1,20 +1,20 @@
-import { Effect, Layer, Schema } from "effect";
+import { Effect, Schema } from "effect";
 import {
   Agent,
   AgentPolicy,
-  Subagent,
-  SubagentPolicy,
-  SubagentRuntime,
-  ToolExecutionClass,
+  AgentRuntime,
   ToolResultBounds,
+  type BudgetAdapterError,
+  type BudgetExceeded,
+  type RunBudgetHook,
   type RuntimeBinding,
 } from "effect-agent";
-import { Tool, Toolkit } from "effect/unstable/ai";
+import { Toolkit } from "effect/unstable/ai";
 
 import { anchorViolation } from "./anchors.ts";
-import { ChangedFileStatus, ChangedPath } from "./diff.ts";
+import { boundedListReason, FailedReviewPass, ReviewAssurance } from "./coverage.ts";
+import { ChangedFileStatus, ChangedPath, type ChangedFile } from "./diff.ts";
 import {
-  clampMaxFindings,
   CodeReview,
   fileReviewEvidenceChunks,
   MAX_PATCH_CHARS,
@@ -22,7 +22,6 @@ import {
   REVIEW_TOOL_RESULT_MAX_BYTES,
   ReviewConcern,
   ReviewFinding,
-  ReviewMission,
   WalkthroughEntry,
 } from "./review-agent.ts";
 import {
@@ -31,23 +30,31 @@ import {
   MAX_UNIT_FILES,
   findingAnchorInUnitEvidence,
   planReviewUnits,
+  rankAndDedupeConcerns,
+  rankAndDedupeFindings,
   ReviewEvidenceShardId,
   ReviewPassId,
   ReviewRiskCategory,
   ReviewUnitId,
-  ReviewUnitPlan,
+  type ReviewDiscoveryPass,
+  type ReviewUnit,
+  type ReviewUnitPlan,
 } from "./review-units.ts";
-import { PullRequestSource, PullRequestSourceFailure } from "./source.ts";
 
 // ---------------------------------------------------------------------------
 // The assured fan-out reviewer is a bounded, deterministic three-stage
-// pipeline driven through attached S1 children:
+// pipeline scheduled ENTIRELY by host code:
 //
 //   host plan -> independent discovery passes -> independent verification
 //
-// Host code owns partitioning, risk classification, bounded evidence, exact
-// pass settlement, candidate provenance, and the final confirmed-candidate
-// fold. The coordinator only schedules the declared work and writes prose.
+// `planReviewUnits` is a pure function, so dispatch is plain Effect structured
+// concurrency over its exact work list — there is no coordinator model, no
+// delegation tool, and therefore no prompt-compliance failure mode. A pass
+// that fails (child fault, malformed output) is retried once; a pass that
+// still fails is recorded and its unit's paths are carried forward as
+// retryable unreviewed scope instead of freezing the run's continuity
+// baseline. A finding whose anchor is invalid is discarded and counted —
+// never a reason to reject the whole pass.
 // ---------------------------------------------------------------------------
 
 /** One discovery pass returns at most this many anchored candidates. */
@@ -59,8 +66,15 @@ export const MAX_CHILD_CONCERNS = 3;
 /** Every unit receives independent general and specialist discovery passes. */
 export const MAX_UNIT_CANDIDATES = (MAX_CHILD_FINDINGS + MAX_CHILD_CONCERNS) * 2;
 
-/** General + specialist discovery for every unit, then one verifier per unit. */
+/**
+ * General + specialist discovery for every unit, then one verifier per unit.
+ * The one-retry budget doubles the worst-case child Run count, but the
+ * schedule itself never exceeds this bound.
+ */
 export const MAX_REVIEW_CHILDREN = MAX_REVIEW_UNITS * 3;
+
+/** Bounded structured concurrency across units; passes inside a unit are sequential. */
+export const REVIEW_UNIT_CONCURRENCY = 4;
 
 /** Structural minimum for a child that exposes no tools. */
 export const MAX_FILE_REVIEW_TOOL_CALLS = 1;
@@ -128,8 +142,8 @@ export class CandidateAssessment extends Schema.Class<CandidateAssessment>(
 
 /**
  * Exact suggestion settlement shape: a carried suggestion must be settled and
- * nothing else may be. Enforced identically by the live delegation projection
- * and the independent host coverage fold.
+ * nothing else may be. A verification report that violates it is treated as a
+ * misbehaving pass and retried within the pass budget.
  */
 export const assessmentSettlesSuggestionExactly = (
   assessment: CandidateAssessment,
@@ -181,21 +195,6 @@ const EvidenceShardIds = Schema.Array(ReviewEvidenceShardId)
   .check(Schema.isMinLength(1))
   .check(Schema.isMaxLength(MAX_UNIT_EVIDENCE_SHARDS));
 
-/** Strict-object coordinator request for either discovery or verification. */
-export class FileReviewRequest extends Schema.Class<FileReviewRequest>(
-  "@effect-agent/pr-review/FileReviewRequest",
-)({
-  phase: ReviewWorkPhase,
-  workId: ReviewPassId,
-  unitId: ReviewUnitId,
-  paths: UnitPaths,
-  evidenceShardIds: EvidenceShardIds,
-  perspective: ReviewWorkPerspective,
-  riskCategories: RiskCategories,
-  /** Empty for discovery; the exact discovered set for unit verification. */
-  candidates: Candidates,
-}) {}
-
 /** One complete host-selected evidence shard supplied to a review child. */
 export class FileReviewEvidence extends Schema.Class<FileReviewEvidence>(
   "@effect-agent/pr-review/FileReviewEvidence",
@@ -220,6 +219,7 @@ export class FileReviewBrief extends Schema.Class<FileReviewBrief>(
   evidenceShardIds: EvidenceShardIds,
   perspective: ReviewWorkPerspective,
   riskCategories: RiskCategories,
+  /** Empty for discovery; the exact discovered set for unit verification. */
   candidates: Candidates,
   evidence: Schema.Array(FileReviewEvidence)
     .check(Schema.isMinLength(1))
@@ -239,35 +239,19 @@ export class FileReviewReport extends Schema.Class<FileReviewReport>(
   assessments: Schema.Array(CandidateAssessment).check(Schema.isMaxLength(MAX_UNIT_CANDIDATES)),
 }) {}
 
-/** Bounded coordinator-visible result with host-assigned candidate IDs. */
-export class FileReviewUnitResult extends Schema.Class<FileReviewUnitResult>(
-  "@effect-agent/pr-review/FileReviewUnitResult",
-)({
-  phase: ReviewWorkPhase,
-  workId: ReviewPassId,
-  unitId: ReviewUnitId,
-  candidates: Candidates,
-  fileSummaries: Schema.Array(WalkthroughEntry).check(Schema.isMaxLength(MAX_UNIT_FILES)),
-  assessments: Schema.Array(CandidateAssessment).check(Schema.isMaxLength(MAX_UNIT_CANDIDATES)),
-}) {}
-
-export class FileReviewUnitFailed extends Schema.TaggedError<FileReviewUnitFailed>()(
-  "FileReviewUnitFailed",
-  {
-    childErrorTag: Schema.NonEmptyString.check(Schema.isMaxLength(256)),
-    message: Schema.String.check(Schema.isMaxLength(400)),
-  },
-) {}
-
-export class FileReviewWorkRejected extends Schema.TaggedError<FileReviewWorkRejected>()(
-  "FileReviewWorkRejected",
+/**
+ * A structurally valid child report that does not answer the scheduled pass:
+ * wrong identity, phase-inapplicable fields, or an inexact assessment set.
+ * Retried once like any other pass fault, because it is model misbehavior,
+ * not evidence about the code under review.
+ */
+export class ReviewPassMisbehaved extends Schema.TaggedError<ReviewPassMisbehaved>()(
+  "ReviewPassMisbehaved",
   {
     workId: ReviewPassId,
     reason: Schema.NonEmptyString.check(Schema.isMaxLength(600)),
   },
 ) {}
-
-export const FileReviewFailure = Schema.Union([FileReviewUnitFailed, FileReviewWorkRejected]);
 
 export interface FanOutInstructionOptions {
   readonly guidance?: string | ReadonlyArray<string> | undefined;
@@ -327,9 +311,6 @@ export const fileReviewerInstructions = makeFileReviewerInstructions();
 
 export const FileReviewToolkit = Toolkit.empty;
 
-/** Compatibility export: the evidence-only child has no handler requirements. */
-export const FileReviewToolkitLayer = Layer.empty;
-
 export const defaultFileReviewerPolicy = AgentPolicy.make({
   maxTurns: 6,
   maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
@@ -344,121 +325,74 @@ export const defaultFileReviewerPolicy = AgentPolicy.make({
   onExhaustion: "fail",
 });
 
-export const fileReviewPolicy = SubagentPolicy.make({
-  maxChildren: MAX_REVIEW_CHILDREN,
-  maxConcurrency: 4,
-  maxTurns: 6,
-  maxToolCalls: MAX_FILE_REVIEW_TOOL_CALLS,
-  maxDuration: "6 minutes",
-  maxResultBytes: 256 * 1024,
-});
-
-export const mapFileReviewChildFailure = (failure: {
-  readonly _tag: string;
-  readonly message?: string;
-}): FileReviewUnitFailed =>
-  FileReviewUnitFailed.make({
-    childErrorTag: failure._tag,
-    message: (failure.message ?? "").slice(0, 400),
+export const makeFileReviewerDefinition = (options: FanOutInstructionOptions = {}) =>
+  Agent.define("pr-review-worker", {
+    input: FileReviewBrief,
+    output: FileReviewReport,
+    instructions: makeFileReviewerInstructions(options),
+    toolkit: FileReviewToolkit,
+    policy: defaultFileReviewerPolicy,
+    description:
+      "Perform one bounded discovery or independent candidate-verification pass over host-supplied pull-request evidence.",
+    metadata: { deploymentClass: "E", surface: "read-only", stage: "discovery-verification" },
   });
 
-const sameStrings = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
-  left.length === right.length && left.every((value, index) => value === right[index]);
+export const FileReviewer = makeFileReviewerDefinition();
 
-const rejectWork = (workId: string, reason: string) =>
-  FileReviewWorkRejected.make({ workId, reason });
+/** The exact child binding shape the host pipeline schedules. */
+export type FileReviewerBinding<Provider, ModelProvides, ModelRequires> = RuntimeBinding<
+  typeof FileReviewBrief,
+  typeof FileReviewReport,
+  ReturnType<typeof makeFileReviewerInstructions>,
+  Toolkit.Tools<typeof FileReviewToolkit>,
+  Provider,
+  ModelProvides,
+  ModelRequires
+>;
 
-/** Validate coordinator scheduling against the current deterministic plan. */
-const prepareReviewBrief = (request: FileReviewRequest) =>
+// ---------------------------------------------------------------------------
+// Host pipeline.
+// ---------------------------------------------------------------------------
+
+/** Everything one settled fan-out pipeline run produced, before publication. */
+export interface FanOutPipelineOutcome {
+  readonly review: CodeReview;
+  readonly assurance: ReviewAssurance;
+  readonly plan: ReviewUnitPlan;
+  /** Paths of units with an unsettled pass — retryable scope for the next run. */
+  readonly unreviewedPaths: ReadonlyArray<string>;
+  /** Total settled child turns across every scheduled pass. */
+  readonly turns: number;
+}
+
+export interface FanOutPipelineInput {
+  readonly files: ReadonlyArray<ChangedFile>;
+  readonly anchorFiles: ReadonlyArray<ChangedFile>;
+  readonly totalChangedFiles: number;
+  readonly maxFindings?: number | undefined;
+  /** Shared run budget observed by every child pass. */
+  readonly budget?: RunBudgetHook<BudgetExceeded | BudgetAdapterError> | undefined;
+}
+
+const candidateOrdinal = (index: number): string => String(index + 1).padStart(3, "0");
+
+/** Rebuild one unit's complete evidence from the same snapshot the plan used. */
+const unitEvidence = (
+  unit: ReviewUnit,
+  files: ReadonlyArray<ChangedFile>,
+): Effect.Effect<ReadonlyArray<FileReviewEvidence>> =>
   Effect.gen(function* () {
-    const source = yield* PullRequestSource;
-    const mapSourceFailure = (failure: PullRequestSourceFailure) =>
-      rejectWork(
-        request.workId,
-        `pull-request source ${failure.operation} failed: ${failure.reason}`.slice(0, 600),
-      );
-    const files = yield* source.changedFiles.pipe(Effect.mapError(mapSourceFailure));
-    const metadata = yield* source.metadata.pipe(Effect.mapError(mapSourceFailure));
-    const plan = planReviewUnits(files, { totalChangedFiles: metadata.totalChangedFiles });
-    const unit = plan.units.find((candidate) => candidate.unitId === request.unitId);
-    if (
-      unit === undefined ||
-      !sameStrings(request.paths, unit.paths) ||
-      !sameStrings(
-        request.evidenceShardIds,
-        unit.evidenceShards.map((shard) => shard.shardId),
-      )
-    ) {
-      return yield* rejectWork(request.workId, "request does not match a host-planned unit");
-    }
-
-    if (request.phase === "discovery") {
-      const pass = plan.discoveryPasses.find((candidate) => candidate.passId === request.workId);
-      if (
-        pass === undefined ||
-        pass.unitId !== request.unitId ||
-        !sameStrings(pass.paths, request.paths) ||
-        !sameStrings(pass.evidenceShardIds, request.evidenceShardIds) ||
-        pass.perspective !== request.perspective ||
-        !sameStrings(pass.riskCategories, request.riskCategories) ||
-        request.candidates.length !== 0
-      ) {
-        return yield* rejectWork(request.workId, "discovery request does not match the host plan");
-      }
-    } else {
-      if (
-        request.workId !== `${request.unitId}-verification` ||
-        request.perspective !== "candidate-verification" ||
-        !sameStrings(request.riskCategories, unit.riskCategories) ||
-        request.candidates.length === 0
-      ) {
-        return yield* rejectWork(
-          request.workId,
-          "verification request does not match the host-planned unit",
-        );
-      }
-      const candidateIds = new Set<string>();
-      const candidateSubjects = new Set<string>();
-      const allowed = new Set(unit.paths);
-      for (const candidate of request.candidates) {
-        const subjectKey = reviewCandidateSubjectKey(candidate);
-        if (
-          candidateIds.has(candidate.candidateId) ||
-          candidateSubjects.has(subjectKey) ||
-          candidate.unitId !== unit.unitId ||
-          candidate.evidencePaths.some((path) => !allowed.has(path)) ||
-          (candidate._tag === "FindingCandidate" && !allowed.has(candidate.finding.path))
-        ) {
-          return yield* rejectWork(
-            request.workId,
-            "verification candidates are duplicated or outside the planned unit",
-          );
-        }
-        candidateIds.add(candidate.candidateId);
-        candidateSubjects.add(subjectKey);
-      }
-    }
-
     const byPath = new Map(files.map((file) => [file.path, file] as const));
     const evidence: Array<FileReviewEvidence> = [];
     for (const shard of unit.evidenceShards) {
       const file = byPath.get(shard.path);
-      if (file === undefined) {
-        return yield* rejectWork(
-          request.workId,
-          `planned evidence path is unavailable: ${shard.path}`,
-        );
-      }
-      const chunks = fileReviewEvidenceChunks(file);
-      const chunk = chunks[shard.ordinal - 1];
-      if (
-        chunk === undefined ||
-        chunks.length !== shard.total ||
-        chunk.annotatedPatch.length !== shard.evidenceChars
-      ) {
-        return yield* rejectWork(
-          request.workId,
-          `planned evidence shard no longer matches source: ${shard.shardId}`,
+      const chunk =
+        file === undefined ? undefined : fileReviewEvidenceChunks(file)[shard.ordinal - 1];
+      if (file === undefined || chunk === undefined) {
+        // The plan and this evidence derive from the same immutable snapshot
+        // via the same pure function; a mismatch is a host defect, not input.
+        return yield* Effect.die(
+          new Error(`planned evidence shard has no source: ${shard.shardId} (${shard.path})`),
         );
       }
       evidence.push(
@@ -473,303 +407,460 @@ const prepareReviewBrief = (request: FileReviewRequest) =>
         }),
       );
     }
-    return FileReviewBrief.make({ ...request, evidence });
+    return evidence;
   });
 
-const candidateOrdinal = (index: number): string => String(index + 1).padStart(3, "0");
+interface SettledPass {
+  readonly report: FileReviewReport;
+  readonly turns: number;
+}
 
-const projectReviewResult = (
+type PassOutcome =
+  | ({ readonly _tag: "settled" } & SettledPass)
+  | { readonly _tag: "failed"; readonly errorTag: string };
+
+const misbehaved = (workId: string, reason: string) =>
+  ReviewPassMisbehaved.make({ workId, reason: reason.slice(0, 600) });
+
+/** Validate that a verification report assesses exactly the scheduled candidates. */
+const validateVerificationReport = (
+  brief: FileReviewBrief,
   report: FileReviewReport,
-  context: { readonly budgetExhausted: boolean },
-  request: FileReviewRequest,
-) => {
-  if (context.budgetExhausted) {
-    return Effect.fail(
-      rejectWork(report.workId, "review work exhausted its budget before exact settlement"),
-    );
+): ReviewPassMisbehaved | undefined => {
+  if (report.findings.length > 0 || report.concerns.length > 0 || report.fileSummaries.length > 0) {
+    return misbehaved(brief.workId, "verification output contained discovery-only fields");
   }
-  if (
-    report.phase !== request.phase ||
-    report.workId !== request.workId ||
-    report.unitId !== request.unitId
-  ) {
-    return Effect.fail(
-      rejectWork(request.workId, "review output identity does not match the scheduled request"),
-    );
-  }
-  if (report.phase === "verification") {
-    if (
-      report.findings.length > 0 ||
-      report.concerns.length > 0 ||
-      report.fileSummaries.length > 0
-    ) {
-      return Effect.fail(
-        rejectWork(report.workId, "verification output contained discovery-only fields"),
+  const expectedById = new Map(
+    brief.candidates.map((candidate) => [candidate.candidateId, candidate] as const),
+  );
+  const assessedIds = new Set<string>();
+  for (const assessment of report.assessments) {
+    const candidate = expectedById.get(assessment.candidateId);
+    if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
+      return misbehaved(brief.workId, "verification output did not assess the exact candidate set");
+    }
+    if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
+      return misbehaved(
+        brief.workId,
+        "verification output did not settle suggestion publication exactly",
       );
     }
-    const expectedById = new Map(
-      request.candidates.map((candidate) => [candidate.candidateId, candidate] as const),
-    );
-    const assessedIds = new Set<string>();
-    for (const assessment of report.assessments) {
-      const candidate = expectedById.get(assessment.candidateId);
-      if (candidate === undefined || assessedIds.has(assessment.candidateId)) {
-        return Effect.fail(
-          rejectWork(report.workId, "verification output did not assess the exact candidate set"),
-        );
-      }
-      if (!assessmentSettlesSuggestionExactly(assessment, candidate)) {
-        return Effect.fail(
-          rejectWork(
-            report.workId,
-            "verification output did not settle suggestion publication exactly",
-          ),
-        );
-      }
-      assessedIds.add(assessment.candidateId);
-    }
-    if (assessedIds.size !== expectedById.size) {
-      return Effect.fail(
-        rejectWork(report.workId, "verification output did not assess the exact candidate set"),
-      );
-    }
-    return Effect.succeed(
-      FileReviewUnitResult.make({
-        phase: report.phase,
-        workId: report.workId,
-        unitId: report.unitId,
-        candidates: [],
-        fileSummaries: [],
-        assessments: report.assessments,
-      }),
-    );
+    assessedIds.add(assessment.candidateId);
   }
-  if (report.assessments.length > 0) {
-    return Effect.fail(
-      rejectWork(report.workId, "discovery output contained verification-only assessments"),
-    );
+  if (assessedIds.size !== expectedById.size) {
+    return misbehaved(brief.workId, "verification output did not assess the exact candidate set");
   }
-  const allowed = new Set(request.paths);
-  if (
-    report.findings.some((finding) => !allowed.has(finding.path)) ||
-    report.concerns.some((candidate) =>
-      candidate.evidencePaths.some((path) => !allowed.has(path)),
-    ) ||
-    report.fileSummaries.some((entry) => !allowed.has(entry.path))
-  ) {
-    return Effect.fail(
-      rejectWork(report.workId, "discovery output referenced evidence outside the scheduled unit"),
-    );
-  }
-  return Effect.gen(function* () {
-    const source = yield* PullRequestSource;
-    const mapSourceFailure = (failure: PullRequestSourceFailure) =>
-      rejectWork(
-        request.workId,
-        `pull-request source ${failure.operation} failed: ${failure.reason}`.slice(0, 600),
-      );
-    const files = yield* source.changedFiles.pipe(Effect.mapError(mapSourceFailure));
-    const metadata = yield* source.metadata.pipe(Effect.mapError(mapSourceFailure));
-    const anchorFiles = yield* source.anchorFiles.pipe(Effect.mapError(mapSourceFailure));
-    const unit = planReviewUnits(files, {
-      totalChangedFiles: metadata.totalChangedFiles,
-    }).units.find((candidate) => candidate.unitId === request.unitId);
-    if (unit === undefined) {
-      return yield* rejectWork(request.workId, "scheduled review unit is no longer available");
-    }
-    for (const finding of report.findings) {
-      const violation = anchorViolation(finding, anchorFiles);
-      if (violation !== undefined || !findingAnchorInUnitEvidence(finding, unit, files)) {
-        return yield* rejectWork(
-          request.workId,
-          `discovery finding has no valid anchor in its assigned evidence: ${violation ?? finding.path}`,
-        );
-      }
-    }
-    const findingCandidates = report.findings.map((finding, index) =>
-      FindingCandidate.make({
-        candidateId: `${request.workId}:finding:${candidateOrdinal(index)}`,
-        workId: request.workId,
-        unitId: request.unitId,
-        finding,
-        evidencePaths: [finding.path],
-      }),
-    );
-    const concernCandidates = report.concerns.map((candidate, index) =>
-      ConcernCandidate.make({
-        candidateId: `${request.workId}:concern:${candidateOrdinal(index)}`,
-        workId: request.workId,
-        unitId: request.unitId,
-        concern: candidate.concern,
-        evidencePaths: candidate.evidencePaths,
-      }),
-    );
-    return FileReviewUnitResult.make({
-      phase: report.phase,
-      workId: report.workId,
-      unitId: report.unitId,
-      candidates: [...findingCandidates, ...concernCandidates],
-      fileSummaries: report.fileSummaries,
-      assessments: [],
-    });
-  });
+  return undefined;
 };
 
-const delegationDescription =
-  "Run exactly one host-planned discovery or candidate-verification child. Copy every plan field and candidate verbatim; never retry failed work.";
-
-const makeFileReviewDelegation = (child: ReturnType<typeof makeFileReviewerDefinition>) =>
-  Subagent.define("delegate_file_review", {
-    description: delegationDescription,
-    target: child,
-    parameters: FileReviewRequest,
-    success: FileReviewUnitResult,
-    failure: FileReviewFailure,
-    failureMode: "return",
-    prepareInput: prepareReviewBrief,
-    projectResult: projectReviewResult,
-    policy: fileReviewPolicy,
-  });
-
-export class ListReviewUnitsQuery extends Schema.Class<ListReviewUnitsQuery>(
-  "@effect-agent/pr-review/ListReviewUnitsQuery",
-)({
-  scope: Schema.Literal("all"),
-}) {}
-
-export const ListReviewUnits = Tool.make("list_review_units", {
-  description:
-    "List deterministic bounded review units, explicit risk categories, every required discovery pass, and paths the pipeline cannot cover.",
-  parameters: ListReviewUnitsQuery,
-  success: ReviewUnitPlan,
-  failure: PullRequestSourceFailure,
-  failureMode: "error",
-  dependencies: [PullRequestSource],
-}).annotate(ToolExecutionClass, "readonly");
-
-export const FanOutCoordinatorToolkit = Toolkit.make(ListReviewUnits);
-
-export const FanOutCoordinatorToolkitLayer = FanOutCoordinatorToolkit.toLayer({
-  list_review_units: () =>
-    Effect.gen(function* () {
-      const source = yield* PullRequestSource;
-      const files = yield* source.changedFiles;
-      const metadata = yield* source.metadata;
-      return planReviewUnits(files, { totalChangedFiles: metadata.totalChangedFiles });
-    }),
-});
-
-export const makeFanOutReviewInstructions =
-  (options: FanOutInstructionOptions & { readonly maxFindings?: number | undefined } = {}) =>
-  (mission: ReviewMission): string => {
-    const maxFindings = clampMaxFindings(options.maxFindings);
-    return [
-      `You coordinate the bounded multi-pass review of pull request #${mission.number} ("${mission.title}") in ${mission.repository}.`,
-      mission.body.length > 0 ? `Author description:\n${mission.body}` : "No author description.",
-      ...staticGuidanceLines(options.guidance),
-      "1. Call list_review_units exactly once.",
-      '2. For EVERY discoveryPass, call delegate_file_review exactly once with phase "discovery", workId=passId, and the pass unitId/paths/evidenceShardIds/perspective/riskCategories verbatim; candidates must be []. Prefer one bounded parallel batch. Never retry.',
-      '3. Group candidates returned by all successful discovery passes by unit. Deterministically deduplicate byte-identical finding or concern payloads, retaining the first candidate in discoveryPass plan order. For every unit with at least one retained candidate, call delegate_file_review exactly once with phase "verification", workId "<unitId>-verification", perspective "candidate-verification", the unit paths/evidenceShardIds/riskCategories, and EVERY retained candidate copied byte-for-byte. Prefer one bounded parallel batch. Never retry.',
-      "4. Verification is authoritative: rejected candidates must not be reported. The host independently reconstructs publishable findings from exact confirmed assessments, so do not select, rewrite, downgrade, or invent findings.",
-      `5. Return ONLY CodeReview JSON. Write a concise summary of completed and failed stages. Set findings=[] and concerns=[]; the host injects exact confirmed candidates. Copy factual fileSummaries into walkthrough without invention. The host publication cap is ${maxFindings}.`,
-      "No configured pipeline can prove absence of defects. Describe settled work, never an exhaustive or defect-free review.",
-    ].join("\n");
-  };
-
-export const fanOutReviewInstructions = makeFanOutReviewInstructions();
-
-export const defaultFanOutPolicy = AgentPolicy.make({
-  maxTurns: 7,
-  maxToolCalls: 1 + MAX_REVIEW_CHILDREN,
-  maxDuration: "20 minutes",
-  toolConcurrency: 4,
-  repeatedFailureLimit: 3,
-  tokenBudget: 400_000,
-  contextTokenLimit: 150_000,
-  // Coordinator exhaustion cannot become an assured result; exact stage
-  // settlement, not this final prose, determines assurance.
-  onExhaustion: "final-answer",
-});
-
-export interface FanOutReviewSuite {
-  readonly child: ReturnType<typeof makeFileReviewerDefinition>;
-  readonly parent: ReturnType<typeof makeFanOutReviewerDefinition>;
-  readonly delegation: ReturnType<typeof makeFileReviewDelegation>;
-}
-
-const makeFileReviewerDefinition = (options: FanOutInstructionOptions = {}) =>
-  Agent.define("pr-review-worker", {
-    input: FileReviewBrief,
-    output: FileReviewReport,
-    instructions: makeFileReviewerInstructions(options),
-    toolkit: FileReviewToolkit,
-    policy: defaultFileReviewerPolicy,
-    description:
-      "Perform one bounded discovery or independent candidate-verification pass over host-supplied pull-request evidence.",
-    metadata: { deploymentClass: "E", surface: "read-only", stage: "discovery-verification" },
-  });
-
-const delegationToolFor = (delegation: ReturnType<typeof makeFileReviewDelegation>) =>
-  delegation.tool.annotate(ToolExecutionClass, "readonly");
-
-const makeFanOutReviewerDefinition = (
-  options: FanOutInstructionOptions & { readonly maxFindings?: number | undefined },
-  delegation: ReturnType<typeof makeFileReviewDelegation>,
+/**
+ * Run one scheduled pass: execute the child, decode its report, and enforce
+ * the pass contract. Any typed fault — child failure, malformed or misdirected
+ * output — is retried once; budget exhaustion is terminal because a retry
+ * would fail the same way. The settled outcome is a value either way, so one
+ * flaky pass can never fail the whole pipeline.
+ */
+const runReviewPass = <Provider, ModelProvides, ModelRequires>(
+  binding: FileReviewerBinding<Provider, ModelProvides, ModelRequires>,
+  brief: FileReviewBrief,
+  budget: RunBudgetHook<BudgetExceeded | BudgetAdapterError> | undefined,
 ) =>
-  Agent.define("pr-fanout-reviewer", {
-    input: ReviewMission,
-    output: CodeReview,
-    instructions: makeFanOutReviewInstructions(options),
-    toolkit: Toolkit.make(ListReviewUnits, delegationToolFor(delegation)),
-    policy: defaultFanOutPolicy,
-    description:
-      "Coordinate deterministic general/specialist discovery and independent candidate verification over bounded review units.",
-    metadata: {
-      deploymentClass: "E",
-      surface: "read-only",
-      delegation: "S1-attached",
-      assurance: "multi-pass",
-    },
-  });
+  Effect.gen(function* () {
+    const result = yield* AgentRuntime.run(binding, brief, {
+      ...(budget === undefined ? {} : { budget }),
+      estimateCostMicrousd: () => Effect.succeed(500),
+    });
+    const report = yield* Schema.decodeUnknownEffect(FileReviewReport)(result.output).pipe(
+      Effect.mapError((error) =>
+        misbehaved(brief.workId, `child report failed to decode: ${error.message}`),
+      ),
+    );
+    if (
+      report.phase !== brief.phase ||
+      report.workId !== brief.workId ||
+      report.unitId !== brief.unitId
+    ) {
+      return yield* misbehaved(
+        brief.workId,
+        "child report identity does not match the scheduled pass",
+      );
+    }
+    if (brief.phase === "verification") {
+      const violation = validateVerificationReport(brief, report);
+      if (violation !== undefined) return yield* violation;
+    } else if (report.assessments.length > 0) {
+      return yield* misbehaved(
+        brief.workId,
+        "discovery output contained verification-only assessments",
+      );
+    }
+    return { report, turns: result.turns } satisfies SettledPass;
+  }).pipe(
+    Effect.scoped,
+    Effect.retry({ times: 1, while: (error) => error._tag !== "BudgetExceeded" }),
+    Effect.map((settled): PassOutcome => ({ _tag: "settled", ...settled })),
+    Effect.catch((error) =>
+      Effect.succeed<PassOutcome>({ _tag: "failed", errorTag: String(error._tag).slice(0, 256) }),
+    ),
+  );
 
-export interface FanOutSuiteOptions extends FanOutInstructionOptions {
-  readonly maxFindings?: number | undefined;
+interface DiscoveryHarvest {
+  readonly candidates: ReadonlyArray<ReviewCandidate>;
+  readonly fileSummaries: ReadonlyArray<WalkthroughEntry>;
+  readonly discarded: number;
 }
 
-export const makeFanOutReviewSuite = (options: FanOutSuiteOptions = {}): FanOutReviewSuite => {
-  const child = makeFileReviewerDefinition({ guidance: options.guidance });
-  const delegation = makeFileReviewDelegation(child);
+/**
+ * Keep only findings anchored inside the pass's exact assigned evidence and
+ * concerns bound to unit paths. Everything else is discarded and counted —
+ * an invalid anchor invalidates one claim, never the pass that produced it.
+ */
+const harvestDiscovery = (
+  pass: ReviewDiscoveryPass,
+  unit: ReviewUnit,
+  files: ReadonlyArray<ChangedFile>,
+  anchorFiles: ReadonlyArray<ChangedFile>,
+  report: FileReviewReport,
+): DiscoveryHarvest => {
+  const allowed = new Set(pass.paths);
+  let discarded = 0;
+  const keptFindings: Array<ReviewFinding> = [];
+  for (const finding of report.findings) {
+    if (
+      !allowed.has(finding.path) ||
+      anchorViolation(finding, anchorFiles) !== undefined ||
+      !findingAnchorInUnitEvidence(finding, unit, files)
+    ) {
+      discarded += 1;
+      continue;
+    }
+    keptFindings.push(finding);
+  }
+  const keptConcerns: Array<DiscoveredConcern> = [];
+  for (const candidate of report.concerns) {
+    if (candidate.evidencePaths.some((path) => !allowed.has(path))) {
+      discarded += 1;
+      continue;
+    }
+    keptConcerns.push(candidate);
+  }
   return {
-    child,
-    parent: makeFanOutReviewerDefinition(options, delegation),
-    delegation,
+    candidates: [
+      ...keptFindings.map((finding, index) =>
+        FindingCandidate.make({
+          candidateId: `${pass.passId}:finding:${candidateOrdinal(index)}`,
+          workId: pass.passId,
+          unitId: pass.unitId,
+          finding,
+          evidencePaths: [finding.path],
+        }),
+      ),
+      ...keptConcerns.map((candidate, index) =>
+        ConcernCandidate.make({
+          candidateId: `${pass.passId}:concern:${candidateOrdinal(index)}`,
+          workId: pass.passId,
+          unitId: pass.unitId,
+          concern: candidate.concern,
+          evidencePaths: candidate.evidencePaths,
+        }),
+      ),
+    ],
+    fileSummaries: report.fileSummaries.filter((entry) => allowed.has(entry.path)),
+    discarded,
   };
 };
 
-const defaultSuite = makeFanOutReviewSuite();
+interface UnitReviewOutcome {
+  readonly failedPasses: ReadonlyArray<FailedReviewPass>;
+  readonly discoveredCandidates: number;
+  readonly confirmed: ReadonlyArray<{
+    readonly assessment: CandidateAssessment;
+    readonly candidate: ReviewCandidate;
+  }>;
+  readonly rejectedCandidates: number;
+  readonly unsettledCandidates: number;
+  readonly discardedFindings: number;
+  readonly walkthrough: ReadonlyArray<WalkthroughEntry>;
+  readonly turns: number;
+  readonly completedGeneralPasses: number;
+  readonly completedSpecialistPasses: number;
+  readonly requiredVerificationPasses: number;
+  readonly completedVerificationPasses: number;
+  readonly unreviewedPaths: ReadonlyArray<string>;
+}
 
-export const FileReviewer = defaultSuite.child;
-export const FanOutReviewer = defaultSuite.parent;
-export const fileReviewDelegation = defaultSuite.delegation;
-export const DelegateFileReview = delegationToolFor(fileReviewDelegation);
-export const FanOutReviewToolkit = FanOutReviewer.toolkit;
-export const FileReviewDelegationFailure = fileReviewDelegation.containedFailure;
+const reviewUnit = <Provider, ModelProvides, ModelRequires>(
+  binding: FileReviewerBinding<Provider, ModelProvides, ModelRequires>,
+  unit: ReviewUnit,
+  passes: ReadonlyArray<ReviewDiscoveryPass>,
+  input: FanOutPipelineInput,
+) =>
+  Effect.gen(function* () {
+    const evidence = yield* unitEvidence(unit, input.files);
+    const failedPasses: Array<FailedReviewPass> = [];
+    const candidates: Array<ReviewCandidate> = [];
+    const subjects = new Set<string>();
+    const walkthrough: Array<WalkthroughEntry> = [];
+    let discardedFindings = 0;
+    let turns = 0;
+    let completedGeneralPasses = 0;
+    let completedSpecialistPasses = 0;
+    for (const pass of passes) {
+      const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+      const brief = FileReviewBrief.make({
+        phase: "discovery",
+        workId: pass.passId,
+        unitId: pass.unitId,
+        paths: pass.paths,
+        evidenceShardIds: pass.evidenceShardIds,
+        perspective: pass.perspective,
+        riskCategories: pass.riskCategories,
+        candidates: [],
+        evidence,
+      });
+      const outcome = yield* runReviewPass(binding, brief, input.budget);
+      if (outcome._tag === "failed") {
+        failedPasses.push(
+          FailedReviewPass.make({ workId: pass.passId, stage, errorTag: outcome.errorTag }),
+        );
+        continue;
+      }
+      turns += outcome.turns;
+      if (stage === "specialist") {
+        completedSpecialistPasses += 1;
+      } else {
+        completedGeneralPasses += 1;
+      }
+      const harvest = harvestDiscovery(pass, unit, input.files, input.anchorFiles, outcome.report);
+      discardedFindings += harvest.discarded;
+      if (pass.perspective === "general") walkthrough.push(...harvest.fileSummaries);
+      for (const candidate of harvest.candidates) {
+        const subject = reviewCandidateSubjectKey(candidate);
+        if (subjects.has(subject)) continue;
+        subjects.add(subject);
+        candidates.push(candidate);
+      }
+    }
+    const confirmed: Array<{
+      readonly assessment: CandidateAssessment;
+      readonly candidate: ReviewCandidate;
+    }> = [];
+    let rejectedCandidates = 0;
+    let unsettledCandidates = 0;
+    let completedVerificationPasses = 0;
+    const requiredVerificationPasses = candidates.length > 0 ? 1 : 0;
+    if (candidates.length > 0) {
+      const workId = `${unit.unitId}-verification`;
+      const brief = FileReviewBrief.make({
+        phase: "verification",
+        workId,
+        unitId: unit.unitId,
+        paths: unit.paths,
+        evidenceShardIds: unit.evidenceShards.map((shard) => shard.shardId),
+        perspective: "candidate-verification",
+        riskCategories: unit.riskCategories,
+        candidates,
+        evidence,
+      });
+      const outcome = yield* runReviewPass(binding, brief, input.budget);
+      if (outcome._tag === "failed") {
+        unsettledCandidates = candidates.length;
+        failedPasses.push(
+          FailedReviewPass.make({ workId, stage: "verification", errorTag: outcome.errorTag }),
+        );
+      } else {
+        turns += outcome.turns;
+        completedVerificationPasses = 1;
+        const byId = new Map(candidates.map((candidate) => [candidate.candidateId, candidate]));
+        for (const assessment of outcome.report.assessments) {
+          const candidate = byId.get(assessment.candidateId);
+          if (candidate === undefined) continue;
+          if (assessment.disposition === "confirmed") {
+            confirmed.push({ assessment, candidate });
+          } else {
+            rejectedCandidates += 1;
+          }
+        }
+      }
+    }
+    return {
+      failedPasses,
+      discoveredCandidates: candidates.length,
+      confirmed,
+      rejectedCandidates,
+      unsettledCandidates,
+      discardedFindings,
+      walkthrough,
+      turns,
+      completedGeneralPasses,
+      completedSpecialistPasses,
+      requiredVerificationPasses,
+      completedVerificationPasses,
+      unreviewedPaths: failedPasses.length > 0 ? unit.paths : [],
+    } satisfies UnitReviewOutcome;
+  });
 
-export const fanOutHandlersLayerFor =
-  (delegation: ReturnType<typeof makeFileReviewDelegation>) =>
-  <Provider, ModelProvides, ModelRequires>(
-    childBinding: RuntimeBinding<
-      typeof FileReviewBrief,
-      typeof FileReviewReport,
-      ReturnType<typeof makeFileReviewerInstructions>,
-      Toolkit.Tools<typeof FileReviewToolkit>,
-      Provider,
-      ModelProvides,
-      ModelRequires
-    >,
-  ) =>
-    SubagentRuntime.layer(delegation, childBinding, {
-      mapChildFailure: mapFileReviewChildFailure,
+const countNoun = (count: number, noun: string): string =>
+  `${count} ${noun}${count === 1 ? "" : "s"}`;
+
+const composeSummary = (plan: ReviewUnitPlan, assurance: ReviewAssurance): string => {
+  const requiredDiscovery =
+    assurance.requiredGeneralDiscoveryPasses + assurance.requiredSpecialistPasses;
+  const completedDiscovery =
+    assurance.completedGeneralDiscoveryPasses + assurance.completedSpecialistPasses;
+  const parts = [
+    `Reviewed ${countNoun(plan.totalFiles, "changed file")} across ${countNoun(plan.units.length, "bounded unit")}: ${completedDiscovery}/${requiredDiscovery} discovery and ${assurance.completedVerificationPasses}/${assurance.requiredVerificationPasses} verification pass(es) settled; ${assurance.confirmedCandidates} of ${countNoun(assurance.discoveredCandidates, "discovered candidate")} confirmed by independent verification.`,
+  ];
+  if (assurance.failedPasses.length > 0) {
+    parts.push(
+      `${countNoun(assurance.failedPasses.length, "pass")} did not settle; the affected paths are carried forward and retried on the next run. This is a reviewer-side gap, not a code defect.`,
+    );
+  }
+  if (assurance.discardedInvalidFindings > 0) {
+    parts.push(
+      `${countNoun(assurance.discardedInvalidFindings, "candidate")} discarded for anchors or paths outside the assigned evidence.`,
+    );
+  }
+  if (plan.undiffablePaths.length > 0) {
+    parts.push(
+      `${countNoun(plan.undiffablePaths.length, "path")} had no reviewable textual evidence.`,
+    );
+  }
+  if (plan.unassignedPaths.length > 0 || plan.unassignedEvidenceShardCount > 0) {
+    parts.push(
+      "The changeset exceeded the bounded fan-out capacity; unassigned scope is reported under input coverage.",
+    );
+  }
+  parts.push(
+    "No configured pipeline can prove absence of defects; this describes settled work only.",
+  );
+  return parts.join(" ").slice(0, 4_000);
+};
+
+/**
+ * Run the complete host-scheduled fan-out pipeline over one selected
+ * changeset snapshot: plan, independent discovery, exact verification, and a
+ * deterministic host-composed CodeReview from verifier-confirmed candidates
+ * only. The verdict is derived from confirmed severities, never model prose.
+ */
+export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
+  binding: FileReviewerBinding<Provider, ModelProvides, ModelRequires>,
+  input: FanOutPipelineInput,
+) =>
+  Effect.gen(function* () {
+    const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
+    const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
+    for (const pass of plan.discoveryPasses) {
+      const passes = passesByUnit.get(pass.unitId) ?? [];
+      passes.push(pass);
+      passesByUnit.set(pass.unitId, passes);
+    }
+    const outcomes = yield* Effect.forEach(
+      plan.units,
+      (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input),
+      { concurrency: REVIEW_UNIT_CONCURRENCY },
+    );
+    const failedPasses = outcomes.flatMap((outcome) => outcome.failedPasses);
+    const unsettledCandidates = outcomes.reduce(
+      (total, outcome) => total + outcome.unsettledCandidates,
+      0,
+    );
+    const reasons: Array<string> = [];
+    if (failedPasses.length > 0) {
+      reasons.push(
+        boundedListReason(
+          "configured review passes did not settle",
+          failedPasses.map((pass) => `${pass.workId} (${pass.errorTag})`),
+        ),
+      );
+    }
+    if (unsettledCandidates > 0) {
+      reasons.push(
+        `${unsettledCandidates} discovered candidate(s) did not receive exact verification`,
+      );
+    }
+    const requiredSpecialistPasses = plan.discoveryPasses.filter(
+      (pass) => pass.perspective === "risk-specialist",
+    ).length;
+    const confirmed = outcomes.flatMap((outcome) => outcome.confirmed);
+    const assurance = ReviewAssurance.make({
+      status: reasons.length === 0 ? "settled" : "incomplete",
+      requiredGeneralDiscoveryPasses: plan.discoveryPasses.length - requiredSpecialistPasses,
+      completedGeneralDiscoveryPasses: outcomes.reduce(
+        (total, outcome) => total + outcome.completedGeneralPasses,
+        0,
+      ),
+      requiredSpecialistPasses,
+      completedSpecialistPasses: outcomes.reduce(
+        (total, outcome) => total + outcome.completedSpecialistPasses,
+        0,
+      ),
+      requiredVerificationPasses: outcomes.reduce(
+        (total, outcome) => total + outcome.requiredVerificationPasses,
+        0,
+      ),
+      completedVerificationPasses: outcomes.reduce(
+        (total, outcome) => total + outcome.completedVerificationPasses,
+        0,
+      ),
+      discoveredCandidates: outcomes.reduce(
+        (total, outcome) => total + outcome.discoveredCandidates,
+        0,
+      ),
+      confirmedCandidates: confirmed.length,
+      rejectedCandidates: outcomes.reduce(
+        (total, outcome) => total + outcome.rejectedCandidates,
+        0,
+      ),
+      unsettledCandidates,
+      discardedInvalidFindings: outcomes.reduce(
+        (total, outcome) => total + outcome.discardedFindings,
+        0,
+      ),
+      failedPasses,
+      reasons,
     });
-
-export const fanOutHandlersLayer = fanOutHandlersLayerFor(fileReviewDelegation);
+    const findings = rankAndDedupeFindings(
+      confirmed.flatMap(({ assessment, candidate }) =>
+        candidate._tag === "FindingCandidate"
+          ? [confirmedFindingForPublication(assessment, candidate)]
+          : [],
+      ),
+    );
+    const concerns = rankAndDedupeConcerns(
+      confirmed.flatMap(({ candidate }) =>
+        candidate._tag === "ConcernCandidate" ? [candidate.concern] : [],
+      ),
+    );
+    const walkthrough = outcomes.flatMap((outcome) => outcome.walkthrough);
+    const blocking =
+      findings.some((finding) => finding.severity === "blocking") ||
+      concerns.some((concern) => concern.severity === "blocking");
+    const review = CodeReview.make({
+      summary: composeSummary(plan, assurance),
+      verdict: blocking
+        ? "request-changes"
+        : findings.length > 0 || concerns.length > 0
+          ? "comment"
+          : "approve",
+      findings,
+      ...(concerns.length === 0 ? {} : { concerns }),
+      ...(walkthrough.length === 0 ? {} : { walkthrough }),
+    });
+    return {
+      review,
+      assurance,
+      plan,
+      // Retryable scope: unsettled units plus reviewable paths the bounded
+      // plan could not fit this run — the next run reviews them in
+      // installments instead of losing them behind an advancing baseline.
+      unreviewedPaths: [
+        ...new Set([
+          ...outcomes.flatMap((outcome) => outcome.unreviewedPaths),
+          ...plan.unassignedPaths,
+          ...plan.partialEvidencePaths,
+        ]),
+      ].sort(),
+      turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0),
+    } satisfies FanOutPipelineOutcome;
+  });

--- a/packages/pr-review/src/internal/profiles.ts
+++ b/packages/pr-review/src/internal/profiles.ts
@@ -38,18 +38,18 @@ export const pullRequestReviewerProfile = PullRequestReviewerProfile.make({
 export class FanOutReviewerProfile extends Schema.Class<FanOutReviewerProfile>(
   "@effect-agent/pr-review/FanOutReviewerProfile",
 )({
-  /** Ephemeral runtime: one bounded AgentRuntime.run per invocation. */
+  /** Ephemeral runtime: bounded host-scheduled child runs per invocation. */
   deploymentClass: Schema.Literal("E"),
-  /** Every model-callable tool — parent and child — is a read; none mutate. */
+  /** Every model-callable surface is evidence-only; children expose no tools. */
   readOnlyToolSurface: Schema.Literal(true),
   /** The review is posted by the host AFTER the run settles, never by a tool. */
   publicationOutsideAgentLoop: Schema.Literal(true),
   /** Child findings are untrusted; anchors are validated against the parsed diff. */
   anchorsValidatedBeforePublication: Schema.Literal(true),
-  /** S1 attached ephemeral delegation at depth 1; nested delegation is rejected. */
-  attachedEphemeralDelegation: Schema.Literal(true),
-  /** A failed unit surfaces to the coordinator as a typed failed result, never retried. */
-  failedUnitsReportedNotRetried: Schema.Literal(true),
+  /** Host code schedules every pass from the deterministic plan; no coordinator model. */
+  hostScheduledPasses: Schema.Literal(true),
+  /** A failed pass is retried once, then reported and carried as unreviewed scope. */
+  failedPassesRetriedOnceThenCarried: Schema.Literal(true),
   /** Risk categories and required specialist passes are pure host policy. */
   hostOwnedRiskClassification: Schema.Literal(true),
   /** Every host-classified high-risk unit receives a fresh specialist pass. */
@@ -69,8 +69,8 @@ export const fanOutReviewerProfile = FanOutReviewerProfile.make({
   readOnlyToolSurface: true,
   publicationOutsideAgentLoop: true,
   anchorsValidatedBeforePublication: true,
-  attachedEphemeralDelegation: true,
-  failedUnitsReportedNotRetried: true,
+  hostScheduledPasses: true,
+  failedPassesRetriedOnceThenCarried: true,
   hostOwnedRiskClassification: true,
   redundantHighRiskDiscovery: true,
   independentCandidateVerification: true,

--- a/packages/pr-review/src/internal/render.ts
+++ b/packages/pr-review/src/internal/render.ts
@@ -2,7 +2,7 @@ import { Schema } from "effect";
 
 import { anchorViolation } from "./anchors.ts";
 export { anchorViolation } from "./anchors.ts";
-import type { ReviewAssurance, ReviewCoverage, ReviewInputCoverage } from "./coverage.ts";
+import type { ReviewAssurance, ReviewInputCoverage } from "./coverage.ts";
 import type { ChangedFile } from "./diff.ts";
 import { renderFingerprintMarker } from "./fingerprint.ts";
 import {
@@ -215,27 +215,27 @@ const renderVerdictCallout = (
   options: {
     readonly carriedFindings?: ReadonlyArray<ReviewFinding> | undefined;
     readonly carriedConcerns?: ReadonlyArray<ReviewConcern> | undefined;
-    readonly coverage?: ReviewCoverage | undefined;
     readonly inputCoverage?: ReviewInputCoverage | undefined;
     readonly assurance?: ReviewAssurance | undefined;
+    readonly unreviewedPaths?: ReadonlyArray<string> | undefined;
   },
 ): string => {
   const counts = severityCounts(review, options.carriedFindings, options.carriedConcerns);
-  if (
-    options.inputCoverage?.status === "incomplete" ||
-    (options.inputCoverage === undefined && options.coverage?.status === "incomplete")
-  ) {
-    const suffix =
-      counts.blocking > 0 ? ` It also has ${countNoun(counts.blocking, "blocking finding")}.` : "";
-    return `> [!CAUTION]\n> Input coverage is incomplete — the check must not pass.${suffix}`;
-  }
-  if (options.assurance !== undefined && options.assurance.status !== "settled") {
-    const suffix =
-      counts.blocking > 0 ? ` It also has ${countNoun(counts.blocking, "blocking finding")}.` : "";
-    return `> [!CAUTION]\n> Configured review assurance did not settle — the check must not pass.${suffix}`;
-  }
+  // Code findings outrank machinery gaps: a blocking finding is the
+  // actionable signal, and unsettled reviewer-side work is carried forward.
   if (counts.blocking > 0) {
     return `> [!CAUTION]\n> ${countNoun(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+  }
+  const carried = options.unreviewedPaths?.length ?? 0;
+  if (
+    options.inputCoverage?.status === "incomplete" ||
+    options.assurance?.status === "incomplete"
+  ) {
+    const carriedNote =
+      carried > 0
+        ? ` ${countNoun(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.`
+        : "";
+    return `> [!WARNING]\n> Review infrastructure did not settle — a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
   }
   if (counts.important > 0) {
     return `> [!IMPORTANT]\n> ${countNoun(counts.important, "important finding")} to address before merging.`;
@@ -393,22 +393,20 @@ export const planPublication = (
     readonly modelLabel?: string | undefined;
     /** Workflow-run URL rendered into the footer. */
     readonly runUrl?: string | undefined;
-    /** Observed run usage rendered into the footer. */
+    /** Observed whole-run usage rendered into the footer. */
     readonly usage?: { readonly inputTokens: number; readonly outputTokens: number } | undefined;
-    /** What the usage observed: the whole run, or the coordinator only. */
-    readonly usageScope?: "run" | "coordinator" | undefined;
     /**
      * Changeset fingerprint embedded invisibly in the review body so a later
      * run can skip re-reviewing an unchanged changeset.
      */
     readonly fingerprint?: string | undefined;
-    /** Host-owned coverage; incomplete coverage is rendered and fails the check. */
-    readonly coverage?: ReviewCoverage | undefined;
     /** Host-owned path/evidence assignment, separate from review assurance. */
     readonly inputCoverage?: ReviewInputCoverage | undefined;
     /** Host-owned discovery/specialist/verification settlement. */
     readonly assurance?: ReviewAssurance | undefined;
-    /** Unchanged unresolved items carried from the prior settled assurance baseline. */
+    /** Retryable scope this run could not settle; carried to the next run. */
+    readonly unreviewedPaths?: ReadonlyArray<string> | undefined;
+    /** Unchanged unresolved items carried from the prior reviewed baseline. */
     readonly carriedFindings?: ReadonlyArray<ReviewFinding> | undefined;
     readonly carriedConcerns?: ReadonlyArray<ReviewConcern> | undefined;
     /** Selected review scope, made visible whenever orchestration chose it. */
@@ -452,14 +450,8 @@ export const planPublication = (
 
   const footerParts = ["Automated review by @effect-agent/pr-review"];
   if (options.modelLabel !== undefined) footerParts.push(options.modelLabel);
-  // Usage renders only under an EXPLICIT scope: this planner cannot know
-  // whether a budget snapshot observed the whole run or only a fan-out
-  // coordinator, and omitting the number is honest where mislabeling is not.
-  if (options.usage !== undefined && options.usageScope !== undefined) {
-    const scope = options.usageScope === "coordinator" ? " (coordinator)" : "";
-    footerParts.push(
-      `${options.usage.inputTokens} in / ${options.usage.outputTokens} out tokens${scope}`,
-    );
+  if (options.usage !== undefined) {
+    footerParts.push(`${options.usage.inputTokens} in / ${options.usage.outputTokens} out tokens`);
   }
   if (options.runUrl !== undefined) footerParts.push(`[run](${options.runUrl})`);
   footerParts.push(`reviewed at ${options.headSha.slice(0, 7)}`);
@@ -490,9 +482,9 @@ export const planPublication = (
       renderVerdictCallout(review, {
         carriedFindings,
         carriedConcerns,
-        coverage: options.coverage,
         inputCoverage: options.inputCoverage,
         assurance: options.assurance,
+        unreviewedPaths: options.unreviewedPaths,
       }),
     ];
     if (options.reviewMode !== undefined && options.reviewReason !== undefined) {
@@ -513,8 +505,14 @@ export const planPublication = (
     if (options.inputCoverage !== undefined && options.assurance !== undefined) {
       parts.push(
         "",
-        `**Input coverage:** ${options.inputCoverage.status} (${options.inputCoverage.assignedPaths.length}/${options.inputCoverage.requiredPaths.length} paths assigned, ${options.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options.assurance.status} (${options.assurance.completedGeneralDiscoveryPasses}/${options.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options.assurance.completedSpecialistPasses}/${options.assurance.requiredSpecialistPasses} specialist, ${options.assurance.completedVerificationPasses}/${options.assurance.requiredVerificationPasses} verification; ${options.assurance.confirmedCandidates} confirmed / ${options.assurance.rejectedCandidates} rejected / ${options.assurance.unsettledCandidates} unsettled candidates)`,
+        `**Input coverage:** ${options.inputCoverage.status} (${options.inputCoverage.assignedPaths.length}/${options.inputCoverage.requiredPaths.length} paths assigned, ${options.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options.assurance.status} (${options.assurance.completedGeneralDiscoveryPasses}/${options.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options.assurance.completedSpecialistPasses}/${options.assurance.requiredSpecialistPasses} specialist, ${options.assurance.completedVerificationPasses}/${options.assurance.requiredVerificationPasses} verification; ${options.assurance.confirmedCandidates} confirmed / ${options.assurance.rejectedCandidates} rejected / ${options.assurance.unsettledCandidates} unsettled${options.assurance.discardedInvalidFindings > 0 ? ` / ${options.assurance.discardedInvalidFindings} discarded` : ""} candidates)`,
       );
+      if (options.inputCoverage.undiffablePaths.length > 0) {
+        parts.push(
+          "",
+          `ℹ️ ${countNoun(options.inputCoverage.undiffablePaths.length, "path")} had no reviewable textual evidence (binary or oversized) and ${options.inputCoverage.undiffablePaths.length === 1 ? "is" : "are"} outside the review surface.`,
+        );
+      }
     }
     parts.push("", review.summary);
     if (walkthroughKept && walkthrough.length > 0) {
@@ -525,22 +523,17 @@ export const planPublication = (
     if (options.inputCoverage?.status === "incomplete") {
       parts.push(
         "",
-        "### 🛑 Incomplete input coverage",
+        "### ⚠️ Incomplete input coverage",
         "",
         ...options.inputCoverage.reasons.map((reason) => `- ${reason}`),
       );
-    } else if (options.inputCoverage === undefined && options.coverage?.status === "incomplete") {
-      parts.push(
-        "",
-        "### 🛑 Incomplete coverage",
-        "",
-        ...options.coverage.reasons.map((reason) => `- ${reason}`),
-      );
     }
-    if (options.assurance !== undefined && options.assurance.status !== "settled") {
+    if (options.assurance?.status === "incomplete") {
       parts.push(
         "",
-        "### 🛑 Incomplete review assurance",
+        "### ⚠️ Unsettled review passes",
+        "",
+        "The passes below failed on the reviewer's side after a bounded retry. Their paths are carried forward and re-reviewed automatically on the next run — do not change code to satisfy this section.",
         "",
         ...options.assurance.reasons.map((reason) => `- ${reason}`),
       );
@@ -613,14 +606,16 @@ export const planPublication = (
     options.carriedFindings ?? [],
     options.carriedConcerns ?? [],
   );
+  // Machinery gaps (incomplete input or unsettled passes) block APPROVE but
+  // never REQUEST_CHANGES: requesting changes for a reviewer-side fault would
+  // tell the author to edit code nobody reviewed.
+  const unclean =
+    options.inputCoverage?.status === "incomplete" || options.assurance?.status === "incomplete";
   const event: ReviewEvent = !options.applyVerdict
     ? "COMMENT"
-    : options.inputCoverage?.status === "incomplete" ||
-        (options.inputCoverage === undefined && options.coverage?.status === "incomplete") ||
-        (options.assurance !== undefined && options.assurance.status !== "settled") ||
-        counts.blocking > 0
+    : counts.blocking > 0
       ? "REQUEST_CHANGES"
-      : review.verdict === "approve" && counts.important === 0
+      : review.verdict === "approve" && counts.important === 0 && !unclean
         ? "APPROVE"
         : "COMMENT";
 

--- a/packages/pr-review/src/internal/render.ts
+++ b/packages/pr-review/src/internal/render.ts
@@ -507,12 +507,6 @@ export const planPublication = (
         "",
         `**Input coverage:** ${options.inputCoverage.status} (${options.inputCoverage.assignedPaths.length}/${options.inputCoverage.requiredPaths.length} paths assigned, ${options.inputCoverage.partialPaths.length} partial) · **Review assurance:** ${options.assurance.status} (${options.assurance.completedGeneralDiscoveryPasses}/${options.assurance.requiredGeneralDiscoveryPasses} general discovery, ${options.assurance.completedSpecialistPasses}/${options.assurance.requiredSpecialistPasses} specialist, ${options.assurance.completedVerificationPasses}/${options.assurance.requiredVerificationPasses} verification; ${options.assurance.confirmedCandidates} confirmed / ${options.assurance.rejectedCandidates} rejected / ${options.assurance.unsettledCandidates} unsettled${options.assurance.discardedInvalidFindings > 0 ? ` / ${options.assurance.discardedInvalidFindings} discarded` : ""} candidates)`,
       );
-      if (options.inputCoverage.undiffablePaths.length > 0) {
-        parts.push(
-          "",
-          `ℹ️ ${countNoun(options.inputCoverage.undiffablePaths.length, "path")} had no reviewable textual evidence (binary or oversized) and ${options.inputCoverage.undiffablePaths.length === 1 ? "is" : "are"} outside the review surface.`,
-        );
-      }
     }
     parts.push("", review.summary);
     if (walkthroughKept && walkthrough.length > 0) {

--- a/packages/pr-review/src/internal/retirement.ts
+++ b/packages/pr-review/src/internal/retirement.ts
@@ -102,8 +102,10 @@ const findingIdentity = (finding: {
 
 const REVIEW_METADATA_PATTERN = /<!-- effect-agent-pr-review metadata\n[\s\S]*?\n-->/g;
 const FINGERPRINT_PATTERN = /<!-- effect-agent-pr-review fingerprint=sha256:[0-9a-f]{64} -->/g;
+// Version-agnostic on purpose: retirement only RECOGNIZES machine markers to
+// keep them byte-identical through an edit; it never authenticates them.
 const STATE_PATTERN =
-  /<!-- effect-agent-pr-review state-v1:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g;
+  /<!-- effect-agent-pr-review state-v\d+:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g;
 const RETIRED_ORIGINAL_PATTERN =
   /<!-- effect-agent-pr-review retired-original:start -->\n([\s\S]*?)\n<!-- effect-agent-pr-review retired-original:end -->/;
 const MACHINE_COMMENT_PATTERN = new RegExp(

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -46,16 +46,22 @@ export class StoredReviewConcern extends Schema.Class<StoredReviewConcern>(
   body: StoredText,
 }) {}
 
+/** The carried-scope bound; a run that cannot fit its leftovers publishes no state. */
+export const MAX_STORED_UNREVIEWED_PATHS = 100;
+
 /**
- * Versioned state embedded only after complete input assignment and settled
- * configured review assurance. The head plus full-scope fingerprint forms an
- * incremental baseline; an absent unresolved item never means the path is
- * defect-free. The `acceptedScopeFingerprint` name is retained for wire
- * compatibility. Storing hundreds of path strings separately would not fit
- * GitHub's bounded review body in the worst case.
+ * Versioned state embedded after EVERY completed run that can be signed. The
+ * head plus full-scope fingerprint forms an incremental baseline; an absent
+ * unresolved item never means the path is defect-free. `unreviewedPaths`
+ * carries retryable review gaps (failed passes) forward so the next
+ * incremental run re-reviews exactly them plus the new delta — the baseline
+ * advances monotonically instead of freezing on one flaky pass and reopening
+ * the whole post-baseline scope. The `acceptedScopeFingerprint` name is
+ * retained for wire compatibility. Storing hundreds of path strings
+ * separately would not fit GitHub's bounded review body in the worst case.
  */
 export class ReviewState extends Schema.Class<ReviewState>("@effect-agent/pr-review/ReviewState")({
-  version: Schema.Literal(1),
+  version: Schema.Literal(2),
   repository: Schema.NonEmptyString.check(Schema.isMaxLength(200)),
   pullRequestNumber: Schema.Int.check(Schema.isGreaterThan(0)),
   baseRef: Schema.NonEmptyString.check(Schema.isMaxLength(300)),
@@ -67,6 +73,14 @@ export class ReviewState extends Schema.Class<ReviewState>("@effect-agent/pr-rev
   reviewedPathCount: Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 300 })),
   unresolvedFindings: Schema.Array(StoredReviewFinding).check(Schema.isMaxLength(20)),
   unresolvedConcerns: Schema.Array(StoredReviewConcern).check(Schema.isMaxLength(10)),
+  /** Retryable review gaps carried into the next incremental run's scope. */
+  unreviewedPaths: Schema.Array(ChangedPath).check(Schema.isMaxLength(MAX_STORED_UNREVIEWED_PATHS)),
+  /**
+   * True only when the producing run had complete input coverage, no
+   * unsettled pass, and nothing carried. Skip-unchanged authority: an
+   * unchanged patch may skip re-review only over a settled state.
+   */
+  settled: Schema.Boolean,
   lastReviewMode: ReviewScopeMode,
 }) {}
 
@@ -100,15 +114,15 @@ export const toStoredConcern = (concern: ReviewConcern): StoredReviewConcern =>
 export const fromStoredConcern = (concern: StoredReviewConcern): ReviewConcern =>
   ReviewConcern.make({ severity: concern.severity, title: concern.title, body: concern.body });
 
-const STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v1:";
+const STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v2:";
 const STATE_MARKER_SUFFIX = " -->";
 const STATE_MARKER_PATTERN =
-  /(?:^|\n)<!-- effect-agent-pr-review state-v1:([A-Za-z0-9+/]+={0,2})\.([0-9a-f]{64}) -->$/;
-const STATE_SIGNATURE_DOMAIN = "effect-agent-pr-review/state-v1\u0000";
+  /(?:^|\n)<!-- effect-agent-pr-review state-v2:([A-Za-z0-9+/]+={0,2})\.([0-9a-f]{64}) -->$/;
+const STATE_SIGNATURE_DOMAIN = "effect-agent-pr-review/state-v2\u0000";
 export const MAX_REVIEW_STATE_MARKER_CHARS = 24_000;
 export const ReviewStateMarker = Schema.NonEmptyString.check(
   Schema.isMaxLength(MAX_REVIEW_STATE_MARKER_CHARS),
-  Schema.isPattern(/^<!-- effect-agent-pr-review state-v1:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->$/),
+  Schema.isPattern(/^<!-- effect-agent-pr-review state-v2:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->$/),
 ).pipe(Schema.brand("@effect-agent/pr-review/ReviewStateMarker"));
 export type ReviewStateMarker = typeof ReviewStateMarker.Type;
 
@@ -402,22 +416,32 @@ export const selectReviewRange = (input: {
       selectedByPath.set(file.path, file);
     }
   }
-  if (input.priorState.baseSha !== input.current.baseSha) {
+  // Retryable gaps carried by the prior state re-enter this run's scope; a
+  // carried path reverted out of the pull request has nothing left to review.
+  const carriedPaths = new Set(
+    input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path)),
+  );
+  for (const path of carriedPaths) affectedPaths.add(path);
+  const rescuePaths = input.priorState.baseSha !== input.current.baseSha;
+  if (rescuePaths || carriedPaths.size > 0) {
     for (const file of input.fullFiles) {
-      if (
-        affectedPaths.has(file.path) ||
-        (file.previousPath !== undefined && affectedPaths.has(file.previousPath))
-      ) {
-        selectedByPath.set(file.path, file);
-      }
+      const affected =
+        (rescuePaths &&
+          (affectedPaths.has(file.path) ||
+            (file.previousPath !== undefined && affectedPaths.has(file.previousPath)))) ||
+        carriedPaths.has(file.path) ||
+        (file.previousPath !== undefined && carriedPaths.has(file.previousPath));
+      if (affected) selectedByPath.set(file.path, file);
     }
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
     left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
   );
+  const carriedReason =
+    carriedPaths.size === 0 ? "" : `; retrying ${carriedPaths.size} carried unreviewed path(s)`;
   return {
     mode: "incremental",
-    reason: `changes since settled review head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
+    reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}${carriedReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
     totalFiles: selectedFiles.length,

--- a/packages/pr-review/src/internal/review-units.ts
+++ b/packages/pr-review/src/internal/review-units.ts
@@ -6,6 +6,7 @@ import {
   fileReviewEvidenceChunks,
   type FindingSeverity,
   MAX_PATCH_CHARS,
+  type ReviewConcern,
   type ReviewFinding,
 } from "./review-agent.ts";
 
@@ -464,4 +465,28 @@ export const rankAndDedupeFindings = (
       return left.startLine - right.startLine;
     })
     .slice(0, MAX_MERGED_FINDINGS);
+};
+
+/**
+ * The concern analogue of `rankAndDedupeFindings`: dedupe by exact content
+ * keeping the most severe duplicate, rank by severity, and cap at the
+ * `CodeReview` concerns bound.
+ */
+export const rankAndDedupeConcerns = (
+  concerns: ReadonlyArray<ReviewConcern>,
+): ReadonlyArray<ReviewConcern> => {
+  const byContent = new Map<string, ReviewConcern>();
+  for (const concern of concerns) {
+    const key = `${concern.title}\u0000${concern.body}`;
+    const previous = byContent.get(key);
+    if (
+      previous === undefined ||
+      severityRank[concern.severity] < severityRank[previous.severity]
+    ) {
+      byContent.set(key, concern);
+    }
+  }
+  return [...byContent.values()]
+    .sort((left, right) => severityRank[left.severity] - severityRank[right.severity])
+    .slice(0, 10);
 };

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -10,13 +10,15 @@ import {
 import { type Tool } from "effect/unstable/ai";
 
 import {
-  assessReviewPipeline,
+  assessFlatReview,
+  compatibilityCoverage,
+  fanOutInputCoverage,
   ReviewAssurance,
   ReviewCoverage,
   ReviewInputCoverage,
-  type ReviewShape,
 } from "./coverage.ts";
 import type { ChangedFile } from "./diff.ts";
+import { runFanOutReview, type FileReviewerBinding } from "./fan-out.ts";
 import { computeChangesetFingerprint } from "./fingerprint.ts";
 import { PublishedReview, ReviewPublisher } from "./github.ts";
 import { planPublication, ReviewPublicationPlan } from "./render.ts";
@@ -30,19 +32,26 @@ import {
 import {
   fromStoredConcern,
   fromStoredFinding,
+  MAX_STORED_UNREVIEWED_PATHS,
   ReviewExecutionContext,
   ReviewState,
   toStoredConcern,
   toStoredFinding,
 } from "./review-state.ts";
-import { rankAndDedupeFindings } from "./review-units.ts";
+import { rankAndDedupeConcerns, rankAndDedupeFindings } from "./review-units.ts";
 import { PullRequestSource, type PullRequestMetadata } from "./source.ts";
 
 // ---------------------------------------------------------------------------
-// One review run, end to end: read the pull request, run the bounded agent,
-// validate the review against the real diff, then (optionally) publish.
-// Publication happens strictly AFTER the agent loop so no model turn can
-// observe or influence the mutation, and a failed run publishes nothing.
+// One review run, end to end: read the pull request, run the bounded review
+// (one flat agent, or the host-scheduled fan-out pipeline), validate the
+// review against the real diff, then (optionally) publish. Publication
+// happens strictly AFTER all model work so no model turn can observe or
+// influence the mutation, and a failed run publishes nothing.
+//
+// Continuity is monotone: every completed run that can be signed advances the
+// stored baseline, carrying genuinely-unsettled scope forward explicitly. A
+// flaky pass therefore costs exactly its own scope on the next run — it can
+// never freeze the baseline and reopen everything reviewed since.
 // ---------------------------------------------------------------------------
 
 /**
@@ -59,12 +68,9 @@ export const reviewBudgetLimits = UsageBudgetLimits.make({
 });
 
 /**
- * Run-level bounds for the fan-out coordinator. This budget observes only
- * the COORDINATOR'S own usage — delegated children are bounded separately by
- * the delegation's `SubagentPolicy` reservation and the child definition's
- * own `AgentPolicy`, never silently by the parent's budget. The duration
- * ceiling is wider because delegation Tool Calls hold the parent turn open
- * while bounded children run.
+ * Run-level bounds for the fan-out pipeline. One budget observes EVERY child
+ * pass, so the ceiling covers bounded parallel discovery and verification
+ * plus the one-retry allowance.
  */
 export const fanOutReviewBudgetLimits = UsageBudgetLimits.make({
   maxInputTokens: 600_000,
@@ -87,23 +93,18 @@ export class ReviewRunOutcome extends Schema.Class<ReviewRunOutcome>(
   coverage: ReviewCoverage,
   /** Exact path/evidence assignment, distinct from semantic review work. */
   inputCoverage: ReviewInputCoverage,
-  /** Settlement of configured discovery, specialist, and verification work. */
+  /** Settlement of scheduled discovery, specialist, and verification work. */
   assurance: ReviewAssurance,
+  /** Retryable scope this run could not settle; carried to the next run. */
+  unreviewedPaths: Schema.Array(Schema.NonEmptyString.check(Schema.isMaxLength(512))).check(
+    Schema.isMaxLength(300),
+  ),
   plan: ReviewPublicationPlan,
   published: Schema.optionalKey(PublishedReview),
-  turns: Schema.Int.check(Schema.isGreaterThan(0)),
-  /**
-   * The run budget's observed usage. For the fan-out reviewer this observes
-   * the COORDINATOR only — delegated children are bounded and accounted
-   * separately by their reservations.
-   */
+  /** Total settled model turns (all child passes for the fan-out pipeline). */
+  turns: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  /** The run budget's observed usage across the whole run. */
   usage: Schema.optionalKey(UsageTotals),
-  /**
-   * What `usage` observed: the whole run, or a fan-out coordinator only.
-   * Absent when the caller declared no scope — consumers must not present
-   * unscoped usage as whole-run totals.
-   */
-  usageScope: Schema.optionalKey(Schema.Literals(["run", "coordinator"])),
   reviewMode: Schema.optionalKey(Schema.Literals(["incremental", "full"])),
   reviewReason: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(1_000))),
   state: Schema.optionalKey(ReviewState),
@@ -114,7 +115,7 @@ export interface ExecuteReviewOptions {
   readonly post: boolean;
   /** Map the model's verdict onto APPROVE/REQUEST_CHANGES instead of COMMENT. */
   readonly applyVerdict: boolean;
-  /** Run-level usage bounds; defaults to `reviewBudgetLimits`. */
+  /** Run-level usage bounds; defaults to the shape's packaged limits. */
   readonly limits?: UsageBudgetLimits | undefined;
   /**
    * Host-side findings bound (fail-closed backstop for the instruction-level
@@ -132,15 +133,6 @@ export interface ExecuteReviewOptions {
   readonly modelLabel?: string | undefined;
   /** Workflow-run URL rendered into the review footer. */
   readonly runUrl?: string | undefined;
-  /**
-   * What the run budget observes: the whole run, or a fan-out coordinator
-   * only. Without a declared scope the footer omits usage entirely — this
-   * generic path cannot know what a caller's binding shape observes, and an
-   * unlabeled number would read as whole-run totals.
-   */
-  readonly usageScope?: "run" | "coordinator" | undefined;
-  /** Host-owned coverage shape; defaults to the flat reviewer. */
-  readonly reviewShape?: ReviewShape | undefined;
 }
 
 /** Build the mission one review run frames from the source's snapshot. */
@@ -173,36 +165,190 @@ export const enforceFindingsBound = (review: CodeReview, maxFindings: number): C
 const findingKey = (finding: ReviewFinding): string =>
   `${finding.path}\u0000${finding.startLine}\u0000${finding.endLine}\u0000${finding.severity}\u0000${finding.title}`;
 
-const severityRank: Record<ReviewConcern["severity"], number> = {
-  blocking: 0,
-  important: 1,
-  nit: 2,
-};
-
-const rankAndDedupeConcerns = (
-  concerns: ReadonlyArray<ReviewConcern>,
-): ReadonlyArray<ReviewConcern> => {
-  const byContent = new Map<string, ReviewConcern>();
-  for (const concern of concerns) {
-    const key = `${concern.title}\u0000${concern.body}`;
-    const previous = byContent.get(key);
-    if (
-      previous === undefined ||
-      severityRank[concern.severity] < severityRank[previous.severity]
-    ) {
-      byContent.set(key, concern);
-    }
-  }
-  return [...byContent.values()]
-    .sort((left, right) => severityRank[left.severity] - severityRank[right.severity])
-    .slice(0, 10);
-};
+/** One shape-specific review result, before the shared settlement tail. */
+interface ReviewCore {
+  readonly review: CodeReview;
+  readonly inputCoverage: ReviewInputCoverage;
+  readonly assurance: ReviewAssurance;
+  readonly unreviewedPaths: ReadonlyArray<string>;
+  readonly turns: number;
+}
 
 /**
- * Execute one review with any explicit Agent Binding whose contract is
- * `ReviewMission -> CodeReview` — the flat reviewer or the fan-out
- * coordinator; the toolkit stays generic because publication only depends on
- * the shared output contract. The binding stays a parameter (D-027): tests
+ * The shared settlement tail: carry unchanged prior scope, decide whether
+ * this run's continuity state can be signed, plan the exact publication, and
+ * (optionally) post it. Continuity requires only that the run COMPLETED with
+ * a trustworthy full-surface fingerprint — never that every pass settled;
+ * unsettled scope travels inside the state instead of freezing it.
+ */
+const settleReviewRun = (
+  core: ReviewCore,
+  context: {
+    readonly metadata: PullRequestMetadata;
+    readonly files: ReadonlyArray<ChangedFile>;
+    readonly anchorFiles: ReadonlyArray<ChangedFile>;
+    readonly fingerprint: string | undefined;
+    readonly usage: UsageTotals | undefined;
+  },
+  options: ExecuteReviewOptions,
+) =>
+  Effect.gen(function* () {
+    const { metadata, files, anchorFiles, fingerprint, usage } = context;
+    const executionContext = Option.getOrUndefined(
+      yield* Effect.serviceOption(ReviewExecutionContext),
+    );
+    const review = enforceFindingsBound(core.review, clampMaxFindings(options.maxFindings));
+    const { inputCoverage, assurance } = core;
+    const unreviewedPaths = [...new Set(core.unreviewedPaths)].sort();
+    const reviewTotalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
+    const affectedPaths = new Set(
+      executionContext?.affectedPaths ??
+        files.flatMap((file) =>
+          file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
+        ),
+    );
+    const priorState =
+      executionContext?.mode === "incremental" ? executionContext.priorState : undefined;
+    const carriedCandidates =
+      priorState?.unresolvedFindings
+        .filter((finding) => !affectedPaths.has(finding.path))
+        .map(fromStoredFinding) ?? [];
+    const activeFindings = rankAndDedupeFindings([...carriedCandidates, ...review.findings]).slice(
+      0,
+      clampMaxFindings(options.maxFindings),
+    );
+    const activeFindingKeys = new Set(activeFindings.map(findingKey));
+    const currentFindingKeys = new Set(review.findings.map(findingKey));
+    const carriedFindings = carriedCandidates.filter(
+      (finding) =>
+        activeFindingKeys.has(findingKey(finding)) && !currentFindingKeys.has(findingKey(finding)),
+    );
+    // Non-anchored concerns cannot be mapped safely to one affected path, so
+    // incremental runs carry them conservatively until the explicit final audit.
+    const carriedConcernCandidates = priorState?.unresolvedConcerns.map(fromStoredConcern) ?? [];
+    const activeConcerns = rankAndDedupeConcerns([
+      ...carriedConcernCandidates,
+      ...(review.concerns ?? []),
+    ]);
+    const currentConcernKeys = new Set(
+      (review.concerns ?? []).map((concern) => `${concern.title}\u0000${concern.body}`),
+    );
+    const activeConcernKeys = new Set(
+      activeConcerns.map((concern) => `${concern.title}\u0000${concern.body}`),
+    );
+    const carriedConcerns = carriedConcernCandidates.filter((concern) => {
+      const key = `${concern.title}\u0000${concern.body}`;
+      return activeConcernKeys.has(key) && !currentConcernKeys.has(key);
+    });
+    const settled =
+      inputCoverage.status === "complete" &&
+      assurance.status !== "incomplete" &&
+      unreviewedPaths.length === 0;
+    // The fingerprint marker is standalone skip authority for fingerprint-only
+    // harnesses, so it is embedded only for a fully settled run.
+    const skipFingerprint = settled ? fingerprint : undefined;
+    const carriedScopeFits = unreviewedPaths.length <= MAX_STORED_UNREVIEWED_PATHS;
+    const stateCandidate =
+      executionContext !== undefined &&
+      fingerprint !== undefined &&
+      metadata.baseSha !== undefined &&
+      // The fingerprint and stored baseline describe the FULL pull-request
+      // surface; a truncated anchor surface cannot make either claim.
+      anchorFiles.length >= metadata.totalChangedFiles &&
+      carriedScopeFits &&
+      executionContext.stateAuthenticator?.status === "available"
+        ? ReviewState.make({
+            version: 2,
+            repository: metadata.repository,
+            pullRequestNumber: metadata.number,
+            baseRef: metadata.baseRef,
+            baseSha: metadata.baseSha,
+            headRef: metadata.headRef,
+            reviewedHeadSha: metadata.headSha,
+            profileFingerprint: executionContext.profileFingerprint,
+            acceptedScopeFingerprint: fingerprint,
+            reviewedPathCount: anchorFiles.length,
+            unresolvedFindings: activeFindings.map(toStoredFinding),
+            unresolvedConcerns: activeConcerns.map(toStoredConcern),
+            unreviewedPaths,
+            settled,
+            lastReviewMode: executionContext.mode,
+          })
+        : undefined;
+    const continuity =
+      stateCandidate === undefined || executionContext?.stateAuthenticator === undefined
+        ? {
+            state: undefined,
+            marker: undefined,
+            notice:
+              executionContext !== undefined && !carriedScopeFits
+                ? `carried unreviewed scope (${unreviewedPaths.length} paths) exceeded the ${MAX_STORED_UNREVIEWED_PATHS}-path continuity bound`
+                : executionContext?.stateAuthenticator?.status === "unavailable"
+                  ? (executionContext.stateAuthenticator.unavailableReason ??
+                    "authenticated continuity state is unavailable")
+                  : undefined,
+          }
+        : yield* executionContext.stateAuthenticator.render(stateCandidate).pipe(
+            Effect.match({
+              onFailure: (error) => ({
+                state: undefined,
+                marker: undefined,
+                notice:
+                  error._tag === "ReviewStateMarkerTooLarge"
+                    ? `authenticated continuity state exceeded its ${error.maximumChars}-character bound`
+                    : `authenticated continuity state could not be signed: ${error.reason}`,
+              }),
+              onSuccess: (marker) => ({ state: stateCandidate, marker, notice: undefined }),
+            }),
+          );
+    const plan = planPublication(review, anchorFiles, {
+      applyVerdict: options.applyVerdict,
+      headSha: metadata.headSha,
+      totalChangedFiles: metadata.totalChangedFiles,
+      baseRef: metadata.baseRef,
+      headRef: metadata.headRef,
+      modelLabel: options.modelLabel,
+      runUrl: options.runUrl,
+      usage,
+      fingerprint: skipFingerprint,
+      inputCoverage,
+      assurance,
+      unreviewedPaths,
+      carriedFindings,
+      carriedConcerns,
+      reviewMode: executionContext?.mode,
+      reviewReason: executionContext?.reason,
+      baselineSha: executionContext?.baselineSha,
+      reviewFilesVisible: files.length,
+      reviewTotalFiles,
+      stateMarker: continuity.marker,
+      stateNotice: continuity.notice,
+    });
+    const shared = {
+      review,
+      activeFindings,
+      activeConcerns,
+      coverage: compatibilityCoverage(inputCoverage, assurance),
+      inputCoverage,
+      assurance,
+      unreviewedPaths,
+      plan,
+      turns: core.turns,
+      ...(usage === undefined ? {} : { usage }),
+      ...(executionContext === undefined
+        ? {}
+        : { reviewMode: executionContext.mode, reviewReason: executionContext.reason }),
+      ...(continuity.state === undefined ? {} : { state: continuity.state }),
+    };
+    if (!options.post) return ReviewRunOutcome.make(shared);
+    const publisher = yield* ReviewPublisher;
+    const published = yield* publisher.publish(plan);
+    return ReviewRunOutcome.make({ ...shared, published });
+  });
+
+/**
+ * Execute one flat review with any explicit Agent Binding whose contract is
+ * `ReviewMission -> CodeReview`. The binding stays a parameter (D-027): tests
  * pass scripted models, hosts pass live provider bindings, and the model
  * Layer's requirements stay visible in this Effect's `R`.
  */
@@ -249,187 +395,78 @@ export const executeReview = <
 
     // The engine validated the terminal JSON against the output schema; this
     // decode recovers the typed value on this side of the generic boundary.
-    const decoded = yield* Schema.decodeUnknownEffect(CodeReview)(result.output);
-    const reviewTotalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
-    const pipeline = assessReviewPipeline({
-      shape: options.reviewShape ?? "flat",
+    const review = yield* Schema.decodeUnknownEffect(CodeReview)(result.output);
+    const assessment = assessFlatReview({
       files,
-      totalFiles: reviewTotalFiles,
+      totalFiles: executionContext?.totalFiles ?? metadata.totalChangedFiles,
       anchorFiles,
       totalAnchorFiles: metadata.totalChangedFiles,
       events,
     });
-    // The coordinator owns prose only. Fan-out findings and concerns are
-    // reconstructed from exact verifier-confirmed discovery candidates; an
-    // unsupported or coordinator-invented candidate cannot reach publication.
-    const verifiedReview =
-      options.reviewShape !== "fan-out"
-        ? decoded
-        : CodeReview.make({
-            summary: decoded.summary,
-            verdict: decoded.verdict,
-            findings: rankAndDedupeFindings(pipeline.confirmedFindings),
-            ...(pipeline.confirmedConcerns.length === 0
-              ? {}
-              : { concerns: rankAndDedupeConcerns(pipeline.confirmedConcerns) }),
-            ...(pipeline.walkthrough.length === 0 ? {} : { walkthrough: pipeline.walkthrough }),
-          });
-    const review = enforceFindingsBound(verifiedReview, clampMaxFindings(options.maxFindings));
     const usage = yield* budget.snapshot;
-    const affectedPaths = new Set(
-      executionContext?.affectedPaths ??
-        files.flatMap((file) =>
-          file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
-        ),
-    );
-    const priorState =
-      executionContext?.mode === "incremental" ? executionContext.priorState : undefined;
-    const carriedCandidates =
-      priorState?.unresolvedFindings
-        .filter((finding) => !affectedPaths.has(finding.path))
-        .map(fromStoredFinding) ?? [];
-    const activeFindings = rankAndDedupeFindings([...carriedCandidates, ...review.findings]).slice(
-      0,
-      clampMaxFindings(options.maxFindings),
-    );
-    const activeFindingKeys = new Set(activeFindings.map(findingKey));
-    const currentFindingKeys = new Set(review.findings.map(findingKey));
-    const carriedFindings = carriedCandidates.filter(
-      (finding) =>
-        activeFindingKeys.has(findingKey(finding)) && !currentFindingKeys.has(findingKey(finding)),
-    );
-    // Non-anchored concerns cannot be mapped safely to one affected path, so
-    // incremental runs carry them conservatively until the explicit final audit.
-    const carriedConcernCandidates = priorState?.unresolvedConcerns.map(fromStoredConcern) ?? [];
-    const activeConcerns = rankAndDedupeConcerns([
-      ...carriedConcernCandidates,
-      ...(review.concerns ?? []),
-    ]);
-    const currentConcernKeys = new Set(
-      (review.concerns ?? []).map((concern) => `${concern.title}\u0000${concern.body}`),
-    );
-    const activeConcernKeys = new Set(
-      activeConcerns.map((concern) => `${concern.title}\u0000${concern.body}`),
-    );
-    const carriedConcerns = carriedConcernCandidates.filter((concern) => {
-      const key = `${concern.title}\u0000${concern.body}`;
-      return activeConcernKeys.has(key) && !currentConcernKeys.has(key);
-    });
-    const { assurance, coverage, inputCoverage } = pipeline;
-    const stateCandidate =
-      executionContext !== undefined &&
-      inputCoverage.status === "complete" &&
-      assurance.status === "settled" &&
-      fingerprint !== undefined &&
-      metadata.baseSha !== undefined &&
-      executionContext.stateAuthenticator?.status === "available"
-        ? ReviewState.make({
-            version: 1,
-            repository: metadata.repository,
-            pullRequestNumber: metadata.number,
-            baseRef: metadata.baseRef,
-            baseSha: metadata.baseSha,
-            headRef: metadata.headRef,
-            reviewedHeadSha: metadata.headSha,
-            profileFingerprint: executionContext.profileFingerprint,
-            acceptedScopeFingerprint: fingerprint,
-            reviewedPathCount: anchorFiles.length,
-            unresolvedFindings: activeFindings.map(toStoredFinding),
-            unresolvedConcerns: activeConcerns.map(toStoredConcern),
-            lastReviewMode: executionContext.mode,
-          })
-        : undefined;
-    const continuity =
-      stateCandidate === undefined || executionContext?.stateAuthenticator === undefined
-        ? {
-            state: undefined,
-            marker: undefined,
-            notice:
-              executionContext?.stateAuthenticator?.status === "unavailable" &&
-              inputCoverage.status === "complete" &&
-              assurance.status === "settled"
-                ? (executionContext.stateAuthenticator.unavailableReason ??
-                  "authenticated continuity state is unavailable")
-                : undefined,
-          }
-        : yield* executionContext.stateAuthenticator.render(stateCandidate).pipe(
-            Effect.match({
-              onFailure: (error) => ({
-                state: undefined,
-                marker: undefined,
-                notice:
-                  error._tag === "ReviewStateMarkerTooLarge"
-                    ? `authenticated continuity state exceeded its ${error.maximumChars}-character bound`
-                    : `authenticated continuity state could not be signed: ${error.reason}`,
-              }),
-              onSuccess: (marker) => ({ state: stateCandidate, marker, notice: undefined }),
-            }),
-          );
-    const plan = planPublication(review, anchorFiles, {
-      applyVerdict: options.applyVerdict,
-      headSha: metadata.headSha,
-      totalChangedFiles: metadata.totalChangedFiles,
-      baseRef: metadata.baseRef,
-      headRef: metadata.headRef,
-      modelLabel: options.modelLabel,
-      runUrl: options.runUrl,
-      usage,
-      usageScope: options.usageScope,
-      fingerprint:
-        inputCoverage.status === "complete" && assurance.status === "settled"
-          ? fingerprint
-          : undefined,
-      coverage,
-      inputCoverage,
-      assurance,
-      carriedFindings,
-      carriedConcerns,
-      reviewMode: executionContext?.mode,
-      reviewReason: executionContext?.reason,
-      baselineSha: executionContext?.baselineSha,
-      reviewFilesVisible: files.length,
-      reviewTotalFiles,
-      stateMarker: continuity.marker,
-      stateNotice: continuity.notice,
-    });
-
-    const scope =
-      options.usageScope === undefined ? {} : ({ usageScope: options.usageScope } as const);
-    if (!options.post) {
-      return ReviewRunOutcome.make({
+    return yield* settleReviewRun(
+      {
         review,
-        activeFindings,
-        activeConcerns,
-        coverage,
-        inputCoverage,
-        assurance,
-        plan,
+        inputCoverage: assessment.inputCoverage,
+        assurance: assessment.assurance,
+        unreviewedPaths: assessment.unreviewedPaths,
         turns: result.turns,
-        usage,
-        ...scope,
-        ...(executionContext === undefined
-          ? {}
-          : { reviewMode: executionContext.mode, reviewReason: executionContext.reason }),
-        ...(continuity.state === undefined ? {} : { state: continuity.state }),
-      });
-    }
-    const publisher = yield* ReviewPublisher;
-    const published = yield* publisher.publish(plan);
-    return ReviewRunOutcome.make({
-      review,
-      activeFindings,
-      activeConcerns,
-      coverage,
-      inputCoverage,
-      assurance,
-      plan,
-      published,
-      turns: result.turns,
-      usage,
-      ...scope,
-      ...(executionContext === undefined
-        ? {}
-        : { reviewMode: executionContext.mode, reviewReason: executionContext.reason }),
-      ...(continuity.state === undefined ? {} : { state: continuity.state }),
+      },
+      { metadata, files, anchorFiles, fingerprint, usage },
+      options,
+    );
+  });
+
+/**
+ * Execute one host-scheduled fan-out review: deterministic planning,
+ * independent discovery and verification child passes with bounded retries,
+ * and a host-composed review from verifier-confirmed candidates only. One
+ * budget observes every child pass, so the reported usage is whole-run.
+ */
+export const executeFanOutReview = <Provider, ModelProvides, ModelRequires>(
+  binding: FileReviewerBinding<Provider, ModelProvides, ModelRequires>,
+  options: ExecuteReviewOptions,
+) =>
+  Effect.gen(function* () {
+    const source = yield* PullRequestSource;
+    const metadata = yield* source.metadata;
+    const files = yield* source.changedFiles;
+    const anchorFiles = yield* source.anchorFiles;
+    const executionContext = Option.getOrUndefined(
+      yield* Effect.serviceOption(ReviewExecutionContext),
+    );
+    const fullMission = buildReviewMission(metadata, anchorFiles);
+    const fingerprint =
+      options.signature === undefined
+        ? undefined
+        : yield* computeChangesetFingerprint(anchorFiles, options.signature(fullMission));
+
+    const budget = yield* makeUsageBudget(options.limits ?? fanOutReviewBudgetLimits);
+    const totalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
+    const pipeline = yield* runFanOutReview(binding, {
+      files,
+      anchorFiles,
+      totalChangedFiles: totalFiles,
+      maxFindings: options.maxFindings,
+      budget: toRunBudgetHook(budget),
     });
+    const inputCoverage = fanOutInputCoverage({
+      plan: pipeline.plan,
+      files,
+      totalFiles,
+      anchorFiles,
+      totalAnchorFiles: metadata.totalChangedFiles,
+    });
+    const usage = yield* budget.snapshot;
+    return yield* settleReviewRun(
+      {
+        review: pipeline.review,
+        inputCoverage,
+        assurance: pipeline.assurance,
+        unreviewedPaths: pipeline.unreviewedPaths,
+        turns: pipeline.turns,
+      },
+      { metadata, files, anchorFiles, fingerprint, usage },
+      options,
+    );
   });

--- a/packages/pr-review/src/internal/source.ts
+++ b/packages/pr-review/src/internal/source.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Schema } from "effect";
 
-import { ChangedFile } from "./diff.ts";
+import type { ChangedFile } from "./diff.ts";
 
 // ---------------------------------------------------------------------------
 // The pull-request source port: everything the review tools may observe about

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -213,6 +213,7 @@ const fakeOutcome = (
       assignedPaths: [],
       partialPaths: [],
       unassignedPaths: [],
+      undiffablePaths: [],
       reasons: options.incomplete ? ["review input was not completely assigned"] : [],
     }),
     assurance: ReviewAssurance.make({
@@ -227,12 +228,14 @@ const fakeOutcome = (
       confirmedCandidates: 0,
       rejectedCandidates: 0,
       unsettledCandidates: 0,
+      discardedInvalidFindings: 0,
       failedPasses: [],
       reasons:
         options.incomplete || options.assuranceIncomplete
           ? ["review discovery did not settle"]
           : [],
     }),
+    unreviewedPaths: options.incomplete || options.assuranceIncomplete ? ["src/a.ts"] : [],
     plan: planPublication(review, [], {
       applyVerdict: false,
       headSha: "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
@@ -362,7 +365,7 @@ describe("runReviewAction", () => {
           }),
         );
         const state = ReviewState.make({
-          version: 1,
+          version: 2,
           repository: "acme/widgets",
           pullRequestNumber: 5,
           baseRef: "main",
@@ -374,6 +377,8 @@ describe("runReviewAction", () => {
           reviewedPathCount: 0,
           unresolvedFindings: [],
           unresolvedConcerns: [],
+          unreviewedPaths: [],
+          settled: true,
           lastReviewMode: "full",
         });
 
@@ -500,6 +505,33 @@ describe("runReviewAction", () => {
     }),
   );
 
+  it.effect(
+    "concludes blocking, not incomplete, when code findings and machinery gaps coexist",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* actionHarness(
+          JSON.stringify({
+            pull_request: { number: 5 },
+            repository: { full_name: "acme/widgets" },
+          }),
+        );
+        const exit = yield* runReviewAction(
+          {
+            run: () =>
+              Effect.succeed(fakeOutcome("comment", { blocking: true, assuranceIncomplete: true })),
+          },
+          { post: false },
+        ).pipe(Effect.provide(harness.layer), Effect.exit);
+        const failure = failureFrom(exit);
+        expect(Schema.is(ReviewGateFailed)(failure)).toBe(true);
+        if (Schema.is(ReviewGateFailed)(failure)) {
+          expect(failure.conclusion).toBe("blocking");
+          expect(failure.reasons[0]).toContain("blocking finding");
+          expect(failure.reasons.join("; ")).toContain("not a code defect");
+        }
+      }),
+  );
+
   it.effect("fails the check when required coverage is incomplete", () =>
     Effect.gen(function* () {
       const harness = yield* actionHarness(
@@ -543,6 +575,10 @@ describe("runReviewAction", () => {
       if (Schema.is(ReviewGateFailed)(failure)) {
         expect(failure.conclusion).toBe("incomplete");
         expect(failure.reasons).toContain("review discovery did not settle");
+        // The failure explicitly tells a coding agent this is reviewer-side
+        // uncertainty carried forward, never an invitation to expand the patch.
+        expect(failure.reasons[0]).toContain("not a code defect");
+        expect(failure.reasons[0]).toContain("carried forward and retried");
       }
       const outputs = yield* Ref.get(harness.written);
       expect(outputs).toContain("input-coverage=complete");
@@ -603,7 +639,7 @@ describe("runReviewAction", () => {
         totalChangedFiles: 0,
       });
       const state = ReviewState.make({
-        version: 1,
+        version: 2,
         repository: metadata.repository,
         pullRequestNumber: metadata.number,
         baseRef: metadata.baseRef,
@@ -624,6 +660,8 @@ describe("runReviewAction", () => {
           }),
         ],
         unresolvedConcerns: [],
+        unreviewedPaths: [],
+        settled: true,
         lastReviewMode: "full",
       });
       const invoked = yield* Ref.make(0);
@@ -681,7 +719,7 @@ describe("runReviewAction", () => {
         patch: "@@ -8 +8 @@\n-before\n+after",
       });
       const state = ReviewState.make({
-        version: 1,
+        version: 2,
         repository: metadata.repository,
         pullRequestNumber: metadata.number,
         baseRef: metadata.baseRef,
@@ -693,6 +731,8 @@ describe("runReviewAction", () => {
         reviewedPathCount: 1,
         unresolvedFindings: [],
         unresolvedConcerns: [],
+        unreviewedPaths: [],
+        settled: true,
         lastReviewMode: "full",
       });
       const invoked = yield* Ref.make(0);
@@ -720,6 +760,75 @@ describe("runReviewAction", () => {
     }),
   );
 
+  it.effect("re-reviews an unchanged patch when the stored state carries unreviewed scope", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const profileFingerprint = "a".repeat(64);
+      const patchFingerprint = "b".repeat(64);
+      const metadata = PullRequestMetadata.make({
+        repository: "acme/widgets",
+        number: 5,
+        title: "Review target",
+        body: "",
+        baseRef: "main",
+        baseSha: "3".repeat(40),
+        headRef: "fix/review",
+        headSha: "2".repeat(40),
+        totalChangedFiles: 1,
+      });
+      const file = ChangedFile.make({
+        path: "src/a.ts",
+        status: "modified",
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -8 +8 @@\n-before\n+after",
+      });
+      const state = ReviewState.make({
+        version: 2,
+        repository: metadata.repository,
+        pullRequestNumber: metadata.number,
+        baseRef: metadata.baseRef,
+        baseSha: metadata.baseSha ?? "3".repeat(40),
+        headRef: metadata.headRef,
+        reviewedHeadSha: metadata.headSha,
+        profileFingerprint,
+        acceptedScopeFingerprint: patchFingerprint,
+        reviewedPathCount: 1,
+        unresolvedFindings: [],
+        unresolvedConcerns: [],
+        // A prior pass failed on src/a.ts; skipping would abandon the retry.
+        unreviewedPaths: ["src/a.ts"],
+        settled: false,
+        lastReviewMode: "incremental",
+      });
+      const invoked = yield* Ref.make(0);
+      const result = yield* runReviewAction(
+        {
+          run: () =>
+            Ref.update(invoked, (count) => count + 1).pipe(
+              Effect.map(() => fakeOutcome("comment")),
+            ),
+          fingerprint: Effect.succeed(patchFingerprint),
+          profileFingerprint: Effect.succeed(profileFingerprint),
+          snapshot: Effect.succeed({ metadata, files: [file] }),
+        },
+        {
+          post: false,
+          priorReviews: staticPriorReviews(Option.none(), { state: Option.some(state) }),
+        },
+      ).pipe(Effect.provide(harness.layer));
+
+      expect(result._tag).toBe("Completed");
+      expect(yield* Ref.get(invoked)).toBe(1);
+      expect(yield* Ref.get(harness.written)).toContain("skipped=false");
+    }),
+  );
+
   it.effect("reviews a rebased head when the effective patch changed", () =>
     Effect.gen(function* () {
       const harness = yield* actionHarness(
@@ -741,7 +850,7 @@ describe("runReviewAction", () => {
         totalChangedFiles: 0,
       });
       const state = ReviewState.make({
-        version: 1,
+        version: 2,
         repository: metadata.repository,
         pullRequestNumber: metadata.number,
         baseRef: metadata.baseRef,
@@ -753,6 +862,8 @@ describe("runReviewAction", () => {
         reviewedPathCount: 0,
         unresolvedFindings: [],
         unresolvedConcerns: [],
+        unreviewedPaths: [],
+        settled: true,
         lastReviewMode: "full",
       });
       const invoked = yield* Ref.make(0);

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -34,6 +34,7 @@ import {
   PullRequestMetadata,
   ReviewCoverage,
   ReviewAssurance,
+  ReviewExecutionContext,
   ReviewFinding,
   ReviewInputCoverage,
   ReviewRunOutcome,
@@ -806,13 +807,23 @@ describe("runReviewAction", () => {
         settled: false,
         lastReviewMode: "incremental",
       });
-      const invoked = yield* Ref.make(0);
+      const reviewedScopes = yield* Ref.make<ReadonlyArray<ReadonlyArray<string>>>([]);
       const result = yield* runReviewAction(
         {
+          // Record the exact selected scope the harness provides, so this
+          // test proves the carried path is actually RE-REVIEWED — not merely
+          // that the skip was declined.
           run: () =>
-            Ref.update(invoked, (count) => count + 1).pipe(
-              Effect.map(() => fakeOutcome("comment")),
-            ),
+            Effect.gen(function* () {
+              const selection = Option.getOrUndefined(
+                yield* Effect.serviceOption(ReviewExecutionContext),
+              );
+              yield* Ref.update(reviewedScopes, (previous) => [
+                ...previous,
+                selection?.files.map((selected) => selected.path) ?? [],
+              ]);
+              return fakeOutcome("comment");
+            }),
           fingerprint: Effect.succeed(patchFingerprint),
           profileFingerprint: Effect.succeed(profileFingerprint),
           snapshot: Effect.succeed({ metadata, files: [file] }),
@@ -824,7 +835,7 @@ describe("runReviewAction", () => {
       ).pipe(Effect.provide(harness.layer));
 
       expect(result._tag).toBe("Completed");
-      expect(yield* Ref.get(invoked)).toBe(1);
+      expect(yield* Ref.get(reviewedScopes)).toEqual([["src/a.ts"]]);
       expect(yield* Ref.get(harness.written)).toContain("skipped=false");
     }),
   );

--- a/packages/pr-review/test/factory.test.ts
+++ b/packages/pr-review/test/factory.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
-import { IdGenerator, ToolExecutionClass } from "effect-agent";
+import type { IdGenerator } from "effect-agent";
+import { ToolExecutionClass } from "effect-agent";
 import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
 
+import type { PullRequestSource, ReviewPublicationPlan, ReviewPublisher } from "../src/index.ts";
 import {
   ChangedFile,
   CodeReview,
@@ -10,10 +12,7 @@ import {
   enforceFindingsBound,
   PrReview,
   PullRequestMetadata,
-  PullRequestSource,
   ReviewFinding,
-  ReviewPublicationPlan,
-  ReviewPublisher,
 } from "../src/index.ts";
 import {
   collectingReviewPublisherLayer,

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -18,7 +18,7 @@ const REVIEWED_HEAD_SHA = "2".repeat(40);
 const FINGERPRINT = "a".repeat(64);
 
 const reviewState = ReviewState.make({
-  version: 1,
+  version: 2,
   repository: "acme/widgets",
   pullRequestNumber: 30,
   baseRef: "main",
@@ -30,6 +30,8 @@ const reviewState = ReviewState.make({
   reviewedPathCount: 1,
   unresolvedFindings: [],
   unresolvedConcerns: [],
+  unreviewedPaths: [],
+  settled: true,
   lastReviewMode: "full",
 });
 

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -454,7 +454,7 @@ describe("deterministic input and risk planning", () => {
     expect(plan.discoveryPasses[1]?.riskCategories).toEqual([]);
   });
 
-  it("reports undiffable paths informationally and over-capacity paths as coverage gaps", () => {
+  it("keeps undiffable and over-capacity paths as fail-closed coverage gaps", () => {
     const binary = ChangedFile.make({
       path: "assets/logo.png",
       status: "added",
@@ -486,12 +486,13 @@ describe("deterministic input and risk planning", () => {
       anchorFiles: files,
       totalAnchorFiles: files.length,
     });
-    // The binary can never be reviewed by re-running; it is reported but is
-    // not an incompleteness reason. The capacity overflow IS a gap.
+    // Fail-closed: an unreviewable binary keeps input coverage incomplete for
+    // as long as it is part of the pull request; ignore globs are the
+    // deliberate way to exclude it. The capacity overflow is a gap too.
     expect(inputCoverage.status).toBe("incomplete");
     expect(inputCoverage.undiffablePaths).toEqual(["assets/logo.png"]);
     expect(inputCoverage.unassignedPaths).toEqual([...plan.unassignedPaths].sort());
-    expect(inputCoverage.reasons.join("\n")).not.toContain("assets/logo.png");
+    expect(inputCoverage.reasons.join("\n")).toContain("assets/logo.png");
   });
 
   it("bounds overflow identifiers while preserving the exact shard count and every path", () => {
@@ -1041,7 +1042,7 @@ describe("host-scheduled discovery and verification pipeline", () => {
     }),
   );
 
-  it.effect("reports the undiffable surface informationally while settling the run", () =>
+  it.effect("keeps an undiffable path fail-closed: incomplete, carried, never skippable", () =>
     Effect.gen(function* () {
       const binaryFixture = FixturePullRequest.make({
         metadata: PullRequestMetadata.make({
@@ -1068,11 +1069,16 @@ describe("host-scheduled discovery and verification pipeline", () => {
         ],
       });
 
-      expect(result.outcome.inputCoverage.status).toBe("complete");
+      // An unreviewable change must never authorize a green check, and the
+      // carry keeps it in scope even after it leaves the incremental delta.
+      expect(result.outcome.inputCoverage.status).toBe("incomplete");
       expect(result.outcome.inputCoverage.undiffablePaths).toEqual(["assets/logo.png"]);
+      expect(result.outcome.inputCoverage.reasons.join("\n")).toContain("assets/logo.png");
       expect(result.outcome.assurance.status).toBe("settled");
-      expect(result.outcome.state?.settled).toBe(true);
-      expect(result.outcome.plan.body).toContain("no reviewable textual evidence");
+      expect(result.outcome.unreviewedPaths).toContain("assets/logo.png");
+      expect(result.outcome.state?.settled).toBe(false);
+      expect(result.outcome.state?.unreviewedPaths).toContain("assets/logo.png");
+      expect(result.outcome.plan.body).toContain("Incomplete input coverage");
     }),
   );
 });

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -891,8 +891,13 @@ describe("host-scheduled discovery and verification pipeline", () => {
         limits: UsageBudgetLimits.make({ maxInputTokens: 1 }),
       });
 
+      // At least one child ran into the budget; no pass spent the retry.
+      expect(result.childCalls).toBeGreaterThanOrEqual(1);
       expect(result.childCalls).toBeLessThanOrEqual(2);
       expect(result.outcome.assurance.status).toBe("incomplete");
+      expect(result.outcome.assurance.failedPasses.map((pass) => pass.workId).sort()).toEqual(
+        [generalPass.passId, specialistPass.passId].sort(),
+      );
       for (const pass of result.outcome.assurance.failedPasses) {
         expect(pass.errorTag).toBe("BudgetExceeded");
       }

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1,28 +1,16 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Duration, Effect, Layer, Redacted, Ref, Schema } from "effect";
-import {
-  Agent,
-  AgentRuntime,
-  IdGenerator,
-  RunEvent,
-  SubagentReservationsMemoryLive,
-} from "effect-agent";
+import { Agent, AgentRuntime, IdGenerator } from "effect-agent";
 import { Tool } from "effect/unstable/ai";
-import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 
 import {
   CandidateAssessment,
   ChangedFile,
   annotatePatch,
-  CodeReview,
-  DelegateFileReview,
-  executeReview,
-  assessReviewPipeline,
-  fanOutHandlersLayer,
-  FanOutCoordinatorToolkitLayer,
+  executeFanOutReview,
+  fanOutInputCoverage,
   fanOutReviewBudgetLimits,
   fanOutReviewerProfile,
-  FanOutReviewer,
   FanOutReviewerProfile,
   findingAnchorInUnitEvidence,
   fileReviewEvidenceChunks,
@@ -30,16 +18,8 @@ import {
   FileReviewBrief,
   FileReviewEvidence,
   FileReviewReport,
-  FileReviewRequest,
   FileReviewToolkit,
-  FileReviewToolkitLayer,
-  FileReviewUnitFailed,
-  FileReviewUnitResult,
-  type FileReviewWorkRejected,
-  FindingCandidate,
-  ListReviewUnits,
-  makeFanOutReviewInstructions,
-  makeFanOutReviewSuite,
+  makeFileReviewerDefinition,
   MAX_FILE_REVIEW_TOOL_CALLS,
   MAX_PATCH_CHARS,
   MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS,
@@ -50,21 +30,19 @@ import {
   rankAndDedupeFindings,
   ReviewFinding,
   ReviewExecutionContext,
-  ReviewMission,
+  type ReviewPassMisbehaved,
   type ReviewPublicationPlan,
   ReviewStateAuthenticator,
   type ReviewRiskCategory,
   WalkthroughEntry,
   webCryptoReviewStateAuthenticatorLayer,
   defaultFileReviewerPolicy,
-  fileReviewPolicy,
 } from "../src/index.ts";
 import {
   collectingReviewPublisherLayer,
   FixtureFile,
   FixturePullRequest,
   fixturePullRequestSourceLayer,
-  makeOfflineFanOutCoordinatorModel,
   makeOfflineFileReviewerModel,
   type OfflineUnitScript,
 } from "../src/testing.ts";
@@ -120,7 +98,7 @@ const highRiskFixture = FixturePullRequest.make({
     repository: "acme/ingress",
     number: 110,
     title: "Authenticate and publish work-order events",
-    body: `Regression fixture; ${MISSION_MARKER} stays with the coordinator.`,
+    body: `Regression fixture; ${MISSION_MARKER} stays with the host.`,
     baseRef: "main",
     baseSha: "0123456789abcdef0123456789abcdef01234567",
     headRef: "work-order-ingress",
@@ -140,6 +118,7 @@ const generalPass = highRiskPlan.discoveryPasses.find((pass) => pass.perspective
 const specialistPass = highRiskPlan.discoveryPasses.find(
   (pass) => pass.perspective === "risk-specialist",
 )!;
+const verificationWorkId = `${highRiskUnit.unitId}-verification`;
 
 const supportedFinding = ReviewFinding.make({
   path: "examples/pr-work-order-ingress/src/authenticate.ts",
@@ -161,33 +140,9 @@ const unsupportedFinding = ReviewFinding.make({
   body: "The candidate claims the true literal disables the path, but the bounded evidence does not support that behavior.",
 });
 
-const candidateFor = (
-  finding: ReviewFinding,
-  index: number,
-  pass: typeof specialistPass = specialistPass,
-): FindingCandidate =>
-  FindingCandidate.make({
-    candidateId: `${pass.passId}:finding:${String(index).padStart(3, "0")}`,
-    workId: pass.passId,
-    unitId: pass.unitId,
-    finding,
-    evidencePaths: [finding.path],
-  });
-
-const supportedCandidate = candidateFor(supportedFinding, 1);
-const unsupportedCandidate = candidateFor(unsupportedFinding, 2);
-
-const discoveryRequest = (pass: typeof generalPass): FileReviewRequest =>
-  FileReviewRequest.make({
-    phase: "discovery",
-    workId: pass.passId,
-    unitId: pass.unitId,
-    paths: pass.paths,
-    evidenceShardIds: pass.evidenceShardIds,
-    perspective: pass.perspective,
-    riskCategories: pass.riskCategories,
-    candidates: [],
-  });
+/** The host assigns candidate IDs by kept-finding position, 1-based. */
+const candidateId = (passId: string, index: number): string =>
+  `${passId}:finding:${String(index).padStart(3, "0")}`;
 
 const discoveryReport = (
   pass: typeof generalPass,
@@ -208,69 +163,32 @@ const discoveryReport = (
     assessments: [],
   });
 
-const verificationRequest = FileReviewRequest.make({
-  phase: "verification",
-  workId: `${highRiskUnit.unitId}-verification`,
-  unitId: highRiskUnit.unitId,
-  paths: highRiskUnit.paths,
-  evidenceShardIds: highRiskUnit.evidenceShards.map((shard) => shard.shardId),
-  perspective: "candidate-verification",
-  riskCategories: highRiskUnit.riskCategories,
-  candidates: [supportedCandidate, unsupportedCandidate],
+const verificationReport = (assessments: ReadonlyArray<CandidateAssessment>): FileReviewReport =>
+  FileReviewReport.make({
+    phase: "verification",
+    workId: verificationWorkId,
+    unitId: highRiskUnit.unitId,
+    findings: [],
+    concerns: [],
+    fileSummaries: [],
+    assessments,
+  });
+
+const report = (workId: string, value: FileReviewReport): OfflineUnitScript => ({
+  workId,
+  outcomes: [{ _tag: "report", report: value }],
 });
 
-const verificationReport = FileReviewReport.make({
-  phase: "verification",
-  workId: verificationRequest.workId,
-  unitId: verificationRequest.unitId,
-  findings: [],
-  concerns: [],
-  fileSummaries: [],
-  assessments: [
-    CandidateAssessment.make({
-      candidateId: supportedCandidate.candidateId,
-      disposition: "confirmed",
-      rationale: "The changed authentication mode is reachable without an identity check.",
-    }),
-    CandidateAssessment.make({
-      candidateId: unsupportedCandidate.candidateId,
-      disposition: "rejected",
-      rationale: "The evidence contains no disabling branch and does not establish the claim.",
-    }),
-  ],
-});
-
-const coordinatorReview = CodeReview.make({
-  summary: "General and specialist discovery completed; candidate verification settled.",
-  verdict: "comment",
-  findings: [unsupportedFinding],
-  concerns: [],
-});
-
+/** Run the host-scheduled pipeline offline over the fixture pull request. */
 const runOfflineFanOut = (script: {
-  readonly discoveryReports: ReadonlyArray<OfflineUnitScript>;
-  readonly discoveryCalls?: ReadonlyArray<FileReviewRequest> | undefined;
-  readonly verificationReports?: ReadonlyArray<OfflineUnitScript> | undefined;
-  readonly verificationCalls?: ReadonlyArray<FileReviewRequest> | undefined;
-  readonly review?: CodeReview | undefined;
+  readonly children: ReadonlyArray<OfflineUnitScript>;
   readonly fixture?: FixturePullRequest | undefined;
+  readonly maxFindings?: number | undefined;
 }) =>
   Effect.gen(function* () {
     const fixture = script.fixture ?? highRiskFixture;
     const reviewFiles = fixture.files.map((entry) => entry.file);
-    const reviewPlan = planReviewUnits(reviewFiles, {
-      totalChangedFiles: fixture.metadata.totalChangedFiles,
-    });
-    const coordinator = yield* makeOfflineFanOutCoordinatorModel({
-      discoveryCalls: script.discoveryCalls ?? reviewPlan.discoveryPasses.map(discoveryRequest),
-      verificationCalls: script.verificationCalls ?? [],
-      review: script.review ?? coordinatorReview,
-    });
-    const children = yield* makeOfflineFileReviewerModel([
-      ...script.discoveryReports,
-      ...(script.verificationReports ?? []),
-    ]);
-    const parentBinding = Agent.withModel(FanOutReviewer, coordinator.model);
+    const children = yield* makeOfflineFileReviewerModel(script.children);
     const childBinding = Agent.withModel(FileReviewer, children.model);
     const published = yield* Ref.make<ReadonlyArray<ReviewPublicationPlan>>([]);
     const stateAuthenticator = yield* Effect.gen(function* () {
@@ -280,23 +198,16 @@ const runOfflineFanOut = (script: {
         webCryptoReviewStateAuthenticatorLayer(Redacted.make("offline-assurance-secret")),
       ),
     );
-    const sourceLayer = fixturePullRequestSourceLayer(fixture);
-    const childSupportLayer = Layer.mergeAll(
-      FileReviewToolkitLayer,
-      SubagentReservationsMemoryLive,
-      IdGenerator.layer,
-    ).pipe(Layer.provideMerge(sourceLayer));
-    const program = executeReview(parentBinding, {
+    const program = executeFanOutReview(childBinding, {
       post: true,
       applyVerdict: false,
       limits: fanOutReviewBudgetLimits,
-      reviewShape: "fan-out",
-      signature: () => "offline-assurance-profile-v2",
+      ...(script.maxFindings === undefined ? {} : { maxFindings: script.maxFindings }),
+      signature: () => "offline-assurance-profile-v3",
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
-          FanOutCoordinatorToolkitLayer.pipe(Layer.provideMerge(sourceLayer)),
-          fanOutHandlersLayer(childBinding).pipe(Layer.provide(childSupportLayer)),
+          fixturePullRequestSourceLayer(fixture),
           collectingReviewPublisherLayer(published),
           IdGenerator.layer,
         ),
@@ -318,42 +229,36 @@ const runOfflineFanOut = (script: {
     return {
       outcome,
       published: yield* Ref.get(published),
-      coordinatorCalls: yield* coordinator.calls,
-      coordinatorPrompts: yield* coordinator.prompts,
       childCalls: yield* children.calls,
       childPrompts: yield* children.prompts,
     };
   });
 
 describe("fan-out review contract", () => {
-  const mission = ReviewMission.make({
-    repository: "acme/ingress",
-    number: 110,
-    title: "Authenticate ingress",
-    body: "",
-    baseRef: "main",
-    headRef: "work-order-ingress",
-    changedFileCount: 2,
-  });
-
-  it("requires discovery, exact independent verification, and honest non-exhaustive prose", () => {
-    const instructions = makeFanOutReviewInstructions({
-      guidance: "Review architecture first.",
-      maxFindings: 7,
-    })(mission);
-    expect(instructions).toContain("Review architecture first.");
-    expect(instructions).toContain("EVERY discoveryPass");
-    expect(instructions).toContain("EVERY retained candidate copied byte-for-byte");
-    expect(instructions).toContain("retaining the first candidate in discoveryPass plan order");
-    expect(instructions).toContain("never an exhaustive or defect-free review");
-    expect(instructions).toContain("publication cap is 7");
+  const discoveryBrief = FileReviewBrief.make({
+    phase: "discovery",
+    workId: generalPass.passId,
+    unitId: generalPass.unitId,
+    paths: generalPass.paths,
+    evidenceShardIds: generalPass.evidenceShardIds,
+    perspective: generalPass.perspective,
+    riskCategories: generalPass.riskCategories,
+    candidates: [],
+    evidence: [
+      FileReviewEvidence.make({
+        shardId: "shard-0001",
+        path: generalPass.paths[0]!,
+        status: "modified",
+        reviewMode: "diff",
+        ordinal: 1,
+        total: 1,
+        annotatedPatch: "@@ -1 +1 @@\nR1 + export const value = 1;",
+      }),
+    ],
   });
 
   it("spells the finding shape and committable-suggestion rule out to discovery workers", () => {
-    const instructions = FileReviewer.instructions({
-      ...discoveryRequest(generalPass),
-      evidence: [],
-    });
+    const instructions = FileReviewer.instructions(discoveryBrief);
     expect(instructions).toContain(
       '"suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>',
     );
@@ -367,10 +272,24 @@ describe("fan-out review contract", () => {
   });
 
   it("requires verifiers to settle every carried suggestion exactly", () => {
-    const instructions = FileReviewer.instructions({
-      ...verificationRequest,
-      evidence: [],
-    });
+    const instructions = FileReviewer.instructions(
+      FileReviewBrief.make({
+        ...discoveryBrief,
+        phase: "verification",
+        workId: verificationWorkId,
+        perspective: "candidate-verification",
+        candidates: [
+          {
+            _tag: "FindingCandidate",
+            candidateId: candidateId(specialistPass.passId, 1),
+            workId: specialistPass.passId,
+            unitId: specialistPass.unitId,
+            finding: supportedFinding,
+            evidencePaths: [supportedFinding.path],
+          },
+        ],
+      }),
+    );
     expect(instructions).toContain('"suggestion": <"committable" | "not-committable"');
     expect(instructions).toContain(
       "full replacement source for exactly lines startLine..endLine and nothing else",
@@ -381,14 +300,11 @@ describe("fan-out review contract", () => {
     );
   });
 
-  it("configures evidence-only children with the framework's bounded concurrency policy", () => {
+  it("configures evidence-only children with the packaged bounded policy", () => {
     expect(Object.keys(FileReviewToolkit.tools)).toEqual([]);
     expect(MAX_FILE_REVIEW_TOOL_CALLS).toBe(1);
     expect(defaultFileReviewerPolicy.maxToolCalls).toBe(1);
-    expect(fileReviewPolicy.maxToolCalls).toBe(1);
-    expect(fileReviewPolicy.maxConcurrency).toBe(4);
-    // The shared attached-subagent scheduler's Scope-owned slot gate is
-    // exercised with deterministic gated children in capabilities tests.
+    expect(defaultFileReviewerPolicy.onExhaustion).toBe("fail");
     expect(Duration.toMillis(defaultFileReviewerPolicy.maxDuration)).toBe(6 * 60_000);
   });
 
@@ -398,20 +314,14 @@ describe("fan-out review contract", () => {
     );
     expect(decoded).toEqual(fanOutReviewerProfile);
     expect(fanOutReviewerProfile).toMatchObject({
+      hostScheduledPasses: true,
+      failedPassesRetriedOnceThenCarried: true,
       hostOwnedRiskClassification: true,
       redundantHighRiskDiscovery: true,
       independentCandidateVerification: true,
       defectAbsenceProven: false,
       exactlyOnceExternalEffects: false,
     });
-  });
-
-  it("keeps coordinator tools compatible with strict provider object schemas", () => {
-    for (const tool of [ListReviewUnits, DelegateFileReview]) {
-      const jsonSchema = Tool.getJsonSchema(tool, { transformer: toCodecOpenAI });
-      expect(jsonSchema.type).toBe("object");
-      expect(jsonSchema.anyOf).toBeUndefined();
-    }
   });
 
   it.effect("selects scripted child outcomes by an exact work-ID marker", () =>
@@ -430,8 +340,8 @@ describe("fan-out review contract", () => {
         workId: "unit-001-general",
       });
       const scripted = yield* makeOfflineFileReviewerModel([
-        { workId: prefixReport.workId, outcome: { _tag: "report", report: prefixReport } },
-        { workId: exactReport.workId, outcome: { _tag: "report", report: exactReport } },
+        report(prefixReport.workId, prefixReport),
+        report(exactReport.workId, exactReport),
       ]);
       const binding = Agent.withModel(FileReviewer, scripted.model);
       const output = yield* AgentRuntime.run(
@@ -457,20 +367,15 @@ describe("fan-out review contract", () => {
             }),
           ],
         }),
-      ).pipe(Effect.provide(Layer.mergeAll(FileReviewToolkitLayer, IdGenerator.layer)));
+      ).pipe(Effect.provide(IdGenerator.layer), Effect.scoped);
 
       expect(output.output.workId).toBe(exactReport.workId);
     }),
   );
 
-  it("carries shared guidance to both coordinator and workers", () => {
-    const suite = makeFanOutReviewSuite({ guidance: "Architecture first.", maxFindings: 7 });
-    expect(suite.parent.instructions(mission)).toContain("Architecture first.");
-    const brief = {
-      ...discoveryRequest(generalPass),
-      evidence: [],
-    };
-    expect(suite.child.instructions(brief)).toContain("Architecture first.");
+  it("carries shared guidance to every worker", () => {
+    const child = makeFileReviewerDefinition({ guidance: "Architecture first." });
+    expect(child.instructions(discoveryBrief)).toContain("Architecture first.");
   });
 });
 
@@ -548,7 +453,7 @@ describe("deterministic input and risk planning", () => {
     expect(plan.discoveryPasses[1]?.riskCategories).toEqual([]);
   });
 
-  it("reports undiffable and over-capacity paths instead of dropping them", () => {
+  it("reports undiffable paths informationally and over-capacity paths as coverage gaps", () => {
     const binary = ChangedFile.make({
       path: "assets/logo.png",
       status: "added",
@@ -564,13 +469,28 @@ describe("deterministic input and risk planning", () => {
         patch: patchFor("wide"),
       }),
     );
-    const plan = planReviewUnits([...many, binary], { totalChangedFiles: 121 });
+    const files = [...many, binary];
+    const plan = planReviewUnits(files, { totalChangedFiles: 121 });
     const assigned = plan.units.flatMap((unit) => unit.paths);
 
     expect(plan.undiffablePaths).toEqual(["assets/logo.png"]);
     expect([...assigned, ...plan.unassignedPaths].sort()).toEqual(
       many.map((file) => file.path).sort(),
     );
+
+    const inputCoverage = fanOutInputCoverage({
+      plan,
+      files,
+      totalFiles: files.length,
+      anchorFiles: files,
+      totalAnchorFiles: files.length,
+    });
+    // The binary can never be reviewed by re-running; it is reported but is
+    // not an incompleteness reason. The capacity overflow IS a gap.
+    expect(inputCoverage.status).toBe("incomplete");
+    expect(inputCoverage.undiffablePaths).toEqual(["assets/logo.png"]);
+    expect(inputCoverage.unassignedPaths).toEqual([...plan.unassignedPaths].sort());
+    expect(inputCoverage.reasons.join("\n")).not.toContain("assets/logo.png");
   });
 
   it("bounds overflow identifiers while preserving the exact shard count and every path", () => {
@@ -602,17 +522,16 @@ describe("deterministic input and risk planning", () => {
       [...new Set([...plan.units.flatMap((unit) => unit.paths), ...plan.unassignedPaths])].sort(),
     ).toEqual(files.map((file) => file.path).sort());
 
-    const assessment = assessReviewPipeline({
-      shape: "fan-out",
+    const inputCoverage = fanOutInputCoverage({
+      plan,
       files,
       totalFiles: files.length,
       anchorFiles: files,
       totalAnchorFiles: files.length,
-      events: [],
     });
-    expect(assessment.inputCoverage.status).toBe("incomplete");
-    expect(assessment.inputCoverage.unassignedPaths).toEqual(plan.unassignedPaths);
-    expect(assessment.inputCoverage.reasons.join("\n")).toContain(
+    expect(inputCoverage.status).toBe("incomplete");
+    expect(inputCoverage.unassignedPaths).toEqual([...plan.unassignedPaths].sort());
+    expect(inputCoverage.reasons.join("\n")).toContain(
       `${plan.unassignedEvidenceShardCount} deterministic evidence shard(s)`,
     );
   });
@@ -641,18 +560,17 @@ describe("deterministic input and risk planning", () => {
     expect(plan.partialEvidencePaths).toEqual([]);
     expect(plan.unassignedEvidenceShardIds).toEqual([]);
 
-    const assessment = assessReviewPipeline({
-      shape: "fan-out",
+    const inputCoverage = fanOutInputCoverage({
+      plan,
       files: [oversized],
       totalFiles: 1,
       anchorFiles: [oversized],
       totalAnchorFiles: 1,
-      events: [],
     });
-    expect(assessment.inputCoverage.status).toBe("complete");
-    expect(assessment.inputCoverage.assignedPaths).toEqual([oversized.path]);
-    expect(assessment.inputCoverage.partialPaths).toEqual([]);
-    expect(assessment.inputCoverage.reasons).toEqual([]);
+    expect(inputCoverage.status).toBe("complete");
+    expect(inputCoverage.assignedPaths).toEqual([oversized.path]);
+    expect(inputCoverage.partialPaths).toEqual([]);
+    expect(inputCoverage.reasons).toEqual([]);
   });
 
   it("binds finding anchors to the exact shards assigned to their unit", () => {
@@ -698,36 +616,39 @@ describe("deterministic input and risk planning", () => {
   });
 });
 
-describe("offline discovery and verification pipeline", () => {
+describe("host-scheduled discovery and verification pipeline", () => {
   const successfulDiscovery: ReadonlyArray<OfflineUnitScript> = [
-    {
-      workId: generalPass.passId,
-      outcome: { _tag: "report", report: discoveryReport(generalPass, []) },
-    },
-    {
-      workId: specialistPass.passId,
-      outcome: {
-        _tag: "report",
-        report: discoveryReport(specialistPass, [supportedFinding, unsupportedFinding]),
-      },
-    },
+    report(generalPass.passId, discoveryReport(generalPass, [])),
+    report(
+      specialistPass.passId,
+      discoveryReport(specialistPass, [supportedFinding, unsupportedFinding]),
+    ),
   ];
+  const settledVerification = report(
+    verificationWorkId,
+    verificationReport([
+      CandidateAssessment.make({
+        candidateId: candidateId(specialistPass.passId, 1),
+        disposition: "confirmed",
+        rationale: "The changed authentication mode is reachable without an identity check.",
+      }),
+      CandidateAssessment.make({
+        candidateId: candidateId(specialistPass.passId, 2),
+        disposition: "rejected",
+        rationale: "The evidence contains no disabling branch and does not establish the claim.",
+      }),
+    ]),
+  );
 
   it.effect(
     "finds a defect missed by general discovery and publishes only verifier-confirmed candidates",
     () =>
       Effect.gen(function* () {
         const result = yield* runOfflineFanOut({
-          discoveryReports: successfulDiscovery,
-          verificationCalls: [verificationRequest],
-          verificationReports: [
-            {
-              workId: verificationRequest.workId,
-              outcome: { _tag: "report", report: verificationReport },
-            },
-          ],
+          children: [...successfulDiscovery, settledVerification],
         });
 
+        expect(result.childCalls).toBe(3);
         expect(result.outcome.inputCoverage.status).toBe("complete");
         expect(result.outcome.assurance).toMatchObject({
           status: "settled",
@@ -741,15 +662,21 @@ describe("offline discovery and verification pipeline", () => {
           confirmedCandidates: 1,
           rejectedCandidates: 1,
           unsettledCandidates: 0,
+          discardedInvalidFindings: 0,
         });
         expect(result.outcome.review.findings).toEqual([supportedFinding]);
         expect(result.outcome.review.findings).not.toContainEqual(unsupportedFinding);
+        expect(result.outcome.review.verdict).toBe("comment");
+        expect(result.outcome.unreviewedPaths).toEqual([]);
+        expect(result.outcome.turns).toBeGreaterThan(0);
         expect(result.outcome.plan.comments.map((comment) => comment.path)).toEqual([
           supportedFinding.path,
         ]);
         expect(result.outcome.plan.body).toContain("**Review assurance:** settled");
         expect(result.outcome.state?.reviewedHeadSha).toBe(FIXTURE_SHA);
-        expect(result.outcome.plan.body).toContain("effect-agent-pr-review state-v1:");
+        expect(result.outcome.state?.settled).toBe(true);
+        expect(result.outcome.state?.unreviewedPaths).toEqual([]);
+        expect(result.outcome.plan.body).toContain("effect-agent-pr-review state-v2:");
         expect(result.published).toHaveLength(1);
 
         const generalPrompt = result.childPrompts.find((prompt) =>
@@ -758,60 +685,37 @@ describe("offline discovery and verification pipeline", () => {
         const specialistPrompt = result.childPrompts.find(
           (prompt) =>
             prompt.includes(specialistPass.passId) &&
-            !prompt.includes(supportedCandidate.candidateId),
+            !prompt.includes(candidateId(specialistPass.passId, 1)),
         );
         const verifierPrompt = result.childPrompts.find((prompt) =>
-          prompt.includes(verificationRequest.workId),
+          prompt.includes(verificationWorkId),
         );
         expect(generalPrompt).toBeDefined();
         expect(specialistPrompt).toBeDefined();
-        expect(verifierPrompt).toContain(supportedCandidate.candidateId);
+        expect(verifierPrompt).toContain(candidateId(specialistPass.passId, 1));
         expect(verifierPrompt).toContain("authenticateMode");
         expect(verifierPrompt).toContain("publishWebhookMode");
+        // Children receive host-planned evidence only, never the PR mission.
         for (const prompt of result.childPrompts) expect(prompt).not.toContain(MISSION_MARKER);
       }),
   );
 
   it.effect("verifies an equivalent cross-pass candidate once and publishes it once", () =>
     Effect.gen(function* () {
-      const canonicalCandidate = candidateFor(supportedFinding, 1, generalPass);
-      const deduplicatedVerificationRequest = FileReviewRequest.make({
-        ...verificationRequest,
-        candidates: [canonicalCandidate],
-      });
-      const deduplicatedVerificationReport = FileReviewReport.make({
-        ...verificationReport,
-        assessments: [
-          CandidateAssessment.make({
-            candidateId: canonicalCandidate.candidateId,
-            disposition: "confirmed",
-            rationale: "The bounded evidence confirms the authentication defect once.",
-          }),
-        ],
-      });
       const result = yield* runOfflineFanOut({
-        discoveryReports: [
-          {
-            workId: generalPass.passId,
-            outcome: {
-              _tag: "report",
-              report: discoveryReport(generalPass, [supportedFinding]),
-            },
-          },
-          {
-            workId: specialistPass.passId,
-            outcome: {
-              _tag: "report",
-              report: discoveryReport(specialistPass, [supportedFinding]),
-            },
-          },
-        ],
-        verificationCalls: [deduplicatedVerificationRequest],
-        verificationReports: [
-          {
-            workId: deduplicatedVerificationRequest.workId,
-            outcome: { _tag: "report", report: deduplicatedVerificationReport },
-          },
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [supportedFinding])),
+          report(specialistPass.passId, discoveryReport(specialistPass, [supportedFinding])),
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                candidateId: candidateId(generalPass.passId, 1),
+                disposition: "confirmed",
+                rationale: "The bounded evidence confirms the authentication defect once.",
+              }),
+            ]),
+          ),
         ],
       });
 
@@ -823,36 +727,6 @@ describe("offline discovery and verification pipeline", () => {
       });
       expect(result.outcome.review.findings).toEqual([supportedFinding]);
       expect(result.outcome.plan.comments).toHaveLength(1);
-    }),
-  );
-
-  it.effect("fails assurance when extra work reuses an expected verification ID", () =>
-    Effect.gen(function* () {
-      const alteredRequest = FileReviewRequest.make({
-        ...verificationRequest,
-        candidates: [supportedCandidate],
-      });
-      const result = yield* runOfflineFanOut({
-        discoveryReports: successfulDiscovery,
-        verificationCalls: [verificationRequest, alteredRequest],
-        verificationReports: [
-          {
-            workId: verificationRequest.workId,
-            outcome: { _tag: "report", report: verificationReport },
-          },
-        ],
-      });
-
-      expect(result.outcome.assurance.status).toBe("incomplete");
-      expect(result.outcome.assurance.failedPasses).toContainEqual(
-        expect.objectContaining({
-          workId: verificationRequest.workId,
-          stage: "verification",
-          errorTag: "UnexpectedPass",
-        }),
-      );
-      expect(result.outcome.state).toBeUndefined();
-      expect(result.outcome.plan.event).toBe("COMMENT");
     }),
   );
 
@@ -872,19 +746,8 @@ describe("offline discovery and verification pipeline", () => {
         }),
         files: [],
       });
-      const result = yield* runOfflineFanOut({
-        fixture: emptyFixture,
-        discoveryCalls: [],
-        discoveryReports: [],
-        review: CodeReview.make({
-          summary: "No reviewable changes were selected.",
-          verdict: "comment",
-          findings: [],
-          concerns: [],
-        }),
-      });
+      const result = yield* runOfflineFanOut({ fixture: emptyFixture, children: [] });
 
-      expect(result.coordinatorCalls).toBe(2);
       expect(result.childCalls).toBe(0);
       expect(result.outcome.inputCoverage.status).toBe("complete");
       expect(result.outcome.assurance).toMatchObject({
@@ -893,15 +756,102 @@ describe("offline discovery and verification pipeline", () => {
         requiredSpecialistPasses: 0,
         requiredVerificationPasses: 0,
       });
+      expect(result.outcome.review.verdict).toBe("approve");
+      expect(result.outcome.turns).toBe(0);
+      expect(result.outcome.state?.settled).toBe(true);
     }),
   );
 
-  it.effect("makes failed specialist discovery visible and prevents settled assurance", () =>
+  // The incident regression (issue #131): one invalid anchor used to reject
+  // the whole pass as FileReviewWorkRejected, which froze the continuity
+  // baseline and reopened the entire post-baseline scope on every push.
+  it.effect("discards an invalid-anchor finding without failing its pass or the baseline", () =>
+    Effect.gen(function* () {
+      const invalidAnchor = ReviewFinding.make({
+        ...supportedFinding,
+        startLine: 99,
+        endLine: 99,
+        title: "Invalid new-version anchor",
+      });
+      const result = yield* runOfflineFanOut({
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          report(
+            specialistPass.passId,
+            discoveryReport(specialistPass, [invalidAnchor, supportedFinding]),
+          ),
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                // The invalid anchor was discarded, so the kept finding is 001.
+                candidateId: candidateId(specialistPass.passId, 1),
+                disposition: "confirmed",
+                rationale: "The changed mode reaches the authenticated path unchecked.",
+              }),
+            ]),
+          ),
+        ],
+      });
+
+      expect(result.outcome.assurance).toMatchObject({
+        status: "settled",
+        discardedInvalidFindings: 1,
+        discoveredCandidates: 1,
+        confirmedCandidates: 1,
+      });
+      expect(result.outcome.review.findings).toEqual([supportedFinding]);
+      expect(result.outcome.unreviewedPaths).toEqual([]);
+      expect(result.outcome.state?.settled).toBe(true);
+    }),
+  );
+
+  it.effect("retries a misdirected child report once and settles on the retry", () =>
+    Effect.gen(function* () {
+      const mismatched = FileReviewReport.make({
+        ...discoveryReport(specialistPass, [supportedFinding]),
+        workId: generalPass.passId,
+      });
+      const result = yield* runOfflineFanOut({
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          {
+            workId: specialistPass.passId,
+            outcomes: [
+              { _tag: "report", report: mismatched },
+              { _tag: "report", report: discoveryReport(specialistPass, [supportedFinding]) },
+            ],
+          },
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                candidateId: candidateId(specialistPass.passId, 1),
+                disposition: "confirmed",
+                rationale: "Confirmed on the retried, correctly addressed pass.",
+              }),
+            ]),
+          ),
+        ],
+      });
+
+      expect(result.childCalls).toBe(4);
+      expect(result.outcome.assurance.status).toBe("settled");
+      expect(result.outcome.assurance.failedPasses).toEqual([]);
+      expect(result.outcome.review.findings).toEqual([supportedFinding]);
+      expect(result.outcome.state?.settled).toBe(true);
+    }),
+  );
+
+  // The second incident regression: a pass that stays failed no longer
+  // freezes continuity — the baseline advances and the unit's paths are
+  // carried as retryable scope for the next run.
+  it.effect("carries a persistently failed pass forward instead of freezing the baseline", () =>
     Effect.gen(function* () {
       const result = yield* runOfflineFanOut({
-        discoveryReports: [
-          successfulDiscovery[0]!,
-          { workId: specialistPass.passId, outcome: { _tag: "malformed-output" } },
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          { workId: specialistPass.passId, outcomes: [{ _tag: "malformed-output" }] },
         ],
       });
 
@@ -915,79 +865,23 @@ describe("offline discovery and verification pipeline", () => {
         }),
       );
       expect(result.outcome.coverage.status).toBe("incomplete");
-      expect(result.outcome.state).toBeUndefined();
-      expect(result.outcome.plan.body).toContain("Incomplete review assurance");
+      expect(result.outcome.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
+      // Continuity ADVANCES with the gap carried explicitly.
+      expect(result.outcome.state?.reviewedHeadSha).toBe(FIXTURE_SHA);
+      expect(result.outcome.state?.settled).toBe(false);
+      expect(result.outcome.state?.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
+      expect(result.outcome.plan.body).toContain("Unsettled review passes");
+      expect(result.outcome.plan.body).toContain("do not change code to satisfy this section");
       expect(result.outcome.plan.event).toBe("COMMENT");
-    }),
-  );
-
-  it.effect("rejects a discovery candidate before assurance when its diff anchor is invalid", () =>
-    Effect.gen(function* () {
-      const invalidAnchor = ReviewFinding.make({
-        ...supportedFinding,
-        startLine: 99,
-        endLine: 99,
-        title: "Invalid new-version anchor",
-      });
-      const result = yield* runOfflineFanOut({
-        discoveryReports: [
-          successfulDiscovery[0]!,
-          {
-            workId: specialistPass.passId,
-            outcome: {
-              _tag: "report",
-              report: discoveryReport(specialistPass, [invalidAnchor]),
-            },
-          },
-        ],
-      });
-
-      expect(result.outcome.assurance.status).toBe("incomplete");
-      expect(result.outcome.assurance.failedPasses).toContainEqual(
-        expect.objectContaining({
-          workId: specialistPass.passId,
-          errorTag: "FileReviewWorkRejected",
-        }),
-      );
-      expect(result.outcome.review.findings).toEqual([]);
-      expect(result.outcome.state).toBeUndefined();
-    }),
-  );
-
-  it.effect("binds projected child output to the exact scheduled request", () =>
-    Effect.gen(function* () {
-      const mismatched = FileReviewReport.make({
-        ...discoveryReport(specialistPass, [supportedFinding]),
-        workId: generalPass.passId,
-      });
-      const result = yield* runOfflineFanOut({
-        discoveryReports: [
-          successfulDiscovery[0]!,
-          {
-            workId: specialistPass.passId,
-            outcome: { _tag: "report", report: mismatched },
-          },
-        ],
-      });
-
-      expect(result.outcome.assurance.status).toBe("incomplete");
-      expect(result.outcome.assurance.failedPasses).toContainEqual(
-        expect.objectContaining({
-          workId: specialistPass.passId,
-          errorTag: "FileReviewWorkRejected",
-        }),
-      );
-      expect(result.outcome.review.findings).toEqual([]);
     }),
   );
 
   it.effect("leaves every candidate unsettled when independent verification fails", () =>
     Effect.gen(function* () {
       const result = yield* runOfflineFanOut({
-        discoveryReports: successfulDiscovery,
-        verificationCalls: [verificationRequest],
-        verificationReports: [
-          { workId: verificationRequest.workId, outcome: { _tag: "malformed-output" } },
+        children: [
+          ...successfulDiscovery,
+          { workId: verificationWorkId, outcomes: [{ _tag: "malformed-output" }] },
         ],
       });
 
@@ -1001,7 +895,7 @@ describe("offline discovery and verification pipeline", () => {
       });
       expect(result.outcome.assurance.failedPasses).toContainEqual(
         expect.objectContaining({
-          workId: verificationRequest.workId,
+          workId: verificationWorkId,
           stage: "verification",
           errorTag: expect.stringContaining("AgentOutputError"),
         }),
@@ -1009,7 +903,8 @@ describe("offline discovery and verification pipeline", () => {
       expect(result.outcome.review.findings).toEqual([]);
       expect(result.outcome.plan.comments).toEqual([]);
       expect(result.outcome.plan.event).toBe("COMMENT");
-      expect(result.outcome.state).toBeUndefined();
+      expect(result.outcome.state?.settled).toBe(false);
+      expect(result.outcome.state?.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
     }),
   );
 
@@ -1027,60 +922,36 @@ describe("offline discovery and verification pipeline", () => {
     body: "The new flag enables the mode unconditionally in every environment.",
     suggestion: "Move the flag behind the environment rollout guard before enabling it.",
   });
-  const committableCandidate = candidateFor(committableSuggestionFinding, 1);
-  const proseCandidate = candidateFor(proseSuggestionFinding, 2);
   const suggestionDiscovery: ReadonlyArray<OfflineUnitScript> = [
-    successfulDiscovery[0]!,
-    {
-      workId: specialistPass.passId,
-      outcome: {
-        _tag: "report",
-        report: discoveryReport(specialistPass, [
-          committableSuggestionFinding,
-          proseSuggestionFinding,
-        ]),
-      },
-    },
+    report(generalPass.passId, discoveryReport(generalPass, [])),
+    report(
+      specialistPass.passId,
+      discoveryReport(specialistPass, [committableSuggestionFinding, proseSuggestionFinding]),
+    ),
   ];
-  const suggestionVerificationRequest = FileReviewRequest.make({
-    ...verificationRequest,
-    candidates: [committableCandidate, proseCandidate],
-  });
 
   it.effect("publishes a suggestion only on an exact committable settlement", () =>
     Effect.gen(function* () {
       const result = yield* runOfflineFanOut({
-        discoveryReports: suggestionDiscovery,
-        verificationCalls: [suggestionVerificationRequest],
-        verificationReports: [
-          {
-            workId: suggestionVerificationRequest.workId,
-            outcome: {
-              _tag: "report",
-              report: FileReviewReport.make({
-                phase: "verification",
-                workId: suggestionVerificationRequest.workId,
-                unitId: suggestionVerificationRequest.unitId,
-                findings: [],
-                concerns: [],
-                fileSummaries: [],
-                assessments: [
-                  CandidateAssessment.make({
-                    candidateId: committableCandidate.candidateId,
-                    disposition: "confirmed",
-                    suggestion: "committable",
-                    rationale: "The replacement is the exact committable source for line 2.",
-                  }),
-                  CandidateAssessment.make({
-                    candidateId: proseCandidate.candidateId,
-                    disposition: "confirmed",
-                    suggestion: "not-committable",
-                    rationale: "The suggestion text is advice prose, not replacement source.",
-                  }),
-                ],
+        children: [
+          ...suggestionDiscovery,
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                candidateId: candidateId(specialistPass.passId, 1),
+                disposition: "confirmed",
+                suggestion: "committable",
+                rationale: "The replacement is the exact committable source for line 2.",
               }),
-            },
-          },
+              CandidateAssessment.make({
+                candidateId: candidateId(specialistPass.passId, 2),
+                disposition: "confirmed",
+                suggestion: "not-committable",
+                rationale: "The suggestion text is advice prose, not replacement source.",
+              }),
+            ]),
+          ),
         ],
       });
 
@@ -1107,242 +978,77 @@ describe("offline discovery and verification pipeline", () => {
     }),
   );
 
-  it.effect("leaves the unit unsettled when a carried suggestion is not settled", () =>
+  it.effect("treats an unsettled carried suggestion as a failed pass after its retry", () =>
     Effect.gen(function* () {
+      const inexact = verificationReport([
+        CandidateAssessment.make({
+          candidateId: candidateId(specialistPass.passId, 1),
+          disposition: "confirmed",
+          rationale: "Confirmed without settling the carried suggestion.",
+        }),
+        CandidateAssessment.make({
+          candidateId: candidateId(specialistPass.passId, 2),
+          disposition: "confirmed",
+          suggestion: "not-committable",
+          rationale: "The suggestion text is advice prose, not replacement source.",
+        }),
+      ]);
       const result = yield* runOfflineFanOut({
-        discoveryReports: suggestionDiscovery,
-        verificationCalls: [suggestionVerificationRequest],
-        verificationReports: [
-          {
-            workId: suggestionVerificationRequest.workId,
-            outcome: {
-              _tag: "report",
-              report: FileReviewReport.make({
-                phase: "verification",
-                workId: suggestionVerificationRequest.workId,
-                unitId: suggestionVerificationRequest.unitId,
-                findings: [],
-                concerns: [],
-                fileSummaries: [],
-                assessments: [
-                  CandidateAssessment.make({
-                    candidateId: committableCandidate.candidateId,
-                    disposition: "confirmed",
-                    rationale: "Confirmed without settling the carried suggestion.",
-                  }),
-                  CandidateAssessment.make({
-                    candidateId: proseCandidate.candidateId,
-                    disposition: "confirmed",
-                    suggestion: "not-committable",
-                    rationale: "The suggestion text is advice prose, not replacement source.",
-                  }),
-                ],
-              }),
-            },
-          },
+        children: [
+          ...suggestionDiscovery,
+          { workId: verificationWorkId, outcomes: [{ _tag: "report", report: inexact }] },
         ],
       });
 
       expect(result.outcome.assurance.status).toBe("incomplete");
       expect(result.outcome.assurance.failedPasses).toContainEqual(
         expect.objectContaining({
-          workId: suggestionVerificationRequest.workId,
+          workId: verificationWorkId,
           stage: "verification",
-          errorTag: "FileReviewWorkRejected",
+          errorTag: "ReviewPassMisbehaved",
         }),
       );
       expect(result.outcome.review.findings).toEqual([]);
       expect(result.outcome.plan.comments).toEqual([]);
-      expect(result.outcome.state).toBeUndefined();
+      expect(result.outcome.state?.settled).toBe(false);
+      expect(result.outcome.state?.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
     }),
   );
 
-  it("surfaces typed policy exhaustion as a failed specialist pass", () => {
-    const generalRequest = discoveryRequest(generalPass);
-    const specialistRequest = discoveryRequest(specialistPass);
-    const base = {
-      eventVersion: 1,
-      runId: "run-assurance-exhaustion",
-      conversationId: "conversation-assurance-exhaustion",
-      agentId: "pr-fanout-reviewer",
-      timestamp: "2026-08-17T20:00:00.000Z",
-      providerExecuted: false,
-    } as const;
-    const events = [
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallDeclared",
-        sequence: 1,
-        toolCallId: "general-call",
-        toolName: "delegate_file_review",
-        parameters: Schema.encodeSync(FileReviewRequest)(generalRequest),
-      }),
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallSucceeded",
-        sequence: 2,
-        toolCallId: "general-call",
-        toolName: "delegate_file_review",
-        result: Schema.encodeSync(FileReviewUnitResult)(
-          FileReviewUnitResult.make({
-            phase: "discovery",
-            workId: generalPass.passId,
-            unitId: generalPass.unitId,
-            candidates: [],
-            fileSummaries: [],
-            assessments: [],
-          }),
-        ),
-      }),
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallDeclared",
-        sequence: 3,
-        toolCallId: "specialist-call",
-        toolName: "delegate_file_review",
-        parameters: Schema.encodeSync(FileReviewRequest)(specialistRequest),
-      }),
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallSucceeded",
-        sequence: 4,
-        toolCallId: "specialist-call",
-        toolName: "delegate_file_review",
-        result: Schema.encodeSync(FileReviewUnitFailed)(
-          FileReviewUnitFailed.make({
-            childErrorTag: "AgentPolicyError",
-            message: "review worker exceeded its bounded turn budget",
-          }),
-        ),
-      }),
-    ];
-    const assessment = assessReviewPipeline({
-      shape: "fan-out",
-      files: highRiskFiles,
-      totalFiles: 2,
-      anchorFiles: highRiskFiles,
-      totalAnchorFiles: 2,
-      events,
-    });
-
-    expect(defaultFileReviewerPolicy.onExhaustion).toBe("fail");
-    expect(assessment.assurance.status).toBe("incomplete");
-    expect(assessment.assurance.failedPasses).toContainEqual(
-      expect.objectContaining({
-        workId: specialistPass.passId,
-        stage: "specialist",
-        errorTag: "FileReviewUnitFailed:AgentPolicyError",
-      }),
-    );
-    expect(assessment.coverage.status).toBe("incomplete");
-  });
-
-  // The independent fold must re-enforce suggestion settlement itself: a
-  // recorded trace can carry verification results the live projection never
-  // vetted, e.g. runs recorded before this contract existed.
-  it("independently rejects a recorded settlement that settles a suggestion nothing carried", () => {
-    const generalRequest = discoveryRequest(generalPass);
-    const specialistRequest = discoveryRequest(specialistPass);
-    const discoveredCandidate = candidateFor(supportedFinding, 1, generalPass);
-    const recordedVerificationRequest = FileReviewRequest.make({
-      ...verificationRequest,
-      candidates: [discoveredCandidate],
-    });
-    const base = {
-      eventVersion: 1,
-      runId: "run-suggestion-settlement",
-      conversationId: "conversation-suggestion-settlement",
-      agentId: "pr-fanout-reviewer",
-      timestamp: "2026-08-18T20:00:00.000Z",
-      providerExecuted: false,
-    } as const;
-    const declared = (sequence: number, toolCallId: string, request: FileReviewRequest) =>
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallDeclared",
-        sequence,
-        toolCallId,
-        toolName: "delegate_file_review",
-        parameters: Schema.encodeSync(FileReviewRequest)(request),
-      });
-    const succeeded = (sequence: number, toolCallId: string, result: FileReviewUnitResult) =>
-      Schema.decodeUnknownSync(RunEvent)({
-        ...base,
-        _tag: "ToolCallSucceeded",
-        sequence,
-        toolCallId,
-        toolName: "delegate_file_review",
-        result: Schema.encodeSync(FileReviewUnitResult)(result),
-      });
-    const events = [
-      declared(1, "general-call", generalRequest),
-      succeeded(
-        2,
-        "general-call",
-        FileReviewUnitResult.make({
-          phase: "discovery",
-          workId: generalPass.passId,
-          unitId: generalPass.unitId,
-          candidates: [discoveredCandidate],
-          fileSummaries: [],
-          assessments: [],
+  it.effect("reports the undiffable surface informationally while settling the run", () =>
+    Effect.gen(function* () {
+      const binaryFixture = FixturePullRequest.make({
+        metadata: PullRequestMetadata.make({
+          ...highRiskFixture.metadata,
+          totalChangedFiles: 3,
         }),
-      ),
-      declared(3, "specialist-call", specialistRequest),
-      succeeded(
-        4,
-        "specialist-call",
-        FileReviewUnitResult.make({
-          phase: "discovery",
-          workId: specialistPass.passId,
-          unitId: specialistPass.unitId,
-          candidates: [],
-          fileSummaries: [],
-          assessments: [],
-        }),
-      ),
-      declared(5, "verification-call", recordedVerificationRequest),
-      succeeded(
-        6,
-        "verification-call",
-        FileReviewUnitResult.make({
-          phase: "verification",
-          workId: recordedVerificationRequest.workId,
-          unitId: recordedVerificationRequest.unitId,
-          candidates: [],
-          fileSummaries: [],
-          assessments: [
-            CandidateAssessment.make({
-              candidateId: discoveredCandidate.candidateId,
-              disposition: "confirmed",
-              // supportedFinding carries no suggestion, so settling one is
-              // an inexact recorded settlement the fold must reject.
-              suggestion: "committable",
-              rationale: "The recorded settlement names a suggestion the candidate never carried.",
+        files: [
+          ...highRiskFixture.files,
+          FixtureFile.make({
+            file: ChangedFile.make({
+              path: "assets/logo.png",
+              status: "added",
+              additions: 0,
+              deletions: 0,
             }),
-          ],
-        }),
-      ),
-    ];
-    const assessment = assessReviewPipeline({
-      shape: "fan-out",
-      files: highRiskFiles,
-      totalFiles: 2,
-      anchorFiles: highRiskFiles,
-      totalAnchorFiles: 2,
-      events,
-    });
+          }),
+        ],
+      });
+      const result = yield* runOfflineFanOut({
+        fixture: binaryFixture,
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          report(specialistPass.passId, discoveryReport(specialistPass, [])),
+        ],
+      });
 
-    expect(assessment.assurance.status).toBe("incomplete");
-    expect(assessment.assurance.failedPasses).toContainEqual(
-      expect.objectContaining({
-        workId: recordedVerificationRequest.workId,
-        stage: "verification",
-        errorTag: "SuggestionSettlementMismatch",
-      }),
-    );
-    expect(assessment.confirmedFindings).toEqual([]);
-  });
+      expect(result.outcome.inputCoverage.status).toBe("complete");
+      expect(result.outcome.inputCoverage.undiffablePaths).toEqual(["assets/logo.png"]);
+      expect(result.outcome.assurance.status).toBe("settled");
+      expect(result.outcome.state?.settled).toBe(true);
+      expect(result.outcome.plan.body).toContain("no reviewable textual evidence");
+    }),
+  );
 });
 
 describe("deterministic finding merge", () => {
@@ -1359,22 +1065,14 @@ type OfflineFanOutProgram = ReturnType<typeof runOfflineFanOut>;
 type OfflineFanOutServices = Effect.Services<OfflineFanOutProgram>;
 type OfflineFanOutFailure = EffectError<OfflineFanOutProgram>;
 type OfflineFanOutRequirementsProof = Assert<Equal<OfflineFanOutServices, never>>;
-type UnitFailureContainedProof = Assert<
-  Equal<Extract<OfflineFanOutFailure, FileReviewUnitFailed>, never>
->;
-type WorkRejectionContainedProof = Assert<
-  Equal<Extract<OfflineFanOutFailure, FileReviewWorkRejected>, never>
+type PassMisbehaviorContainedProof = Assert<
+  Equal<Extract<OfflineFanOutFailure, ReviewPassMisbehaved>, never>
 >;
 
 describe("fan-out Effect channels", () => {
-  it("keeps provided requirements empty and expected child failures contained", () => {
+  it("keeps provided requirements empty and expected pass failures contained", () => {
     const noRequirements: OfflineFanOutRequirementsProof = true;
-    const unitFailuresAreResults: UnitFailureContainedProof = true;
-    const workRejectionsAreResults: WorkRejectionContainedProof = true;
-    expect([noRequirements, unitFailuresAreResults, workRejectionsAreResults]).toEqual([
-      true,
-      true,
-      true,
-    ]);
+    const passFailuresAreResults: PassMisbehaviorContainedProof = true;
+    expect([noRequirements, passFailuresAreResults]).toEqual([true, true]);
   });
 });

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Duration, Effect, Layer, Redacted, Ref, Schema } from "effect";
-import { Agent, AgentRuntime, IdGenerator } from "effect-agent";
+import { Agent, AgentRuntime, IdGenerator, UsageBudgetLimits } from "effect-agent";
 import { Tool } from "effect/unstable/ai";
 
 import {
@@ -184,6 +184,7 @@ const runOfflineFanOut = (script: {
   readonly children: ReadonlyArray<OfflineUnitScript>;
   readonly fixture?: FixturePullRequest | undefined;
   readonly maxFindings?: number | undefined;
+  readonly limits?: UsageBudgetLimits | undefined;
 }) =>
   Effect.gen(function* () {
     const fixture = script.fixture ?? highRiskFixture;
@@ -201,7 +202,7 @@ const runOfflineFanOut = (script: {
     const program = executeFanOutReview(childBinding, {
       post: true,
       applyVerdict: false,
-      limits: fanOutReviewBudgetLimits,
+      limits: script.limits ?? fanOutReviewBudgetLimits,
       ...(script.maxFindings === undefined ? {} : { maxFindings: script.maxFindings }),
       signature: () => "offline-assurance-profile-v3",
     }).pipe(
@@ -873,6 +874,31 @@ describe("host-scheduled discovery and verification pipeline", () => {
       expect(result.outcome.plan.body).toContain("Unsettled review passes");
       expect(result.outcome.plan.body).toContain("do not change code to satisfy this section");
       expect(result.outcome.plan.event).toBe("COMMENT");
+    }),
+  );
+
+  it.effect("never retries budget exhaustion and still advances continuity", () =>
+    Effect.gen(function* () {
+      const result = yield* runOfflineFanOut({
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          report(specialistPass.passId, discoveryReport(specialistPass, [])),
+        ],
+        // The first child's turn-seam consumption trips the shared budget, so
+        // every scheduled pass fails with BudgetExceeded. A retry would fail
+        // identically, so the pipeline must not double the child calls.
+        limits: UsageBudgetLimits.make({ maxInputTokens: 1 }),
+      });
+
+      expect(result.childCalls).toBeLessThanOrEqual(2);
+      expect(result.outcome.assurance.status).toBe("incomplete");
+      for (const pass of result.outcome.assurance.failedPasses) {
+        expect(pass.errorTag).toBe("BudgetExceeded");
+      }
+      // Continuity still advances; the whole unit is carried for retry.
+      expect(result.outcome.state?.reviewedHeadSha).toBe(FIXTURE_SHA);
+      expect(result.outcome.state?.settled).toBe(false);
+      expect(result.outcome.state?.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
     }),
   );
 

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -6,7 +6,7 @@ import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput";
 
 import {
   anchorViolation,
-  assessReviewCoverage,
+  assessFlatReview,
   annotatePatch,
   ChangedFile,
   CodeReview,
@@ -29,8 +29,8 @@ import {
   ReadFile,
   ReadFileDiff,
   ReviewConcern,
-  ReviewCoverage,
   ReviewExecutionContext,
+  ReviewInputCoverage,
   ReviewFinding,
   ReviewHeadComparison,
   ReviewPublicationPlan,
@@ -75,17 +75,18 @@ describe("host coverage diagnostics", () => {
         patch: "@@ -0,0 +1 @@\n+export {};",
       }),
     );
-    const coverage = assessReviewCoverage({
-      shape: "flat",
+    const assessment = assessFlatReview({
       files: longFiles,
       totalFiles: longFiles.length,
       anchorFiles: longFiles,
       totalAnchorFiles: longFiles.length,
       events: [],
     });
-    expect(coverage.status).toBe("incomplete");
-    expect(coverage.reasons.every((reason) => reason.length <= 1_000)).toBe(true);
-    expect(coverage.reasons.join("\n")).toContain("(+2 more)");
+    expect(assessment.inputCoverage.status).toBe("incomplete");
+    expect(assessment.inputCoverage.reasons.every((reason) => reason.length <= 1_000)).toBe(true);
+    expect(assessment.inputCoverage.reasons.join("\n")).toContain("(+2 more)");
+    // Every unassigned reviewable path is a retryable gap for the next run.
+    expect(assessment.unreviewedPaths).toEqual(longFiles.map((file) => file.path));
   });
 });
 
@@ -347,22 +348,26 @@ describe("publication planning", () => {
         totalChangedFiles: 2,
       }).event,
     ).toBe("APPROVE");
-    const legacyIncomplete = planPublication(approving, files, {
+    // A machinery gap blocks APPROVE but never REQUEST_CHANGES: requesting
+    // changes for a reviewer-side fault would tell the author to edit code
+    // nobody reviewed.
+    const machineryGap = planPublication(approving, files, {
       applyVerdict: true,
       headSha: FIXTURE_SHA,
       totalChangedFiles: 2,
-      coverage: ReviewCoverage.make({
+      inputCoverage: ReviewInputCoverage.make({
         status: "incomplete",
-        requiredPaths: [],
-        reviewedPaths: [],
-        unreviewedPaths: [],
-        failedUnits: [],
-        reasons: ["required review unit did not complete"],
+        requiredPaths: ["src/hello.ts"],
+        assignedPaths: [],
+        partialPaths: [],
+        unassignedPaths: ["src/hello.ts"],
+        undiffablePaths: [],
+        reasons: ["required paths received no successful diff input (1): src/hello.ts"],
       }),
     });
-    expect(legacyIncomplete.event).toBe("REQUEST_CHANGES");
-    expect(legacyIncomplete.body).toContain("### 🛑 Incomplete coverage");
-    expect(legacyIncomplete.body).toContain("required review unit did not complete");
+    expect(machineryGap.event).toBe("COMMENT");
+    expect(machineryGap.body).toContain("### ⚠️ Incomplete input coverage");
+    expect(machineryGap.body).toContain("received no successful diff input");
   });
 
   it("extends the suggestion fence past any backticks in the replacement", () => {
@@ -891,7 +896,6 @@ describe("concerns, metadata, and footer", () => {
       totalChangedFiles: 2,
       modelLabel: "openai/gpt-5.6-sol (effort high)",
       usage: { inputTokens: 1234, outputTokens: 56 },
-      usageScope: "run",
       runUrl: "https://github.com/acme/widgets/actions/runs/42",
     });
     expect(plan.body).toContain(
@@ -966,17 +970,6 @@ describe("concerns, metadata, and footer", () => {
     expect(plan.body).toContain(`<!-- effect-agent-pr-review fingerprint=sha256:${"a".repeat(64)}`);
     // The plan's data is complete regardless of what the body could hold.
     expect(plan.demoted).toHaveLength(20);
-  });
-
-  it("labels coordinator-scoped usage honestly", () => {
-    const plan = planPublication(scriptedReview, files, {
-      applyVerdict: false,
-      headSha: FIXTURE_SHA,
-      totalChangedFiles: 2,
-      usage: { inputTokens: 10, outputTokens: 2 },
-      usageScope: "coordinator",
-    });
-    expect(plan.body).toContain("10 in / 2 out tokens (coordinator)");
   });
 });
 
@@ -1174,7 +1167,7 @@ describe("offline review run", () => {
         body: "A new delta touching this path invalidates the carried finding.",
       });
       const priorState = ReviewState.make({
-        version: 1,
+        version: 2,
         repository: metadata.repository,
         pullRequestNumber: metadata.number,
         baseRef: metadata.baseRef,
@@ -1186,6 +1179,8 @@ describe("offline review run", () => {
         reviewedPathCount: 2,
         unresolvedFindings: [priorFinding, affectedPriorFinding],
         unresolvedConcerns: [],
+        unreviewedPaths: [],
+        settled: true,
         lastReviewMode: "full",
       });
       const selection = selectReviewRange({
@@ -1230,7 +1225,6 @@ describe("offline review run", () => {
       const outcome = yield* executeReview(binding, {
         post: false,
         applyVerdict: false,
-        reviewShape: "flat",
       }).pipe(
         Effect.provide(
           Layer.mergeAll(

--- a/packages/pr-review/test/providers.test.ts
+++ b/packages/pr-review/test/providers.test.ts
@@ -1,4 +1,5 @@
-import { OpenAiClient, OpenAiSchema } from "@effect/ai-openai";
+import type { OpenAiSchema } from "@effect/ai-openai";
+import { OpenAiClient } from "@effect/ai-openai";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Ref } from "effect";
 import { LanguageModel } from "effect/unstable/ai";

--- a/packages/pr-review/test/review-retirement.test.ts
+++ b/packages/pr-review/test/review-retirement.test.ts
@@ -47,7 +47,7 @@ const makeState = (
   unresolvedFindings: ReadonlyArray<StoredReviewFinding>,
 ) =>
   ReviewState.make({
-    version: 1,
+    version: 2,
     repository: "acme/widgets",
     pullRequestNumber: 42,
     baseRef: "main",
@@ -59,6 +59,8 @@ const makeState = (
     reviewedPathCount: 2,
     unresolvedFindings,
     unresolvedConcerns: [],
+    unreviewedPaths: [],
+    settled: true,
     lastReviewMode: "incremental",
   });
 
@@ -96,7 +98,7 @@ const renderPriorBody = Effect.gen(function* () {
 const machineComments = (body: string): ReadonlyArray<string> =>
   Array.from(
     body.matchAll(
-      /<!-- effect-agent-pr-review metadata\n[\s\S]*?\n-->|<!-- effect-agent-pr-review fingerprint=sha256:[0-9a-f]{64} -->|<!-- effect-agent-pr-review state-v1:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g,
+      /<!-- effect-agent-pr-review metadata\n[\s\S]*?\n-->|<!-- effect-agent-pr-review fingerprint=sha256:[0-9a-f]{64} -->|<!-- effect-agent-pr-review state-v\d+:[A-Za-z0-9+/]+={0,2}\.[0-9a-f]{64} -->/g,
     ),
     (match) => match[0],
   );

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -57,7 +57,7 @@ const unresolvedFinding = StoredReviewFinding.make({
 });
 
 const priorState = ReviewState.make({
-  version: 1,
+  version: 2,
   repository: metadata.repository,
   pullRequestNumber: metadata.number,
   baseRef: metadata.baseRef,
@@ -69,6 +69,8 @@ const priorState = ReviewState.make({
   reviewedPathCount: 1,
   unresolvedFindings: [unresolvedFinding],
   unresolvedConcerns: [],
+  unreviewedPaths: [],
+  settled: true,
   lastReviewMode: "full",
 });
 
@@ -230,6 +232,27 @@ describe("review state", () => {
     });
     expect(rewrittenBase.mode).toBe("full");
     expect(rewrittenBase.reason).toContain("changed materially");
+  });
+
+  it("retries carried unreviewed paths inside the incremental scope", () => {
+    const carryingState = ReviewState.make({
+      ...priorState,
+      unreviewedPaths: ["src/accepted.ts", "src/reverted.ts"],
+      settled: false,
+    });
+    const selection = select({ priorState: carryingState });
+
+    expect(selection.mode).toBe("incremental");
+    // The delta plus the carried path still present in the pull request; a
+    // carried path reverted out of the PR has nothing left to review.
+    expect(selection.files.map((file) => file.path)).toEqual([
+      "src/accepted.ts",
+      "src/corrective.ts",
+    ]);
+    // Carried paths count as affected: their stored findings are re-derived
+    // by the fresh re-review instead of being carried blindly.
+    expect(selection.affectedPaths).toContain("src/accepted.ts");
+    expect(selection.reason).toContain("retrying 1 carried unreviewed path(s)");
   });
 
   it("forces fresh full-diff discovery only when final mode is explicit", () => {

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -255,6 +255,34 @@ describe("review state", () => {
     expect(selection.reason).toContain("retrying 1 carried unreviewed path(s)");
   });
 
+  it("keeps a carried unreviewed path in scope across a rename", () => {
+    const renamedFile = ChangedFile.make({
+      path: "src/renamed.ts",
+      previousPath: "src/accepted.ts",
+      status: "renamed",
+      additions: 0,
+      deletions: 0,
+      patch: "@@ -1 +1 @@\n-old\n+accepted",
+    });
+    const carryingState = ReviewState.make({
+      ...priorState,
+      unreviewedPaths: ["src/accepted.ts"],
+      settled: false,
+    });
+    const selection = select({
+      priorState: carryingState,
+      fullFiles: [renamedFile, correctiveFile],
+    });
+
+    expect(selection.mode).toBe("incremental");
+    expect(selection.files.map((file) => file.path)).toEqual([
+      "src/corrective.ts",
+      "src/renamed.ts",
+    ]);
+    expect(selection.affectedPaths).toContain("src/accepted.ts");
+    expect(selection.reason).toContain("retrying 1 carried unreviewed path(s)");
+  });
+
   it("forces fresh full-diff discovery only when final mode is explicit", () => {
     const selection = select({ requestedMode: "final" });
     expect(selection.mode).toBe("full");


### PR DESCRIPTION
## Summary

- Fixes #131: `@effect-agent/pr-review` could enter a non-converging incremental review/fix loop — an agent fixed every finding from review N, and review N+1 reopened the entire post-baseline scope and failed again on freshly discovered issues, with no principled place to stop.
- The fan-out reviewer is now scheduled entirely by [host code over the deterministic unit plan](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/internal/fan-out.ts#L746) — the coordinator model, the `delegate_file_review` Subagent, and the ~600-line event-trace fold that verified the coordinator copied the plan byte-for-byte are deleted. [Each pass is retried once on failure](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/internal/fan-out.ts#L463), and [an invalid-anchor finding is discarded and counted](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/internal/fan-out.ts#L518) instead of rejecting its whole pass.
- Continuity is now monotone: [every completed signed run advances the baseline](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/internal/run.ts#L184) (`ReviewState` v2), carrying genuinely-unsettled work as retryable `unreviewedPaths` that the [next incremental selection folds back into scope](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/internal/review-state.ts#L344). A remediation push is reviewed against its immediate predecessor plus the real leftovers — never the whole post-baseline blob.
- The [check conclusion](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/src/action.ts#L380) ranks blocking code findings above machinery gaps, and an `incomplete` conclusion now leads with "a reviewer-side gap, not a code defect; N path(s) are carried forward and retried automatically" — the explicit stop signal the issue asked for. Machinery gaps cap the GitHub review event at COMMENT (never REQUEST_CHANGES, never APPROVE).
- Net **~−400 lines** with functionality added (retries, carried scope, installment reviews of whole-file capacity overflow), plus a latent flat-shape fix: `unverified` assurance no longer fails every flat check. Unreviewable scope stays **fail-closed**: undiffable (binary/oversized) and partially-assignable paths keep input coverage incomplete *and* are carried, so they can never move behind a green check even after leaving the incremental delta — ignore globs remain the deliberate exclusion path.

## What went wrong

The incident PR (reve-ai/kommunikasie#684, 56 workflow runs, 51 failures) was a systems failure with three interlocking causes:

1. **All-or-nothing continuity.** The signed baseline (`ReviewState`) was embedded only when *every* configured pass settled. One rejected pass meant no new baseline, so the next run's incremental selection reopened everything changed since the last fully-settled head (`Incremental scope: reopened 18 affected file(s)…` on every push). More reopened files → more scheduled passes → higher probability that at least one flaked → the baseline stayed frozen. Self-reinforcing.
2. **Unretryable prompt-compliance failures.** The coordinator LLM had to copy the deterministic plan into tool calls verbatim, and the assurance fold rejected any deviation (`PassNotAssigned`, `PassAssignedMultipleTimes`, `FileReviewWorkRejected`, …) with instructions to "never retry" — a retry would itself have failed the fold as a duplicate declaration. In the incident's terminal runs, a specialist pass whose finding had no anchorable line was rejected wholesale and never retried, keeping assurance incomplete.
3. **A red check with no stop signal.** `fail-on: never` was ignored (already removed in #125), and the failure text gave a coding agent no way to distinguish "your code has problems" from "the reviewer's machinery flaked" — so each red check read as an invitation to write more code, expanding the very scope that kept reopening.

The fix removes each cause structurally rather than tuning it: host dispatch makes scheduling non-compliance unrepresentable and retries trivial; monotone continuity makes a flaky pass cost exactly its own scope on the next run; and the conclusion text tells an agent literally not to change code for machinery gaps.

## Architecture

- **`fan-out.ts`** now owns a plain-Effect pipeline: `planReviewUnits` → per-unit general + specialist discovery → per-unit candidate verification, `Effect.forEach` over units at concurrency 4, passes sequential within a unit, one retry per pass (`BudgetExceeded` excepted). Children are unchanged evidence-only agents; the review summary/verdict are composed deterministically from verifier-confirmed severities (the coordinator never saw the diffs — its prose was always secondhand).
- **`coverage.ts`** shrinks to the claim schemas plus the flat reviewer's event-trace assessment; fan-out assurance is computed from direct pass results in the pipeline, so the reconstruct-from-events fold is gone.
- **`run.ts`** splits into `executeReview` (flat) and `executeFanOutReview` sharing one settlement tail; one budget observes every child, so reported usage is whole-run (the old "coordinator-only" usage under-reported real cost) and the `usageScope` plumbing is deleted.
- **`ReviewState` v2** (`state-v2` marker) adds `unreviewedPaths` + `settled`; skip-unchanged requires `settled`, so a carried gap is always retried instead of skipped over. Old `state-v1` markers no longer validate — the first run after upgrading performs one full review, per the development-data reset policy.

Rejected alternative — a cross-run novelty/scope budget ("stop reporting new findings after N cycles"): it would silently suppress genuinely new defects in genuinely new code and add cross-run policy state; with scope convergence and honest conclusions the loop's *mechanism* is gone, and a reviewer that keeps finding real issues in new code is doing its job.

## Dogfood review round

The repository's own review action reviewed this PR and requested changes with 9 findings — the exact reviewer/remediation dynamic this PR is about. Dispositions (each thread carries its reply): **6 fixed** (fail-closed undiffable/partial carry, fingerprint framing, changeset format, two test-strength findings), **3 rejected with pinned evidence** (two findings wanted `BudgetExceeded` to fail the whole run — which would reintroduce the non-converging repeat-the-identical-run shape for budget-bound PRs; one claimed renamed carried paths are dropped — refuted by a new regression test).

## Evidence

Two deterministic regression tests pin the incident's exact failure shapes (offline scripted children, no network):

- [`discards an invalid-anchor finding without failing its pass or the baseline`](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/test/pr-review-fanout.test.ts#L768) — the incident's `FileReviewWorkRejected` case: assurance stays `settled`, the valid sibling finding still publishes, `discardedInvalidFindings: 1`.
- [`carries a persistently failed pass forward instead of freezing the baseline`](https://github.com/danieljvdm/effect-agent/blob/dan/doom-loop/packages/pr-review/test/pr-review-fanout.test.ts#L849) — a pass that fails even after its retry: the baseline **advances** to the new head with `settled: false` and the unit's paths stored as `unreviewedPaths`, and the posted body says "do not change code to satisfy this section".

Plus: host-level retry pinned exactly (`retries a misdirected child report once and settles on the retry`, child call count 4), the skip guard (`re-reviews an unchanged patch when the stored state carries unreviewed scope`), carried-scope selection (`retries carried unreviewed paths inside the incremental scope`), and blocking-over-incomplete gate ordering. Full package suite: 12 files, 145 tests passing; repo `check` (types, lint, fmt, per-package tsc, action-bundle freshness) passes. The committed `action/dist` bundle is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
