### PR TITLE
fix(pr-review): keep incremental reviews incremental after rebase

### DIFF
--- a/.changeset/incremental-rewrite-retry.md
+++ b/.changeset/incremental-rewrite-retry.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Keep incremental reviews incremental after a rebase, and retry only the failed pass on unchanged leftover paths.
+
+A rewritten head no longer fail-closes to a full-diff rediscovery when a two-dot tree comparison can name the current PR paths whose contents changed. Outdated GitHub comments that omit `line` no longer block stale-review retirement.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -43149,7 +43149,11 @@ var reviewUnit = (binding, unit, passes, input) => exports_Effect.gen(function* 
     completedSpecialistPasses,
     requiredVerificationPasses,
     completedVerificationPasses,
-    unreviewedPaths: failedPasses.length > 0 ? unit.paths : []
+    unreviewedPaths: failedPasses.length > 0 ? unit.paths : [],
+    unreviewedPasses: failedPasses.map((pass) => ({
+      stage: pass.stage,
+      paths: unit.paths
+    }))
   };
 });
 var countNoun = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
@@ -43174,14 +43178,99 @@ var composeSummary = (plan, assurance) => {
   parts2.push("No configured pipeline can prove absence of defects; this describes settled work only.");
   return parts2.join(" ").slice(0, 4000);
 };
-var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
-  const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
+var remapPlanUnitIds = (plan, offset) => {
+  if (offset === 0)
+    return plan;
+  const units = plan.units.map((unit, index2) => ReviewUnit.make({
+    ...unit,
+    unitId: `unit-${String(offset + index2 + 1).padStart(3, "0")}`
+  }));
+  const mappedIds = new Map;
+  for (const [index2, unit] of plan.units.entries()) {
+    const remapped = units[index2];
+    if (remapped !== undefined) {
+      mappedIds.set(unit.unitId, remapped.unitId);
+    }
+  }
+  return ReviewUnitPlan.make({
+    ...plan,
+    units,
+    discoveryPasses: plan.discoveryPasses.map((pass) => {
+      const unitId = mappedIds.get(pass.unitId) ?? pass.unitId;
+      return ReviewDiscoveryPass.make({
+        ...pass,
+        unitId,
+        passId: `${unitId}${pass.passId.slice(pass.unitId.length)}`
+      });
+    })
+  });
+};
+var scheduleFanOutWork = (input) => {
+  const retryPathSet = new Set(input.retry?.paths ?? []);
+  const retryStages = new Set(input.retry?.stages ?? []);
+  if (retryPathSet.size === 0) {
+    const plan2 = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
+    const passesByUnit2 = new Map;
+    for (const pass of plan2.discoveryPasses) {
+      const passes = passesByUnit2.get(pass.unitId) ?? [];
+      passes.push(pass);
+      passesByUnit2.set(pass.unitId, passes);
+    }
+    return { plan: plan2, passesByUnit: passesByUnit2, overflowRetryPaths: [] };
+  }
+  const freshFiles = input.files.filter((file2) => !retryPathSet.has(file2.path));
+  const retryFiles = input.files.filter((file2) => retryPathSet.has(file2.path));
+  const freshPlan = planReviewUnits(freshFiles, { totalChangedFiles: input.totalChangedFiles });
+  const retryPlan = remapPlanUnitIds(planReviewUnits(retryFiles, { totalChangedFiles: input.totalChangedFiles }), freshPlan.units.length);
+  const acceptedFresh = freshPlan.units.slice(0, MAX_REVIEW_UNITS);
+  const acceptedRetry = retryPlan.units.slice(0, Math.max(0, MAX_REVIEW_UNITS - acceptedFresh.length));
+  const overflowRetryPaths = retryPlan.units.slice(acceptedRetry.length).flatMap((unit) => [...unit.paths]);
+  const retryPassFilter = (pass) => {
+    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+    return retryStages.has(stage);
+  };
+  const acceptedRetryIds = new Set(acceptedRetry.map((unit) => unit.unitId));
+  let retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId) && retryPassFilter(pass));
+  if (retryStages.has("verification") && !retryStages.has("discovery") && !retryStages.has("specialist")) {
+    retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId));
+  }
+  const acceptedFreshIds = new Set(acceptedFresh.map((unit) => unit.unitId));
+  const freshPasses = freshPlan.discoveryPasses.filter((pass) => acceptedFreshIds.has(pass.unitId));
+  const discoveryPasses = [...freshPasses, ...retryPasses];
+  const plan = ReviewUnitPlan.make({
+    totalFiles: input.files.length,
+    truncated: freshPlan.truncated || retryPlan.truncated,
+    units: [...acceptedFresh, ...acceptedRetry],
+    discoveryPasses,
+    undiffablePaths: [
+      ...new Set([...freshPlan.undiffablePaths, ...retryPlan.undiffablePaths])
+    ].sort(),
+    partialEvidencePaths: [
+      ...new Set([...freshPlan.partialEvidencePaths, ...retryPlan.partialEvidencePaths])
+    ].sort(),
+    unassignedEvidenceShardCount: freshPlan.unassignedEvidenceShardCount + retryPlan.unassignedEvidenceShardCount,
+    unassignedEvidenceShardIds: [
+      ...freshPlan.unassignedEvidenceShardIds,
+      ...retryPlan.unassignedEvidenceShardIds
+    ].slice(0, MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS),
+    unassignedPaths: [
+      ...new Set([
+        ...freshPlan.unassignedPaths,
+        ...retryPlan.unassignedPaths,
+        ...overflowRetryPaths
+      ])
+    ].sort()
+  });
   const passesByUnit = new Map;
-  for (const pass of plan.discoveryPasses) {
+  for (const pass of discoveryPasses) {
     const passes = passesByUnit.get(pass.unitId) ?? [];
     passes.push(pass);
     passesByUnit.set(pass.unitId, passes);
   }
+  return { plan, passesByUnit, overflowRetryPaths };
+};
+var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
+  const { plan, passesByUnit, overflowRetryPaths } = scheduleFanOutWork(input);
   const outcomes = yield* exports_Effect.forEach(plan.units, (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input), { concurrency: REVIEW_UNIT_CONCURRENCY });
   const failedPasses = outcomes.flatMap((outcome) => outcome.failedPasses);
   const unsettledCandidates = outcomes.reduce((total, outcome) => total + outcome.unsettledCandidates, 0);
@@ -43233,6 +43322,10 @@ var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
         ...plan.undiffablePaths
       ])
     ].sort(),
+    unreviewedPasses: [
+      ...outcomes.flatMap((outcome) => outcome.unreviewedPasses),
+      ...overflowRetryPaths.length === 0 ? [] : ((input.retry?.stages.length) ? input.retry.stages : ["discovery", "specialist", "verification"]).map((stage) => ({ stage, paths: overflowRetryPaths }))
+    ],
     turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0)
   };
 });
@@ -43322,6 +43415,14 @@ class StoredReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/
 }) {
 }
 var MAX_STORED_UNREVIEWED_PATHS = 100;
+var MAX_STORED_UNREVIEWED_PASSES = 24;
+var UnreviewedStage = exports_Schema.Literals(["discovery", "specialist", "verification"]);
+
+class StoredUnreviewedPass extends exports_Schema.Class("@effect-agent/pr-review/StoredUnreviewedPass")({
+  stage: UnreviewedStage,
+  paths: exports_Schema.Array(ChangedPath).check(exports_Schema.isMinLength(1)).check(exports_Schema.isMaxLength(12))
+}) {
+}
 
 class ReviewState extends exports_Schema.Class("@effect-agent/pr-review/ReviewState")({
   version: exports_Schema.Literal(2),
@@ -43337,6 +43438,7 @@ class ReviewState extends exports_Schema.Class("@effect-agent/pr-review/ReviewSt
   unresolvedFindings: exports_Schema.Array(StoredReviewFinding).check(exports_Schema.isMaxLength(20)),
   unresolvedConcerns: exports_Schema.Array(StoredReviewConcern).check(exports_Schema.isMaxLength(10)),
   unreviewedPaths: exports_Schema.Array(ChangedPath).check(exports_Schema.isMaxLength(MAX_STORED_UNREVIEWED_PATHS)),
+  unreviewedPasses: exports_Schema.optionalKey(exports_Schema.Array(StoredUnreviewedPass).check(exports_Schema.isMaxLength(MAX_STORED_UNREVIEWED_PASSES))),
   settled: exports_Schema.Boolean,
   lastReviewMode: ReviewScopeMode
 }) {
@@ -43478,11 +43580,14 @@ var fullSelection = (input) => ({
   reason: input.reason,
   files: input.files,
   affectedPaths: input.files.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]),
+  retryPaths: [],
+  retryStages: [],
   totalFiles: input.totalFiles,
   baselineSha: undefined,
   priorState: undefined,
   profileFingerprint: input.profileFingerprint
 });
