### PR TITLE
fix(pr-review): report undiffable paths honestly instead of promising retries

### DIFF
--- a/.changeset/honest-undiffable-gate-reasons.md
+++ b/.changeset/honest-undiffable-gate-reasons.md
@@ -1,0 +1,8 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Report undiffable files (binaries, oversized files) in gate reasons, the posted
+review callout, and the step summary with the honest remedy — remove them from
+the pull request or exclude them with ignore globs — instead of promising an
+automatic retry that can never settle them.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -41704,44 +41704,6 @@ var fetch = /* @__PURE__ */ make58((request3, url2, signal, fiber3) => {
   return send(undefined);
 });
 var layer15 = /* @__PURE__ */ layerMergedContext(/* @__PURE__ */ succeed6(fetch));
-// packages/pr-review/src/internal/effort.ts
-var EFFORT_ALIASES = {
-  low: 0,
-  medium: 0.25,
-  high: 0.5,
-  xhigh: 0.75,
-  max: 1
-};
-var aliasPosition = EFFORT_ALIASES;
-
-class InvalidEffortInput extends exports_Schema.TaggedError()("InvalidEffortInput", {
-  input: exports_Schema.String
-}) {
-  get message() {
-    return `Invalid effort '${this.input}': expected one of ` + `${Object.keys(EFFORT_ALIASES).join(", ")} or a number between 0 and 1.`;
-  }
-}
-var isEffortPosition = (value4) => Number.isFinite(value4) && value4 >= 0 && value4 <= 1;
-var parseEffortPosition = (raw2) => {
-  const normalized = raw2.trim().toLowerCase();
-  const named = aliasPosition[normalized];
-  if (named !== undefined)
-    return named;
-  if (normalized === "")
-    return;
-  const numeric = Number(normalized);
-  return isEffortPosition(numeric) ? numeric : undefined;
-};
-var resolveEffortRung = (position, rungs) => {
-  const clamped = Math.min(1, Math.max(0, position));
-  let selected = rungs[0];
-  for (const rung of rungs) {
-    if (EFFORT_ALIASES[rung] <= clamped)
-      selected = rung;
-  }
-  return selected;
-};
-
 // packages/pr-review/src/internal/diff.ts
 var ChangedPath = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512));
 var ChangedFileStatus = exports_Schema.Literals([
@@ -41887,25 +41849,6 @@ var annotatePatch = (patch3) => {
   }
   return output.join(`
 `);
-};
-
-// packages/pr-review/src/internal/anchors.ts
-var anchorViolation = (finding, files) => {
-  const file2 = files.find((candidate) => candidate.path === finding.path);
-  if (file2 === undefined)
-    return "path is not part of the changeset";
-  if (file2.patch === undefined)
-    return "file has no anchorable textual diff";
-  if (finding.endLine < finding.startLine)
-    return "endLine precedes startLine";
-  if (finding.endLine - finding.startLine + 1 > 100)
-    return "range is implausibly large";
-  const anchors = commentableLines(file2.patch);
-  for (let line = finding.startLine;line <= finding.endLine; line += 1) {
-    if (!anchors.has(line))
-      return `line ${line} is not part of the diff`;
-  }
-  return;
 };
 
 // packages/pr-review/src/internal/source.ts
@@ -42337,6 +42280,17 @@ var boundedListReason = (label, values3) => {
   }
   return rendered;
 };
+var splitCarriedScope = (input) => {
+  const undiffable = new Set(input.inputCoverage?.undiffablePaths ?? []);
+  const retryablePaths = (input.unreviewedPaths ?? []).filter((path) => !undiffable.has(path));
+  const undiffablePaths = sortedUnique(undiffable);
+  const coverageGapBeyondUndiffable = input.inputCoverage?.status === "incomplete" && input.inputCoverage.reasons.length > (undiffablePaths.length > 0 ? 1 : 0);
+  return {
+    retryablePaths,
+    undiffablePaths,
+    retryableGap: input.assurance?.status === "incomplete" || retryablePaths.length > 0 || coverageGapBeyondUndiffable
+  };
+};
 var anchorSurfaceAdjusted = (inputCoverage, anchorFiles, totalAnchorFiles) => anchorFiles.length >= totalAnchorFiles ? inputCoverage : ReviewInputCoverage.make({
   ...inputCoverage,
   status: "incomplete",
@@ -42447,6 +42401,63 @@ var fanOutInputCoverage = (input) => {
     undiffablePaths: sortedUnique(plan.undiffablePaths),
     reasons
   }), input.anchorFiles, input.totalAnchorFiles);
