### PR TITLE
fix(pr-review): revalidate carried concerns by path

### DIFF
--- a/.changeset/path-bound-review-concerns.md
+++ b/.changeset/path-bound-review-concerns.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Bind review-body concerns to their changed evidence paths so incremental reviews recheck them when related files change or disappear. Distinguish current findings from carried concerns in posted review counts.

--- a/.github/review-guidance.md
+++ b/.github/review-guidance.md
@@ -9,6 +9,7 @@ Architecture review method — apply to every changed service, Layer, tool, hand
 - Resource safety. Every acquired resource belongs to a Scope. Flag daemon fibers, missing finalizers on new acquire paths, and unbounded concurrency — tool and task batches use structured concurrency with Semaphore permits, never a detached Promise scheduler.
 - Pass-through abstractions. Apply the deletion test: a wrapper that only yields a service and forwards one method, or an abstraction whose removal leaves equally clear code, should be folded into its owner. Do not propose a wrapper, service, or Schema merely for symmetry.
 - Public surface. Public asynchronous operations return Effect or Stream, never naked Promises; Promise conversion exists only at external boundaries.
+- Effect failure semantics. Values that implement `YieldableError`, including `Schema.TaggedError` instances, are themselves failing Effects. Returning one directly from a function whose return type is `Effect` preserves the typed failure channel; do not require `Effect.fail(error)`. Inside an `Effect.gen` generator, plain `return error` succeeds with the error value, while `return yield* error` fails. Inspect the enclosing function before reporting this pattern.
 
 Review-assurance posture:
 

--- a/action/README.md
+++ b/action/README.md
@@ -49,11 +49,13 @@ base branch. Do not combine `guidance-file` with `pull_request_target`.
 ## Incremental reviews and authenticated continuity state
 
 Each completed review may embed a bounded, schema-validated state marker. `state-secret` signs the
-PR identity, base/head lineage, reviewer profile, settled-scope fingerprint, unresolved findings,
-retryable paths, and settlement status. On `synchronize`, the action reviews changed paths still
-present in the PR plus carried unreviewed paths. Unchanged findings remain active; changed or
-reverted paths receive fresh discovery. A failed pass carries only its own scope forward, and the
-baseline still advances. A compatible base advance also includes overlapping PR paths.
+PR identity, base/head lineage, reviewer profile, settled-scope fingerprint, unresolved findings
+and concerns, retryable paths, and settlement status. On `synchronize`, the action reviews changed
+paths still present in the PR plus carried unreviewed paths. Unchanged findings and path-bound
+concerns remain active. Changing, reverting, or removing a supporting path invalidates its prior
+review item and schedules the current paths for fresh discovery. A legacy pathless concern forces a
+full review. A failed pass carries only its own scope forward, and the baseline still advances. A
+compatible base advance also includes overlapping PR paths.
 
 Before comparing ancestry, the action checks the authenticated settled-scope fingerprint. It
 hashes the effective diff, bounded patchless
@@ -93,9 +95,10 @@ Logs render one line per event. Use `log-level: Debug` for per-turn and per-hand
 candidates. This repository runs it when an operator applies `pr-review:final-audit`. The required
 `review` check blocks merges on a blocking or incomplete result.
 
-Posted reviews contain a host-derived severity callout and statistics, a path-validated walkthrough,
-concerns, inline comments, a copyable agent prompt, and a run footer. Full-review fallbacks name
-their reason. The action also writes a step summary and `conclusion`, `input-coverage`,
+Posted reviews contain a host-derived severity callout and statistics that distinguish findings,
+concerns, and carried items. They also contain a path-validated walkthrough, concerns with their
+affected paths, inline comments, a copyable agent prompt, and a run footer. Full-review fallbacks
+name their reason. The action also writes a step summary and `conclusion`, `input-coverage`,
 `review-assurance`, `review-mode`, and `review-reason` outputs.
 
 The check ignores the model verdict. Blocking findings or concerns produce `blocking`; incomplete

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -42193,6 +42193,7 @@ class ReviewFinding extends exports_Schema.Class("@effect-agent/pr-review/Review
 var ReviewVerdict = exports_Schema.Literals(["approve", "comment", "request-changes"]);
 
 class ReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/ReviewConcern")({
+  evidencePaths: exports_Schema.optionalKey(exports_Schema.Array(ChangedPath).check(exports_Schema.isMinLength(1)).check(exports_Schema.isMaxLength(3))),
   severity: FindingSeverity,
   title: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(120)),
   body: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2000))
