### PR TITLE
fix(platform-cloudflare): run Code Mode host calls on the pass Scope

### DIFF
--- a/.changeset/code-mode-pass-scope.md
+++ b/.changeset/code-mode-pass-scope.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Run Dynamic Worker Code Mode host calls on a Scope-owned pass fiber so they inherit the `execute` Context and die with the pass.
+
+BEHAVIOR CHANGE: `CodeExecutionHost.call` now sees services provided to `execute` instead of Effect defaults from a `runFork` root.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -354,10 +354,11 @@ explicitly allowed structured values, applies the configured Dynamic Worker CPU 
 limits plus an executor-owned wall-clock deadline (an asynchronously suspended pass consumes no
 CPU and must not outlive its deadline), invokes one fixed entrypoint, validates the returned
 envelope through Effect Schema, and disposes the entrypoint and Worker handles in Scope
-finalizers. Host callbacks run one at a time on retained independent root Effect fibers so their
-return RPC is not coupled to the still-open guest RPC; pass teardown closes callback admission,
-interrupts and awaits active work, and settles queued calls. One absolute monotonic deadline
-applies to the worker RPC and every host callback. A synchronous runaway program is stopped by
+finalizers. Host callbacks run one at a time on a Scope-owned child fiber of the pass so they
+inherit the `execute` Context and die with the pass Scope, while remaining a sibling of the
+guest RPC waiter so the return RPC is not coupled to the still-open `entrypoint.run()`; pass
+teardown closes callback admission, interrupts and awaits active work, and settles queued
+calls. One absolute monotonic deadline applies to the worker RPC and every host callback. A synchronous runaway program is stopped by
 platform CPU limits, not only by a JavaScript timer.
 
 The adapter records no persistent state and adds no deployment-class claim beyond `E`: the `DN`

--- a/packages/platform-cloudflare/src/code-mode-executor.ts
+++ b/packages/platform-cloudflare/src/code-mode-executor.ts
@@ -19,7 +19,7 @@ import {
   type CodeExecutionRequest,
 } from "@effect-agent/sandbox";
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { Cause, Duration, Effect, Exit, Fiber, Layer, Option, Schema } from "effect";
+import { Duration, Effect, Exit, Fiber, Layer, Option, Queue, Schema } from "effect";
 
 /**
  * The Cloudflare Dynamic Worker `CodeExecutor` adapter (C4 of ADR-0017;
@@ -346,23 +346,21 @@ const utf8ByteLength = (value: string): number => {
   return total;
 };
 
-type HostDispatchFailure =
-  | { readonly _tag: "host-call-limit" }
-  | { readonly _tag: "host-call-result-limit"; readonly observed: number }
-  | { readonly _tag: "host-call-protocol" }
-  | { readonly _tag: "wall-clock-timeout" }
-  | { readonly _tag: "host-call-defect"; readonly cause: Cause.Cause<never> };
-
 interface QueuedHostCall {
   readonly call: CodeHostCall;
   readonly resolve: (value: unknown) => void;
   readonly reject: (reason: unknown) => void;
 }
 
-interface ActiveHostCall {
-  readonly fiber: Fiber.Fiber<Record<string, unknown>, never>;
-  readonly settlement: Promise<void>;
-}
+type HostWork =
+  | { readonly _tag: "call"; readonly queued: QueuedHostCall }
+  | { readonly _tag: "limit" };
+
+type HostDispatchError =
+  | CodeExecutionTimeoutError
+  | CodeOutputLimitError
+  | CodeExecutionProtocolError
+  | CodeHostCallLimitError;
 
 /** Reserved global names the harness owns inside the dynamic worker. */
 const reservedHarnessGlobals = new Set(["console"]);
@@ -426,131 +424,92 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
     let issuedHostCalls = 0;
     let passOpen = true;
     const queuedHostCalls: Array<QueuedHostCall> = [];
-    let activeHostCall: ActiveHostCall | undefined;
-    let hostDispatchFailure: HostDispatchFailure | undefined;
-    let propagatedHostDispatchFailure: HostDispatchFailure | undefined;
-    let signalHostDispatchFailure = (_failure: HostDispatchFailure): void => undefined;
-    const hostDispatchFailureSignal = new Promise<HostDispatchFailure>((resolve) => {
-      signalHostDispatchFailure = resolve;
-    });
+    let passFailure: HostDispatchError | undefined;
+    const failPass = (error: HostDispatchError): void => {
+      if (passFailure === undefined) passFailure = error;
+    };
     const rejectQueuedHostCalls = (reason: Error): void => {
       for (const queued of queuedHostCalls.splice(0)) {
         queued.reject(reason);
       }
     };