+var isLineageAncestor = (comparison, priorState, currentHeadSha) => comparison.baseSha === priorState.reviewedHeadSha && comparison.headSha === currentHeadSha && comparison.mergeBaseSha === priorState.reviewedHeadSha && !comparison.truncated && (comparison.status === "ahead" || comparison.status === "identical");
 var validateReviewState = (state, current, profileFingerprint) => {
   if (state.repository !== current.repository || state.pullRequestNumber !== current.number) {
     return "stored state belongs to a different pull request";
@@ -43497,6 +43602,70 @@ var validateReviewState = (state, current, profileFingerprint) => {
     return "the reviewer profile or model configuration changed";
   }
   return;
+};
+var filePaths = (file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath];
+var incrementalFromDelta = (input) => {
+  const currentPaths = new Set(input.fullFiles.flatMap(filePaths));
+  const affectedPaths = new Set([
+    ...input.deltaFiles.flatMap(filePaths),
+    ...input.extraAffectedPaths ?? []
+  ]);
+  const selectedByPath = new Map;
+  for (const file2 of input.deltaFiles) {
+    if (currentPaths.has(file2.path) || file2.previousPath !== undefined && currentPaths.has(file2.previousPath)) {
+      selectedByPath.set(file2.path, file2);
+    }
+  }
+  const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
+  const surgical = input.priorState.unreviewedPasses !== undefined;
+  const retryOnly = new Set;
+  const retryStages = new Set;
+  for (const path of carriedPaths) {
+    if (affectedPaths.has(path))
+      continue;
+    retryOnly.add(path);
+    if (surgical) {
+      for (const pass of input.priorState.unreviewedPasses ?? []) {
+        if (pass.paths.includes(path))
+          retryStages.add(pass.stage);
+      }
+    } else {
+      affectedPaths.add(path);
+    }
+  }
+  if (surgical && retryStages.has("verification") && !retryStages.has("discovery") && !retryStages.has("specialist")) {
+    retryStages.add("discovery");
+    retryStages.add("specialist");
+  }
+  if (surgical && retryOnly.size > 0 && retryStages.size === 0) {
+    for (const path of retryOnly)
+      affectedPaths.add(path);
+    retryStages.add("discovery");
+    retryStages.add("specialist");
+    retryStages.add("verification");
+  }
+  if (carriedPaths.length > 0 || (input.extraAffectedPaths?.length ?? 0) > 0) {
+    for (const file2 of input.fullFiles) {
+      const needed = affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath) || retryOnly.has(file2.path) || file2.previousPath !== undefined && retryOnly.has(file2.previousPath);
+      if (needed)
+        selectedByPath.set(file2.path, file2);
+    }
+  }
+  const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  const leftoverCount = [...retryOnly].filter((path) => !affectedPaths.has(path)).length;
+  const carriedReason = leftoverCount > 0 && surgical ? `; retrying ${leftoverCount} unchanged leftover path(s) without rediscovery` : carriedPaths.length > 0 ? `; retrying ${carriedPaths.length} carried unreviewed path(s)` : "";
+  return {
+    mode: "incremental",
+    reason: `${input.reason}${carriedReason}`,
+    files: selectedFiles,
+    affectedPaths: [...affectedPaths].sort(),
+    retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),
+    retryStages: [...retryStages].sort(),
+    totalFiles: selectedFiles.length,
+    baselineSha: input.priorState.reviewedHeadSha,
+    priorState: input.priorState,
+    profileFingerprint: input.profileFingerprint
+  };
 };
 var selectReviewRange = (input) => {
   const full = (reason) => fullSelection({
@@ -43516,60 +43685,47 @@ var selectReviewRange = (input) => {
   if (invalid2 !== undefined)
     return full(invalid2);
   const comparison = input.comparison;
+  if (comparison !== undefined && isLineageAncestor(comparison, input.priorState, input.current.headSha)) {
+    const extraAffected = [];
+    let baseReason = "";
+    if (input.priorState.baseSha !== input.current.baseSha) {
+      const baseComparison = input.baseComparison;
+      if (baseComparison === undefined) {
+        return full("the pull request base changed and its lineage comparison was unavailable");
+      }
+      if (baseComparison.baseSha !== input.priorState.baseSha || baseComparison.headSha !== input.current.baseSha || baseComparison.mergeBaseSha !== input.priorState.baseSha || baseComparison.status !== "ahead" && baseComparison.status !== "identical" || baseComparison.truncated) {
+        return full("the pull request base changed materially or exceeded the comparison bound");
+      }
+      for (const file2 of baseComparison.files)
+        extraAffected.push(...filePaths(file2));
+      baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
+    }
+    return incrementalFromDelta({
+      current: input.current,
+      fullFiles: input.fullFiles,
+      profileFingerprint: input.profileFingerprint,
+      priorState: input.priorState,
+      deltaFiles: comparison.files,
+      extraAffectedPaths: extraAffected,
+      reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`
+    });
+  }
+  const contentComparison = input.contentComparison;
+  if (contentComparison !== undefined && !contentComparison.truncated) {
+    return incrementalFromDelta({
+      current: input.current,
+      fullFiles: input.fullFiles,
+      profileFingerprint: input.profileFingerprint,
+      priorState: input.priorState,
+      deltaFiles: contentComparison.files,
+      reason: `rewritten history; contents changed since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}`
+    });
+  }
   if (comparison === undefined)
     return full("the incremental head comparison was unavailable");
-  if (comparison.baseSha !== input.priorState.reviewedHeadSha || comparison.headSha !== input.current.headSha || comparison.mergeBaseSha !== input.priorState.reviewedHeadSha || comparison.status !== "ahead" && comparison.status !== "identical") {
-    return full("the prior reviewed head is not an ancestor of the current head");
-  }
   if (comparison.truncated)
     return full("the incremental comparison exceeded GitHub's file bound");
-  const affectedPaths = new Set(comparison.files.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]));
-  let baseReason = "";
-  if (input.priorState.baseSha !== input.current.baseSha) {
-    const baseComparison = input.baseComparison;
-    if (baseComparison === undefined) {
-      return full("the pull request base changed and its lineage comparison was unavailable");
-    }
-    if (baseComparison.baseSha !== input.priorState.baseSha || baseComparison.headSha !== input.current.baseSha || baseComparison.mergeBaseSha !== input.priorState.baseSha || baseComparison.status !== "ahead" && baseComparison.status !== "identical" || baseComparison.truncated) {
-      return full("the pull request base changed materially or exceeded the comparison bound");
-    }
-    for (const file2 of baseComparison.files) {
-      affectedPaths.add(file2.path);
-      if (file2.previousPath !== undefined)
-        affectedPaths.add(file2.previousPath);
-    }
-    baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
-  }
-  const currentPaths = new Set(input.fullFiles.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]));
-  const selectedByPath = new Map;
-  for (const file2 of comparison.files) {
-    if (currentPaths.has(file2.path) || file2.previousPath !== undefined && currentPaths.has(file2.previousPath)) {
-      selectedByPath.set(file2.path, file2);
-    }
-  }
-  const carriedPaths = new Set(input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path)));
-  for (const path of carriedPaths)
-    affectedPaths.add(path);
-  const rescuePaths = input.priorState.baseSha !== input.current.baseSha;
-  if (rescuePaths || carriedPaths.size > 0) {
-    for (const file2 of input.fullFiles) {
-      const affected = rescuePaths && (affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath)) || carriedPaths.has(file2.path) || file2.previousPath !== undefined && carriedPaths.has(file2.previousPath);
-      if (affected)
-        selectedByPath.set(file2.path, file2);
-    }
-  }
-  const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
-  const carriedReason = carriedPaths.size === 0 ? "" : `; retrying ${carriedPaths.size} carried unreviewed path(s)`;
-  return {
-    mode: "incremental",
-    reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}${carriedReason}`,
-    files: selectedFiles,
-    affectedPaths: [...affectedPaths].sort(),
-    totalFiles: selectedFiles.length,
-    baselineSha: input.priorState.reviewedHeadSha,
-    priorState: input.priorState,
-    profileFingerprint: input.profileFingerprint
-  };
+  return full("the prior reviewed head is not an ancestor of the current head");
 };
 
 class ReviewExecutionContext extends exports_Context.Service()("@effect-agent/pr-review/ReviewExecutionContext") {
@@ -43863,8 +44019,8 @@ var GitHubReviewCommentWire = exports_Schema.Struct({
   node_id: exports_Schema.String,
   path: exports_Schema.String,
   body: exports_Schema.String,
-  line: exports_Schema.NullOr(exports_Schema.Int),
-  original_line: exports_Schema.NullOr(exports_Schema.Int),
+  line: exports_Schema.optionalKey(exports_Schema.NullOr(exports_Schema.Int)),
+  original_line: exports_Schema.optionalKey(exports_Schema.NullOr(exports_Schema.Int)),
   start_line: exports_Schema.optionalKey(exports_Schema.NullOr(exports_Schema.Int)),
   original_start_line: exports_Schema.optionalKey(exports_Schema.NullOr(exports_Schema.Int))
 });
@@ -44107,8 +44263,9 @@ var gitHubReviewRetirementHostLayer = exports_Layer.effect(ReviewRetirementHost)
       url: `${prefix}/reviews/${reviewId}/comments`,
       decode: decodeRetirement(GitHubReviewCommentsPageWire, "listReviewCommentsForRetirement")
     }).pipe(exports_Effect.map((comments) => comments.map((comment) => {
-      const endLine = comment.line ?? comment.original_line;
-      const startLine = comment.start_line ?? comment.original_start_line ?? endLine;
+      const positiveLine = (value4) => value4 !== undefined && value4 !== null && value4 > 0 ? value4 : null;
+      const endLine = positiveLine(comment.line ?? comment.original_line);
+      const startLine = positiveLine(comment.start_line ?? comment.original_start_line) ?? endLine;
       return RetirableReviewComment.make({
         nodeId: comment.node_id,
         path: comment.path,
@@ -44205,8 +44362,8 @@ var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.
     }
     return { latestFingerprint: latest, latestState };
   }).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
-  const compareHeads = (baseSha, headSha) => exports_Effect.gen(function* () {
-    const response = yield* exports_HttpClient.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`).pipe(exports_HttpClientRequest.acceptJson), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asLookupFailure));
+  const compareCommits = (baseSha, headSha, separator) => exports_Effect.gen(function* () {
+    const response = yield* exports_HttpClient.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}${separator}${encodeURIComponent(headSha)}`).pipe(exports_HttpClientRequest.acceptJson), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asLookupFailure));
     const wire = yield* response.json.pipe(exports_Effect.mapError(asLookupFailure), exports_Effect.flatMap((body) => exports_Schema.decodeUnknownEffect(GitHubCompareWire)(body).pipe(exports_Effect.mapError(asLookupFailure))));
     const files = wire.files.map(toChangedFile);
     return ReviewHeadComparison.make({
@@ -44218,13 +44375,22 @@ var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.
       truncated: files.length >= MAX_CHANGED_FILES
     });
   }).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
+  const compareTrees = (baseSha, headSha) => compareCommits(baseSha, headSha, "..").pipe(exports_Effect.map((comparison) => ReviewHeadComparison.make({
+    status: comparison.status === "identical" ? "identical" : "ahead",
+    baseSha,
+    headSha,
+    mergeBaseSha: baseSha,
+    files: comparison.files,
+    truncated: comparison.truncated
+  })));
   return PriorReviews.of({
     latestFingerprint: readMarkers(exports_Option.none()).pipe(exports_Effect.map((markers) => markers.latestFingerprint)),
     latestState: exports_Effect.gen(function* () {
       const authenticator = yield* ReviewStateAuthenticator;
       return yield* readMarkers(exports_Option.some(authenticator)).pipe(exports_Effect.map((markers) => markers.latestState));
     }),
-    compareHeads
+    compareHeads: (baseSha, headSha) => compareCommits(baseSha, headSha, "..."),
+    compareTrees
   });
 }));
 // packages/pr-review/src/internal/render.ts
