### PR TITLE
fix(platform-cloudflare): keep Code Mode RPC request-owned

### DIFF
--- a/.agents/skills/cloudflare/references/miniflare/configuration.md
+++ b/.agents/skills/cloudflare/references/miniflare/configuration.md
@@ -70,7 +70,7 @@ new Miniflare({
     COUNTER: "Counter", // className
     API_OBJECT: { className: "ApiObject", scriptName: "api-worker" },
   },
-  durableObjectsPersist: "./do-data",
+  resourcePersistencePath: "./worker-data",
   
   // D1
   d1Databases: ["DB"],

--- a/.changeset/bright-rivers-own.md
+++ b/.changeset/bright-rivers-own.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Route Dynamic Worker host calls through a pass-scoped RPC target owned by the caller's event context.
+Remove the application-provided Code Mode host entrypoint binding.

--- a/bun.lock
+++ b/bun.lock
@@ -451,7 +451,7 @@
     "effect-cf": "0.27.0",
     "esbuild": "0.28.1",
     "lucide-react": "1.27.0",
-    "miniflare": "4.20260730.0",
+    "miniflare": "5.20260811.1-alpha",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "scheduler": "0.27.0",
@@ -643,15 +643,15 @@
 
     "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.21.3", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260811.1-alpha", "wrangler": "4.123.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-jCoGRQ6FlsP5adp1GJISvITOGdTHTpsWOq3KkSGIfeDY/5RKjTUagDwaXjpqBXY5gAk6id/QbgnGuCTAg6lSTQ=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260730.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260730.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260730.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260730.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260730.1", "", { "os": "win32", "cpu": "x64" }, "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260813.1", "", {}, "sha512-RQNfm7xD10hNHEQZFxQPmyGMJ9+aDGPcdFZ0x1LtmjRoLFcgZkGvfaqJAbOMQBAUFSESO3bYJS4p9mOLv28Ihg=="],
 
@@ -2431,7 +2431,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "miniflare": ["miniflare@4.20260730.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.28.0", "workerd": "1.20260730.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg=="],
+    "miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
@@ -2943,7 +2943,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260730.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260730.1", "@cloudflare/workerd-darwin-arm64": "1.20260730.1", "@cloudflare/workerd-linux-64": "1.20260730.1", "@cloudflare/workerd-linux-arm64": "1.20260730.1", "@cloudflare/workerd-windows-64": "1.20260730.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA=="],
+    "workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
 
     "wrangler": ["wrangler@4.123.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260811.1-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260811.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260811.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q=="],
 
@@ -3014,8 +3014,6 @@
     "@chevrotain/cst-dts-gen/@chevrotain/types": ["@chevrotain/types@10.5.0", "", {}, "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="],
 
     "@chevrotain/gast/@chevrotain/types": ["@chevrotain/types@10.5.0", "", {}, "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
 
     "@cloudflare/vitest-pool-workers/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -3177,7 +3175,7 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "miniflare/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -3224,10 +3222,6 @@
     "vitepress/vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "vitest/vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
-
-    "wrangler/miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
-
-    "wrangler/workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -3292,10 +3286,6 @@
     "@alchemy.run/cloudflare-runtime/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260704.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Opo7cPTPg4x0WwK+eZSDszCyFLKQkOGNCWxF005HRTJ5SJH8h0K9KyrC1k4LBwx3haXSVi+E1eGqo1gZ1Hmhkg=="],
 
     "@alchemy.run/cloudflare-runtime/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260704.1", "", { "os": "win32", "cpu": "x64" }, "sha512-a97Ecnzhy04x3U052VKPCNp863F7Wf00WY7Ga5P0SbtYvaO1PDzylsHrvFMPKeiDFcOwqiredawmJ+v6bhIgeQ=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -3385,33 +3375,11 @@
 
     "vitest/vite/rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
 
-    "wrangler/miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
-    "wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
-
-    "wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
-
-    "wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
-
-    "wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
-
-    "wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
-
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
-
-    "@cloudflare/vitest-pool-workers/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -16,27 +16,27 @@ and the Worker entries in the repository are test fixtures.
 
 The root `package.json` is the only version source for shared dependencies.
 
-| Tool                              |        Current pin | Purpose                                                                           |
-| --------------------------------- | -----------------: | --------------------------------------------------------------------------------- |
-| Bun                               |           `1.3.14` | Package manager, workspace resolver, and lockfile                                 |
-| Vite+                             |            `0.2.6` | Formatting, linting, tests, library builds, staged checks, and task orchestration |
-| Vitest                            |           `4.1.10` | Vite+ test runtime, pinned through an override so integrations share one instance |
-| Effect                            |   `4.0.0-beta.107` | Runtime, Schema, services, and Effect AI                                          |
-| `@effect/platform-node`           |   `4.0.0-beta.107` | Node services used by repository scripts                                          |
-| `@effect/platform-browser`        |   `4.0.0-beta.107` | `BrowserCrypto` for the workerd runtime (Cloudflare packages)                     |
-| `@effect/sql-sqlite-do`           |   `4.0.0-beta.107` | Durable Object SQLite `SqlClient` and Migrator (Cloudflare packages)              |
-| `@effect/vitest`                  |   `4.0.0-beta.107` | Effect-aware test execution and scoped Layer composition                          |
-| `effect-cf`                       |           `0.27.0` | Effect-native Cloudflare runtime boundary used by `platform-cloudflare`           |
-| `@cloudflare/vitest-pool-workers` |           `0.21.3` | In-workerd Vitest pool for the Cloudflare package suites (vendors wrangler)       |
-| `@cloudflare/workers-types`       |     `5.20260813.1` | Cloudflare runtime types (types-only devDependency)                               |
-| Miniflare                         |     `4.20260730.0` | Programmatic workerd runtimes for the restart-persistence test lane               |
-| esbuild                           |           `0.28.1` | Bundles the Miniflare-lane worker entry (Miniflare no longer bundles)             |
-| Node.js                           | `22.18+ or 24.11+` | Runtime range compatible with Vite+                                               |
-| TypeScript                        |            `7.0.2` | Type checker used with the Effect compiler patch                                  |
-| `@effect/tsgo`                    |           `0.33.0` | Effect-aware TypeScript diagnostics                                               |
-| `@types/node`                     |           `26.1.2` | Node types for repository scripts                                                 |
-| VitePress                         |   `2.0.0-alpha.18` | Markdown-driven documentation site                                                |
-| Vue                               |           `3.5.40` | VitePress theme components                                                        |
+| Tool                              |          Current pin | Purpose                                                                           |
+| --------------------------------- | -------------------: | --------------------------------------------------------------------------------- |
+| Bun                               |             `1.3.14` | Package manager, workspace resolver, and lockfile                                 |
+| Vite+                             |              `0.2.6` | Formatting, linting, tests, library builds, staged checks, and task orchestration |
+| Vitest                            |             `4.1.10` | Vite+ test runtime, pinned through an override so integrations share one instance |
+| Effect                            |     `4.0.0-beta.107` | Runtime, Schema, services, and Effect AI                                          |
+| `@effect/platform-node`           |     `4.0.0-beta.107` | Node services used by repository scripts                                          |
+| `@effect/platform-browser`        |     `4.0.0-beta.107` | `BrowserCrypto` for the workerd runtime (Cloudflare packages)                     |
+| `@effect/sql-sqlite-do`           |     `4.0.0-beta.107` | Durable Object SQLite `SqlClient` and Migrator (Cloudflare packages)              |
+| `@effect/vitest`                  |     `4.0.0-beta.107` | Effect-aware test execution and scoped Layer composition                          |
+| `effect-cf`                       |             `0.27.0` | Effect-native Cloudflare runtime boundary used by `platform-cloudflare`           |
+| `@cloudflare/vitest-pool-workers` |             `0.21.3` | In-workerd Vitest pool for the Cloudflare package suites (vendors wrangler)       |
+| `@cloudflare/workers-types`       |       `5.20260813.1` | Cloudflare runtime types (types-only devDependency)                               |
+| Miniflare                         | `5.20260811.1-alpha` | Programmatic workerd runtimes for Code Mode and restart-persistence test lanes    |
+| esbuild                           |             `0.28.1` | Bundles the Miniflare-lane worker entry (Miniflare no longer bundles)             |
+| Node.js                           |   `22.18+ or 24.11+` | Runtime range compatible with Vite+                                               |
+| TypeScript                        |              `7.0.2` | Type checker used with the Effect compiler patch                                  |
+| `@effect/tsgo`                    |             `0.33.0` | Effect-aware TypeScript diagnostics                                               |
+| `@types/node`                     |             `26.1.2` | Node types for repository scripts                                                 |
+| VitePress                         |     `2.0.0-alpha.18` | Markdown-driven documentation site                                                |
+| Vue                               |             `3.5.40` | VitePress theme components                                                        |
 
 Workspace packages refer to shared versions with `catalog:`. They must not introduce a second
 Effect version. The Bun lockfile is committed and CI installs it with `--frozen-lockfile`.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -349,14 +349,17 @@ outside the claims until open-source preparation revisits it.
 
 The first isolated `CodeExecutor` adapter is a Cloudflare Dynamic Worker Layer in
 `@effect-agent/platform-cloudflare`. Each pass creates one fresh Worker through the
-Worker Loader with `globalOutbound: null`, supplies only the scoped Tool-broker RPC stub and
+Worker Loader with `globalOutbound: null`, supplies only the scoped Tool-broker RPC capability and
 explicitly allowed structured values, applies the configured Dynamic Worker CPU and subrequest
 limits plus an executor-owned wall-clock deadline (an asynchronously suspended pass consumes no
 CPU and must not outlive its deadline), invokes one fixed entrypoint, validates the returned
 envelope through Effect Schema, and disposes the entrypoint and Worker handles in Scope
-finalizers. Host callbacks run one at a time on a Scope-owned child fiber of the pass so they
-inherit the `execute` Context and die with the pass Scope, while remaining a sibling of the
-guest RPC waiter so the return RPC is not coupled to the still-open `entrypoint.run()`; pass
+finalizers. The executor creates one `RpcTarget` in the caller's current event and passes it as the
+entrypoint invocation's argument. Workers RPC routes each callback to that target's owning event
+context and releases the remote stub with the invocation; no callback registry or request state
+lives at module scope. Host callbacks run one at a time on a Scope-owned child fiber of the pass
+so they inherit the `execute` Context and die with the pass Scope, while remaining a sibling of
+the guest RPC waiter so the return RPC is not coupled to the still-open `entrypoint.run()`; pass
 teardown closes callback admission, interrupts and awaits active work, and settles queued
 calls. One absolute monotonic deadline applies to the worker RPC and every host callback. A synchronous runaway program is stopped by
 platform CPU limits rather than relying on a JavaScript timer alone.
@@ -409,8 +412,9 @@ Current platform references:
 - **DEPLOY-010**: Cloudflare platform bindings are supplied as Effect services/Layers and remain
   experimental until they pass the shared durability suite.
 - **DEPLOY-011**: The Dynamic Worker Code Mode executor denies ambient egress, enforces platform
-  CPU and executor wall-clock limits, disposes Worker and RPC handles in Scope finalizers, and
-  claims deployment class `E` only.
+  CPU and executor wall-clock limits, routes host calls through a pass-scoped RPC target owned by
+  the caller's event context, disposes Worker and RPC handles in Scope finalizers, and claims
+  deployment class `E` only.
 - **DEPLOY-012**: Cloudflare Conversation maintenance is generation-incremental and quiescent for
   stable external waits; pre-armed mutations, pass acknowledgement, restart recovery, and
   autonomous rearming obey the protocol above.

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -243,6 +243,8 @@ Every `CodeExecutor` adapter runs the shared contract cases. This includes the d
 - interruption running every pass finalizer;
 - honest `isolated` versus `unisolated` posture reporting;
 - typed rejection of every limit or network policy the adapter cannot enforce.
+- host-call settlement when a Durable Object reuses one managed runtime across later event
+  contexts, without moving request-owned Promise state between those contexts.
 
 Enforcement cases run only against `isolated` adapters, because the `unisolated` substitute
 cannot honestly prove them and must not pass them by simulation:

--- a/examples/code-mode-cloudflare/README.md
+++ b/examples/code-mode-cloudflare/README.md
@@ -104,11 +104,11 @@ rejects requests without a matching bearer token, so the paid path never
 serves anonymous callers. The offline scripted default (no `OPENAI_API_KEY`)
 needs no token.
 
-`wrangler.jsonc` wires the `WAREHOUSE` Durable Object, the `LOADER`
+`wrangler.jsonc` wires the `WAREHOUSE` Durable Object and the `LOADER`
 (`worker_loaders`) binding the Dynamic Worker executor loads generated programs
-through, and the `CODE_MODE_HOST` self service binding to
-`CodeModeHostEntrypoint` (the production seam for
-`ctx.exports.CodeModeHostEntrypoint()`).
+through. The executor passes a request-owned RPC capability directly to each
+loaded program, so the application needs no callback entrypoint or self service
+binding.
 
 Worker Loader is currently a Cloudflare beta; this example makes no hosted-
 platform, cost, or durability claim beyond deployment class E. Without

--- a/examples/code-mode-cloudflare/src/worker.ts
+++ b/examples/code-mode-cloudflare/src/worker.ts
@@ -1,10 +1,8 @@
 import { IdGenerator } from "@effect-agent/core";
 import { AgentRuntime } from "@effect-agent/engine";
 import {
-  CodeModeHostEntrypoint,
   dynamicWorkerCodeExecutorLayer,
   dynamicWorkerImplementation,
-  type CodeModeHostStub,
 } from "@effect-agent/platform-cloudflare";
 import { Effect, Layer, Stream } from "effect";
 
@@ -22,17 +20,15 @@ import { isValidTenant, Warehouse, WarehouseObject, warehouseLayer } from "./war
  * Agent runs ephemerally; the Durable Object is the warehouse data store, not
  * a Conversation store.
  *
- * `WarehouseObject` and `CodeModeHostEntrypoint` are exported for the Worker
- * runtime; the host entrypoint is bound to itself as `CODE_MODE_HOST` (see
- * wrangler.jsonc), matching the production `ctx.exports.CodeModeHostEntrypoint()`
- * seam.
+ * `WarehouseObject` is exported for the Worker runtime. The Code Mode
+ * executor creates each host RPC capability inside the request that owns it,
+ * so the application needs no callback entrypoint or self service binding.
  */
-export { WarehouseObject, CodeModeHostEntrypoint };
+export { WarehouseObject };
 
 interface WorkerEnv {
   readonly WAREHOUSE: DurableObjectNamespace<WarehouseObject>;
   readonly LOADER: WorkerLoader;
-  readonly CODE_MODE_HOST: CodeModeHostStub;
   readonly OPENAI_API_KEY?: string;
   /**
    * Optional shared secret. When set, `/ask` requires a matching
@@ -117,9 +113,7 @@ const runBound = (
   const layers = Layer.mergeAll(
     codeModeHandlersLayer.pipe(
       Layer.provide(warehouseLayer(env.WAREHOUSE, tenant)),
-      Layer.provide(
-        dynamicWorkerCodeExecutorLayer({ loader: env.LOADER, hostStub: env.CODE_MODE_HOST }),
-      ),
+      Layer.provide(dynamicWorkerCodeExecutorLayer({ loader: env.LOADER })),
     ),
     IdGenerator.layer,
   );

--- a/examples/code-mode-cloudflare/test/demo.test.ts
+++ b/examples/code-mode-cloudflare/test/demo.test.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { build } from "esbuild";
-import { Miniflare, kCurrentWorker } from "miniflare";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 
 /**
@@ -18,20 +18,19 @@ const workerEntry = join(import.meta.dirname, "..", "src", "worker.ts");
 let workerScript = "";
 
 const openRuntime = (): Miniflare =>
-  new Miniflare({
-    modules: true,
-    script: workerScript,
-    modulesRoot: "/",
-    compatibilityDate: "2025-05-01",
-    compatibilityFlags: ["nodejs_compat", "experimental"],
-    durableObjects: {
-      WAREHOUSE: { className: "WarehouseObject", useSQLite: true },
-    },
-    workerLoaders: { LOADER: {} },
-    serviceBindings: {
-      CODE_MODE_HOST: { name: kCurrentWorker, entrypoint: "CodeModeHostEntrypoint" },
-    },
-  });
+  new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script: workerScript,
+      modulesRoot: "/",
+      compatibilityDate: "2025-05-01",
+      compatibilityFlags: ["nodejs_compat", "experimental"],
+      durableObjects: {
+        WAREHOUSE: { className: "WarehouseObject", useSQLite: true },
+      },
+      workerLoaders: { LOADER: {} },
+    }),
+  );
 
 interface AskResult {
   readonly answer: string;

--- a/examples/code-mode-cloudflare/wrangler.jsonc
+++ b/examples/code-mode-cloudflare/wrangler.jsonc
@@ -12,15 +12,6 @@
   // The Worker Loader binding the Dynamic Worker Code Mode executor loads
   // generated programs through (currently beta).
   "worker_loaders": [{ "binding": "LOADER" }],
-  // The host RPC entrypoint the isolated program calls back into, bound to
-  // this same Worker (the production seam is ctx.exports.CodeModeHostEntrypoint()).
-  "services": [
-    {
-      "binding": "CODE_MODE_HOST",
-      "service": "code-mode-cloudflare",
-      "entrypoint": "CodeModeHostEntrypoint",
-    },
-  ],
   // OPENAI_API_KEY is an optional secret (`wrangler secret put OPENAI_API_KEY`);
   // without it the Worker runs the deterministic scripted profile.
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "effect-cf": "0.27.0",
     "esbuild": "0.28.1",
     "lucide-react": "1.27.0",
-    "miniflare": "4.20260730.0",
+    "miniflare": "5.20260811.1-alpha",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "scheduler": "0.27.0",

--- a/packages/platform-cloudflare/src/code-mode-executor.ts
+++ b/packages/platform-cloudflare/src/code-mode-executor.ts
@@ -18,9 +18,8 @@ import {
   type CodeExecutorExecute,
   type CodeExecutionRequest,
 } from "@effect-agent/sandbox";
-import { BrowserCrypto } from "@effect/platform-browser";
-import { WorkerEntrypoint } from "cloudflare:workers";
-import { Clock, Crypto, Duration, Effect, Exit, Fiber, Layer, Option, Queue, Schema } from "effect";
+import { RpcTarget } from "cloudflare:workers";
+import { Clock, Duration, Effect, Exit, Fiber, Layer, Option, Queue, Schema } from "effect";
 
 import { safeCauseDiagnostic, safeCauseMessage } from "./boundary.ts";
 
@@ -28,56 +27,43 @@ import { safeCauseDiagnostic, safeCauseMessage } from "./boundary.ts";
  * The Cloudflare Dynamic Worker `CodeExecutor` adapter (C4 of ADR-0017;
  * DEPLOY-011). Each pass loads one fresh Worker through the Worker Loader
  * with `globalOutbound: null`, so generated code has no ambient network,
- * bindings, or secrets; its only authority is the pass-scoped host stub that
- * routes back to `CodeModeHostEntrypoint` and, from there, into the pass's
- * `CodeExecutionHost` service. Platform CPU limits stop synchronous runaway
- * programs; the executor-owned wall-clock deadline interrupts asynchronously
- * suspended passes. Deployment class `E` only: the adapter records no
- * persistent state and a later pass may run in a completely different
- * isolate.
+ * bindings, or secrets; its only authority is the pass-scoped RPC target that
+ * routes back into the owning event's `CodeExecutionHost` service. Platform
+ * CPU limits stop synchronous runaway programs; the executor-owned wall-clock
+ * deadline interrupts asynchronously suspended passes. Deployment class `E`
+ * only: the adapter records no persistent state and a later pass may run in a
+ * completely different isolate.
  */
 export const dynamicWorkerImplementation = SandboxImplementation.make({
   isolation: "isolated",
   identity: "cloudflare-dynamic-worker",
 });
 
-/** The narrow host stub the dynamic worker receives (Workers RPC). */
-export interface CodeModeHostStub {
-  readonly call: (passId: string, hostCall: unknown) => Promise<unknown>;
+interface CodeModePassHost extends Rpc.RpcTargetBranded {
+  readonly call: (hostCall: unknown) => Promise<unknown>;
 }
 
 interface CodeModeHarnessEntrypoint extends Rpc.WorkerEntrypointBranded {
-  readonly run: () => Promise<unknown>;
-}
-
-interface RegisteredPass {
-  readonly dispatch: (hostCall: unknown) => Promise<unknown>;
+  readonly run: (host: CodeModePassHost) => Promise<unknown>;
 }
 
 /**
- * Live passes by identity. Entries are Scope-managed: registered when a pass
- * opens and removed by its finalizer, so a stale harness (or a forged
- * `passId`) cannot reach any host authority.
+ * One object-capability endpoint for one execution pass. Workers RPC invokes
+ * the target in the request context where it was created, so the native
+ * Promise returned by `dispatch` and the Effect fiber that settles it share
+ * one I/O owner. Passing the target as `run()`'s argument also scopes the
+ * remote stub to that RPC call; no request state lives at module scope.
  */
-const passRegistry = new Map<string, RegisteredPass>();
+class CodeModePassHostTarget extends RpcTarget implements CodeModePassHost {
+  readonly #dispatch: (hostCall: unknown) => Promise<unknown>;
 
-/**
- * The host-side RPC target for dynamic workers. The application exposes it
- * from its Worker entry (`export { CodeModeHostEntrypoint }`) and hands the
- * adapter a same-instance stub — `ctx.exports.CodeModeHostEntrypoint()` in
- * production (a self service binding may reach a different instance and must
- * not be used there); tests bind it through Miniflare's `kCurrentWorker`.
- */
-export class CodeModeHostEntrypoint extends WorkerEntrypoint {
-  async call(passId: unknown, hostCall: unknown): Promise<unknown> {
-    if (typeof passId !== "string") {
-      throw new TypeError("Code Mode pass identities must be strings");
-    }
-    const pass = passRegistry.get(passId);
-    if (pass === undefined) {
-      throw new Error("Unknown Code Mode pass");
-    }
-    return pass.dispatch(hostCall);
+  constructor(dispatch: (hostCall: unknown) => Promise<unknown>) {
+    super();
+    this.#dispatch = dispatch;
+  }
+
+  call(hostCall: unknown): Promise<unknown> {
+    return this.#dispatch(hostCall);
   }
 }
 
@@ -113,9 +99,8 @@ const safeJson = (value) => {
 };
 
 export default class CodeModeHarness extends WorkerEntrypoint {
-  async run() {
+  async run(host) {
     const config = this.env.CODE_MODE_PASS;
-    const host = this.env.CODE_MODE_HOST;
     const limits = config.limits;
     const logs = [];
     let logBytes = 0;
@@ -153,7 +138,7 @@ export default class CodeModeHarness extends WorkerEntrypoint {
         };
         throw new Error("code-mode host-call argument limit exceeded");
       }
-      const outcome = await host.call(config.passId, {
+      const outcome = await host.call({
         namespace,
         method,
         argument: JSON.parse(argText),
@@ -287,7 +272,6 @@ const HarnessOutcome = Schema.Union([
 ]);
 
 const HarnessPassConfig = Schema.Struct({
-  passId: Schema.NonEmptyString,
   namespaces: Schema.Array(
     Schema.Struct({
       name: Schema.NonEmptyString,
@@ -409,19 +393,12 @@ const reservedHarnessGlobals = new Set(["console"]);
 export interface DynamicWorkerCodeExecutorOptions {
   /** The `worker_loader` binding. */
   readonly loader: WorkerLoader;
-  /**
-   * A SAME-INSTANCE stub of `CodeModeHostEntrypoint`. In production create it
-   * with `ctx.exports.CodeModeHostEntrypoint()`; a cross-instance stub would
-   * dispatch host calls into an isolate without this pass's registry entry.
-   */
-  readonly hostStub: CodeModeHostStub;
   /** Compatibility date for dynamic workers; defaults to `2025-05-01`. */
   readonly compatibilityDate?: string | undefined;
 }
 
 const makeExecute = (
   options: DynamicWorkerCodeExecutorOptions,
-  crypto: Crypto.Crypto,
   clock: Clock.Clock,
 ): CodeExecutorExecute =>
   Effect.fn("DynamicWorkerCodeExecutor.execute")(function* (request: CodeExecutionRequest) {
@@ -450,25 +427,7 @@ const makeExecute = (
         });
       }
     }
-
     const host = yield* CodeExecutionHost;
-    // The pass id is the only credential a loaded program presents to reach
-    // its host authority, so it must be unguessable: a program cannot forge
-    // another pass's id even if two passes were ever concurrent (the broker
-    // keeps them sequential, but the id must not rely on that).
-    const passId = yield* crypto.randomUUIDv4.pipe(
-      Effect.mapError((cause) =>
-        CodeExecutorStartError.make({
-          implementation: dynamicWorkerImplementation,
-          message: `Could not mint the Code Mode pass identity: ${safeCauseMessage(
-            cause,
-            "the crypto service failed without a diagnostic",
-          )}`.slice(0, 8_000),
-          cause,
-        }),
-      ),
-      Effect.map((uuid) => `code-mode-pass-${uuid}`),
-    );
 
     // This synchronous clock access is confined to callbacks that must compute a timeout
     // immediately. The Clock service remains the authority, so tests and hosts can replace it.
@@ -604,16 +563,9 @@ const makeExecute = (
 
     const closeAdmission = Effect.sync(() => {
       passOpen = false;
-      passRegistry.delete(passId);
       rejectQueuedHostCalls(new Error("Code Mode pass is closing"));
     });
-
-    yield* Effect.acquireRelease(
-      Effect.sync(() => {
-        passRegistry.set(passId, { dispatch });
-      }),
-      () => closeAdmission.pipe(Effect.andThen(Fiber.interrupt(server))),
-    );
+    yield* Effect.addFinalizer(() => closeAdmission.pipe(Effect.andThen(Fiber.interrupt(server))));
 
     // No `allowExperimental`: the runtime only accepts it when the CALLING
     // worker carries the `experimental` compatibility flag, which deployed
@@ -627,9 +579,7 @@ const makeExecute = (
         "program.js": `export default (\n${request.source}\n);`,
       },
       env: {
-        CODE_MODE_HOST: options.hostStub,
         CODE_MODE_PASS: encodeHarnessPassConfig({
-          passId,
           namespaces: request.namespaces.map((namespace) => ({
             name: namespace.name,
             methods: namespace.methods,
@@ -687,7 +637,7 @@ const makeExecute = (
     );
 
     const rpc = Effect.tryPromise({
-      try: () => entrypoint.run(),
+      try: () => entrypoint.run(new CodeModePassHostTarget(dispatch)),
       catch: (cause) => classifyWorkerFailure(cause, request.limits.maxWallTime),
     });
 
@@ -860,8 +810,7 @@ export const dynamicWorkerCodeExecutorLayer = (
   Layer.effect(
     CodeExecutor,
     Effect.gen(function* () {
-      const crypto = yield* Crypto.Crypto;
       const clock = yield* Clock.Clock;
-      return CodeExecutor.of({ execute: makeExecute(options, crypto, clock) });
+      return CodeExecutor.of({ execute: makeExecute(options, clock) });
     }),
-  ).pipe(Layer.provide(BrowserCrypto.layer));
+  );

--- a/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
+++ b/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
@@ -1,23 +1,16 @@
 import { join } from "node:path";
 
 import { build } from "esbuild";
-import { Miniflare, kCurrentWorker } from "miniflare";
+import { Miniflare, convertV4MiniflareOptions } from "miniflare";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 
 /**
  * The Cloudflare Dynamic Worker `CodeExecutor` lane (C4 of ADR-0017,
  * DEPLOY-011). The real adapter runs inside a bundled worker under
  * programmatic Miniflare — a genuine workerd runtime with a real
- * `worker_loaders` binding. The worker exports `CodeModeHostEntrypoint` and
- * self-binds it via `kCurrentWorker` (the production seam is
- * `ctx.exports.CodeModeHostEntrypoint()`), then runs the shared executor
- * conformance suite plus the isolated-only enforcement cases (ambient network
- * denial, synchronous CPU runaway) in-worker and reports failures.
- *
- * Pool-workers cannot host this: it wraps the user worker, so a
- * `kCurrentWorker` self-binding to a named entrypoint is unreachable. The
- * programmatic runtime, where the bundled worker IS the top-level worker,
- * makes the self-binding resolve — the same approach as the restart lane.
+ * `worker_loaders` binding, then runs the shared executor conformance suite
+ * plus the isolated-only enforcement cases (ambient network denial,
+ * synchronous CPU runaway) in-worker and reports failures.
  */
 
 const workerEntry = join(import.meta.dirname, "conformance-worker.ts");
@@ -25,21 +18,27 @@ const workerEntry = join(import.meta.dirname, "conformance-worker.ts");
 let workerScript = "";
 
 const openRuntime = (): Miniflare =>
-  new Miniflare({
-    modules: true,
-    script: workerScript,
-    modulesRoot: "/",
-    compatibilityDate: "2025-05-01",
-    // Deployed consumers cannot set the `experimental` compatibility flag, so
-    // the conformance runtime must not either: with it present, a load payload
-    // that requires experimental features (e.g. `allowExperimental: true`)
-    // passes here while rejecting every pass in production.
-    compatibilityFlags: ["nodejs_compat"],
-    workerLoaders: { LOADER: {} },
-    serviceBindings: {
-      CODE_MODE_HOST: { name: kCurrentWorker, entrypoint: "CodeModeHostEntrypoint" },
-    },
-  });
+  new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script: workerScript,
+      modulesRoot: "/",
+      compatibilityDate: "2025-05-01",
+      // Deployed consumers cannot set the `experimental` compatibility flag, so
+      // the conformance runtime must not either: with it present, a load payload
+      // that requires experimental features (e.g. `allowExperimental: true`)
+      // passes here while rejecting every pass in production.
+      compatibilityFlags: [
+        "nodejs_compat",
+        "enable_ctx_exports",
+        "no_handle_cross_request_promise_resolution",
+      ],
+      workerLoaders: { LOADER: {} },
+      durableObjects: {
+        CODE_MODE_EXECUTORS: { className: "CodeModeExecutorObject" },
+      },
+    }),
+  );
 
 describe("DEPLOY-011 Cloudflare Dynamic Worker CodeExecutor", () => {
   const cleanups: Array<() => Promise<void>> = [];
@@ -85,6 +84,20 @@ describe("DEPLOY-011 Cloudflare Dynamic Worker CodeExecutor", () => {
     expect(await response.json()).toMatchObject({
       tag: "success",
       detail: { value: "executor" },
+    });
+  }, 30_000);
+
+  // Regression evidence:
+  // https://github.com/reve-ai/kommunikasie/actions/runs/32474947060
+  // https://github.com/reve-ai/kommunikasie/actions/runs/32483559567
+  it("keeps host-call settlement inside each owning Durable Object context", async () => {
+    const response = await runtime.dispatchFetch("http://placeholder/durable-object-host-call");
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toMatchObject({
+      outcomes: [
+        { tag: "success", value: "executor" },
+        { tag: "success", value: "executor" },
+      ],
     });
   }, 30_000);
 

--- a/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
+++ b/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
@@ -12,28 +12,35 @@ import {
   type CodeHostCall,
   type CodeHostCallResult,
 } from "@effect-agent/sandbox";
-import { Cause, Context, Duration, Effect, Exit, Option, Predicate, type Layer } from "effect";
+import { DurableObject } from "cloudflare:workers";
+import {
+  Cause,
+  Context,
+  Duration,
+  Effect,
+  Exit,
+  ManagedRuntime,
+  Option,
+  Predicate,
+  type Layer,
+} from "effect";
 
 // Workspace-relative source import: esbuild bundles it, and the package
 // barrel would pull in Node-only storage fixtures the worker cannot load.
 import { codeExecutorConformanceCases } from "../../../testing/src/code-executor-conformance.ts";
 import {
-  CodeModeHostEntrypoint,
   disposeRpcHandle,
   dynamicWorkerCodeExecutorLayer,
   dynamicWorkerImplementation,
-  type CodeModeHostStub,
 } from "../../src/code-mode-executor.ts";
-
-export { CodeModeHostEntrypoint };
 
 interface WorkerEnv {
   readonly LOADER: WorkerLoader;
-  readonly CODE_MODE_HOST: CodeModeHostStub;
+  readonly CODE_MODE_EXECUTORS: DurableObjectNamespace<CodeModeExecutorObject>;
 }
 
 const executorLayerFor = (env: WorkerEnv): Layer.Layer<CodeExecutor> =>
-  dynamicWorkerCodeExecutorLayer({ loader: env.LOADER, hostStub: env.CODE_MODE_HOST });
+  dynamicWorkerCodeExecutorLayer({ loader: env.LOADER });
 
 const baseLimits = CodeExecutionLimits.make({
   maxSourceBytes: 64 * 1024,
@@ -65,11 +72,10 @@ const unusedHost: CodeExecutionHost["Service"] = {
   call: () => Effect.die(new Error("no host call expected")),
 };
 
-const runOutcome = (
+const executeOutcome = (
   req: CodeExecutionRequest,
-  layer: Layer.Layer<CodeExecutor>,
   host: CodeExecutionHost["Service"] = unusedHost,
-): Effect.Effect<{ readonly tag: string; readonly detail: unknown }> =>
+): Effect.Effect<{ readonly tag: string; readonly detail: unknown }, never, CodeExecutor> =>
   Effect.gen(function* () {
     const executor = yield* CodeExecutor;
     return yield* executor
@@ -77,13 +83,19 @@ const runOutcome = (
       .pipe(Effect.provideService(CodeExecutionHost, CodeExecutionHost.of(host)));
   }).pipe(
     Effect.scoped,
-    Effect.provide(layer),
     Effect.map((result) => ({
       tag: "success",
       detail: { value: result.value, logs: result.logs, implementation: result.implementation },
     })),
     Effect.catch((error: CodeExecutionError) => Effect.succeed({ tag: error._tag, detail: error })),
   );
+
+const runOutcome = (
+  req: CodeExecutionRequest,
+  layer: Layer.Layer<CodeExecutor>,
+  host: CodeExecutionHost["Service"] = unusedHost,
+): Effect.Effect<{ readonly tag: string; readonly detail: unknown }> =>
+  executeOutcome(req, host).pipe(Effect.provide(layer));
 
 /**
  * A representative subset of the shared conformance suite plus the
@@ -273,6 +285,57 @@ const runHostCallScopeRegression = (env: WorkerEnv) => {
   ).pipe(Effect.provideService(ExecutorFiberMarker, "executor"));
 };
 
+export class CodeModeExecutorObject extends DurableObject<WorkerEnv> {
+  readonly #runtime: ManagedRuntime.ManagedRuntime<CodeExecutor, never>;
+
+  constructor(ctx: DurableObjectState, env: WorkerEnv) {
+    super(ctx, env);
+    this.#runtime = ManagedRuntime.make(executorLayerFor(this.env));
+  }
+
+  async prime(): Promise<void> {
+    await this.ctx.storage.put("marker", "executor");
+    await this.#runtime.runPromise(
+      Effect.promise(() => this.ctx.storage.get("marker")).pipe(
+        Effect.andThen(CodeExecutor),
+        Effect.asVoid,
+      ),
+    );
+  }
+
+  async run(): Promise<{ readonly tag: string; readonly value: unknown }> {
+    await this.ctx.storage.put("marker", "executor");
+    const namespace = CodeExecutionNamespace.make({ name: "warehouse", methods: ["query"] });
+    const host: CodeExecutionHost["Service"] = {
+      call: () =>
+        Effect.promise(() => this.ctx.storage.get<string>("marker")).pipe(
+          Effect.map((value) => CodeHostCallSuccess.make({ value })),
+        ),
+    };
+    return this.#runtime.runPromise(
+      executeOutcome(
+        request("async () => warehouse.query({ sql: 'select 1' })", {
+          namespaces: [namespace],
+        }),
+        host,
+      ).pipe(
+        Effect.map((outcome) => ({
+          tag: outcome.tag,
+          value:
+            Predicate.isObject(outcome.detail) && "value" in outcome.detail
+              ? outcome.detail.value
+              : null,
+        })),
+      ),
+    );
+  }
+}
+
+interface CodeModeExecutorStub {
+  readonly prime: () => Promise<void>;
+  readonly run: () => Promise<{ readonly tag: string; readonly value: unknown }>;
+}
+
 const runDisposalRegression = Effect.gen(function* () {
   const hostileHandles: ReadonlyArray<unknown> = [
     new Proxy(
@@ -306,6 +369,16 @@ const runDisposalRegression = Effect.gen(function* () {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     try {
+      if (new URL(request.url).pathname === "/durable-object-host-call") {
+        const first = env.CODE_MODE_EXECUTORS.getByName("first") as unknown as CodeModeExecutorStub;
+        const second = env.CODE_MODE_EXECUTORS.getByName(
+          "second",
+        ) as unknown as CodeModeExecutorStub;
+        await first.prime();
+        await second.prime();
+        const outcomes = [await second.run(), await first.run()];
+        return Response.json({ outcomes });
+      }
       if (new URL(request.url).pathname === "/host-call-pass-scope") {
         return Response.json(await Effect.runPromise(runHostCallScopeRegression(env)));
       }

--- a/packages/platform-cloudflare/test/restart/miniflare-restart-probe.test.ts
+++ b/packages/platform-cloudflare/test/restart/miniflare-restart-probe.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { Miniflare } from "miniflare";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
 /**
@@ -64,16 +64,18 @@ export default {
 `;
 
 const openRuntime = (persistDirectory: string, alarmReportUrl: string) =>
-  new Miniflare({
-    modules: true,
-    script: probeWorkerScript,
-    compatibilityDate: "2025-05-01",
-    durableObjects: {
-      PROBE: { className: "RestartProbeObject", useSQLite: true },
-    },
-    durableObjectsPersist: persistDirectory,
-    bindings: { ALARM_REPORT_URL: alarmReportUrl },
-  });
+  new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script: probeWorkerScript,
+      compatibilityDate: "2025-05-01",
+      durableObjects: {
+        PROBE: { className: "RestartProbeObject", useSQLite: true },
+      },
+      resourcePersistencePath: persistDirectory,
+      bindings: { ALARM_REPORT_URL: alarmReportUrl },
+    }),
+  );
 
 describe("Miniflare persist-dir restart lane (WP0 probe 4)", () => {
   const cleanups: Array<() => Promise<void>> = [];

--- a/packages/platform-cloudflare/test/restart/travel-planner-restart.test.ts
+++ b/packages/platform-cloudflare/test/restart/travel-planner-restart.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { build } from "esbuild";
-import { Miniflare } from "miniflare";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 
 /**
@@ -26,16 +26,18 @@ const workerEntry = join(import.meta.dirname, "travel-planner-restart-worker.ts"
 let workerScript = "";
 
 const openRuntime = (persistDirectory: string): Miniflare =>
-  new Miniflare({
-    modules: true,
-    script: workerScript,
-    compatibilityDate: "2025-05-01",
-    compatibilityFlags: ["nodejs_compat"],
-    durableObjects: {
-      CONVERSATIONS: { className: "TravelPlannerRestartObject", useSQLite: true },
-    },
-    durableObjectsPersist: persistDirectory,
-  });
+  new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script: workerScript,
+      compatibilityDate: "2025-05-01",
+      compatibilityFlags: ["nodejs_compat"],
+      durableObjects: {
+        CONVERSATIONS: { className: "TravelPlannerRestartObject", useSQLite: true },
+      },
+      resourcePersistencePath: persistDirectory,
+    }),
+  );
 
 const call = async <A>(runtime: Miniflare, path: string, body?: unknown): Promise<A> => {
   const response = await runtime.dispatchFetch(`http://placeholder${path}`, {

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -81,9 +81,8 @@ export default defineConfig({
       {
         // The Code Mode Dynamic Worker executor lane runs the real adapter
         // inside a bundled worker under programmatic Miniflare (like the
-        // restart lane): pool-workers wraps the user worker, so a
-        // `kCurrentWorker` self-binding to the host entrypoint is only
-        // reachable when the worker under test IS the top-level worker.
+        // restart lane) so Worker Loader and cross-event RPC ownership use a
+        // real workerd process rather than a Node substitute.
         test: {
           name: "code-mode",
           include: ["test/code-mode/**/*.test.ts"],


### PR DESCRIPTION
## Summary

- Keep Dynamic Worker Code Mode host callbacks in the Durable Object event that owns the Effect runtime and its I/O.
- Replace the process-global pass registry, generated pass IDs, exported callback entrypoint, and self service binding with a single pass-scoped `RpcTarget` capability.
- Upgrade the direct Miniflare test runtime to the repository's current Workerd generation and add a real cross-event Durable Object regression.

## What went wrong

The previous bridge registered each pass's dispatcher in a module-global map, then let a separately invoked `WorkerEntrypoint` look it up through a self service binding. In a Durable Object, the host entrypoint call and the cached Effect runtime can belong to different request contexts: the entrypoint created a native Promise in its event, while the Effect fiber and Durable Object I/O in the original event later settled it. Workerd rejects that ownership transfer as `Cannot perform I/O on behalf of a different Durable Object (I/O type: Value>)`, surfaced through `RefcountedFulfiller`.

This change creates a private [`CodeModePassHostTarget`](https://github.com/danieljvdm/effect-agent/blob/1c90e12330ed724c04f58f89f081b82ca33114f2/packages/platform-cloudflare/src/code-mode-executor.ts#L42-L68) inside the caller event and passes it directly to the loaded worker's [`run()` invocation](https://github.com/danieljvdm/effect-agent/blob/1c90e12330ed724c04f58f89f081b82ca33114f2/packages/platform-cloudflare/src/code-mode-executor.ts#L631-L642). Workers RPC routes callbacks to the target's creation context and releases the parameter stub when that invocation returns, so Promise allocation, Effect settlement, and I/O retain one owner.

## Architecture

- The generated worker receives one unforgeable pass capability as an RPC argument; it receives no host binding or pass credential.
- Queue state, counters, failure state, admission, and the host-call server remain local to one `execute` Scope. The [Scope finalizer](https://github.com/danieljvdm/effect-agent/blob/1c90e12330ed724c04f58f89f081b82ca33114f2/packages/platform-cloudflare/src/code-mode-executor.ts#L564-L568) closes admission and interrupts the server.
- Applications now construct `dynamicWorkerCodeExecutorLayer({ loader })`. They remove `CodeModeHostEntrypoint` exports, `hostStub`, and `CODE_MODE_HOST`; the [Cloudflare example](https://github.com/danieljvdm/effect-agent/blob/1c90e12330ed724c04f58f89f081b82ca33114f2/examples/code-mode-cloudflare/src/worker.ts#L23-L32) demonstrates the smaller surface.

## Evidence

- Production CI failure: [Kommunikasie run 32474947060](https://github.com/reve-ai/kommunikasie/actions/runs/32474947060); recurrence: [run 32483559567](https://github.com/reve-ai/kommunikasie/actions/runs/32483559567).
- The [Workerd regression](https://github.com/danieljvdm/effect-agent/blob/1c90e12330ed724c04f58f89f081b82ca33114f2/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts#L90-L102) primes cached runtimes in two Durable Objects during earlier events, then performs storage-backed host calls in later events. On beta.25 it deterministically fails under strict cross-request Promise handling; without the strict flag Workerd emits its cross-request Promise-resolution diagnostic.
- The fixed regression passed 20/20 fresh Workerd process starts without timing sleeps. The full platform-cloudflare suite passed 132/132, and the runnable Code Mode example passed 3/3.