@@ -42238,9 +42239,9 @@ ${mission.body}` : "The author provided no description.",
     "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
     "Go shallow only when the diff has no behavioral surface at all: doc typos, formatting, lockfile or generated-code regeneration, a mechanical rename. Line count is not the signal — a one-line change to auth, money, SQL, a comparison operator, or a config default is not trivial.",
     "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
-    '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor; report none when none exist.',
+    '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor. Every concern must list 1-3 exact changed evidencePaths that support it so later incremental reviews can recheck it when those files change. Report none when none exist, and never split one root concern into differently worded restatements.',
     `6. Write a walkthrough: for every file whose evidence you examined, one factual sentence (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars) describing what changed in that file — written for a reader scanning the pull request, never restating the diff line by line. Use only paths from list_changed_files; invented paths are dropped.`,
-    '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL: "correctness" | "security" | "concurrency" | "performance" | "resources" | "error-handling" | "testing" | "maintainability" | "style" | "docs">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>, "walkthrough": <array, OPTIONAL: [{"path": <string, a changed file path>, "summary": <string, the step-6 sentence>}], one entry per reviewed file>}.',
+    '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL: "correctness" | "security" | "concurrency" | "performance" | "resources" | "error-handling" | "testing" | "maintainability" | "style" | "docs">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"evidencePaths": <array of 1-3 exact changed file paths>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>, "walkthrough": <array, OPTIONAL: [{"path": <string, a changed file path>, "summary": <string, the step-6 sentence>}], one entry per reviewed file>}.',
     `Report at most ${maxFindings} findings and at most ${MAX_CONCERNS} concerns; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
     'Use verdict "request-changes" only when at least one finding or concern is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.'
   ].join(`
@@ -42735,10 +42736,11 @@ var rankAndDedupeFindings = (findings) => {
     return left.startLine - right.startLine;
   }).slice(0, MAX_MERGED_FINDINGS);
 };
+var reviewConcernKey = (concern) => `${(concern.evidencePaths ?? []).join("\x00")}\x01${concern.title}\x00${concern.body}`;
 var rankAndDedupeConcerns = (concerns) => {
   const byContent = new Map;
   for (const concern of concerns) {
-    const key = `${concern.title}\x00${concern.body}`;
+    const key = reviewConcernKey(concern);
     const previous = byContent.get(key);
     if (previous === undefined || severityRank[concern.severity] < severityRank[previous.severity]) {
       byContent.set(key, concern);
@@ -42883,7 +42885,7 @@ var makeFileReviewerInstructions = (options3 = {}) => (brief) => {
     ...common,
     focus,
     "The discovery evidence array contains every complete shard in the unit. Review every entry and every shard of a multi-shard path. A later independent verifier, not you, decides which candidates publish.",
-    "When a non-anchored concern depends on one or more unit files, list 1-3 exact evidencePaths to bind the claim to scheduled evidence.",
+    "Every non-anchored concern must list 1-3 exact evidencePaths to bind the claim to scheduled evidence. Report one root concern once; never split it into differently worded restatements.",
     `Return ONLY JSON with phase "discovery", the exact workId/unitId, up to ${MAX_CHILD_FINDINGS} findings, up to ${MAX_CHILD_CONCERNS} concerns shaped as {concern, evidencePaths}, one factual file summary per path (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars), and an empty assessments array. Empty candidate arrays are valid; do not invent defects.`,
     'Each finding is {"path": <a unit file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL problem-kind label>, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>}.',
     'Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement source for every line in the range and nothing else — never prose describing the change, which belongs in "body".'
@@ -43263,7 +43265,12 @@ var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
     reasons
   });
   const findings = rankAndDedupeFindings(confirmed.flatMap(({ assessment, candidate }) => candidate._tag === "FindingCandidate" ? [confirmedFindingForPublication(assessment, candidate)] : []));
-  const concerns = rankAndDedupeConcerns(confirmed.flatMap(({ candidate }) => candidate._tag === "ConcernCandidate" ? [candidate.concern] : []));
+  const concerns = rankAndDedupeConcerns(confirmed.flatMap(({ candidate }) => candidate._tag === "ConcernCandidate" ? [
+    ReviewConcern.make({
+      ...candidate.concern,
+      evidencePaths: [...new Set(candidate.evidencePaths)].sort()
+    })
+  ] : []));
   const walkthrough = outcomes.flatMap((outcome) => outcome.walkthrough);
   const blocking = findings.some((finding) => finding.severity === "blocking") || concerns.some((concern) => concern.severity === "blocking");
   const review = CodeReview.make({
@@ -43372,6 +43379,7 @@ class StoredReviewFinding extends exports_Schema.Class("@effect-agent/pr-review/
 }
 
 class StoredReviewConcern extends exports_Schema.Class("@effect-agent/pr-review/StoredReviewConcern")({
+  evidencePaths: exports_Schema.optionalKey(exports_Schema.Array(ChangedPath).check(exports_Schema.isMinLength(1)).check(exports_Schema.isMaxLength(3))),
   severity: FindingSeverity,
   title: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(120)),
   body: StoredText
@@ -43423,11 +43431,17 @@ var fromStoredFinding = (finding) => ReviewFinding.make({
   body: finding.body
 });
 var toStoredConcern = (concern) => StoredReviewConcern.make({
+  ...concern.evidencePaths === undefined ? {} : { evidencePaths: concern.evidencePaths },
   severity: concern.severity,
   title: concern.title,
   body: concern.body.slice(0, 800)
 });
-var fromStoredConcern = (concern) => ReviewConcern.make({ severity: concern.severity, title: concern.title, body: concern.body });
+var fromStoredConcern = (concern) => ReviewConcern.make({
+  ...concern.evidencePaths === undefined ? {} : { evidencePaths: concern.evidencePaths },
+  severity: concern.severity,
+  title: concern.title,
+  body: concern.body
+});
 var STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v1:";
 var STATE_MARKER_SUFFIX = " -->";
 var STATE_MARKER_PATTERN = /(?:^|\n)<!-- effect-agent-pr-review state-v1:([A-Za-z0-9+/]+={0,2})\.([0-9a-f]{64}) -->$/;
@@ -43564,6 +43578,9 @@ var validateReviewState = (state, current, profileFingerprint) => {
   if (state.profileFingerprint !== profileFingerprint) {
     return "the reviewer profile or model configuration changed";
   }
+  if (state.unresolvedConcerns.some((concern) => concern.evidencePaths === undefined)) {
+    return "stored concerns predate affected-path tracking";
+  }
   return;
 };
 var filePaths = (file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath];
@@ -43573,6 +43590,22 @@ var incrementalFromDelta = (input) => {
     ...input.deltaFiles.flatMap(filePaths),
     ...input.extraAffectedPaths ?? []
   ]);
+  const initialAffectedCount = affectedPaths.size;
+  let expanded = true;
+  while (expanded) {
+    expanded = false;
+    for (const concern of input.priorState.unresolvedConcerns) {
+      const paths = concern.evidencePaths ?? [];
+      if (!paths.some((path) => affectedPaths.has(path)))
+        continue;
+      for (const path of paths) {
+        if (!affectedPaths.has(path)) {
+          affectedPaths.add(path);
+          expanded = true;
+        }
+      }
+    }
+  }
   const selectedByPath = new Map;
   for (const file2 of input.deltaFiles) {
     if (currentPaths.has(file2.path) || file2.previousPath !== undefined && currentPaths.has(file2.previousPath)) {
@@ -43602,19 +43635,19 @@ var incrementalFromDelta = (input) => {
     retryStages.add("specialist");
     retryStages.add("verification");
   }
-  if (carriedPaths.length > 0 || (input.extraAffectedPaths?.length ?? 0) > 0) {
-    for (const file2 of input.fullFiles) {
-      const needed = affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath) || retryOnly.has(file2.path) || file2.previousPath !== undefined && retryOnly.has(file2.previousPath);
-      if (needed)
-        selectedByPath.set(file2.path, file2);
-    }
+  for (const file2 of input.fullFiles) {
+    const needed = affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath) || retryOnly.has(file2.path) || file2.previousPath !== undefined && retryOnly.has(file2.previousPath);
+    if (needed)
+      selectedByPath.set(file2.path, file2);
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
   const leftoverCount = [...retryOnly].filter((path) => !affectedPaths.has(path)).length;
   const carriedReason = leftoverCount > 0 ? `; retrying ${leftoverCount} unchanged leftover path(s) without rediscovery` : carriedPaths.length > 0 ? `; retrying ${carriedPaths.length} carried unreviewed path(s)` : "";
+  const concernPathCount = affectedPaths.size - initialAffectedCount;
+  const concernReason = concernPathCount === 0 ? "" : `; reopening ${concernPathCount} related concern path(s) for context`;
   return {
     mode: "incremental",
-    reason: `${input.reason}${carriedReason}`,
+    reason: `${input.reason}${carriedReason}${concernReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
     retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),
@@ -44446,41 +44479,65 @@ var renderDemoted = (finding, reason) => {
   return `- ${location2} **[${findingLabel(finding)}] ${finding.title}** — ${finding.body} _(demoted: ${reason})_`;
 };
 var countNoun2 = (count2, noun) => `${count2} ${noun}${count2 === 1 ? "" : "s"}`;
+var tallySeverities = (items) => {
+  const blocking = items.filter((item) => item.severity === "blocking").length;
+  const important = items.filter((item) => item.severity === "important").length;
+  const nit = items.length - blocking - important;
+  return { blocking, important, nit, total: items.length };
+};
 var severityCounts = (review, carriedFindings = [], carriedConcerns = []) => {
-  const severities = [
-    ...review.findings.map((finding) => finding.severity),
-    ...(review.concerns ?? []).map((concern) => concern.severity),
-    ...carriedFindings.map((finding) => finding.severity),
-    ...carriedConcerns.map((concern) => concern.severity)
-  ];
+  const findings = tallySeverities(review.findings);
+  const concerns = tallySeverities(review.concerns ?? []);
+  const priorFindings = tallySeverities(carriedFindings);
+  const priorConcerns = tallySeverities(carriedConcerns);
   return {
-    blocking: severities.filter((severity2) => severity2 === "blocking").length,
-    important: severities.filter((severity2) => severity2 === "important").length,
-    total: severities.length
+    findings,
+    concerns,
+    carriedFindings: priorFindings,
+    carriedConcerns: priorConcerns,
+    total: {
+      blocking: findings.blocking + concerns.blocking + priorFindings.blocking + priorConcerns.blocking,
+      important: findings.important + concerns.important + priorFindings.important + priorConcerns.important,
+      nit: findings.nit + concerns.nit + priorFindings.nit + priorConcerns.nit,
+      total: findings.total + concerns.total + priorFindings.total + priorConcerns.total
+    }
   };
 };
+var joinItemCounts = (items) => items.length <= 1 ? items[0] ?? "none" : items.length === 2 ? `${items[0]} and ${items[1]}` : `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+var severityItemParts = (counts, severity2) => [
+  ...counts.findings[severity2] === 0 ? [] : [countNoun2(counts.findings[severity2], `${severity2} finding`)],
+  ...counts.concerns[severity2] === 0 ? [] : [countNoun2(counts.concerns[severity2], `${severity2} concern`)],
+  ...counts.carriedFindings[severity2] === 0 ? [] : [countNoun2(counts.carriedFindings[severity2], `carried ${severity2} finding`)],
+  ...counts.carriedConcerns[severity2] === 0 ? [] : [countNoun2(counts.carriedConcerns[severity2], `carried ${severity2} concern`)]
+];
+var renderSeverityItems = (counts, severity2) => joinItemCounts(severityItemParts(counts, severity2));
 var renderVerdictCallout = (review, options3) => {
   const counts = severityCounts(review, options3.carriedFindings, options3.carriedConcerns);
-  if (counts.blocking > 0) {
+  if (counts.total.blocking > 0) {
     return `> [!CAUTION]
-> ${countNoun2(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+> ${renderSeverityItems(counts, "blocking")}. Do not merge before addressing ${counts.total.blocking === 1 ? "it" : "them"}.`;
   }
   const carried = options3.unreviewedPaths?.length ?? 0;
   if (options3.inputCoverage?.status === "incomplete" || options3.assurance?.status === "incomplete") {
     const carriedNote = carried > 0 ? ` ${countNoun2(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.` : "";
     return `> [!WARNING]
-> Review infrastructure did not settle — a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
+> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
   }
-  if (counts.important > 0) {
+  if (counts.total.important > 0) {
     return `> [!IMPORTANT]
-> ${countNoun2(counts.important, "important finding")} to address before merging.`;
+> ${renderSeverityItems(counts, "important")} to address before merging.`;
   }
-  if (counts.total > 0) {
-    return "> ℹ️ Minor suggestions only — mergeable as-is.";
+  if (counts.total.total > 0) {
+    return `> ℹ️ ${renderSeverityItems(counts, "nit")}; mergeable as-is.`;
   }
-  return review.verdict === "approve" ? "> ✅ No issues found." : "> ℹ️ No findings — see the summary.";
+  return review.verdict === "approve" ? "> ✅ No issues found." : "> ℹ️ No review items. See the summary.";
 };
-var renderConcern = (concern) => [`### ${severityEmoji[concern.severity]} ${concern.title}`, "", concern.body].join(`
+var renderConcern = (concern) => [
+  `### ${severityEmoji[concern.severity]} ${concern.title}`,
+  ...concern.evidencePaths === undefined ? [] : ["", `_Affected paths: ${concern.evidencePaths.map((path) => `\`${path}\``).join(", ")}_`],
+  "",
+  concern.body
+].join(`
 `);
 var renderCarriedFinding = (finding) => `- \`${finding.path}:${finding.startLine}${finding.endLine === finding.startLine ? "" : `-${finding.endLine}`}\` **[${findingLabel(finding)}] ${finding.title}** — ${finding.body}`;
 var planWalkthrough = (entries3, files) => {
@@ -44517,14 +44574,9 @@ var renderReviewStats = (files, totalChangedFiles, counts) => {
   const additions = files.reduce((total, file2) => total + file2.additions, 0);
   const deletions = files.reduce((total, file2) => total + file2.deletions, 0);
   const fileCount = files.length < totalChangedFiles ? `${files.length} of ${totalChangedFiles} files` : countNoun2(files.length, "file");
-  const nits = counts.total - counts.blocking - counts.important;
-  const tally = counts.total === 0 ? "none" : [
-    ...counts.blocking > 0 ? [`${counts.blocking} blocking`] : [],
-    ...counts.important > 0 ? [`${counts.important} important`] : [],
-    ...nits > 0 ? [`${nits} nit`] : []
-  ].join(", ");
+  const tally = counts.total.total === 0 ? "none" : joinItemCounts(["blocking", "important", "nit"].flatMap((severity2) => severityItemParts(counts, severity2)));
   const effort = estimateReviewEffort(files);
-  return `**Changeset:** ${fileCount} (+${additions} / −${deletions}) · **Findings:** ${tally} · **Review effort:** ${effort.score}/5 (${effort.label})`;
+  return `**Changeset:** ${fileCount} (+${additions} / −${deletions}) · **Review items:** ${tally} · **Review effort:** ${effort.score}/5 (${effort.label})`;
 };
 var commentSafe = (value4) => value4.replaceAll("--", "- -");
 var renderReviewMetadata = (options3) => [
@@ -44614,7 +44666,7 @@ var planPublication = (review, files, options3) => {
       parts2.push("", "<details>", `<summary>Unresolved findings carried from unchanged scope (${carriedFindings.length})</summary>`, "", ...carriedFindings.map(renderCarriedFinding), "", "</details>");
     }
     if (carriedConcerns.length > 0) {
-      parts2.push("", "### Unresolved concerns carried to the final audit");
+      parts2.push("", `### Unresolved concerns from unchanged paths (${carriedConcerns.length})`, "", "These concerns were reported in an earlier review and were not reverified in this incremental pass. They remain active because none of their affected paths changed.");
       for (const concern of carriedConcerns)
         parts2.push("", renderConcern(concern));
     }
@@ -44639,7 +44691,7 @@ var planPublication = (review, files, options3) => {
   };
   const counts = severityCounts(review, options3.carriedFindings ?? [], options3.carriedConcerns ?? []);
   const unclean = options3.inputCoverage?.status === "incomplete" || options3.assurance?.status === "incomplete";
-  const event = !options3.applyVerdict ? "COMMENT" : counts.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.important === 0 && !unclean ? "APPROVE" : "COMMENT";
+  const event = !options3.applyVerdict ? "COMMENT" : counts.total.blocking > 0 ? "REQUEST_CHANGES" : review.verdict === "approve" && counts.total.important === 0 && !unclean ? "APPROVE" : "COMMENT";
   const tail = [
     renderReviewMetadata({
       headSha: options3.headSha,
@@ -44738,7 +44790,24 @@ var findingKey = (finding) => `${finding.path}\x00${finding.startLine}\x00${find
 var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function* () {
   const { metadata, files, anchorFiles, fingerprint, usage } = context4;
   const executionContext = exports_Option.getOrUndefined(yield* exports_Effect.serviceOption(ReviewExecutionContext));
-  const review = enforceFindingsBound(core2.review, clampMaxFindings(options3.maxFindings));
+  const boundedReview = enforceFindingsBound(core2.review, clampMaxFindings(options3.maxFindings));
+  const reviewPaths = new Set(files.map((file2) => file2.path));
+  const review = CodeReview.make({
+    ...boundedReview,
+    ...boundedReview.concerns === undefined ? {} : {
+      concerns: boundedReview.concerns.map((concern) => {
+        const evidencePaths = concern.evidencePaths;
+        if (evidencePaths === undefined || evidencePaths.some((path) => !reviewPaths.has(path))) {
+          const { evidencePaths: _invalid, ...pathless } = concern;
+          return ReviewConcern.make(pathless);
+        }
+        return ReviewConcern.make({
+          ...concern,
+          evidencePaths: [...new Set(evidencePaths)].sort()
+        });
+      })
+    }
+  });
   const { inputCoverage, assurance } = core2;
   const unreviewedPaths = [...new Set(core2.unreviewedPaths)].sort();
   const reviewTotalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
@@ -44749,21 +44818,22 @@ var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function
   const activeFindingKeys = new Set(activeFindings.map(findingKey));
   const currentFindingKeys = new Set(review.findings.map(findingKey));
   const carriedFindings = carriedCandidates.filter((finding) => activeFindingKeys.has(findingKey(finding)) && !currentFindingKeys.has(findingKey(finding)));
-  const carriedConcernCandidates = priorState?.unresolvedConcerns.map(fromStoredConcern) ?? [];
+  const carriedConcernCandidates = priorState?.unresolvedConcerns.filter((concern) => concern.evidencePaths !== undefined && concern.evidencePaths.every((path) => !affectedPaths.has(path))).map(fromStoredConcern) ?? [];
   const activeConcerns = rankAndDedupeConcerns([
     ...carriedConcernCandidates,
     ...review.concerns ?? []
   ]);
-  const currentConcernKeys = new Set((review.concerns ?? []).map((concern) => `${concern.title}\x00${concern.body}`));
-  const activeConcernKeys = new Set(activeConcerns.map((concern) => `${concern.title}\x00${concern.body}`));
+  const currentConcernKeys = new Set((review.concerns ?? []).map(reviewConcernKey));
+  const activeConcernKeys = new Set(activeConcerns.map(reviewConcernKey));
   const carriedConcerns = carriedConcernCandidates.filter((concern) => {
-    const key = `${concern.title}\x00${concern.body}`;
+    const key = reviewConcernKey(concern);
     return activeConcernKeys.has(key) && !currentConcernKeys.has(key);
   });
   const settled = inputCoverage.status === "complete" && assurance.status !== "incomplete" && unreviewedPaths.length === 0;
-  const skipFingerprint = settled ? fingerprint : undefined;
+  const concernsHaveEvidencePaths = activeConcerns.every((concern) => concern.evidencePaths !== undefined);
+  const skipFingerprint = settled && concernsHaveEvidencePaths ? fingerprint : undefined;
   const carriedScopeFits = unreviewedPaths.length <= MAX_STORED_UNREVIEWED_PATHS;
-  const stateCandidate = executionContext !== undefined && fingerprint !== undefined && metadata.baseSha !== undefined && anchorFiles.length >= metadata.totalChangedFiles && carriedScopeFits && executionContext.stateAuthenticator?.status === "available" ? ReviewState.make({
+  const stateCandidate = executionContext !== undefined && fingerprint !== undefined && metadata.baseSha !== undefined && anchorFiles.length >= metadata.totalChangedFiles && carriedScopeFits && concernsHaveEvidencePaths && executionContext.stateAuthenticator?.status === "available" ? ReviewState.make({
     version: 1,
     repository: metadata.repository,
     pullRequestNumber: metadata.number,
@@ -44784,7 +44854,7 @@ var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function
   const continuity = stateCandidate === undefined || executionContext?.stateAuthenticator === undefined ? {
     state: undefined,
     marker: undefined,
-    notice: executionContext !== undefined && !carriedScopeFits ? `carried unreviewed scope (${unreviewedPaths.length} paths) exceeded the ${MAX_STORED_UNREVIEWED_PATHS}-path continuity bound` : executionContext?.stateAuthenticator?.status === "unavailable" ? executionContext.stateAuthenticator.unavailableReason ?? "authenticated continuity state is unavailable" : undefined
+    notice: executionContext !== undefined && !carriedScopeFits ? `carried unreviewed scope (${unreviewedPaths.length} paths) exceeded the ${MAX_STORED_UNREVIEWED_PATHS}-path continuity bound` : executionContext !== undefined && !concernsHaveEvidencePaths ? "one or more review concerns lacked host-validated affected paths" : executionContext?.stateAuthenticator?.status === "unavailable" ? executionContext.stateAuthenticator.unavailableReason ?? "authenticated continuity state is unavailable" : undefined
   } : yield* executionContext.stateAuthenticator.render(stateCandidate).pipe(exports_Effect.match({
     onFailure: (error2) => ({
       state: undefined,
@@ -45087,7 +45157,7 @@ var settleCallout = (info2) => {
     case "success":
       return `> ✅ **Code review posted** — verdict \`${info2.verdict}\`, ${info2.inlineComments} inline comment(s), nothing blocking.`;
     case "blocking":
-      return `> \uD83D\uDED1 **Code review posted** — blocking findings; the check fails until they are addressed.`;
+      return `> \uD83D\uDED1 **Code review posted:** blocking review items; the check fails until they are addressed.`;
     case "incomplete":
       return `> ⚠️ **Code review posted** — input coverage or configured review assurance is incomplete, so the check fails.`;
   }

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -355,8 +355,11 @@ a defect missed by general discovery can still become a candidate; and an indepe
 rejects an unsupported candidate before host-side publication. Failed or exhausted discovery and
 verification passes remain visible, leave candidates unsettled, emit no authenticated continuity
 state, and cannot produce a successful Action conclusion. Incremental fixtures prove that newly
-affected paths invalidate carried findings while unchanged findings remain active. Explicit final
-mode discards prior assurance scope and plans fresh discovery over the complete bounded diff.
+affected paths invalidate carried findings while unchanged findings remain active. Confirmed
+non-anchored concerns retain their host-validated evidence paths; changing or deleting any one
+invalidates the old concern and reopens the remaining current paths for context, while legacy
+pathless concern state forces a full review. Explicit final mode discards prior assurance scope and
+plans fresh discovery over the complete bounded diff.
 Overflow fixtures preserve every affected path and the exact unassigned-shard count while bounding
 identifier diagnostics. Extra or duplicate delegation declarations cannot hide behind an expected
 work ID, equivalent cross-pass candidates are verified once, and an empty plan settles without

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -174,8 +174,8 @@ export const confirmedFindingForPublication = (
 /**
  * Concern candidates need explicit paths internally to bind the claim to
  * scheduled evidence. The verifier receives the complete bounded unit so it
- * can use neighboring evidence to falsify the claim. The public ReviewConcern
- * remains path-free after the host confirms and projects it.
+ * can use neighboring evidence to falsify the claim. The host copies these
+ * validated paths onto a confirmed public concern for incremental continuity.
  */
 export class DiscoveredConcern extends Schema.Class<DiscoveredConcern>(
   "@effect-agent/pr-review/DiscoveredConcern",
@@ -301,7 +301,7 @@ export const makeFileReviewerInstructions =
       ...common,
       focus,
       "The discovery evidence array contains every complete shard in the unit. Review every entry and every shard of a multi-shard path. A later independent verifier, not you, decides which candidates publish.",
-      "When a non-anchored concern depends on one or more unit files, list 1-3 exact evidencePaths to bind the claim to scheduled evidence.",
+      "Every non-anchored concern must list 1-3 exact evidencePaths to bind the claim to scheduled evidence. Report one root concern once; never split it into differently worded restatements.",
       `Return ONLY JSON with phase "discovery", the exact workId/unitId, up to ${MAX_CHILD_FINDINGS} findings, up to ${MAX_CHILD_CONCERNS} concerns shaped as {concern, evidencePaths}, one factual file summary per path (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars), and an empty assessments array. Empty candidate arrays are valid; do not invent defects.`,
       'Each finding is {"path": <a unit file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL problem-kind label>, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement source code for exactly lines startLine..endLine, ready to commit>}.',
       'Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement source for every line in the range and nothing else — never prose describing the change, which belongs in "body".',
@@ -962,7 +962,14 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
     );
     const concerns = rankAndDedupeConcerns(
       confirmed.flatMap(({ candidate }) =>
-        candidate._tag === "ConcernCandidate" ? [candidate.concern] : [],
+        candidate._tag === "ConcernCandidate"
+          ? [
+              ReviewConcern.make({
+                ...candidate.concern,
+                evidencePaths: [...new Set(candidate.evidencePaths)].sort(),
+              }),
+            ]
+          : [],
       ),
     );
     const walkthrough = outcomes.flatMap((outcome) => outcome.walkthrough);

--- a/packages/pr-review/src/internal/progress.ts
+++ b/packages/pr-review/src/internal/progress.ts
@@ -133,7 +133,7 @@ const settleCallout = (info: ReviewProgressSettle): string => {
     case "success":
       return `> ✅ **Code review posted** — verdict \`${info.verdict}\`, ${info.inlineComments} inline comment(s), nothing blocking.`;
     case "blocking":
-      return `> 🛑 **Code review posted** — blocking findings; the check fails until they are addressed.`;
+      return `> 🛑 **Code review posted:** blocking review items; the check fails until they are addressed.`;
     case "incomplete":
       return `> ⚠️ **Code review posted** — input coverage or configured review assurance is incomplete, so the check fails.`;
   }

--- a/packages/pr-review/src/internal/render.ts
+++ b/packages/pr-review/src/internal/render.ts
@@ -185,24 +185,85 @@ const renderDemoted = (finding: ReviewFinding, reason: string): string => {
 const countNoun = (count: number, noun: string): string =>
   `${count} ${noun}${count === 1 ? "" : "s"}`;
 
-/** The validated finding + concern severities, tallied for callout and event. */
+interface SeverityTally {
+  readonly blocking: number;
+  readonly important: number;
+  readonly nit: number;
+  readonly total: number;
+}
+
+interface ReviewItemCounts {
+  readonly findings: SeverityTally;
+  readonly concerns: SeverityTally;
+  readonly carriedFindings: SeverityTally;
+  readonly carriedConcerns: SeverityTally;
+  readonly total: SeverityTally;
+}
+
+const tallySeverities = (
+  items: ReadonlyArray<{ readonly severity: ReviewFinding["severity"] }>,
+): SeverityTally => {
+  const blocking = items.filter((item) => item.severity === "blocking").length;
+  const important = items.filter((item) => item.severity === "important").length;
+  const nit = items.length - blocking - important;
+  return { blocking, important, nit, total: items.length };
+};
+
+/** The validated finding + concern severities, kept separate by provenance. */
 const severityCounts = (
   review: CodeReview,
   carriedFindings: ReadonlyArray<ReviewFinding> = [],
   carriedConcerns: ReadonlyArray<ReviewConcern> = [],
-) => {
-  const severities = [
-    ...review.findings.map((finding) => finding.severity),
-    ...(review.concerns ?? []).map((concern) => concern.severity),
-    ...carriedFindings.map((finding) => finding.severity),
-    ...carriedConcerns.map((concern) => concern.severity),
-  ];
+): ReviewItemCounts => {
+  const findings = tallySeverities(review.findings);
+  const concerns = tallySeverities(review.concerns ?? []);
+  const priorFindings = tallySeverities(carriedFindings);
+  const priorConcerns = tallySeverities(carriedConcerns);
   return {
-    blocking: severities.filter((severity) => severity === "blocking").length,
-    important: severities.filter((severity) => severity === "important").length,
-    total: severities.length,
+    findings,
+    concerns,
+    carriedFindings: priorFindings,
+    carriedConcerns: priorConcerns,
+    total: {
+      blocking:
+        findings.blocking + concerns.blocking + priorFindings.blocking + priorConcerns.blocking,
+      important:
+        findings.important + concerns.important + priorFindings.important + priorConcerns.important,
+      nit: findings.nit + concerns.nit + priorFindings.nit + priorConcerns.nit,
+      total: findings.total + concerns.total + priorFindings.total + priorConcerns.total,
+    },
   };
 };
+
+const joinItemCounts = (items: ReadonlyArray<string>): string =>
+  items.length <= 1
+    ? (items[0] ?? "none")
+    : items.length === 2
+      ? `${items[0]} and ${items[1]}`
+      : `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+
+const severityItemParts = (
+  counts: ReviewItemCounts,
+  severity: keyof Pick<SeverityTally, "blocking" | "important" | "nit">,
+): ReadonlyArray<string> => [
+  ...(counts.findings[severity] === 0
+    ? []
+    : [countNoun(counts.findings[severity], `${severity} finding`)]),
+  ...(counts.concerns[severity] === 0
+    ? []
+    : [countNoun(counts.concerns[severity], `${severity} concern`)]),
+  ...(counts.carriedFindings[severity] === 0
+    ? []
+    : [countNoun(counts.carriedFindings[severity], `carried ${severity} finding`)]),
+  ...(counts.carriedConcerns[severity] === 0
+    ? []
+    : [countNoun(counts.carriedConcerns[severity], `carried ${severity} concern`)]),
+];
+
+const renderSeverityItems = (
+  counts: ReviewItemCounts,
+  severity: keyof Pick<SeverityTally, "blocking" | "important" | "nit">,
+): string => joinItemCounts(severityItemParts(counts, severity));
 
 /**
  * The opening callout: the review's overall tier, derived HOST-SIDE from the
@@ -223,8 +284,8 @@ const renderVerdictCallout = (
   const counts = severityCounts(review, options.carriedFindings, options.carriedConcerns);
   // Code findings outrank machinery gaps: a blocking finding is the
   // actionable signal, and unsettled reviewer-side work is carried forward.
-  if (counts.blocking > 0) {
-    return `> [!CAUTION]\n> ${countNoun(counts.blocking, "blocking finding")} — do not merge before addressing ${counts.blocking === 1 ? "it" : "them"}.`;
+  if (counts.total.blocking > 0) {
+    return `> [!CAUTION]\n> ${renderSeverityItems(counts, "blocking")}. Do not merge before addressing ${counts.total.blocking === 1 ? "it" : "them"}.`;
   }
   const carried = options.unreviewedPaths?.length ?? 0;
   if (
@@ -235,21 +296,28 @@ const renderVerdictCallout = (
       carried > 0
         ? ` ${countNoun(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.`
         : "";
-    return `> [!WARNING]\n> Review infrastructure did not settle — a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
+    return `> [!WARNING]\n> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
   }
-  if (counts.important > 0) {
-    return `> [!IMPORTANT]\n> ${countNoun(counts.important, "important finding")} to address before merging.`;
+  if (counts.total.important > 0) {
+    return `> [!IMPORTANT]\n> ${renderSeverityItems(counts, "important")} to address before merging.`;
   }
-  if (counts.total > 0) {
-    return "> ℹ️ Minor suggestions only — mergeable as-is.";
+  if (counts.total.total > 0) {
+    return `> ℹ️ ${renderSeverityItems(counts, "nit")}; mergeable as-is.`;
   }
   return review.verdict === "approve"
     ? "> ✅ No issues found."
-    : "> ℹ️ No findings — see the summary.";
+    : "> ℹ️ No review items. See the summary.";
 };
 
 const renderConcern = (concern: ReviewConcern): string =>
-  [`### ${severityEmoji[concern.severity]} ${concern.title}`, "", concern.body].join("\n");
+  [
+    `### ${severityEmoji[concern.severity]} ${concern.title}`,
+    ...(concern.evidencePaths === undefined
+      ? []
+      : ["", `_Affected paths: ${concern.evidencePaths.map((path) => `\`${path}\``).join(", ")}_`]),
+    "",
+    concern.body,
+  ].join("\n");
 
 const renderCarriedFinding = (finding: ReviewFinding): string =>
   `- \`${finding.path}:${finding.startLine}${finding.endLine === finding.startLine ? "" : `-${finding.endLine}`}\` **[${findingLabel(finding)}] ${finding.title}** — ${finding.body}`;
@@ -311,7 +379,7 @@ export const estimateReviewEffort = (
 const renderReviewStats = (
   files: ReadonlyArray<ChangedFile>,
   totalChangedFiles: number,
-  counts: { readonly blocking: number; readonly important: number; readonly total: number },
+  counts: ReviewItemCounts,
 ): string => {
   const additions = files.reduce((total, file) => total + file.additions, 0);
   const deletions = files.reduce((total, file) => total + file.deletions, 0);
@@ -319,17 +387,16 @@ const renderReviewStats = (
     files.length < totalChangedFiles
       ? `${files.length} of ${totalChangedFiles} files`
       : countNoun(files.length, "file");
-  const nits = counts.total - counts.blocking - counts.important;
   const tally =
-    counts.total === 0
+    counts.total.total === 0
       ? "none"
-      : [
-          ...(counts.blocking > 0 ? [`${counts.blocking} blocking`] : []),
-          ...(counts.important > 0 ? [`${counts.important} important`] : []),
-          ...(nits > 0 ? [`${nits} nit`] : []),
-        ].join(", ");
+      : joinItemCounts(
+          (["blocking", "important", "nit"] as const).flatMap((severity) =>
+            severityItemParts(counts, severity),
+          ),
+        );
   const effort = estimateReviewEffort(files);
-  return `**Changeset:** ${fileCount} (+${additions} / −${deletions}) · **Findings:** ${tally} · **Review effort:** ${effort.score}/5 (${effort.label})`;
+  return `**Changeset:** ${fileCount} (+${additions} / −${deletions}) · **Review items:** ${tally} · **Review effort:** ${effort.score}/5 (${effort.label})`;
 };
 
 /** HTML comments must not contain `--`; interpolated values are sanitized. */
@@ -544,7 +611,12 @@ export const planPublication = (
       );
     }
     if (carriedConcerns.length > 0) {
-      parts.push("", "### Unresolved concerns carried to the final audit");
+      parts.push(
+        "",
+        `### Unresolved concerns from unchanged paths (${carriedConcerns.length})`,
+        "",
+        "These concerns were reported in an earlier review and were not reverified in this incremental pass. They remain active because none of their affected paths changed.",
+      );
       for (const concern of carriedConcerns) parts.push("", renderConcern(concern));
     }
     for (const concern of sortedConcerns.slice(0, concernsKept)) {
@@ -607,9 +679,9 @@ export const planPublication = (
     options.inputCoverage?.status === "incomplete" || options.assurance?.status === "incomplete";
   const event: ReviewEvent = !options.applyVerdict
     ? "COMMENT"
-    : counts.blocking > 0
+    : counts.total.blocking > 0
       ? "REQUEST_CHANGES"
-      : review.verdict === "approve" && counts.important === 0 && !unclean
+      : review.verdict === "approve" && counts.total.important === 0 && !unclean
         ? "APPROVE"
         : "COMMENT";
 

--- a/packages/pr-review/src/internal/review-agent.ts
+++ b/packages/pr-review/src/internal/review-agent.ts
@@ -361,12 +361,18 @@ export type ReviewVerdict = typeof ReviewVerdict.Type;
  * A concern with no diff line to anchor to: a missing deletion or cleanup,
  * rollout or migration sequencing, a coverage gap the diff implies but does
  * not add, or a scope question only the author can answer. Rendered as a
- * review-body section — never as an inline comment, so it needs no anchor and
- * is never demoted.
+ * review-body section instead of an inline comment. `evidencePaths` binds the
+ * concern to changed files so a later incremental review can invalidate and
+ * recheck it when any supporting path changes. It remains optional only for
+ * decoding review output and continuity state written before path binding was
+ * introduced; a pathless concern cannot authorize incremental continuity.
  */
 export class ReviewConcern extends Schema.Class<ReviewConcern>(
   "@effect-agent/pr-review/ReviewConcern",
 )({
+  evidencePaths: Schema.optionalKey(
+    Schema.Array(ChangedPath).check(Schema.isMinLength(1)).check(Schema.isMaxLength(3)),
+  ),
   severity: FindingSeverity,
   title: Schema.NonEmptyString.check(Schema.isMaxLength(120)),
   body: Schema.NonEmptyString.check(Schema.isMaxLength(2_000)),
@@ -456,9 +462,9 @@ export const makeReviewInstructions =
       "When the diff adds or changes a test, check that it can actually fail: a test that would still pass with the bug present is theatre, not coverage. The usual tell is a loose assertion standing where an exact one belongs — >= or a truthiness check over an expected value, or a snapshot that absorbs whatever it is handed.",
       "Go shallow only when the diff has no behavioral surface at all: doc typos, formatting, lockfile or generated-code regeneration, a mechanical rename. Line count is not the signal — a one-line change to auth, money, SQL, a comparison operator, or a config default is not trivial.",
       "Drop bloat-shaped findings before reporting: defensive checks for cases that cannot happen, abstractions used once, comments restating obvious code, tests asserting tautologies, just-in-case guards. A finding must be sound, correct, and worth acting on; prefer an explicit keep over an invented finding.",
-      '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor; report none when none exist.',
+      '5. After collecting anchored findings, deliberately scan for concerns with NO line to point at: deletion or cleanup plans for code the diff replaces, rollout or migration sequencing, coverage gaps the diff implies but does not add, scope questions only the author can answer. Report each as a "concern", never as a finding with an invented anchor. Every concern must list 1-3 exact changed evidencePaths that support it so later incremental reviews can recheck it when those files change. Report none when none exist, and never split one root concern into differently worded restatements.',
       `6. Write a walkthrough: for every file whose evidence you examined, one factual sentence (<= ${MAX_WALKTHROUGH_SUMMARY_CHARS} chars) describing what changed in that file — written for a reader scanning the pull request, never restating the diff line by line. Use only paths from list_changed_files; invented paths are dropped.`,
-      '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL: "correctness" | "security" | "concurrency" | "performance" | "resources" | "error-handling" | "testing" | "maintainability" | "style" | "docs">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>, "walkthrough": <array, OPTIONAL: [{"path": <string, a changed file path>, "summary": <string, the step-6 sentence>}], one entry per reviewed file>}.',
+      '7. Then return ONLY a JSON object — no Markdown fences, no prose before or after — exactly this shape: {"summary": <string, 1-3 paragraphs of overall assessment>, "verdict": <"approve" | "comment" | "request-changes">, "findings": [{"path": <string, a changed file path>, "startLine": <integer, an R-marked new-file line>, "endLine": <integer, >= startLine, same file, R-marked>, "severity": <"blocking" | "important" | "nit">, "category": <OPTIONAL: "correctness" | "security" | "concurrency" | "performance" | "resources" | "error-handling" | "testing" | "maintainability" | "style" | "docs">, "title": <string, <= 120 chars>, "body": <string, why it matters and what to do>, "suggestion": <string, OPTIONAL: replacement text for exactly lines startLine..endLine, ready to commit>}], "concerns": <array, OPTIONAL: [{"evidencePaths": <array of 1-3 exact changed file paths>, "severity": <"blocking" | "important" | "nit">, "title": <string, <= 120 chars>, "body": <string>}], only for step-5 concerns with no valid anchor — never duplicate a finding here>, "walkthrough": <array, OPTIONAL: [{"path": <string, a changed file path>, "summary": <string, the step-6 sentence>}], one entry per reviewed file>}.',
       `Report at most ${maxFindings} findings and at most ${MAX_CONCERNS} concerns; prefer the most important ones. An empty findings array with verdict "approve" is a valid review. Include "suggestion" only when you are confident the replacement compiles and preserves intent; its text must contain the full replacement for every line in the range and nothing else.`,
       'Use verdict "request-changes" only when at least one finding or concern is "blocking". Line anchors you invent will be discarded, so copy R-numbers from read_file_diff output.',
     ].join("\n");

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -37,10 +37,14 @@ export class StoredReviewFinding extends Schema.Class<StoredReviewFinding>(
   body: StoredText,
 }) {}
 
-/** A compact unresolved non-anchored concern carried until a final audit. */
+/** A compact unresolved non-anchored concern with its invalidation paths. */
 export class StoredReviewConcern extends Schema.Class<StoredReviewConcern>(
   "@effect-agent/pr-review/StoredReviewConcern",
 )({
+  /** Absent only on legacy state written before concern path binding. */
+  evidencePaths: Schema.optionalKey(
+    Schema.Array(ChangedPath).check(Schema.isMinLength(1)).check(Schema.isMaxLength(3)),
+  ),
   severity: FindingSeverity,
   title: Schema.NonEmptyString.check(Schema.isMaxLength(120)),
   body: StoredText,
@@ -124,13 +128,19 @@ export const fromStoredFinding = (finding: StoredReviewFinding): ReviewFinding =
 
 export const toStoredConcern = (concern: ReviewConcern): StoredReviewConcern =>
   StoredReviewConcern.make({
+    ...(concern.evidencePaths === undefined ? {} : { evidencePaths: concern.evidencePaths }),
     severity: concern.severity,
     title: concern.title,
     body: concern.body.slice(0, 800),
   });
 
 export const fromStoredConcern = (concern: StoredReviewConcern): ReviewConcern =>
-  ReviewConcern.make({ severity: concern.severity, title: concern.title, body: concern.body });
+  ReviewConcern.make({
+    ...(concern.evidencePaths === undefined ? {} : { evidencePaths: concern.evidencePaths }),
+    severity: concern.severity,
+    title: concern.title,
+    body: concern.body,
+  });
 
 const STATE_MARKER_PREFIX = "<!-- effect-agent-pr-review state-v1:";
 const STATE_MARKER_SUFFIX = " -->";
@@ -375,6 +385,9 @@ export const validateReviewState = (
   if (state.profileFingerprint !== profileFingerprint) {
     return "the reviewer profile or model configuration changed";
   }
+  if (state.unresolvedConcerns.some((concern) => concern.evidencePaths === undefined)) {
+    return "stored concerns predate affected-path tracking";
+  }
   return undefined;
 };
 
@@ -395,6 +408,23 @@ const incrementalFromDelta = (input: {
     ...input.deltaFiles.flatMap(filePaths),
     ...(input.extraAffectedPaths ?? []),
   ]);
+  const initialAffectedCount = affectedPaths.size;
+  // Reopen every current path needed to reassess a concern touched by this
+  // delta. Repeat to a fixed point because two concerns may overlap on a path.
+  let expanded = true;
+  while (expanded) {
+    expanded = false;
+    for (const concern of input.priorState.unresolvedConcerns) {
+      const paths = concern.evidencePaths ?? [];
+      if (!paths.some((path) => affectedPaths.has(path))) continue;
+      for (const path of paths) {
+        if (!affectedPaths.has(path)) {
+          affectedPaths.add(path);
+          expanded = true;
+        }
+      }
+    }
+  }
   const selectedByPath = new Map<string, ChangedFile>();
   for (const file of input.deltaFiles) {
     if (
@@ -428,15 +458,13 @@ const incrementalFromDelta = (input: {
     retryStages.add("specialist");
     retryStages.add("verification");
   }
-  if (carriedPaths.length > 0 || (input.extraAffectedPaths?.length ?? 0) > 0) {
-    for (const file of input.fullFiles) {
-      const needed =
-        affectedPaths.has(file.path) ||
-        (file.previousPath !== undefined && affectedPaths.has(file.previousPath)) ||
-        retryOnly.has(file.path) ||
-        (file.previousPath !== undefined && retryOnly.has(file.previousPath));
-      if (needed) selectedByPath.set(file.path, file);
-    }
+  for (const file of input.fullFiles) {
+    const needed =
+      affectedPaths.has(file.path) ||
+      (file.previousPath !== undefined && affectedPaths.has(file.previousPath)) ||
+      retryOnly.has(file.path) ||
+      (file.previousPath !== undefined && retryOnly.has(file.previousPath));
+    if (needed) selectedByPath.set(file.path, file);
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
     left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
@@ -448,9 +476,14 @@ const incrementalFromDelta = (input: {
       : carriedPaths.length > 0
         ? `; retrying ${carriedPaths.length} carried unreviewed path(s)`
         : "";
+  const concernPathCount = affectedPaths.size - initialAffectedCount;
+  const concernReason =
+    concernPathCount === 0
+      ? ""
+      : `; reopening ${concernPathCount} related concern path(s) for context`;
   return {
     mode: "incremental",
-    reason: `${input.reason}${carriedReason}`,
+    reason: `${input.reason}${carriedReason}${concernReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
     retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),

--- a/packages/pr-review/src/internal/review-units.ts
+++ b/packages/pr-review/src/internal/review-units.ts
@@ -462,8 +462,15 @@ export const rankAndDedupeFindings = (
 };
 
 /**
- * The concern analogue of `rankAndDedupeFindings`: dedupe by exact content
- * keeping the most severe duplicate, rank by severity, and cap at the
+ * Stable identity for one concern. The paths are part of the claim: identical
+ * prose about two independent files must not collapse into one item.
+ */
+export const reviewConcernKey = (concern: ReviewConcern): string =>
+  `${(concern.evidencePaths ?? []).join("\u0000")}\u0001${concern.title}\u0000${concern.body}`;
+
+/**
+ * The concern analogue of `rankAndDedupeFindings`: dedupe by exact scoped
+ * content keeping the most severe duplicate, rank by severity, and cap at the
  * `CodeReview` concerns bound.
  */
 export const rankAndDedupeConcerns = (
@@ -471,7 +478,7 @@ export const rankAndDedupeConcerns = (
 ): ReadonlyArray<ReviewConcern> => {
   const byContent = new Map<string, ReviewConcern>();
   for (const concern of concerns) {
-    const key = `${concern.title}\u0000${concern.body}`;
+    const key = reviewConcernKey(concern);
     const previous = byContent.get(key);
     if (
       previous === undefined ||

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -38,7 +38,7 @@ import {
   toStoredConcern,
   toStoredFinding,
 } from "./review-state.ts";
-import { rankAndDedupeConcerns, rankAndDedupeFindings } from "./review-units.ts";
+import { rankAndDedupeConcerns, rankAndDedupeFindings, reviewConcernKey } from "./review-units.ts";
 import { PullRequestSource, type PullRequestMetadata } from "./source.ts";
 
 // ---------------------------------------------------------------------------
@@ -196,7 +196,29 @@ const settleReviewRun = (
     const executionContext = Option.getOrUndefined(
       yield* Effect.serviceOption(ReviewExecutionContext),
     );
-    const review = enforceFindingsBound(core.review, clampMaxFindings(options.maxFindings));
+    const boundedReview = enforceFindingsBound(core.review, clampMaxFindings(options.maxFindings));
+    const reviewPaths = new Set(files.map((file) => file.path));
+    const review = CodeReview.make({
+      ...boundedReview,
+      ...(boundedReview.concerns === undefined
+        ? {}
+        : {
+            concerns: boundedReview.concerns.map((concern) => {
+              const evidencePaths = concern.evidencePaths;
+              if (
+                evidencePaths === undefined ||
+                evidencePaths.some((path) => !reviewPaths.has(path))
+              ) {
+                const { evidencePaths: _invalid, ...pathless } = concern;
+                return ReviewConcern.make(pathless);
+              }
+              return ReviewConcern.make({
+                ...concern,
+                evidencePaths: [...new Set(evidencePaths)].sort(),
+              });
+            }),
+          }),
+    });
     const { inputCoverage, assurance } = core;
     const unreviewedPaths = [...new Set(core.unreviewedPaths)].sort();
     const reviewTotalFiles = executionContext?.totalFiles ?? metadata.totalChangedFiles;
@@ -222,30 +244,37 @@ const settleReviewRun = (
       (finding) =>
         activeFindingKeys.has(findingKey(finding)) && !currentFindingKeys.has(findingKey(finding)),
     );
-    // Non-anchored concerns cannot be mapped safely to one affected path, so
-    // incremental runs carry them conservatively until the explicit final audit.
-    const carriedConcernCandidates = priorState?.unresolvedConcerns.map(fromStoredConcern) ?? [];
+    // A concern remains active only while every host-validated evidence path
+    // is unchanged. Touching or removing any one invalidates the old claim;
+    // range selection reopens its remaining current paths for fresh context.
+    const carriedConcernCandidates =
+      priorState?.unresolvedConcerns
+        .filter(
+          (concern) =>
+            concern.evidencePaths !== undefined &&
+            concern.evidencePaths.every((path) => !affectedPaths.has(path)),
+        )
+        .map(fromStoredConcern) ?? [];
     const activeConcerns = rankAndDedupeConcerns([
       ...carriedConcernCandidates,
       ...(review.concerns ?? []),
     ]);
-    const currentConcernKeys = new Set(
-      (review.concerns ?? []).map((concern) => `${concern.title}\u0000${concern.body}`),
-    );
-    const activeConcernKeys = new Set(
-      activeConcerns.map((concern) => `${concern.title}\u0000${concern.body}`),
-    );
+    const currentConcernKeys = new Set((review.concerns ?? []).map(reviewConcernKey));
+    const activeConcernKeys = new Set(activeConcerns.map(reviewConcernKey));
     const carriedConcerns = carriedConcernCandidates.filter((concern) => {
-      const key = `${concern.title}\u0000${concern.body}`;
+      const key = reviewConcernKey(concern);
       return activeConcernKeys.has(key) && !currentConcernKeys.has(key);
     });
     const settled =
       inputCoverage.status === "complete" &&
       assurance.status !== "incomplete" &&
       unreviewedPaths.length === 0;
+    const concernsHaveEvidencePaths = activeConcerns.every(
+      (concern) => concern.evidencePaths !== undefined,
+    );
     // The fingerprint marker is standalone skip authority for fingerprint-only
     // harnesses, so it is embedded only for a fully settled run.
-    const skipFingerprint = settled ? fingerprint : undefined;
+    const skipFingerprint = settled && concernsHaveEvidencePaths ? fingerprint : undefined;
     const carriedScopeFits = unreviewedPaths.length <= MAX_STORED_UNREVIEWED_PATHS;
     const stateCandidate =
       executionContext !== undefined &&
@@ -255,6 +284,7 @@ const settleReviewRun = (
       // surface; a truncated anchor surface cannot make either claim.
       anchorFiles.length >= metadata.totalChangedFiles &&
       carriedScopeFits &&
+      concernsHaveEvidencePaths &&
       executionContext.stateAuthenticator?.status === "available"
         ? ReviewState.make({
             version: 1,
@@ -283,10 +313,12 @@ const settleReviewRun = (
             notice:
               executionContext !== undefined && !carriedScopeFits
                 ? `carried unreviewed scope (${unreviewedPaths.length} paths) exceeded the ${MAX_STORED_UNREVIEWED_PATHS}-path continuity bound`
-                : executionContext?.stateAuthenticator?.status === "unavailable"
-                  ? (executionContext.stateAuthenticator.unavailableReason ??
-                    "authenticated continuity state is unavailable")
-                  : undefined,
+                : executionContext !== undefined && !concernsHaveEvidencePaths
+                  ? "one or more review concerns lacked host-validated affected paths"
+                  : executionContext?.stateAuthenticator?.status === "unavailable"
+                    ? (executionContext.stateAuthenticator.unavailableReason ??
+                      "authenticated continuity state is unavailable")
+                    : undefined,
           }
         : yield* executionContext.stateAuthenticator.render(stateCandidate).pipe(
             Effect.match({

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -7,6 +7,7 @@ import { Tool } from "effect/unstable/ai";
 import {
   CandidateAssessment,
   ChangedFile,
+  DiscoveredConcern,
   annotatePatch,
   executeFanOutReview,
   fanOutInputCoverage,
@@ -29,6 +30,7 @@ import {
   planReviewUnits,
   PullRequestMetadata,
   rankAndDedupeFindings,
+  ReviewConcern,
   ReviewFinding,
   ReviewExecutionContext,
   type ReviewPassMisbehaved,
@@ -141,6 +143,15 @@ const unsupportedFinding = ReviewFinding.make({
   body: "The candidate claims the true literal disables the path, but the bounded evidence does not support that behavior.",
 });
 
+const supportedConcern = DiscoveredConcern.make({
+  concern: ReviewConcern.make({
+    severity: "blocking",
+    title: "Authentication rollout has no old-version gate",
+    body: "The bounded configuration removes the old path without a mixed-version guard.",
+  }),
+  evidencePaths: ["examples/pr-work-order-ingress/src/authenticate.ts"],
+});
+
 /** The host assigns candidate IDs by kept-finding position, 1-based. */
 const candidateId = (passId: string, index: number): string =>
   `${passId}:finding:${String(index).padStart(3, "0")}`;
@@ -148,13 +159,14 @@ const candidateId = (passId: string, index: number): string =>
 const discoveryReport = (
   pass: typeof generalPass,
   findings: ReadonlyArray<ReviewFinding>,
+  concerns: ReadonlyArray<DiscoveredConcern> = [],
 ): FileReviewReport =>
   FileReviewReport.make({
     phase: "discovery",
     workId: pass.passId,
     unitId: pass.unitId,
     findings,
-    concerns: [],
+    concerns,
     fileSummaries:
       pass.perspective === "general"
         ? pass.paths.map((path) =>
@@ -713,6 +725,40 @@ describe("host-scheduled discovery and verification pipeline", () => {
         // Children receive host-planned evidence only, never the PR mission.
         for (const prompt of result.childPrompts) expect(prompt).not.toContain(MISSION_MARKER);
       }),
+  );
+
+  it.effect("preserves a confirmed concern's validated evidence paths", () =>
+    Effect.gen(function* () {
+      const result = yield* runOfflineFanOut({
+        children: [
+          report(generalPass.passId, discoveryReport(generalPass, [])),
+          report(specialistPass.passId, discoveryReport(specialistPass, [], [supportedConcern])),
+          report(
+            verificationWorkId,
+            verificationReport([
+              CandidateAssessment.make({
+                candidateId: `${specialistPass.passId}:concern:001`,
+                disposition: "confirmed",
+                rationale: "The bounded evidence confirms the rollout concern.",
+              }),
+            ]),
+          ),
+        ],
+      });
+
+      expect(result.outcome.review.concerns).toEqual([
+        ReviewConcern.make({
+          ...supportedConcern.concern,
+          evidencePaths: supportedConcern.evidencePaths,
+        }),
+      ]);
+      expect(result.outcome.state?.unresolvedConcerns[0]?.evidencePaths).toEqual(
+        supportedConcern.evidencePaths,
+      );
+      expect(result.outcome.plan.body).toContain(
+        "_Affected paths: `examples/pr-work-order-ingress/src/authenticate.ts`_",
+      );
+    }),
   );
 
   it.effect("verifies an equivalent cross-pass candidate once and publishes it once", () =>

--- a/packages/pr-review/test/pr-review.test.ts
+++ b/packages/pr-review/test/pr-review.test.ts
@@ -39,6 +39,7 @@ import {
   ReviewToolkitLayer,
   selectReviewRange,
   selectedPullRequestSourceLayer,
+  StoredReviewConcern,
   StoredReviewFinding,
   WalkthroughEntry,
 } from "../src/index.ts";
@@ -151,6 +152,7 @@ const fixture = FixturePullRequest.make({
  * plus one non-anchored concern so the structured-output decode boundary is
  * exercised end-to-end, not only the planner. */
 const scriptedConcern = ReviewConcern.make({
+  evidencePaths: ["src/hello.ts"],
   severity: "important",
   title: "No test pins the new export",
   body: "The diff exports `three` but adds no coverage for it.",
@@ -528,14 +530,15 @@ describe("review presentation", () => {
   });
 
   it("opens with the host-derived stats line under the callout", () => {
-    // 2 files, +2 −1; 2 important (1 demoted + 1 concern), 2 nits; cost
+    // 2 files, +2 −1; 1 important finding + 1 important concern, 2 nit
+    // findings; cost
     // 3 + 2*15 = 33 → effort 1/5.
     expect(planFor(scriptedReview).body).toContain(
-      "**Changeset:** 2 files (+2 / −1) · **Findings:** 2 important, 2 nit · **Review effort:** 1/5 (trivial)",
+      "**Changeset:** 2 files (+2 / −1) · **Review items:** 1 important finding, 1 important concern, and 2 nit findings · **Review effort:** 1/5 (trivial)",
     );
     expect(
       planFor(CodeReview.make({ summary: "s", verdict: "approve", findings: [] })).body,
-    ).toContain("**Findings:** none");
+    ).toContain("**Review items:** none");
   });
 
   it("pins the effort thresholds to the changeset shape alone", () => {
@@ -686,6 +689,44 @@ describe("verdict callout", () => {
     expect(plan.body.startsWith("> [!CAUTION]\n> 1 blocking finding")).toBe(true);
   });
 
+  it("separates current findings from carried concerns in the blocker count", () => {
+    const carriedConcerns = [
+      ReviewConcern.make({
+        evidencePaths: ["src/hello.ts"],
+        severity: "blocking",
+        title: "Prior migration concern",
+        body: "This unchanged path still needs a migration answer.",
+      }),
+      ReviewConcern.make({
+        evidencePaths: ["src/hello.ts"],
+        severity: "blocking",
+        title: "Prior rollback concern",
+        body: "This unchanged path still needs a rollback answer.",
+      }),
+    ];
+    const plan = planPublication(
+      CodeReview.make({
+        summary: "One current finding.",
+        verdict: "request-changes",
+        findings: [finding("blocking")],
+      }),
+      files,
+      {
+        applyVerdict: false,
+        headSha: FIXTURE_SHA,
+        totalChangedFiles: 2,
+        carriedConcerns,
+      },
+    );
+
+    expect(plan.body).toContain(
+      "> 1 blocking finding and 2 carried blocking concerns. Do not merge before addressing them.",
+    );
+    expect(plan.body).toContain(
+      "**Review items:** 1 blocking finding and 2 carried blocking concerns",
+    );
+  });
+
   it("opens with IMPORTANT when the worst finding is important", () => {
     const plan = planFor(
       CodeReview.make({
@@ -701,7 +742,7 @@ describe("verdict callout", () => {
     expect(
       planFor(
         CodeReview.make({ summary: "s", verdict: "comment", findings: [finding("nit")] }),
-      ).body.startsWith("> ℹ️ Minor suggestions only"),
+      ).body.startsWith("> ℹ️ 1 nit finding; mergeable as-is."),
     ).toBe(true);
     expect(
       planFor(CodeReview.make({ summary: "s", verdict: "approve", findings: [] })).body.startsWith(
@@ -710,7 +751,7 @@ describe("verdict callout", () => {
     ).toBe(true);
     expect(
       planFor(CodeReview.make({ summary: "s", verdict: "comment", findings: [] })).body.startsWith(
-        "> ℹ️ No findings",
+        "> ℹ️ No review items",
       ),
     ).toBe(true);
   });
@@ -732,7 +773,7 @@ describe("verdict callout", () => {
         ],
       }),
     );
-    expect(plan.body.startsWith("> [!CAUTION]\n> 1 blocking finding")).toBe(true);
+    expect(plan.body.startsWith("> [!CAUTION]\n> 1 blocking concern")).toBe(true);
   });
 
   it("clamps the mapped event fail-closed against the validated severities", () => {
@@ -828,6 +869,7 @@ describe("concerns, metadata, and footer", () => {
         findings: [],
         concerns: [
           ReviewConcern.make({
+            evidencePaths: ["src/hello.ts"],
             severity: "important",
             title: "No rollout note for the schema change",
             body: "In-flight records decode against the old shape during deploy.",
@@ -838,6 +880,7 @@ describe("concerns, metadata, and footer", () => {
       { applyVerdict: false, headSha: FIXTURE_SHA, totalChangedFiles: 2 },
     );
     expect(plan.body).toContain("### ⚠️ No rollout note for the schema change");
+    expect(plan.body).toContain("_Affected paths: `src/hello.ts`_");
     expect(plan.body).toContain("In-flight records decode against the old shape during deploy.");
   });
 
@@ -1022,7 +1065,6 @@ describe("offline review run", () => {
       const prompts = yield* scripted.prompts;
       expect(prompts[0]).toContain("pull request #7");
       expect(prompts[0]).toContain("acme/widgets");
-
       // Anchor validation split the findings exactly as planned.
       expect(outcome.plan.comments).toHaveLength(1);
       expect(outcome.plan.demoted).toHaveLength(2);
@@ -1123,7 +1165,7 @@ describe("offline review run", () => {
     }),
   );
 
-  it.effect("carries unresolved findings from unchanged scope without re-reviewing it", () =>
+  it.effect("carries unresolved items only from unchanged scope", () =>
     Effect.gen(function* () {
       const baseSha = "1".repeat(40);
       const reviewedHeadSha = "2".repeat(40);
@@ -1170,6 +1212,25 @@ describe("offline review run", () => {
         title: "Affected finding must be revalidated",
         body: "A new delta touching this path invalidates the carried finding.",
       });
+      const priorConcern = StoredReviewConcern.make({
+        evidencePaths: [unchangedFile.path],
+        severity: "blocking",
+        title: "Unchanged rollout concern",
+        body: "This remains active while its evidence path is unchanged.",
+      });
+      const affectedPriorConcern = StoredReviewConcern.make({
+        evidencePaths: [correctiveFile.path],
+        severity: "blocking",
+        title: "Affected concern must be revalidated",
+        body: "Changing its evidence path invalidates the carried concern.",
+      });
+      const removedConcernPath = "ops/temporary-repair.ts";
+      const removedPriorConcern = StoredReviewConcern.make({
+        evidencePaths: [removedConcernPath],
+        severity: "blocking",
+        title: "Removed repair worker concern",
+        body: "Deleting its evidence path invalidates the carried concern.",
+      });
       const priorState = ReviewState.make({
         version: 1,
         repository: metadata.repository,
@@ -1182,7 +1243,7 @@ describe("offline review run", () => {
         settledScopeFingerprint: "b".repeat(64),
         reviewedPathCount: 2,
         unresolvedFindings: [priorFinding, affectedPriorFinding],
-        unresolvedConcerns: [],
+        unresolvedConcerns: [priorConcern, affectedPriorConcern, removedPriorConcern],
         unreviewedPaths: [],
         unreviewedPasses: [],
         settled: true,
@@ -1199,7 +1260,16 @@ describe("offline review run", () => {
           baseSha: reviewedHeadSha,
           headSha,
           mergeBaseSha: reviewedHeadSha,
-          files: [correctiveFile],
+          files: [
+            correctiveFile,
+            ChangedFile.make({
+              path: removedConcernPath,
+              status: "removed",
+              additions: 0,
+              deletions: 1,
+              patch: "@@ -1 +0,0 @@\n-export {};",
+            }),
+          ],
           truncated: false,
         }),
       });
@@ -1248,8 +1318,17 @@ describe("offline review run", () => {
       expect(outcome.activeFindings.map((finding) => finding.title)).not.toContain(
         affectedPriorFinding.title,
       );
+      expect(outcome.activeConcerns.map((concern) => concern.title)).toEqual([priorConcern.title]);
+      expect(outcome.activeConcerns.map((concern) => concern.title)).not.toContain(
+        affectedPriorConcern.title,
+      );
+      expect(outcome.activeConcerns.map((concern) => concern.title)).not.toContain(
+        removedPriorConcern.title,
+      );
       expect(outcome.plan.body).toContain("Unresolved findings carried from unchanged scope");
       expect(outcome.plan.body).toContain(priorFinding.title);
+      expect(outcome.plan.body).toContain("Unresolved concerns from unchanged paths (1)");
+      expect(outcome.plan.body).toContain(priorConcern.title);
       expect((yield* scripted.prompts).join("\n")).not.toContain("src/unchanged.ts");
     }),
   );

--- a/packages/pr-review/test/progress.test.ts
+++ b/packages/pr-review/test/progress.test.ts
@@ -74,7 +74,7 @@ describe("progress comment rendering", () => {
     expect(parseProgressClaim(success)).toEqual(CLAIM);
 
     expect(renderProgressSettleBody({ ...base, conclusion: "blocking" }, CLAIM)).toContain(
-      "🛑 **Code review posted** — blocking findings",
+      "🛑 **Code review posted:** blocking review items",
     );
     expect(renderProgressSettleBody({ ...base, conclusion: "incomplete" }, CLAIM)).toContain(
       "input coverage or configured review assurance is incomplete",

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -9,6 +9,7 @@ import {
   ReviewState,
   ReviewStateAuthenticator,
   selectReviewRange,
+  StoredReviewConcern,
   StoredReviewFinding,
   StoredUnreviewedPass,
   webCryptoReviewStateAuthenticatorLayer,
@@ -183,6 +184,46 @@ describe("review state", () => {
     });
     expect(changedBase.mode).toBe("full");
     expect(changedBase.reason).toContain("base changed");
+  });
+
+  it("falls back to the full diff for legacy pathless concerns", () => {
+    const legacyState = ReviewState.make({
+      ...priorState,
+      unresolvedConcerns: [
+        StoredReviewConcern.make({
+          severity: "blocking",
+          title: "Legacy concern",
+          body: "This state predates affected-path tracking.",
+        }),
+      ],
+    });
+    const selection = select({ priorState: legacyState });
+
+    expect(selection.mode).toBe("full");
+    expect(selection.reason).toContain("concerns predate affected-path tracking");
+  });
+
+  it("reopens every current evidence path when a concern path changes", () => {
+    const concernState = ReviewState.make({
+      ...priorState,
+      unresolvedConcerns: [
+        StoredReviewConcern.make({
+          evidencePaths: ["src/accepted.ts", "src/corrective.ts"],
+          severity: "blocking",
+          title: "Cross-file cutover is incomplete",
+          body: "Both files are needed to reassess the cutover.",
+        }),
+      ],
+    });
+    const selection = select({ priorState: concernState });
+
+    expect(selection.mode).toBe("incremental");
+    expect(selection.files.map((file) => file.path)).toEqual([
+      "src/accepted.ts",
+      "src/corrective.ts",
+    ]);
+    expect(selection.affectedPaths).toEqual(["src/accepted.ts", "src/corrective.ts"]);
+    expect(selection.reason).toContain("reopening 1 related concern path(s) for context");
   });
 
   it("falls back to the full diff for unsafe or incomplete head comparisons", () => {


### PR DESCRIPTION
## Summary

- Bind every confirmed non-anchored concern to one to three host-validated changed paths. Incremental review now invalidates a concern when any supporting path changes or disappears, then reopens the remaining paths needed to review it again. [Continuity selection](https://github.com/danieljvdm/effect-agent/blob/ce2bff6c99ebe695c5206a0ad21b493362749214/packages/pr-review/src/internal/review-state.ts#L397)
- Report current findings, current concerns, and carried items separately in callouts and statistics. Carried concerns remain visible with their affected paths without masquerading as fresh inline findings. [Review rendering](https://github.com/danieljvdm/effect-agent/blob/ce2bff6c99ebe695c5206a0ad21b493362749214/packages/pr-review/src/internal/render.ts#L199)
- Keep Effect-specific API facts in repository guidance. The profile now explains direct `YieldableError` returns and the distinct `Effect.gen` return rule. [Effect review rule](https://github.com/danieljvdm/effect-agent/blob/ce2bff6c99ebe695c5206a0ad21b493362749214/.github/review-guidance.md#L12)

## What went wrong

Review concerns had no evidence paths. Incremental runs therefore carried every unresolved concern until a final audit, even after the files behind the claim changed or disappeared. Independent passes could also restate the same root concern. The renderer then counted those body-only concerns under a generic findings label, so a review could announce many blockers while GitHub showed only one anchored comment.

The false Effect finding on [kommunikasie #805](https://github.com/reve-ai/kommunikasie/pull/805#discussion_r3825951974) had a separate cause. The repository profile did not spell out that a `Schema.TaggedError` implements `YieldableError` and is already a failing Effect outside `Effect.gen`. That fact now lives in repo-owned guidance instead of the generic review engine.

## Architecture

Discovery supplies concern evidence paths, and the host validates them against the bounded review unit before publication. Authenticated continuity state persists those paths and uses them as invalidation keys. Legacy state with pathless concerns fails closed into a full review. The publication layer receives current and carried items separately so counts describe what GitHub actually rendered during this run.

## Evidence

- The complete `packages/pr-review/test` suite passes: 156 tests passed and 1 existing test skipped.
- The generated Action bundle matches the rebased source.
- `vp run ready` completed its check stage, then the nested Vite+ test task hit macOS process-spawn `EINVAL` for two package processes after 10 of 12 task results. No test assertion failed; the full changed-package suite passed separately.