-    const recordHostDispatchFailure = (failure: HostDispatchFailure): void => {
-      if (hostDispatchFailure !== undefined) return;
-      hostDispatchFailure = failure;
-      signalHostDispatchFailure(failure);
-      rejectQueuedHostCalls(new Error("Code Mode pass failed"));
-    };
-    const failHostDispatch = (failure: HostDispatchFailure) => {
-      switch (failure._tag) {
-        case "host-call-limit":
-          return Effect.fail(
-            CodeHostCallLimitError.make({
-              implementation: dynamicWorkerImplementation,
-              limit: request.limits.maxHostCalls,
-              logs: [],
-            }),
-          );
-        case "host-call-result-limit":
-          return Effect.fail(
-            CodeOutputLimitError.make({
-              implementation: dynamicWorkerImplementation,
-              surface: "host-call-result",
-              limit: request.limits.maxHostCallResultBytes,
-              observed: failure.observed,
-              logs: [],
-            }),
-          );
-        case "host-call-protocol":
-          return Effect.fail(
-            CodeExecutionProtocolError.make({
-              implementation: dynamicWorkerImplementation,
-              message: "The execution host returned a value outside the CodeHostCallResult schema",
-            }),
-          );
-        case "wall-clock-timeout":
-          return Effect.fail(
-            CodeExecutionTimeoutError.make({
-              implementation: dynamicWorkerImplementation,
-              kind: "wall-clock",
-              maxWallTime: request.limits.maxWallTime,
-              logs: [],
-            }),
-          );
-        case "host-call-defect":
-          return Effect.failCause(failure.cause);
-      }
-    };
-    const propagateHostDispatchFailure = (failure: HostDispatchFailure) =>
+    const queue = yield* Queue.unbounded<HostWork>();
+
+    const deliverHostOutcome = (
+      queued: QueuedHostCall,
+      outcome: CodeHostCallResult,
+    ): Effect.Effect<void, CodeExecutionProtocolError | CodeOutputLimitError> =>
       Effect.gen(function* () {
-        propagatedHostDispatchFailure = failure;
-        return yield* failHostDispatch(failure);
+        const decoded = decodeHostCallResult(outcome);
+        if (Option.isNone(decoded)) {
+          const error = CodeExecutionProtocolError.make({
+            implementation: dynamicWorkerImplementation,
+            message: "The execution host returned a value outside the CodeHostCallResult schema",
+          });
+          failPass(error);
+          return yield* error;
+        }
+        const encoded = encodeHostResultPayload(decoded.value);
+        if (encoded === undefined || encoded.resultBytes > request.limits.maxHostCallResultBytes) {
+          const error = CodeOutputLimitError.make({
+            implementation: dynamicWorkerImplementation,
+            surface: "host-call-result",
+            limit: request.limits.maxHostCallResultBytes,
+            observed: encoded?.resultBytes ?? 0,
+            logs: [],
+          });
+          failPass(error);
+          return yield* error;
+        }
+        const normalizedPayload: unknown = JSON.parse(encoded.encodedPayload);
+        queued.resolve(
+          decoded.value._tag === "CodeHostCallSuccess"
+            ? { _tag: "CodeHostCallSuccess", value: normalizedPayload }
+            : { _tag: "CodeHostCallFailure", error: normalizedPayload },
+        );
       });
 