+};
+
+// packages/pr-review/src/internal/effort.ts
+var EFFORT_ALIASES = {
+  low: 0,
+  medium: 0.25,
+  high: 0.5,
+  xhigh: 0.75,
+  max: 1
+};
+var aliasPosition = EFFORT_ALIASES;
+
+class InvalidEffortInput extends exports_Schema.TaggedError()("InvalidEffortInput", {
+  input: exports_Schema.String
+}) {
+  get message() {
+    return `Invalid effort '${this.input}': expected one of ` + `${Object.keys(EFFORT_ALIASES).join(", ")} or a number between 0 and 1.`;
+  }
+}
+var isEffortPosition = (value4) => Number.isFinite(value4) && value4 >= 0 && value4 <= 1;
+var parseEffortPosition = (raw2) => {
+  const normalized = raw2.trim().toLowerCase();
+  const named = aliasPosition[normalized];
+  if (named !== undefined)
+    return named;
+  if (normalized === "")
+    return;
+  const numeric = Number(normalized);
+  return isEffortPosition(numeric) ? numeric : undefined;
+};
+var resolveEffortRung = (position, rungs) => {
+  const clamped = Math.min(1, Math.max(0, position));
+  let selected = rungs[0];
+  for (const rung of rungs) {
+    if (EFFORT_ALIASES[rung] <= clamped)
+      selected = rung;
+  }
+  return selected;
+};
+
+// packages/pr-review/src/internal/anchors.ts
+var anchorViolation = (finding, files) => {
+  const file2 = files.find((candidate) => candidate.path === finding.path);
+  if (file2 === undefined)
+    return "path is not part of the changeset";
+  if (file2.patch === undefined)
+    return "file has no anchorable textual diff";
+  if (finding.endLine < finding.startLine)
+    return "endLine precedes startLine";
+  if (finding.endLine - finding.startLine + 1 > 100)
+    return "range is implausibly large";
+  const anchors = commentableLines(file2.patch);
+  for (let line = finding.startLine;line <= finding.endLine; line += 1) {
+    if (!anchors.has(line))
+      return `line ${line} is not part of the diff`;
+  }
+  return;
 };
 
 // packages/pr-review/src/internal/review-units.ts
@@ -44517,11 +44528,18 @@ var renderVerdictCallout = (review, options3) => {
     return `> [!CAUTION]
 > ${renderSeverityItems(counts, "blocking")}. Do not merge before addressing ${counts.total.blocking === 1 ? "it" : "them"}.`;
   }