@@ -44654,6 +44820,7 @@ var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function
     unresolvedFindings: activeFindings.map(toStoredFinding),
     unresolvedConcerns: activeConcerns.map(toStoredConcern),
     unreviewedPaths,
+    unreviewedPasses: (core2.unreviewedPasses ?? []).slice(0, MAX_STORED_UNREVIEWED_PASSES),
     settled,
     lastReviewMode: executionContext.mode
   }) : undefined;
@@ -44760,7 +44927,13 @@ var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* ()
     anchorFiles,
     totalChangedFiles: totalFiles,
     maxFindings: options3.maxFindings,
-    budget: toRunBudgetHook(budget2)
+    budget: toRunBudgetHook(budget2),
+    ...executionContext !== undefined && executionContext.retryPaths.length > 0 ? {
+      retry: {
+        paths: executionContext.retryPaths,
+        stages: executionContext.retryStages
+      }
+    } : {}
   });
   const inputCoverage = fanOutInputCoverage({
     plan: pipeline.plan,
@@ -44775,6 +44948,10 @@ var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* ()
     inputCoverage,
     assurance: pipeline.assurance,
     unreviewedPaths: pipeline.unreviewedPaths,
+    unreviewedPasses: pipeline.unreviewedPasses.slice(0, MAX_STORED_UNREVIEWED_PASSES).map((pass) => StoredUnreviewedPass.make({
+      stage: pass.stage,
+      paths: pass.paths.slice(0, 12)
+    })),
     turns: pipeline.turns
   }, { metadata, files, anchorFiles, fingerprint, usage }, options3);
 });
@@ -56135,6 +56312,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       }
       let comparison;
       let baseComparison;
+      let contentComparison;
       if ((options3.reviewMode ?? "incremental") === "incremental" && recovered.state !== undefined) {
         if (recovered.state.reviewedHeadSha === metadata.headSha) {
           comparison = ReviewHeadComparison.make({
@@ -56167,6 +56345,17 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
             });
           }
         }
+        if (recovered.state.reviewedHeadSha !== metadata.headSha && (comparison === undefined || !isLineageAncestor(comparison, recovered.state, metadata.headSha))) {
+          contentComparison = yield* history.compareTrees(recovered.state.reviewedHeadSha, metadata.headSha).pipe(exports_Effect.orElseSucceed(() => {
+            return;
+          }));
+          if (contentComparison !== undefined && reviewer.filterFiles !== undefined) {
+            contentComparison = ReviewHeadComparison.make({
+              ...contentComparison,
+              files: reviewer.filterFiles(contentComparison.files)
+            });
+          }
+        }
       }
       selection = {
         ...selectReviewRange({
@@ -56177,6 +56366,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           priorState: recovered.state,
           comparison,
           baseComparison,
+          contentComparison,
           lookupFailure: recovered.failure
         }),
         stateAuthenticator

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -126,7 +126,10 @@ and only exactly confirmed candidates publish. Its public result separates path/
 coverage from pass settlement; neither claim means exhaustive defect detection. Every
 completed run that can be signed advances the authenticated incremental baseline; a pass
 that stays failed carries its paths forward as retryable scope inside the state instead of
-freezing the baseline, and only a fully settled state authorizes skip-unchanged. Subpath
+freezing the baseline, and only a fully settled state authorizes skip-unchanged. A rewritten
+head that is no longer a git ancestor stays incremental when a two-dot tree comparison can
+name the current PR paths whose contents changed; unchanged leftovers retry only the failed
+pass and keep their stored findings. Subpath
 entries: `./testing`
 (fixture source, collecting publisher,
 prompt-keyed scripted models), `./action` and `./cli` (platform-node host entrypoints). Consumes

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -190,9 +190,14 @@ own scope forward instead of freezing the baseline and reopening everything
 reviewed since (the non-converging loop of issue #131). A later Action run
 validates the state and reviews the GitHub comparison from that reviewed head
 to the current head plus the carried unreviewed paths, not the complete
-base...HEAD diff. Unchanged settled scope is not sent back to the model;
-unchanged unresolved findings remain active; changed or reverted paths
-invalidate their prior findings and receive fresh discovery and verification.
+base...HEAD diff. When that head is not a git ancestor — a rebase, amend, or
+force-push — the host falls back to a two-dot tree comparison and reviews only
+the current PR paths whose contents actually changed, plus leftovers. Unchanged
+settled scope is not sent back to the model; unchanged unresolved findings
+remain active; changed or reverted paths invalidate their prior findings and
+receive fresh discovery and verification. An unchanged leftover from a failed
+pass retries only that failed stage and keeps its stored findings — it does
+not run a second general discovery.
 Whole overflow files are reviewed in bounded installments across pushes
 through the same carry; a single file beyond total plan capacity and
 undiffable paths stay explicitly incomplete instead — an unreviewable tail
@@ -207,9 +212,11 @@ pinned to the reviewed commit. The expected author defaults to
 App token. State lookup, authentication, schema, identity, ancestry, profile,
 and comparison checks are fail-closed for scope selection: missing, stale,
 incompatible, or truncated state/comparisons produce a visible full-diff
-fallback. An ancestor base advance remains incremental and adds overlapping
+fallback unless a two-dot content comparison can still name the changed PR
+paths. An ancestor base advance remains incremental and adds overlapping
 PR paths as affected context; a materially changed base lineage falls back to
-full unless the authenticated settled-scope fingerprint still matches. The
+full unless the authenticated settled-scope fingerprint still matches or the
+content comparison intersects the current PR path set. The
 schema field retains the compatibility name `acceptedScopeFingerprint`. That
 fingerprint hashes the ignore-filtered effective diff, patchless base/head
 evidence, PR framing, and review-shaping profile while excluding commit IDs,

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -24,6 +24,7 @@ import {
   ReviewExecutionContext,
   ReviewHeadComparison,
   ReviewStateAuthenticator,
+  isLineageAncestor,
   type ReviewMode,
   type ReviewState,
   selectReviewRange,
@@ -558,6 +559,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
         }
         let comparison: ReviewHeadComparison | undefined;
         let baseComparison: ReviewHeadComparison | undefined;
+        let contentComparison: ReviewHeadComparison | undefined;
         if (
           (options.reviewMode ?? "incremental") === "incremental" &&
           recovered.state !== undefined
@@ -593,6 +595,21 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
               });
             }
           }
+          if (
+            recovered.state.reviewedHeadSha !== metadata.headSha &&
+            (comparison === undefined ||
+              !isLineageAncestor(comparison, recovered.state, metadata.headSha))
+          ) {
+            contentComparison = yield* history
+              .compareTrees(recovered.state.reviewedHeadSha, metadata.headSha)
+              .pipe(Effect.orElseSucceed(() => undefined));
+            if (contentComparison !== undefined && reviewer.filterFiles !== undefined) {
+              contentComparison = ReviewHeadComparison.make({
+                ...contentComparison,
+                files: reviewer.filterFiles(contentComparison.files),
+              });
+            }
+          }
         }
         selection = {
           ...selectReviewRange({
@@ -603,6 +620,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
             priorState: recovered.state,
             comparison,
             baseComparison,
+            contentComparison,
             lookupFailure: recovered.failure,
           }),
           stateAuthenticator,

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -25,6 +25,7 @@ import {
   WalkthroughEntry,
 } from "./review-agent.ts";
 import {
+  MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS,
   MAX_REVIEW_UNITS,
   MAX_UNIT_EVIDENCE_SHARDS,
   MAX_UNIT_FILES,
@@ -32,13 +33,13 @@ import {
   planReviewUnits,
   rankAndDedupeConcerns,
   rankAndDedupeFindings,
+  ReviewDiscoveryPass,
   ReviewEvidenceShardId,
   ReviewPassId,
   ReviewRiskCategory,
+  ReviewUnit,
   ReviewUnitId,
-  type ReviewDiscoveryPass,
-  type ReviewUnit,
-  type ReviewUnitPlan,
+  ReviewUnitPlan,
 } from "./review-units.ts";
 
 // ---------------------------------------------------------------------------
@@ -361,6 +362,11 @@ export interface FanOutPipelineOutcome {
   readonly plan: ReviewUnitPlan;
   /** Paths of units with an unsettled pass — retryable scope for the next run. */
   readonly unreviewedPaths: ReadonlyArray<string>;
+  /** Failed stages paired with the leftover paths they still own. */
+  readonly unreviewedPasses: ReadonlyArray<{
+    readonly stage: FailedReviewPass["stage"];
+    readonly paths: ReadonlyArray<string>;
+  }>;
   /** Total settled child turns across every scheduled pass. */
   readonly turns: number;
 }
@@ -372,6 +378,16 @@ export interface FanOutPipelineInput {
   readonly maxFindings?: number | undefined;
   /** Shared run budget observed by every child pass. */
   readonly budget?: RunBudgetHook<BudgetExceeded | BudgetAdapterError> | undefined;
+  /**
+   * Unchanged leftover paths from a prior failed pass. Those units retry only
+   * the recorded stages — no second general discovery on files nobody touched.
+   */
+  readonly retry?:
+    | {
+        readonly paths: ReadonlyArray<string>;
+        readonly stages: ReadonlyArray<FailedReviewPass["stage"]>;
+      }
+    | undefined;
 }
 
 const candidateOrdinal = (index: number): string => String(index + 1).padStart(3, "0");
@@ -587,6 +603,10 @@ interface UnitReviewOutcome {
   readonly requiredVerificationPasses: number;
   readonly completedVerificationPasses: number;
   readonly unreviewedPaths: ReadonlyArray<string>;
+  readonly unreviewedPasses: ReadonlyArray<{
+    readonly stage: FailedReviewPass["stage"];
+    readonly paths: ReadonlyArray<string>;
+  }>;
 }
 
 const reviewUnit = <Provider, ModelProvides, ModelRequires>(
@@ -697,6 +717,10 @@ const reviewUnit = <Provider, ModelProvides, ModelRequires>(
       requiredVerificationPasses,
       completedVerificationPasses,
       unreviewedPaths: failedPasses.length > 0 ? unit.paths : [],
+      unreviewedPasses: failedPasses.map((pass) => ({
+        stage: pass.stage,
+        paths: unit.paths,
+      })),
     } satisfies UnitReviewOutcome;
   });
 
@@ -737,6 +761,121 @@ const composeSummary = (plan: ReviewUnitPlan, assurance: ReviewAssurance): strin
   return parts.join(" ").slice(0, 4_000);
 };
 