-    const startNextHostCall = (): void => {
-      if (!passOpen || hostDispatchFailure !== undefined || activeHostCall !== undefined) return;
-      const queued = queuedHostCalls.shift();
-      if (queued === undefined) return;
-
-      // A Dynamic Worker callback is a new Workers RPC into the loader isolate. Running the
-      // complete host call on an independent root fiber breaks its dependency on the still-open
-      // guest RPC. Retaining the handle and starting one call at a time preserves bounded,
-      // serialized execution and lets pass teardown interrupt and await the active call.
-      const fiber = Effect.runFork(
-        Effect.yieldNow.pipe(
-          Effect.andThen(host.call(queued.call)),
+    // Workers RPC into the loader isolate cannot settle on the fiber blocked
+    // in `entrypoint.run()`. A Scope-owned sibling fiber keeps that
+    // independence while inheriting the pass Context and dying with the Scope.
+    const serveHostCalls = Effect.gen(function* () {
+      while (true) {
+        const work = yield* Queue.take(queue);
+        if (work._tag === "limit") {
+          const error = CodeHostCallLimitError.make({
+            implementation: dynamicWorkerImplementation,
+            limit: request.limits.maxHostCalls,
+            logs: [],
+          });
+          failPass(error);
+          return yield* error;
+        }
+        const queued = work.queued;
+        yield* host.call(queued.call).pipe(
           Effect.timeoutOrElse({
             duration: remainingPassWallTime(),
-            orElse: () =>
-              Effect.sync(() => {
-                recordHostDispatchFailure({ _tag: "wall-clock-timeout" });
-                throw new Error("code-mode host call exceeded the pass wall-clock limit");
-              }),
-          }),
-          Effect.map((outcome) => {
-            const decoded = decodeHostCallResult(outcome);
-            if (Option.isNone(decoded)) {
-              recordHostDispatchFailure({ _tag: "host-call-protocol" });
-              throw new Error("host-call protocol violation");
-            }
-            const encoded = encodeHostResultPayload(decoded.value);
-            if (
-              encoded === undefined ||
-              encoded.resultBytes > request.limits.maxHostCallResultBytes
-            ) {
-              recordHostDispatchFailure({
-                _tag: "host-call-result-limit",
-                observed: encoded?.resultBytes ?? 0,
+            orElse: () => {
+              const error = CodeExecutionTimeoutError.make({
+                implementation: dynamicWorkerImplementation,
+                kind: "wall-clock",
+                maxWallTime: request.limits.maxWallTime,
+                logs: [],
               });
-              throw new Error("host-call result limit exceeded");
-            }
-            const normalizedPayload: unknown = JSON.parse(encoded.encodedPayload);
-            return decoded.value._tag === "CodeHostCallSuccess"
-              ? { _tag: "CodeHostCallSuccess", value: normalizedPayload }
-              : { _tag: "CodeHostCallFailure", error: normalizedPayload };
+              failPass(error);
+              return error;
+            },
           }),
-        ),
-      );
-      const settlement = Effect.runPromise(Fiber.await(fiber))
-        .then((exit) => {
-          if (Exit.isSuccess(exit)) {
-            queued.resolve(exit.value);
-            return;
-          }
-          if (!Cause.hasInterruptsOnly(exit.cause)) {
-            recordHostDispatchFailure({ _tag: "host-call-defect", cause: exit.cause });
-          }
-          queued.reject(new Error("Code Mode host call failed"));
-        })
-        .finally(() => {
-          if (activeHostCall?.fiber === fiber) activeHostCall = undefined;
-          startNextHostCall();
-        });
-      activeHostCall = { fiber, settlement };
-    };
+          Effect.flatMap((outcome) => deliverHostOutcome(queued, outcome)),
+          Effect.tapError(() =>
+            Effect.sync(() => queued.reject(new Error("Code Mode host call failed"))),
+          ),
+          Effect.onInterrupt(() =>
+            Effect.sync(() => queued.reject(new Error("Code Mode pass is closing"))),
+          ),
+        );
+      }
+    });
+    const server = yield* serveHostCalls.pipe(Effect.forkScoped);
 
     const dispatch = (hostCall: unknown): Promise<unknown> => {
       if (!passOpen) {
@@ -558,7 +517,13 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
       }
       issuedHostCalls += 1;
       if (issuedHostCalls > request.limits.maxHostCalls) {
-        recordHostDispatchFailure({ _tag: "host-call-limit" });
+        const error = CodeHostCallLimitError.make({
+          implementation: dynamicWorkerImplementation,
+          limit: request.limits.maxHostCalls,
+          logs: [],
+        });
+        failPass(error);
+        Queue.offerUnsafe(queue, { _tag: "limit" });
         return Promise.reject(new Error("host-call limit exceeded"));
       }
       const decoded = decodeHostCall(hostCall);
@@ -566,45 +531,23 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
         return Promise.reject(new TypeError("host calls must match the CodeHostCall schema"));
       }
       return new Promise((resolve, reject) => {
-        queuedHostCalls.push({ call: decoded.value, resolve, reject });
-        startNextHostCall();
+        const queued = { call: decoded.value, resolve, reject };
+        queuedHostCalls.push(queued);
+        Queue.offerUnsafe(queue, { _tag: "call", queued });
       });
     };
 
-    const closeHostDispatch = Effect.gen(function* () {
+    const closeAdmission = Effect.sync(() => {
       passOpen = false;
       passRegistry.delete(passId);
       rejectQueuedHostCalls(new Error("Code Mode pass is closing"));
-      const active = activeHostCall;
-      if (active !== undefined) {
-        yield* Fiber.interrupt(active.fiber);
-        yield* Effect.promise(() => active.settlement);
-        if (activeHostCall === active) activeHostCall = undefined;
-      }
-      return hostDispatchFailure;
     });
-    const stopHostDispatch = closeHostDispatch.pipe(
-      Effect.flatMap((failure) =>
-        failure !== undefined && propagatedHostDispatchFailure !== failure
-          ? propagateHostDispatchFailure(failure)
-          : Effect.void,
-      ),
-    );
-    const releaseHostDispatch = closeHostDispatch.pipe(
-      Effect.flatMap((failure) => {
-        if (failure?._tag !== "host-call-defect" || propagatedHostDispatchFailure === failure) {
-          return Effect.void;
-        }
-        propagatedHostDispatchFailure = failure;
-        return Effect.failCause(failure.cause);
-      }),
-    );
 
     yield* Effect.acquireRelease(
       Effect.sync(() => {
         passRegistry.set(passId, { dispatch });
       }),
-      () => releaseHostDispatch,
+      () => closeAdmission.pipe(Effect.andThen(Fiber.interrupt(server))),
     );
 
     // No `allowExperimental`: the runtime only accepts it when the CALLING
@@ -683,7 +626,7 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
       catch: (cause) => classifyWorkerFailure(cause, request.limits.maxWallTime),
     });
 
-    const raw = yield* Effect.raceFirst(
+    const exit = yield* Effect.raceFirst(
       rpc.pipe(
         Effect.timeoutOrElse({
           duration: remainingPassWallTime(),
@@ -696,16 +639,18 @@ const makeExecute = (options: DynamicWorkerCodeExecutorOptions): CodeExecutorExe
             }),
         }),
       ),
-      Effect.promise(() => hostDispatchFailureSignal).pipe(
-        Effect.flatMap(propagateHostDispatchFailure),
-      ),
-    );
-    yield* stopHostDispatch;
-    const finishedAt = performance.now();
-
-    if (hostDispatchFailure !== undefined) {
-      return yield* propagateHostDispatchFailure(hostDispatchFailure);
+      Fiber.join(server),
+    ).pipe(Effect.exit);
+    yield* closeAdmission;
+    yield* Fiber.interrupt(server);
+    if (passFailure !== undefined) {
+      return yield* passFailure;
     }