-  const carried = options3.unreviewedPaths?.length ?? 0;
   if (options3.inputCoverage?.status === "incomplete" || options3.assurance?.status === "incomplete") {
-    const carriedNote = carried > 0 ? ` ${countNoun2(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.` : "";
+    const scope3 = splitCarriedScope(options3);
+    const undiffableCount = scope3.undiffablePaths.length;
+    const undiffableNote = undiffableCount > 0 ? ` ${countNoun2(undiffableCount, "unreviewable file")} (binary or oversized) ${undiffableCount === 1 ? "has" : "have"} no diff a retry could settle — remove ${undiffableCount === 1 ? "it" : "them"} from the pull request or exclude ${undiffableCount === 1 ? "it" : "them"} with ignore globs.` : "";
+    if (!scope3.retryableGap) {
+      return `> [!WARNING]
+>${undiffableNote} The check reports "incomplete" while ${undiffableCount === 1 ? "it remains" : "they remain"} part of the pull request.`;
+    }
+    const retryableCount = scope3.retryablePaths.length;
+    const carriedNote = retryableCount > 0 ? ` ${countNoun2(retryableCount, "affected path")} ${retryableCount === 1 ? "is" : "are"} carried forward and retried automatically on the next run.` : "";
     return `> [!WARNING]
-> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
+> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote}${undiffableNote} The check reports "incomplete" until a run settles.`;
   }
   if (counts.total.important > 0) {
     return `> [!IMPORTANT]
@@ -56200,20 +56218,26 @@ var outcomeOutputs = (outcome, conclusion) => [
   ],
   ["review-url", outcome.published?.url ?? ""]
 ];
-var outcomeSummary = (outcome, modelLabel, conclusion) => [
-  "### Pull-request review",
-  `- Check conclusion: **${conclusion}**`,
-  `- Verdict: **${outcome.review.verdict}**`,
-  `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
-  `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
-  `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
-  ...outcome.unreviewedPaths.length === 0 ? [] : [
-    `- Carried forward: ${outcome.unreviewedPaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`
-  ],
-  ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
-  ...outcome.usage === undefined ? [] : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`],
-  ...outcome.published === undefined ? ["- Dry run: nothing posted"] : [`- Posted: ${outcome.published.url}`]
-];
+var outcomeSummary = (outcome, modelLabel, conclusion) => {
+  const scope3 = splitCarriedScope(outcome);
+  return [
+    "### Pull-request review",
+    `- Check conclusion: **${conclusion}**`,
+    `- Verdict: **${outcome.review.verdict}**`,
+    `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
+    `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
+    `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
+    ...scope3.retryablePaths.length === 0 ? [] : [
+      `- Carried forward: ${scope3.retryablePaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`
+    ],
+    ...scope3.undiffablePaths.length === 0 ? [] : [
+      `- Unreviewable: ${scope3.undiffablePaths.length} path(s) with no reviewable diff (binary or oversized) — remove them from the pull request or exclude them with ignore globs`
+    ],
+    ...modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``],
+    ...outcome.usage === undefined ? [] : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`],
+    ...outcome.published === undefined ? ["- Dry run: nothing posted"] : [`- Posted: ${outcome.published.url}`]
+  ];
+};
 var skip = (reason) => exports_Effect.gen(function* () {
   yield* exports_Console.log(`Skipping review: ${reason}`);
   yield* writeActionOutputs([
@@ -56238,7 +56262,13 @@ var blockingReasons = (input) => [
 var concludeReviewOutcome = (outcome) => {
   const machinery = [];
   if (outcome.inputCoverage.status === "incomplete" || outcome.assurance.status === "incomplete") {
-    machinery.push(outcome.unreviewedPaths.length > 0 ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${outcome.unreviewedPaths.length} path(s) are carried forward and retried automatically on the next run` : "review infrastructure did not settle — a reviewer-side gap, not a code defect");
+    const scope3 = splitCarriedScope(outcome);
+    if (scope3.retryableGap) {
+      machinery.push(scope3.retryablePaths.length > 0 ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${scope3.retryablePaths.length} path(s) are carried forward and retried automatically on the next run` : "review infrastructure did not settle — a reviewer-side gap, not a code defect");
+    }
+    if (scope3.undiffablePaths.length > 0) {
+      machinery.push(`${scope3.undiffablePaths.length} path(s) have no reviewable diff (binary or oversized) and no retry can settle them — remove them from the pull request or exclude them with ignore globs`);
+    }
     if (outcome.inputCoverage.status === "incomplete") {
       machinery.push(...outcome.inputCoverage.reasons);
     }

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -3,6 +3,7 @@ import { Config, Console, Effect, FileSystem, Layer, Option, Redacted, Schema } 
 import { BudgetExceeded, UsageBudgetLimits } from "effect-agent";
 import { FetchHttpClient } from "effect/unstable/http";
 
+import { splitCarriedScope } from "./internal/coverage.ts";
 import type { ChangedFile } from "./internal/diff.ts";
 import { InvalidEffortInput, parseEffortPosition, type EffortPosition } from "./internal/effort.ts";
 import { PrReview, type RunReviewOptions } from "./internal/factory.ts";
@@ -279,26 +280,34 @@ const outcomeSummary = (
   outcome: ReviewRunOutcome,
   modelLabel: string | undefined,
   conclusion: ReviewCheckConclusion,
-): ReadonlyArray<string> => [
-  "### Pull-request review",
-  `- Check conclusion: **${conclusion}**`,
-  `- Verdict: **${outcome.review.verdict}**`,
-  `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
-  `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
-  `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
-  ...(outcome.unreviewedPaths.length === 0
-    ? []
-    : [
-        `- Carried forward: ${outcome.unreviewedPaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`,
-      ]),
-  ...(modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``]),
-  ...(outcome.usage === undefined
-    ? []
-    : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`]),
-  ...(outcome.published === undefined
-    ? ["- Dry run: nothing posted"]
-    : [`- Posted: ${outcome.published.url}`]),
-];
+): ReadonlyArray<string> => {
+  const scope = splitCarriedScope(outcome);
+  return [
+    "### Pull-request review",
+    `- Check conclusion: **${conclusion}**`,
+    `- Verdict: **${outcome.review.verdict}**`,
+    `- Input coverage: **${outcome.inputCoverage.status}** · scope: ${outcome.reviewMode ?? "full"}`,
+    `- Review assurance: **${outcome.assurance.status}** · general discovery ${outcome.assurance.completedGeneralDiscoveryPasses}/${outcome.assurance.requiredGeneralDiscoveryPasses} · specialist ${outcome.assurance.completedSpecialistPasses}/${outcome.assurance.requiredSpecialistPasses} · verification ${outcome.assurance.completedVerificationPasses}/${outcome.assurance.requiredVerificationPasses}`,
+    `- Inline comments: ${outcome.plan.comments.length} · demoted findings: ${outcome.plan.demoted.length} · concerns: ${outcome.review.concerns?.length ?? 0}`,
+    ...(scope.retryablePaths.length === 0
+      ? []
+      : [
+          `- Carried forward: ${scope.retryablePaths.length} unreviewed path(s) retried automatically on the next run (reviewer-side gap, not a code defect)`,
+        ]),
+    ...(scope.undiffablePaths.length === 0
+      ? []
+      : [
+          `- Unreviewable: ${scope.undiffablePaths.length} path(s) with no reviewable diff (binary or oversized) — remove them from the pull request or exclude them with ignore globs`,
+        ]),
+    ...(modelLabel === undefined ? [] : [`- Model: \`${modelLabel}\``]),
+    ...(outcome.usage === undefined
+      ? []
+      : [`- Tokens: ${outcome.usage.inputTokens} in / ${outcome.usage.outputTokens} out`]),
+    ...(outcome.published === undefined
+      ? ["- Dry run: nothing posted"]
+      : [`- Posted: ${outcome.published.url}`]),
+  ];
+};
 
 /** The result of one action invocation: a typed skip or a settled review. */
 export type ReviewActionResult =
