### PR TITLE
fix(pr-review): hash fingerprints through Crypto.Crypto

### DIFF
--- a/.changeset/pr-review-crypto-fingerprint.md
+++ b/.changeset/pr-review-crypto-fingerprint.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Hash review fingerprints through Effect `Crypto.Crypto` instead of `globalThis.crypto`.
+
+BEHAVIOR CHANGE: `computeChangesetFingerprint`, `computeProfileFingerprint`, and `PrReview` fingerprint/`run` Effects now require `Crypto.Crypto`. Node CLI/Action hosts already satisfy this via `NodeServices.layer`.

--- a/examples/pr-review/test/example-reviewer.test.ts
+++ b/examples/pr-review/test/example-reviewer.test.ts
@@ -1,9 +1,9 @@
+import type { ReviewPublicationPlan } from "@effect-agent/pr-review";
 import {
   ChangedFile,
   CodeReview,
   PullRequestMetadata,
   ReviewFinding,
-  ReviewPublicationPlan,
 } from "@effect-agent/pr-review";
 import {
   collectingReviewPublisherLayer,
@@ -14,6 +14,7 @@ import {
   scriptedFinalParts,
   scriptedToolTurn,
 } from "@effect-agent/pr-review/testing";
+import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Ref, Schema } from "effect";
 
@@ -110,6 +111,7 @@ describe("example reviewer", () => {
               fixturePullRequestSourceLayer(fixture),
               collectingReviewPublisherLayer(published),
               ReadReviewConventionsLayer,
+              NodeCrypto.layer,
             ),
           ),
         );

--- a/packages/pr-review/src/internal/factory.ts
+++ b/packages/pr-review/src/internal/factory.ts
@@ -11,7 +11,7 @@ import { Toolkit, type LanguageModel, type Model, type Tool } from "effect/unsta
 
 import type { ChangedFile } from "./diff.ts";
 import { makeFileReviewerDefinition } from "./fan-out.ts";
-import { computeChangesetFingerprint } from "./fingerprint.ts";
+import { computeChangesetFingerprint, computeProfileFingerprint } from "./fingerprint.ts";
 import { compileIgnoreGlobs, ignoringPullRequestSourceLayer } from "./ignore.ts";
 import {
   clampMaxFindings,
@@ -26,7 +26,7 @@ import {
   resolveGuidance as resolveReviewGuidance,
   type ReviewGuidance,
 } from "./review-agent.ts";
-import { buildProfileMission, computeProfileFingerprint } from "./review-state.ts";
+import { buildProfileMission } from "./review-state.ts";
 import {
   buildReviewMission,
   executeFanOutReview,
@@ -175,8 +175,8 @@ const makeReviewSnapshot = (ignore: ReadonlyArray<string> | undefined) =>
  * Build the flat reviewer: one bounded read-only agent over the whole
  * changeset. Returns the model-agnostic definition, the explicit binding, and
  * a `run` whose error and requirement channels stay fully inferred — the
- * pull-request source, the publisher, extra tool handlers, and the Model
- * Layer's requirements all remain visible to the caller.
+ * pull-request source, the publisher, `Crypto.Crypto`, extra tool handlers,
+ * and the Model Layer's requirements all remain visible to the caller.
  */
 const make = <
   Provider,

--- a/packages/pr-review/src/internal/fingerprint.ts
+++ b/packages/pr-review/src/internal/fingerprint.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Crypto, Effect, Encoding } from "effect";
 
 import type { ChangedFile } from "./diff.ts";
 
@@ -36,14 +36,14 @@ export const extractFingerprint = (body: string): string | undefined => {
   return last;
 };
 
-/** WebCrypto SHA-256; unavailable crypto is a defect, not an expected failure. */
-const sha256Hex = (text: string): Effect.Effect<string> =>
-  Effect.promise(async () => {
-    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
-    return Array.from(new Uint8Array(digest))
-      .map((byte) => byte.toString(16).padStart(2, "0"))
-      .join("");
-  });
+/** SHA-256 via `Crypto.Crypto`; unavailable crypto is a defect, not an expected failure. */
+const sha256Hex = Effect.fn("sha256Hex")(function* (
+  text: string,
+): Effect.fn.Return<string, never, Crypto.Crypto> {
+  const crypto = yield* Crypto.Crypto;
+  const digest = yield* crypto.digest("SHA-256", new TextEncoder().encode(text)).pipe(Effect.orDie);
+  return Encoding.encodeHex(digest);
+});
 
 const FIELD = "\u0000";
 const RECORD = "\u0001";
@@ -80,4 +80,10 @@ const canonicalChangeset = (files: ReadonlyArray<ChangedFile>): string =>
 export const computeChangesetFingerprint = (
   files: ReadonlyArray<ChangedFile>,
   signature: string,
-): Effect.Effect<string> => sha256Hex(`${canonicalChangeset(files)}${SECTION}${signature}`);
+): Effect.Effect<string, never, Crypto.Crypto> =>
+  sha256Hex(`${canonicalChangeset(files)}${SECTION}${signature}`);
+
+/** Profile fingerprints are SHA-256 over configuration-only signatures. */
+export const computeProfileFingerprint = (
+  signature: string,
+): Effect.Effect<string, never, Crypto.Crypto> => sha256Hex(signature);

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -506,18 +506,6 @@ export const selectedPullRequestSourceLayer = (
     }),
   );
 