+    if (Exit.isFailure(exit)) {
+      return yield* Effect.failCause(exit.cause);
+    }
+    const raw = exit.value;
+    const finishedAt = performance.now();
 
     const outcome = decodeHarnessOutcome(raw);
     if (Option.isNone(outcome)) {

--- a/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
+++ b/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
@@ -79,12 +79,12 @@ describe("DEPLOY-011 Cloudflare Dynamic Worker CodeExecutor", () => {
     expect(payload.failures).toEqual([]);
   }, 120_000);
 
-  it("runs guest host calls outside the in-flight executor fiber", async () => {
-    const response = await runtime.dispatchFetch("http://placeholder/host-call-root-fiber");
+  it("host calls inherit the pass Scope and stay off the guest RPC fiber", async () => {
+    const response = await runtime.dispatchFetch("http://placeholder/host-call-pass-scope");
     expect(response.ok).toBe(true);
     expect(await response.json()).toMatchObject({
       tag: "success",
-      detail: { value: "root" },
+      detail: { value: "executor" },
     });
   }, 30_000);
 });

--- a/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
+++ b/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
@@ -107,6 +107,7 @@ const workerdConformanceCaseNames: ReadonlyArray<string> = [
   "TEST-015 surfaces an uncaught program throw with its bounded log capture",
   "TEST-015 fails typed when the program returns a non-JSON value",
   "CAP-015 rejects a network allowlist it cannot enforce with a typed unsupported error",
+  "TEST-015 interruption reaches in-flight host calls and pass teardown",
 ];
 
 const runAllChecks = (env: WorkerEnv): Effect.Effect<ReadonlyArray<string>> =>
@@ -244,12 +245,18 @@ const runAllChecks = (env: WorkerEnv): Effect.Effect<ReadonlyArray<string>> =>
     return failures;
   });
 