@@ -379,10 +388,13 @@ const blockingReasons = (input: {
  * Host-derived check conclusion; model verdict prose cannot weaken it.
  *
  * Blocking code findings outrank machinery gaps — they are the actionable
- * signal. A machinery gap (incomplete input, unsettled passes) concludes
- * `incomplete` with reasons that explicitly say the failure is reviewer-side
- * uncertainty carried forward for retry, never an invitation to change code.
- * The flat reviewer's constant `unverified` assurance is not a gap.
+ * signal. A retryable machinery gap (failed passes, capacity overflow)
+ * concludes `incomplete` with reasons that explicitly say the failure is
+ * reviewer-side uncertainty carried forward for retry, never an invitation to
+ * change code. Undiffable files are the deliberate exception: no retry can
+ * settle them, so their reason instructs removal or ignore globs instead of
+ * promising an automatic retry. The flat reviewer's constant `unverified`
+ * assurance is not a gap.
  */
 export const concludeReviewOutcome = (
   outcome: ReviewRunOutcome,
@@ -392,11 +404,19 @@ export const concludeReviewOutcome = (
 } => {
   const machinery: Array<string> = [];
   if (outcome.inputCoverage.status === "incomplete" || outcome.assurance.status === "incomplete") {
-    machinery.push(
-      outcome.unreviewedPaths.length > 0
-        ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${outcome.unreviewedPaths.length} path(s) are carried forward and retried automatically on the next run`
-        : "review infrastructure did not settle — a reviewer-side gap, not a code defect",
-    );
+    const scope = splitCarriedScope(outcome);
+    if (scope.retryableGap) {
+      machinery.push(
+        scope.retryablePaths.length > 0
+          ? `review infrastructure did not settle — a reviewer-side gap, not a code defect; ${scope.retryablePaths.length} path(s) are carried forward and retried automatically on the next run`
+          : "review infrastructure did not settle — a reviewer-side gap, not a code defect",
+      );
+    }
+    if (scope.undiffablePaths.length > 0) {
+      machinery.push(
+        `${scope.undiffablePaths.length} path(s) have no reviewable diff (binary or oversized) and no retry can settle them — remove them from the pull request or exclude them with ignore globs`,
+      );
+    }
     if (outcome.inputCoverage.status === "incomplete") {
       machinery.push(...outcome.inputCoverage.reasons);
     }

--- a/packages/pr-review/src/internal/coverage.ts
+++ b/packages/pr-review/src/internal/coverage.ts
@@ -128,6 +128,47 @@ export const boundedListReason = (label: string, values: Iterable<string>): stri
   return rendered;
 };
 
+export interface CarriedScope {
+  /** Carried paths a retry can actually settle (failed passes, overflow). */
+  readonly retryablePaths: ReadonlyArray<string>;
+  /** Carried paths no retry can settle (binaries, oversized files). */
+  readonly undiffablePaths: ReadonlyArray<string>;
+  /** Whether any incompleteness beyond the undiffable files exists. */
+  readonly retryableGap: boolean;
+}
+
+/**
+ * Split carried scope into paths a retry can settle and paths it never can.
+ * Undiffable files are a property of the pull request, not a transient
+ * reviewer-side failure: gate reasons and rendered callouts must never promise
+ * they are "retried automatically" — the honest instruction is to remove them
+ * from the pull request or exclude them with ignore globs.
+ */
+export const splitCarriedScope = (input: {
+  readonly inputCoverage?: ReviewInputCoverage | undefined;
+  readonly assurance?: ReviewAssurance | undefined;
+  readonly unreviewedPaths?: ReadonlyArray<string> | undefined;
+}): CarriedScope => {
+  const undiffable = new Set(input.inputCoverage?.undiffablePaths ?? []);
+  const retryablePaths = (input.unreviewedPaths ?? []).filter((path) => !undiffable.has(path));
+  const undiffablePaths = sortedUnique(undiffable);
+  // Every non-undiffable coverage gap (range truncation, capacity overflow,
+  // truncated or missing evidence, anchor surface) contributes its own reason
+  // line, so a lone reason alongside undiffable paths means the undiffable
+  // files are the entire gap.
+  const coverageGapBeyondUndiffable =
+    input.inputCoverage?.status === "incomplete" &&
+    input.inputCoverage.reasons.length > (undiffablePaths.length > 0 ? 1 : 0);
+  return {
+    retryablePaths,
+    undiffablePaths,
+    retryableGap:
+      input.assurance?.status === "incomplete" ||
+      retryablePaths.length > 0 ||
+      coverageGapBeyondUndiffable,
+  };
+};
+
 const anchorSurfaceAdjusted = (
   inputCoverage: ReviewInputCoverage,
   anchorFiles: ReadonlyArray<ChangedFile>,

--- a/packages/pr-review/src/internal/render.ts
+++ b/packages/pr-review/src/internal/render.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect";
 
 import { anchorViolation } from "./anchors.ts";
 export { anchorViolation } from "./anchors.ts";
+import { splitCarriedScope } from "./coverage.ts";
 import type { ReviewAssurance, ReviewInputCoverage } from "./coverage.ts";
 import type { ChangedFile } from "./diff.ts";
 import { renderFingerprintMarker } from "./fingerprint.ts";
@@ -287,16 +288,28 @@ const renderVerdictCallout = (
   if (counts.total.blocking > 0) {
     return `> [!CAUTION]\n> ${renderSeverityItems(counts, "blocking")}. Do not merge before addressing ${counts.total.blocking === 1 ? "it" : "them"}.`;
   }
-  const carried = options.unreviewedPaths?.length ?? 0;
   if (
     options.inputCoverage?.status === "incomplete" ||
     options.assurance?.status === "incomplete"
   ) {
-    const carriedNote =
-      carried > 0
-        ? ` ${countNoun(carried, "affected path")} ${carried === 1 ? "is" : "are"} carried forward and retried automatically on the next run.`
+    const scope = splitCarriedScope(options);
+    const undiffableCount = scope.undiffablePaths.length;
+    const undiffableNote =
+      undiffableCount > 0
+        ? ` ${countNoun(undiffableCount, "unreviewable file")} (binary or oversized) ${undiffableCount === 1 ? "has" : "have"} no diff a retry could settle — remove ${undiffableCount === 1 ? "it" : "them"} from the pull request or exclude ${undiffableCount === 1 ? "it" : "them"} with ignore globs.`
         : "";
-    return `> [!WARNING]\n> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote} The check reports "incomplete" until a run settles.`;
+    // Undiffable-only gaps are NOT reviewer-side and DO ask for a change (to
+    // the changeset or the ignore configuration), so they get their own
+    // banner instead of the carried-forward retry promise.
+    if (!scope.retryableGap) {
+      return `> [!WARNING]\n>${undiffableNote} The check reports "incomplete" while ${undiffableCount === 1 ? "it remains" : "they remain"} part of the pull request.`;
+    }
+    const retryableCount = scope.retryablePaths.length;
+    const carriedNote =
+      retryableCount > 0
+        ? ` ${countNoun(retryableCount, "affected path")} ${retryableCount === 1 ? "is" : "are"} carried forward and retried automatically on the next run.`
+        : "";
+    return `> [!WARNING]\n> Review infrastructure did not settle. This is a reviewer-side gap, NOT a request to change code.${carriedNote}${undiffableNote} The check reports "incomplete" until a run settles.`;
   }
   if (counts.total.important > 0) {
     return `> [!IMPORTANT]\n> ${renderSeverityItems(counts, "important")} to address before merging.`;

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -177,6 +177,8 @@ const fakeOutcome = (
     readonly blocking?: boolean;
     readonly incomplete?: boolean;
     readonly assuranceIncomplete?: boolean;
+    /** The only gap is a binary: settled assurance, one undiffable path. */
+    readonly undiffableOnly?: boolean;
     readonly state?: ReviewState;
   } = {},
 ): ReviewRunOutcome => {
@@ -198,13 +200,17 @@ const fakeOutcome = (
     activeFindings: findings,
     activeConcerns: review.concerns ?? [],
     inputCoverage: ReviewInputCoverage.make({
-      status: options.incomplete ? "incomplete" : "complete",
+      status: options.incomplete || options.undiffableOnly ? "incomplete" : "complete",
       requiredPaths: [],
       assignedPaths: [],
       partialPaths: [],
       unassignedPaths: [],
-      undiffablePaths: [],
-      reasons: options.incomplete ? ["review input was not completely assigned"] : [],
+      undiffablePaths: options.undiffableOnly ? ["assets/logo.png"] : [],
+      reasons: options.undiffableOnly
+        ? ["required paths have no reviewable diff or bounded text (1): assets/logo.png"]
+        : options.incomplete
+          ? ["review input was not completely assigned"]
+          : [],
     }),
     assurance: ReviewAssurance.make({
       status: options.incomplete || options.assuranceIncomplete ? "incomplete" : "settled",
@@ -225,7 +231,11 @@ const fakeOutcome = (
           ? ["review discovery did not settle"]
           : [],
     }),
-    unreviewedPaths: options.incomplete || options.assuranceIncomplete ? ["src/a.ts"] : [],
+    unreviewedPaths: options.undiffableOnly
+      ? ["assets/logo.png"]
+      : options.incomplete || options.assuranceIncomplete
+        ? ["src/a.ts"]
+        : [],
     plan: planPublication(review, [], {
       applyVerdict: false,
       headSha: "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
@@ -573,6 +583,33 @@ describe("runReviewAction", () => {
       expect(outputs).toContain("input-coverage=complete");
       expect(outputs).toContain("review-assurance=incomplete");
       expect(outputs).toContain("conclusion=incomplete");
+    }),
+  );
+
+  it.effect("names removal or ignore globs — not retry — for an undiffable-only gap", () =>
+    Effect.gen(function* () {
+      const harness = yield* actionHarness(
+        JSON.stringify({
+          pull_request: { number: 5 },
+          repository: { full_name: "acme/widgets" },
+        }),
+      );
+      const exit = yield* runReviewAction(
+        { run: () => Effect.succeed(fakeOutcome("approve", { undiffableOnly: true })) },
+        { post: false },
+      ).pipe(Effect.provide(harness.layer), Effect.exit);
+      const failure = failureFrom(exit);
+      expect(Schema.is(ReviewGateFailed)(failure)).toBe(true);
+      if (Schema.is(ReviewGateFailed)(failure)) {
+        expect(failure.conclusion).toBe("incomplete");
+        // A retry can never settle a binary: the gate must instruct the one
+        // real remedy (remove the file or ignore-glob it) and must not promise
+        // an automatic retry that cannot succeed.
+        const joined = failure.reasons.join("\n");
+        expect(joined).not.toContain("retried automatically");
+        expect(joined).toContain("remove them from the pull request or exclude them");
+        expect(joined).toContain("assets/logo.png");
+      }
     }),
   );
 

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -1181,6 +1181,10 @@ describe("host-scheduled discovery and verification pipeline", () => {
       expect(result.outcome.state?.settled).toBe(false);
       expect(result.outcome.state?.unreviewedPaths).toContain("assets/logo.png");
       expect(result.outcome.plan.body).toContain("Incomplete input coverage");
+      // The rendered callout must not promise a retry that can never settle a
+      // binary; it instructs removal or ignore globs instead.
+      expect(result.outcome.plan.body).not.toContain("retried automatically");
+      expect(result.outcome.plan.body).toContain("ignore globs");
     }),
   );
 });


### PR DESCRIPTION
## Summary

- When a pull request contains files the reviewer cannot diff (binaries, oversized files), the check's gate reasons, the posted review callout, and the Actions step summary now tell the author the one real remedy — remove the files from the pull request or exclude them with ignore globs — instead of promising they are "carried forward and retried automatically on the next run".
- A new [`splitCarriedScope`](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/src/internal/coverage.ts#L162-L201) helper divides carried scope into genuinely retryable paths (failed passes, capacity overflow) and undiffable paths, and is used by the [check-conclusion gate](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/src/action.ts#L392-L421), the [verdict callout](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/src/internal/render.ts#L230-L252), and the [step summary](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/src/action.ts#L284-L312).
- Fail-closed semantics are unchanged: undiffable paths still keep input coverage incomplete and still carry forward in review state so the check can never go green around an unreviewable file. Only the reporting changed.

## What went wrong

A consumer PR (reve-ai/kommunikasie#820) accidentally committed a screenshot and a screen recording. The review itself settled, but the check failed with:

> ReviewGateFailed: Review check concluded 'incomplete': review infrastructure did not settle — a reviewer-side gap, not a code defect; 2 path(s) are carried forward and retried automatically on the next run; required paths have no reviewable diff or bounded text (2): shimmer-check.png, shimmer-timing.webm

Both halves of the headline were wrong for this case. `concludeReviewOutcome` counted every carried path in the "retried automatically" promise, but undiffable files never regain a diff, so retries can never settle them and the check would stay red forever while claiming it would self-heal — and claiming no change was being requested when the fix is precisely a change to the changeset or the ignore configuration. The rendered `[!WARNING]` callout and the step summary repeated the same promise.

Now an undiffable-only gap gets its own banner and gate reason naming removal or ignore globs, and mixed gaps report the retryable count and the undiffable instruction separately.

## Evidence

Gate reasons for the kommunikasie case after this change:

```
ReviewGateFailed: Review check concluded 'incomplete': 2 path(s) have no reviewable diff (binary or oversized) and no retry can settle them — remove them from the pull request or exclude them with ignore globs; required paths have no reviewable diff or bounded text (2): shimmer-check.png, shimmer-timing.webm
```

Pinned by a new gate test ([action.test.ts](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/test/action.test.ts#L604-L630)) and by extending the existing fail-closed fan-out test to assert the rendered callout no longer promises an automatic retry ([pr-review-fanout.test.ts](https://github.com/danieljvdm/effect-agent/blob/dan/investigate-ci-bug/packages/pr-review/test/pr-review-fanout.test.ts#L1088-L1092)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