-/** Profile fingerprints are SHA-256 over configuration-only signatures. */
-export const computeProfileFingerprint = (signature: string): Effect.Effect<string> =>
-  Effect.promise(async () => {
-    const digest = await globalThis.crypto.subtle.digest(
-      "SHA-256",
-      new TextEncoder().encode(signature),
-    );
-    return Array.from(new Uint8Array(digest))
-      .map((byte) => byte.toString(16).padStart(2, "0"))
-      .join("");
-  });
-
 /** Build the full-surface mission used only to resolve profile guidance. */
 export const buildProfileMission = (
   metadata: PullRequestMetadata,

--- a/packages/pr-review/test/factory.test.ts
+++ b/packages/pr-review/test/factory.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "@effect/vitest";
+import { NodeCrypto } from "@effect/platform-node";
+import { describe, expect, it, layer } from "@effect/vitest";
+import type { Crypto } from "effect";
 import { Effect, Layer, Ref, Schema, Stream } from "effect";
 import type { IdGenerator } from "effect-agent";
 import { ToolExecutionClass } from "effect-agent";
@@ -168,7 +170,7 @@ const runFactoryReviewer = <E, R>(
     return { outcome, published: yield* Ref.get(published) };
   });
 
-describe("PrReview.make", () => {
+layer(NodeCrypto.layer)("PrReview.make", (it) => {
   it.effect("injects guidance between the mission framing and the intact contract", () =>
     Effect.gen(function* () {
       const scripted = yield* makeOfflineReviewerModel({
@@ -368,9 +370,11 @@ type PlainServices = ServicesOf<typeof plainRun>;
 type ExtraServices = ServicesOf<typeof extraRun>;
 type FanOutServices = ServicesOf<typeof fanOutRun>;
 
-// The two ports stay visible on every shape.
+// The two ports and Crypto stay visible on every shape.
 type PlainSourceProof = Assert<Equal<Extract<PlainServices, PullRequestSource>, PullRequestSource>>;
 type PlainPublisherProof = Assert<Equal<Extract<PlainServices, ReviewPublisher>, ReviewPublisher>>;
+type PlainCryptoProof = Assert<Equal<Extract<PlainServices, Crypto.Crypto>, Crypto.Crypto>>;
+type FanOutCryptoProof = Assert<Equal<Extract<FanOutServices, Crypto.Crypto>, Crypto.Crypto>>;
 type FanOutSourceProof = Assert<
   Equal<Extract<FanOutServices, PullRequestSource>, PullRequestSource>
 >;
@@ -393,6 +397,8 @@ describe("factory type proofs", () => {
   it("keeps ports and extra handlers visible while hiding framework plumbing", () => {
     const plainSourceProof: PlainSourceProof = true;
     const plainPublisherProof: PlainPublisherProof = true;
+    const plainCryptoProof: PlainCryptoProof = true;
+    const fanOutCryptoProof: FanOutCryptoProof = true;
     const fanOutSourceProof: FanOutSourceProof = true;
     const plainIdGeneratorExcludedProof: PlainIdGeneratorExcludedProof = true;
     const fanOutIdGeneratorExcludedProof: FanOutIdGeneratorExcludedProof = true;
@@ -401,12 +407,14 @@ describe("factory type proofs", () => {
     expect([
       plainSourceProof,
       plainPublisherProof,
+      plainCryptoProof,
+      fanOutCryptoProof,
       fanOutSourceProof,
       plainIdGeneratorExcludedProof,
       fanOutIdGeneratorExcludedProof,
       extraHandlerProof,
       plainHandlerExcludedProof,
-    ]).toEqual([true, true, true, true, true, true, true]);
+    ]).toEqual([true, true, true, true, true, true, true, true, true]);
   });
 });
 
@@ -416,7 +424,7 @@ describe("factory type proofs", () => {
 // regression: PR #26's third review died on exactly this).
 // ---------------------------------------------------------------------------
 
-describe("out-of-changeset reads", () => {
+layer(NodeCrypto.layer)("out-of-changeset reads", (it) => {
   it.effect("refuses the read as a result and completes the review", () =>
     Effect.gen(function* () {
       const scripted = yield* makePromptKeyedModel("bad-read-reviewer", (promptJson) => {

--- a/packages/pr-review/test/fingerprint.test.ts
+++ b/packages/pr-review/test/fingerprint.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "@effect/vitest";
+import { NodeCrypto } from "@effect/platform-node";
+import { describe, expect, it, layer } from "@effect/vitest";
 import { Effect } from "effect";
 
 import {
@@ -49,7 +50,7 @@ describe("fingerprint marker", () => {
   });
 });
 
-describe("computeChangesetFingerprint", () => {
+layer(NodeCrypto.layer)("computeChangesetFingerprint", (it) => {
   it.effect("ignores provider file ordering but not content or signature", () =>
     Effect.gen(function* () {
       const forward = yield* computeChangesetFingerprint([fileA, fileB], "sig");
@@ -159,7 +160,7 @@ describe("plan fingerprint embedding", () => {
 // configurations, and blind to ignored files.
 // ---------------------------------------------------------------------------
 
-describe("reviewer fingerprint", () => {
+layer(NodeCrypto.layer)("reviewer fingerprint", (it) => {
   const fixtureWith = (files: ReadonlyArray<ChangedFile>) =>
     FixturePullRequest.make({
       metadata: PullRequestMetadata.make({

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1,3 +1,4 @@
+import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Duration, Effect, Layer, Redacted, Ref, Schema } from "effect";
 import { Agent, AgentRuntime, IdGenerator, UsageBudgetLimits } from "effect-agent";
@@ -211,6 +212,7 @@ const runOfflineFanOut = (script: {
           fixturePullRequestSourceLayer(fixture),
           collectingReviewPublisherLayer(published),
           IdGenerator.layer,
+          NodeCrypto.layer,
         ),
       ),
       Effect.provideService(ReviewExecutionContext, {

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -1,3 +1,4 @@
+import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Ref, Schema } from "effect";
 import { Agent, IdGenerator } from "effect-agent";
@@ -996,6 +997,7 @@ describe("offline review run", () => {
             ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
             collectingReviewPublisherLayer(published),
             IdGenerator.layer,
+            NodeCrypto.layer,
           ),
         ),
         Effect.scoped,
@@ -1058,6 +1060,7 @@ describe("offline review run", () => {
             ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
             collectingReviewPublisherLayer(published),
             IdGenerator.layer,
+            NodeCrypto.layer,
           ),
         ),
         Effect.scoped,
@@ -1109,6 +1112,7 @@ describe("offline review run", () => {
             ReviewToolkitLayer.pipe(Layer.provideMerge(fixturePullRequestSourceLayer(fixture))),
             collectingReviewPublisherLayer(published),
             IdGenerator.layer,
+            NodeCrypto.layer,
           ),
         ),
         Effect.scoped,
@@ -1231,6 +1235,7 @@ describe("offline review run", () => {
             ReviewToolkitLayer.pipe(Layer.provideMerge(selectedSource)),
             collectingReviewPublisherLayer(published),
             IdGenerator.layer,
+            NodeCrypto.layer,
           ),
         ),
         Effect.provideService(ReviewExecutionContext, selection),
@@ -1275,6 +1280,7 @@ describe.skipIf(!liveEnabled)("pr-review live profile (opt-in)", () => {
               collectingReviewPublisherLayer(published),
               openAiClientLayer,
               IdGenerator.layer,
+              NodeCrypto.layer,
             ),
           ),
           Effect.scoped,


### PR DESCRIPTION
## Summary

- Review changeset and profile fingerprints now hash through Effect [`Crypto.Crypto`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-crypto-fingerprint/packages/pr-review/src/internal/fingerprint.ts) instead of `globalThis.crypto.subtle`.
- `computeChangesetFingerprint`, `computeProfileFingerprint`, and `PrReview` fingerprint/`run` Effects require `Crypto.Crypto` in `R`. Error channel stays `never` (`orDie`). Node CLI/Action hosts already satisfy this via `NodeServices.layer`.

## What went wrong

Skip-unchanged and incremental continuity depend on SHA-256 fingerprints, but both helpers (`fingerprint.ts` and a second copy in `review-state.ts`) called WebCrypto through `Effect.promise`. That hid the platform crypto requirement, escaped Effect's `Crypto` service, and would silently use whatever `globalThis.crypto` the isolate happened to have.

One shared `sha256Hex` now yields `Crypto.Crypto` and hex-encodes the digest. The profile helper lives next to the changeset helper so there is a single hash owner.

## Architecture

- Library stays platform-free: `Crypto.Crypto` remains visible in `R` (factory type proofs assert it; `IdGenerator` stays hidden).
- Hosts provide the adapter. Node composition roots already merge `NodeCrypto` through `NodeServices.layer`; tests provide `NodeCrypto.layer`.

## Evidence

Factory type proofs now extract `Crypto.Crypto` from `PrReview.make` / `makeFanOut` `run` services. Existing fingerprint stability tests still pass against `NodeCrypto` (same SHA-256, different owner).


Made with [Cursor](https://cursor.com)