+/**
+ * Distinguishes a `runFork` root fiber (default `"root"`) from a child of
+ * the `execute` Scope (provided `"executor"`). Host calls must see the pass
+ * Context — they still run on a sibling fiber of the guest RPC waiter so
+ * the return RPC is not coupled to `entrypoint.run()`.
+ */
 const ExecutorFiberMarker = Context.Reference<"root" | "executor">(
   "@effect-agent/platform-cloudflare/test/ExecutorFiberMarker",
   { defaultValue: () => "root" },
 );
 
-const runHostCallRegression = (env: WorkerEnv) => {
+const runHostCallScopeRegression = (env: WorkerEnv) => {
   const layer = executorLayerFor(env);
   const namespace = CodeExecutionNamespace.make({ name: "warehouse", methods: ["query"] });
   const host: CodeExecutionHost["Service"] = {
@@ -268,8 +275,8 @@ const runHostCallRegression = (env: WorkerEnv) => {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     try {
-      if (new URL(request.url).pathname === "/host-call-root-fiber") {
-        return Response.json(await Effect.runPromise(runHostCallRegression(env)));
+      if (new URL(request.url).pathname === "/host-call-pass-scope") {
+        return Response.json(await Effect.runPromise(runHostCallScopeRegression(env)));
       }
       const failures = await Effect.runPromise(runAllChecks(env));
       return Response.json({ failures });


### PR DESCRIPTION
## Summary

- Dynamic Worker Code Mode host calls now run on a [Scope-owned sibling fiber](https://github.com/danieljvdm/effect-agent/blob/fix/code-mode-pass-scope/packages/platform-cloudflare/src/code-mode-executor.ts#L472-L512) of the guest RPC waiter, so `CodeExecutionHost.call` inherits the `execute` Context and dies with the pass.
- The Workers RPC callback still cannot settle on the fiber blocked in `entrypoint.run()`; admission stays a `Queue.offerUnsafe` from that callback, matching the in-process substitute.

## What went wrong

`startNextHostCall` used `Effect.runFork` plus `Effect.runPromise(Fiber.await(fiber))`. That starts a **runtime root** — not a child of the pass Scope — so:

1. `host.call` saw Effect defaults, not services provided to `execute`.
2. Closing the pass Scope did not interrupt the host-call fiber unless teardown remembered the handle and called `Fiber.interrupt` itself.
3. Protocol and timeout failures were `throw new Error` on that root, then remapped through Promise settlement.

The existing `/host-call-root-fiber` test encoded this: it provided `ExecutorFiberMarker = "executor"` on `execute` and asserted the host call observed the default `"root"`.

Serving the same work with `Queue.take` on `Effect.forkScoped` keeps the host call off the guest RPC fiber (Cloudflare still requires that) while making it a real child of the pass Scope. The marker test now expects `"executor"`.

## Architecture

- **Pass executor** owns Scope, Context, wall-clock deadline, and typed failure. [`serveHostCalls`](https://github.com/danieljvdm/effect-agent/blob/fix/code-mode-pass-scope/packages/platform-cloudflare/src/code-mode-executor.ts#L475) is the single-consumer loop; [`dispatch`](https://github.com/danieljvdm/effect-agent/blob/fix/code-mode-pass-scope/packages/platform-cloudflare/src/code-mode-executor.ts#L514) remains the Promise RPC boundary.
- **Guest RPC waiter** stays `Effect.tryPromise(() => entrypoint.run())`, raced with `Fiber.join(server)`.
- **Spec**: [deployment.md](https://github.com/danieljvdm/effect-agent/blob/fix/code-mode-pass-scope/docs/spec/deployment.md#L357) no longer describes host callbacks as independent root fibers.

## Evidence

The marker test was red on `runFork` before the executor change:

```
AssertionError: expected { tag: 'success', detail: { … } } to match object { tag: 'success', … }
-     "value": "executor",
+     "value": "root",
```

After `forkScoped`, the same workerd lane is green, including `TEST-015 interruption reaches in-flight host calls and pass teardown` now run against the isolated adapter (it previously lived only on the in-process substitute):

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```


Made with [Cursor](https://cursor.com)