+const remapPlanUnitIds = (plan: ReviewUnitPlan, offset: number): ReviewUnitPlan => {
+  if (offset === 0) return plan;
+  const units = plan.units.map((unit, index) =>
+    ReviewUnit.make({
+      ...unit,
+      unitId: `unit-${String(offset + index + 1).padStart(3, "0")}`,
+    }),
+  );
+  const mappedIds = new Map<string, string>();
+  for (const [index, unit] of plan.units.entries()) {
+    const remapped = units[index];
+    if (remapped !== undefined) {
+      mappedIds.set(unit.unitId, remapped.unitId);
+    }
+  }
+  return ReviewUnitPlan.make({
+    ...plan,
+    units,
+    discoveryPasses: plan.discoveryPasses.map((pass) => {
+      const unitId = mappedIds.get(pass.unitId) ?? pass.unitId;
+      return ReviewDiscoveryPass.make({
+        ...pass,
+        unitId,
+        passId: `${unitId}${pass.passId.slice(pass.unitId.length)}`,
+      });
+    }),
+  });
+};
+
+const scheduleFanOutWork = (
+  input: FanOutPipelineInput,
+): {
+  readonly plan: ReviewUnitPlan;
+  readonly passesByUnit: Map<string, ReadonlyArray<ReviewDiscoveryPass>>;
+  readonly overflowRetryPaths: ReadonlyArray<string>;
+} => {
+  const retryPathSet = new Set(input.retry?.paths ?? []);
+  const retryStages = new Set(input.retry?.stages ?? []);
+  if (retryPathSet.size === 0) {
+    const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
+    const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
+    for (const pass of plan.discoveryPasses) {
+      const passes = passesByUnit.get(pass.unitId) ?? [];
+      passes.push(pass);
+      passesByUnit.set(pass.unitId, passes);
+    }
+    return { plan, passesByUnit, overflowRetryPaths: [] };
+  }
+  const freshFiles = input.files.filter((file) => !retryPathSet.has(file.path));
+  const retryFiles = input.files.filter((file) => retryPathSet.has(file.path));
+  const freshPlan = planReviewUnits(freshFiles, { totalChangedFiles: input.totalChangedFiles });
+  const retryPlan = remapPlanUnitIds(
+    planReviewUnits(retryFiles, { totalChangedFiles: input.totalChangedFiles }),
+    freshPlan.units.length,
+  );
+  const acceptedFresh = freshPlan.units.slice(0, MAX_REVIEW_UNITS);
+  const acceptedRetry = retryPlan.units.slice(
+    0,
+    Math.max(0, MAX_REVIEW_UNITS - acceptedFresh.length),
+  );
+  const overflowRetryPaths = retryPlan.units
+    .slice(acceptedRetry.length)
+    .flatMap((unit) => [...unit.paths]);
+  const retryPassFilter = (pass: ReviewDiscoveryPass): boolean => {
+    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+    return retryStages.has(stage);
+  };
+  const acceptedRetryIds = new Set(acceptedRetry.map((unit) => unit.unitId));
+  let retryPasses = retryPlan.discoveryPasses.filter(
+    (pass) => acceptedRetryIds.has(pass.unitId) && retryPassFilter(pass),
+  );
+  if (
+    retryStages.has("verification") &&
+    !retryStages.has("discovery") &&
+    !retryStages.has("specialist")
+  ) {
+    retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId));
+  }
+  const acceptedFreshIds = new Set(acceptedFresh.map((unit) => unit.unitId));
+  const freshPasses = freshPlan.discoveryPasses.filter((pass) => acceptedFreshIds.has(pass.unitId));
+  const discoveryPasses = [...freshPasses, ...retryPasses];
+  const plan = ReviewUnitPlan.make({
+    totalFiles: input.files.length,
+    truncated: freshPlan.truncated || retryPlan.truncated,
+    units: [...acceptedFresh, ...acceptedRetry],
+    discoveryPasses,
+    undiffablePaths: [
+      ...new Set([...freshPlan.undiffablePaths, ...retryPlan.undiffablePaths]),
+    ].sort(),
+    partialEvidencePaths: [
+      ...new Set([...freshPlan.partialEvidencePaths, ...retryPlan.partialEvidencePaths]),
+    ].sort(),
+    unassignedEvidenceShardCount:
+      freshPlan.unassignedEvidenceShardCount + retryPlan.unassignedEvidenceShardCount,
+    unassignedEvidenceShardIds: [
+      ...freshPlan.unassignedEvidenceShardIds,
+      ...retryPlan.unassignedEvidenceShardIds,
+    ].slice(0, MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS),
+    unassignedPaths: [
+      ...new Set([
+        ...freshPlan.unassignedPaths,
+        ...retryPlan.unassignedPaths,
+        ...overflowRetryPaths,
+      ]),
+    ].sort(),
+  });
+  const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
+  for (const pass of discoveryPasses) {
+    const passes = passesByUnit.get(pass.unitId) ?? [];
+    passes.push(pass);
+    passesByUnit.set(pass.unitId, passes);
+  }
+  return { plan, passesByUnit, overflowRetryPaths };
+};
+
 /**
  * Run the complete host-scheduled fan-out pipeline over one selected
  * changeset snapshot: plan, independent discovery, exact verification, and a
@@ -748,13 +887,7 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
   input: FanOutPipelineInput,
 ) =>
   Effect.gen(function* () {
-    const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
-    const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
-    for (const pass of plan.discoveryPasses) {
-      const passes = passesByUnit.get(pass.unitId) ?? [];
-      passes.push(pass);
-      passesByUnit.set(pass.unitId, passes);
-    }
+    const { plan, passesByUnit, overflowRetryPaths } = scheduleFanOutWork(input);
     const outcomes = yield* Effect.forEach(
       plan.units,
       (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input),
@@ -865,6 +998,15 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
           ...plan.undiffablePaths,
         ]),
       ].sort(),
+      unreviewedPasses: [
+        ...outcomes.flatMap((outcome) => outcome.unreviewedPasses),
+        ...(overflowRetryPaths.length === 0
+          ? []
+          : (input.retry?.stages.length
+              ? input.retry.stages
+              : (["discovery", "specialist", "verification"] as const)
+            ).map((stage) => ({ stage, paths: overflowRetryPaths }))),
+      ],
       turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0),
     } satisfies FanOutPipelineOutcome;
   });

--- a/packages/pr-review/src/internal/fixtures.ts
+++ b/packages/pr-review/src/internal/fixtures.ts
@@ -120,6 +120,7 @@ export const staticPriorReviews = (
   options: {
     readonly state?: Option.Option<ReviewState> | undefined;
     readonly comparison?: ReviewHeadComparison | undefined;
+    readonly treeComparison?: ReviewHeadComparison | undefined;
   } = {},
 ): PriorReviews["Service"] =>
   PriorReviews.of({
@@ -129,6 +130,10 @@ export const staticPriorReviews = (
       options.comparison === undefined
         ? Effect.fail(PriorReviewLookupFailure.make({ reason: "no fixture comparison" }))
         : Effect.succeed(options.comparison),
+    compareTrees: () =>
+      options.treeComparison === undefined
+        ? Effect.fail(PriorReviewLookupFailure.make({ reason: "no fixture tree comparison" }))
+        : Effect.succeed(options.treeComparison),
   });
 
 /** Layer form for consumers whose Effect explicitly requires `PriorReviews`. */
@@ -137,6 +142,7 @@ export const staticPriorReviewsLayer = (
   options: {
     readonly state?: Option.Option<ReviewState> | undefined;
     readonly comparison?: ReviewHeadComparison | undefined;
+    readonly treeComparison?: ReviewHeadComparison | undefined;
   } = {},
 ): Layer.Layer<PriorReviews> =>
   Layer.succeed(PriorReviews)(staticPriorReviews(fingerprint, options));

--- a/packages/pr-review/src/internal/github.ts
+++ b/packages/pr-review/src/internal/github.ts
@@ -130,8 +130,9 @@ const GitHubReviewCommentWire = Schema.Struct({
   node_id: Schema.String,
   path: Schema.String,
   body: Schema.String,
-  line: Schema.NullOr(Schema.Int),
-  original_line: Schema.NullOr(Schema.Int),
+  // Outdated comments omit `line` entirely instead of sending null.
+  line: Schema.optionalKey(Schema.NullOr(Schema.Int)),
+  original_line: Schema.optionalKey(Schema.NullOr(Schema.Int)),
   start_line: Schema.optionalKey(Schema.NullOr(Schema.Int)),
   original_start_line: Schema.optionalKey(Schema.NullOr(Schema.Int)),
 });
@@ -578,8 +579,11 @@ export const gitHubReviewRetirementHostLayer: Layer.Layer<
         }).pipe(
           Effect.map((comments) =>
             comments.map((comment) => {
-              const endLine = comment.line ?? comment.original_line;
-              const startLine = comment.start_line ?? comment.original_start_line ?? endLine;
+              const positiveLine = (value: number | null | undefined): number | null =>
+                value !== undefined && value !== null && value > 0 ? value : null;
+              const endLine = positiveLine(comment.line ?? comment.original_line);
+              const startLine =
+                positiveLine(comment.start_line ?? comment.original_start_line) ?? endLine;
               return RetirableReviewComment.make({
                 nodeId: comment.node_id,
                 path: comment.path,
@@ -669,6 +673,15 @@ export class PriorReviews extends Context.Service<
     >;
     /** Compare a previously reviewed head to the live current head. */
     readonly compareHeads: (
+      baseSha: string,
+      headSha: string,
+    ) => Effect.Effect<ReviewHeadComparison, PriorReviewLookupFailure>;
+    /**
+     * Two-dot tree comparison (`base..head`). Used when the reviewed head is
+     * not a git ancestor so a rebase or amend can still name the paths whose
+     * blob contents actually changed.
+     */
+    readonly compareTrees: (
       baseSha: string,
       headSha: string,
     ) => Effect.Effect<ReviewHeadComparison, PriorReviewLookupFailure>;
@@ -775,12 +788,12 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
         }
         return { latestFingerprint: latest, latestState };
       }).pipe(Effect.provideService(HttpClient.HttpClient, client));
-    const compareHeads = (baseSha: string, headSha: string) =>
+    const compareCommits = (baseSha: string, headSha: string, separator: "..." | "..") =>
       Effect.gen(function* () {
         const response = yield* HttpClient.execute(
           withCommonHeaders(
             HttpClientRequest.get(
-              `${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`,
+              `${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}${separator}${encodeURIComponent(headSha)}`,
             ).pipe(HttpClientRequest.acceptJson),
             target.token,
           ),
@@ -803,6 +816,21 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
           truncated: files.length >= MAX_CHANGED_FILES,
         });
       }).pipe(Effect.provideService(HttpClient.HttpClient, client));
+    const compareTrees = (baseSha: string, headSha: string) =>
+      compareCommits(baseSha, headSha, "..").pipe(
+        Effect.map((comparison) =>
+          ReviewHeadComparison.make({
+            // This is a content snapshot, not a lineage claim. Selection
+            // intersects these files with the current PR path set.
+            status: comparison.status === "identical" ? "identical" : "ahead",
+            baseSha,
+            headSha,
+            mergeBaseSha: baseSha,
+            files: comparison.files,
+            truncated: comparison.truncated,
+          }),
+        ),
+      );
     return PriorReviews.of({
       latestFingerprint: readMarkers(Option.none()).pipe(
         Effect.map((markers) => markers.latestFingerprint),
@@ -813,7 +841,8 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
           Effect.map((markers) => markers.latestState),
         );
       }),
-      compareHeads,
+      compareHeads: (baseSha, headSha) => compareCommits(baseSha, headSha, "..."),
+      compareTrees,
     });
   }),
 );

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -49,6 +49,21 @@ export class StoredReviewConcern extends Schema.Class<StoredReviewConcern>(
 /** The carried-scope bound; a run that cannot fit its leftovers publishes no state. */
 export const MAX_STORED_UNREVIEWED_PATHS = 100;
 
+/** Failed-pass records stored beside the leftover paths; one per unit stage. */
+export const MAX_STORED_UNREVIEWED_PASSES = 24;
+
+/** Stages a leftover path may need retried without a second general discovery. */
+export const UnreviewedStage = Schema.Literals(["discovery", "specialist", "verification"]);
+export type UnreviewedStage = typeof UnreviewedStage.Type;
+
+/** One failed fan-out pass whose paths should be retried, not rediscovered. */
+export class StoredUnreviewedPass extends Schema.Class<StoredUnreviewedPass>(
+  "@effect-agent/pr-review/StoredUnreviewedPass",
+)({
+  stage: UnreviewedStage,
+  paths: Schema.Array(ChangedPath).check(Schema.isMinLength(1)).check(Schema.isMaxLength(12)),
+}) {}
+
 /**
  * Versioned state embedded after EVERY completed run that can be signed. The
  * head plus full-scope fingerprint forms an incremental baseline; an absent
@@ -75,6 +90,14 @@ export class ReviewState extends Schema.Class<ReviewState>("@effect-agent/pr-rev
   unresolvedConcerns: Schema.Array(StoredReviewConcern).check(Schema.isMaxLength(10)),
   /** Retryable review gaps carried into the next incremental run's scope. */
   unreviewedPaths: Schema.Array(ChangedPath).check(Schema.isMaxLength(MAX_STORED_UNREVIEWED_PATHS)),
+  /**
+   * Which failed pass produced those leftovers. Absent on state-v2 markers
+   * written before this field existed; those leftovers still re-enter scope
+   * but cannot skip rediscovery. Present (including empty) on new markers.
+   */
+  unreviewedPasses: Schema.optionalKey(
+    Schema.Array(StoredUnreviewedPass).check(Schema.isMaxLength(MAX_STORED_UNREVIEWED_PASSES)),
+  ),
   /**
    * True only when the producing run had complete input coverage, no
    * unsettled pass, and nothing carried. Skip-unchanged authority: an
@@ -292,6 +315,12 @@ export interface ReviewSelection {
   readonly files: ReadonlyArray<ChangedFile>;
   /** Paths whose changes invalidate prior findings, including paths reverted out of the PR. */
   readonly affectedPaths: ReadonlyArray<string>;
+  /**
+   * Leftover paths whose contents did not change. Fan-out retries only the
+   * recorded failed stages on these paths and keeps their stored findings.
+   */
+  readonly retryPaths: ReadonlyArray<string>;
+  readonly retryStages: ReadonlyArray<UnreviewedStage>;
   readonly totalFiles: number;
   readonly baselineSha: string | undefined;
   readonly priorState: ReviewState | undefined;
@@ -312,11 +341,25 @@ const fullSelection = (input: {
   affectedPaths: input.files.flatMap((file) =>
     file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
   ),
+  retryPaths: [],
+  retryStages: [],
   totalFiles: input.totalFiles,
   baselineSha: undefined,
   priorState: undefined,
   profileFingerprint: input.profileFingerprint,
 });
+
+/** Three-dot lineage from the reviewed head to the current head is usable. */
+export const isLineageAncestor = (
+  comparison: ReviewHeadComparison,
+  priorState: ReviewState,
+  currentHeadSha: string,
+): boolean =>
+  comparison.baseSha === priorState.reviewedHeadSha &&
+  comparison.headSha === currentHeadSha &&
+  comparison.mergeBaseSha === priorState.reviewedHeadSha &&
+  !comparison.truncated &&
+  (comparison.status === "ahead" || comparison.status === "identical");
 
 /**
  * Validate that persisted state belongs to this exact PR/base lineage and the
@@ -340,6 +383,96 @@ export const validateReviewState = (
   return undefined;
 };
 
+const filePaths = (file: ChangedFile): ReadonlyArray<string> =>
+  file.previousPath === undefined ? [file.path] : [file.path, file.previousPath];
+
+const incrementalFromDelta = (input: {
+  readonly current: PullRequestMetadata;
+  readonly fullFiles: ReadonlyArray<ChangedFile>;
+  readonly profileFingerprint: string;
+  readonly priorState: ReviewState;
+  readonly deltaFiles: ReadonlyArray<ChangedFile>;
+  readonly extraAffectedPaths?: ReadonlyArray<string> | undefined;
+  readonly reason: string;
+}): ReviewSelection => {
+  const currentPaths = new Set(input.fullFiles.flatMap(filePaths));
+  const affectedPaths = new Set([
+    ...input.deltaFiles.flatMap(filePaths),
+    ...(input.extraAffectedPaths ?? []),
+  ]);
+  const selectedByPath = new Map<string, ChangedFile>();
+  for (const file of input.deltaFiles) {
+    if (
+      currentPaths.has(file.path) ||
+      (file.previousPath !== undefined && currentPaths.has(file.previousPath))
+    ) {
+      selectedByPath.set(file.path, file);
+    }
+  }
+  const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
+  const surgical = input.priorState.unreviewedPasses !== undefined;
+  const retryOnly = new Set<string>();
+  const retryStages = new Set<UnreviewedStage>();
+  for (const path of carriedPaths) {
+    if (affectedPaths.has(path)) continue;
+    retryOnly.add(path);
+    if (surgical) {
+      for (const pass of input.priorState.unreviewedPasses ?? []) {
+        if (pass.paths.includes(path)) retryStages.add(pass.stage);
+      }
+    } else {
+      affectedPaths.add(path);
+    }
+  }
+  if (
+    surgical &&
+    retryStages.has("verification") &&
+    !retryStages.has("discovery") &&
+    !retryStages.has("specialist")
+  ) {
+    retryStages.add("discovery");
+    retryStages.add("specialist");
+  }
+  if (surgical && retryOnly.size > 0 && retryStages.size === 0) {
+    for (const path of retryOnly) affectedPaths.add(path);
+    retryStages.add("discovery");
+    retryStages.add("specialist");
+    retryStages.add("verification");
+  }
+  if (carriedPaths.length > 0 || (input.extraAffectedPaths?.length ?? 0) > 0) {
+    for (const file of input.fullFiles) {
+      const needed =
+        affectedPaths.has(file.path) ||
+        (file.previousPath !== undefined && affectedPaths.has(file.previousPath)) ||
+        retryOnly.has(file.path) ||
+        (file.previousPath !== undefined && retryOnly.has(file.previousPath));
+      if (needed) selectedByPath.set(file.path, file);
+    }
+  }
+  const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
+    left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
+  );
+  const leftoverCount = [...retryOnly].filter((path) => !affectedPaths.has(path)).length;
+  const carriedReason =
+    leftoverCount > 0 && surgical
+      ? `; retrying ${leftoverCount} unchanged leftover path(s) without rediscovery`
+      : carriedPaths.length > 0
+        ? `; retrying ${carriedPaths.length} carried unreviewed path(s)`
+        : "";
+  return {
+    mode: "incremental",
+    reason: `${input.reason}${carriedReason}`,
+    files: selectedFiles,
+    affectedPaths: [...affectedPaths].sort(),
+    retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),
+    retryStages: [...retryStages].sort(),
+    totalFiles: selectedFiles.length,
+    baselineSha: input.priorState.reviewedHeadSha,
+    priorState: input.priorState,
+    profileFingerprint: input.profileFingerprint,
+  };
+};
+
 /** Pure, deterministic range selection with conservative full-review fallbacks. */
 export const selectReviewRange = (input: {
   readonly requestedMode: ReviewMode;
@@ -349,6 +482,12 @@ export const selectReviewRange = (input: {
   readonly priorState: ReviewState | undefined;
   readonly comparison: ReviewHeadComparison | undefined;
   readonly baseComparison?: ReviewHeadComparison | undefined;
+  /**
+   * Two-dot tree comparison used when the reviewed head is not a git ancestor
+   * (rebase, amend, force-push). Intersected with the current PR path set so
+   * main-drift outside the pull request never re-enters scope.
+   */
+  readonly contentComparison?: ReviewHeadComparison | undefined;
   readonly lookupFailure?: string | undefined;
 }): ReviewSelection => {
   const full = (reason: string) =>
@@ -366,89 +505,53 @@ export const selectReviewRange = (input: {
   const invalid = validateReviewState(input.priorState, input.current, input.profileFingerprint);
   if (invalid !== undefined) return full(invalid);
   const comparison = input.comparison;
-  if (comparison === undefined) return full("the incremental head comparison was unavailable");
   if (
-    comparison.baseSha !== input.priorState.reviewedHeadSha ||
-    comparison.headSha !== input.current.headSha ||
-    comparison.mergeBaseSha !== input.priorState.reviewedHeadSha ||
-    (comparison.status !== "ahead" && comparison.status !== "identical")
+    comparison !== undefined &&
+    isLineageAncestor(comparison, input.priorState, input.current.headSha)
   ) {
-    return full("the prior reviewed head is not an ancestor of the current head");
+    const extraAffected: Array<string> = [];
+    let baseReason = "";
+    if (input.priorState.baseSha !== input.current.baseSha) {
+      const baseComparison = input.baseComparison;
+      if (baseComparison === undefined) {
+        return full("the pull request base changed and its lineage comparison was unavailable");
+      }
+      if (
+        baseComparison.baseSha !== input.priorState.baseSha ||
+        baseComparison.headSha !== input.current.baseSha ||
+        baseComparison.mergeBaseSha !== input.priorState.baseSha ||
+        (baseComparison.status !== "ahead" && baseComparison.status !== "identical") ||
+        baseComparison.truncated
+      ) {
+        return full("the pull request base changed materially or exceeded the comparison bound");
+      }
+      for (const file of baseComparison.files) extraAffected.push(...filePaths(file));
+      baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
+    }
+    return incrementalFromDelta({
+      current: input.current,
+      fullFiles: input.fullFiles,
+      profileFingerprint: input.profileFingerprint,
+      priorState: input.priorState,
+      deltaFiles: comparison.files,
+      extraAffectedPaths: extraAffected,
+      reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
+    });
   }
+  const contentComparison = input.contentComparison;
+  if (contentComparison !== undefined && !contentComparison.truncated) {
+    return incrementalFromDelta({
+      current: input.current,
+      fullFiles: input.fullFiles,
+      profileFingerprint: input.profileFingerprint,
+      priorState: input.priorState,
+      deltaFiles: contentComparison.files,
+      reason: `rewritten history; contents changed since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}`,
+    });
+  }
+  if (comparison === undefined) return full("the incremental head comparison was unavailable");
   if (comparison.truncated) return full("the incremental comparison exceeded GitHub's file bound");
-  const affectedPaths = new Set(
-    comparison.files.flatMap((file) =>
-      file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
-    ),
-  );
-  let baseReason = "";
-  if (input.priorState.baseSha !== input.current.baseSha) {
-    const baseComparison = input.baseComparison;
-    if (baseComparison === undefined) {
-      return full("the pull request base changed and its lineage comparison was unavailable");
-    }
-    if (
-      baseComparison.baseSha !== input.priorState.baseSha ||
-      baseComparison.headSha !== input.current.baseSha ||
-      baseComparison.mergeBaseSha !== input.priorState.baseSha ||
-      (baseComparison.status !== "ahead" && baseComparison.status !== "identical") ||
-      baseComparison.truncated
-    ) {
-      return full("the pull request base changed materially or exceeded the comparison bound");
-    }
-    for (const file of baseComparison.files) {
-      affectedPaths.add(file.path);
-      if (file.previousPath !== undefined) affectedPaths.add(file.previousPath);
-    }
-    baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
-  }
-  const currentPaths = new Set(
-    input.fullFiles.flatMap((file) =>
-      file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
-    ),
-  );
-  const selectedByPath = new Map<string, ChangedFile>();
-  for (const file of comparison.files) {
-    if (
-      currentPaths.has(file.path) ||
-      (file.previousPath !== undefined && currentPaths.has(file.previousPath))
-    ) {
-      selectedByPath.set(file.path, file);
-    }
-  }
-  // Retryable gaps carried by the prior state re-enter this run's scope; a
-  // carried path reverted out of the pull request has nothing left to review.
-  const carriedPaths = new Set(
-    input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path)),
-  );
-  for (const path of carriedPaths) affectedPaths.add(path);
-  const rescuePaths = input.priorState.baseSha !== input.current.baseSha;
-  if (rescuePaths || carriedPaths.size > 0) {
-    for (const file of input.fullFiles) {
-      const affected =
-        (rescuePaths &&
-          (affectedPaths.has(file.path) ||
-            (file.previousPath !== undefined && affectedPaths.has(file.previousPath)))) ||
-        carriedPaths.has(file.path) ||
-        (file.previousPath !== undefined && carriedPaths.has(file.previousPath));
-      if (affected) selectedByPath.set(file.path, file);
-    }
-  }
-  const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
-    left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
-  );
-  const carriedReason =
-    carriedPaths.size === 0 ? "" : `; retrying ${carriedPaths.size} carried unreviewed path(s)`;
-  return {
-    mode: "incremental",
-    reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}${carriedReason}`,
-    files: selectedFiles,
-    affectedPaths: [...affectedPaths].sort(),
-    totalFiles: selectedFiles.length,
-    baselineSha: input.priorState.reviewedHeadSha,
-    priorState: input.priorState,
-    profileFingerprint: input.profileFingerprint,
-  };
+  return full("the prior reviewed head is not an ancestor of the current head");
 };
 
 /** Per-run context consumed by orchestration and publication, not by the model. */

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -32,9 +32,11 @@ import {
 import {
   fromStoredConcern,
   fromStoredFinding,
+  MAX_STORED_UNREVIEWED_PASSES,
   MAX_STORED_UNREVIEWED_PATHS,
   ReviewExecutionContext,
   ReviewState,
+  StoredUnreviewedPass,
   toStoredConcern,
   toStoredFinding,
 } from "./review-state.ts";
@@ -171,6 +173,7 @@ interface ReviewCore {
   readonly inputCoverage: ReviewInputCoverage;
   readonly assurance: ReviewAssurance;
   readonly unreviewedPaths: ReadonlyArray<string>;
+  readonly unreviewedPasses?: ReadonlyArray<StoredUnreviewedPass> | undefined;
   readonly turns: number;
 }
 
@@ -271,6 +274,7 @@ const settleReviewRun = (
             unresolvedFindings: activeFindings.map(toStoredFinding),
             unresolvedConcerns: activeConcerns.map(toStoredConcern),
             unreviewedPaths,
+            unreviewedPasses: (core.unreviewedPasses ?? []).slice(0, MAX_STORED_UNREVIEWED_PASSES),
             settled,
             lastReviewMode: executionContext.mode,
           })
@@ -449,6 +453,14 @@ export const executeFanOutReview = <Provider, ModelProvides, ModelRequires>(
       totalChangedFiles: totalFiles,
       maxFindings: options.maxFindings,
       budget: toRunBudgetHook(budget),
+      ...(executionContext !== undefined && executionContext.retryPaths.length > 0
+        ? {
+            retry: {
+              paths: executionContext.retryPaths,
+              stages: executionContext.retryStages,
+            },
+          }
+        : {}),
     });
     const inputCoverage = fanOutInputCoverage({
       plan: pipeline.plan,
@@ -464,6 +476,14 @@ export const executeFanOutReview = <Provider, ModelProvides, ModelRequires>(
         inputCoverage,
         assurance: pipeline.assurance,
         unreviewedPaths: pipeline.unreviewedPaths,
+        unreviewedPasses: pipeline.unreviewedPasses
+          .slice(0, MAX_STORED_UNREVIEWED_PASSES)
+          .map((pass) =>
+            StoredUnreviewedPass.make({
+              stage: pass.stage,
+              paths: pass.paths.slice(0, 12),
+            }),
+          ),
         turns: pipeline.turns,
       },
       { metadata, files, anchorFiles, fingerprint, usage },

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -36,6 +36,7 @@ import {
   ReviewAssurance,
   ReviewExecutionContext,
   ReviewFinding,
+  ReviewHeadComparison,
   ReviewInputCoverage,
   ReviewRunOutcome,
   ReviewState,
@@ -837,6 +838,107 @@ describe("runReviewAction", () => {
       expect(result._tag).toBe("Completed");
       expect(yield* Ref.get(reviewedScopes)).toEqual([["src/a.ts"]]);
       expect(yield* Ref.get(harness.written)).toContain("skipped=false");
+    }),
+  );
+
+  it.effect("reviews only content-changed PR paths after a rewritten head", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const profileFingerprint = "a".repeat(64);
+      const reviewedHeadSha = "1".repeat(40);
+      const currentHeadSha = "2".repeat(40);
+      const metadata = PullRequestMetadata.make({
+        repository: "acme/widgets",
+        number: 5,
+        title: "Review target",
+        body: "",
+        baseRef: "main",
+        baseSha: "3".repeat(40),
+        headRef: "fix/review",
+        headSha: currentHeadSha,
+        totalChangedFiles: 2,
+      });
+      const changed = ChangedFile.make({
+        path: "src/fix.ts",
+        status: "modified",
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -1 +1 @@\n-before\n+after",
+      });
+      const untouched = ChangedFile.make({
+        path: "src/untouched.ts",
+        status: "modified",
+        additions: 1,
+        deletions: 0,
+        patch: "@@ -1 +1 @@\n-old\n+kept",
+      });
+      const state = ReviewState.make({
+        version: 2,
+        repository: metadata.repository,
+        pullRequestNumber: metadata.number,
+        baseRef: metadata.baseRef,
+        baseSha: metadata.baseSha ?? "3".repeat(40),
+        headRef: metadata.headRef,
+        reviewedHeadSha,
+        profileFingerprint,
+        acceptedScopeFingerprint: "b".repeat(64),
+        reviewedPathCount: 2,
+        unresolvedFindings: [],
+        unresolvedConcerns: [],
+        unreviewedPaths: [],
+        unreviewedPasses: [],
+        settled: true,
+        lastReviewMode: "full",
+      });
+      const reviewedScopes = yield* Ref.make<ReadonlyArray<ReadonlyArray<string>>>([]);
+      const result = yield* runReviewAction(
+        {
+          run: () =>
+            Effect.gen(function* () {
+              const selection = Option.getOrUndefined(
+                yield* Effect.serviceOption(ReviewExecutionContext),
+              );
+              yield* Ref.update(reviewedScopes, (previous) => [
+                ...previous,
+                selection?.files.map((selected) => selected.path) ?? [],
+              ]);
+              return fakeOutcome("comment");
+            }),
+          fingerprint: Effect.succeed("c".repeat(64)),
+          profileFingerprint: Effect.succeed(profileFingerprint),
+          snapshot: Effect.succeed({ metadata, files: [changed, untouched] }),
+        },
+        {
+          post: false,
+          priorReviews: staticPriorReviews(Option.none(), {
+            state: Option.some(state),
+            comparison: ReviewHeadComparison.make({
+              status: "diverged",
+              baseSha: reviewedHeadSha,
+              headSha: currentHeadSha,
+              mergeBaseSha: "4".repeat(40),
+              files: [changed, untouched],
+              truncated: false,
+            }),
+            treeComparison: ReviewHeadComparison.make({
+              status: "ahead",
+              baseSha: reviewedHeadSha,
+              headSha: currentHeadSha,
+              mergeBaseSha: reviewedHeadSha,
+              files: [changed],
+              truncated: false,
+            }),
+          }),
+        },
+      ).pipe(Effect.provide(harness.layer));
+
+      expect(result._tag).toBe("Completed");
+      expect(yield* Ref.get(reviewedScopes)).toEqual([["src/fix.ts"]]);
     }),
   );
 

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -6,9 +6,11 @@ import {
   GitHubReviewTarget,
   gitHubPullRequestSourceLayer,
   gitHubPriorReviewsLayer,
+  gitHubReviewRetirementHostLayer,
   PriorReviews,
   PullRequestSource,
   renderFingerprintMarker,
+  ReviewRetirementHost,
   ReviewState,
   ReviewStateAuthenticator,
   webCryptoReviewStateAuthenticatorLayer,
@@ -99,6 +101,131 @@ describe("GitHub prior reviews", () => {
 
       expect(Option.getOrUndefined(result.fingerprint)).toBe(FINGERPRINT);
       expect(Option.getOrUndefined(result.state)).toEqual(reviewState);
+    }),
+  );
+
+  it.effect("compares rewritten heads with a two-dot tree request", () =>
+    Effect.gen(function* () {
+      const requested: Array<string> = [];
+      const client = HttpClient.make((request, url) => {
+        requested.push(url.pathname);
+        return Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              JSON.stringify({
+                status: "diverged",
+                base_commit: { sha: REVIEWED_HEAD_SHA },
+                merge_base_commit: { sha: "1".repeat(40) },
+                files: [
+                  {
+                    filename: "src/fix.ts",
+                    status: "modified",
+                    additions: 1,
+                    deletions: 1,
+                    patch: "@@ -1 +1 @@\n-before\n+after",
+                  },
+                ],
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          ),
+        );
+      });
+      const comparison = yield* Effect.gen(function* () {
+        const priorReviews = yield* PriorReviews;
+        return yield* priorReviews.compareTrees(REVIEWED_HEAD_SHA, "3".repeat(40));
+      }).pipe(
+        Effect.provide(
+          gitHubPriorReviewsLayer.pipe(
+            Layer.provide(
+              Layer.merge(
+                GitHubReviewTarget.layer({
+                  apiUrl: "https://api.github.test",
+                  repository: "acme/widgets",
+                  number: 30,
+                  token: Option.some(Redacted.make("github-app-token")),
+                }),
+                Layer.succeed(HttpClient.HttpClient)(client),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(requested).toEqual([
+        `/repos/acme/widgets/compare/${REVIEWED_HEAD_SHA}..${"3".repeat(40)}`,
+      ]);
+      expect(comparison.status).toBe("ahead");
+      expect(comparison.mergeBaseSha).toBe(REVIEWED_HEAD_SHA);
+      expect(comparison.files.map((file) => file.path)).toEqual(["src/fix.ts"]);
+    }),
+  );
+});
+
+describe("GitHub review retirement comments", () => {
+  it.effect("decodes outdated inline comments that omit the current line", () =>
+    Effect.gen(function* () {
+      const client = HttpClient.make((request, url) => {
+        if (url.pathname === "/repos/acme/widgets/pulls/30/reviews") {
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(JSON.stringify([]), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }),
+            ),
+          );
+        }
+        expect(url.pathname).toBe("/repos/acme/widgets/pulls/30/reviews/9/comments");
+        return Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              JSON.stringify([
+                {
+                  node_id: "PRRC_outdated",
+                  path: "src/a.ts",
+                  body: "**[🛑 blocking] Gone stale**\n\nThe line moved.",
+                  original_line: 12,
+                },
+              ]),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          ),
+        );
+      });
+      const comments = yield* Effect.gen(function* () {
+        const host = yield* ReviewRetirementHost;
+        return yield* host.listComments(9);
+      }).pipe(
+        Effect.provide(
+          gitHubReviewRetirementHostLayer.pipe(
+            Layer.provide(
+              Layer.merge(
+                GitHubReviewTarget.layer({
+                  apiUrl: "https://api.github.test",
+                  repository: "acme/widgets",
+                  number: 30,
+                  token: Option.some(Redacted.make("github-app-token")),
+                }),
+                Layer.succeed(HttpClient.HttpClient)(client),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(comments).toEqual([
+        {
+          nodeId: "PRRC_outdated",
+          path: "src/a.ts",
+          startLine: 12,
+          endLine: 12,
+          body: "**[🛑 blocking] Gone stale**\n\nThe line moved.",
+        },
+      ]);
     }),
   );
 });

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -186,6 +186,12 @@ const runOfflineFanOut = (script: {
   readonly fixture?: FixturePullRequest | undefined;
   readonly maxFindings?: number | undefined;
   readonly limits?: UsageBudgetLimits | undefined;
+  readonly retry?:
+    | {
+        readonly paths: ReadonlyArray<string>;
+        readonly stages: ReadonlyArray<"discovery" | "specialist" | "verification">;
+      }
+    | undefined;
 }) =>
   Effect.gen(function* () {
     const fixture = script.fixture ?? highRiskFixture;
@@ -216,10 +222,15 @@ const runOfflineFanOut = (script: {
         ),
       ),
       Effect.provideService(ReviewExecutionContext, {
-        mode: "full",
-        reason: "offline full-diff assurance fixture",
+        mode: script.retry === undefined ? "full" : "incremental",
+        reason:
+          script.retry === undefined
+            ? "offline full-diff assurance fixture"
+            : "offline leftover-pass retry fixture",
         files: reviewFiles,
-        affectedPaths: reviewFiles.map((file) => file.path),
+        affectedPaths: script.retry === undefined ? reviewFiles.map((file) => file.path) : [],
+        retryPaths: script.retry?.paths ?? [],
+        retryStages: script.retry?.stages ?? [],
         totalFiles: reviewFiles.length,
         baselineSha: undefined,
         priorState: undefined,
@@ -874,9 +885,48 @@ describe("host-scheduled discovery and verification pipeline", () => {
       expect(result.outcome.state?.reviewedHeadSha).toBe(FIXTURE_SHA);
       expect(result.outcome.state?.settled).toBe(false);
       expect(result.outcome.state?.unreviewedPaths).toEqual([...highRiskUnit.paths].sort());
+      expect(result.outcome.state?.unreviewedPasses).toMatchObject([
+        {
+          stage: "specialist",
+          paths: highRiskUnit.paths,
+        },
+      ]);
       expect(result.outcome.plan.body).toContain("Unsettled review passes");
       expect(result.outcome.plan.body).toContain("do not change code to satisfy this section");
       expect(result.outcome.plan.event).toBe("COMMENT");
+    }),
+  );
+
+  it.effect("retries only the failed leftover pass without a second general discovery", () =>
+    Effect.gen(function* () {
+      const result = yield* runOfflineFanOut({
+        retry: { paths: [...highRiskUnit.paths], stages: ["specialist"] },
+        children: [
+          report(specialistPass.passId, discoveryReport(specialistPass, [supportedFinding])),
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                candidateId: candidateId(specialistPass.passId, 1),
+                disposition: "confirmed",
+                rationale: "Confirmed on the leftover specialist retry.",
+              }),
+            ]),
+          ),
+        ],
+      });
+
+      expect(result.childCalls).toBe(2);
+      expect(result.outcome.assurance).toMatchObject({
+        status: "settled",
+        requiredGeneralDiscoveryPasses: 0,
+        completedGeneralDiscoveryPasses: 0,
+        requiredSpecialistPasses: 1,
+        completedSpecialistPasses: 1,
+      });
+      expect(result.outcome.review.findings).toEqual([supportedFinding]);
+      expect(result.outcome.unreviewedPaths).toEqual([]);
+      expect(result.outcome.state?.unreviewedPasses).toEqual([]);
     }),
   );
 

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -10,6 +10,7 @@ import {
   ReviewStateAuthenticator,
   selectReviewRange,
   StoredReviewFinding,
+  StoredUnreviewedPass,
   webCryptoReviewStateAuthenticatorLayer,
 } from "../src/index.ts";
 
@@ -249,10 +250,57 @@ describe("review state", () => {
       "src/accepted.ts",
       "src/corrective.ts",
     ]);
-    // Carried paths count as affected: their stored findings are re-derived
-    // by the fresh re-review instead of being carried blindly.
+    // Legacy markers without unreviewedPasses still rediscover leftovers.
     expect(selection.affectedPaths).toContain("src/accepted.ts");
+    expect(selection.retryPaths).toEqual([]);
     expect(selection.reason).toContain("retrying 1 carried unreviewed path(s)");
+  });
+
+  it("retries an unchanged leftover without invalidating its stored findings", () => {
+    const carryingState = ReviewState.make({
+      ...priorState,
+      unreviewedPaths: ["src/accepted.ts"],
+      unreviewedPasses: [
+        StoredUnreviewedPass.make({ stage: "specialist", paths: ["src/accepted.ts"] }),
+      ],
+      settled: false,
+    });
+    const selection = select({ priorState: carryingState });
+
+    expect(selection.mode).toBe("incremental");
+    expect(selection.files.map((file) => file.path)).toEqual([
+      "src/accepted.ts",
+      "src/corrective.ts",
+    ]);
+    expect(selection.affectedPaths).not.toContain("src/accepted.ts");
+    expect(selection.retryPaths).toEqual(["src/accepted.ts"]);
+    expect(selection.retryStages).toEqual(["specialist"]);
+    expect(selection.reason).toContain("without rediscovery");
+  });
+
+  it("reviews only content-changed PR paths after a rewritten head", () => {
+    const rewritten = ReviewHeadComparison.make({
+      status: "diverged",
+      baseSha: REVIEWED_HEAD_SHA,
+      headSha: CURRENT_HEAD_SHA,
+      mergeBaseSha: "5".repeat(40),
+      files: [acceptedFile, correctiveFile],
+      truncated: false,
+    });
+    const contentComparison = ReviewHeadComparison.make({
+      status: "ahead",
+      baseSha: REVIEWED_HEAD_SHA,
+      headSha: CURRENT_HEAD_SHA,
+      mergeBaseSha: REVIEWED_HEAD_SHA,
+      files: [correctiveFile],
+      truncated: false,
+    });
+    const selection = select({ comparison: rewritten, contentComparison });
+
+    expect(selection.mode).toBe("incremental");
+    expect(selection.files.map((file) => file.path)).toEqual(["src/corrective.ts"]);
+    expect(selection.reason).toContain("rewritten history");
+    expect(selection.affectedPaths).toEqual(["src/corrective.ts"]);
   });
 
   it("keeps a carried unreviewed path in scope across a rename", () => {


### PR DESCRIPTION
## Summary

- After a rebase, amend, or force-push, incremental Action reviews stay incremental: they use a two-dot tree comparison of the last reviewed head against the current head, then review only current PR paths whose contents actually changed. GitHub's three-dot compare is `diverged` after a rewrite and previously fail-closed to a full-diff rediscovery.
- Unchanged leftover paths from a failed pass retry only that failed stage and keep their stored findings. They no longer re-enter `affectedPaths` and mint a second general+specialist candidate set.
- Outdated GitHub review comments that omit `line` no longer fail the whole retirement decode, so resolved threads can still be minimized.

This is the remaining loop from [#131](https://github.com/danieljvdm/effect-agent/issues/131) after [#132](https://github.com/danieljvdm/effect-agent/pull/132) made the baseline monotone. Observed on [reve-ai/kommunikasie#687](https://github.com/reve-ai/kommunikasie/pull/687): `#132` advanced off an unsettled head, then every rewrite ran a fresh `effort: high` / `max-findings: 12` pass over already-reviewed files.

## What went wrong

`#132` stopped incomplete assurance from freezing the baseline. It did not stop a rewritten head from looking like a brand-new PR.

1. **Rewrite → full rediscovery.** `selectReviewRange` accepted a head-to-head compare only when the reviewed SHA was a git ancestor (`mergeBaseSha === reviewedHead`, status `ahead`/`identical`). After rebase, GitHub three-dot compare is `diverged` and the file list is the whole PR (plus main-drift). Fail-closed reason: `the prior reviewed head is not an ancestor of the current head`.
2. **Leftover retry rediscovered the unit.** A specialist `BudgetExceeded` carried every path in the unit. The next "incremental" run treated those leftovers as affected, ran fresh general+specialist discovery, and published a new max-findings set on files that already had confirmed findings.
3. **Retirement collapsed.** `GitHubReviewCommentWire.line` required the key. GitHub omits `line` on outdated comments (`SchemaError: Missing key at [0]["line"]`). Bodies were collapsed; inline comments stayed visible even after the host marked them resolved.

The extra findings after the first pass were mostly restatements of the same seams, not new defects on new code. This change does **not** cap novelty: changed bytes still get full discovery, leftovers still retry, unresolved findings still fail the check, and `pr-review:final-audit` still re-reviews the bounded full diff.

## Architecture

- **Content incremental:** [`PriorReviews.compareTrees`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/github.ts#L819-L845) hits `/compare/{reviewed}..{current}` and returns a content snapshot (`status` forced to `ahead`/`identical`, `mergeBaseSha = baseSha`). [`runReviewAction`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/action.ts#L598-L625) fetches it only when three-dot lineage is not an ancestor. [`selectReviewRange`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/review-state.ts#L541-L554) intersects those files with the current PR path set so main-drift stays out. Missing or truncated two-dot still fail-closes to full-diff.
- **Surgical leftover retry:** New markers persist [`unreviewedPasses`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/review-state.ts#L90-L101) (`stage` + `paths`). Unchanged leftovers become [`retryPaths` / `retryStages`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/review-state.ts#L412-L468), not `affectedPaths`. [`scheduleFanOutWork`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/fan-out.ts#L793-L844) plans fresh files and retry files separately and filters retry discovery to the recorded stages. Legacy markers without the key still rediscover, so old continuity state stays safe.
- **Retirement decode:** [`GitHubReviewCommentWire.line` / `original_line`](https://github.com/danieljvdm/effect-agent/blob/fix/pr-review-incremental-rewrite/packages/pr-review/src/internal/github.ts#L129-L137) are `optionalKey(NullOr(Int))`. Missing lines cannot be matched; they no longer fail the list.

## Evidence

Deterministic coverage for the three loops:

```text
reviews only content-changed PR paths after a rewritten head
  → incremental, files = [src/corrective.ts], reason contains "rewritten history"

retries an unchanged leftover without invalidating its stored findings
  → retryPaths = [src/accepted.ts], retryStages = [specialist], not in affectedPaths

retries only the failed leftover pass without a second general discovery
  → childCalls = 2, requiredGeneralDiscoveryPasses = 0, requiredSpecialistPasses = 1

compares rewritten heads with a two-dot tree request
decodes outdated inline comments that omit the current line
reviews only content-changed PR paths after a rewritten head  (action host)
```

Consumers pinned to `#132` (`15f041f`) will not see this until they move the pin.

## Test plan

- [ ] Confirm a rebase that also changes one file reviews only that file plus leftovers, not the whole PR
- [ ] Confirm a specialist leftover retry does not mint a new general-discovery candidate set
- [ ] Confirm outdated inline comments still retire after a follow-up push
- [ ] Confirm `pr-review:final-audit` still does a bounded full-diff rediscovery
- [ ] After merge, bump the kommunikasie Action pin and watch #687


Made with [Cursor](https://cursor.com)