### PR TITLE
feat(browser-run): add policy-bound page capture

### DIFF
--- a/.changeset/browser-run-page-capture.md
+++ b/.changeset/browser-run-page-capture.md
@@ -1,0 +1,15 @@
+---
+"@effect-agent/sandbox": patch
+"@effect-agent/capabilities": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Add the schema-first `PageCapture` port and conservative `WebCapture.make`/`WebCapture.makeExtract` Tools over an immutable, deny-by-default browser-request allowlist. Add `browserQuickActionCaptureLayer` with bounded response streaming and explicit Workers AI authorization for structured extraction.
+
+```ts
+const readDocs = WebCapture.make("read_webpage", {
+  description: "Read documentation pages.",
+  urls: ["docs.example.com", "*.effect.website"],
+});
+// worker: readDocs.handlers.pipe(Layer.provide(browserQuickActionCaptureLayer({ browser: env.BROWSER })))
+```

--- a/.changeset/browser-run-page-capture.md
+++ b/.changeset/browser-run-page-capture.md
@@ -4,12 +4,14 @@
 "@effect-agent/platform-cloudflare": patch
 ---
 
-Add the schema-first `PageCapture` port and conservative `WebCapture.make`/`WebCapture.makeExtract` Tools over an immutable, deny-by-default browser-request allowlist. Add `browserQuickActionCaptureLayer` with bounded response streaming and explicit Workers AI authorization for structured extraction.
+Add the schema-first `PageCapture` port and conservative `WebCapture.make`/`WebCapture.makeExtract` Tools over an immutable, deny-by-default browser-request allowlist. Add native `BrowserRun` Quick Action Layers with bounded response streaming and a typed Workers AI authorization and accounting failure for structured extraction.
 
 ```ts
 const readDocs = WebCapture.make("read_webpage", {
   description: "Read documentation pages.",
   urls: ["docs.example.com", "*.effect.website"],
 });
-// worker: readDocs.handlers.pipe(Layer.provide(browserQuickActionCaptureLayer({ browser: env.BROWSER })))
+// worker: browserQuickActionCaptureLayer().pipe(
+//   Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })),
+// )
 ```

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -136,6 +136,14 @@ publication, and thread presentation are implemented by the separately named
 A scoped capability set for filesystem, process, and optional network operations. It is not a
 generic bag of provider SDK methods.
 
+**Page Capture**
+
+A stateless render of one page in a managed headless browser returning exactly one bounded
+output. Its host allowlist, action set, and byte budget are immutable; the host policy governs
+navigation, redirects, and subrequests. Capture results are untrusted, browser JavaScript makes
+execution uncertain rather than read-only, and separately billed model inference requires
+explicit host authorization and accounting.
+
 **Approval**  
 A policy decision that suspends or denies a proposed Tool Call before its Handler starts. Approval
 is not inferred from model prose.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38598,7 +38598,8 @@ class PageCaptureOutputLimitError extends exports_Schema.TaggedError()("PageCapt
 
 class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCaptureProtocolError", {
   implementation: SandboxImplementation,
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 var PageCaptureError = exports_Schema.Union([

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38565,13 +38565,15 @@ class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCapt
   implementation: SandboxImplementation,
   reason: exports_Schema.Literals(["rate", "quota"]),
   retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural),
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 
 class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
   implementation: SandboxImplementation,
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38265,6 +38265,8 @@ var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLe
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
 var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
 var ResponseFormatPrimitive = exports_Schema.Literals([
@@ -38277,24 +38279,74 @@ var ResponseFormatPrimitive = exports_Schema.Literals([
   "integer"
 ]);
 var ResponseFormatPrimitiveList = exports_Schema.Array(ResponseFormatPrimitive).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(7), exports_Schema.isUnique());
-var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.StructWithRest(exports_Schema.Struct({
-  type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
-  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
-  items: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  anyOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  oneOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  allOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
-}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]));
-var ResponseFormatDocument = exports_Schema.StructWithRest(exports_Schema.Struct({
-  type: exports_Schema.Literal("object"),
-  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
-  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
-}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]);
+var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.Struct(responseFormatFields()).pipe(exports_Schema.annotate({ parseOptions: { onExcessProperty: "error" } })));
+var responseFormatFields = () => {
+  const boundedNodes = exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH));
+  const boundedDefinitions = exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH));
+  const boundedRequired = exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique());
+  const subschema = exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode]);
+  return {
+    $schema: exports_Schema.optionalKey(BoundedSchemaReference),
+    $id: exports_Schema.optionalKey(BoundedSchemaReference),
+    $ref: exports_Schema.optionalKey(BoundedSchemaReference),
+    $anchor: exports_Schema.optionalKey(BoundedSchemaReference),
+    $dynamicRef: exports_Schema.optionalKey(BoundedSchemaReference),
+    $dynamicAnchor: exports_Schema.optionalKey(BoundedSchemaReference),
+    $comment: exports_Schema.optionalKey(BoundedSchemaText),
+    title: exports_Schema.optionalKey(BoundedSchemaText),
+    description: exports_Schema.optionalKey(BoundedSchemaText),
+    default: exports_Schema.optionalKey(exports_Schema.Json),
+    deprecated: exports_Schema.optionalKey(exports_Schema.Boolean),
+    readOnly: exports_Schema.optionalKey(exports_Schema.Boolean),
+    writeOnly: exports_Schema.optionalKey(exports_Schema.Boolean),
+    examples: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Json).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+    type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
+    enum: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Json).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+    const: exports_Schema.optionalKey(exports_Schema.Json),
+    multipleOf: exports_Schema.optionalKey(exports_Schema.Finite.check(exports_Schema.isGreaterThan(0))),
+    maximum: exports_Schema.optionalKey(exports_Schema.Finite),
+    exclusiveMaximum: exports_Schema.optionalKey(exports_Schema.Finite),
+    minimum: exports_Schema.optionalKey(exports_Schema.Finite),
+    exclusiveMinimum: exports_Schema.optionalKey(exports_Schema.Finite),
+    maxLength: exports_Schema.optionalKey(exports_Schema.Natural),
+    minLength: exports_Schema.optionalKey(exports_Schema.Natural),
+    pattern: exports_Schema.optionalKey(BoundedSchemaText),
+    format: exports_Schema.optionalKey(BoundedSchemaText),
+    maxItems: exports_Schema.optionalKey(exports_Schema.Natural),
+    minItems: exports_Schema.optionalKey(exports_Schema.Natural),
+    uniqueItems: exports_Schema.optionalKey(exports_Schema.Boolean),
+    prefixItems: exports_Schema.optionalKey(boundedNodes),
+    items: exports_Schema.optionalKey(subschema),
+    additionalItems: exports_Schema.optionalKey(subschema),
+    unevaluatedItems: exports_Schema.optionalKey(subschema),
+    contains: exports_Schema.optionalKey(subschema),
+    minContains: exports_Schema.optionalKey(exports_Schema.Natural),
+    maxContains: exports_Schema.optionalKey(exports_Schema.Natural),
+    properties: exports_Schema.optionalKey(boundedDefinitions),
+    patternProperties: exports_Schema.optionalKey(boundedDefinitions),
+    required: exports_Schema.optionalKey(boundedRequired),
+    dependentRequired: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, boundedRequired).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+    dependentSchemas: exports_Schema.optionalKey(boundedDefinitions),
+    additionalProperties: exports_Schema.optionalKey(subschema),
+    unevaluatedProperties: exports_Schema.optionalKey(subschema),
+    propertyNames: exports_Schema.optionalKey(subschema),
+    minProperties: exports_Schema.optionalKey(exports_Schema.Natural),
+    maxProperties: exports_Schema.optionalKey(exports_Schema.Natural),
+    anyOf: exports_Schema.optionalKey(boundedNodes),
+    oneOf: exports_Schema.optionalKey(boundedNodes),
+    allOf: exports_Schema.optionalKey(boundedNodes),
+    not: exports_Schema.optionalKey(subschema),
+    contentEncoding: exports_Schema.optionalKey(BoundedSchemaText),
+    contentMediaType: exports_Schema.optionalKey(BoundedSchemaText),
+    contentSchema: exports_Schema.optionalKey(subschema),
+    $defs: exports_Schema.optionalKey(boundedDefinitions),
+    definitions: exports_Schema.optionalKey(boundedDefinitions)
+  };
+};
+var ResponseFormatDocument = exports_Schema.Struct({
+  ...responseFormatFields(),
+  type: exports_Schema.Literal("object")
+}).pipe(exports_Schema.annotate({ parseOptions: { onExcessProperty: "error" } }));
 var isResponseFormatDocument = exports_Schema.is(ResponseFormatDocument);
 var isBoundedResponseFormat = (input) => {
   if (!exports_Predicate.isObject(input))

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38264,6 +38264,7 @@ var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLeng
 var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var BoundedInferenceProvider = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8 * 1024));
 var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
@@ -38543,7 +38544,7 @@ var PageCaptureOutput = exports_Schema.Union([
 ]);
 
 class PageCaptureInferenceUse extends exports_Schema.Class("PageCaptureInferenceUse")({
-  provider: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
+  provider: BoundedInferenceProvider,
   modelCalls: PositiveInt4
 }) {
 }
@@ -38572,6 +38573,15 @@ class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCapt
 
 class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
   implementation: SandboxImplementation,
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
+}) {
+}
+
+class PageCaptureInferencePolicyError extends exports_Schema.TaggedError()("PageCaptureInferencePolicyError", {
+  implementation: SandboxImplementation,
+  provider: BoundedInferenceProvider,
+  reason: exports_Schema.Literals(["authorization", "accounting"]),
   message: BoundedMessage2,
   cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
@@ -38607,6 +38617,7 @@ class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCapture
 var PageCaptureError = exports_Schema.Union([
   PageCaptureRateLimitedError,
   PageCaptureNavigationError,
+  PageCaptureInferencePolicyError,
   PageCaptureUnsupportedError,
   PageCaptureOutputLimitError,
   PageCaptureProtocolError

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38253,6 +38253,10 @@ class CodeExecutor extends exports_Context.Service()("@effect-agent/sandbox/Code
 // packages/sandbox/src/page-capture.ts
 var MAX_OUTPUT_BYTES2 = 8 * 1024 * 1024;
 var MAX_LINKS = 4096;
+var MAX_RESPONSE_FORMAT_BYTES = 64 * 1024;
+var MAX_RESPONSE_FORMAT_DEPTH = 32;
+var MAX_RESPONSE_FORMAT_NODES = 4096;
+var MAX_RESPONSE_FORMAT_COLLECTION_LENGTH = 256;
 var BoundedOutputText2 = exports_Schema.String.check(exports_Schema.isMaxLength(MAX_OUTPUT_BYTES2));
 var BoundedUrl = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var BoundedHtml = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2 * 1024 * 1024));
@@ -38260,8 +38264,92 @@ var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLeng
 var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+var ResponseFormatPrimitive = exports_Schema.Literals([
+  "string",
+  "number",
+  "boolean",
+  "array",
+  "object",
+  "null",
+  "integer"
+]);
+var ResponseFormatPrimitiveList = exports_Schema.Array(ResponseFormatPrimitive).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(7), exports_Schema.isUnique());
+var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.StructWithRest(exports_Schema.Struct({
+  type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
+  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+  items: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  anyOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  oneOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  allOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
+}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]));
+var ResponseFormatDocument = exports_Schema.StructWithRest(exports_Schema.Struct({
+  type: exports_Schema.Literal("object"),
+  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
+}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]);
+var isResponseFormatDocument = exports_Schema.is(ResponseFormatDocument);
+var isBoundedResponseFormat = (input) => {
+  if (!exports_Predicate.isObject(input))
+    return false;
+  const pending = [
+    { value: input, depth: 0 }
+  ];
+  const visited = new WeakSet;
+  let nodes = 0;
+  let textUnits = 0;
+  try {
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (current === undefined || current.depth > MAX_RESPONSE_FORMAT_DEPTH || ++nodes > MAX_RESPONSE_FORMAT_NODES) {
+        return false;
+      }
+      const value4 = current.value;
+      if (value4 === null || typeof value4 === "boolean")
+        continue;
+      if (typeof value4 === "number") {
+        if (!Number.isFinite(value4))
+          return false;
+        continue;
+      }
+      if (typeof value4 === "string") {
+        textUnits += value4.length;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES)
+          return false;
+        continue;
+      }
+      if (!exports_Predicate.isObjectOrArray(value4) || visited.has(value4))
+        return false;
+      visited.add(value4);
+      const entries3 = Array.isArray(value4) ? value4.map((entry, index2) => [index2, entry]) : Object.entries(value4);
+      if (entries3.length > MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)
+        return false;
+      for (const [key, entry] of entries3) {
+        textUnits += typeof key === "string" ? key.length : 0;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES)
+          return false;
+        pending.push({ value: entry, depth: current.depth + 1 });
+      }
+    }
+    if (!isResponseFormatDocument(input))
+      return false;
+    const encoded = JSON.stringify(input);
+    return exports_Encoding.encodeHex(encoded).length / 2 <= MAX_RESPONSE_FORMAT_BYTES;
+  } catch {
+    return false;
+  }
+};
+var PageCaptureResponseFormat = exports_Schema.declare(isBoundedResponseFormat, {
+  identifier: "@effect-agent/sandbox/PageCaptureResponseFormat",
+  description: "An object JSON Schema bounded to 64 KiB, depth 32, and 4096 nodes"
+});
 
 class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
   url: BoundedUrl
@@ -38287,7 +38375,7 @@ class CapturePageLinks extends exports_Schema.TaggedClass()("CapturePageLinks", 
 }
 
 class CapturePageStructured extends exports_Schema.TaggedClass()("CapturePageStructured", {
-  responseFormat: exports_Schema.Json,
+  responseFormat: PageCaptureResponseFormat,
   prompt: exports_Schema.optionalKey(BoundedPrompt)
 }) {
 }

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38250,6 +38250,204 @@ var CodeExecutionError = exports_Schema.Union([
 
 class CodeExecutor extends exports_Context.Service()("@effect-agent/sandbox/CodeExecutor") {
 }
+// packages/sandbox/src/page-capture.ts
+var MAX_OUTPUT_BYTES2 = 8 * 1024 * 1024;
+var MAX_LINKS = 4096;
+var BoundedOutputText2 = exports_Schema.String.check(exports_Schema.isMaxLength(MAX_OUTPUT_BYTES2));
+var BoundedUrl = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedHtml = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2 * 1024 * 1024));
+var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
+var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
+var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+
+class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
+  url: BoundedUrl
+}) {
+}
+
+class PageHtmlTarget extends exports_Schema.TaggedClass()("PageHtmlTarget", {
+  html: BoundedHtml
+}) {
+}
+var PageCaptureTarget = exports_Schema.Union([PageUrlTarget, PageHtmlTarget]);
+var PageCaptureEngine = exports_Schema.Literals(["chromium", "kitesurf"]);
+
+class CapturePageContent extends exports_Schema.TaggedClass()("CapturePageContent", {}) {
+}
+
+class CapturePageMarkdown extends exports_Schema.TaggedClass()("CapturePageMarkdown", {}) {
+}
+
+class CapturePageLinks extends exports_Schema.TaggedClass()("CapturePageLinks", {
+  visibleLinksOnly: exports_Schema.optionalKey(exports_Schema.Boolean)
+}) {
+}
+
+class CapturePageStructured extends exports_Schema.TaggedClass()("CapturePageStructured", {
+  responseFormat: exports_Schema.Json,
+  prompt: exports_Schema.optionalKey(BoundedPrompt)
+}) {
+}
+var PageCaptureAction = exports_Schema.Union([
+  CapturePageContent,
+  CapturePageMarkdown,
+  CapturePageLinks,
+  CapturePageStructured
+]);
+
+class PageSelectorWait extends exports_Schema.Class("PageSelectorWait")({
+  selector: BoundedSelector,
+  timeoutMillis: exports_Schema.optionalKey(BoundedTimeoutMillis)
+}) {
+}
+
+class PageNavigationOptions extends exports_Schema.Class("PageNavigationOptions")({
+  waitUntil: exports_Schema.optionalKey(exports_Schema.Literals(["load", "domcontentloaded", "networkidle0", "networkidle2"])),
+  timeoutMillis: exports_Schema.optionalKey(BoundedTimeoutMillis),
+  waitForSelector: exports_Schema.optionalKey(PageSelectorWait)
+}) {
+}
+
+class PageViewport extends exports_Schema.Class("PageViewport")({
+  width: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(7680)),
+  height: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(7680))
+}) {
+}
+
+class PageResourcePolicy extends exports_Schema.Class("PageResourcePolicy")({
+  rejectResourceTypes: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Literals([
+    "document",
+    "stylesheet",
+    "image",
+    "media",
+    "font",
+    "script",
+    "texttrack",
+    "xhr",
+    "fetch",
+    "eventsource",
+    "websocket",
+    "manifest",
+    "other"
+  ])).check(exports_Schema.isMaxLength(16))),
+  allowRequestPatterns: exports_Schema.optionalKey(exports_Schema.Array(BoundedPattern).check(exports_Schema.isMaxLength(64)))
+}) {
+}
+
+class PageCaptureLimits extends exports_Schema.Class("PageCaptureLimits")({
+  maxOutputBytes: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(MAX_OUTPUT_BYTES2))
+}) {
+}
+
+class PageCaptureRequest extends exports_Schema.Class("PageCaptureRequest")({
+  target: PageCaptureTarget,
+  action: PageCaptureAction,
+  engine: PageCaptureEngine,
+  limits: PageCaptureLimits,
+  navigation: exports_Schema.optionalKey(PageNavigationOptions),
+  viewport: exports_Schema.optionalKey(PageViewport),
+  resourcePolicy: exports_Schema.optionalKey(PageResourcePolicy)
+}) {
+}
+
+class PageContentCaptured extends exports_Schema.TaggedClass()("PageContentCaptured", {
+  html: BoundedOutputText2
+}) {
+}
+
+class PageMarkdownCaptured extends exports_Schema.TaggedClass()("PageMarkdownCaptured", {
+  markdown: BoundedOutputText2
+}) {
+}
+
+class PageLinksCaptured extends exports_Schema.TaggedClass()("PageLinksCaptured", {
+  links: exports_Schema.Array(BoundedUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
+}) {
+}
+
+class PageStructuredCaptured extends exports_Schema.TaggedClass()("PageStructuredCaptured", {
+  value: exports_Schema.Json
+}) {
+}
+var PageCaptureOutput = exports_Schema.Union([
+  PageContentCaptured,
+  PageMarkdownCaptured,
+  PageLinksCaptured,
+  PageStructuredCaptured
+]);
+
+class PageCaptureInferenceUse extends exports_Schema.Class("PageCaptureInferenceUse")({
+  provider: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
+  modelCalls: PositiveInt4
+}) {
+}
+
+class PageCaptureResourceUse extends exports_Schema.Class("PageCaptureResourceUse")({
+  browserMillis: exports_Schema.optionalKey(exports_Schema.Natural),
+  inference: exports_Schema.optionalKey(PageCaptureInferenceUse)
+}) {
+}
+
+class PageCaptureResult extends exports_Schema.Class("PageCaptureResult")({
+  implementation: SandboxImplementation,
+  output: PageCaptureOutput,
+  resourceUse: PageCaptureResourceUse
+}) {
+}
+
+class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCaptureRateLimitedError", {
+  implementation: SandboxImplementation,
+  reason: exports_Schema.Literals(["rate", "quota"]),
+  retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural),
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
+  implementation: SandboxImplementation,
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureUnsupportedError extends exports_Schema.TaggedError()("PageCaptureUnsupportedError", {
+  implementation: SandboxImplementation,
+  feature: exports_Schema.Literals([
+    "engine",
+    "action",
+    "target",
+    "navigation",
+    "viewport",
+    "resource-policy"
+  ]),
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureOutputLimitError extends exports_Schema.TaggedError()("PageCaptureOutputLimitError", {
+  implementation: SandboxImplementation,
+  limit: PositiveInt4,
+  observed: exports_Schema.Natural
+}) {
+}
+
+class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCaptureProtocolError", {
+  implementation: SandboxImplementation,
+  message: BoundedMessage2
+}) {
+}
+var PageCaptureError = exports_Schema.Union([
+  PageCaptureRateLimitedError,
+  PageCaptureNavigationError,
+  PageCaptureUnsupportedError,
+  PageCaptureOutputLimitError,
+  PageCaptureProtocolError
+]);
+
+class PageCapture extends exports_Context.Service()("@effect-agent/sandbox/PageCapture") {
+}
 // packages/capabilities/src/code-mode.ts
 var maxFailureTextLength = 4 * 1024;
 var BoundedFailureText = exports_Schema.String.check(exports_Schema.isMaxLength(maxFailureTextLength));
@@ -38542,7 +38740,7 @@ var EphemeralConversationsLive = exports_Layer.effect(EphemeralConversations, ex
 }));
 
 // packages/capabilities/src/commands.ts
-var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt5 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 
 class SteeringCommand extends exports_Schema.TaggedClass()("SteeringCommand", {
   id: exports_Schema.NonEmptyString,
@@ -38566,7 +38764,7 @@ class FollowUpCommand extends exports_Schema.TaggedClass()("FollowUpCommand", {
 var RunCommand = exports_Schema.Union([SteeringCommand, FollowUpCommand]);
 var CommandDrainPolicy = exports_Schema.Literals(["one", "all"]);
 
-class RunCommandQueueConfig extends exports_Schema.Class("@effect-agent/capabilities/RunCommandQueueConfig")({ capacity: PositiveInt4 }) {
+class RunCommandQueueConfig extends exports_Schema.Class("@effect-agent/capabilities/RunCommandQueueConfig")({ capacity: PositiveInt5 }) {
 }
 
 class RunCommandQueueClosed extends exports_Schema.TaggedError()("RunCommandQueueClosed", { runId: RunId }) {
@@ -39769,7 +39967,7 @@ class ElicitationDeclined extends (/* @__PURE__ */ Error4("@effect/ai/McpSchema/
 // packages/capabilities/src/mcp.ts
 var MAX_MCP_TOOLS = 128;
 var MAX_MCP_DISCOVERY_BYTES = 1024 * 1024;
-var PositiveInt5 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt6 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var Sha256Digest = exports_Schema.String.check(exports_Schema.isPattern(/^sha256:[a-f0-9]{64}$/));
 var JsonArray = exports_Schema.Array(exports_Schema.Json);
 var isJsonArray = exports_Schema.is(JsonArray);
@@ -39782,10 +39980,10 @@ class McpServerIdentity extends exports_Schema.Class("@effect-agent/capabilities
 
 class McpConnectionRequest extends exports_Schema.Class("@effect-agent/capabilities/McpConnectionRequest")({
   serverId: exports_Schema.NonEmptyString,
-  maxToolCount: PositiveInt5.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_TOOLS)),
-  maxToolDescriptionBytes: PositiveInt5,
-  maxDiscoveryBytes: PositiveInt5.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_DISCOVERY_BYTES)),
-  connectTimeoutMillis: PositiveInt5
+  maxToolCount: PositiveInt6.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_TOOLS)),
+  maxToolDescriptionBytes: PositiveInt6,
+  maxDiscoveryBytes: PositiveInt6.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_DISCOVERY_BYTES)),
+  connectTimeoutMillis: PositiveInt6
 }) {
 }
 
@@ -39987,9 +40185,9 @@ var connectMcp = exports_Effect.fn("connectMcp")(function* (request3) {
   };
 });
 // packages/capabilities/src/scheduling.ts
-var PositiveInt6 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt7 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var RunSchedulingOverride = exports_Schema.Union([
-  exports_Schema.Struct({ mode: exports_Schema.Literal("bounded"), concurrency: PositiveInt6 }),
+  exports_Schema.Struct({ mode: exports_Schema.Literal("bounded"), concurrency: PositiveInt7 }),
   exports_Schema.Struct({ mode: exports_Schema.Literal("sequential") })
 ]);
 // packages/capabilities/src/subagent-reservation.ts
@@ -40478,19 +40676,19 @@ var SubagentReservationsMemoryLive = exports_Layer.effect(SubagentReservations, 
 }));
 
 // packages/capabilities/src/subagent.ts
-var PositiveInt7 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt8 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var Natural4 = exports_Schema.Natural;
 var FinitePositiveDuration4 = exports_Schema.Duration.pipe(exports_Schema.refine((duration2) => exports_Duration.isFinite(duration2) && exports_Duration.isPositive(duration2), { expected: "a finite positive duration" }));
 var SubagentPolicyFields = exports_Schema.Struct({
-  maxChildren: PositiveInt7,
-  maxConcurrency: PositiveInt7,
-  maxTurns: PositiveInt7,
-  maxToolCalls: PositiveInt7,
+  maxChildren: PositiveInt8,
+  maxConcurrency: PositiveInt8,
+  maxTurns: PositiveInt8,
+  maxToolCalls: PositiveInt8,
   maxDuration: FinitePositiveDuration4,
-  maxInputTokens: exports_Schema.optionalKey(PositiveInt7),
-  maxOutputTokens: exports_Schema.optionalKey(PositiveInt7),
+  maxInputTokens: exports_Schema.optionalKey(PositiveInt8),
+  maxOutputTokens: exports_Schema.optionalKey(PositiveInt8),
   maxCostMicrousd: exports_Schema.optionalKey(Natural4),
-  maxResultBytes: exports_Schema.optionalKey(PositiveInt7)
+  maxResultBytes: exports_Schema.optionalKey(PositiveInt8)
 });
 
 class SubagentPolicy extends exports_Schema.Class("@effect-agent/capabilities/SubagentPolicy")(SubagentPolicyFields) {
@@ -40585,6 +40783,38 @@ var neverStartedUsage = SubagentObservedUsage.make({
   costMicrousd: 0,
   resultBytes: 0
 });
+// packages/capabilities/src/web-capture.ts
+var maxFailureTextLength2 = 4 * 1024;
+var BoundedFailureText3 = exports_Schema.String.check(exports_Schema.isMaxLength(maxFailureTextLength2));
+var BoundedErrorTag3 = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+var BoundedUrl2 = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedContent = exports_Schema.String.check(exports_Schema.isMaxLength(1024 * 1024));
+var WebCaptureAction = exports_Schema.Literals(["markdown", "content", "links"]);
+var WebCaptureParameters = exports_Schema.Struct({
+  url: BoundedUrl2,
+  action: WebCaptureAction
+});
+var WebCaptureExtractParameters = exports_Schema.Struct({
+  url: BoundedUrl2
+});
+
+class WebCaptureSuccess extends exports_Schema.Class("@effect-agent/capabilities/WebCaptureSuccess")({
+  url: BoundedUrl2,
+  action: WebCaptureAction,
+  markdown: exports_Schema.optionalKey(BoundedContent),
+  html: exports_Schema.optionalKey(BoundedContent),
+  links: exports_Schema.optionalKey(exports_Schema.Array(BoundedUrl2).check(exports_Schema.isMaxLength(4096)))
+}) {
+}
+
+class WebCaptureFailure extends exports_Schema.TaggedError()("WebCaptureFailure", {
+  errorTag: BoundedErrorTag3,
+  message: BoundedFailureText3,
+  retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural)
+}) {
+}
+var defaultMaxResponseBytes = 128 * 1024;
+var urlConstructor2 = Reflect.get(globalThis, "URL");
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/FetchHttpClient.js
 var exports_FetchHttpClient = {};
 __export(exports_FetchHttpClient, {

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -38269,6 +38269,29 @@ var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8
 var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+var pageUrlConstructor = Reflect.get(globalThis, "URL");
+var isCredentialFreeWebUrl = (value4, allowHttp) => {
+  if (typeof pageUrlConstructor !== "function")
+    return false;
+  try {
+    const parsed = Reflect.construct(pageUrlConstructor, [value4]);
+    if (!exports_Predicate.isObject(parsed))
+      return false;
+    const protocol = Reflect.get(parsed, "protocol");
+    const hostname = Reflect.get(parsed, "hostname");
+    const username = Reflect.get(parsed, "username");
+    const password = Reflect.get(parsed, "password");
+    return (protocol === "https:" || allowHttp && protocol === "http:") && typeof hostname === "string" && hostname.length > 0 && username === "" && password === "";
+  } catch {
+    return false;
+  }
+};
+var PageCaptureTargetUrl = BoundedUrl.check(exports_Schema.makeFilter((value4) => isCredentialFreeWebUrl(value4, false), {
+  title: "an absolute HTTPS URL without embedded credentials"
+}));
+var PageCaptureLinkUrl = BoundedUrl.check(exports_Schema.makeFilter((value4) => isCredentialFreeWebUrl(value4, true), {
+  title: "an absolute HTTP or HTTPS URL without embedded credentials"
+}));
 var ResponseFormatPrimitive = exports_Schema.Literals([
   "string",
   "number",
@@ -38404,7 +38427,7 @@ var PageCaptureResponseFormat = exports_Schema.declare(isBoundedResponseFormat, 
 });
 
 class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
-  url: BoundedUrl
+  url: PageCaptureTargetUrl
 }) {
 }
 
@@ -38504,7 +38527,7 @@ class PageMarkdownCaptured extends exports_Schema.TaggedClass()("PageMarkdownCap
 }
 
 class PageLinksCaptured extends exports_Schema.TaggedClass()("PageLinksCaptured", {
-  links: exports_Schema.Array(BoundedUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
+  links: exports_Schema.Array(PageCaptureLinkUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
 }) {
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -151,6 +151,7 @@
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
+        "@effect-agent/platform-cloudflare": "workspace:*",
         "@effect-agent/testing": "workspace:*",
         "@effect/ai-anthropic": "catalog:",
         "@effect/ai-openai": "catalog:",

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -39,7 +39,7 @@ approval and audit, budgets, context/compaction, scheduling, MCP, structural red
 capture through `WebCapture.make` and `WebCapture.makeExtract` over the `PageCapture` port, and
 Subagent authoring through `Subagent.define`, `SubagentPolicy`, `SubagentGrant`, and
 `SubagentRuntime.layer`. Capture Tools have uncertain execution class; extraction handler Layers
-retain their Effect Schema's decoding-service requirements.
+and Tool invocations retain their Effect Schema's decoding-service requirements.
 
 It depends outward from engine; the engine does not import it.
 
@@ -117,10 +117,11 @@ so its composition root owns collision-resistant cancellation identity generatio
 client reading ambient time or randomness. `CloudflareBindingSource` may capture registered worker
 Bindings from `CloudflareBindingSourceContext` once per Object incarnation, after identity
 derivation. `browserQuickActionCaptureLayer` adapts the Wrangler `browser` binding's
-`quickAction()` to the `PageCapture` port; structured extraction additionally requires explicit
-`workersAi.authorizeAndAccount` host policy. The `./browser-quick-action` export provides that
-adapter without loading Durable Object runtime modules. It is a Layer-assembly library, not an
-application entrypoint.
+`quickAction()` to the `PageCapture` port without granting Workers AI authority.
+`browserQuickActionWorkersAiCaptureLayer` additionally requires the explicit
+`BrowserQuickActionWorkersAi` authorization and accounting service before permitting structured
+extraction. The `./browser-quick-action` export provides these adapters without loading Durable
+Object runtime modules. It is a Layer-assembly library, not an application entrypoint.
 
 ### `@effect-agent/pr-review`
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -116,12 +116,14 @@ and sends explicit scoped cancellation on interruption. The client Layer require
 so its composition root owns collision-resistant cancellation identity generation instead of the
 client reading ambient time or randomness. `CloudflareBindingSource` may capture registered worker
 Bindings from `CloudflareBindingSourceContext` once per Object incarnation, after identity
-derivation. `browserQuickActionCaptureLayer` adapts the Wrangler `browser` binding's
-`quickAction()` to the `PageCapture` port without granting Workers AI authority.
-`browserQuickActionWorkersAiCaptureLayer` additionally requires the explicit
-`BrowserQuickActionWorkersAi` authorization and accounting service before permitting structured
-extraction. The `./browser-quick-action` export provides these adapters without loading Durable
-Object runtime modules. It is a Layer-assembly library, not an application entrypoint.
+derivation. `BrowserQuickActionBrowserBinding.layer` lifts a host-resolved Wrangler `browser`
+binding into an explicit Effect service. `browserQuickActionCaptureLayer` visibly requires that
+service to adapt `quickAction()` to the `PageCapture` port without granting Workers AI authority.
+`browserQuickActionWorkersAiCaptureLayer` requires both the browser-binding service and the
+explicit `BrowserQuickActionWorkersAi` authorization and accounting service before permitting
+structured extraction. The `./browser-quick-action` export provides these adapters without
+loading Durable Object runtime modules. It is a Layer-assembly library, not an application
+entrypoint.
 
 ### `@effect-agent/pr-review`
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -35,16 +35,18 @@ Exports include `AgentRuntime`, `DetachedRun`, `RunOptions`, and the operational
 ### `@effect-agent/capabilities`
 
 Adapts richer optional services to the engine: process-local Conversations, command queues,
-approval and audit, budgets, context/compaction, scheduling, MCP, structural redaction, and
+approval and audit, budgets, context/compaction, scheduling, MCP, structural redaction, web
+capture through `WebCapture.make` and `WebCapture.makeExtract` over the `PageCapture` port, and
 Subagent authoring through `Subagent.define`, `SubagentPolicy`, `SubagentGrant`, and
-`SubagentRuntime.layer`.
+`SubagentRuntime.layer`. Capture Tools have uncertain execution class; extraction handler Layers
+retain their Effect Schema's decoding-service requirements.
 
 It depends outward from engine; the engine does not import it.
 
 ### `@effect-agent/sandbox`
 
-Defines schema-first, platform-neutral sandbox requests, events, errors, and the streaming `Sandbox`
-service.
+Defines schema-first, platform-neutral sandbox requests, events, errors, the streaming `Sandbox`
+service, the callback-shaped `CodeExecutor` port, and the stateless `PageCapture` port.
 
 ### `@effect-agent/sandbox-local`
 
@@ -114,7 +116,11 @@ and sends explicit scoped cancellation on interruption. The client Layer require
 so its composition root owns collision-resistant cancellation identity generation instead of the
 client reading ambient time or randomness. `CloudflareBindingSource` may capture registered worker
 Bindings from `CloudflareBindingSourceContext` once per Object incarnation, after identity
-derivation. It is a Layer-assembly library, not an application entrypoint.
+derivation. `browserQuickActionCaptureLayer` adapts the Wrangler `browser` binding's
+`quickAction()` to the `PageCapture` port; structured extraction additionally requires explicit
+`workersAi.authorizeAndAccount` host policy. The `./browser-quick-action` export provides that
+adapter without loading Durable Object runtime modules. It is a Layer-assembly library, not an
+application entrypoint.
 
 ### `@effect-agent/pr-review`
 

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -351,9 +351,10 @@ Schema boundary.
 Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
 they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
 the platform's own backoff hint. Foreign browser or transport failures retain their original live
-cause inside the concrete typed protocol error; model-visible failure envelopes and logs receive
-only a bounded, fixed operation description, never foreign exception text. Capture resource use
-records browser time and, when an adapter
+cause; remote error bodies and provider envelopes retain only a bounded host-only cause. Public
+failure messages and cleanup logs use fixed operation or status descriptions and never include
+foreign exception text, response bodies, or provider diagnostics. Capture resource use records
+browser time and, when an adapter
 performs separately authorized model inference, its provider and model-call count. Everything a
 capture returns is untrusted, attacker-influenced content
 ([security §9](./security-operations.md)).

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -351,8 +351,9 @@ Schema boundary.
 Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
 they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
 the platform's own backoff hint. Foreign browser or transport failures retain their original live
-cause inside the concrete typed protocol error; model-visible failure envelopes receive only the
-bounded error tag and message. Capture resource use records browser time and, when an adapter
+cause inside the concrete typed protocol error; model-visible failure envelopes and logs receive
+only a bounded, fixed operation description, never foreign exception text. Capture resource use
+records browser time and, when an adapter
 performs separately authorized model inference, its provider and model-call count. Everything a
 capture returns is untrusted, attacker-influenced content
 ([security §9](./security-operations.md)).

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -341,6 +341,9 @@ interface PageCapture {
 Requests, results, limits, and expected errors are Effect Schemas. The request selects the
 engine (`chromium`, or the lightweight `kitesurf` where an adapter supports it), bounds the
 response in UTF-8 bytes, and may constrain navigation readiness, viewport, and request egress.
+Structured requests accept only object-shaped JSON Schema documents with valid nested schema
+nodes, at most 64 KiB of encoded data, depth 32, 4,096 total nodes, and 256 entries per
+collection. Malformed, cyclic, or over-budget documents fail at the request Schema boundary.
 Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
 they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
 the platform's own backoff hint. Capture resource use records browser time and, when an adapter
@@ -355,7 +358,8 @@ The same allowlist is projected into the browser's request policy, covering init
 redirect destinations, and every rendered-page subrequest. `WebCapture.makeExtract` derives the
 platform-side JSON response format from one Effect Schema and decodes the untrusted result
 through that exact Schema; its handler Layer visibly requires both `PageCapture` and the
-Schema's decoding services.
+Schema's decoding services, and the Tool invocation keeps those decoding services visible in
+its own requirement channel.
 
 Both builders return ordinary Tools with `failureMode: "return"` and execution class
 `uncertain`: page JavaScript can mutate remote state, so captures are neither safely replayable
@@ -442,5 +446,7 @@ default and are excluded from ordinary span attributes.
   live-context estimate.
 - **CAP-018**: Page capture is deny-by-default: its immutable target-host allowlist governs
   navigation, redirects, and subrequests; its action set, engine, and byte budget are fixed at
-  capability construction; browser execution remains `uncertain`; model inference requires
-  explicit host authorization and accounting; and every result is treated as untrusted input.
+  capability construction; structured extraction accepts only a bounded object JSON Schema and
+  exposes its decoder requirements; browser execution remains `uncertain`; model inference
+  requires explicit host authorization and accounting; and every result is treated as untrusted
+  input.

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -372,7 +372,9 @@ its own requirement channel.
 Both builders return ordinary Tools with `failureMode: "return"` and execution class
 `uncertain`: page JavaScript can mutate remote state, so captures are neither safely replayable
 nor eligible for readonly-only Code Mode. Platform-side model inference is never implicit; the
-host must authorize and account for its provider before extraction starts. Construction fails
+host must authorize and account for its provider before extraction starts. Authorization and
+accounting refusals fail as `PageCaptureInferencePolicyError`, identifying the provider and which
+policy step failed while retaining host diagnostics only as the live cause. Construction fails
 closed on an empty or malformed host pattern, an invalid response byte budget, an empty action
 set, and an extraction Schema the deriver cannot express. Stateful browser sessions,
 screenshots, PDFs, snapshot bundles, crawling, and accessibility trees were considered and

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -350,7 +350,9 @@ Malformed keywords, unsupported keywords, cycles, and over-budget documents fail
 Schema boundary.
 Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
 they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
-the platform's own backoff hint. Capture resource use records browser time and, when an adapter
+the platform's own backoff hint. Foreign browser or transport failures retain their original live
+cause inside the concrete typed protocol error; model-visible failure envelopes receive only the
+bounded error tag and message. Capture resource use records browser time and, when an adapter
 performs separately authorized model inference, its provider and model-call count. Everything a
 capture returns is untrusted, attacker-influenced content
 ([security §9](./security-operations.md)).

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -338,7 +338,9 @@ interface PageCapture {
 }
 ```
 
-Requests, results, limits, and expected errors are Effect Schemas. The request selects the
+Requests, results, limits, and expected errors are Effect Schemas. Navigation targets must be
+absolute HTTPS URLs without embedded credentials. Returned links are data, never navigation
+authority, and must be absolute credential-free HTTP or HTTPS URLs. The request selects the
 engine (`chromium`, or the lightweight `kitesurf` where an adapter supports it), bounds the
 response in UTF-8 bytes, and may constrain navigation readiness, viewport, and request egress.
 Structured requests accept only object-shaped JSON Schema documents whose root and every nested
@@ -447,8 +449,8 @@ default and are excluded from ordinary span attributes.
   remaining the total), and totals expose the most recent call's input/output tokens as the
   live-context estimate.
 - **CAP-018**: Page capture is deny-by-default: its immutable target-host allowlist governs
-  navigation, redirects, and subrequests; its action set, engine, and byte budget are fixed at
-  capability construction; structured extraction accepts only a bounded object JSON Schema and
-  exposes its decoder requirements; browser execution remains `uncertain`; model inference
-  requires explicit host authorization and accounting; and every result is treated as untrusted
-  input.
+  credential-free HTTPS navigation, redirects, and subrequests; returned links are validated
+  credential-free HTTP(S) data; its action set, engine, and byte budget are fixed at capability
+  construction; structured extraction accepts only a bounded object JSON Schema and exposes its
+  decoder requirements; browser execution remains `uncertain`; model inference requires explicit
+  host authorization and accounting; and every result is treated as untrusted input.

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -341,9 +341,11 @@ interface PageCapture {
 Requests, results, limits, and expected errors are Effect Schemas. The request selects the
 engine (`chromium`, or the lightweight `kitesurf` where an adapter supports it), bounds the
 response in UTF-8 bytes, and may constrain navigation readiness, viewport, and request egress.
-Structured requests accept only object-shaped JSON Schema documents with valid nested schema
-nodes, at most 64 KiB of encoded data, depth 32, 4,096 total nodes, and 256 entries per
-collection. Malformed, cyclic, or over-budget documents fail at the request Schema boundary.
+Structured requests accept only object-shaped JSON Schema documents whose root and every nested
+node use the explicitly supported, type-checked JSON Schema vocabulary. The document is limited
+to 64 KiB of encoded data, depth 32, 4,096 total nodes, and 256 entries per collection.
+Malformed keywords, unsupported keywords, cycles, and over-budget documents fail at the request
+Schema boundary.
 Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
 they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
 the platform's own backoff hint. Capture resource use records browser time and, when an adapter

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -20,6 +20,7 @@ must detect absence explicitly; it must not silently substitute weaker behavior.
 | MCP client                 | Implemented |                          No |                              No |
 | Sandbox                    | Implemented |                          No |     For untrusted commands/code |
 | Code Mode                  | Implemented |                          No |                              No |
+| Page capture               | Implemented |                          No |                              No |
 | Subagents                  | Implemented |                          No |                              No |
 | Persistent agent state     | Implemented |                          No |                              No |
 | Durable steps              | Implemented |                          No |                              No |
@@ -320,6 +321,52 @@ Call and its bounded final result, with inner-call evidence in telemetry counts 
 audit metadata. Code Mode claims deployment class `E` only; the `DN` and `DC` assemblies make
 no Code Mode claim until this specification says otherwise.
 
+## 9.2 Page capture and the PageCapture port
+
+Page capture renders one page — a navigated https URL or supplied HTML — in a managed headless
+browser and returns exactly one bounded output: rendered HTML, Markdown, discovered links, or
+schema-shaped structured data. The port is a stateless sibling of `Sandbox` and `CodeExecutor`
+in `@effect-agent/sandbox`: a browser is intrinsically an egress device, so it carries its own
+explicit capture contract instead of widening the sandbox network policy that every existing
+adapter rejects typed.
+
+```ts
+interface PageCapture {
+  readonly capture: (
+    request: PageCaptureRequest,
+  ) => Effect.Effect<PageCaptureResult, PageCaptureError>;
+}
+```
+
+Requests, results, limits, and expected errors are Effect Schemas. The request selects the
+engine (`chromium`, or the lightweight `kitesurf` where an adapter supports it), bounds the
+response in UTF-8 bytes, and may constrain navigation readiness, viewport, and request egress.
+Adapters reuse the `SandboxImplementation` posture idiom (CAP-010), reject any feature or engine
+they cannot honor, and surface platform rate and quota refusals as one typed failure carrying
+the platform's own backoff hint. Capture resource use records browser time and, when an adapter
+performs separately authorized model inference, its provider and model-call count. Everything a
+capture returns is untrusted, attacker-influenced content
+([security §9](./security-operations.md)).
+
+The model-facing builders live in `@effect-agent/capabilities` and follow the Delegation
+pattern: `WebCapture.make` exposes a fixed action set over an immutable construction-time https
+host allowlist (deny-by-default; a `*.example.com` wildcard matches the apex and its subdomains).
+The same allowlist is projected into the browser's request policy, covering initial navigation,
+redirect destinations, and every rendered-page subrequest. `WebCapture.makeExtract` derives the
+platform-side JSON response format from one Effect Schema and decodes the untrusted result
+through that exact Schema; its handler Layer visibly requires both `PageCapture` and the
+Schema's decoding services.
+
+Both builders return ordinary Tools with `failureMode: "return"` and execution class
+`uncertain`: page JavaScript can mutate remote state, so captures are neither safely replayable
+nor eligible for readonly-only Code Mode. Platform-side model inference is never implicit; the
+host must authorize and account for its provider before extraction starts. Construction fails
+closed on an empty or malformed host pattern, an invalid response byte budget, an empty action
+set, and an extraction Schema the deriver cannot express. Stateful browser sessions,
+screenshots, PDFs, snapshot bundles, crawling, and accessibility trees were considered and
+deliberately excluded from this first slice — each needs binary transport or session semantics
+this stateless contract does not promise. Page capture claims deployment class `E` only.
+
 ## 10. Subagents
 
 The proposed Subagent capability is specified in [subagents.md](./subagents.md). It uses declared
@@ -393,3 +440,7 @@ default and are excluded from ordinary span attributes.
   `UsageDelta` carry cache-read and cache-write input tokens distinctly (with `inputTokens`
   remaining the total), and totals expose the most recent call's input/output tokens as the
   live-context estimate.
+- **CAP-018**: Page capture is deny-by-default: its immutable target-host allowlist governs
+  navigation, redirects, and subrequests; its action set, engine, and byte budget are fixed at
+  capability construction; browser execution remains `uncertain`; model inference requires
+  explicit host authorization and accounting; and every result is treated as untrusted input.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -371,8 +371,44 @@ made before measurement. Current Dynamic Workers billing counts no-ID `load()` u
 Dynamic Worker per invocation, and any future stable-ID Worker caching must include tenant and
 binding context in cache identity.
 
+### Browser Run Quick Action page capture
+
+The first `PageCapture` adapter (capability spec §9.2) is the Cloudflare Browser Run Quick
+Action Layer in `@effect-agent/platform-cloudflare` (`browserQuickActionCaptureLayer`). Each
+capture is one stateless `quickAction()` RPC on the Wrangler `browser` binding, supplied as a
+resolved constructor option (DEPLOY-010) and never read ambiently. Construction-time host
+patterns reach the binding as `allowRequestPattern`, restricting navigation, redirects, and
+subrequests alike. A capture-owned Scope reads response bytes incrementally, stops at the first
+chunk exceeding the request budget, and cancels and unlocks its reader on success, failure, or
+interruption. HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when
+conversion to milliseconds remains a safe integer.
+
+The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
+unless the host supplies `workersAi.authorizeAndAccount`; that Effect runs before the browser
+RPC, and successful results report `cloudflare-workers-ai` plus one model call alongside any
+`X-Browser-Ms-Used` observation. The adapter rejects typed the `kitesurf` engine the binding
+cannot select (the REST and CDP surfaces can; a REST adapter is a possible later slice).
+`quickAction()` requires a Worker compatibility date of `2026-03-24` or later and has no local
+implementation: local `wrangler dev` needs remote mode. Ordinary tests use a scripted binding
+inside workerd. An opt-in live smoke in the provider-owning `examples/providers` leaf additionally
+runs one real OpenAI-backed Agent through the production capability and adapter against
+Cloudflare's real `markdown` Quick Action. It reads Linear's public pricing page, compares two
+actual subscription prices, and prints a bounded page excerpt with the Agent's schema-validated
+recommendation. Its test-only Effect HTTP transport maps the binding contract onto the documented
+Quick Action REST endpoint, so the smoke needs no deployed Worker and does not invoke separately
+billed Workers AI extraction. It requires `EFFECT_AGENT_LIVE=1`, `OPENAI_API_KEY`,
+`CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_API_TOKEN`:
+
+```sh
+vp run --no-cache -F @effect-agent/example-providers test test/browser-live-smoke.test.ts --reporter=verbose
+```
+
+The adapter records no persistent state and claims deployment class `E` only.
+
 Current platform references:
 
+- [Browser Run Quick Actions](https://developers.cloudflare.com/browser-run/quick-actions/)
+- [Browser Run structured extraction and Workers AI](https://developers.cloudflare.com/browser-run/quick-actions/json-endpoint/)
 - [SQLite-backed Durable Object storage](https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/)
 - [Rules of Durable Objects](https://developers.cloudflare.com/durable-objects/best-practices/rules-of-durable-objects/)
 - [Durable Object alarms](https://developers.cloudflare.com/durable-objects/api/alarms/)
@@ -421,3 +457,8 @@ Current platform references:
 - **DEPLOY-013**: A Cloudflare host context-preparation Layer is acquired once per Object
   incarnation, runs only after canonical resume reconstruction, never replaces canonical history,
   and is reconstructible without process-global state.
+- **DEPLOY-014**: The Browser Run Quick Action page-capture adapter receives its binding as a
+  resolved option, applies the fixed browser-request allowlist, incrementally enforces the
+  response byte budget with scoped reader cleanup, keeps platform refusals and safe backoff
+  hints typed, denies Workers AI without explicit host authorization and accounting, and claims
+  deployment class `E` only.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -378,12 +378,17 @@ Action Layer in `@effect-agent/platform-cloudflare` (`browserQuickActionCaptureL
 capture is one stateless `quickAction()` RPC on the Wrangler `browser` binding. The host resolves
 that binding explicitly and supplies it through `BrowserQuickActionBrowserBinding.layer`; both
 capture Layers visibly require the resulting Effect service (DEPLOY-010) and never read ambiently.
+The Layer accepts Cloudflare's pinned native `BrowserRun` and exposes the four supported actions
+as Effect methods using the native option types, so incompatible Quick Action options fail
+compilation. Native Promise rejection becomes a typed binding RPC error before the capture adapter
+maps it into the `PageCapture` error union.
 Construction-time host patterns reach the binding as `allowRequestPattern`, restricting navigation,
 redirects, and subrequests alike. A capture-owned Scope reads response bytes incrementally and
 stops at the first chunk exceeding the request budget. It cancels and unlocks its reader on
 success, failure, or interruption. Response `Content-Type`, not attacker-controlled page text,
-identifies the
-Cloudflare JSON response envelope. Every returned link must satisfy the canonical bounded,
+identifies the Cloudflare JSON response envelope. A successful native binding response without
+that documented envelope fails typed instead of being reinterpreted as a REST payload. Every
+returned link must satisfy the canonical bounded,
 credential-free HTTP(S) link Schema; malformed entries, unsupported schemes, embedded credentials,
 and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
@@ -395,7 +400,9 @@ operation, quota, or HTTP-status descriptions and never expose foreign diagnosti
 The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
 unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies its visible
 `BrowserQuickActionWorkersAi` service. That service's `authorizeAndAccount` Effect runs before
-the browser RPC, and successful results report `cloudflare-workers-ai` plus one model call
+the browser RPC. Its narrow policy error maps to `PageCaptureInferencePolicyError` with a fixed
+public message; the host diagnostic remains only in the live cause. Successful results report
+`cloudflare-workers-ai` plus one model call
 alongside any `X-Browser-Ms-Used` observation. The ordinary
 `browserQuickActionCaptureLayer` has no Workers AI authority. The host-owned binding service
 keeps browser RPC authority visible in both adapter requirement channels, while the opt-in Layer

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -387,7 +387,9 @@ Cloudflare JSON response envelope. Every returned link must satisfy the canonica
 credential-free HTTP(S) link Schema; malformed entries, unsupported schemes, embedded credentials,
 and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
-milliseconds remains a safe integer.
+milliseconds remains a safe integer. Foreign browser RPC and response-stream failures retain
+their original cause inside the typed protocol error without exposing that cause to model-visible
+failure envelopes.
 
 The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
 unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies its visible

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -388,8 +388,9 @@ credential-free HTTP(S) link Schema; malformed entries, unsupported schemes, emb
 and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
 milliseconds remains a safe integer. Foreign browser RPC and response-stream failures retain
-their original cause inside the typed protocol error; model-visible messages and cleanup logs use
-fixed operation descriptions and never expose foreign diagnostic text.
+their original cause; provider envelope errors, rate-limit bodies, and non-success HTTP bodies
+remain bounded host-only diagnostics. Model-visible messages and cleanup logs use fixed
+operation, quota, or HTTP-status descriptions and never expose foreign diagnostic text.
 
 The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
 unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies its visible

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -383,8 +383,9 @@ redirects, and subrequests alike. A capture-owned Scope reads response bytes inc
 stops at the first chunk exceeding the request budget. It cancels and unlocks its reader on
 success, failure, or interruption. Response `Content-Type`, not attacker-controlled page text,
 identifies the
-Cloudflare JSON response envelope. Every returned link must satisfy the canonical bounded-link
-Schema; malformed entries and over-limit collections fail typed instead of being discarded.
+Cloudflare JSON response envelope. Every returned link must satisfy the canonical bounded,
+credential-free HTTP(S) link Schema; malformed entries, unsupported schemes, embedded credentials,
+and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
 milliseconds remains a safe integer.
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -375,12 +375,14 @@ binding context in cache identity.
 
 The first `PageCapture` adapter (capability spec §9.2) is the Cloudflare Browser Run Quick
 Action Layer in `@effect-agent/platform-cloudflare` (`browserQuickActionCaptureLayer`). Each
-capture is one stateless `quickAction()` RPC on the Wrangler `browser` binding, supplied as a
-resolved constructor option (DEPLOY-010) and never read ambiently. Construction-time host
-patterns reach the binding as `allowRequestPattern`, restricting navigation, redirects, and
-subrequests alike. A capture-owned Scope reads response bytes incrementally, stops at the first
-chunk exceeding the request budget, and cancels and unlocks its reader on success, failure, or
-interruption. Response `Content-Type`, not attacker-controlled page text, identifies the
+capture is one stateless `quickAction()` RPC on the Wrangler `browser` binding. The host resolves
+that binding explicitly and supplies it through `BrowserQuickActionBrowserBinding.layer`; both
+capture Layers visibly require the resulting Effect service (DEPLOY-010) and never read ambiently.
+Construction-time host patterns reach the binding as `allowRequestPattern`, restricting navigation,
+redirects, and subrequests alike. A capture-owned Scope reads response bytes incrementally and
+stops at the first chunk exceeding the request budget. It cancels and unlocks its reader on
+success, failure, or interruption. Response `Content-Type`, not attacker-controlled page text,
+identifies the
 Cloudflare JSON response envelope. Every returned link must satisfy the canonical bounded-link
 Schema; malformed entries and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
@@ -391,10 +393,10 @@ unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies i
 `BrowserQuickActionWorkersAi` service. That service's `authorizeAndAccount` Effect runs before
 the browser RPC, and successful results report `cloudflare-workers-ai` plus one model call
 alongside any `X-Browser-Ms-Used` observation. The ordinary
-`browserQuickActionCaptureLayer` has no Workers AI authority. Both Layers receive the browser
-binding as the explicit resolved constructor value required by DEPLOY-014. The adapter rejects
-typed the `kitesurf` engine the binding cannot select (the REST and CDP surfaces can; a REST
-adapter is a possible later slice).
+`browserQuickActionCaptureLayer` has no Workers AI authority. The host-owned binding service
+keeps browser RPC authority visible in both adapter requirement channels, while the opt-in Layer
+also requires Workers AI authority. The adapter rejects typed the `kitesurf` engine the binding
+cannot select (the REST and CDP surfaces can; a REST adapter is a possible later slice).
 `quickAction()` requires a Worker compatibility date of `2026-03-24` or later and has no local
 implementation: local `wrangler dev` needs remote mode. Ordinary tests use a scripted binding
 inside workerd. An opt-in live smoke in the provider-owning `examples/providers` leaf additionally
@@ -464,9 +466,9 @@ Current platform references:
 - **DEPLOY-013**: A Cloudflare host context-preparation Layer is acquired once per Object
   incarnation, runs only after canonical resume reconstruction, never replaces canonical history,
   and is reconstructible without process-global state.
-- **DEPLOY-014**: The Browser Run Quick Action page-capture adapter receives its binding as a
-  resolved option, applies the fixed browser-request allowlist, incrementally enforces the
-  response byte budget with scoped reader cleanup, distinguishes response envelopes by trusted
-  metadata, rejects malformed link payloads, keeps platform refusals and safe backoff hints
-  typed, denies Workers AI without its explicit host authorization and accounting service, and
-  claims deployment class `E` only.
+- **DEPLOY-014**: The Browser Run Quick Action page-capture adapter visibly requires the
+  host-provided service for an explicitly resolved browser binding, applies the fixed
+  browser-request allowlist, incrementally enforces the response byte budget with scoped reader
+  cleanup, distinguishes response envelopes by trusted metadata, rejects malformed link
+  payloads, keeps platform refusals and safe backoff hints typed, denies Workers AI without its
+  explicit host authorization and accounting service, and claims deployment class `E` only.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -380,14 +380,21 @@ resolved constructor option (DEPLOY-010) and never read ambiently. Construction-
 patterns reach the binding as `allowRequestPattern`, restricting navigation, redirects, and
 subrequests alike. A capture-owned Scope reads response bytes incrementally, stops at the first
 chunk exceeding the request budget, and cancels and unlocks its reader on success, failure, or
-interruption. HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when
-conversion to milliseconds remains a safe integer.
+interruption. Response `Content-Type`, not attacker-controlled page text, identifies the
+Cloudflare JSON response envelope. Every returned link must satisfy the canonical bounded-link
+Schema; malformed entries and over-limit collections fail typed instead of being discarded.
+HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
+milliseconds remains a safe integer.
 
 The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
-unless the host supplies `workersAi.authorizeAndAccount`; that Effect runs before the browser
-RPC, and successful results report `cloudflare-workers-ai` plus one model call alongside any
-`X-Browser-Ms-Used` observation. The adapter rejects typed the `kitesurf` engine the binding
-cannot select (the REST and CDP surfaces can; a REST adapter is a possible later slice).
+unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies its visible
+`BrowserQuickActionWorkersAi` service. That service's `authorizeAndAccount` Effect runs before
+the browser RPC, and successful results report `cloudflare-workers-ai` plus one model call
+alongside any `X-Browser-Ms-Used` observation. The ordinary
+`browserQuickActionCaptureLayer` has no Workers AI authority. Both Layers receive the browser
+binding as the explicit resolved constructor value required by DEPLOY-014. The adapter rejects
+typed the `kitesurf` engine the binding cannot select (the REST and CDP surfaces can; a REST
+adapter is a possible later slice).
 `quickAction()` requires a Worker compatibility date of `2026-03-24` or later and has no local
 implementation: local `wrangler dev` needs remote mode. Ordinary tests use a scripted binding
 inside workerd. An opt-in live smoke in the provider-owning `examples/providers` leaf additionally
@@ -459,6 +466,7 @@ Current platform references:
   and is reconstructible without process-global state.
 - **DEPLOY-014**: The Browser Run Quick Action page-capture adapter receives its binding as a
   resolved option, applies the fixed browser-request allowlist, incrementally enforces the
-  response byte budget with scoped reader cleanup, keeps platform refusals and safe backoff
-  hints typed, denies Workers AI without explicit host authorization and accounting, and claims
-  deployment class `E` only.
+  response byte budget with scoped reader cleanup, distinguishes response envelopes by trusted
+  metadata, rejects malformed link payloads, keeps platform refusals and safe backoff hints
+  typed, denies Workers AI without its explicit host authorization and accounting service, and
+  claims deployment class `E` only.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -388,8 +388,8 @@ credential-free HTTP(S) link Schema; malformed entries, unsupported schemes, emb
 and over-limit collections fail typed instead of being discarded.
 HTTP 429 becomes a typed rate/quota failure; `Retry-After` is included only when conversion to
 milliseconds remains a safe integer. Foreign browser RPC and response-stream failures retain
-their original cause inside the typed protocol error without exposing that cause to model-visible
-failure envelopes.
+their original cause inside the typed protocol error; model-visible messages and cleanup logs use
+fixed operation descriptions and never expose foreign diagnostic text.
 
 The `json` Quick Action uses Cloudflare's separately billed Workers AI provider. It fails closed
 unless the host selects `browserQuickActionWorkersAiCaptureLayer` and supplies its visible

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -63,7 +63,9 @@ Platform capabilities that invoke a different provider remain explicit too. Brow
 structured extraction must not silently select Workers AI or bypass the host's provider policy:
 both browser adapters require the visible `BrowserQuickActionBrowserBinding` service, and the
 opt-in extraction adapter additionally requires `BrowserQuickActionWorkersAi` for host-owned
-authorization and accounting before inference. Successful extraction records the provider and
+authorization and accounting before inference. A policy refusal remains a typed
+`PageCaptureInferencePolicyError`, distinct from browser navigation and protocol failures.
+Successful extraction records the provider and
 model-call count in its capture result.
 
 ## 3. Prompt and Response

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -59,6 +59,11 @@ provenance in declaration, progress, and terminal semantic events, but does not 
 `ToolCallStarted`: no application handler entered the framework scheduler. Provider-executed calls
 still consume the Agent's Tool Call budget and may require another Turn before final output.
 
+Platform capabilities that invoke a different provider remain explicit too. Browser-side
+structured extraction must not silently select Workers AI or bypass the host's provider policy:
+the adapter requires host-owned authorization and accounting before inference and records the
+provider and model-call count in its capture result.
+
 ## 3. Prompt and Response
 
 Effect AI `Prompt.Prompt` is the model-facing conversation representation.

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -61,8 +61,9 @@ still consume the Agent's Tool Call budget and may require another Turn before f
 
 Platform capabilities that invoke a different provider remain explicit too. Browser-side
 structured extraction must not silently select Workers AI or bypass the host's provider policy:
-the adapter requires host-owned authorization and accounting before inference and records the
-provider and model-call count in its capture result.
+the opt-in extraction adapter requires the visible `BrowserQuickActionWorkersAi` service for
+host-owned authorization and accounting before inference, and records the provider and
+model-call count in its capture result.
 
 ## 3. Prompt and Response
 

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -61,8 +61,9 @@ still consume the Agent's Tool Call budget and may require another Turn before f
 
 Platform capabilities that invoke a different provider remain explicit too. Browser-side
 structured extraction must not silently select Workers AI or bypass the host's provider policy:
-the opt-in extraction adapter requires the visible `BrowserQuickActionWorkersAi` service for
-host-owned authorization and accounting before inference, and records the provider and
+both browser adapters require the visible `BrowserQuickActionBrowserBinding` service, and the
+opt-in extraction adapter additionally requires `BrowserQuickActionWorkersAi` for host-owned
+authorization and accounting before inference. Successful extraction records the provider and
 model-call count in its capture result.
 
 ## 3. Prompt and Response

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -173,9 +173,11 @@ or included in an executor binding, and the deterministic test substitute identi
 `unisolated` rather than masquerading as a boundary.
 
 Page capture output is a rendered web page and therefore untrusted, attacker-influenced input.
-The capture capability is deny-by-default: an immutable construction-time https host allowlist
-governs navigation, redirects, and every browser subrequest; credentials never ride in capture
-requests; and responses are byte-bounded before buffering. Rendered JavaScript may mutate
+The capture capability is deny-by-default: an immutable construction-time HTTPS host allowlist
+governs navigation, redirects, and every browser subrequest. The request Schema rejects malformed
+URLs, non-HTTPS targets, and embedded credentials; discovered links must be absolute,
+credential-free HTTP(S) URLs and grant no navigation authority. Responses are byte-bounded before
+buffering. Rendered JavaScript may mutate
 remote state, so capture Tools remain `uncertain`, are not automatically replayed, and cannot
 enter readonly-only Code Mode. Structured extraction accepts only a bounded object JSON Schema;
 the request rejects malformed or unsupported root and nested keywords, excessive encoded bytes,

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -185,7 +185,8 @@ excessive depth, oversized collections, and cycles before any provider can run. 
 authority is an explicit host-owned service. Extraction additionally requires an explicit
 host authorization and accounting service for any platform-selected model provider, and results
 are decoded through the caller's service-aware Effect Schema before use. Foreign provider failure
-causes remain host-only diagnostics; model-visible failures carry only bounded tags and messages.
+causes remain host-only diagnostics; model-visible failures and cleanup logs carry only bounded,
+fixed operation descriptions and never interpolate foreign exception text.
 A page that instructs the model is data, never authority.
 
 The read-only SQL reference Tool's guarantee is database authority, not SQL text inspection: a

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -186,7 +186,8 @@ authority is an explicit host-owned service. Extraction additionally requires an
 host authorization and accounting service for any platform-selected model provider, and results
 are decoded through the caller's service-aware Effect Schema before use. Foreign provider failure
 causes remain host-only diagnostics; model-visible failures and cleanup logs carry only bounded,
-fixed operation descriptions and never interpolate foreign exception text.
+fixed operation or HTTP-status descriptions and never interpolate foreign exception text,
+rate-limit bodies, provider envelopes, or other remote error bodies.
 A page that instructs the model is data, never authority.
 
 The read-only SQL reference Tool's guarantee is database authority, not SQL text inspection: a

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -184,8 +184,9 @@ the request rejects malformed or unsupported root and nested keywords, excessive
 excessive depth, oversized collections, and cycles before any provider can run. Browser RPC
 authority is an explicit host-owned service. Extraction additionally requires an explicit
 host authorization and accounting service for any platform-selected model provider, and results
-are decoded through the caller's service-aware Effect Schema before use. A page that instructs
-the model is data, never authority.
+are decoded through the caller's service-aware Effect Schema before use. Foreign provider failure
+causes remain host-only diagnostics; model-visible failures carry only bounded tags and messages.
+A page that instructs the model is data, never authority.
 
 The read-only SQL reference Tool's guarantee is database authority, not SQL text inspection: a
 database identity without mutation, DDL, administrative, or extension privileges; denial of

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -177,10 +177,12 @@ The capture capability is deny-by-default: an immutable construction-time https 
 governs navigation, redirects, and every browser subrequest; credentials never ride in capture
 requests; and responses are byte-bounded before buffering. Rendered JavaScript may mutate
 remote state, so capture Tools remain `uncertain`, are not automatically replayed, and cannot
-enter readonly-only Code Mode. Structured extractions require explicit host authorization and
-accounting for any platform-selected model provider and are decoded through the caller's
-service-aware Effect Schema before use. A page that instructs the model is data, never
-authority.
+enter readonly-only Code Mode. Structured extraction accepts only a bounded object JSON Schema;
+the request rejects malformed nested schema nodes, excessive encoded bytes, excessive depth,
+oversized collections, and cycles before any provider can run. Extraction requires an explicit
+host authorization and accounting service for any platform-selected model provider, and results
+are decoded through the caller's service-aware Effect Schema before use. A page that instructs
+the model is data, never authority.
 
 The read-only SQL reference Tool's guarantee is database authority, not SQL text inspection: a
 database identity without mutation, DDL, administrative, or extension privileges; denial of

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -185,7 +185,9 @@ excessive depth, oversized collections, and cycles before any provider can run. 
 authority is an explicit host-owned service. Extraction additionally requires an explicit
 host authorization and accounting service for any platform-selected model provider, and results
 are decoded through the caller's service-aware Effect Schema before use. Foreign provider failure
-causes remain host-only diagnostics; model-visible failures and cleanup logs carry only bounded,
+causes and inference-policy diagnostics remain host-only; the typed public policy error identifies
+the provider and authorization or accounting step without copying the host's message.
+Model-visible failures and cleanup logs carry only bounded,
 fixed operation or HTTP-status descriptions and never interpolate foreign exception text,
 rate-limit bodies, provider envelopes, or other remote error bodies.
 A page that instructs the model is data, never authority.

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -172,6 +172,16 @@ least-authority bindings, and enforced limits are. No raw secret may be returned
 or included in an executor binding, and the deterministic test substitute identifies itself as
 `unisolated` rather than masquerading as a boundary.
 
+Page capture output is a rendered web page and therefore untrusted, attacker-influenced input.
+The capture capability is deny-by-default: an immutable construction-time https host allowlist
+governs navigation, redirects, and every browser subrequest; credentials never ride in capture
+requests; and responses are byte-bounded before buffering. Rendered JavaScript may mutate
+remote state, so capture Tools remain `uncertain`, are not automatically replayed, and cannot
+enter readonly-only Code Mode. Structured extractions require explicit host authorization and
+accounting for any platform-selected model provider and are decoded through the caller's
+service-aware Effect Schema before use. A page that instructs the model is data, never
+authority.
+
 The read-only SQL reference Tool's guarantee is database authority, not SQL text inspection: a
 database identity without mutation, DDL, administrative, or extension privileges; denial of
 side-effecting functions reachable from a `SELECT`, including installed extensions and

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -178,8 +178,9 @@ governs navigation, redirects, and every browser subrequest; credentials never r
 requests; and responses are byte-bounded before buffering. Rendered JavaScript may mutate
 remote state, so capture Tools remain `uncertain`, are not automatically replayed, and cannot
 enter readonly-only Code Mode. Structured extraction accepts only a bounded object JSON Schema;
-the request rejects malformed nested schema nodes, excessive encoded bytes, excessive depth,
-oversized collections, and cycles before any provider can run. Extraction requires an explicit
+the request rejects malformed or unsupported root and nested keywords, excessive encoded bytes,
+excessive depth, oversized collections, and cycles before any provider can run. Browser RPC
+authority is an explicit host-owned service. Extraction additionally requires an explicit
 host authorization and accounting service for any platform-selected model provider, and results
 are decoded through the caller's service-aware Effect Schema before use. A page that instructs
 the model is data, never authority.

--- a/examples/providers/package.json
+++ b/examples/providers/package.json
@@ -12,6 +12,7 @@
     "@effect-agent/capabilities": "workspace:*",
     "@effect-agent/core": "workspace:*",
     "@effect-agent/engine": "workspace:*",
+    "@effect-agent/platform-cloudflare": "workspace:*",
     "@effect-agent/testing": "workspace:*",
     "@effect/ai-anthropic": "catalog:",
     "@effect/ai-openai": "catalog:",

--- a/examples/providers/test/browser-live-smoke.test.ts
+++ b/examples/providers/test/browser-live-smoke.test.ts
@@ -3,8 +3,9 @@ import { Agent, AgentPolicy, IdGenerator } from "@effect-agent/core";
 import { AgentRuntime } from "@effect-agent/engine";
 import {
   BrowserQuickActionBrowserBinding,
+  BrowserQuickActionRpcError,
   browserQuickActionCaptureLayer,
-  type BrowserQuickActionBinding,
+  type BrowserQuickActionClient,
 } from "@effect-agent/platform-cloudflare/browser-quick-action";
 import { PHASE7_LIVE_CREDENTIAL_ENV, phase7LiveProfileEnabled } from "@effect-agent/testing";
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
@@ -28,35 +29,54 @@ const liveEnabled =
   (process.env[CLOUDFLARE_TOKEN_ENV] ?? "") !== "";
 
 interface RecordedQuickAction {
-  readonly action: string;
+  readonly action: "content" | "markdown" | "links" | "json";
   readonly options: Record<string, unknown>;
 }
 
-/** The platform binding is Promise-shaped; keep that boundary outside the Effect HTTP workflow. */
+/** Map the REST smoke transport onto the Effect-native binding client. */
 const makeLiveBrowserBinding = Effect.gen(function* () {
   const accountId = yield* Config.nonEmptyString(CLOUDFLARE_ACCOUNT_ENV);
   const apiToken = yield* Config.redacted(CLOUDFLARE_TOKEN_ENV);
   const client = yield* HttpClient.HttpClient;
   const calls = yield* Ref.make<ReadonlyArray<RecordedQuickAction>>([]);
 
-  const binding: BrowserQuickActionBinding = {
-    quickAction: (action, options) =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          yield* Ref.update(calls, (previous) => [...previous, { action, options }]);
+  const runQuickAction = Effect.fn("BrowserLiveSmoke.runQuickAction")(function* (
+    action: RecordedQuickAction["action"],
+    options: object,
+  ): Effect.fn.Return<Response, BrowserQuickActionRpcError> {
+    const rpcError = (cause: unknown) => BrowserQuickActionRpcError.make({ action, cause });
+    yield* Ref.update(calls, (previous) => [...previous, { action, options: { ...options } }]);
 
-          const request = yield* HttpClientRequest.post(
-            `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/browser-rendering/${encodeURIComponent(action)}`,
-          ).pipe(HttpClientRequest.bearerToken(apiToken), HttpClientRequest.bodyJson(options));
-          const response = yield* client.execute(request);
-          const body = yield* Stream.toReadableStreamEffect(response.stream);
+    const request = yield* HttpClientRequest.post(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/browser-rendering/${encodeURIComponent(action)}`,
+    ).pipe(
+      HttpClientRequest.bearerToken(apiToken),
+      HttpClientRequest.bodyJson(options),
+      Effect.mapError(rpcError),
+    );
+    const response = yield* client.execute(request).pipe(Effect.mapError(rpcError));
+    const rawBody = yield* response.text.pipe(Effect.mapError(rpcError));
+    const contentType = response.headers["content-type"]?.toLowerCase() ?? "";
+    const wrapTextResult =
+      response.status >= 200 &&
+      response.status < 300 &&
+      (action === "content" || action === "markdown") &&
+      !contentType.includes("application/json");
+    const body = wrapTextResult ? JSON.stringify({ success: true, result: rawBody }) : rawBody;
 
-          return new Response(body, {
-            status: response.status,
-            headers: response.headers,
-          });
-        }),
-      ),
+    return new Response(body, {
+      status: response.status,
+      headers: {
+        ...response.headers,
+        ...(wrapTextResult ? { "content-type": "application/json" } : {}),
+      },
+    });
+  });
+  const binding: BrowserQuickActionClient = {
+    content: (options) => runQuickAction("content", options),
+    markdown: (options) => runQuickAction("markdown", options),
+    links: (options) => runQuickAction("links", options),
+    json: (options) => runQuickAction("json", options),
   };
 
   return { binding, calls };
@@ -133,7 +153,7 @@ describe.skipIf(!liveEnabled)("Browser Run live smoke (opt-in)", () => {
           const browserHandlers = readWebpage.handlers.pipe(
             Layer.provide(
               browserQuickActionCaptureLayer().pipe(
-                Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: browser.binding })),
+                Layer.provide(Layer.succeed(BrowserQuickActionBrowserBinding)(browser.binding)),
               ),
             ),
           );

--- a/examples/providers/test/browser-live-smoke.test.ts
+++ b/examples/providers/test/browser-live-smoke.test.ts
@@ -1,0 +1,210 @@
+import { WebCapture, WebCaptureSuccess } from "@effect-agent/capabilities";
+import { Agent, AgentPolicy, IdGenerator } from "@effect-agent/core";
+import { AgentRuntime } from "@effect-agent/engine";
+import {
+  browserQuickActionCaptureLayer,
+  type BrowserQuickActionBinding,
+} from "@effect-agent/platform-cloudflare/browser-quick-action";
+import { PHASE7_LIVE_CREDENTIAL_ENV, phase7LiveProfileEnabled } from "@effect-agent/testing";
+import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
+import { Config, Console, Effect, Layer, Ref, Schema, Stream } from "effect";
+import { Toolkit } from "effect/unstable/ai";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { describe, expect, it } from "vite-plus/test";
+
+const CLOUDFLARE_ACCOUNT_ENV = "CLOUDFLARE_ACCOUNT_ID";
+const CLOUDFLARE_TOKEN_ENV = "CLOUDFLARE_API_TOKEN";
+const PRICING_URL = "https://linear.app/pricing";
+const FIRST_PLAN = "Basic";
+const SECOND_PLAN = "Business";
+const OPENAI_MODEL = "gpt-5.6-luna";
+const REASONING_EFFORT = "medium";
+const SERVICE_TIER = "fast";
+
+const liveEnabled =
+  phase7LiveProfileEnabled(process.env) &&
+  (process.env[CLOUDFLARE_ACCOUNT_ENV] ?? "") !== "" &&
+  (process.env[CLOUDFLARE_TOKEN_ENV] ?? "") !== "";
+
+interface RecordedQuickAction {
+  readonly action: string;
+  readonly options: Record<string, unknown>;
+}
+
+/** The platform binding is Promise-shaped; keep that boundary outside the Effect HTTP workflow. */
+const makeLiveBrowserBinding = Effect.gen(function* () {
+  const accountId = yield* Config.nonEmptyString(CLOUDFLARE_ACCOUNT_ENV);
+  const apiToken = yield* Config.redacted(CLOUDFLARE_TOKEN_ENV);
+  const client = yield* HttpClient.HttpClient;
+  const calls = yield* Ref.make<ReadonlyArray<RecordedQuickAction>>([]);
+
+  const binding: BrowserQuickActionBinding = {
+    quickAction: (action, options) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          yield* Ref.update(calls, (previous) => [...previous, { action, options }]);
+
+          const request = yield* HttpClientRequest.post(
+            `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/browser-rendering/${encodeURIComponent(action)}`,
+          ).pipe(HttpClientRequest.bearerToken(apiToken), HttpClientRequest.bodyJson(options));
+          const response = yield* client.execute(request);
+          const body = yield* Stream.toReadableStreamEffect(response.stream);
+
+          return new Response(body, {
+            status: response.status,
+            headers: response.headers,
+          });
+        }),
+      ),
+  };
+
+  return { binding, calls };
+});
+
+const PricingPlan = Schema.Struct({
+  name: Schema.NonEmptyString.check(Schema.isMaxLength(64)),
+  monthlyUsdPerUser: Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0)),
+  billingTerms: Schema.NonEmptyString.check(Schema.isMaxLength(128)),
+});
+
+const PricingComparison = Schema.Struct({
+  company: Schema.NonEmptyString.check(Schema.isMaxLength(128)),
+  plans: Schema.Array(PricingPlan).check(Schema.isMinLength(2), Schema.isMaxLength(2)),
+  cheaperPlan: Schema.NonEmptyString.check(Schema.isMaxLength(64)),
+  monthlySavingsUsdPerUser: Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0)),
+  recommendation: Schema.NonEmptyString.check(Schema.isMaxLength(2_048)),
+});
+
+const readWebpage = WebCapture.make("read_webpage", {
+  description: "Render Linear's public pricing page and return its Markdown.",
+  urls: ["linear.app"],
+  actions: ["markdown"],
+  maxResponseBytes: 32 * 1024,
+});
+
+const BrowserResearcher = Agent.withModel(
+  Agent.define("live-pricing-researcher", {
+    input: Schema.Struct({
+      url: Schema.NonEmptyString,
+      firstPlan: Schema.NonEmptyString,
+      secondPlan: Schema.NonEmptyString,
+    }),
+    output: PricingComparison,
+    instructions:
+      "You must call read_webpage exactly once with the input URL and action markdown. " +
+      "Use the returned public pricing page to identify the two requested plans. " +
+      "Return the company, exactly those two plan names, their actual monthly USD price per " +
+      "user, and their stated billing terms. Name the cheaper plan, calculate its monthly " +
+      "savings per user, and explain the recommendation without inventing prices. " +
+      "Keep the recommendation to one sentence under 240 characters.",
+    toolkit: Toolkit.make(readWebpage.tool),
+    policy: AgentPolicy.make({
+      maxTurns: 3,
+      maxToolCalls: 1,
+      maxDuration: "90 seconds",
+      toolConcurrency: 1,
+    }),
+  }),
+  OpenAiLanguageModel.model(OPENAI_MODEL, {
+    reasoning: { effort: REASONING_EFFORT },
+    service_tier: SERVICE_TIER,
+  }),
+);
+
+const OpenAiClientLayer = OpenAiClient.layerConfig({
+  apiKey: Config.redacted(PHASE7_LIVE_CREDENTIAL_ENV),
+}).pipe(Layer.provide(FetchHttpClient.layer));
+
+const BrowserSmokeLayer = Layer.mergeAll(
+  IdGenerator.layer,
+  OpenAiClientLayer,
+  FetchHttpClient.layer,
+);
+
+describe.skipIf(!liveEnabled)("Browser Run live smoke (opt-in)", () => {
+  it(
+    "compares real Linear subscription prices through OpenAI and Cloudflare Browser Run",
+    { timeout: 120_000 },
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const browser = yield* makeLiveBrowserBinding;
+          const browserHandlers = readWebpage.handlers.pipe(
+            Layer.provide(browserQuickActionCaptureLayer({ browser: browser.binding })),
+          );
+          const events = yield* AgentRuntime.stream(BrowserResearcher, {
+            url: PRICING_URL,
+            firstPlan: FIRST_PLAN,
+            secondPlan: SECOND_PLAN,
+          }).pipe(Stream.runCollect, Effect.provide(browserHandlers));
+
+          const toolResults = events.filter((event) => event._tag === "ToolCallSucceeded");
+
+          expect(toolResults.length).toBe(1);
+          expect(toolResults[0]?.toolName).toBe("read_webpage");
+
+          const capturedPage = yield* Schema.decodeUnknownEffect(WebCaptureSuccess)(
+            toolResults[0]?.result,
+          );
+
+          expect(capturedPage.url).toBe(PRICING_URL);
+          expect(capturedPage.action).toBe("markdown");
+          expect(capturedPage.markdown?.includes(FIRST_PLAN)).toBe(true);
+          expect(capturedPage.markdown?.includes(SECOND_PLAN)).toBe(true);
+
+          const completed = events.filter((event) => event._tag === "RunCompleted");
+
+          expect(completed.length).toBe(1);
+
+          const answer = yield* Schema.decodeUnknownEffect(PricingComparison)(completed[0]?.output);
+          const firstPlan = answer.plans.find((plan) => plan.name === FIRST_PLAN);
+          const secondPlan = answer.plans.find((plan) => plan.name === SECOND_PLAN);
+          const firstPrice = firstPlan?.monthlyUsdPerUser ?? Number.NaN;
+          const secondPrice = secondPlan?.monthlyUsdPerUser ?? Number.NaN;
+
+          expect(answer.company.toLowerCase()).toBe("linear");
+          expect(firstPrice).toBeGreaterThan(0);
+          expect(secondPrice).toBeGreaterThan(firstPrice);
+          expect(capturedPage.markdown?.includes(`$${String(firstPrice)}`)).toBe(true);
+          expect(capturedPage.markdown?.includes(`$${String(secondPrice)}`)).toBe(true);
+          expect(answer.cheaperPlan).toBe(FIRST_PLAN);
+          expect(answer.monthlySavingsUsdPerUser).toBeCloseTo(secondPrice - firstPrice, 2);
+
+          const calls = yield* Ref.get(browser.calls);
+
+          expect(calls.length).toBe(1);
+          expect(calls[0]?.action).toBe("markdown");
+          expect(calls[0]?.options.url).toBe(PRICING_URL);
+          expect(calls[0]?.options.allowRequestPattern).toEqual([
+            "^https://linear\\.app(?::[0-9]+)?(?:[/?#]|$)",
+          ]);
+
+          yield* Console.log(
+            "\nCloudflare Browser Run result:",
+            JSON.stringify(
+              {
+                url: capturedPage.url,
+                action: capturedPage.action,
+                markdown: capturedPage.markdown?.slice(0, 2_048),
+              },
+              null,
+              2,
+            ),
+          );
+          yield* Console.log(
+            "\nOpenAI pricing comparison:",
+            JSON.stringify(
+              {
+                model: OPENAI_MODEL,
+                reasoningEffort: REASONING_EFFORT,
+                serviceTier: SERVICE_TIER,
+                comparison: answer,
+              },
+              null,
+              2,
+            ),
+          );
+        }).pipe(Effect.scoped, Effect.provide(BrowserSmokeLayer)),
+      ),
+  );
+});

--- a/examples/providers/test/browser-live-smoke.test.ts
+++ b/examples/providers/test/browser-live-smoke.test.ts
@@ -2,6 +2,7 @@ import { WebCapture, WebCaptureSuccess } from "@effect-agent/capabilities";
 import { Agent, AgentPolicy, IdGenerator } from "@effect-agent/core";
 import { AgentRuntime } from "@effect-agent/engine";
 import {
+  BrowserQuickActionBrowserBinding,
   browserQuickActionCaptureLayer,
   type BrowserQuickActionBinding,
 } from "@effect-agent/platform-cloudflare/browser-quick-action";
@@ -130,7 +131,11 @@ describe.skipIf(!liveEnabled)("Browser Run live smoke (opt-in)", () => {
         Effect.gen(function* () {
           const browser = yield* makeLiveBrowserBinding;
           const browserHandlers = readWebpage.handlers.pipe(
-            Layer.provide(browserQuickActionCaptureLayer({ browser: browser.binding })),
+            Layer.provide(
+              browserQuickActionCaptureLayer().pipe(
+                Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: browser.binding })),
+              ),
+            ),
           );
           const events = yield* AgentRuntime.stream(BrowserResearcher, {
             url: PRICING_URL,

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -10,3 +10,4 @@ export * from "./redaction.ts";
 export * from "./scheduling.ts";
 export * from "./subagent.ts";
 export * from "./subagent-reservation.ts";
+export * from "./web-capture.ts";

--- a/packages/capabilities/src/web-capture.ts
+++ b/packages/capabilities/src/web-capture.ts
@@ -331,6 +331,7 @@ const portFailure = (error: PageCaptureError): WebCaptureFailure => {
       );
     }
     case "PageCaptureNavigationError":
+    case "PageCaptureInferencePolicyError":
     case "PageCaptureProtocolError":
     case "PageCaptureUnsupportedError": {
       return failure(error._tag, error.message);

--- a/packages/capabilities/src/web-capture.ts
+++ b/packages/capabilities/src/web-capture.ts
@@ -7,6 +7,7 @@ import {
   PageCapture,
   PageCaptureLimits,
   PageCaptureRequest,
+  PageCaptureResponseFormat,
   PageResourcePolicy,
   PageUrlTarget,
   type PageCaptureAction,
@@ -99,7 +100,8 @@ export type WebCaptureExtractTool<Name extends string, S extends Schema.Top> = T
     readonly success: S;
     readonly failure: typeof WebCaptureFailure;
     readonly failureMode: "return";
-  }
+  },
+  S["DecodingServices"]
 >;
 
 /** Singleton Tool record provided by one web-capture handler Layer. */
@@ -181,7 +183,7 @@ export interface WebCaptureExtractDefinition<Name extends string, S extends Sche
   readonly engine: PageCaptureEngine;
   readonly maxResponseBytes: number;
   /** The JSON Schema document derived from the extraction Schema. */
-  readonly responseFormat: Schema.Json;
+  readonly responseFormat: PageCaptureResponseFormat;
   readonly tool: WebCaptureExtractTool<Name, S>;
   readonly handlers: Layer.Layer<
     Tool.HandlersFor<WebCaptureExtractTools<Name, S>>,
@@ -490,12 +492,12 @@ const makeExtract = <const Name extends string, S extends Schema.Top>(
   // The derived JSON Schema is BOTH the platform-side response format and
   // documentation that the deriver can express the Schema at all; anything it
   // cannot derive fails construction closed rather than degrading at runtime.
-  const derived = ((): Schema.Json => {
+  const derived = ((): PageCaptureResponseFormat => {
     const jsonSchema = Tool.getJsonSchemaFromSchema(options.schema);
-    const decoded = Schema.decodeUnknownOption(Schema.Json)(jsonSchema);
+    const decoded = Schema.decodeUnknownOption(PageCaptureResponseFormat)(jsonSchema);
     if (Option.isNone(decoded)) {
       throw new Error(
-        `Web capture cannot derive a JSON response format from the extraction Schema for ${name}`,
+        `Web capture cannot derive a bounded object JSON response format from the extraction Schema for ${name}`,
       );
     }
     return decoded.value;
@@ -522,7 +524,6 @@ const makeExtract = <const Name extends string, S extends Schema.Top>(
 
   const build = Effect.gen(function* () {
     const pageCapture = yield* PageCapture;
-    const schemaServices = yield* Effect.context<S["DecodingServices"]>();
 
     const invoke = Effect.fn(`WebCapture.${name}`)(function* (parameters: {
       readonly url: string;
@@ -554,7 +555,6 @@ const makeExtract = <const Name extends string, S extends Schema.Top>(
       // The platform's extraction is untrusted; only the original Effect
       // Schema decides whether the value is the promised shape.
       return yield* decodeExtracted(result.output.value).pipe(
-        Effect.provideContext(schemaServices),
         Effect.catch((error) =>
           Effect.fail(
             failure(

--- a/packages/capabilities/src/web-capture.ts
+++ b/packages/capabilities/src/web-capture.ts
@@ -1,0 +1,598 @@
+import { ToolExecutionClass as ToolExecutionClassAnnotation } from "@effect-agent/engine";
+import {
+  CapturePageContent,
+  CapturePageLinks,
+  CapturePageMarkdown,
+  CapturePageStructured,
+  PageCapture,
+  PageCaptureLimits,
+  PageCaptureRequest,
+  PageResourcePolicy,
+  PageUrlTarget,
+  type PageCaptureAction,
+  type PageCaptureEngine,
+  type PageCaptureError,
+} from "@effect-agent/sandbox";
+import { Effect, Option, Schema, type Layer } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+/**
+ * Web capture (capability spec §9.2): native Effect AI Tools over the
+ * stateless `PageCapture` port. The builders follow the Delegation pattern:
+ * every security-relevant choice — the host allowlist, the action set, the
+ * engine, the response byte budget — is fixed at construction and never
+ * model-selectable. Construction fails closed on an invalid policy. The
+ * handler Layer's `PageCapture` and Schema-decoding requirements stay
+ * visible in `R`.
+ *
+ * Everything a capture returns is untrusted, attacker-influenced content
+ * (security spec §9); results are bounded here and pass through the engine's
+ * ordinary result redaction like any other Tool output.
+ */
+
+const maxFailureTextLength = 4 * 1024;
+const BoundedFailureText = Schema.String.check(Schema.isMaxLength(maxFailureTextLength));
+const BoundedErrorTag = Schema.NonEmptyString.check(Schema.isMaxLength(256));
+const BoundedUrl = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
+const BoundedContent = Schema.String.check(Schema.isMaxLength(1024 * 1024));
+
+/** The model-selectable capture actions the first slice exposes. */
+export const WebCaptureAction = Schema.Literals(["markdown", "content", "links"]);
+export type WebCaptureAction = typeof WebCaptureAction.Type;
+
+/** Model-decoded parameters: one absolute https URL plus one capture action. */
+export const WebCaptureParameters = Schema.Struct({
+  url: BoundedUrl,
+  action: WebCaptureAction,
+});
+
+/** Model-decoded extraction parameters: one absolute https URL. */
+export const WebCaptureExtractParameters = Schema.Struct({
+  url: BoundedUrl,
+});
+
+/**
+ * The bounded model-visible capture success. Exactly the field matching the
+ * requested action is present.
+ */
+export class WebCaptureSuccess extends Schema.Class<WebCaptureSuccess>(
+  "@effect-agent/capabilities/WebCaptureSuccess",
+)({
+  url: BoundedUrl,
+  action: WebCaptureAction,
+  markdown: Schema.optionalKey(BoundedContent),
+  html: Schema.optionalKey(BoundedContent),
+  links: Schema.optionalKey(Schema.Array(BoundedUrl).check(Schema.isMaxLength(4_096))),
+}) {}
+
+/**
+ * The bounded model-visible failure envelope. `failureMode: "return"` turns
+ * it into a failed Tool result, so a model can pick a different target or
+ * action without a blind retry. `retryAfterMillis` carries the platform's
+ * backoff hint when the capture was rate-limited.
+ */
+export class WebCaptureFailure extends Schema.TaggedError<WebCaptureFailure>()(
+  "WebCaptureFailure",
+  {
+    errorTag: BoundedErrorTag,
+    message: BoundedFailureText,
+    retryAfterMillis: Schema.optionalKey(Schema.Natural),
+  },
+) {}
+
+/** The native Effect AI Tool created by `WebCapture.make`. */
+export type WebCaptureTool<Name extends string> = Tool.Tool<
+  Name,
+  {
+    readonly parameters: typeof WebCaptureParameters;
+    readonly success: typeof WebCaptureSuccess;
+    readonly failure: typeof WebCaptureFailure;
+    readonly failureMode: "return";
+  }
+>;
+
+/** The native Effect AI Tool created by `WebCapture.makeExtract`. */
+export type WebCaptureExtractTool<Name extends string, S extends Schema.Top> = Tool.Tool<
+  Name,
+  {
+    readonly parameters: typeof WebCaptureExtractParameters;
+    readonly success: S;
+    readonly failure: typeof WebCaptureFailure;
+    readonly failureMode: "return";
+  }
+>;
+
+/** Singleton Tool record provided by one web-capture handler Layer. */
+export type WebCaptureTools<Name extends string> = {
+  readonly [Key in Name]: WebCaptureTool<Name>;
+};
+
+/** Singleton Tool record provided by one extraction handler Layer. */
+export type WebCaptureExtractTools<Name extends string, S extends Schema.Top> = {
+  readonly [Key in Name]: WebCaptureExtractTool<Name, S>;
+};
+
+/** Construction requirements of a schema-shaped extraction handler Layer. */
+export type WebCaptureExtractLayerRequirements<S extends Schema.Top> =
+  | PageCapture
+  | S["DecodingServices"];
+
+interface WebCaptureSharedOptions {
+  /** Model-visible description; the builder appends the policy contract. */
+  readonly description: string;
+  /**
+   * Allowed target hosts: bare host names (`docs.example.com`) or one-level
+   * wildcards (`*.example.com`, matching the apex and every subdomain). The
+   * list must be non-empty — capture is deny-by-default (security spec §9).
+   */
+  readonly urls: ReadonlyArray<string>;
+  /** Rendering engine; defaults to `chromium`. */
+  readonly engine?: PageCaptureEngine | undefined;
+  /**
+   * Response byte budget measured on the UTF-8 encoded platform response.
+   * Default 131072 (128 KiB); construction fails closed outside
+   * [1024, 1048576].
+   */
+  readonly maxResponseBytes?: number | undefined;
+}
+
+export interface WebCaptureOptions extends WebCaptureSharedOptions {
+  /** Model-selectable actions; defaults to every first-slice action. */
+  readonly actions?: ReadonlyArray<WebCaptureAction> | undefined;
+}
+
+export interface WebCaptureExtractOptions<S extends Schema.Top> extends WebCaptureSharedOptions {
+  /**
+   * The extraction Schema. Its derived JSON Schema shapes the platform-side
+   * extraction, and the untrusted result is decoded through this exact
+   * Schema before it becomes the Tool success. Any decoding services remain
+   * visible in the handler Layer's requirements.
+   */
+  readonly schema: S;
+  /** Optional natural-language guidance sent alongside the derived schema. */
+  readonly prompt?: string | undefined;
+}
+
+/**
+ * An immutable web-capture definition: one model-facing Tool over a fixed
+ * URL policy, plus the handler Layer that runs captures through the
+ * `PageCapture` port. It owns no acquired resources.
+ */
+export interface WebCaptureDefinition<Name extends string> {
+  readonly name: Name;
+  /** The assembled model-facing description including the policy contract. */
+  readonly description: string;
+  /** The normalized allowed-host patterns. */
+  readonly urlPatterns: ReadonlyArray<string>;
+  readonly actions: ReadonlyArray<WebCaptureAction>;
+  readonly engine: PageCaptureEngine;
+  readonly maxResponseBytes: number;
+  /** The ordinary Effect AI Tool to include in the model-facing Toolkit. */
+  readonly tool: WebCaptureTool<Name>;
+  /** Handler Layer; the `PageCapture` requirement stays visible in `R`. */
+  readonly handlers: Layer.Layer<Tool.HandlersFor<WebCaptureTools<Name>>, never, PageCapture>;
+}
+
+/** An immutable schema-shaped extraction definition. */
+export interface WebCaptureExtractDefinition<Name extends string, S extends Schema.Top> {
+  readonly name: Name;
+  readonly description: string;
+  readonly urlPatterns: ReadonlyArray<string>;
+  readonly engine: PageCaptureEngine;
+  readonly maxResponseBytes: number;
+  /** The JSON Schema document derived from the extraction Schema. */
+  readonly responseFormat: Schema.Json;
+  readonly tool: WebCaptureExtractTool<Name, S>;
+  readonly handlers: Layer.Layer<
+    Tool.HandlersFor<WebCaptureExtractTools<Name, S>>,
+    never,
+    WebCaptureExtractLayerRequirements<S>
+  >;
+}
+
+const defaultMaxResponseBytes = 128 * 1024;
+const allActions: ReadonlyArray<WebCaptureAction> = ["markdown", "content", "links"];
+
+const HOST_PATTERN = /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+const compileUrlPolicy = (patterns: ReadonlyArray<string>): ReadonlyArray<string> => {
+  if (patterns.length === 0) {
+    throw new Error(
+      "Web capture requires at least one allowed host pattern; capture is deny-by-default",
+    );
+  }
+  return Object.freeze(
+    patterns.map((raw) => {
+      const pattern = raw.trim().toLowerCase();
+      if (!HOST_PATTERN.test(pattern)) {
+        throw new Error(
+          `Web capture host pattern ${JSON.stringify(raw)} must be a bare host name such as docs.example.com or *.example.com — no scheme, path, port, or credentials`,
+        );
+      }
+      return pattern;
+    }),
+  );
+};
+
+const compileResourcePolicy = (patterns: ReadonlyArray<string>): PageResourcePolicy =>
+  PageResourcePolicy.make({
+    allowRequestPatterns: patterns.map((pattern) => {
+      const wildcard = pattern.startsWith("*.");
+      const escapedHost = (wildcard ? pattern.slice(2) : pattern).replaceAll(".", "\\.");
+      const subdomains = wildcard ? "(?:[a-z0-9-]+\\.)*" : "";
+      return `^https://${subdomains}${escapedHost}(?::[0-9]+)?(?:[/?#]|$)`;
+    }),
+  });
+
+const validateMaxResponseBytes = (value: number | undefined): number => {
+  const bytes = value ?? defaultMaxResponseBytes;
+  // Fail closed on an invalid budget: NaN would make every comparison false.
+  if (!Number.isSafeInteger(bytes) || bytes < 1_024 || bytes > 1024 * 1024) {
+    throw new Error(
+      `Web capture maxResponseBytes must be an integer between 1024 and ${1024 * 1024}; received ${String(value)}`,
+    );
+  }
+  return bytes;
+};
+
+const hostMatches = (host: string, pattern: string): boolean => {
+  if (pattern.startsWith("*.")) {
+    const base = pattern.slice(2);
+    return host === base || host.endsWith(`.${base}`);
+  }
+  return host === pattern;
+};
+
+const failure = (errorTag: string, message: string, retryAfterMillis?: number): WebCaptureFailure =>
+  WebCaptureFailure.make({
+    errorTag,
+    message: message.slice(0, maxFailureTextLength),
+    ...(retryAfterMillis === undefined ? {} : { retryAfterMillis }),
+  });
+
+interface ParsedTargetUrl {
+  readonly protocol: string;
+  readonly hostname: string;
+  readonly username: string;
+  readonly password: string;
+}
+
+// The framework's TypeScript lib is bare ES2023 while every supported runtime
+// ships the WHATWG URL constructor, so it is read off globalThis the same way
+// the engine's bounded-value internals do. A runtime without it denies every
+// target rather than guessing at URL syntax.
+const urlConstructor = Reflect.get(globalThis, "URL");
+
+const parseTargetUrl = (raw: string): ParsedTargetUrl | undefined => {
+  if (typeof urlConstructor !== "function") return undefined;
+  try {
+    const parsed: unknown = Reflect.construct(urlConstructor, [raw]);
+    if (parsed === null || typeof parsed !== "object") return undefined;
+    const read = (key: string): string | undefined => {
+      const value: unknown = Reflect.get(parsed, key);
+      return typeof value === "string" ? value : undefined;
+    };
+    const protocol = read("protocol");
+    const hostname = read("hostname");
+    const username = read("username");
+    const password = read("password");
+    return protocol === undefined ||
+      hostname === undefined ||
+      username === undefined ||
+      password === undefined
+      ? undefined
+      : { protocol, hostname, username, password };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Fail-closed target validation over untrusted model output: absolute https
+ * URLs without embedded credentials, whose host matches the construction-time
+ * allowlist. Returns the denial, or `undefined` for an allowed target.
+ */
+const deniedUrl = (raw: string, patterns: ReadonlyArray<string>): WebCaptureFailure | undefined => {
+  const parsed = parseTargetUrl(raw);
+  if (parsed === undefined) {
+    return failure("WebCaptureInvalidUrl", `${raw.slice(0, 256)} is not an absolute URL`);
+  }
+  if (parsed.protocol !== "https:") {
+    return failure("WebCaptureUrlDenied", "Only https:// targets are allowed");
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    return failure("WebCaptureUrlDenied", "URLs carrying credentials are not allowed");
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!patterns.some((pattern) => hostMatches(host, pattern))) {
+    return failure(
+      "WebCaptureUrlDenied",
+      `Host ${host} is outside the allowed set: ${patterns.join(", ")}`,
+    );
+  }
+  return undefined;
+};
+
+const portFailure = (error: PageCaptureError): WebCaptureFailure => {
+  switch (error._tag) {
+    case "PageCaptureRateLimitedError": {
+      return failure(
+        error._tag,
+        error.message === "" ? "The platform rate-limited the capture" : error.message,
+        error.retryAfterMillis,
+      );
+    }
+    case "PageCaptureOutputLimitError": {
+      return failure(
+        error._tag,
+        `The page response of ${error.observed} bytes exceeds the ${error.limit}-byte budget; capture a smaller page or a narrower action`,
+      );
+    }
+    case "PageCaptureNavigationError":
+    case "PageCaptureProtocolError":
+    case "PageCaptureUnsupportedError": {
+      return failure(error._tag, error.message);
+    }
+  }
+};
+
+const policyContract = (
+  actionsText: string,
+  patterns: ReadonlyArray<string>,
+  maxResponseBytes: number,
+): string =>
+  `Allowed actions: ${actionsText}. Allowed hosts: ${patterns.join(", ")} (https:// only). Responses are bounded to ${maxResponseBytes} bytes; a larger page fails with a typed result you can react to.`;
+
+const captureAction = (action: WebCaptureAction): PageCaptureAction => {
+  switch (action) {
+    case "markdown": {
+      return CapturePageMarkdown.make({});
+    }
+    case "content": {
+      return CapturePageContent.make({});
+    }
+    case "links": {
+      return CapturePageLinks.make({});
+    }
+  }
+};
+
+const make = <const Name extends string>(
+  name: Name,
+  options: WebCaptureOptions,
+): WebCaptureDefinition<Name> => {
+  const patterns = compileUrlPolicy(options.urls);
+  const resourcePolicy = compileResourcePolicy(patterns);
+  const maxResponseBytes = validateMaxResponseBytes(options.maxResponseBytes);
+  const engine = options.engine ?? "chromium";
+  const actions = Object.freeze([...new Set(options.actions ?? allActions)]);
+  if (actions.length === 0) {
+    throw new Error("Web capture requires at least one model-selectable action");
+  }
+
+  const description = [
+    options.description,
+    "",
+    policyContract(actions.join(", "), patterns, maxResponseBytes),
+  ].join("\n");
+
+  const tool = Tool.make(name, {
+    description,
+    parameters: WebCaptureParameters,
+    success: WebCaptureSuccess,
+    failure: WebCaptureFailure,
+    failureMode: "return",
+  })
+    .annotate(Tool.Readonly, false)
+    .annotate(ToolExecutionClassAnnotation, "uncertain") as WebCaptureTool<Name>;
+
+  const toolkit = Toolkit.make(tool);
+  const allowed = new Set(actions);
+
+  const build = Effect.gen(function* () {
+    const pageCapture = yield* PageCapture;
+
+    const invoke = Effect.fn(`WebCapture.${name}`)(function* (parameters: {
+      readonly url: string;
+      readonly action: WebCaptureAction;
+    }) {
+      if (!allowed.has(parameters.action)) {
+        return yield* failure(
+          "WebCaptureActionDenied",
+          `Action ${parameters.action} is not enabled; allowed actions: ${actions.join(", ")}`,
+        );
+      }
+      const denied = deniedUrl(parameters.url, patterns);
+      if (denied !== undefined) {
+        return yield* denied;
+      }
+      const result = yield* pageCapture
+        .capture(
+          PageCaptureRequest.make({
+            target: PageUrlTarget.make({ url: parameters.url }),
+            action: captureAction(parameters.action),
+            engine,
+            limits: PageCaptureLimits.make({ maxOutputBytes: maxResponseBytes }),
+            resourcePolicy,
+          }),
+        )
+        .pipe(Effect.catch((error) => Effect.fail(portFailure(error))));
+      const output = result.output;
+      if (parameters.action === "markdown" && output._tag === "PageMarkdownCaptured") {
+        return WebCaptureSuccess.make({
+          url: parameters.url,
+          action: parameters.action,
+          markdown: output.markdown,
+        });
+      }
+      if (parameters.action === "content" && output._tag === "PageContentCaptured") {
+        return WebCaptureSuccess.make({
+          url: parameters.url,
+          action: parameters.action,
+          html: output.html,
+        });
+      }
+      if (parameters.action === "links" && output._tag === "PageLinksCaptured") {
+        return WebCaptureSuccess.make({
+          url: parameters.url,
+          action: parameters.action,
+          links: output.links,
+        });
+      }
+      return yield* failure(
+        "WebCaptureProtocolMismatch",
+        `The capture adapter answered a ${parameters.action} request with ${output._tag}`,
+      );
+    });
+
+    return { [name]: invoke } as unknown as Toolkit.HandlersFrom<WebCaptureTools<Name>>;
+  });
+
+  /**
+   * TypeScript cannot unify the two spellings of the singleton Tool record
+   * over a generic `Name` (the same limit as Code Mode); the assertions pin
+   * the layer to its documented requirement surface and never bypass
+   * validation.
+   */
+  const handlers = toolkit.toLayer(
+    build as unknown as Effect.Effect<
+      Toolkit.HandlersFrom<Toolkit.ToolsByName<readonly [WebCaptureTool<Name>]>>,
+      never,
+      PageCapture
+    >,
+  ) as unknown as Layer.Layer<Tool.HandlersFor<WebCaptureTools<Name>>, never, PageCapture>;
+
+  return Object.freeze({
+    name,
+    description,
+    urlPatterns: patterns,
+    actions,
+    engine,
+    maxResponseBytes,
+    tool,
+    handlers,
+  });
+};
+
+const makeExtract = <const Name extends string, S extends Schema.Top>(
+  name: Name,
+  options: WebCaptureExtractOptions<S>,
+): WebCaptureExtractDefinition<Name, S> => {
+  const patterns = compileUrlPolicy(options.urls);
+  const resourcePolicy = compileResourcePolicy(patterns);
+  const maxResponseBytes = validateMaxResponseBytes(options.maxResponseBytes);
+  const engine = options.engine ?? "chromium";
+  const prompt = options.prompt;
+  if (prompt !== undefined && (prompt.length === 0 || prompt.length > 8_192)) {
+    throw new Error("Web capture extraction prompt must be between 1 and 8192 characters");
+  }
+
+  // The derived JSON Schema is BOTH the platform-side response format and
+  // documentation that the deriver can express the Schema at all; anything it
+  // cannot derive fails construction closed rather than degrading at runtime.
+  const derived = ((): Schema.Json => {
+    const jsonSchema = Tool.getJsonSchemaFromSchema(options.schema);
+    const decoded = Schema.decodeUnknownOption(Schema.Json)(jsonSchema);
+    if (Option.isNone(decoded)) {
+      throw new Error(
+        `Web capture cannot derive a JSON response format from the extraction Schema for ${name}`,
+      );
+    }
+    return decoded.value;
+  })();
+
+  const description = [
+    options.description,
+    "",
+    `Extracts structured data matching a fixed schema from the rendered page. ${policyContract("structured extraction", patterns, maxResponseBytes)}`,
+  ].join("\n");
+
+  const tool = Tool.make(name, {
+    description,
+    parameters: WebCaptureExtractParameters,
+    success: options.schema,
+    failure: WebCaptureFailure,
+    failureMode: "return",
+  })
+    .annotate(Tool.Readonly, false)
+    .annotate(ToolExecutionClassAnnotation, "uncertain") as WebCaptureExtractTool<Name, S>;
+
+  const toolkit = Toolkit.make(tool);
+  const decodeExtracted = Schema.decodeUnknownEffect(options.schema);
+
+  const build = Effect.gen(function* () {
+    const pageCapture = yield* PageCapture;
+    const schemaServices = yield* Effect.context<S["DecodingServices"]>();
+
+    const invoke = Effect.fn(`WebCapture.${name}`)(function* (parameters: {
+      readonly url: string;
+    }) {
+      const denied = deniedUrl(parameters.url, patterns);
+      if (denied !== undefined) {
+        return yield* denied;
+      }
+      const result = yield* pageCapture
+        .capture(
+          PageCaptureRequest.make({
+            target: PageUrlTarget.make({ url: parameters.url }),
+            action: CapturePageStructured.make({
+              responseFormat: derived,
+              ...(prompt === undefined ? {} : { prompt }),
+            }),
+            engine,
+            limits: PageCaptureLimits.make({ maxOutputBytes: maxResponseBytes }),
+            resourcePolicy,
+          }),
+        )
+        .pipe(Effect.catch((error) => Effect.fail(portFailure(error))));
+      if (result.output._tag !== "PageStructuredCaptured") {
+        return yield* failure(
+          "WebCaptureProtocolMismatch",
+          `The capture adapter answered a structured request with ${result.output._tag}`,
+        );
+      }
+      // The platform's extraction is untrusted; only the original Effect
+      // Schema decides whether the value is the promised shape.
+      return yield* decodeExtracted(result.output.value).pipe(
+        Effect.provideContext(schemaServices),
+        Effect.catch((error) =>
+          Effect.fail(
+            failure(
+              "WebCaptureDecodeFailed",
+              `The extracted value did not match the expected schema: ${String(error).slice(0, 2_048)}`,
+            ),
+          ),
+        ),
+      );
+    });
+
+    return { [name]: invoke } as unknown as Toolkit.HandlersFrom<WebCaptureExtractTools<Name, S>>;
+  });
+
+  // Same private-assertion contract as `make` above.
+  const handlers = toolkit.toLayer(
+    build as unknown as Effect.Effect<
+      Toolkit.HandlersFrom<Toolkit.ToolsByName<readonly [WebCaptureExtractTool<Name, S>]>>,
+      never,
+      WebCaptureExtractLayerRequirements<S>
+    >,
+  ) as unknown as Layer.Layer<
+    Tool.HandlersFor<WebCaptureExtractTools<Name, S>>,
+    never,
+    WebCaptureExtractLayerRequirements<S>
+  >;
+
+  return Object.freeze({
+    name,
+    description,
+    urlPatterns: patterns,
+    engine,
+    maxResponseBytes,
+    responseFormat: derived,
+    tool,
+    handlers,
+  });
+};
+
+/** Web capture builder namespace (capability spec §9.2). */
+export const WebCapture = { make, makeExtract } as const;

--- a/packages/capabilities/test/web-capture.test.ts
+++ b/packages/capabilities/test/web-capture.test.ts
@@ -114,6 +114,16 @@ describe("WebCapture construction", () => {
     expect(Context.get(definition.tool.annotations, ToolExecutionClass)).toBe("uncertain");
     expect(Object.isFrozen(definition.urlPatterns)).toBe(true);
   });
+
+  it("rejects extraction schemas that cannot produce a bounded object response format", () => {
+    expect(() =>
+      WebCapture.makeExtract("extract_text", {
+        description: "Extract text.",
+        urls: ["docs.example.com"],
+        schema: Schema.String,
+      }),
+    ).toThrow(/bounded object JSON response format/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -541,7 +551,7 @@ layer(identifiers)("WebCapture handlers through a scripted port", (it) => {
         {},
       ).pipe(
         Effect.provide(
-          definition.handlers.pipe(Layer.provide(Layer.merge(scripted.port, decoderLayer))),
+          definition.handlers.pipe(Layer.provideMerge(Layer.merge(scripted.port, decoderLayer))),
         ),
         Effect.scoped,
       );
@@ -601,6 +611,10 @@ type ServiceExtractKeepsDecoderRequirement = Equal<
   ServiceExtractLayerRequirements,
   PageCapture | ExtractionDecoderService
 >;
+type ServiceExtractToolKeepsDecoderRequirement = Equal<
+  Tool.HandlerServices<typeof typedServiceExtract.tool>,
+  ExtractionDecoderService
+>;
 
 describe("WebCapture type proofs", () => {
   it("pins the PageCapture requirement, envelope failure, and decoded success", () => {
@@ -610,13 +624,15 @@ describe("WebCapture type proofs", () => {
     const extractRequirementProof: ExtractRequiresPageCapture = true;
     const extractSuccessProof: ExtractSuccessIsDecoded = true;
     const decoderRequirementProof: ServiceExtractKeepsDecoderRequirement = true;
+    const decoderInvocationProof: ServiceExtractToolKeepsDecoderRequirement = true;
     expect(
       requirementProof &&
         failureProof &&
         successProof &&
         extractRequirementProof &&
         extractSuccessProof &&
-        decoderRequirementProof,
+        decoderRequirementProof &&
+        decoderInvocationProof,
     ).toBe(true);
   });
 });

--- a/packages/capabilities/test/web-capture.test.ts
+++ b/packages/capabilities/test/web-capture.test.ts
@@ -2,6 +2,7 @@ import { Agent, AgentPolicy, ConversationId, IdGenerator, RunId, TurnId } from "
 import { AgentRuntime, ToolExecutionClass } from "@effect-agent/engine";
 import {
   PageCapture,
+  PageCaptureInferencePolicyError,
   PageCaptureProtocolError,
   PageCaptureRateLimitedError,
   PageCaptureResult,
@@ -192,6 +193,17 @@ const makeScriptedPort = Effect.gen(function* () {
                   implementation: scriptedImplementation,
                   message: "The browser RPC failed",
                   cause: new Error("secret-token=host-only-diagnostic"),
+                }),
+              );
+            }
+            if (url.includes("/inference-policy")) {
+              return Effect.fail(
+                PageCaptureInferencePolicyError.make({
+                  implementation: scriptedImplementation,
+                  provider: "cloudflare-workers-ai",
+                  reason: "authorization",
+                  message: "Workers AI extraction was not authorized",
+                  cause: new Error("secret tenant budget detail"),
                 }),
               );
             }
@@ -503,6 +515,23 @@ layer(identifiers)("WebCapture handlers through a scripted port", (it) => {
       });
       expect(outcome.toolResults[0].result).not.toHaveProperty("cause");
       expect(JSON.stringify(outcome.toolResults[0].result)).not.toContain("secret-token");
+    }),
+  );
+
+  it.effect("returns inference policy failures without their host-only cause", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({
+        url: "https://docs.example.com/inference-policy",
+        action: "markdown",
+      });
+
+      expect(outcome.toolResults[0].result).toMatchObject({
+        _tag: "WebCaptureFailure",
+        errorTag: "PageCaptureInferencePolicyError",
+        message: "Workers AI extraction was not authorized",
+      });
+      expect(outcome.toolResults[0].result).not.toHaveProperty("cause");
+      expect(JSON.stringify(outcome.toolResults[0].result)).not.toContain("secret tenant");
     }),
   );
 

--- a/packages/capabilities/test/web-capture.test.ts
+++ b/packages/capabilities/test/web-capture.test.ts
@@ -1,0 +1,622 @@
+import { Agent, AgentPolicy, ConversationId, IdGenerator, RunId, TurnId } from "@effect-agent/core";
+import { AgentRuntime, ToolExecutionClass } from "@effect-agent/engine";
+import {
+  PageCapture,
+  PageCaptureRateLimitedError,
+  PageCaptureResult,
+  PageLinksCaptured,
+  PageMarkdownCaptured,
+  PageStructuredCaptured,
+  SandboxImplementation,
+  type PageCaptureRequest,
+} from "@effect-agent/sandbox";
+import { describe, expect, it, layer } from "@effect/vitest";
+import { Context, Effect, Layer, Ref, Schema, SchemaGetter, Stream } from "effect";
+import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
+
+import type { WebCaptureFailure, WebCaptureSuccess } from "../src/index.ts";
+import { CodeMode, WebCapture } from "../src/index.ts";
+
+describe("WebCapture construction", () => {
+  it("classifies browser JavaScript as uncertain and excludes capture from readonly Code Mode", () => {
+    const definition = WebCapture.make("read_webpage", {
+      description: "Read documentation pages.",
+      urls: ["docs.example.com", "*.Effect.website"],
+      actions: ["markdown", "links"],
+    });
+    expect(Context.get(definition.tool.annotations, Tool.Readonly)).toBe(false);
+    expect(Context.get(definition.tool.annotations, ToolExecutionClass)).toBe("uncertain");
+    expect(definition.tool.failureMode).toBe("return");
+    expect(definition.urlPatterns).toEqual(["docs.example.com", "*.effect.website"]);
+    expect(definition.engine).toBe("chromium");
+    expect(definition.description).toContain("Allowed actions: markdown, links");
+    expect(definition.description).toContain("docs.example.com");
+    expect(() =>
+      CodeMode.make("run_javascript", {
+        description: "Read a page through Code Mode",
+        tools: { browser: { capture: definition.tool } },
+      }),
+    ).toThrow(/uncertain/);
+  });
+
+  it("snapshots and freezes security-sensitive host and action policies", () => {
+    const urls = ["docs.example.com"];
+    const actions: Array<"markdown" | "content" | "links"> = ["markdown"];
+    const definition = WebCapture.make("read_webpage", {
+      description: "Read documentation pages.",
+      urls,
+      actions,
+    });
+
+    urls.push("attacker.example");
+    actions.push("links");
+
+    expect(definition.urlPatterns).toEqual(["docs.example.com"]);
+    expect(definition.actions).toEqual(["markdown"]);
+    expect(Object.isFrozen(definition.urlPatterns)).toBe(true);
+    expect(Object.isFrozen(definition.actions)).toBe(true);
+    expect(() =>
+      Reflect.apply(Array.prototype.push, definition.urlPatterns, ["attacker.example"]),
+    ).toThrow(/extensible|read.only|frozen/i);
+    expect(() => Reflect.apply(Array.prototype.push, definition.actions, ["links"])).toThrow(
+      /extensible|read.only|frozen/i,
+    );
+  });
+
+  it("fails closed on an empty or malformed host allowlist", () => {
+    expect(() => WebCapture.make("read_webpage", { description: "d", urls: [] })).toThrow(
+      /deny-by-default/,
+    );
+    for (const pattern of [
+      "https://docs.example.com",
+      "docs.example.com/path",
+      "docs.example.com:8443",
+      "*",
+      "example",
+    ]) {
+      expect(() => WebCapture.make("read_webpage", { description: "d", urls: [pattern] })).toThrow(
+        /bare host name/,
+      );
+    }
+  });
+
+  it("fails closed on an invalid response byte budget or empty action set", () => {
+    for (const bytes of [0, 512, 2 * 1024 * 1024, Number.NaN, 1.5]) {
+      expect(() =>
+        WebCapture.make("read_webpage", {
+          description: "d",
+          urls: ["docs.example.com"],
+          maxResponseBytes: bytes,
+        }),
+      ).toThrow(/maxResponseBytes/);
+    }
+    expect(() =>
+      WebCapture.make("read_webpage", {
+        description: "d",
+        urls: ["docs.example.com"],
+        actions: [],
+      }),
+    ).toThrow(/at least one/);
+  });
+
+  it("derives the extraction response format from the Effect Schema at construction", () => {
+    const definition = WebCapture.makeExtract("extract_pricing", {
+      description: "Extract pricing plans.",
+      urls: ["docs.example.com"],
+      schema: Schema.Struct({
+        plans: Schema.Array(Schema.Struct({ name: Schema.String, monthlyUsd: Schema.Number })),
+      }),
+    });
+    expect(definition.responseFormat).toMatchObject({ type: "object" });
+    expect(JSON.stringify(definition.responseFormat)).toContain("monthlyUsd");
+    expect(definition.tool.failureMode).toBe("return");
+    expect(Context.get(definition.tool.annotations, Tool.Readonly)).toBe(false);
+    expect(Context.get(definition.tool.annotations, ToolExecutionClass)).toBe("uncertain");
+    expect(Object.isFrozen(definition.urlPatterns)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler behavior through a full Run with a scripted PageCapture port and a
+// scripted model, so the URL policy, request projection, typed failure
+// envelopes, and schema decoding are observable at the public seam.
+// ---------------------------------------------------------------------------
+
+const scriptedImplementation = SandboxImplementation.make({
+  isolation: "unisolated",
+  identity: "scripted-page-capture",
+});
+
+const PricingSchema = Schema.Struct({
+  plans: Schema.Array(Schema.Struct({ name: Schema.String, monthlyUsd: Schema.Number })),
+});
+
+class ExtractionDecoderService extends Context.Service<
+  ExtractionDecoderService,
+  { readonly normalize: (value: string) => string }
+>()("@effect-agent/capabilities/test/ExtractionDecoderService") {}
+
+const ServicePricingSchema = Schema.Struct({
+  plans: Schema.Array(
+    Schema.Struct({
+      name: Schema.String.pipe(
+        Schema.decode({
+          decode: SchemaGetter.transformOrFail((value) =>
+            Effect.map(ExtractionDecoderService, (service) => service.normalize(value)),
+          ),
+          encode: SchemaGetter.transform((value) => value),
+        }),
+      ),
+      monthlyUsd: Schema.Number,
+    }),
+  ),
+});
+
+/**
+ * A scripted PageCapture: the target URL's path selects the outcome so each
+ * scenario controls the port without a real browser.
+ */
+const makeScriptedPort = Effect.gen(function* () {
+  const requests = yield* Ref.make<ReadonlyArray<PageCaptureRequest>>([]);
+  const port = Layer.succeed(PageCapture)(
+    PageCapture.of({
+      capture: (request) =>
+        Ref.update(requests, (all) => [...all, request]).pipe(
+          Effect.flatMap(() => {
+            const url = request.target._tag === "PageUrlTarget" ? request.target.url : "";
+            if (url.includes("/rate-limited")) {
+              return Effect.fail(
+                PageCaptureRateLimitedError.make({
+                  implementation: scriptedImplementation,
+                  reason: "rate",
+                  retryAfterMillis: 7_000,
+                  message: "429 Too many requests",
+                }),
+              );
+            }
+            const finish = (output: PageCaptureResult["output"]) =>
+              Effect.succeed(
+                PageCaptureResult.make({
+                  implementation: scriptedImplementation,
+                  output,
+                  resourceUse: { browserMillis: 42 },
+                }),
+              );
+            if (url.includes("/mismatch")) {
+              return finish(PageLinksCaptured.make({ links: ["https://docs.example.com/a"] }));
+            }
+            switch (request.action._tag) {
+              case "CapturePageMarkdown": {
+                return finish(PageMarkdownCaptured.make({ markdown: "# Pricing" }));
+              }
+              case "CapturePageLinks": {
+                return finish(
+                  PageLinksCaptured.make({ links: ["https://docs.example.com/plans"] }),
+                );
+              }
+              case "CapturePageStructured": {
+                return finish(
+                  PageStructuredCaptured.make({
+                    value: url.includes("/malformed")
+                      ? { nope: true }
+                      : { plans: [{ name: "Pro", monthlyUsd: 20 }] },
+                  }),
+                );
+              }
+              case "CapturePageContent": {
+                return finish(PageMarkdownCaptured.make({ markdown: "unused" }));
+              }
+            }
+          }),
+        ),
+    }),
+  );
+  return { requests, port };
+});
+
+const usage = { inputTokens: {}, outputTokens: {} };
+
+const identifiers = Layer.succeed(IdGenerator, {
+  nextConversationId: Effect.succeed(Schema.decodeSync(ConversationId)("conversation-web-capture")),
+  nextRunId: Effect.succeed(Schema.decodeSync(RunId)("run-web-capture")),
+  nextTurnId: Effect.succeed(Schema.decodeSync(TurnId)("turn-web-capture")),
+});
+
+interface ToolResultPart {
+  readonly result: unknown;
+  readonly isFailure: boolean;
+}
+
+/** One scripted Run: turn 0 declares the tool call, turn 1 answers. */
+const scriptedModel = (
+  toolName: string,
+  params: Record<string, unknown>,
+  toolResults: Ref.Ref<ReadonlyArray<ToolResultPart>>,
+) =>
+  Model.make(
+    "scripted",
+    "web-capture",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      Effect.gen(function* () {
+        const turn = yield* Ref.make(0);
+        return yield* LanguageModel.make({
+          generateText: () => Effect.succeed([]),
+          streamText: ({ prompt }) =>
+            Stream.unwrap(
+              Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                Effect.tap(() =>
+                  Ref.update(toolResults, (all) => [
+                    ...all,
+                    ...prompt.content
+                      .filter((message) => message.role === "tool")
+                      .flatMap((message) => message.content)
+                      .filter((part) => part.type === "tool-result")
+                      .map((part) => ({
+                        result: part.result,
+                        isFailure: part.isFailure === true,
+                      })),
+                  ]),
+                ),
+                Effect.map((value) =>
+                  Stream.fromIterable<Response.StreamPartEncoded>(
+                    value === 0
+                      ? [
+                          {
+                            type: "tool-call",
+                            id: "capture-1",
+                            name: toolName,
+                            params,
+                            providerExecuted: false,
+                          },
+                          { type: "finish", reason: "tool-calls", usage },
+                        ]
+                      : [
+                          { type: "text-start", id: "answer" },
+                          { type: "text-delta", id: "answer", delta: '{"answer":"done"}' },
+                          { type: "text-end", id: "answer" },
+                          { type: "finish", reason: "stop", usage },
+                        ],
+                  ),
+                ),
+              ),
+            ),
+        });
+      }),
+    ),
+  );
+
+const policy = AgentPolicy.make({
+  maxTurns: 2,
+  maxToolCalls: 2,
+  maxDuration: "30 seconds",
+  toolConcurrency: 1,
+});
+
+interface ScenarioOutcome {
+  readonly toolResults: ReadonlyArray<ToolResultPart>;
+  readonly requests: ReadonlyArray<PageCaptureRequest>;
+}
+
+const runCapture = (
+  params: Record<string, unknown>,
+  options?: { readonly actions?: ReadonlyArray<"markdown" | "content" | "links"> },
+): Effect.Effect<ScenarioOutcome, unknown, IdGenerator> =>
+  Effect.gen(function* () {
+    const definition = WebCapture.make("read_webpage", {
+      description: "Read documentation pages.",
+      urls: ["docs.example.com", "*.effect.website"],
+      ...(options?.actions === undefined ? {} : { actions: options.actions }),
+    });
+    const agent = Agent.define("web-capture-host", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Use read_webpage.",
+      toolkit: Toolkit.make(definition.tool),
+      policy,
+    });
+    const toolResults = yield* Ref.make<ReadonlyArray<ToolResultPart>>([]);
+    const scripted = yield* makeScriptedPort;
+    yield* AgentRuntime.run(
+      Agent.withModel(agent, scriptedModel("read_webpage", params, toolResults)),
+      { question: "go" },
+      {},
+    ).pipe(Effect.provide(definition.handlers.pipe(Layer.provide(scripted.port))), Effect.scoped);
+    return {
+      toolResults: yield* Ref.get(toolResults),
+      requests: yield* Ref.get(scripted.requests),
+    };
+  });
+
+const runExtract = (
+  params: Record<string, unknown>,
+): Effect.Effect<ScenarioOutcome, unknown, IdGenerator> =>
+  Effect.gen(function* () {
+    const definition = WebCapture.makeExtract("extract_pricing", {
+      description: "Extract pricing plans.",
+      urls: ["docs.example.com"],
+      schema: PricingSchema,
+      prompt: "Extract every plan",
+    });
+    const agent = Agent.define("web-extract-host", {
+      input: Schema.Struct({ question: Schema.String }),
+      output: Schema.Struct({ answer: Schema.String }),
+      instructions: "Use extract_pricing.",
+      toolkit: Toolkit.make(definition.tool),
+      policy,
+    });
+    const toolResults = yield* Ref.make<ReadonlyArray<ToolResultPart>>([]);
+    const scripted = yield* makeScriptedPort;
+    yield* AgentRuntime.run(
+      Agent.withModel(agent, scriptedModel("extract_pricing", params, toolResults)),
+      { question: "go" },
+      {},
+    ).pipe(Effect.provide(definition.handlers.pipe(Layer.provide(scripted.port))), Effect.scoped);
+    return {
+      toolResults: yield* Ref.get(toolResults),
+      requests: yield* Ref.get(scripted.requests),
+    };
+  });
+
+layer(identifiers)("WebCapture handlers through a scripted port", (it) => {
+  it.effect("projects an allowed markdown capture onto the port and returns the page", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({
+        url: "https://docs.example.com/pricing",
+        action: "markdown",
+      });
+      expect(outcome.requests).toHaveLength(1);
+      expect(outcome.requests[0].engine).toBe("chromium");
+      expect(outcome.requests[0].limits.maxOutputBytes).toBe(128 * 1024);
+      expect(outcome.requests[0].action._tag).toBe("CapturePageMarkdown");
+      const requestPatterns = outcome.requests[0].resourcePolicy?.allowRequestPatterns;
+      expect(requestPatterns).toEqual([
+        "^https://docs\\.example\\.com(?::[0-9]+)?(?:[/?#]|$)",
+        "^https://(?:[a-z0-9-]+\\.)*effect\\.website(?::[0-9]+)?(?:[/?#]|$)",
+      ]);
+      const allowsRequest = (url: string): boolean =>
+        requestPatterns?.some((pattern) => new RegExp(pattern).test(url)) ?? false;
+      for (const allowed of [
+        "https://docs.example.com/pricing",
+        "https://docs.example.com:8443/redirect-target",
+        "https://effect.website/",
+        "https://nested.docs.effect.website/resource.js",
+      ]) {
+        expect(allowsRequest(allowed)).toBe(true);
+      }
+      for (const denied of [
+        "https://docs.example.com.attacker.test/",
+        "https://effect.website.attacker.test/",
+        "https://evil.example.net/redirect-target",
+        "https://docs.example.com@attacker.test/",
+        "http://docs.example.com/resource.js",
+      ]) {
+        expect(allowsRequest(denied)).toBe(false);
+      }
+      expect(outcome.toolResults).toHaveLength(1);
+      expect(outcome.toolResults[0].isFailure).toBe(false);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        url: "https://docs.example.com/pricing",
+        action: "markdown",
+        markdown: "# Pricing",
+      });
+    }),
+  );
+
+  it.effect("denies an off-allowlist host fail-closed before the port is reached", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({ url: "https://evil.example.net/x", action: "markdown" });
+      expect(outcome.requests).toHaveLength(0);
+      expect(outcome.toolResults[0].isFailure).toBe(true);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        _tag: "WebCaptureFailure",
+        errorTag: "WebCaptureUrlDenied",
+      });
+    }),
+  );
+
+  it.effect("allows wildcard apexes and subdomains while rejecting hostname-boundary attacks", () =>
+    Effect.gen(function* () {
+      for (const url of ["https://effect.website/", "https://docs.effect.website/pricing"]) {
+        const allowed = yield* runCapture({ url, action: "markdown" });
+        expect(allowed.requests).toHaveLength(1);
+        expect(allowed.toolResults[0].isFailure).toBe(false);
+      }
+
+      const denied = yield* runCapture({
+        url: "https://effect.website.attacker.test/pricing",
+        action: "markdown",
+      });
+      expect(denied.requests).toHaveLength(0);
+      expect(denied.toolResults[0].result).toMatchObject({ errorTag: "WebCaptureUrlDenied" });
+    }),
+  );
+
+  it.effect("denies a non-https target and a disabled action without a port call", () =>
+    Effect.gen(function* () {
+      const insecure = yield* runCapture({
+        url: "http://docs.example.com/pricing",
+        action: "markdown",
+      });
+      expect(insecure.requests).toHaveLength(0);
+      expect(insecure.toolResults[0].result).toMatchObject({ errorTag: "WebCaptureUrlDenied" });
+
+      const disabled = yield* runCapture(
+        { url: "https://docs.example.com/pricing", action: "links" },
+        { actions: ["markdown"] },
+      );
+      expect(disabled.requests).toHaveLength(0);
+      expect(disabled.toolResults[0].result).toMatchObject({
+        errorTag: "WebCaptureActionDenied",
+      });
+    }),
+  );
+
+  it.effect("returns the platform backoff hint as a typed model-visible failure", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({
+        url: "https://docs.example.com/rate-limited",
+        action: "markdown",
+      });
+      expect(outcome.toolResults[0].isFailure).toBe(true);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        _tag: "WebCaptureFailure",
+        errorTag: "PageCaptureRateLimitedError",
+        retryAfterMillis: 7_000,
+      });
+    }),
+  );
+
+  it.effect("fails typed when the adapter answers with the wrong output kind", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({
+        url: "https://docs.example.com/mismatch",
+        action: "markdown",
+      });
+      expect(outcome.toolResults[0].isFailure).toBe(true);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        errorTag: "WebCaptureProtocolMismatch",
+      });
+    }),
+  );
+
+  it.effect("sends the derived response format and decodes the extraction through the Schema", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runExtract({ url: "https://docs.example.com/pricing" });
+      expect(outcome.requests).toHaveLength(1);
+      const action = outcome.requests[0].action;
+      expect(action._tag).toBe("CapturePageStructured");
+      if (action._tag === "CapturePageStructured") {
+        expect(JSON.stringify(action.responseFormat)).toContain("monthlyUsd");
+        expect(action.prompt).toBe("Extract every plan");
+      }
+      expect(outcome.toolResults[0].isFailure).toBe(false);
+      expect(outcome.toolResults[0].result).toEqual({
+        plans: [{ name: "Pro", monthlyUsd: 20 }],
+      });
+    }),
+  );
+
+  it.effect("an extraction outside the Schema fails typed, never a fabricated success", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runExtract({ url: "https://docs.example.com/malformed" });
+      expect(outcome.toolResults[0].isFailure).toBe(true);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        _tag: "WebCaptureFailure",
+        errorTag: "WebCaptureDecodeFailed",
+      });
+    }),
+  );
+
+  it.effect("keeps decoder services visible and supplies them when validating extraction", () =>
+    Effect.gen(function* () {
+      const definition = WebCapture.makeExtract("extract_normalized_pricing", {
+        description: "Extract normalized pricing plans.",
+        urls: ["docs.example.com"],
+        schema: ServicePricingSchema,
+      });
+      const agent = Agent.define("web-service-extract-host", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ answer: Schema.String }),
+        instructions: "Use extract_normalized_pricing.",
+        toolkit: Toolkit.make(definition.tool),
+        policy,
+      });
+      const toolResults = yield* Ref.make<ReadonlyArray<ToolResultPart>>([]);
+      const scripted = yield* makeScriptedPort;
+      const decoderLayer = Layer.succeed(ExtractionDecoderService, {
+        normalize: (value) => value.toUpperCase(),
+      });
+
+      yield* AgentRuntime.run(
+        Agent.withModel(
+          agent,
+          scriptedModel(
+            "extract_normalized_pricing",
+            { url: "https://docs.example.com/pricing" },
+            toolResults,
+          ),
+        ),
+        { question: "go" },
+        {},
+      ).pipe(
+        Effect.provide(
+          definition.handlers.pipe(Layer.provide(Layer.merge(scripted.port, decoderLayer))),
+        ),
+        Effect.scoped,
+      );
+
+      expect(yield* Ref.get(toolResults)).toMatchObject([
+        {
+          isFailure: false,
+          result: { plans: [{ name: "PRO", monthlyUsd: 20 }] },
+        },
+      ]);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Compile-time E/R proofs (change discipline: type tests whenever Agent or
+// Effect AI composition changes).
+// ---------------------------------------------------------------------------
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2 ? true : false;
+
+const typedDefinition = WebCapture.make("typed_web_capture", {
+  description: "typed",
+  urls: ["docs.example.com"],
+});
+
+type LayerContext<L> = L extends Layer.Layer<infer _Out, infer _Error, infer R> ? R : never;
+type CaptureLayerRequirements = LayerContext<typeof typedDefinition.handlers>;
+type RequiresPageCapture = Equal<CaptureLayerRequirements, PageCapture>;
+type FailureIsEnvelope = Equal<
+  (typeof typedDefinition.tool.failureSchema)["Type"],
+  WebCaptureFailure
+>;
+type SuccessIsBounded =
+  Tool.Success<typeof typedDefinition.tool> extends WebCaptureSuccess ? true : false;
+
+const typedExtract = WebCapture.makeExtract("typed_extract", {
+  description: "typed",
+  urls: ["docs.example.com"],
+  schema: PricingSchema,
+});
+type ExtractLayerRequirements = LayerContext<typeof typedExtract.handlers>;
+type ExtractRequiresPageCapture = Equal<ExtractLayerRequirements, PageCapture>;
+type ExtractSuccessIsDecoded = Equal<
+  Tool.Success<typeof typedExtract.tool>,
+  typeof PricingSchema.Type
+>;
+
+const typedServiceExtract = WebCapture.makeExtract("typed_service_extract", {
+  description: "typed",
+  urls: ["docs.example.com"],
+  schema: ServicePricingSchema,
+});
+type ServiceExtractLayerRequirements = LayerContext<typeof typedServiceExtract.handlers>;
+type ServiceExtractKeepsDecoderRequirement = Equal<
+  ServiceExtractLayerRequirements,
+  PageCapture | ExtractionDecoderService
+>;
+
+describe("WebCapture type proofs", () => {
+  it("pins the PageCapture requirement, envelope failure, and decoded success", () => {
+    const requirementProof: RequiresPageCapture = true;
+    const failureProof: FailureIsEnvelope = true;
+    const successProof: SuccessIsBounded = true;
+    const extractRequirementProof: ExtractRequiresPageCapture = true;
+    const extractSuccessProof: ExtractSuccessIsDecoded = true;
+    const decoderRequirementProof: ServiceExtractKeepsDecoderRequirement = true;
+    expect(
+      requirementProof &&
+        failureProof &&
+        successProof &&
+        extractRequirementProof &&
+        extractSuccessProof &&
+        decoderRequirementProof,
+    ).toBe(true);
+  });
+});

--- a/packages/capabilities/test/web-capture.test.ts
+++ b/packages/capabilities/test/web-capture.test.ts
@@ -2,12 +2,14 @@ import { Agent, AgentPolicy, ConversationId, IdGenerator, RunId, TurnId } from "
 import { AgentRuntime, ToolExecutionClass } from "@effect-agent/engine";
 import {
   PageCapture,
+  PageCaptureProtocolError,
   PageCaptureRateLimitedError,
   PageCaptureResult,
   PageLinksCaptured,
   PageMarkdownCaptured,
   PageStructuredCaptured,
   SandboxImplementation,
+  type PageCaptureError,
   type PageCaptureRequest,
 } from "@effect-agent/sandbox";
 import { describe, expect, it, layer } from "@effect/vitest";
@@ -172,7 +174,7 @@ const makeScriptedPort = Effect.gen(function* () {
     PageCapture.of({
       capture: (request) =>
         Ref.update(requests, (all) => [...all, request]).pipe(
-          Effect.flatMap(() => {
+          Effect.flatMap((): Effect.Effect<PageCaptureResult, PageCaptureError> => {
             const url = request.target._tag === "PageUrlTarget" ? request.target.url : "";
             if (url.includes("/rate-limited")) {
               return Effect.fail(
@@ -181,6 +183,15 @@ const makeScriptedPort = Effect.gen(function* () {
                   reason: "rate",
                   retryAfterMillis: 7_000,
                   message: "429 Too many requests",
+                }),
+              );
+            }
+            if (url.includes("/protocol-failure")) {
+              return Effect.fail(
+                PageCaptureProtocolError.make({
+                  implementation: scriptedImplementation,
+                  message: "The browser RPC failed",
+                  cause: new Error("secret-token=host-only-diagnostic"),
                 }),
               );
             }
@@ -474,6 +485,24 @@ layer(identifiers)("WebCapture handlers through a scripted port", (it) => {
         errorTag: "PageCaptureRateLimitedError",
         retryAfterMillis: 7_000,
       });
+    }),
+  );
+
+  it.effect("keeps foreign protocol failure causes out of the model-visible result", () =>
+    Effect.gen(function* () {
+      const outcome = yield* runCapture({
+        url: "https://docs.example.com/protocol-failure",
+        action: "markdown",
+      });
+
+      expect(outcome.toolResults[0].isFailure).toBe(true);
+      expect(outcome.toolResults[0].result).toMatchObject({
+        _tag: "WebCaptureFailure",
+        errorTag: "PageCaptureProtocolError",
+        message: "The browser RPC failed",
+      });
+      expect(outcome.toolResults[0].result).not.toHaveProperty("cause");
+      expect(JSON.stringify(outcome.toolResults[0].result)).not.toContain("secret-token");
     }),
   );
 

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -14,7 +14,8 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./browser-quick-action": "./src/browser-quick-action.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -194,11 +194,16 @@ const protocolError = (message: string, cause?: unknown): PageCaptureProtocolErr
     ...(cause === undefined ? {} : { cause }),
   });
 
-const navigationError = (message: string): PageCaptureNavigationError =>
+const navigationError = (message: string, cause?: unknown): PageCaptureNavigationError =>
   PageCaptureNavigationError.make({
     implementation: browserQuickActionImplementation,
     message: boundedDiagnostic(message),
+    ...(cause === undefined ? {} : { cause }),
   });
+
+/** Preserve bounded remote diagnostics for the host without exposing their text to a model. */
+const privateResponseCause = (bodyText: string): Error | undefined =>
+  bodyText.length === 0 ? undefined : new Error(boundedDiagnostic(bodyText));
 
 const releaseResponseReader = (
   reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -265,15 +270,6 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
   );
 }, Effect.scoped);
 
-const renderErrors = (envelope: typeof QuickActionEnvelope.Type): string => {
-  try {
-    const encoded = JSON.stringify(envelope.errors ?? envelope);
-    return encoded === undefined ? "The Quick Action reported failure" : encoded;
-  } catch {
-    return "The Quick Action reported failure";
-  }
-};
-
 /**
  * Retry-After arrives in whole seconds; a non-integer form (an HTTP date) is
  * dropped rather than guessed at.
@@ -310,10 +306,16 @@ const parseOutput = (
   const expectsEnvelope = isJsonResponse(response);
   const envelope = expectsEnvelope ? decodeEnvelope(bodyText) : Option.none();
   if (expectsEnvelope && Option.isNone(envelope)) {
-    return protocolError("The JSON Quick Action response did not carry a valid response envelope");
+    return protocolError(
+      "The JSON Quick Action response did not carry a valid response envelope",
+      privateResponseCause(bodyText),
+    );
   }
   if (Option.isSome(envelope) && !envelope.value.success) {
-    return navigationError(renderErrors(envelope.value));
+    return navigationError(
+      "The Quick Action reported a navigation failure",
+      privateResponseCause(bodyText),
+    );
   }
   switch (action._tag) {
     case "CapturePageContent":
@@ -399,19 +401,26 @@ const makeCapture = (
     const bodyText = yield* readBoundedResponse(response, request);
     if (response.status === 429) {
       const retryAfter = retryAfterMillis(response);
+      const reason = isQuotaMessage(bodyText) ? "quota" : "rate";
+      const cause = privateResponseCause(bodyText);
       return yield* PageCaptureRateLimitedError.make({
         implementation: browserQuickActionImplementation,
-        reason: isQuotaMessage(bodyText) ? "quota" : "rate",
+        reason,
         ...(retryAfter === undefined ? {} : { retryAfterMillis: retryAfter }),
-        message: boundedDiagnostic(bodyText),
+        ...(cause === undefined ? {} : { cause }),
+        message:
+          reason === "quota"
+            ? "The Quick Action exceeded its browser quota"
+            : "The Quick Action was rate limited",
       });
     }
     if (!response.ok) {
-      const message = `The Quick Action answered ${response.status}: ${bodyText}`;
+      const message = `The Quick Action answered HTTP ${response.status}`;
+      const cause = privateResponseCause(bodyText);
       if (response.status >= 500) {
-        return yield* protocolError(message);
+        return yield* protocolError(message, cause);
       }
-      return yield* navigationError(message);
+      return yield* navigationError(message, cause);
     }
     const output = parseOutput(request.action, bodyText, response);
     if (

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -21,8 +21,6 @@ import {
 } from "@effect-agent/sandbox";
 import { Context, Effect, Layer, Option, Schema } from "effect";
 
-import { safeCauseMessage } from "./boundary.ts";
-
 /**
  * The Cloudflare Browser Run Quick Action `PageCapture` adapter (capability
  * spec §9.2). Each capture is one stateless `quickAction()` RPC on the
@@ -207,21 +205,13 @@ const releaseResponseReader = (
 ): Effect.Effect<void> =>
   Effect.tryPromise({
     try: () => reader.cancel(),
-    catch: (cause) =>
-      protocolError(
-        `Canceling the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-        cause,
-      ),
+    catch: (cause) => protocolError("Canceling the Quick Action response failed", cause),
   }).pipe(
     Effect.catch((error) => Effect.logWarning(error.message)),
     Effect.ensuring(
       Effect.try({
         try: () => reader.releaseLock(),
-        catch: (cause) =>
-          protocolError(
-            `Releasing the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-            cause,
-          ),
+        catch: (cause) => protocolError("Releasing the Quick Action response failed", cause),
       }).pipe(Effect.catch((error) => Effect.logWarning(error.message))),
     ),
   );
@@ -236,11 +226,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
   const reader = yield* Effect.acquireRelease(
     Effect.try({
       try: () => body.getReader(),
-      catch: (cause) =>
-        protocolError(
-          `Opening the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-          cause,
-        ),
+      catch: (cause) => protocolError("Opening the Quick Action response failed", cause),
     }),
     releaseResponseReader,
   );
@@ -251,11 +237,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
   while (true) {
     const chunk = yield* Effect.tryPromise({
       try: () => reader.read(),
-      catch: (cause) =>
-        protocolError(
-          `Reading the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-          cause,
-        ),
+      catch: (cause) => protocolError("Reading the Quick Action response failed", cause),
     });
     if (chunk.done) break;
 
@@ -270,11 +252,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
 
     bodyText += yield* Effect.try({
       try: () => decoder.decode(chunk.value, { stream: true }),
-      catch: (cause) =>
-        protocolError(
-          `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-          cause,
-        ),
+      catch: (cause) => protocolError("Decoding the Quick Action response failed", cause),
     });
   }
 
@@ -282,11 +260,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
     bodyText +
     (yield* Effect.try({
       try: () => decoder.decode(),
-      catch: (cause) =>
-        protocolError(
-          `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
-          cause,
-        ),
+      catch: (cause) => protocolError("Decoding the Quick Action response failed", cause),
     }))
   );
 }, Effect.scoped);
@@ -420,11 +394,7 @@ const makeCapture = (
 
     const response = yield* Effect.tryPromise({
       try: () => browser.quickAction(quickActionName(request.action), quickActionOptions(request)),
-      catch: (cause) =>
-        protocolError(
-          `The browser binding rejected the Quick Action: ${safeCauseMessage(cause, "no diagnostic")}`,
-          cause,
-        ),
+      catch: (cause) => protocolError("The browser binding rejected the Quick Action", cause),
     });
     const bodyText = yield* readBoundedResponse(response, request);
     if (response.status === 429) {

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -1,0 +1,438 @@
+import {
+  PageCapture,
+  PageCaptureInferenceUse,
+  PageCaptureNavigationError,
+  PageCaptureOutputLimitError,
+  PageCaptureProtocolError,
+  PageCaptureRateLimitedError,
+  PageCaptureResourceUse,
+  PageCaptureResult,
+  PageCaptureUnsupportedError,
+  PageContentCaptured,
+  PageLinksCaptured,
+  PageMarkdownCaptured,
+  PageStructuredCaptured,
+  SandboxImplementation,
+  type PageCaptureAction,
+  type PageCaptureCapture,
+  type PageCaptureError,
+  type PageCaptureOutput,
+  type PageCaptureRequest,
+} from "@effect-agent/sandbox";
+import { Effect, Layer, Option, Schema } from "effect";
+
+import { safeCauseMessage } from "./boundary.ts";
+
+/**
+ * The Cloudflare Browser Run Quick Action `PageCapture` adapter (capability
+ * spec §9.2). Each capture is one stateless `quickAction()` RPC on the
+ * Wrangler `browser` binding: the platform renders the target in a managed
+ * headless browser and returns one bounded output; the adapter holds no
+ * session and no state between passes. The binding requires a Worker
+ * compatibility date of `2026-03-24` or later, and local `wrangler dev` needs
+ * remote mode (`"remote": true` on the binding) because `quickAction` has no
+ * local implementation.
+ *
+ * Rendered output is untrusted, attacker-influenced content; this adapter
+ * only bounds and types it. Deployment class `E` only: no durability claim.
+ */
+export const browserQuickActionImplementation = SandboxImplementation.make({
+  isolation: "isolated",
+  identity: "cloudflare-browser-quick-action",
+});
+
+/**
+ * The structural surface this adapter needs from the Wrangler `browser`
+ * binding. Typed here rather than through a platform global so the adapter
+ * compiles against the pinned `@cloudflare/workers-types` regardless of when
+ * that package ships a `quickAction` declaration.
+ */
+export interface BrowserQuickActionBinding {
+  quickAction(action: string, options: Record<string, unknown>): Promise<Response>;
+}
+
+export interface BrowserQuickActionCaptureOptions {
+  /** The resolved Wrangler `browser` binding (DEPLOY-010: supplied, never ambient). */
+  readonly browser: BrowserQuickActionBinding;
+  /**
+   * Explicit authority for Cloudflare's separately billed Workers AI model.
+   * Structured capture is denied unless this policy authorizes and accounts
+   * for its model call before the browser binding is invoked.
+   */
+  readonly workersAi?: BrowserQuickActionWorkersAiPolicy | undefined;
+}
+
+/** Host-owned authorization and accounting for one Workers AI extraction. */
+export interface BrowserQuickActionWorkersAiPolicy {
+  readonly authorizeAndAccount: (
+    request: PageCaptureRequest,
+  ) => Effect.Effect<void, PageCaptureError>;
+}
+
+const MAX_DIAGNOSTIC_LENGTH = 8_000;
+const boundedDiagnostic = (message: string): string => message.slice(0, MAX_DIAGNOSTIC_LENGTH);
+
+/** The REST-shaped Quick Action response envelope; raw payloads also occur. */
+const QuickActionEnvelope = Schema.Struct({
+  success: Schema.Boolean,
+  result: Schema.optionalKey(Schema.Json),
+  errors: Schema.optionalKey(Schema.Json),
+});
+
+const decodeEnvelope = (text: string): Option.Option<typeof QuickActionEnvelope.Type> => {
+  try {
+    return Schema.decodeUnknownOption(QuickActionEnvelope)(JSON.parse(text));
+  } catch {
+    return Option.none();
+  }
+};
+
+const decodeJson = (text: string): Option.Option<Schema.Json> => {
+  try {
+    return Schema.decodeUnknownOption(Schema.Json)(JSON.parse(text));
+  } catch {
+    return Option.none();
+  }
+};
+
+const quickActionName = (action: PageCaptureAction): string => {
+  switch (action._tag) {
+    case "CapturePageContent": {
+      return "content";
+    }
+    case "CapturePageMarkdown": {
+      return "markdown";
+    }
+    case "CapturePageLinks": {
+      return "links";
+    }
+    case "CapturePageStructured": {
+      return "json";
+    }
+  }
+};
+
+/** Project the schema-validated request onto the Quick Action wire options. */
+const quickActionOptions = (request: PageCaptureRequest): Record<string, unknown> => {
+  const options: Record<string, unknown> = {};
+  if (request.target._tag === "PageUrlTarget") {
+    options.url = request.target.url;
+  } else {
+    options.html = request.target.html;
+  }
+  const navigation = request.navigation;
+  if (navigation !== undefined) {
+    const goto: Record<string, unknown> = {};
+    if (navigation.waitUntil !== undefined) goto.waitUntil = navigation.waitUntil;
+    if (navigation.timeoutMillis !== undefined) goto.timeout = navigation.timeoutMillis;
+    if (Object.keys(goto).length > 0) options.gotoOptions = goto;
+    if (navigation.waitForSelector !== undefined) {
+      options.waitForSelector = {
+        selector: navigation.waitForSelector.selector,
+        ...(navigation.waitForSelector.timeoutMillis === undefined
+          ? {}
+          : { timeout: navigation.waitForSelector.timeoutMillis }),
+      };
+    }
+  }
+  if (request.viewport !== undefined) {
+    options.viewport = { width: request.viewport.width, height: request.viewport.height };
+  }
+  if (request.resourcePolicy !== undefined) {
+    if (request.resourcePolicy.rejectResourceTypes !== undefined) {
+      options.rejectResourceTypes = request.resourcePolicy.rejectResourceTypes;
+    }
+    if (request.resourcePolicy.allowRequestPatterns !== undefined) {
+      options.allowRequestPattern = request.resourcePolicy.allowRequestPatterns;
+    }
+  }
+  switch (request.action._tag) {
+    case "CapturePageLinks": {
+      if (request.action.visibleLinksOnly !== undefined) {
+        options.visibleLinksOnly = request.action.visibleLinksOnly;
+      }
+      break;
+    }
+    case "CapturePageStructured": {
+      options.response_format = {
+        type: "json_schema",
+        json_schema: request.action.responseFormat,
+      };
+      if (request.action.prompt !== undefined) {
+        options.prompt = request.action.prompt;
+      }
+      break;
+    }
+    case "CapturePageContent":
+    case "CapturePageMarkdown": {
+      break;
+    }
+  }
+  return options;
+};
+
+const protocolError = (message: string): PageCaptureProtocolError =>
+  PageCaptureProtocolError.make({
+    implementation: browserQuickActionImplementation,
+    message: boundedDiagnostic(message),
+  });
+
+const navigationError = (message: string): PageCaptureNavigationError =>
+  PageCaptureNavigationError.make({
+    implementation: browserQuickActionImplementation,
+    message: boundedDiagnostic(message),
+  });
+
+const releaseResponseReader = (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Effect.Effect<void> =>
+  Effect.tryPromise({
+    try: () => reader.cancel(),
+    catch: (cause) =>
+      protocolError(
+        `Canceling the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+      ),
+  }).pipe(
+    Effect.catch((error) => Effect.logWarning(error.message)),
+    Effect.ensuring(
+      Effect.try({
+        try: () => reader.releaseLock(),
+        catch: (cause) =>
+          protocolError(
+            `Releasing the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+          ),
+      }).pipe(Effect.catch((error) => Effect.logWarning(error.message))),
+    ),
+  );
+
+const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(function* (
+  response: Response,
+  request: PageCaptureRequest,
+) {
+  const body = response.body;
+  if (body === null) return "";
+
+  const reader = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => body.getReader(),
+      catch: (cause) =>
+        protocolError(
+          `Opening the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+        ),
+    }),
+    releaseResponseReader,
+  );
+  const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+  let observedBytes = 0;
+  let bodyText = "";
+
+  while (true) {
+    const chunk = yield* Effect.tryPromise({
+      try: () => reader.read(),
+      catch: (cause) =>
+        protocolError(
+          `Reading the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+        ),
+    });
+    if (chunk.done) break;
+
+    observedBytes += chunk.value.byteLength;
+    if (observedBytes > request.limits.maxOutputBytes) {
+      return yield* PageCaptureOutputLimitError.make({
+        implementation: browserQuickActionImplementation,
+        limit: request.limits.maxOutputBytes,
+        observed: observedBytes,
+      });
+    }
+
+    bodyText += yield* Effect.try({
+      try: () => decoder.decode(chunk.value, { stream: true }),
+      catch: (cause) =>
+        protocolError(
+          `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+        ),
+    });
+  }
+
+  return (
+    bodyText +
+    (yield* Effect.try({
+      try: () => decoder.decode(),
+      catch: (cause) =>
+        protocolError(
+          `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+        ),
+    }))
+  );
+}, Effect.scoped);
+
+const renderErrors = (envelope: typeof QuickActionEnvelope.Type): string => {
+  try {
+    const encoded = JSON.stringify(envelope.errors ?? envelope);
+    return encoded === undefined ? "The Quick Action reported failure" : encoded;
+  } catch {
+    return "The Quick Action reported failure";
+  }
+};
+
+/**
+ * Retry-After arrives in whole seconds; a non-integer form (an HTTP date) is
+ * dropped rather than guessed at.
+ */
+const retryAfterMillis = (response: Response): number | undefined => {
+  const header = response.headers.get("Retry-After");
+  if (header === null) return undefined;
+  const seconds = Number(header);
+  if (!Number.isSafeInteger(seconds) || seconds < 0) return undefined;
+  const millis = seconds * 1_000;
+  return Number.isSafeInteger(millis) ? millis : undefined;
+};
+
+const browserMillis = (response: Response): number | undefined => {
+  const header = response.headers.get("X-Browser-Ms-Used");
+  if (header === null) return undefined;
+  const millis = Number(header);
+  return Number.isSafeInteger(millis) && millis >= 0 ? millis : undefined;
+};
+
+/** Bound and validate a links payload instead of letting `.make` throw on hostile values. */
+const boundedLinks = (values: ReadonlyArray<Schema.Json>): ReadonlyArray<string> =>
+  values
+    .filter((value): value is string => typeof value === "string")
+    .filter((value) => value.length > 0 && value.length <= 8 * 1024)
+    .slice(0, 4_096);
+
+const parseOutput = (
+  action: PageCaptureAction,
+  bodyText: string,
+): PageCaptureOutput | PageCaptureNavigationError | PageCaptureProtocolError => {
+  const envelope = decodeEnvelope(bodyText);
+  if (Option.isSome(envelope) && !envelope.value.success) {
+    return navigationError(renderErrors(envelope.value));
+  }
+  switch (action._tag) {
+    case "CapturePageContent":
+    case "CapturePageMarkdown": {
+      // The envelope wraps the text on the REST shape; a raw text body is the
+      // payload itself. An envelope whose result is not text is a protocol
+      // violation rather than something to coerce.
+      let text = bodyText;
+      if (Option.isSome(envelope)) {
+        if (typeof envelope.value.result !== "string") {
+          return protocolError("The Quick Action envelope carried a non-text result");
+        }
+        text = envelope.value.result;
+      }
+      return action._tag === "CapturePageContent"
+        ? PageContentCaptured.make({ html: text })
+        : PageMarkdownCaptured.make({ markdown: text });
+    }
+    case "CapturePageLinks": {
+      const values = Option.isSome(envelope)
+        ? envelope.value.result
+        : Option.getOrUndefined(decodeJson(bodyText));
+      if (!Array.isArray(values)) {
+        return protocolError("The links Quick Action did not return an array of URLs");
+      }
+      return PageLinksCaptured.make({ links: boundedLinks(values) });
+    }
+    case "CapturePageStructured": {
+      if (Option.isSome(envelope)) {
+        if (envelope.value.result === undefined) {
+          return protocolError("The json Quick Action envelope carried no result");
+        }
+        return PageStructuredCaptured.make({ value: envelope.value.result });
+      }
+      const value = decodeJson(bodyText);
+      if (Option.isNone(value)) {
+        return protocolError("The json Quick Action did not return a JSON value");
+      }
+      return PageStructuredCaptured.make({ value: value.value });
+    }
+  }
+};
+
+const isQuotaMessage = (text: string): boolean => /time limit|daily|quota/i.test(text);
+
+const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapture =>
+  Effect.fn("BrowserQuickActionCapture.capture")(function* (
+    request: PageCaptureRequest,
+  ): Effect.fn.Return<PageCaptureResult, PageCaptureError> {
+    if (request.engine !== "chromium") {
+      return yield* PageCaptureUnsupportedError.make({
+        implementation: browserQuickActionImplementation,
+        feature: "engine",
+        message:
+          "The browser binding's quickAction() exposes no engine selector; kitesurf requires the REST or CDP surface",
+      });
+    }
+
+    const usesWorkersAi = request.action._tag === "CapturePageStructured";
+    if (usesWorkersAi) {
+      const workersAi = options.workersAi;
+      if (workersAi === undefined) {
+        return yield* PageCaptureUnsupportedError.make({
+          implementation: browserQuickActionImplementation,
+          feature: "action",
+          message:
+            "Structured capture invokes separately billed Workers AI and requires an explicit authorization and accounting policy",
+        });
+      }
+      yield* workersAi.authorizeAndAccount(request);
+    }
+
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        options.browser.quickAction(quickActionName(request.action), quickActionOptions(request)),
+      catch: (cause) =>
+        protocolError(
+          `The browser binding rejected the Quick Action: ${safeCauseMessage(cause, "no diagnostic")}`,
+        ),
+    });
+    const bodyText = yield* readBoundedResponse(response, request);
+    if (response.status === 429) {
+      const retryAfter = retryAfterMillis(response);
+      return yield* PageCaptureRateLimitedError.make({
+        implementation: browserQuickActionImplementation,
+        reason: isQuotaMessage(bodyText) ? "quota" : "rate",
+        ...(retryAfter === undefined ? {} : { retryAfterMillis: retryAfter }),
+        message: boundedDiagnostic(bodyText),
+      });
+    }
+    if (!response.ok) {
+      const message = `The Quick Action answered ${response.status}: ${bodyText}`;
+      if (response.status >= 500) {
+        return yield* protocolError(message);
+      }
+      return yield* navigationError(message);
+    }
+    const output = parseOutput(request.action, bodyText);
+    if (
+      output._tag === "PageCaptureNavigationError" ||
+      output._tag === "PageCaptureProtocolError"
+    ) {
+      return yield* output;
+    }
+    const millis = browserMillis(response);
+    return PageCaptureResult.make({
+      implementation: browserQuickActionImplementation,
+      output,
+      resourceUse: PageCaptureResourceUse.make({
+        ...(millis === undefined ? {} : { browserMillis: millis }),
+        ...(usesWorkersAi
+          ? {
+              inference: PageCaptureInferenceUse.make({
+                provider: "cloudflare-workers-ai",
+                modelCalls: 1,
+              }),
+            }
+          : {}),
+      }),
+    });
+  });
+
+/** Layer building the Browser Run Quick Action `PageCapture` from the resolved binding. */
+export const browserQuickActionCaptureLayer = (
+  options: BrowserQuickActionCaptureOptions,
+): Layer.Layer<PageCapture> =>
+  Layer.succeed(PageCapture)(PageCapture.of({ capture: makeCapture(options) }));

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -189,10 +189,11 @@ const quickActionOptions = (request: PageCaptureRequest): Record<string, unknown
   return options;
 };
 
-const protocolError = (message: string): PageCaptureProtocolError =>
+const protocolError = (message: string, cause?: unknown): PageCaptureProtocolError =>
   PageCaptureProtocolError.make({
     implementation: browserQuickActionImplementation,
     message: boundedDiagnostic(message),
+    ...(cause === undefined ? {} : { cause }),
   });
 
 const navigationError = (message: string): PageCaptureNavigationError =>
@@ -209,6 +210,7 @@ const releaseResponseReader = (
     catch: (cause) =>
       protocolError(
         `Canceling the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+        cause,
       ),
   }).pipe(
     Effect.catch((error) => Effect.logWarning(error.message)),
@@ -218,6 +220,7 @@ const releaseResponseReader = (
         catch: (cause) =>
           protocolError(
             `Releasing the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+            cause,
           ),
       }).pipe(Effect.catch((error) => Effect.logWarning(error.message))),
     ),
@@ -236,6 +239,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
       catch: (cause) =>
         protocolError(
           `Opening the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+          cause,
         ),
     }),
     releaseResponseReader,
@@ -250,6 +254,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
       catch: (cause) =>
         protocolError(
           `Reading the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+          cause,
         ),
     });
     if (chunk.done) break;
@@ -268,6 +273,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
       catch: (cause) =>
         protocolError(
           `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+          cause,
         ),
     });
   }
@@ -279,6 +285,7 @@ const readBoundedResponse = Effect.fn("BrowserQuickActionCapture.readResponse")(
       catch: (cause) =>
         protocolError(
           `Decoding the Quick Action response failed: ${safeCauseMessage(cause, "no diagnostic")}`,
+          cause,
         ),
     }))
   );
@@ -416,6 +423,7 @@ const makeCapture = (
       catch: (cause) =>
         protocolError(
           `The browser binding rejected the Quick Action: ${safeCauseMessage(cause, "no diagnostic")}`,
+          cause,
         ),
     });
     const bodyText = yield* readBoundedResponse(response, request);

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -19,7 +19,7 @@ import {
   type PageCaptureOutput,
   type PageCaptureRequest,
 } from "@effect-agent/sandbox";
-import { Effect, Layer, Option, Schema } from "effect";
+import { Context, Effect, Layer, Option, Schema } from "effect";
 
 import { safeCauseMessage } from "./boundary.ts";
 
@@ -52,14 +52,8 @@ export interface BrowserQuickActionBinding {
 }
 
 export interface BrowserQuickActionCaptureOptions {
-  /** The resolved Wrangler `browser` binding (DEPLOY-010: supplied, never ambient). */
+  /** The resolved Wrangler `browser` binding (DEPLOY-014: supplied, never ambient). */
   readonly browser: BrowserQuickActionBinding;
-  /**
-   * Explicit authority for Cloudflare's separately billed Workers AI model.
-   * Structured capture is denied unless this policy authorizes and accounts
-   * for its model call before the browser binding is invoked.
-   */
-  readonly workersAi?: BrowserQuickActionWorkersAiPolicy | undefined;
 }
 
 /** Host-owned authorization and accounting for one Workers AI extraction. */
@@ -67,6 +61,18 @@ export interface BrowserQuickActionWorkersAiPolicy {
   readonly authorizeAndAccount: (
     request: PageCaptureRequest,
   ) => Effect.Effect<void, PageCaptureError>;
+}
+
+/** Explicit host-owned authority and accounting for separately billed Workers AI extraction. */
+export class BrowserQuickActionWorkersAi extends Context.Service<
+  BrowserQuickActionWorkersAi,
+  BrowserQuickActionWorkersAiPolicy
+>()("@effect-agent/platform-cloudflare/BrowserQuickActionWorkersAi") {
+  static layer(
+    policy: BrowserQuickActionWorkersAiPolicy,
+  ): Layer.Layer<BrowserQuickActionWorkersAi> {
+    return Layer.succeed(BrowserQuickActionWorkersAi)(policy);
+  }
 }
 
 const MAX_DIAGNOSTIC_LENGTH = 8_000;
@@ -295,18 +301,24 @@ const browserMillis = (response: Response): number | undefined => {
   return Number.isSafeInteger(millis) && millis >= 0 ? millis : undefined;
 };
 
-/** Bound and validate a links payload instead of letting `.make` throw on hostile values. */
-const boundedLinks = (values: ReadonlyArray<Schema.Json>): ReadonlyArray<string> =>
-  values
-    .filter((value): value is string => typeof value === "string")
-    .filter((value) => value.length > 0 && value.length <= 8 * 1024)
-    .slice(0, 4_096);
+/** Only trusted response metadata chooses transport framing; page text never does. */
+const isJsonResponse = (response: Response): boolean => {
+  const contentType = response.headers.get("Content-Type");
+  if (contentType === null) return false;
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json" || mediaType?.endsWith("+json") === true;
+};
 
 const parseOutput = (
   action: PageCaptureAction,
   bodyText: string,
+  response: Response,
 ): PageCaptureOutput | PageCaptureNavigationError | PageCaptureProtocolError => {
-  const envelope = decodeEnvelope(bodyText);
+  const expectsEnvelope = isJsonResponse(response);
+  const envelope = expectsEnvelope ? decodeEnvelope(bodyText) : Option.none();
+  if (expectsEnvelope && Option.isNone(envelope)) {
+    return protocolError("The JSON Quick Action response did not carry a valid response envelope");
+  }
   if (Option.isSome(envelope) && !envelope.value.success) {
     return navigationError(renderErrors(envelope.value));
   }
@@ -331,10 +343,14 @@ const parseOutput = (
       const values = Option.isSome(envelope)
         ? envelope.value.result
         : Option.getOrUndefined(decodeJson(bodyText));
-      if (!Array.isArray(values)) {
-        return protocolError("The links Quick Action did not return an array of URLs");
+      const decoded = Schema.decodeUnknownOption(PageLinksCaptured)({
+        _tag: "PageLinksCaptured",
+        links: values,
+      });
+      if (Option.isNone(decoded)) {
+        return protocolError("The links Quick Action did not return a bounded array of valid URLs");
       }
-      return PageLinksCaptured.make({ links: boundedLinks(values) });
+      return decoded.value;
     }
     case "CapturePageStructured": {
       if (Option.isSome(envelope)) {
@@ -354,7 +370,10 @@ const parseOutput = (
 
 const isQuotaMessage = (text: string): boolean => /time limit|daily|quota/i.test(text);
 
-const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapture =>
+const makeCapture = (
+  browser: BrowserQuickActionBinding,
+  workersAi?: BrowserQuickActionWorkersAiPolicy,
+): PageCaptureCapture =>
   Effect.fn("BrowserQuickActionCapture.capture")(function* (
     request: PageCaptureRequest,
   ): Effect.fn.Return<PageCaptureResult, PageCaptureError> {
@@ -369,7 +388,6 @@ const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapt
 
     const usesWorkersAi = request.action._tag === "CapturePageStructured";
     if (usesWorkersAi) {
-      const workersAi = options.workersAi;
       if (workersAi === undefined) {
         return yield* PageCaptureUnsupportedError.make({
           implementation: browserQuickActionImplementation,
@@ -382,8 +400,7 @@ const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapt
     }
 
     const response = yield* Effect.tryPromise({
-      try: () =>
-        options.browser.quickAction(quickActionName(request.action), quickActionOptions(request)),
+      try: () => browser.quickAction(quickActionName(request.action), quickActionOptions(request)),
       catch: (cause) =>
         protocolError(
           `The browser binding rejected the Quick Action: ${safeCauseMessage(cause, "no diagnostic")}`,
@@ -406,7 +423,7 @@ const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapt
       }
       return yield* navigationError(message);
     }
-    const output = parseOutput(request.action, bodyText);
+    const output = parseOutput(request.action, bodyText, response);
     if (
       output._tag === "PageCaptureNavigationError" ||
       output._tag === "PageCaptureProtocolError"
@@ -431,8 +448,22 @@ const makeCapture = (options: BrowserQuickActionCaptureOptions): PageCaptureCapt
     });
   });
 
-/** Layer building the Browser Run Quick Action `PageCapture` from the resolved binding. */
+/**
+ * Ordinary Quick Actions from the resolved browser binding. Workers AI stays
+ * unavailable unless the host deliberately selects its separate Layer.
+ */
 export const browserQuickActionCaptureLayer = (
   options: BrowserQuickActionCaptureOptions,
 ): Layer.Layer<PageCapture> =>
-  Layer.succeed(PageCapture)(PageCapture.of({ capture: makeCapture(options) }));
+  Layer.succeed(PageCapture)(PageCapture.of({ capture: makeCapture(options.browser) }));
+
+/** Structured Quick Actions additionally require visible host-owned Workers AI authority. */
+export const browserQuickActionWorkersAiCaptureLayer = (
+  options: BrowserQuickActionCaptureOptions,
+): Layer.Layer<PageCapture, never, BrowserQuickActionWorkersAi> =>
+  Layer.effect(
+    PageCapture,
+    Effect.map(BrowserQuickActionWorkersAi, (workersAi) =>
+      PageCapture.of({ capture: makeCapture(options.browser, workersAi) }),
+    ),
+  );

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -1,6 +1,9 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import {
   PageCapture,
   PageCaptureInferenceUse,
+  PageCaptureInferencePolicyError,
   PageCaptureNavigationError,
   PageCaptureOutputLimitError,
   PageCaptureProtocolError,
@@ -40,29 +43,62 @@ export const browserQuickActionImplementation = SandboxImplementation.make({
 });
 
 /**
- * The structural surface this adapter needs from the Wrangler `browser`
- * binding. Typed here rather than through a platform global so the adapter
- * compiles against the pinned `@cloudflare/workers-types` regardless of when
- * that package ships a `quickAction` declaration.
+ * Effect-native client captured by the binding service. Its option types come
+ * directly from the pinned Workers declarations rather than a local copy.
  */
-export interface BrowserQuickActionBinding {
-  quickAction(action: string, options: Record<string, unknown>): Promise<Response>;
+export interface BrowserQuickActionClient {
+  readonly content: (
+    options: BrowserRunContentOptions,
+  ) => Effect.Effect<Response, BrowserQuickActionRpcError>;
+  readonly markdown: (
+    options: BrowserRunMarkdownOptions,
+  ) => Effect.Effect<Response, BrowserQuickActionRpcError>;
+  readonly links: (
+    options: BrowserRunLinksOptions,
+  ) => Effect.Effect<Response, BrowserQuickActionRpcError>;
+  readonly json: (
+    options: BrowserRunJsonOptions,
+  ) => Effect.Effect<Response, BrowserQuickActionRpcError>;
 }
+
+/** A native binding RPC rejected before it returned an HTTP response. */
+export class BrowserQuickActionRpcError extends Schema.TaggedError<BrowserQuickActionRpcError>()(
+  "BrowserQuickActionRpcError",
+  {
+    action: Schema.Literals(["content", "markdown", "links", "json"]),
+    cause: Schema.Defect(),
+  },
+) {}
 
 export interface BrowserQuickActionCaptureOptions {
   /** The resolved Wrangler `browser` binding (DEPLOY-014: supplied, never ambient). */
-  readonly browser: BrowserQuickActionBinding;
+  readonly browser: BrowserRun;
 }
 
 /** Host-owned browser binding authority, supplied explicitly at the composition root. */
 export class BrowserQuickActionBrowserBinding extends Context.Service<
   BrowserQuickActionBrowserBinding,
-  BrowserQuickActionBinding
+  BrowserQuickActionClient
 >()("@effect-agent/platform-cloudflare/BrowserQuickActionBrowserBinding") {
   static layer(
     options: BrowserQuickActionCaptureOptions,
   ): Layer.Layer<BrowserQuickActionBrowserBinding> {
-    return Layer.succeed(BrowserQuickActionBrowserBinding)(options.browser);
+    const browser = options.browser;
+    const invoke = Effect.fn("BrowserQuickActionBrowserBinding.invoke")(function* (
+      action: "content" | "markdown" | "links" | "json",
+      evaluate: () => Promise<Response>,
+    ): Effect.fn.Return<Response, BrowserQuickActionRpcError> {
+      return yield* Effect.tryPromise({
+        try: evaluate,
+        catch: (cause) => BrowserQuickActionRpcError.make({ action, cause }),
+      });
+    });
+    return Layer.succeed(BrowserQuickActionBrowserBinding)({
+      content: (request) => invoke("content", () => browser.quickAction("content", request)),
+      markdown: (request) => invoke("markdown", () => browser.quickAction("markdown", request)),
+      links: (request) => invoke("links", () => browser.quickAction("links", request)),
+      json: (request) => invoke("json", () => browser.quickAction("json", request)),
+    });
   }
 }
 
@@ -70,8 +106,18 @@ export class BrowserQuickActionBrowserBinding extends Context.Service<
 export interface BrowserQuickActionWorkersAiPolicy {
   readonly authorizeAndAccount: (
     request: PageCaptureRequest,
-  ) => Effect.Effect<void, PageCaptureError>;
+  ) => Effect.Effect<void, BrowserQuickActionWorkersAiPolicyError>;
 }
+
+/** Host-only diagnostic for a denied or unaccounted Workers AI extraction. */
+export class BrowserQuickActionWorkersAiPolicyError extends Schema.TaggedError<BrowserQuickActionWorkersAiPolicyError>()(
+  "BrowserQuickActionWorkersAiPolicyError",
+  {
+    reason: Schema.Literals(["authorization", "accounting"]),
+    message: Schema.String.check(Schema.isMaxLength(8_000)),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
 
 /** Explicit host-owned authority and accounting for separately billed Workers AI extraction. */
 export class BrowserQuickActionWorkersAi extends Context.Service<
@@ -88,57 +134,33 @@ export class BrowserQuickActionWorkersAi extends Context.Service<
 const MAX_DIAGNOSTIC_LENGTH = 8_000;
 const boundedDiagnostic = (message: string): string => message.slice(0, MAX_DIAGNOSTIC_LENGTH);
 
-/** The REST-shaped Quick Action response envelope; raw payloads also occur. */
-const QuickActionEnvelope = Schema.Struct({
-  success: Schema.Boolean,
-  result: Schema.optionalKey(Schema.Json),
-  errors: Schema.optionalKey(Schema.Json),
+const QuickActionSuccessEnvelope = Schema.Struct({
+  success: Schema.Literal(true),
+  result: Schema.Json,
 });
 
-const decodeEnvelope = (text: string): Option.Option<typeof QuickActionEnvelope.Type> => {
-  try {
-    return Schema.decodeUnknownOption(QuickActionEnvelope)(JSON.parse(text));
-  } catch {
-    return Option.none();
-  }
-};
+const QuickActionErrorEnvelope = Schema.Struct({
+  success: Schema.Literal(false),
+  errors: Schema.Array(
+    Schema.Struct({
+      message: Schema.String,
+      code: Schema.optionalKey(Schema.Number),
+      detail: Schema.optionalKey(Schema.String),
+      path: Schema.optionalKey(Schema.String),
+    }),
+  ),
+  rawAiResponse: Schema.optionalKey(Schema.String),
+});
 
-const decodeJson = (text: string): Option.Option<Schema.Json> => {
-  try {
-    return Schema.decodeUnknownOption(Schema.Json)(JSON.parse(text));
-  } catch {
-    return Option.none();
-  }
-};
+const QuickActionEnvelope = Schema.Union([QuickActionSuccessEnvelope, QuickActionErrorEnvelope]);
+const decodeEnvelope = Schema.decodeUnknownOption(Schema.fromJsonString(QuickActionEnvelope));
 
-const quickActionName = (action: PageCaptureAction): string => {
-  switch (action._tag) {
-    case "CapturePageContent": {
-      return "content";
-    }
-    case "CapturePageMarkdown": {
-      return "markdown";
-    }
-    case "CapturePageLinks": {
-      return "links";
-    }
-    case "CapturePageStructured": {
-      return "json";
-    }
-  }
-};
-
-/** Project the schema-validated request onto the Quick Action wire options. */
-const quickActionOptions = (request: PageCaptureRequest): Record<string, unknown> => {
-  const options: Record<string, unknown> = {};
-  if (request.target._tag === "PageUrlTarget") {
-    options.url = request.target.url;
-  } else {
-    options.html = request.target.html;
-  }
+/** Project the schema-validated request onto Cloudflare's native common options. */
+const quickActionCommonOptions = (request: PageCaptureRequest): BrowserRunCommonOptions => {
+  const options: BrowserRunBaseOptions = {};
   const navigation = request.navigation;
   if (navigation !== undefined) {
-    const goto: Record<string, unknown> = {};
+    const goto: NonNullable<BrowserRunBaseOptions["gotoOptions"]> = {};
     if (navigation.waitUntil !== undefined) goto.waitUntil = navigation.waitUntil;
     if (navigation.timeoutMillis !== undefined) goto.timeout = navigation.timeoutMillis;
     if (Object.keys(goto).length > 0) options.gotoOptions = goto;
@@ -156,35 +178,49 @@ const quickActionOptions = (request: PageCaptureRequest): Record<string, unknown
   }
   if (request.resourcePolicy !== undefined) {
     if (request.resourcePolicy.rejectResourceTypes !== undefined) {
-      options.rejectResourceTypes = request.resourcePolicy.rejectResourceTypes;
+      options.rejectResourceTypes = [...request.resourcePolicy.rejectResourceTypes];
     }
     if (request.resourcePolicy.allowRequestPatterns !== undefined) {
-      options.allowRequestPattern = request.resourcePolicy.allowRequestPatterns;
+      options.allowRequestPattern = [...request.resourcePolicy.allowRequestPatterns];
     }
   }
+  return request.target._tag === "PageUrlTarget"
+    ? { ...options, url: request.target.url }
+    : { ...options, html: request.target.html };
+};
+
+/** Dispatch through Cloudflare's native action-specific overloads. */
+const executeQuickAction = (
+  browser: BrowserQuickActionClient,
+  request: PageCaptureRequest,
+): Effect.Effect<Response, BrowserQuickActionRpcError> => {
+  const options = quickActionCommonOptions(request);
   switch (request.action._tag) {
+    case "CapturePageContent": {
+      return browser.content(options);
+    }
+    case "CapturePageMarkdown": {
+      return browser.markdown(options);
+    }
     case "CapturePageLinks": {
-      if (request.action.visibleLinksOnly !== undefined) {
-        options.visibleLinksOnly = request.action.visibleLinksOnly;
-      }
-      break;
+      return browser.links({
+        ...options,
+        ...(request.action.visibleLinksOnly === undefined
+          ? {}
+          : { visibleLinksOnly: request.action.visibleLinksOnly }),
+      });
     }
     case "CapturePageStructured": {
-      options.response_format = {
-        type: "json_schema",
-        json_schema: request.action.responseFormat,
-      };
-      if (request.action.prompt !== undefined) {
-        options.prompt = request.action.prompt;
-      }
-      break;
-    }
-    case "CapturePageContent":
-    case "CapturePageMarkdown": {
-      break;
+      return browser.json({
+        ...options,
+        response_format: {
+          type: "json_schema",
+          json_schema: request.action.responseFormat,
+        },
+        ...(request.action.prompt === undefined ? {} : { prompt: request.action.prompt }),
+      });
     }
   }
-  return options;
 };
 
 const protocolError = (message: string, cause?: unknown): PageCaptureProtocolError =>
@@ -303,15 +339,20 @@ const parseOutput = (
   bodyText: string,
   response: Response,
 ): PageCaptureOutput | PageCaptureNavigationError | PageCaptureProtocolError => {
-  const expectsEnvelope = isJsonResponse(response);
-  const envelope = expectsEnvelope ? decodeEnvelope(bodyText) : Option.none();
-  if (expectsEnvelope && Option.isNone(envelope)) {
+  if (!isJsonResponse(response)) {
+    return protocolError(
+      "The Quick Action success response was not a JSON response envelope",
+      privateResponseCause(bodyText),
+    );
+  }
+  const envelope = decodeEnvelope(bodyText);
+  if (Option.isNone(envelope)) {
     return protocolError(
       "The JSON Quick Action response did not carry a valid response envelope",
       privateResponseCause(bodyText),
     );
   }
-  if (Option.isSome(envelope) && !envelope.value.success) {
+  if (!envelope.value.success) {
     return navigationError(
       "The Quick Action reported a navigation failure",
       privateResponseCause(bodyText),
@@ -320,27 +361,17 @@ const parseOutput = (
   switch (action._tag) {
     case "CapturePageContent":
     case "CapturePageMarkdown": {
-      // The envelope wraps the text on the REST shape; a raw text body is the
-      // payload itself. An envelope whose result is not text is a protocol
-      // violation rather than something to coerce.
-      let text = bodyText;
-      if (Option.isSome(envelope)) {
-        if (typeof envelope.value.result !== "string") {
-          return protocolError("The Quick Action envelope carried a non-text result");
-        }
-        text = envelope.value.result;
+      if (typeof envelope.value.result !== "string") {
+        return protocolError("The Quick Action envelope carried a non-text result");
       }
       return action._tag === "CapturePageContent"
-        ? PageContentCaptured.make({ html: text })
-        : PageMarkdownCaptured.make({ markdown: text });
+        ? PageContentCaptured.make({ html: envelope.value.result })
+        : PageMarkdownCaptured.make({ markdown: envelope.value.result });
     }
     case "CapturePageLinks": {
-      const values = Option.isSome(envelope)
-        ? envelope.value.result
-        : Option.getOrUndefined(decodeJson(bodyText));
       const decoded = Schema.decodeUnknownOption(PageLinksCaptured)({
         _tag: "PageLinksCaptured",
-        links: values,
+        links: envelope.value.result,
       });
       if (Option.isNone(decoded)) {
         return protocolError("The links Quick Action did not return a bounded array of valid URLs");
@@ -348,17 +379,7 @@ const parseOutput = (
       return decoded.value;
     }
     case "CapturePageStructured": {
-      if (Option.isSome(envelope)) {
-        if (envelope.value.result === undefined) {
-          return protocolError("The json Quick Action envelope carried no result");
-        }
-        return PageStructuredCaptured.make({ value: envelope.value.result });
-      }
-      const value = decodeJson(bodyText);
-      if (Option.isNone(value)) {
-        return protocolError("The json Quick Action did not return a JSON value");
-      }
-      return PageStructuredCaptured.make({ value: value.value });
+      return PageStructuredCaptured.make({ value: envelope.value.result });
     }
   }
 };
@@ -366,7 +387,7 @@ const parseOutput = (
 const isQuotaMessage = (text: string): boolean => /time limit|daily|quota/i.test(text);
 
 const makeCapture = (
-  browser: BrowserQuickActionBinding,
+  browser: BrowserQuickActionClient,
   workersAi?: BrowserQuickActionWorkersAiPolicy,
 ): PageCaptureCapture =>
   Effect.fn("BrowserQuickActionCapture.capture")(function* (
@@ -391,13 +412,27 @@ const makeCapture = (
             "Structured capture invokes separately billed Workers AI and requires an explicit authorization and accounting policy",
         });
       }
-      yield* workersAi.authorizeAndAccount(request);
+      yield* workersAi.authorizeAndAccount(request).pipe(
+        Effect.mapError((cause) =>
+          PageCaptureInferencePolicyError.make({
+            implementation: browserQuickActionImplementation,
+            provider: "cloudflare-workers-ai",
+            reason: cause.reason,
+            message:
+              cause.reason === "authorization"
+                ? "Workers AI extraction was not authorized"
+                : "Workers AI extraction could not be accounted for",
+            cause,
+          }),
+        ),
+      );
     }
 
-    const response = yield* Effect.tryPromise({
-      try: () => browser.quickAction(quickActionName(request.action), quickActionOptions(request)),
-      catch: (cause) => protocolError("The browser binding rejected the Quick Action", cause),
-    });
+    const response = yield* executeQuickAction(browser, request).pipe(
+      Effect.mapError((error) =>
+        protocolError("The browser binding rejected the Quick Action", error.cause),
+      ),
+    );
     const bodyText = yield* readBoundedResponse(response, request);
     if (response.status === 429) {
       const retryAfter = retryAfterMillis(response);

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -56,6 +56,18 @@ export interface BrowserQuickActionCaptureOptions {
   readonly browser: BrowserQuickActionBinding;
 }
 
+/** Host-owned browser binding authority, supplied explicitly at the composition root. */
+export class BrowserQuickActionBrowserBinding extends Context.Service<
+  BrowserQuickActionBrowserBinding,
+  BrowserQuickActionBinding
+>()("@effect-agent/platform-cloudflare/BrowserQuickActionBrowserBinding") {
+  static layer(
+    options: BrowserQuickActionCaptureOptions,
+  ): Layer.Layer<BrowserQuickActionBrowserBinding> {
+    return Layer.succeed(BrowserQuickActionBrowserBinding)(options.browser);
+  }
+}
+
 /** Host-owned authorization and accounting for one Workers AI extraction. */
 export interface BrowserQuickActionWorkersAiPolicy {
   readonly authorizeAndAccount: (
@@ -449,21 +461,32 @@ const makeCapture = (
   });
 
 /**
- * Ordinary Quick Actions from the resolved browser binding. Workers AI stays
- * unavailable unless the host deliberately selects its separate Layer.
+ * Ordinary Quick Actions require host-owned browser binding authority. Workers
+ * AI stays unavailable unless the host deliberately selects its separate Layer.
  */
-export const browserQuickActionCaptureLayer = (
-  options: BrowserQuickActionCaptureOptions,
-): Layer.Layer<PageCapture> =>
-  Layer.succeed(PageCapture)(PageCapture.of({ capture: makeCapture(options.browser) }));
-
-/** Structured Quick Actions additionally require visible host-owned Workers AI authority. */
-export const browserQuickActionWorkersAiCaptureLayer = (
-  options: BrowserQuickActionCaptureOptions,
-): Layer.Layer<PageCapture, never, BrowserQuickActionWorkersAi> =>
+export const browserQuickActionCaptureLayer = (): Layer.Layer<
+  PageCapture,
+  never,
+  BrowserQuickActionBrowserBinding
+> =>
   Layer.effect(
     PageCapture,
-    Effect.map(BrowserQuickActionWorkersAi, (workersAi) =>
-      PageCapture.of({ capture: makeCapture(options.browser, workersAi) }),
+    Effect.map(BrowserQuickActionBrowserBinding, (browser) =>
+      PageCapture.of({ capture: makeCapture(browser) }),
     ),
+  );
+
+/** Structured Quick Actions require host-owned browser and Workers AI authority. */
+export const browserQuickActionWorkersAiCaptureLayer = (): Layer.Layer<
+  PageCapture,
+  never,
+  BrowserQuickActionBrowserBinding | BrowserQuickActionWorkersAi
+> =>
+  Layer.effect(
+    PageCapture,
+    Effect.gen(function* () {
+      const browser = yield* BrowserQuickActionBrowserBinding;
+      const workersAi = yield* BrowserQuickActionWorkersAi;
+      return PageCapture.of({ capture: makeCapture(browser, workersAi) });
+    }),
   );

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -23,3 +23,4 @@ export * from "./layers.ts";
 export * from "./conversation-object.ts";
 export * from "./client.ts";
 export * from "./code-mode-executor.ts";
+export * from "./browser-quick-action.ts";

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -4,8 +4,8 @@ import {
   CapturePageMarkdown,
   CapturePageStructured,
   PageCapture,
+  PageCaptureInferencePolicyError,
   PageCaptureLimits,
-  PageCaptureNavigationError,
   PageCaptureRequest,
   PageUrlTarget,
   type PageCaptureError,
@@ -16,33 +16,49 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   BrowserQuickActionBrowserBinding,
+  BrowserQuickActionRpcError,
   BrowserQuickActionWorkersAi,
-  browserQuickActionImplementation,
+  BrowserQuickActionWorkersAiPolicyError,
   browserQuickActionCaptureLayer,
   browserQuickActionWorkersAiCaptureLayer,
-  type BrowserQuickActionBinding,
+  type BrowserQuickActionCaptureOptions,
+  type BrowserQuickActionClient,
   type BrowserQuickActionWorkersAiPolicy,
 } from "../src/browser-quick-action.ts";
 
 interface RecordedCall {
-  readonly action: string;
-  readonly options: Record<string, unknown>;
+  readonly action: "content" | "markdown" | "links" | "json";
+  readonly options: unknown;
 }
 
 /** A scripted binding: hands back the queued responses in order. */
 const makeBinding = (responses: ReadonlyArray<Response | Error>) => {
   const calls: Array<RecordedCall> = [];
   let index = 0;
-  const binding: BrowserQuickActionBinding = {
-    quickAction: (action, options) => {
-      calls.push({ action, options });
-      const next = responses[index];
-      index += 1;
-      if (next === undefined) {
-        return Promise.reject(new Error("no scripted response left"));
-      }
-      return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
-    },
+  const respond = (
+    action: RecordedCall["action"],
+    options: unknown,
+  ): Effect.Effect<Response, BrowserQuickActionRpcError> => {
+    calls.push({ action, options });
+    const next = responses[index];
+    index += 1;
+    if (next === undefined) {
+      return Effect.fail(
+        BrowserQuickActionRpcError.make({
+          action,
+          cause: new Error("no scripted response left"),
+        }),
+      );
+    }
+    return next instanceof Error
+      ? Effect.fail(BrowserQuickActionRpcError.make({ action, cause: next }))
+      : Effect.succeed(next);
+  };
+  const binding: BrowserQuickActionClient = {
+    content: (options) => respond("content", options),
+    markdown: (options) => respond("markdown", options),
+    links: (options) => respond("links", options),
+    json: (options) => respond("json", options),
   };
   return { binding, calls };
 };
@@ -70,7 +86,7 @@ const request = (
   });
 
 const capture = (
-  binding: BrowserQuickActionBinding,
+  binding: BrowserQuickActionClient,
   input: PageCaptureRequest,
   workersAi?: BrowserQuickActionWorkersAiPolicy,
 ): Promise<PageCaptureResult> =>
@@ -82,7 +98,7 @@ const capture = (
   );
 
 const captureError = (
-  binding: BrowserQuickActionBinding,
+  binding: BrowserQuickActionClient,
   input: PageCaptureRequest,
   workersAi?: BrowserQuickActionWorkersAiPolicy,
 ): Promise<PageCaptureError> =>
@@ -94,17 +110,17 @@ const captureError = (
   );
 
 const captureLayer = (
-  binding: BrowserQuickActionBinding,
+  binding: BrowserQuickActionClient,
   workersAi?: BrowserQuickActionWorkersAiPolicy,
 ): Layer.Layer<PageCapture> =>
   workersAi === undefined
     ? browserQuickActionCaptureLayer().pipe(
-        Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: binding })),
+        Layer.provide(Layer.succeed(BrowserQuickActionBrowserBinding)(binding)),
       )
     : browserQuickActionWorkersAiCaptureLayer().pipe(
         Layer.provide(
           Layer.merge(
-            BrowserQuickActionBrowserBinding.layer({ browser: binding }),
+            Layer.succeed(BrowserQuickActionBrowserBinding)(binding),
             BrowserQuickActionWorkersAi.layer(workersAi),
           ),
         ),
@@ -130,13 +146,16 @@ type WorkersAiAuthorityIsVisible = Equal<
   LayerRequirements<ReturnType<typeof browserQuickActionWorkersAiCaptureLayer>>,
   BrowserQuickActionBrowserBinding | BrowserQuickActionWorkersAi
 >;
+type NativeBrowserRunIsLayerInput = Equal<BrowserQuickActionCaptureOptions["browser"], BrowserRun>;
 
 describe("Browser Run Quick Action PageCapture adapter", () => {
   it("keeps browser RPC and separately billed Workers AI authority visible in adapter Layers", () => {
     const browserProof: BrowserBindingAuthorityIsVisible = true;
     const workersAiProof: WorkersAiAuthorityIsVisible = true;
+    const nativeBindingProof: NativeBrowserRunIsLayerInput = true;
     expect(browserProof).toBe(true);
     expect(workersAiProof).toBe(true);
+    expect(nativeBindingProof).toBe(true);
   });
 
   it("projects the request onto the wire options and unwraps the envelope", async () => {
@@ -176,10 +195,10 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     expect(result.implementation.identity).toBe("cloudflare-browser-quick-action");
   });
 
-  it("accepts a raw text body, bounded links, and explicitly authorized structured envelopes", async () => {
+  it("decodes native content, links, and explicitly authorized structured envelopes", async () => {
     const rawHtml = "<!doctype html><h1>Pricing</h1>";
     const { binding, calls } = makeBinding([
-      new Response(rawHtml, { headers: { "Content-Type": "text/html" } }),
+      jsonResponse({ success: true, result: rawHtml }),
       jsonResponse({
         success: true,
         result: ["https://docs.example.com/a", "https://docs.example.com/b"],
@@ -240,7 +259,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     }
   });
 
-  it("preserves JSON-shaped page text when response metadata identifies a raw payload", async () => {
+  it("rejects success bodies outside the native BrowserRun response envelope", async () => {
     const rawFailure = JSON.stringify({ success: false, errors: "page content" });
     const rawSuccess = JSON.stringify({ success: true, result: "page content" });
     const { binding } = makeBinding([
@@ -248,13 +267,13 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
       new Response(rawSuccess, { headers: { "Content-Type": "text/plain" } }),
     ]);
 
-    expect((await capture(binding, request(CapturePageMarkdown.make({})))).output).toMatchObject({
-      _tag: "PageMarkdownCaptured",
-      markdown: rawFailure,
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: expect.stringContaining("JSON response envelope"),
     });
-    expect((await capture(binding, request(CapturePageContent.make({})))).output).toMatchObject({
-      _tag: "PageContentCaptured",
-      html: rawSuccess,
+    expect(await captureError(binding, request(CapturePageContent.make({})))).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: expect.stringContaining("JSON response envelope"),
     });
   });
 
@@ -269,15 +288,21 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     });
     expect(calls).toHaveLength(0);
 
-    const denial = PageCaptureNavigationError.make({
-      implementation: browserQuickActionImplementation,
+    const denial = BrowserQuickActionWorkersAiPolicyError.make({
+      reason: "authorization",
       message: "Workers AI is outside this tenant's provider budget",
     });
-    expect(
-      await captureError(binding, structured, {
-        authorizeAndAccount: () => Effect.fail(denial),
-      }),
-    ).toEqual(denial);
+    const refused = await captureError(binding, structured, {
+      authorizeAndAccount: () => Effect.fail(denial),
+    });
+    expect(refused).toMatchObject({
+      _tag: "PageCaptureInferencePolicyError",
+      provider: "cloudflare-workers-ai",
+      reason: "authorization",
+      message: "Workers AI extraction was not authorized",
+    });
+    expect(refused).toBeInstanceOf(PageCaptureInferencePolicyError);
+    expect(refused._tag === "PageCaptureInferencePolicyError" && refused.cause).toBe(denial);
     expect(calls).toHaveLength(0);
   });
 

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -222,6 +222,9 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     const hostilePayloads: ReadonlyArray<ReadonlyArray<unknown>> = [
       ["https://docs.example.com/a", 7],
       ["https://docs.example.com/a", ""],
+      ["https://docs.example.com/a", "not a URL"],
+      ["https://docs.example.com/a", "javascript:alert(1)"],
+      ["https://docs.example.com/a", "https://user:secret@docs.example.com/private"],
       ["https://docs.example.com/a", "x".repeat(8 * 1024 + 1)],
       Array.from({ length: 4_097 }, () => "https://a"),
     ];

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -407,7 +407,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
   });
 
   it("rejects kitesurf typed without calling the binding and types binding rejections", async () => {
-    const foreignCause = new Error("binding exploded");
+    const foreignCause = new Error("binding exploded; token=host-only-secret");
     const { binding, calls } = makeBinding([foreignCause]);
     const unsupported = await captureError(
       binding,
@@ -419,13 +419,14 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     const failure = await captureError(binding, request(CapturePageMarkdown.make({})));
     expect(failure).toMatchObject({
       _tag: "PageCaptureProtocolError",
-      message: expect.stringContaining("binding exploded"),
+      message: "The browser binding rejected the Quick Action",
     });
+    expect(failure.message).not.toContain("host-only-secret");
     expect(failure._tag === "PageCaptureProtocolError" && failure.cause).toBe(foreignCause);
   });
 
   it("preserves foreign stream-read failures inside the typed protocol error", async () => {
-    const foreignCause = new Error("response stream exploded");
+    const foreignCause = new Error("response stream exploded; token=host-only-secret");
     const response = new Response(
       new ReadableStream<Uint8Array>({
         pull() {
@@ -438,8 +439,9 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     const failure = await captureError(binding, request(CapturePageMarkdown.make({})));
     expect(failure).toMatchObject({
       _tag: "PageCaptureProtocolError",
-      message: expect.stringContaining("response stream exploded"),
+      message: "Reading the Quick Action response failed",
     });
+    expect(failure.message).not.toContain("host-only-secret");
     expect(failure._tag === "PageCaptureProtocolError" && failure.cause).toBe(foreignCause);
   });
 });

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -282,18 +282,35 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
   });
 
   it("maps 429 responses to typed rate/quota failures with the backoff hint", async () => {
+    const privateDiagnostic = "token=host-only-secret";
     const { binding } = makeBinding([
-      new Response("Too many requests", { status: 429, headers: { "Retry-After": "12" } }),
-      new Response("Browser time limit exceeded for today", { status: 429 }),
+      new Response(`Too many requests; ${privateDiagnostic}`, {
+        status: 429,
+        headers: { "Retry-After": "12" },
+      }),
+      new Response(`Browser time limit exceeded for today; ${privateDiagnostic}`, { status: 429 }),
     ]);
     const rate = await captureError(binding, request(CapturePageMarkdown.make({})));
     expect(rate).toMatchObject({
       _tag: "PageCaptureRateLimitedError",
       reason: "rate",
       retryAfterMillis: 12_000,
+      message: "The Quick Action was rate limited",
+    });
+    expect(rate.message).not.toContain(privateDiagnostic);
+    expect(rate._tag === "PageCaptureRateLimitedError" && rate.cause).toMatchObject({
+      message: expect.stringContaining(privateDiagnostic),
     });
     const quota = await captureError(binding, request(CapturePageMarkdown.make({})));
-    expect(quota).toMatchObject({ _tag: "PageCaptureRateLimitedError", reason: "quota" });
+    expect(quota).toMatchObject({
+      _tag: "PageCaptureRateLimitedError",
+      reason: "quota",
+      message: "The Quick Action exceeded its browser quota",
+    });
+    expect(quota.message).not.toContain(privateDiagnostic);
+    expect(quota._tag === "PageCaptureRateLimitedError" && quota.cause).toMatchObject({
+      message: expect.stringContaining(privateDiagnostic),
+    });
   });
 
   it("drops overflowing Retry-After values without defecting the typed rate-limit failure", async () => {
@@ -310,21 +327,44 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
   });
 
   it("keeps remote failures typed: 4xx, 5xx, and reported envelope errors", async () => {
+    const privateDiagnostic = "token=host-only-secret";
     const { binding } = makeBinding([
-      new Response("bad request", { status: 400 }),
-      new Response("internal", { status: 500 }),
-      jsonResponse({ success: false, errors: [{ code: 1, message: "navigation failed" }] }),
+      new Response(`bad request; ${privateDiagnostic}`, { status: 400 }),
+      new Response(`internal; ${privateDiagnostic}`, { status: 500 }),
+      jsonResponse({
+        success: false,
+        errors: [{ code: 1, message: `navigation failed; ${privateDiagnostic}` }],
+      }),
       jsonResponse({ result: "missing success discriminator" }),
     ]);
-    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+    const navigation = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(navigation).toMatchObject({
       _tag: "PageCaptureNavigationError",
+      message: "The Quick Action answered HTTP 400",
     });
-    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+    expect(navigation.message).not.toContain(privateDiagnostic);
+    expect(navigation._tag === "PageCaptureNavigationError" && navigation.cause).toMatchObject({
+      message: expect.stringContaining(privateDiagnostic),
+    });
+
+    const protocol = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(protocol).toMatchObject({
       _tag: "PageCaptureProtocolError",
+      message: "The Quick Action answered HTTP 500",
     });
-    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+    expect(protocol.message).not.toContain(privateDiagnostic);
+    expect(protocol._tag === "PageCaptureProtocolError" && protocol.cause).toMatchObject({
+      message: expect.stringContaining(privateDiagnostic),
+    });
+
+    const envelope = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(envelope).toMatchObject({
       _tag: "PageCaptureNavigationError",
-      message: expect.stringContaining("navigation failed"),
+      message: "The Quick Action reported a navigation failure",
+    });
+    expect(envelope.message).not.toContain(privateDiagnostic);
+    expect(envelope._tag === "PageCaptureNavigationError" && envelope.cause).toMatchObject({
+      message: expect.stringContaining(privateDiagnostic),
     });
     expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
       _tag: "PageCaptureProtocolError",

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -407,7 +407,8 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
   });
 
   it("rejects kitesurf typed without calling the binding and types binding rejections", async () => {
-    const { binding, calls } = makeBinding([new Error("binding exploded")]);
+    const foreignCause = new Error("binding exploded");
+    const { binding, calls } = makeBinding([foreignCause]);
     const unsupported = await captureError(
       binding,
       request(CapturePageMarkdown.make({}), { engine: "kitesurf" }),
@@ -415,9 +416,30 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     expect(unsupported).toMatchObject({ _tag: "PageCaptureUnsupportedError", feature: "engine" });
     expect(calls).toHaveLength(0);
 
-    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+    const failure = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(failure).toMatchObject({
       _tag: "PageCaptureProtocolError",
       message: expect.stringContaining("binding exploded"),
     });
+    expect(failure._tag === "PageCaptureProtocolError" && failure.cause).toBe(foreignCause);
+  });
+
+  it("preserves foreign stream-read failures inside the typed protocol error", async () => {
+    const foreignCause = new Error("response stream exploded");
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          throw foreignCause;
+        },
+      }),
+    );
+    const { binding } = makeBinding([response]);
+
+    const failure = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(failure).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: expect.stringContaining("response stream exploded"),
+    });
+    expect(failure._tag === "PageCaptureProtocolError" && failure.cause).toBe(foreignCause);
   });
 });

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -15,6 +15,7 @@ import { Deferred, Effect, Fiber, Layer } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  BrowserQuickActionBrowserBinding,
   BrowserQuickActionWorkersAi,
   browserQuickActionImplementation,
   browserQuickActionCaptureLayer,
@@ -97,9 +98,16 @@ const captureLayer = (
   workersAi?: BrowserQuickActionWorkersAiPolicy,
 ): Layer.Layer<PageCapture> =>
   workersAi === undefined
-    ? browserQuickActionCaptureLayer({ browser: binding })
-    : browserQuickActionWorkersAiCaptureLayer({ browser: binding }).pipe(
-        Layer.provide(BrowserQuickActionWorkersAi.layer(workersAi)),
+    ? browserQuickActionCaptureLayer().pipe(
+        Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: binding })),
+      )
+    : browserQuickActionWorkersAiCaptureLayer().pipe(
+        Layer.provide(
+          Layer.merge(
+            BrowserQuickActionBrowserBinding.layer({ browser: binding }),
+            BrowserQuickActionWorkersAi.layer(workersAi),
+          ),
+        ),
       );
 
 const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
@@ -114,15 +122,21 @@ type Equal<Left, Right> =
     : false;
 type LayerRequirements<Value> =
   Value extends Layer.Layer<infer _Output, infer _Error, infer Requirements> ? Requirements : never;
+type BrowserBindingAuthorityIsVisible = Equal<
+  LayerRequirements<ReturnType<typeof browserQuickActionCaptureLayer>>,
+  BrowserQuickActionBrowserBinding
+>;
 type WorkersAiAuthorityIsVisible = Equal<
   LayerRequirements<ReturnType<typeof browserQuickActionWorkersAiCaptureLayer>>,
-  BrowserQuickActionWorkersAi
+  BrowserQuickActionBrowserBinding | BrowserQuickActionWorkersAi
 >;
 
 describe("Browser Run Quick Action PageCapture adapter", () => {
-  it("keeps separately billed Workers AI authority visible in the adapter Layer", () => {
-    const proof: WorkersAiAuthorityIsVisible = true;
-    expect(proof).toBe(true);
+  it("keeps browser RPC and separately billed Workers AI authority visible in adapter Layers", () => {
+    const browserProof: BrowserBindingAuthorityIsVisible = true;
+    const workersAiProof: WorkersAiAuthorityIsVisible = true;
+    expect(browserProof).toBe(true);
+    expect(workersAiProof).toBe(true);
   });
 
   it("projects the request onto the wire options and unwraps the envelope", async () => {
@@ -377,7 +391,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
         const program = Effect.gen(function* () {
           const port = yield* PageCapture;
           return yield* port.capture(request(CapturePageMarkdown.make({})));
-        }).pipe(Effect.provide(browserQuickActionCaptureLayer({ browser: binding })));
+        }).pipe(Effect.provide(captureLayer(binding)));
 
         const fiber = yield* Effect.forkChild(program);
         yield* Deferred.await(readStarted);

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -11,12 +11,14 @@ import {
   type PageCaptureError,
   type PageCaptureResult,
 } from "@effect-agent/sandbox";
-import { Deferred, Effect, Fiber } from "effect";
+import { Deferred, Effect, Fiber, Layer } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  BrowserQuickActionWorkersAi,
   browserQuickActionImplementation,
   browserQuickActionCaptureLayer,
+  browserQuickActionWorkersAiCaptureLayer,
   type BrowserQuickActionBinding,
   type BrowserQuickActionWorkersAiPolicy,
 } from "../src/browser-quick-action.ts";
@@ -75,14 +77,7 @@ const capture = (
     Effect.gen(function* () {
       const port = yield* PageCapture;
       return yield* port.capture(input);
-    }).pipe(
-      Effect.provide(
-        browserQuickActionCaptureLayer({
-          browser: binding,
-          ...(workersAi === undefined ? {} : { workersAi }),
-        }),
-      ),
-    ),
+    }).pipe(Effect.provide(captureLayer(binding, workersAi))),
   );
 
 const captureError = (
@@ -94,15 +89,18 @@ const captureError = (
     Effect.gen(function* () {
       const port = yield* PageCapture;
       return yield* port.capture(input).pipe(Effect.flip);
-    }).pipe(
-      Effect.provide(
-        browserQuickActionCaptureLayer({
-          browser: binding,
-          ...(workersAi === undefined ? {} : { workersAi }),
-        }),
-      ),
-    ),
+    }).pipe(Effect.provide(captureLayer(binding, workersAi))),
   );
+
+const captureLayer = (
+  binding: BrowserQuickActionBinding,
+  workersAi?: BrowserQuickActionWorkersAiPolicy,
+): Layer.Layer<PageCapture> =>
+  workersAi === undefined
+    ? browserQuickActionCaptureLayer({ browser: binding })
+    : browserQuickActionWorkersAiCaptureLayer({ browser: binding }).pipe(
+        Layer.provide(BrowserQuickActionWorkersAi.layer(workersAi)),
+      );
 
 const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
   new Response(JSON.stringify(body), {
@@ -110,7 +108,23 @@ const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
     ...init,
   });
 
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type LayerRequirements<Value> =
+  Value extends Layer.Layer<infer _Output, infer _Error, infer Requirements> ? Requirements : never;
+type WorkersAiAuthorityIsVisible = Equal<
+  LayerRequirements<ReturnType<typeof browserQuickActionWorkersAiCaptureLayer>>,
+  BrowserQuickActionWorkersAi
+>;
+
 describe("Browser Run Quick Action PageCapture adapter", () => {
+  it("keeps separately billed Workers AI authority visible in the adapter Layer", () => {
+    const proof: WorkersAiAuthorityIsVisible = true;
+    expect(proof).toBe(true);
+  });
+
   it("projects the request onto the wire options and unwraps the envelope", async () => {
     const { binding, calls } = makeBinding([
       jsonResponse(
@@ -154,7 +168,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
       new Response(rawHtml, { headers: { "Content-Type": "text/html" } }),
       jsonResponse({
         success: true,
-        result: ["https://docs.example.com/a", 7, "", "https://docs.example.com/b"],
+        result: ["https://docs.example.com/a", "https://docs.example.com/b"],
       }),
       jsonResponse({ success: true, result: { plans: [{ name: "Pro" }] } }),
     ]);
@@ -187,6 +201,43 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     expect(structured.resourceUse.inference).toEqual({
       provider: "cloudflare-workers-ai",
       modelCalls: 1,
+    });
+  });
+
+  it("rejects malformed and oversized link arrays instead of silently filtering their values", async () => {
+    const hostilePayloads: ReadonlyArray<ReadonlyArray<unknown>> = [
+      ["https://docs.example.com/a", 7],
+      ["https://docs.example.com/a", ""],
+      ["https://docs.example.com/a", "x".repeat(8 * 1024 + 1)],
+      Array.from({ length: 4_097 }, () => "https://a"),
+    ];
+    const { binding } = makeBinding(
+      hostilePayloads.map((result) => jsonResponse({ success: true, result })),
+    );
+
+    for (const _payload of hostilePayloads) {
+      expect(await captureError(binding, request(CapturePageLinks.make({})))).toMatchObject({
+        _tag: "PageCaptureProtocolError",
+        message: expect.stringContaining("bounded array of valid URLs"),
+      });
+    }
+  });
+
+  it("preserves JSON-shaped page text when response metadata identifies a raw payload", async () => {
+    const rawFailure = JSON.stringify({ success: false, errors: "page content" });
+    const rawSuccess = JSON.stringify({ success: true, result: "page content" });
+    const { binding } = makeBinding([
+      new Response(rawFailure, { headers: { "Content-Type": "text/markdown; charset=utf-8" } }),
+      new Response(rawSuccess, { headers: { "Content-Type": "text/plain" } }),
+    ]);
+
+    expect((await capture(binding, request(CapturePageMarkdown.make({})))).output).toMatchObject({
+      _tag: "PageMarkdownCaptured",
+      markdown: rawFailure,
+    });
+    expect((await capture(binding, request(CapturePageContent.make({})))).output).toMatchObject({
+      _tag: "PageContentCaptured",
+      html: rawSuccess,
     });
   });
 
@@ -246,6 +297,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
       new Response("bad request", { status: 400 }),
       new Response("internal", { status: 500 }),
       jsonResponse({ success: false, errors: [{ code: 1, message: "navigation failed" }] }),
+      jsonResponse({ result: "missing success discriminator" }),
     ]);
     expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
       _tag: "PageCaptureNavigationError",
@@ -256,6 +308,10 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
       _tag: "PageCaptureNavigationError",
       message: expect.stringContaining("navigation failed"),
+    });
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: expect.stringContaining("valid response envelope"),
     });
   });
 

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -1,0 +1,350 @@
+import {
+  CapturePageContent,
+  CapturePageLinks,
+  CapturePageMarkdown,
+  CapturePageStructured,
+  PageCapture,
+  PageCaptureLimits,
+  PageCaptureNavigationError,
+  PageCaptureRequest,
+  PageUrlTarget,
+  type PageCaptureError,
+  type PageCaptureResult,
+} from "@effect-agent/sandbox";
+import { Deferred, Effect, Fiber } from "effect";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  browserQuickActionImplementation,
+  browserQuickActionCaptureLayer,
+  type BrowserQuickActionBinding,
+  type BrowserQuickActionWorkersAiPolicy,
+} from "../src/browser-quick-action.ts";
+
+interface RecordedCall {
+  readonly action: string;
+  readonly options: Record<string, unknown>;
+}
+
+/** A scripted binding: hands back the queued responses in order. */
+const makeBinding = (responses: ReadonlyArray<Response | Error>) => {
+  const calls: Array<RecordedCall> = [];
+  let index = 0;
+  const binding: BrowserQuickActionBinding = {
+    quickAction: (action, options) => {
+      calls.push({ action, options });
+      const next = responses[index];
+      index += 1;
+      if (next === undefined) {
+        return Promise.reject(new Error("no scripted response left"));
+      }
+      return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
+    },
+  };
+  return { binding, calls };
+};
+
+const request = (
+  action: PageCaptureRequest["action"],
+  overrides?: Partial<{
+    readonly engine: PageCaptureRequest["engine"];
+    readonly maxOutputBytes: number;
+    readonly navigation: PageCaptureRequest["navigation"];
+    readonly viewport: PageCaptureRequest["viewport"];
+    readonly resourcePolicy: PageCaptureRequest["resourcePolicy"];
+  }>,
+): PageCaptureRequest =>
+  PageCaptureRequest.make({
+    target: PageUrlTarget.make({ url: "https://docs.example.com/pricing" }),
+    action,
+    engine: overrides?.engine ?? "chromium",
+    limits: PageCaptureLimits.make({ maxOutputBytes: overrides?.maxOutputBytes ?? 128 * 1024 }),
+    ...(overrides?.navigation === undefined ? {} : { navigation: overrides.navigation }),
+    ...(overrides?.viewport === undefined ? {} : { viewport: overrides.viewport }),
+    ...(overrides?.resourcePolicy === undefined
+      ? {}
+      : { resourcePolicy: overrides.resourcePolicy }),
+  });
+
+const capture = (
+  binding: BrowserQuickActionBinding,
+  input: PageCaptureRequest,
+  workersAi?: BrowserQuickActionWorkersAiPolicy,
+): Promise<PageCaptureResult> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const port = yield* PageCapture;
+      return yield* port.capture(input);
+    }).pipe(
+      Effect.provide(
+        browserQuickActionCaptureLayer({
+          browser: binding,
+          ...(workersAi === undefined ? {} : { workersAi }),
+        }),
+      ),
+    ),
+  );
+
+const captureError = (
+  binding: BrowserQuickActionBinding,
+  input: PageCaptureRequest,
+  workersAi?: BrowserQuickActionWorkersAiPolicy,
+): Promise<PageCaptureError> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const port = yield* PageCapture;
+      return yield* port.capture(input).pipe(Effect.flip);
+    }).pipe(
+      Effect.provide(
+        browserQuickActionCaptureLayer({
+          browser: binding,
+          ...(workersAi === undefined ? {} : { workersAi }),
+        }),
+      ),
+    ),
+  );
+
+const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+describe("Browser Run Quick Action PageCapture adapter", () => {
+  it("projects the request onto the wire options and unwraps the envelope", async () => {
+    const { binding, calls } = makeBinding([
+      jsonResponse(
+        { success: true, result: "# Pricing" },
+        { headers: { "Content-Type": "application/json", "X-Browser-Ms-Used": "1234" } },
+      ),
+    ]);
+    const result = await capture(
+      binding,
+      request(CapturePageMarkdown.make({}), {
+        navigation: {
+          waitUntil: "networkidle0",
+          timeoutMillis: 15_000,
+          waitForSelector: { selector: "#plans", timeoutMillis: 5_000 },
+        },
+        viewport: { width: 1_280, height: 800 },
+        resourcePolicy: {
+          rejectResourceTypes: ["image"],
+          allowRequestPatterns: ["https://docs.example.com/*"],
+        },
+      }),
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].action).toBe("markdown");
+    expect(calls[0].options).toMatchObject({
+      url: "https://docs.example.com/pricing",
+      gotoOptions: { waitUntil: "networkidle0", timeout: 15_000 },
+      waitForSelector: { selector: "#plans", timeout: 5_000 },
+      viewport: { width: 1_280, height: 800 },
+      rejectResourceTypes: ["image"],
+      allowRequestPattern: ["https://docs.example.com/*"],
+    });
+    expect(result.output).toMatchObject({ _tag: "PageMarkdownCaptured", markdown: "# Pricing" });
+    expect(result.resourceUse.browserMillis).toBe(1_234);
+    expect(result.implementation.identity).toBe("cloudflare-browser-quick-action");
+  });
+
+  it("accepts a raw text body, bounded links, and explicitly authorized structured envelopes", async () => {
+    const rawHtml = "<!doctype html><h1>Pricing</h1>";
+    const { binding, calls } = makeBinding([
+      new Response(rawHtml, { headers: { "Content-Type": "text/html" } }),
+      jsonResponse({
+        success: true,
+        result: ["https://docs.example.com/a", 7, "", "https://docs.example.com/b"],
+      }),
+      jsonResponse({ success: true, result: { plans: [{ name: "Pro" }] } }),
+    ]);
+    const content = await capture(binding, request(CapturePageContent.make({})));
+    expect(content.output).toMatchObject({ _tag: "PageContentCaptured", html: rawHtml });
+
+    const links = await capture(binding, request(CapturePageLinks.make({})));
+    expect(links.output).toMatchObject({
+      _tag: "PageLinksCaptured",
+      links: ["https://docs.example.com/a", "https://docs.example.com/b"],
+    });
+
+    const authorized: Array<PageCaptureRequest["action"]["_tag"]> = [];
+    const structured = await capture(
+      binding,
+      request(CapturePageStructured.make({ responseFormat: { type: "object" } })),
+      {
+        authorizeAndAccount: (input) =>
+          Effect.sync(() => {
+            expect(calls).toHaveLength(2);
+            authorized.push(input.action._tag);
+          }),
+      },
+    );
+    expect(structured.output).toMatchObject({
+      _tag: "PageStructuredCaptured",
+      value: { plans: [{ name: "Pro" }] },
+    });
+    expect(authorized).toEqual(["CapturePageStructured"]);
+    expect(structured.resourceUse.inference).toEqual({
+      provider: "cloudflare-workers-ai",
+      modelCalls: 1,
+    });
+  });
+
+  it("denies hidden or host-refused Workers AI extraction before invoking the browser", async () => {
+    const { binding, calls } = makeBinding([]);
+    const structured = request(CapturePageStructured.make({ responseFormat: { type: "object" } }));
+
+    expect(await captureError(binding, structured)).toMatchObject({
+      _tag: "PageCaptureUnsupportedError",
+      feature: "action",
+      message: expect.stringContaining("authorization and accounting"),
+    });
+    expect(calls).toHaveLength(0);
+
+    const denial = PageCaptureNavigationError.make({
+      implementation: browserQuickActionImplementation,
+      message: "Workers AI is outside this tenant's provider budget",
+    });
+    expect(
+      await captureError(binding, structured, {
+        authorizeAndAccount: () => Effect.fail(denial),
+      }),
+    ).toEqual(denial);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("maps 429 responses to typed rate/quota failures with the backoff hint", async () => {
+    const { binding } = makeBinding([
+      new Response("Too many requests", { status: 429, headers: { "Retry-After": "12" } }),
+      new Response("Browser time limit exceeded for today", { status: 429 }),
+    ]);
+    const rate = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(rate).toMatchObject({
+      _tag: "PageCaptureRateLimitedError",
+      reason: "rate",
+      retryAfterMillis: 12_000,
+    });
+    const quota = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(quota).toMatchObject({ _tag: "PageCaptureRateLimitedError", reason: "quota" });
+  });
+
+  it("drops overflowing Retry-After values without defecting the typed rate-limit failure", async () => {
+    const { binding } = makeBinding([
+      new Response("Too many requests", {
+        status: 429,
+        headers: { "Retry-After": String(Number.MAX_SAFE_INTEGER) },
+      }),
+    ]);
+
+    const error = await captureError(binding, request(CapturePageMarkdown.make({})));
+    expect(error).toMatchObject({ _tag: "PageCaptureRateLimitedError", reason: "rate" });
+    expect(error).not.toHaveProperty("retryAfterMillis");
+  });
+
+  it("keeps remote failures typed: 4xx, 5xx, and reported envelope errors", async () => {
+    const { binding } = makeBinding([
+      new Response("bad request", { status: 400 }),
+      new Response("internal", { status: 500 }),
+      jsonResponse({ success: false, errors: [{ code: 1, message: "navigation failed" }] }),
+    ]);
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureNavigationError",
+    });
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+    });
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureNavigationError",
+      message: expect.stringContaining("navigation failed"),
+    });
+  });
+
+  it("enforces the output byte budget on the encoded response", async () => {
+    const { binding } = makeBinding([jsonResponse({ success: true, result: "x".repeat(4_096) })]);
+    const error = await captureError(
+      binding,
+      request(CapturePageMarkdown.make({}), { maxOutputBytes: 1_024 }),
+    );
+    expect(error).toMatchObject({ _tag: "PageCaptureOutputLimitError", limit: 1_024 });
+  });
+
+  it("stops oversized streams at the first exceeding chunk and releases their reader", async () => {
+    let chunksRead = 0;
+    let canceled = false;
+    const stream = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          chunksRead += 1;
+          controller.enqueue(new Uint8Array(512));
+        },
+        cancel() {
+          canceled = true;
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const { binding } = makeBinding([new Response(stream)]);
+
+    const error = await captureError(
+      binding,
+      request(CapturePageMarkdown.make({}), { maxOutputBytes: 1_024 }),
+    );
+
+    expect(error).toMatchObject({
+      _tag: "PageCaptureOutputLimitError",
+      limit: 1_024,
+      observed: 1_536,
+    });
+    expect(chunksRead).toBe(3);
+    expect(canceled).toBe(true);
+    expect(stream.locked).toBe(false);
+  });
+
+  it("cancels and unlocks an in-flight response reader when capture is interrupted", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const readStarted = yield* Deferred.make<void>();
+        let canceled = false;
+        const stream = new ReadableStream<Uint8Array>(
+          {
+            pull() {
+              Effect.runSync(Deferred.succeed(readStarted, undefined));
+              return new Promise<void>(() => {});
+            },
+            cancel() {
+              canceled = true;
+            },
+          },
+          { highWaterMark: 0 },
+        );
+        const { binding } = makeBinding([new Response(stream)]);
+        const program = Effect.gen(function* () {
+          const port = yield* PageCapture;
+          return yield* port.capture(request(CapturePageMarkdown.make({})));
+        }).pipe(Effect.provide(browserQuickActionCaptureLayer({ browser: binding })));
+
+        const fiber = yield* Effect.forkChild(program);
+        yield* Deferred.await(readStarted);
+        yield* Fiber.interrupt(fiber);
+
+        expect(canceled).toBe(true);
+        expect(stream.locked).toBe(false);
+      }),
+    );
+  });
+
+  it("rejects kitesurf typed without calling the binding and types binding rejections", async () => {
+    const { binding, calls } = makeBinding([new Error("binding exploded")]);
+    const unsupported = await captureError(
+      binding,
+      request(CapturePageMarkdown.make({}), { engine: "kitesurf" }),
+    );
+    expect(unsupported).toMatchObject({ _tag: "PageCaptureUnsupportedError", feature: "engine" });
+    expect(calls).toHaveLength(0);
+
+    expect(await captureError(binding, request(CapturePageMarkdown.make({})))).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: expect.stringContaining("binding exploded"),
+    });
+  });
+});

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   // defaults, so the published artifact's declarations and sourcemap are
   // pinned explicitly here.
   pack: {
+    entry: ["src/index.ts", "src/browser-quick-action.ts"],
     dts: true,
     sourcemap: true,
   },

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./code-executor.ts";
+export * from "./page-capture.ts";
 export * from "./sandbox.ts";

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -33,6 +33,7 @@ const BoundedPrompt = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
 const BoundedSelector = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedPattern = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedMessage = Schema.String.check(Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+const BoundedInferenceProvider = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 const BoundedSchemaProperty = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 const BoundedSchemaText = Schema.String.check(Schema.isMaxLength(8 * 1024));
 const BoundedSchemaReference = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
@@ -502,7 +503,7 @@ export type PageCaptureOutput = typeof PageCaptureOutput.Type;
 export class PageCaptureInferenceUse extends Schema.Class<PageCaptureInferenceUse>(
   "PageCaptureInferenceUse",
 )({
-  provider: Schema.NonEmptyString.check(Schema.isMaxLength(256)),
+  provider: BoundedInferenceProvider,
   modelCalls: PositiveInt,
 }) {}
 
@@ -542,6 +543,18 @@ export class PageCaptureNavigationError extends Schema.TaggedError<PageCaptureNa
   "PageCaptureNavigationError",
   {
     implementation: SandboxImplementation,
+    message: BoundedMessage,
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
+
+/** Host authorization or accounting blocked provider inference before capture. */
+export class PageCaptureInferencePolicyError extends Schema.TaggedError<PageCaptureInferencePolicyError>()(
+  "PageCaptureInferencePolicyError",
+  {
+    implementation: SandboxImplementation,
+    provider: BoundedInferenceProvider,
+    reason: Schema.Literals(["authorization", "accounting"]),
     message: BoundedMessage,
     cause: Schema.optionalKey(Schema.Defect()),
   },
@@ -588,6 +601,7 @@ export class PageCaptureProtocolError extends Schema.TaggedError<PageCaptureProt
 export const PageCaptureError = Schema.Union([
   PageCaptureRateLimitedError,
   PageCaptureNavigationError,
+  PageCaptureInferencePolicyError,
   PageCaptureUnsupportedError,
   PageCaptureOutputLimitError,
   PageCaptureProtocolError,

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -578,6 +578,7 @@ export class PageCaptureProtocolError extends Schema.TaggedError<PageCaptureProt
   {
     implementation: SandboxImplementation,
     message: BoundedMessage,
+    cause: Schema.optionalKey(Schema.Defect()),
   },
 ) {}
 

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -1,4 +1,4 @@
-import { Context, Schema, type Effect } from "effect";
+import { Context, Encoding, Predicate, Schema, type Effect } from "effect";
 
 import { SANDBOX_DIAGNOSTIC_MAX_LENGTH, SandboxImplementation } from "./sandbox.ts";
 
@@ -19,6 +19,10 @@ import { SANDBOX_DIAGNOSTIC_MAX_LENGTH, SandboxImplementation } from "./sandbox.
 
 const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 const MAX_LINKS = 4_096;
+const MAX_RESPONSE_FORMAT_BYTES = 64 * 1024;
+const MAX_RESPONSE_FORMAT_DEPTH = 32;
+const MAX_RESPONSE_FORMAT_NODES = 4_096;
+const MAX_RESPONSE_FORMAT_COLLECTION_LENGTH = 256;
 // Schema `isMaxLength` counts UTF-16 elements: these are transport sanity
 // bounds. The authoritative byte budget is `PageCaptureLimits.maxOutputBytes`,
 // which adapters enforce on the UTF-8 encoded response.
@@ -29,9 +33,179 @@ const BoundedPrompt = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
 const BoundedSelector = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedPattern = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedMessage = Schema.String.check(Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+const BoundedSchemaProperty = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
 /** Bounded by the platform's 60-second browser inactivity ceiling. */
 const BoundedTimeoutMillis = PositiveInt.check(Schema.isLessThanOrEqualTo(60_000));
+
+const ResponseFormatPrimitive = Schema.Literals([
+  "string",
+  "number",
+  "boolean",
+  "array",
+  "object",
+  "null",
+  "integer",
+]);
+const ResponseFormatPrimitiveList = Schema.Array(ResponseFormatPrimitive).check(
+  Schema.isMinLength(1),
+  Schema.isMaxLength(7),
+  Schema.isUnique(),
+);
+
+type ResponseFormatNode = Schema.JsonObject & {
+  readonly type?:
+    | typeof ResponseFormatPrimitive.Type
+    | typeof ResponseFormatPrimitiveList.Type
+    | undefined;
+  readonly properties?: Readonly<Record<string, ResponseFormatNode>> | undefined;
+  readonly required?: ReadonlyArray<string> | undefined;
+  readonly items?: ResponseFormatNode | boolean | undefined;
+  readonly additionalProperties?: ResponseFormatNode | boolean | undefined;
+  readonly anyOf?: ReadonlyArray<ResponseFormatNode> | undefined;
+  readonly oneOf?: ReadonlyArray<ResponseFormatNode> | undefined;
+  readonly allOf?: ReadonlyArray<ResponseFormatNode> | undefined;
+  readonly $defs?: Readonly<Record<string, ResponseFormatNode>> | undefined;
+};
+
+const ResponseFormatNode: Schema.Codec<ResponseFormatNode> = Schema.suspend(
+  (): Schema.Codec<ResponseFormatNode> =>
+    Schema.StructWithRest(
+      Schema.Struct({
+        type: Schema.optionalKey(
+          Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList]),
+        ),
+        properties: Schema.optionalKey(
+          Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+            Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+          ),
+        ),
+        required: Schema.optionalKey(
+          Schema.Array(BoundedSchemaProperty).check(
+            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+            Schema.isUnique(),
+          ),
+        ),
+        items: Schema.optionalKey(Schema.Union([Schema.Boolean, ResponseFormatNode])),
+        additionalProperties: Schema.optionalKey(
+          Schema.Union([Schema.Boolean, ResponseFormatNode]),
+        ),
+        anyOf: Schema.optionalKey(
+          Schema.Array(ResponseFormatNode).check(
+            Schema.isMinLength(1),
+            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+          ),
+        ),
+        oneOf: Schema.optionalKey(
+          Schema.Array(ResponseFormatNode).check(
+            Schema.isMinLength(1),
+            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+          ),
+        ),
+        allOf: Schema.optionalKey(
+          Schema.Array(ResponseFormatNode).check(
+            Schema.isMinLength(1),
+            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+          ),
+        ),
+        $defs: Schema.optionalKey(
+          Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+            Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+          ),
+        ),
+      }),
+      [Schema.Record(Schema.String, Schema.Json)],
+    ),
+);
+
+const ResponseFormatDocument = Schema.StructWithRest(
+  Schema.Struct({
+    type: Schema.Literal("object"),
+    properties: Schema.optionalKey(
+      Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+        Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+      ),
+    ),
+    required: Schema.optionalKey(
+      Schema.Array(BoundedSchemaProperty).check(
+        Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+        Schema.isUnique(),
+      ),
+    ),
+    additionalProperties: Schema.optionalKey(Schema.Union([Schema.Boolean, ResponseFormatNode])),
+    $defs: Schema.optionalKey(
+      Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+        Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+      ),
+    ),
+  }),
+  [Schema.Record(Schema.String, Schema.Json)],
+);
+
+const isResponseFormatDocument = Schema.is(ResponseFormatDocument);
+
+/** Preflight graph bounds before recursively decoding an untrusted JSON Schema. */
+const isBoundedResponseFormat = (input: unknown): input is typeof ResponseFormatDocument.Type => {
+  if (!Predicate.isObject(input)) return false;
+
+  const pending: Array<{ readonly value: unknown; readonly depth: number }> = [
+    { value: input, depth: 0 },
+  ];
+  const visited = new WeakSet<object>();
+  let nodes = 0;
+  let textUnits = 0;
+
+  try {
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (
+        current === undefined ||
+        current.depth > MAX_RESPONSE_FORMAT_DEPTH ||
+        ++nodes > MAX_RESPONSE_FORMAT_NODES
+      ) {
+        return false;
+      }
+
+      const value = current.value;
+      if (value === null || typeof value === "boolean") continue;
+      if (typeof value === "number") {
+        if (!Number.isFinite(value)) return false;
+        continue;
+      }
+      if (typeof value === "string") {
+        textUnits += value.length;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES) return false;
+        continue;
+      }
+      if (!Predicate.isObjectOrArray(value) || visited.has(value)) return false;
+      visited.add(value);
+
+      const entries = Array.isArray(value)
+        ? value.map((entry, index) => [index, entry] as const)
+        : Object.entries(value);
+      if (entries.length > MAX_RESPONSE_FORMAT_COLLECTION_LENGTH) return false;
+
+      for (const [key, entry] of entries) {
+        textUnits += typeof key === "string" ? key.length : 0;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES) return false;
+        pending.push({ value: entry, depth: current.depth + 1 });
+      }
+    }
+
+    if (!isResponseFormatDocument(input)) return false;
+    const encoded = JSON.stringify(input);
+    return Encoding.encodeHex(encoded).length / 2 <= MAX_RESPONSE_FORMAT_BYTES;
+  } catch {
+    return false;
+  }
+};
+
+/** A platform-supported object JSON Schema with bounded depth, entries, nodes, and UTF-8 bytes. */
+export const PageCaptureResponseFormat = Schema.declare(isBoundedResponseFormat, {
+  identifier: "@effect-agent/sandbox/PageCaptureResponseFormat",
+  description: "An object JSON Schema bounded to 64 KiB, depth 32, and 4096 nodes",
+});
+export type PageCaptureResponseFormat = typeof PageCaptureResponseFormat.Type;
 
 /** Capture a URL after a full render, the common case. */
 export class PageUrlTarget extends Schema.TaggedClass<PageUrlTarget>()("PageUrlTarget", {
@@ -74,15 +248,15 @@ export class CapturePageLinks extends Schema.TaggedClass<CapturePageLinks>()("Ca
 }) {}
 
 /**
- * Extract structured data from the rendered page. `responseFormat` is a JSON
- * Schema document (typically derived from an Effect Schema) that shapes the
- * extraction; the untrusted result must still be decoded by the caller
+ * Extract structured data from the rendered page. `responseFormat` is a
+ * bounded, object-shaped JSON Schema document, typically derived from an
+ * Effect Schema. The untrusted result must still be decoded by the caller
  * through the original Effect Schema.
  */
 export class CapturePageStructured extends Schema.TaggedClass<CapturePageStructured>()(
   "CapturePageStructured",
   {
-    responseFormat: Schema.Json,
+    responseFormat: PageCaptureResponseFormat,
     prompt: Schema.optionalKey(BoundedPrompt),
   },
 ) {}

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -34,6 +34,8 @@ const BoundedSelector = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedPattern = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const BoundedMessage = Schema.String.check(Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
 const BoundedSchemaProperty = Schema.NonEmptyString.check(Schema.isMaxLength(256));
+const BoundedSchemaText = Schema.String.check(Schema.isMaxLength(8 * 1024));
+const BoundedSchemaReference = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
 /** Bounded by the platform's 60-second browser inactivity ceiling. */
 const BoundedTimeoutMillis = PositiveInt.check(Schema.isLessThanOrEqualTo(60_000));
@@ -54,93 +56,162 @@ const ResponseFormatPrimitiveList = Schema.Array(ResponseFormatPrimitive).check(
 );
 
 type ResponseFormatNode = Schema.JsonObject & {
+  readonly $schema?: string | undefined;
+  readonly $id?: string | undefined;
+  readonly $ref?: string | undefined;
+  readonly $anchor?: string | undefined;
+  readonly $dynamicRef?: string | undefined;
+  readonly $dynamicAnchor?: string | undefined;
+  readonly $comment?: string | undefined;
+  readonly title?: string | undefined;
+  readonly description?: string | undefined;
+  readonly default?: Schema.Json | undefined;
+  readonly deprecated?: boolean | undefined;
+  readonly readOnly?: boolean | undefined;
+  readonly writeOnly?: boolean | undefined;
+  readonly examples?: ReadonlyArray<Schema.Json> | undefined;
   readonly type?:
     | typeof ResponseFormatPrimitive.Type
     | typeof ResponseFormatPrimitiveList.Type
     | undefined;
+  readonly enum?: ReadonlyArray<Schema.Json> | undefined;
+  readonly const?: Schema.Json | undefined;
+  readonly multipleOf?: number | undefined;
+  readonly maximum?: number | undefined;
+  readonly exclusiveMaximum?: number | undefined;
+  readonly minimum?: number | undefined;
+  readonly exclusiveMinimum?: number | undefined;
+  readonly maxLength?: number | undefined;
+  readonly minLength?: number | undefined;
+  readonly pattern?: string | undefined;
+  readonly format?: string | undefined;
+  readonly maxItems?: number | undefined;
+  readonly minItems?: number | undefined;
+  readonly uniqueItems?: boolean | undefined;
+  readonly prefixItems?: ReadonlyArray<ResponseFormatNode> | undefined;
   readonly properties?: Readonly<Record<string, ResponseFormatNode>> | undefined;
+  readonly patternProperties?: Readonly<Record<string, ResponseFormatNode>> | undefined;
   readonly required?: ReadonlyArray<string> | undefined;
+  readonly dependentRequired?: Readonly<Record<string, ReadonlyArray<string>>> | undefined;
+  readonly dependentSchemas?: Readonly<Record<string, ResponseFormatNode>> | undefined;
   readonly items?: ResponseFormatNode | boolean | undefined;
+  readonly additionalItems?: ResponseFormatNode | boolean | undefined;
+  readonly unevaluatedItems?: ResponseFormatNode | boolean | undefined;
+  readonly contains?: ResponseFormatNode | boolean | undefined;
+  readonly minContains?: number | undefined;
+  readonly maxContains?: number | undefined;
   readonly additionalProperties?: ResponseFormatNode | boolean | undefined;
+  readonly unevaluatedProperties?: ResponseFormatNode | boolean | undefined;
+  readonly propertyNames?: ResponseFormatNode | boolean | undefined;
+  readonly minProperties?: number | undefined;
+  readonly maxProperties?: number | undefined;
   readonly anyOf?: ReadonlyArray<ResponseFormatNode> | undefined;
   readonly oneOf?: ReadonlyArray<ResponseFormatNode> | undefined;
   readonly allOf?: ReadonlyArray<ResponseFormatNode> | undefined;
+  readonly not?: ResponseFormatNode | boolean | undefined;
+  readonly contentEncoding?: string | undefined;
+  readonly contentMediaType?: string | undefined;
+  readonly contentSchema?: ResponseFormatNode | boolean | undefined;
   readonly $defs?: Readonly<Record<string, ResponseFormatNode>> | undefined;
+  readonly definitions?: Readonly<Record<string, ResponseFormatNode>> | undefined;
 };
 
 const ResponseFormatNode: Schema.Codec<ResponseFormatNode> = Schema.suspend(
   (): Schema.Codec<ResponseFormatNode> =>
-    Schema.StructWithRest(
-      Schema.Struct({
-        type: Schema.optionalKey(
-          Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList]),
-        ),
-        properties: Schema.optionalKey(
-          Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
-            Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-          ),
-        ),
-        required: Schema.optionalKey(
-          Schema.Array(BoundedSchemaProperty).check(
-            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-            Schema.isUnique(),
-          ),
-        ),
-        items: Schema.optionalKey(Schema.Union([Schema.Boolean, ResponseFormatNode])),
-        additionalProperties: Schema.optionalKey(
-          Schema.Union([Schema.Boolean, ResponseFormatNode]),
-        ),
-        anyOf: Schema.optionalKey(
-          Schema.Array(ResponseFormatNode).check(
-            Schema.isMinLength(1),
-            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-          ),
-        ),
-        oneOf: Schema.optionalKey(
-          Schema.Array(ResponseFormatNode).check(
-            Schema.isMinLength(1),
-            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-          ),
-        ),
-        allOf: Schema.optionalKey(
-          Schema.Array(ResponseFormatNode).check(
-            Schema.isMinLength(1),
-            Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-          ),
-        ),
-        $defs: Schema.optionalKey(
-          Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
-            Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-          ),
-        ),
-      }),
-      [Schema.Record(Schema.String, Schema.Json)],
+    Schema.Struct(responseFormatFields()).pipe(
+      Schema.annotate({ parseOptions: { onExcessProperty: "error" } }),
     ),
 );
 
-const ResponseFormatDocument = Schema.StructWithRest(
-  Schema.Struct({
-    type: Schema.Literal("object"),
-    properties: Schema.optionalKey(
-      Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
-        Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
-      ),
+const responseFormatFields = () => {
+  const boundedNodes = Schema.Array(ResponseFormatNode).check(
+    Schema.isMinLength(1),
+    Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+  );
+  const boundedDefinitions = Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+    Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+  );
+  const boundedRequired = Schema.Array(BoundedSchemaProperty).check(
+    Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
+    Schema.isUnique(),
+  );
+  const subschema = Schema.Union([Schema.Boolean, ResponseFormatNode]);
+
+  return {
+    $schema: Schema.optionalKey(BoundedSchemaReference),
+    $id: Schema.optionalKey(BoundedSchemaReference),
+    $ref: Schema.optionalKey(BoundedSchemaReference),
+    $anchor: Schema.optionalKey(BoundedSchemaReference),
+    $dynamicRef: Schema.optionalKey(BoundedSchemaReference),
+    $dynamicAnchor: Schema.optionalKey(BoundedSchemaReference),
+    $comment: Schema.optionalKey(BoundedSchemaText),
+    title: Schema.optionalKey(BoundedSchemaText),
+    description: Schema.optionalKey(BoundedSchemaText),
+    default: Schema.optionalKey(Schema.Json),
+    deprecated: Schema.optionalKey(Schema.Boolean),
+    readOnly: Schema.optionalKey(Schema.Boolean),
+    writeOnly: Schema.optionalKey(Schema.Boolean),
+    examples: Schema.optionalKey(
+      Schema.Array(Schema.Json).check(Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)),
     ),
-    required: Schema.optionalKey(
-      Schema.Array(BoundedSchemaProperty).check(
+    type: Schema.optionalKey(Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
+    enum: Schema.optionalKey(
+      Schema.Array(Schema.Json).check(
+        Schema.isMinLength(1),
         Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
         Schema.isUnique(),
       ),
     ),
-    additionalProperties: Schema.optionalKey(Schema.Union([Schema.Boolean, ResponseFormatNode])),
-    $defs: Schema.optionalKey(
-      Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(
+    const: Schema.optionalKey(Schema.Json),
+    multipleOf: Schema.optionalKey(Schema.Finite.check(Schema.isGreaterThan(0))),
+    maximum: Schema.optionalKey(Schema.Finite),
+    exclusiveMaximum: Schema.optionalKey(Schema.Finite),
+    minimum: Schema.optionalKey(Schema.Finite),
+    exclusiveMinimum: Schema.optionalKey(Schema.Finite),
+    maxLength: Schema.optionalKey(Schema.Natural),
+    minLength: Schema.optionalKey(Schema.Natural),
+    pattern: Schema.optionalKey(BoundedSchemaText),
+    format: Schema.optionalKey(BoundedSchemaText),
+    maxItems: Schema.optionalKey(Schema.Natural),
+    minItems: Schema.optionalKey(Schema.Natural),
+    uniqueItems: Schema.optionalKey(Schema.Boolean),
+    prefixItems: Schema.optionalKey(boundedNodes),
+    items: Schema.optionalKey(subschema),
+    additionalItems: Schema.optionalKey(subschema),
+    unevaluatedItems: Schema.optionalKey(subschema),
+    contains: Schema.optionalKey(subschema),
+    minContains: Schema.optionalKey(Schema.Natural),
+    maxContains: Schema.optionalKey(Schema.Natural),
+    properties: Schema.optionalKey(boundedDefinitions),
+    patternProperties: Schema.optionalKey(boundedDefinitions),
+    required: Schema.optionalKey(boundedRequired),
+    dependentRequired: Schema.optionalKey(
+      Schema.Record(BoundedSchemaProperty, boundedRequired).check(
         Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH),
       ),
     ),
-  }),
-  [Schema.Record(Schema.String, Schema.Json)],
-);
+    dependentSchemas: Schema.optionalKey(boundedDefinitions),
+    additionalProperties: Schema.optionalKey(subschema),
+    unevaluatedProperties: Schema.optionalKey(subschema),
+    propertyNames: Schema.optionalKey(subschema),
+    minProperties: Schema.optionalKey(Schema.Natural),
+    maxProperties: Schema.optionalKey(Schema.Natural),
+    anyOf: Schema.optionalKey(boundedNodes),
+    oneOf: Schema.optionalKey(boundedNodes),
+    allOf: Schema.optionalKey(boundedNodes),
+    not: Schema.optionalKey(subschema),
+    contentEncoding: Schema.optionalKey(BoundedSchemaText),
+    contentMediaType: Schema.optionalKey(BoundedSchemaText),
+    contentSchema: Schema.optionalKey(subschema),
+    $defs: Schema.optionalKey(boundedDefinitions),
+    definitions: Schema.optionalKey(boundedDefinitions),
+  };
+};
+
+const ResponseFormatDocument = Schema.Struct({
+  ...responseFormatFields(),
+  type: Schema.Literal("object"),
+}).pipe(Schema.annotate({ parseOptions: { onExcessProperty: "error" } }));
 
 const isResponseFormatDocument = Schema.is(ResponseFormatDocument);
 

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -40,6 +40,51 @@ const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
 /** Bounded by the platform's 60-second browser inactivity ceiling. */
 const BoundedTimeoutMillis = PositiveInt.check(Schema.isLessThanOrEqualTo(60_000));
 
+// The platform-neutral package targets bare ES2023, while supported runtimes
+// provide the WHATWG URL constructor. Missing or malformed runtime support
+// denies URLs instead of guessing at web syntax or importing a Node builtin.
+const pageUrlConstructor = Reflect.get(globalThis, "URL");
+
+const isCredentialFreeWebUrl = (value: string, allowHttp: boolean): boolean => {
+  if (typeof pageUrlConstructor !== "function") return false;
+
+  try {
+    const parsed: unknown = Reflect.construct(pageUrlConstructor, [value]);
+    if (!Predicate.isObject(parsed)) return false;
+
+    const protocol: unknown = Reflect.get(parsed, "protocol");
+    const hostname: unknown = Reflect.get(parsed, "hostname");
+    const username: unknown = Reflect.get(parsed, "username");
+    const password: unknown = Reflect.get(parsed, "password");
+
+    return (
+      (protocol === "https:" || (allowHttp && protocol === "http:")) &&
+      typeof hostname === "string" &&
+      hostname.length > 0 &&
+      username === "" &&
+      password === ""
+    );
+  } catch {
+    return false;
+  }
+};
+
+/** Absolute, bounded HTTPS navigation URL that never carries embedded credentials. */
+export const PageCaptureTargetUrl = BoundedUrl.check(
+  Schema.makeFilter((value) => isCredentialFreeWebUrl(value, false), {
+    title: "an absolute HTTPS URL without embedded credentials",
+  }),
+);
+export type PageCaptureTargetUrl = typeof PageCaptureTargetUrl.Type;
+
+/** Discovered HTTP(S) links are data, never navigation authority, and carry no credentials. */
+export const PageCaptureLinkUrl = BoundedUrl.check(
+  Schema.makeFilter((value) => isCredentialFreeWebUrl(value, true), {
+    title: "an absolute HTTP or HTTPS URL without embedded credentials",
+  }),
+);
+export type PageCaptureLinkUrl = typeof PageCaptureLinkUrl.Type;
+
 const ResponseFormatPrimitive = Schema.Literals([
   "string",
   "number",
@@ -280,7 +325,7 @@ export type PageCaptureResponseFormat = typeof PageCaptureResponseFormat.Type;
 
 /** Capture a URL after a full render, the common case. */
 export class PageUrlTarget extends Schema.TaggedClass<PageUrlTarget>()("PageUrlTarget", {
-  url: BoundedUrl,
+  url: PageCaptureTargetUrl,
 }) {}
 
 /** Render caller-supplied HTML instead of navigating. */
@@ -432,7 +477,7 @@ export class PageMarkdownCaptured extends Schema.TaggedClass<PageMarkdownCapture
 export class PageLinksCaptured extends Schema.TaggedClass<PageLinksCaptured>()(
   "PageLinksCaptured",
   {
-    links: Schema.Array(BoundedUrl).check(Schema.isMaxLength(MAX_LINKS)),
+    links: Schema.Array(PageCaptureLinkUrl).check(Schema.isMaxLength(MAX_LINKS)),
   },
 ) {}
 

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -533,6 +533,7 @@ export class PageCaptureRateLimitedError extends Schema.TaggedError<PageCaptureR
     reason: Schema.Literals(["rate", "quota"]),
     retryAfterMillis: Schema.optionalKey(Schema.Natural),
     message: BoundedMessage,
+    cause: Schema.optionalKey(Schema.Defect()),
   },
 ) {}
 
@@ -542,6 +543,7 @@ export class PageCaptureNavigationError extends Schema.TaggedError<PageCaptureNa
   {
     implementation: SandboxImplementation,
     message: BoundedMessage,
+    cause: Schema.optionalKey(Schema.Defect()),
   },
 ) {}
 

--- a/packages/sandbox/src/page-capture.ts
+++ b/packages/sandbox/src/page-capture.ts
@@ -1,0 +1,323 @@
+import { Context, Schema, type Effect } from "effect";
+
+import { SANDBOX_DIAGNOSTIC_MAX_LENGTH, SandboxImplementation } from "./sandbox.ts";
+
+/**
+ * Page capture (capability spec §9.2): one stateless, schema-first rendering
+ * pass over a remote or supplied page — navigate (or load raw HTML), render
+ * with JavaScript, and return exactly one bounded output. It is a sibling of
+ * the command-shaped `Sandbox` and callback-shaped `CodeExecutor` ports: a
+ * browser is intrinsically an egress device, so it carries its own explicit
+ * capture contract instead of widening the sandbox network policy that every
+ * existing adapter rejects.
+ *
+ * Everything a capture returns is untrusted, attacker-influenced content
+ * (security spec §9). Stateful browser sessions, screenshots, PDFs, snapshot
+ * bundles, crawling, and accessibility trees are deliberately outside this
+ * port's first slice.
+ */
+
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+const MAX_LINKS = 4_096;
+// Schema `isMaxLength` counts UTF-16 elements: these are transport sanity
+// bounds. The authoritative byte budget is `PageCaptureLimits.maxOutputBytes`,
+// which adapters enforce on the UTF-8 encoded response.
+const BoundedOutputText = Schema.String.check(Schema.isMaxLength(MAX_OUTPUT_BYTES));
+const BoundedUrl = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
+const BoundedHtml = Schema.NonEmptyString.check(Schema.isMaxLength(2 * 1024 * 1024));
+const BoundedPrompt = Schema.NonEmptyString.check(Schema.isMaxLength(8 * 1024));
+const BoundedSelector = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
+const BoundedPattern = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
+const BoundedMessage = Schema.String.check(Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
+/** Bounded by the platform's 60-second browser inactivity ceiling. */
+const BoundedTimeoutMillis = PositiveInt.check(Schema.isLessThanOrEqualTo(60_000));
+
+/** Capture a URL after a full render, the common case. */
+export class PageUrlTarget extends Schema.TaggedClass<PageUrlTarget>()("PageUrlTarget", {
+  url: BoundedUrl,
+}) {}
+
+/** Render caller-supplied HTML instead of navigating. */
+export class PageHtmlTarget extends Schema.TaggedClass<PageHtmlTarget>()("PageHtmlTarget", {
+  html: BoundedHtml,
+}) {}
+
+/** What the pass renders: a navigated URL or raw HTML. */
+export const PageCaptureTarget = Schema.Union([PageUrlTarget, PageHtmlTarget]);
+export type PageCaptureTarget = typeof PageCaptureTarget.Type;
+
+/**
+ * The rendering engine. `chromium` is the full headless browser; `kitesurf`
+ * is a lightweight stateless engine an adapter may support for lower-cost
+ * captures. An adapter that cannot honor the requested engine
+ * rejects it typed rather than silently substituting the other.
+ */
+export const PageCaptureEngine = Schema.Literals(["chromium", "kitesurf"]);
+export type PageCaptureEngine = typeof PageCaptureEngine.Type;
+
+/** Return the fully rendered HTML document. */
+export class CapturePageContent extends Schema.TaggedClass<CapturePageContent>()(
+  "CapturePageContent",
+  {},
+) {}
+
+/** Return the rendered page converted to Markdown. */
+export class CapturePageMarkdown extends Schema.TaggedClass<CapturePageMarkdown>()(
+  "CapturePageMarkdown",
+  {},
+) {}
+
+/** Return the hyperlinks discovered on the rendered page. */
+export class CapturePageLinks extends Schema.TaggedClass<CapturePageLinks>()("CapturePageLinks", {
+  visibleLinksOnly: Schema.optionalKey(Schema.Boolean),
+}) {}
+
+/**
+ * Extract structured data from the rendered page. `responseFormat` is a JSON
+ * Schema document (typically derived from an Effect Schema) that shapes the
+ * extraction; the untrusted result must still be decoded by the caller
+ * through the original Effect Schema.
+ */
+export class CapturePageStructured extends Schema.TaggedClass<CapturePageStructured>()(
+  "CapturePageStructured",
+  {
+    responseFormat: Schema.Json,
+    prompt: Schema.optionalKey(BoundedPrompt),
+  },
+) {}
+
+/** Exactly one bounded output per pass. */
+export const PageCaptureAction = Schema.Union([
+  CapturePageContent,
+  CapturePageMarkdown,
+  CapturePageLinks,
+  CapturePageStructured,
+]);
+export type PageCaptureAction = typeof PageCaptureAction.Type;
+
+/** Wait for one CSS selector to appear before capturing. */
+export class PageSelectorWait extends Schema.Class<PageSelectorWait>("PageSelectorWait")({
+  selector: BoundedSelector,
+  timeoutMillis: Schema.optionalKey(BoundedTimeoutMillis),
+}) {}
+
+/** Navigation and readiness options applied before the capture. */
+export class PageNavigationOptions extends Schema.Class<PageNavigationOptions>(
+  "PageNavigationOptions",
+)({
+  waitUntil: Schema.optionalKey(
+    Schema.Literals(["load", "domcontentloaded", "networkidle0", "networkidle2"]),
+  ),
+  timeoutMillis: Schema.optionalKey(BoundedTimeoutMillis),
+  waitForSelector: Schema.optionalKey(PageSelectorWait),
+}) {}
+
+/** The rendered viewport. */
+export class PageViewport extends Schema.Class<PageViewport>("PageViewport")({
+  width: PositiveInt.check(Schema.isLessThanOrEqualTo(7_680)),
+  height: PositiveInt.check(Schema.isLessThanOrEqualTo(7_680)),
+}) {}
+
+/**
+ * Request egress policy for the render. Rejected resource types are never
+ * fetched; when request patterns are given, only matching navigation,
+ * redirect, and subresource requests are allowed. Calling capabilities own
+ * the capture-target allowlist and project it into this policy so rendered
+ * JavaScript cannot escape the same construction-time authority.
+ */
+export class PageResourcePolicy extends Schema.Class<PageResourcePolicy>("PageResourcePolicy")({
+  rejectResourceTypes: Schema.optionalKey(
+    Schema.Array(
+      Schema.Literals([
+        "document",
+        "stylesheet",
+        "image",
+        "media",
+        "font",
+        "script",
+        "texttrack",
+        "xhr",
+        "fetch",
+        "eventsource",
+        "websocket",
+        "manifest",
+        "other",
+      ]),
+    ).check(Schema.isMaxLength(16)),
+  ),
+  allowRequestPatterns: Schema.optionalKey(
+    Schema.Array(BoundedPattern).check(Schema.isMaxLength(64)),
+  ),
+}) {}
+
+/** Limits an adapter must either enforce or reject. Bytes are UTF-8 encoded. */
+export class PageCaptureLimits extends Schema.Class<PageCaptureLimits>("PageCaptureLimits")({
+  maxOutputBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(MAX_OUTPUT_BYTES)),
+}) {}
+
+/** Schema-first page capture request: one target, one action, one output. */
+export class PageCaptureRequest extends Schema.Class<PageCaptureRequest>("PageCaptureRequest")({
+  target: PageCaptureTarget,
+  action: PageCaptureAction,
+  engine: PageCaptureEngine,
+  limits: PageCaptureLimits,
+  navigation: Schema.optionalKey(PageNavigationOptions),
+  viewport: Schema.optionalKey(PageViewport),
+  resourcePolicy: Schema.optionalKey(PageResourcePolicy),
+}) {}
+
+/** The rendered HTML document. */
+export class PageContentCaptured extends Schema.TaggedClass<PageContentCaptured>()(
+  "PageContentCaptured",
+  {
+    html: BoundedOutputText,
+  },
+) {}
+
+/** The rendered page as Markdown. */
+export class PageMarkdownCaptured extends Schema.TaggedClass<PageMarkdownCaptured>()(
+  "PageMarkdownCaptured",
+  {
+    markdown: BoundedOutputText,
+  },
+) {}
+
+/** The hyperlinks discovered on the rendered page. */
+export class PageLinksCaptured extends Schema.TaggedClass<PageLinksCaptured>()(
+  "PageLinksCaptured",
+  {
+    links: Schema.Array(BoundedUrl).check(Schema.isMaxLength(MAX_LINKS)),
+  },
+) {}
+
+/** The extracted structured value; untrusted until decoded by the caller. */
+export class PageStructuredCaptured extends Schema.TaggedClass<PageStructuredCaptured>()(
+  "PageStructuredCaptured",
+  {
+    value: Schema.Json,
+  },
+) {}
+
+/** Exactly one output kind per pass, matching the requested action. */
+export const PageCaptureOutput = Schema.Union([
+  PageContentCaptured,
+  PageMarkdownCaptured,
+  PageLinksCaptured,
+  PageStructuredCaptured,
+]);
+export type PageCaptureOutput = typeof PageCaptureOutput.Type;
+
+/** Explicit accounting for model inference performed by a capture adapter. */
+export class PageCaptureInferenceUse extends Schema.Class<PageCaptureInferenceUse>(
+  "PageCaptureInferenceUse",
+)({
+  provider: Schema.NonEmptyString.check(Schema.isMaxLength(256)),
+  modelCalls: PositiveInt,
+}) {}
+
+/** Accounting an adapter observed for one capture. */
+export class PageCaptureResourceUse extends Schema.Class<PageCaptureResourceUse>(
+  "PageCaptureResourceUse",
+)({
+  browserMillis: Schema.optionalKey(Schema.Natural),
+  inference: Schema.optionalKey(PageCaptureInferenceUse),
+}) {}
+
+/** The bounded outcome of one capture pass. */
+export class PageCaptureResult extends Schema.Class<PageCaptureResult>("PageCaptureResult")({
+  implementation: SandboxImplementation,
+  output: PageCaptureOutput,
+  resourceUse: PageCaptureResourceUse,
+}) {}
+
+/**
+ * The platform refused the pass for rate or quota reasons. `retryAfterMillis`
+ * carries the platform's own backoff hint when one exists; retrying earlier
+ * only re-fails.
+ */
+export class PageCaptureRateLimitedError extends Schema.TaggedError<PageCaptureRateLimitedError>()(
+  "PageCaptureRateLimitedError",
+  {
+    implementation: SandboxImplementation,
+    reason: Schema.Literals(["rate", "quota"]),
+    retryAfterMillis: Schema.optionalKey(Schema.Natural),
+    message: BoundedMessage,
+  },
+) {}
+
+/** Navigation, readiness, or capture of the target page failed. */
+export class PageCaptureNavigationError extends Schema.TaggedError<PageCaptureNavigationError>()(
+  "PageCaptureNavigationError",
+  {
+    implementation: SandboxImplementation,
+    message: BoundedMessage,
+  },
+) {}
+
+/** The adapter cannot honestly honor one requested feature (CAP-010 idiom). */
+export class PageCaptureUnsupportedError extends Schema.TaggedError<PageCaptureUnsupportedError>()(
+  "PageCaptureUnsupportedError",
+  {
+    implementation: SandboxImplementation,
+    feature: Schema.Literals([
+      "engine",
+      "action",
+      "target",
+      "navigation",
+      "viewport",
+      "resource-policy",
+    ]),
+    message: BoundedMessage,
+  },
+) {}
+
+/** The response exceeded the request's output byte budget. */
+export class PageCaptureOutputLimitError extends Schema.TaggedError<PageCaptureOutputLimitError>()(
+  "PageCaptureOutputLimitError",
+  {
+    implementation: SandboxImplementation,
+    limit: PositiveInt,
+    observed: Schema.Natural,
+  },
+) {}
+
+/** The platform or transport produced a value outside the capture protocol. */
+export class PageCaptureProtocolError extends Schema.TaggedError<PageCaptureProtocolError>()(
+  "PageCaptureProtocolError",
+  {
+    implementation: SandboxImplementation,
+    message: BoundedMessage,
+  },
+) {}
+
+/** Expected capture failures. Interruption stays an Effect interruption. */
+export const PageCaptureError = Schema.Union([
+  PageCaptureRateLimitedError,
+  PageCaptureNavigationError,
+  PageCaptureUnsupportedError,
+  PageCaptureOutputLimitError,
+  PageCaptureProtocolError,
+]);
+export type PageCaptureError = typeof PageCaptureError.Type;
+
+/**
+ * Stateless page-capture port. One `capture` is one pass: the adapter owns no
+ * session, replay, approval, or Conversation semantics, identifies its
+ * isolation posture honestly (CAP-010), enforces or rejects every requested
+ * limit and policy, and returns exactly one bounded output. Capture results
+ * are untrusted input to whatever reads them.
+ */
+export class PageCapture extends Context.Service<
+  PageCapture,
+  {
+    readonly capture: (
+      request: PageCaptureRequest,
+    ) => Effect.Effect<PageCaptureResult, PageCaptureError>;
+  }
+>()("@effect-agent/sandbox/PageCapture") {}
+
+/** Type helper for implementations that preserve the public PageCapture contract. */
+export type PageCaptureCapture = (
+  request: PageCaptureRequest,
+) => Effect.Effect<PageCaptureResult, PageCaptureError>;

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -5,6 +5,7 @@ import {
   CapturePageStructured,
   PageCaptureError,
   PageCaptureInferenceUse,
+  PageCaptureInferencePolicyError,
   PageCaptureOutput,
   PageCaptureProtocolError,
   PageCaptureRateLimitedError,
@@ -90,6 +91,13 @@ describe("PageCapture schemas", () => {
       message: "The browser RPC failed",
       cause: foreignCause,
     });
+    const inferenceFailure = PageCaptureInferencePolicyError.make({
+      implementation,
+      provider: "cloudflare-workers-ai",
+      reason: "authorization",
+      message: "The capture provider was not authorized",
+      cause: new Error("tenant budget denied the provider"),
+    });
 
     expect(
       Schema.decodeSync(PageCaptureOutput)({ _tag: "PageLinksCaptured", links: ["https://a"] }),
@@ -106,6 +114,14 @@ describe("PageCapture schemas", () => {
       _tag: "PageCaptureProtocolError",
       message: "The browser RPC failed",
       cause: expect.objectContaining({ message: "browser RPC failed" }),
+    });
+    expect(
+      Schema.decodeSync(PageCaptureError)(Schema.encodeSync(PageCaptureError)(inferenceFailure)),
+    ).toMatchObject({
+      _tag: "PageCaptureInferencePolicyError",
+      provider: "cloudflare-workers-ai",
+      reason: "authorization",
+      cause: expect.objectContaining({ message: "tenant budget denied the provider" }),
     });
   });
 

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -95,6 +95,47 @@ describe("PageCapture schemas", () => {
     ).toEqual(failure);
   });
 
+  it("accepts only credential-free HTTPS targets and credential-free absolute web links", () => {
+    for (const url of [
+      "not a URL",
+      "http://docs.example.com/pricing",
+      "javascript:alert(1)",
+      "data:text/html,hello",
+      "/pricing",
+      "https://user:secret@docs.example.com/pricing",
+      "https://user@docs.example.com/pricing",
+    ]) {
+      expect(Schema.decodeUnknownExit(PageUrlTarget)({ _tag: "PageUrlTarget", url })._tag).toBe(
+        "Failure",
+      );
+    }
+
+    expect(
+      Schema.decodeSync(PageCaptureOutput)({
+        _tag: "PageLinksCaptured",
+        links: ["http://docs.example.com/legacy", "https://docs.example.com/current"],
+      }),
+    ).toEqual({
+      _tag: "PageLinksCaptured",
+      links: ["http://docs.example.com/legacy", "https://docs.example.com/current"],
+    });
+
+    for (const link of [
+      "not a URL",
+      "javascript:alert(1)",
+      "mailto:person@example.com",
+      "/pricing",
+      "https://user:secret@docs.example.com/pricing",
+    ]) {
+      expect(
+        Schema.decodeUnknownExit(PageCaptureOutput)({
+          _tag: "PageLinksCaptured",
+          links: [link],
+        })._tag,
+      ).toBe("Failure");
+    }
+  });
+
   it("accepts only bounded object JSON Schema documents for structured capture", () => {
     const invalidDocuments: ReadonlyArray<unknown> = [
       null,

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -23,7 +23,30 @@ describe("PageCapture schemas", () => {
     const request = PageCaptureRequest.make({
       target: PageUrlTarget.make({ url: "https://docs.example.com/pricing" }),
       action: CapturePageStructured.make({
-        responseFormat: { type: "object", properties: { plans: { type: "array" } } },
+        responseFormat: {
+          type: "object",
+          title: "Pricing plans",
+          description: "The public subscription plans.",
+          properties: {
+            plans: {
+              type: "array",
+              minItems: 1,
+              items: { $ref: "#/$defs/Plan" },
+            },
+          },
+          required: ["plans"],
+          additionalProperties: false,
+          $defs: {
+            Plan: {
+              type: "object",
+              properties: {
+                tier: { type: "string", enum: ["Basic", "Business"] },
+                monthlyUsd: { type: "number", minimum: 0 },
+              },
+              required: ["tier", "monthlyUsd"],
+            },
+          },
+        },
         prompt: "Extract the pricing plans",
       }),
       engine: "chromium",
@@ -83,6 +106,12 @@ describe("PageCapture schemas", () => {
       { type: "object", properties: { price: 7 } },
       { type: "object", properties: { price: { type: "unsupported" } } },
       { type: "object", required: ["price", "price"] },
+      { type: "object", $ref: 42 },
+      { type: "object", enum: "not-an-array" },
+      { type: "object", description: 7 },
+      { type: "object", unsupportedKeyword: true },
+      { type: "object", properties: { price: { type: "number", minimum: "zero" } } },
+      { type: "object", properties: { price: { type: "number", unsupportedKeyword: true } } },
       { type: "object", description: "x".repeat(64 * 1024 + 1) },
       {
         type: "object",

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -1,0 +1,98 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  CapturePageStructured,
+  PageCaptureError,
+  PageCaptureInferenceUse,
+  PageCaptureOutput,
+  PageCaptureRateLimitedError,
+  PageCaptureRequest,
+  PageCaptureResult,
+  PageUrlTarget,
+  SandboxImplementation,
+} from "../src/index.ts";
+
+const implementation = SandboxImplementation.make({
+  isolation: "isolated",
+  identity: "test-page-capture",
+});
+
+describe("PageCapture schemas", () => {
+  it("round-trips a complete structured capture request", () => {
+    const request = PageCaptureRequest.make({
+      target: PageUrlTarget.make({ url: "https://docs.example.com/pricing" }),
+      action: CapturePageStructured.make({
+        responseFormat: { type: "object", properties: { plans: { type: "array" } } },
+        prompt: "Extract the pricing plans",
+      }),
+      engine: "chromium",
+      limits: { maxOutputBytes: 128 * 1024 },
+      navigation: {
+        waitUntil: "networkidle0",
+        timeoutMillis: 15_000,
+        waitForSelector: { selector: "#plans", timeoutMillis: 5_000 },
+      },
+      viewport: { width: 1_280, height: 800 },
+      resourcePolicy: {
+        rejectResourceTypes: ["image", "media", "font"],
+        allowRequestPatterns: ["https://docs.example.com/*"],
+      },
+    });
+
+    expect(
+      Schema.decodeSync(PageCaptureRequest)(Schema.encodeSync(PageCaptureRequest)(request)),
+    ).toEqual(request);
+  });
+
+  it("keeps outputs, results, and expected failures schema-decodable", () => {
+    const result = PageCaptureResult.make({
+      implementation,
+      output: { _tag: "PageMarkdownCaptured", markdown: "# Title" },
+      resourceUse: {
+        browserMillis: 1_234,
+        inference: { provider: "cloudflare-workers-ai", modelCalls: 1 },
+      },
+    });
+    const failure = PageCaptureRateLimitedError.make({
+      implementation,
+      reason: "rate",
+      retryAfterMillis: 7_000,
+      message: "429 Too many requests",
+    });
+
+    expect(
+      Schema.decodeSync(PageCaptureOutput)({ _tag: "PageLinksCaptured", links: ["https://a"] }),
+    ).toEqual({ _tag: "PageLinksCaptured", links: ["https://a"] });
+    expect(
+      Schema.decodeSync(PageCaptureResult)(Schema.encodeSync(PageCaptureResult)(result)),
+    ).toEqual(result);
+    expect(
+      Schema.decodeSync(PageCaptureError)(Schema.encodeSync(PageCaptureError)(failure)),
+    ).toEqual(failure);
+  });
+
+  it("rejects out-of-bounds untrusted values at the Schema boundary", () => {
+    expect(() =>
+      PageCaptureRequest.make({
+        target: PageUrlTarget.make({ url: "https://docs.example.com" }),
+        action: { _tag: "CapturePageContent" },
+        engine: "chromium",
+        limits: { maxOutputBytes: 16 * 1024 * 1024 },
+      }),
+    ).toThrow(/Schema validation failed/);
+    expect(() => PageUrlTarget.make({ url: "" })).toThrow(/Schema validation failed/);
+    expect(() =>
+      PageCaptureInferenceUse.make({ provider: "cloudflare-workers-ai", modelCalls: 0 }),
+    ).toThrow(/Schema validation failed/);
+    expect(() =>
+      PageCaptureRequest.make({
+        target: PageUrlTarget.make({ url: "https://docs.example.com" }),
+        action: { _tag: "CapturePageContent" },
+        engine: "chromium",
+        limits: { maxOutputBytes: 1_024 },
+        navigation: { timeoutMillis: 120_000 },
+      }),
+    ).toThrow(/Schema validation failed/);
+  });
+});

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -6,6 +6,7 @@ import {
   PageCaptureError,
   PageCaptureInferenceUse,
   PageCaptureOutput,
+  PageCaptureProtocolError,
   PageCaptureRateLimitedError,
   PageCaptureRequest,
   PageCaptureResult,
@@ -83,6 +84,12 @@ describe("PageCapture schemas", () => {
       retryAfterMillis: 7_000,
       message: "429 Too many requests",
     });
+    const foreignCause = new Error("browser RPC failed");
+    const protocolFailure = PageCaptureProtocolError.make({
+      implementation,
+      message: "The browser RPC failed",
+      cause: foreignCause,
+    });
 
     expect(
       Schema.decodeSync(PageCaptureOutput)({ _tag: "PageLinksCaptured", links: ["https://a"] }),
@@ -93,6 +100,13 @@ describe("PageCapture schemas", () => {
     expect(
       Schema.decodeSync(PageCaptureError)(Schema.encodeSync(PageCaptureError)(failure)),
     ).toEqual(failure);
+    expect(
+      Schema.decodeSync(PageCaptureError)(Schema.encodeSync(PageCaptureError)(protocolFailure)),
+    ).toMatchObject({
+      _tag: "PageCaptureProtocolError",
+      message: "The browser RPC failed",
+      cause: expect.objectContaining({ message: "browser RPC failed" }),
+    });
   });
 
   it("accepts only credential-free HTTPS targets and credential-free absolute web links", () => {

--- a/packages/sandbox/test/page-capture.test.ts
+++ b/packages/sandbox/test/page-capture.test.ts
@@ -72,6 +72,47 @@ describe("PageCapture schemas", () => {
     ).toEqual(failure);
   });
 
+  it("accepts only bounded object JSON Schema documents for structured capture", () => {
+    const invalidDocuments: ReadonlyArray<unknown> = [
+      null,
+      "object",
+      [],
+      {},
+      { type: "string" },
+      { type: "object", properties: [] },
+      { type: "object", properties: { price: 7 } },
+      { type: "object", properties: { price: { type: "unsupported" } } },
+      { type: "object", required: ["price", "price"] },
+      { type: "object", description: "x".repeat(64 * 1024 + 1) },
+      {
+        type: "object",
+        properties: Object.fromEntries(
+          Array.from({ length: 257 }, (_, index) => [`field${String(index)}`, { type: "string" }]),
+        ),
+      },
+    ];
+
+    let tooDeep: unknown = { type: "string" };
+    for (let depth = 0; depth < 40; depth++) {
+      tooDeep = { type: "object", properties: { nested: tooDeep } };
+    }
+
+    const cyclic: { readonly type: "object"; readonly properties: Record<string, unknown> } = {
+      type: "object",
+      properties: {},
+    };
+    cyclic.properties.self = cyclic;
+
+    for (const responseFormat of [...invalidDocuments, tooDeep, cyclic]) {
+      expect(
+        Schema.decodeUnknownExit(CapturePageStructured)({
+          _tag: "CapturePageStructured",
+          responseFormat,
+        })._tag,
+      ).toBe("Failure");
+    }
+  });
+
   it("rejects out-of-bounds untrusted values at the Schema boundary", () => {
     expect(() =>
       PageCaptureRequest.make({

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -39964,6 +39964,204 @@ var CodeExecutionError = exports_Schema.Union([
 
 class CodeExecutor extends exports_Context.Service()("@effect-agent/sandbox/CodeExecutor") {
 }
+// packages/sandbox/src/page-capture.ts
+var MAX_OUTPUT_BYTES2 = 8 * 1024 * 1024;
+var MAX_LINKS = 4096;
+var BoundedOutputText2 = exports_Schema.String.check(exports_Schema.isMaxLength(MAX_OUTPUT_BYTES2));
+var BoundedUrl = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedHtml = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2 * 1024 * 1024));
+var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
+var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
+var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+
+class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
+  url: BoundedUrl
+}) {
+}
+
+class PageHtmlTarget extends exports_Schema.TaggedClass()("PageHtmlTarget", {
+  html: BoundedHtml
+}) {
+}
+var PageCaptureTarget = exports_Schema.Union([PageUrlTarget, PageHtmlTarget]);
+var PageCaptureEngine = exports_Schema.Literals(["chromium", "kitesurf"]);
+
+class CapturePageContent extends exports_Schema.TaggedClass()("CapturePageContent", {}) {
+}
+
+class CapturePageMarkdown extends exports_Schema.TaggedClass()("CapturePageMarkdown", {}) {
+}
+
+class CapturePageLinks extends exports_Schema.TaggedClass()("CapturePageLinks", {
+  visibleLinksOnly: exports_Schema.optionalKey(exports_Schema.Boolean)
+}) {
+}
+
+class CapturePageStructured extends exports_Schema.TaggedClass()("CapturePageStructured", {
+  responseFormat: exports_Schema.Json,
+  prompt: exports_Schema.optionalKey(BoundedPrompt)
+}) {
+}
+var PageCaptureAction = exports_Schema.Union([
+  CapturePageContent,
+  CapturePageMarkdown,
+  CapturePageLinks,
+  CapturePageStructured
+]);
+
+class PageSelectorWait extends exports_Schema.Class("PageSelectorWait")({
+  selector: BoundedSelector,
+  timeoutMillis: exports_Schema.optionalKey(BoundedTimeoutMillis)
+}) {
+}
+
+class PageNavigationOptions extends exports_Schema.Class("PageNavigationOptions")({
+  waitUntil: exports_Schema.optionalKey(exports_Schema.Literals(["load", "domcontentloaded", "networkidle0", "networkidle2"])),
+  timeoutMillis: exports_Schema.optionalKey(BoundedTimeoutMillis),
+  waitForSelector: exports_Schema.optionalKey(PageSelectorWait)
+}) {
+}
+
+class PageViewport extends exports_Schema.Class("PageViewport")({
+  width: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(7680)),
+  height: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(7680))
+}) {
+}
+
+class PageResourcePolicy extends exports_Schema.Class("PageResourcePolicy")({
+  rejectResourceTypes: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Literals([
+    "document",
+    "stylesheet",
+    "image",
+    "media",
+    "font",
+    "script",
+    "texttrack",
+    "xhr",
+    "fetch",
+    "eventsource",
+    "websocket",
+    "manifest",
+    "other"
+  ])).check(exports_Schema.isMaxLength(16))),
+  allowRequestPatterns: exports_Schema.optionalKey(exports_Schema.Array(BoundedPattern).check(exports_Schema.isMaxLength(64)))
+}) {
+}
+
+class PageCaptureLimits extends exports_Schema.Class("PageCaptureLimits")({
+  maxOutputBytes: PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(MAX_OUTPUT_BYTES2))
+}) {
+}
+
+class PageCaptureRequest extends exports_Schema.Class("PageCaptureRequest")({
+  target: PageCaptureTarget,
+  action: PageCaptureAction,
+  engine: PageCaptureEngine,
+  limits: PageCaptureLimits,
+  navigation: exports_Schema.optionalKey(PageNavigationOptions),
+  viewport: exports_Schema.optionalKey(PageViewport),
+  resourcePolicy: exports_Schema.optionalKey(PageResourcePolicy)
+}) {
+}
+
+class PageContentCaptured extends exports_Schema.TaggedClass()("PageContentCaptured", {
+  html: BoundedOutputText2
+}) {
+}
+
+class PageMarkdownCaptured extends exports_Schema.TaggedClass()("PageMarkdownCaptured", {
+  markdown: BoundedOutputText2
+}) {
+}
+
+class PageLinksCaptured extends exports_Schema.TaggedClass()("PageLinksCaptured", {
+  links: exports_Schema.Array(BoundedUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
+}) {
+}
+
+class PageStructuredCaptured extends exports_Schema.TaggedClass()("PageStructuredCaptured", {
+  value: exports_Schema.Json
+}) {
+}
+var PageCaptureOutput = exports_Schema.Union([
+  PageContentCaptured,
+  PageMarkdownCaptured,
+  PageLinksCaptured,
+  PageStructuredCaptured
+]);
+
+class PageCaptureInferenceUse extends exports_Schema.Class("PageCaptureInferenceUse")({
+  provider: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
+  modelCalls: PositiveInt4
+}) {
+}
+
+class PageCaptureResourceUse extends exports_Schema.Class("PageCaptureResourceUse")({
+  browserMillis: exports_Schema.optionalKey(exports_Schema.Natural),
+  inference: exports_Schema.optionalKey(PageCaptureInferenceUse)
+}) {
+}
+
+class PageCaptureResult extends exports_Schema.Class("PageCaptureResult")({
+  implementation: SandboxImplementation,
+  output: PageCaptureOutput,
+  resourceUse: PageCaptureResourceUse
+}) {
+}
+
+class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCaptureRateLimitedError", {
+  implementation: SandboxImplementation,
+  reason: exports_Schema.Literals(["rate", "quota"]),
+  retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural),
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
+  implementation: SandboxImplementation,
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureUnsupportedError extends exports_Schema.TaggedError()("PageCaptureUnsupportedError", {
+  implementation: SandboxImplementation,
+  feature: exports_Schema.Literals([
+    "engine",
+    "action",
+    "target",
+    "navigation",
+    "viewport",
+    "resource-policy"
+  ]),
+  message: BoundedMessage2
+}) {
+}
+
+class PageCaptureOutputLimitError extends exports_Schema.TaggedError()("PageCaptureOutputLimitError", {
+  implementation: SandboxImplementation,
+  limit: PositiveInt4,
+  observed: exports_Schema.Natural
+}) {
+}
+
+class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCaptureProtocolError", {
+  implementation: SandboxImplementation,
+  message: BoundedMessage2
+}) {
+}
+var PageCaptureError = exports_Schema.Union([
+  PageCaptureRateLimitedError,
+  PageCaptureNavigationError,
+  PageCaptureUnsupportedError,
+  PageCaptureOutputLimitError,
+  PageCaptureProtocolError
+]);
+
+class PageCapture extends exports_Context.Service()("@effect-agent/sandbox/PageCapture") {
+}
 // packages/capabilities/src/code-mode.ts
 var maxFailureTextLength = 4 * 1024;
 var BoundedFailureText = exports_Schema.String.check(exports_Schema.isMaxLength(maxFailureTextLength));
@@ -40256,7 +40454,7 @@ var EphemeralConversationsLive = exports_Layer.effect(EphemeralConversations, ex
 }));
 
 // packages/capabilities/src/commands.ts
-var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt5 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 
 class SteeringCommand extends exports_Schema.TaggedClass()("SteeringCommand", {
   id: exports_Schema.NonEmptyString,
@@ -40280,7 +40478,7 @@ class FollowUpCommand extends exports_Schema.TaggedClass()("FollowUpCommand", {
 var RunCommand = exports_Schema.Union([SteeringCommand, FollowUpCommand]);
 var CommandDrainPolicy = exports_Schema.Literals(["one", "all"]);
 
-class RunCommandQueueConfig extends exports_Schema.Class("@effect-agent/capabilities/RunCommandQueueConfig")({ capacity: PositiveInt4 }) {
+class RunCommandQueueConfig extends exports_Schema.Class("@effect-agent/capabilities/RunCommandQueueConfig")({ capacity: PositiveInt5 }) {
 }
 
 class RunCommandQueueClosed extends exports_Schema.TaggedError()("RunCommandQueueClosed", { runId: RunId }) {
@@ -41469,7 +41667,7 @@ class ElicitationDeclined extends (/* @__PURE__ */ Error4("@effect/ai/McpSchema/
 // packages/capabilities/src/mcp.ts
 var MAX_MCP_TOOLS = 128;
 var MAX_MCP_DISCOVERY_BYTES = 1024 * 1024;
-var PositiveInt5 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt6 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var Sha256Digest = exports_Schema.String.check(exports_Schema.isPattern(/^sha256:[a-f0-9]{64}$/));
 var JsonArray2 = exports_Schema.Array(exports_Schema.Json);
 var isJsonArray2 = exports_Schema.is(JsonArray2);
@@ -41482,10 +41680,10 @@ class McpServerIdentity extends exports_Schema.Class("@effect-agent/capabilities
 
 class McpConnectionRequest extends exports_Schema.Class("@effect-agent/capabilities/McpConnectionRequest")({
   serverId: exports_Schema.NonEmptyString,
-  maxToolCount: PositiveInt5.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_TOOLS)),
-  maxToolDescriptionBytes: PositiveInt5,
-  maxDiscoveryBytes: PositiveInt5.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_DISCOVERY_BYTES)),
-  connectTimeoutMillis: PositiveInt5
+  maxToolCount: PositiveInt6.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_TOOLS)),
+  maxToolDescriptionBytes: PositiveInt6,
+  maxDiscoveryBytes: PositiveInt6.check(exports_Schema.isLessThanOrEqualTo(MAX_MCP_DISCOVERY_BYTES)),
+  connectTimeoutMillis: PositiveInt6
 }) {
 }
 
@@ -41687,9 +41885,9 @@ var connectMcp = exports_Effect.fn("connectMcp")(function* (request3) {
   };
 });
 // packages/capabilities/src/scheduling.ts
-var PositiveInt6 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt7 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var RunSchedulingOverride = exports_Schema.Union([
-  exports_Schema.Struct({ mode: exports_Schema.Literal("bounded"), concurrency: PositiveInt6 }),
+  exports_Schema.Struct({ mode: exports_Schema.Literal("bounded"), concurrency: PositiveInt7 }),
   exports_Schema.Struct({ mode: exports_Schema.Literal("sequential") })
 ]);
 // packages/capabilities/src/subagent-reservation.ts
@@ -42178,19 +42376,19 @@ var SubagentReservationsMemoryLive = exports_Layer.effect(SubagentReservations, 
 }));
 
 // packages/capabilities/src/subagent.ts
-var PositiveInt7 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
+var PositiveInt8 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var Natural4 = exports_Schema.Natural;
 var FinitePositiveDuration4 = exports_Schema.Duration.pipe(exports_Schema.refine((duration2) => exports_Duration.isFinite(duration2) && exports_Duration.isPositive(duration2), { expected: "a finite positive duration" }));
 var SubagentPolicyFields = exports_Schema.Struct({
-  maxChildren: PositiveInt7,
-  maxConcurrency: PositiveInt7,
-  maxTurns: PositiveInt7,
-  maxToolCalls: PositiveInt7,
+  maxChildren: PositiveInt8,
+  maxConcurrency: PositiveInt8,
+  maxTurns: PositiveInt8,
+  maxToolCalls: PositiveInt8,
   maxDuration: FinitePositiveDuration4,
-  maxInputTokens: exports_Schema.optionalKey(PositiveInt7),
-  maxOutputTokens: exports_Schema.optionalKey(PositiveInt7),
+  maxInputTokens: exports_Schema.optionalKey(PositiveInt8),
+  maxOutputTokens: exports_Schema.optionalKey(PositiveInt8),
   maxCostMicrousd: exports_Schema.optionalKey(Natural4),
-  maxResultBytes: exports_Schema.optionalKey(PositiveInt7)
+  maxResultBytes: exports_Schema.optionalKey(PositiveInt8)
 });
 
 class SubagentPolicy extends exports_Schema.Class("@effect-agent/capabilities/SubagentPolicy")(SubagentPolicyFields) {
@@ -42285,6 +42483,38 @@ var neverStartedUsage = SubagentObservedUsage.make({
   costMicrousd: 0,
   resultBytes: 0
 });
+// packages/capabilities/src/web-capture.ts
+var maxFailureTextLength2 = 4 * 1024;
+var BoundedFailureText3 = exports_Schema.String.check(exports_Schema.isMaxLength(maxFailureTextLength2));
+var BoundedErrorTag3 = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+var BoundedUrl2 = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedContent = exports_Schema.String.check(exports_Schema.isMaxLength(1024 * 1024));
+var WebCaptureAction = exports_Schema.Literals(["markdown", "content", "links"]);
+var WebCaptureParameters = exports_Schema.Struct({
+  url: BoundedUrl2,
+  action: WebCaptureAction
+});
+var WebCaptureExtractParameters = exports_Schema.Struct({
+  url: BoundedUrl2
+});
+
+class WebCaptureSuccess extends exports_Schema.Class("@effect-agent/capabilities/WebCaptureSuccess")({
+  url: BoundedUrl2,
+  action: WebCaptureAction,
+  markdown: exports_Schema.optionalKey(BoundedContent),
+  html: exports_Schema.optionalKey(BoundedContent),
+  links: exports_Schema.optionalKey(exports_Schema.Array(BoundedUrl2).check(exports_Schema.isMaxLength(4096)))
+}) {
+}
+
+class WebCaptureFailure extends exports_Schema.TaggedError()("WebCaptureFailure", {
+  errorTag: BoundedErrorTag3,
+  message: BoundedFailureText3,
+  retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural)
+}) {
+}
+var defaultMaxResponseBytes = 128 * 1024;
+var urlConstructor2 = Reflect.get(globalThis, "URL");
 // examples/pr-work-orders/src/workspace.ts
 class WorkspaceSearchHit extends exports_Schema.Class("@effect-agent/example-pr-work-orders/WorkspaceSearchHit")({
   path: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(512)),
@@ -53762,7 +53992,7 @@ var readTerminalArtifactOption = exports_Effect.fn("readTerminalArtifactOption")
 });
 
 // examples/pr-work-order-ingress/src/action-checks.ts
-var MAX_OUTPUT_BYTES2 = 4000000;
+var MAX_OUTPUT_BYTES3 = 4000000;
 var TRUSTED_VITE_PLUS_BINARY = "/home/vp/.vite-plus/bin/vp";
 var TRUSTED_INSTALL_PATH = "/runtime/.vite-plus/bin:/home/vp/.vite-plus/bin:/usr/local/bin:/usr/bin:/bin";
 var CHECK_PATH = "/workspace/node_modules/.bin:/runtime/.vite-plus/bin:/home/vp/.vite-plus/bin:/usr/local/bin:/usr/bin:/bin";
@@ -53782,10 +54012,10 @@ var runProcess = exports_Effect.fn("workOrderAction.runProcess")(function* (inpu
     const [collected, exitCode] = yield* exports_Effect.all([
       exports_Stream.runFoldEffect(handle.all, () => ({ size: 0, chunks: [] }), (state, chunk) => {
         const size9 = state.size + chunk.length;
-        if (size9 > MAX_OUTPUT_BYTES2) {
+        if (size9 > MAX_OUTPUT_BYTES3) {
           return WorkspaceOperationFailure.make({
             operation: input.operation,
-            reason: `process output exceeds ${String(MAX_OUTPUT_BYTES2)} bytes`
+            reason: `process output exceeds ${String(MAX_OUTPUT_BYTES3)} bytes`
           });
         }
         return exports_Effect.succeed({ size: size9, chunks: [...state.chunks, chunk] });

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -40120,6 +40120,29 @@ var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8
 var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+var pageUrlConstructor = Reflect.get(globalThis, "URL");
+var isCredentialFreeWebUrl = (value4, allowHttp) => {
+  if (typeof pageUrlConstructor !== "function")
+    return false;
+  try {
+    const parsed = Reflect.construct(pageUrlConstructor, [value4]);
+    if (!exports_Predicate.isObject(parsed))
+      return false;
+    const protocol = Reflect.get(parsed, "protocol");
+    const hostname = Reflect.get(parsed, "hostname");
+    const username = Reflect.get(parsed, "username");
+    const password = Reflect.get(parsed, "password");
+    return (protocol === "https:" || allowHttp && protocol === "http:") && typeof hostname === "string" && hostname.length > 0 && username === "" && password === "";
+  } catch {
+    return false;
+  }
+};
+var PageCaptureTargetUrl = BoundedUrl.check(exports_Schema.makeFilter((value4) => isCredentialFreeWebUrl(value4, false), {
+  title: "an absolute HTTPS URL without embedded credentials"
+}));
+var PageCaptureLinkUrl = BoundedUrl.check(exports_Schema.makeFilter((value4) => isCredentialFreeWebUrl(value4, true), {
+  title: "an absolute HTTP or HTTPS URL without embedded credentials"
+}));
 var ResponseFormatPrimitive = exports_Schema.Literals([
   "string",
   "number",
@@ -40255,7 +40278,7 @@ var PageCaptureResponseFormat = exports_Schema.declare(isBoundedResponseFormat, 
 });
 
 class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
-  url: BoundedUrl
+  url: PageCaptureTargetUrl
 }) {
 }
 
@@ -40355,7 +40378,7 @@ class PageMarkdownCaptured extends exports_Schema.TaggedClass()("PageMarkdownCap
 }
 
 class PageLinksCaptured extends exports_Schema.TaggedClass()("PageLinksCaptured", {
-  links: exports_Schema.Array(BoundedUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
+  links: exports_Schema.Array(PageCaptureLinkUrl).check(exports_Schema.isMaxLength(MAX_LINKS))
 }) {
 }
 

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -40115,6 +40115,7 @@ var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLeng
 var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var BoundedInferenceProvider = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8 * 1024));
 var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
@@ -40394,7 +40395,7 @@ var PageCaptureOutput = exports_Schema.Union([
 ]);
 
 class PageCaptureInferenceUse extends exports_Schema.Class("PageCaptureInferenceUse")({
-  provider: exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256)),
+  provider: BoundedInferenceProvider,
   modelCalls: PositiveInt4
 }) {
 }
@@ -40423,6 +40424,15 @@ class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCapt
 
 class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
   implementation: SandboxImplementation,
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
+}) {
+}
+
+class PageCaptureInferencePolicyError extends exports_Schema.TaggedError()("PageCaptureInferencePolicyError", {
+  implementation: SandboxImplementation,
+  provider: BoundedInferenceProvider,
+  reason: exports_Schema.Literals(["authorization", "accounting"]),
   message: BoundedMessage2,
   cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
@@ -40458,6 +40468,7 @@ class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCapture
 var PageCaptureError = exports_Schema.Union([
   PageCaptureRateLimitedError,
   PageCaptureNavigationError,
+  PageCaptureInferencePolicyError,
   PageCaptureUnsupportedError,
   PageCaptureOutputLimitError,
   PageCaptureProtocolError

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -292,6 +292,68 @@ var getAllObjectKeys = (obj) => {
 var byReferenceInstances = /* @__PURE__ */ new WeakSet;
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Predicate.js
+var exports_Predicate = {};
+__export(exports_Predicate, {
+  xor: () => xor,
+  some: () => some,
+  or: () => or,
+  not: () => not,
+  nor: () => nor,
+  nand: () => nand,
+  mapInput: () => mapInput,
+  isUnknown: () => isUnknown,
+  isUndefined: () => isUndefined,
+  isUint8Array: () => isUint8Array,
+  isTupleOfAtLeast: () => isTupleOfAtLeast,
+  isTupleOf: () => isTupleOf,
+  isTruthy: () => isTruthy,
+  isTagged: () => isTagged,
+  isSymbol: () => isSymbol,
+  isString: () => isString,
+  isSet: () => isSet,
+  isRegExp: () => isRegExp,
+  isReadonlyObject: () => isReadonlyObject,
+  isPropertyKey: () => isPropertyKey,
+  isPromiseLike: () => isPromiseLike,
+  isPromise: () => isPromise,
+  isObjectOrArray: () => isObjectOrArray,
+  isObjectKeyword: () => isObjectKeyword,
+  isObject: () => isObject,
+  isNumber: () => isNumber,
+  isNullish: () => isNullish,
+  isNull: () => isNull,
+  isNotUndefined: () => isNotUndefined,
+  isNotNullish: () => isNotNullish,
+  isNotNull: () => isNotNull,
+  isNever: () => isNever,
+  isMap: () => isMap,
+  isIterable: () => isIterable,
+  isFunction: () => isFunction,
+  isError: () => isError,
+  isDate: () => isDate,
+  isBoolean: () => isBoolean,
+  isBigInt: () => isBigInt,
+  implies: () => implies,
+  hasProperty: () => hasProperty,
+  every: () => every,
+  eqv: () => eqv,
+  compose: () => compose,
+  and: () => and,
+  Tuple: () => Tuple,
+  Struct: () => Struct
+});
+var mapInput = /* @__PURE__ */ dual(2, (self, f) => (b) => self(f(b)));
+var isTupleOf = /* @__PURE__ */ dual(2, (self, n) => self.length === n);
+var isTupleOfAtLeast = /* @__PURE__ */ dual(2, (self, n) => self.length >= n);
+function isTruthy(input) {
+  return !!input;
+}
+function isSet(input) {
+  return input instanceof Set;
+}
+function isMap(input) {
+  return input instanceof Map;
+}
 function isString(input) {
   return typeof input === "string";
 }
@@ -319,6 +381,9 @@ function isUndefined(input) {
 function isNotUndefined(input) {
   return input !== undefined;
 }
+function isNull(input) {
+  return input === null;
+}
 function isNotNull(input) {
   return input !== null;
 }
@@ -334,8 +399,14 @@ function isNever(_) {
 function isUnknown(_) {
   return true;
 }
+function isObjectOrArray(input) {
+  return typeof input === "object" && input !== null;
+}
 function isObject(input) {
   return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+function isReadonlyObject(input) {
+  return isObject(input);
 }
 function isObjectKeyword(input) {
   return typeof input === "object" && input !== null || isFunction(input);
@@ -345,10 +416,76 @@ var isTagged = /* @__PURE__ */ dual(2, (self, tag) => hasProperty(self, "_tag") 
 function isError(input) {
   return input instanceof Error;
 }
+function isUint8Array(input) {
+  return input instanceof Uint8Array;
+}
+function isDate(input) {
+  return input instanceof Date;
+}
 function isIterable(input) {
   return hasProperty(input, Symbol.iterator) || isString(input);
 }
+function isPromise(input) {
+  return hasProperty(input, "then") && "catch" in input && isFunction(input.then) && isFunction(input.catch);
+}
+function isPromiseLike(input) {
+  return hasProperty(input, "then") && isFunction(input.then);
+}
+function isRegExp(input) {
+  return input instanceof RegExp;
+}
+var compose = /* @__PURE__ */ dual(2, (ab, bc) => (a) => ab(a) && bc(a));
+function Tuple(elements) {
+  return (as) => {
+    for (let i = 0;i < elements.length; i++) {
+      if (elements[i](as[i]) === false) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+function Struct(fields) {
+  const keys = Object.keys(fields);
+  return (a) => {
+    for (const key of keys) {
+      if (!fields[key](a[key])) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+function not(self) {
+  return (a) => !self(a);
+}
 var or = /* @__PURE__ */ dual(2, (self, that) => (a) => self(a) || that(a));
+var and = /* @__PURE__ */ dual(2, (self, that) => (a) => self(a) && that(a));
+var xor = /* @__PURE__ */ dual(2, (self, that) => (a) => self(a) !== that(a));
+var eqv = /* @__PURE__ */ dual(2, (self, that) => (a) => self(a) === that(a));
+var implies = /* @__PURE__ */ dual(2, (antecedent, consequent) => (a) => antecedent(a) ? consequent(a) : true);
+var nor = /* @__PURE__ */ dual(2, (self, that) => (a) => !(self(a) || that(a)));
+var nand = /* @__PURE__ */ dual(2, (self, that) => (a) => !(self(a) && that(a)));
+function every(collection) {
+  return (a) => {
+    for (const p of collection) {
+      if (!p(a)) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+function some(collection) {
+  return (a) => {
+    for (const p of collection) {
+      if (p(a)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Hash.js
 var symbol = "~effect/interfaces/Hash";
@@ -1305,7 +1442,7 @@ __export(exports_Option, {
   toRefinement: () => toRefinement,
   toArray: () => toArray,
   tap: () => tap,
-  some: () => some2,
+  some: () => some3,
   reduceCompact: () => reduceCompact,
   productMany: () => productMany,
   product: () => product,
@@ -1392,7 +1529,7 @@ function make2(combine2, initialValue, combineAll) {
 var make3 = (isEquivalent) => (self, that) => self === that || isEquivalent(self, that);
 var isStrictEquivalent = (x, y) => x === y;
 var strictEqual = () => isStrictEquivalent;
-function Tuple(elements) {
+function Tuple2(elements) {
   return make3((self, that) => {
     if (self.length !== that.length) {
       return false;
@@ -1490,7 +1627,7 @@ var isOption = (input) => hasProperty(input, TypeId);
 var isNone = (fa) => fa._tag === "None";
 var isSome = (fa) => fa._tag === "Some";
 var none = /* @__PURE__ */ Object.create(NoneProto);
-var some = (value) => {
+var some2 = (value) => {
   const a = Object.create(SomeProto);
   a.value = value;
   return a;
@@ -1561,8 +1698,8 @@ var succeed = (success) => {
   a.success = success;
   return a;
 };
-var getFailure = (self) => isSuccess(self) ? none : some(self.failure);
-var getSuccess = (self) => isFailure(self) ? none : some(self.success);
+var getFailure = (self) => isSuccess(self) ? none : some2(self.failure);
+var getSuccess = (self) => isFailure(self) ? none : some2(self.success);
 var fromOption = /* @__PURE__ */ dual(2, (self, onNone) => isNone(self) ? fail(onNone()) : succeed(self.value));
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Order.js
@@ -1580,8 +1717,8 @@ var Number2 = /* @__PURE__ */ make4((self, that) => {
   return self < that ? -1 : 1;
 });
 var BigInt2 = /* @__PURE__ */ make4((self, that) => self < that ? -1 : 1);
-var mapInput = /* @__PURE__ */ dual(2, (self, f) => make4((b1, b2) => self(f(b1), f(b2))));
-var Date2 = /* @__PURE__ */ mapInput(Number2, (date) => date.getTime());
+var mapInput2 = /* @__PURE__ */ dual(2, (self, f) => make4((b1, b2) => self(f(b1), f(b2))));
+var Date2 = /* @__PURE__ */ mapInput2(Number2, (date) => date.getTime());
 var isLessThan = (O) => dual(2, (self, that) => O(self, that) === -1);
 var isGreaterThan = (O) => dual(2, (self, that) => O(self, that) === 1);
 var isLessThanOrEqualTo = (O) => dual(2, (self, that) => O(self, that) !== 1);
@@ -1593,7 +1730,7 @@ var isBetween = (O) => dual(2, (self, options) => !isLessThan(O)(self, options.m
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Option.js
 var none2 = () => none;
-var some2 = some;
+var some3 = some2;
 var isOption2 = isOption;
 var isNone2 = isNone;
 var isSome2 = isSome;
@@ -1604,7 +1741,7 @@ var match = /* @__PURE__ */ dual(2, (self, {
 var toRefinement = (f) => (a) => isSome2(f(a));
 var fromIterable = (collection) => {
   for (const a of collection) {
-    return some2(a);
+    return some3(a);
   }
   return none2();
 };
@@ -1612,7 +1749,7 @@ var getSuccess2 = getSuccess;
 var getFailure2 = getFailure;
 var getOrElse = /* @__PURE__ */ dual(2, (self, onNone) => isNone2(self) ? onNone() : self.value);
 var orElse = /* @__PURE__ */ dual(2, (self, that) => isNone2(self) ? that() : self);
-var orElseSome = /* @__PURE__ */ dual(2, (self, onNone) => isNone2(self) ? some2(onNone()) : self);
+var orElseSome = /* @__PURE__ */ dual(2, (self, onNone) => isNone2(self) ? some3(onNone()) : self);
 var orElseResult = /* @__PURE__ */ dual(2, (self, that) => isNone2(self) ? map(that(), succeed) : map(self, fail));
 var firstSomeOf = (collection) => {
   let out = none2();
@@ -1623,15 +1760,15 @@ var firstSomeOf = (collection) => {
   }
   return out;
 };
-var fromNullishOr = (a) => a == null ? none2() : some2(a);
-var fromUndefinedOr = (a) => a === undefined ? none2() : some2(a);
-var fromNullOr = (a) => a === null ? none2() : some2(a);
+var fromNullishOr = (a) => a == null ? none2() : some3(a);
+var fromUndefinedOr = (a) => a === undefined ? none2() : some3(a);
+var fromNullOr = (a) => a === null ? none2() : some3(a);
 var liftNullishOr = (f) => (...a) => fromNullishOr(f(...a));
 var getOrNull = /* @__PURE__ */ getOrElse(constNull);
 var getOrUndefined = /* @__PURE__ */ getOrElse(constUndefined);
 var liftThrowable = (f) => (...a) => {
   try {
-    return some2(f(...a));
+    return some3(f(...a));
   } catch {
     return none2();
   }
@@ -1643,14 +1780,14 @@ var getOrThrowWith = /* @__PURE__ */ dual(2, (self, onNone) => {
   throw onNone();
 });
 var getOrThrow = /* @__PURE__ */ getOrThrowWith(() => new Error("getOrThrow called on a None"));
-var map = /* @__PURE__ */ dual(2, (self, f) => isNone2(self) ? none2() : some2(f(self.value)));
+var map = /* @__PURE__ */ dual(2, (self, f) => isNone2(self) ? none2() : some3(f(self.value)));
 var as = /* @__PURE__ */ dual(2, (self, b) => map(self, () => b));
 var asVoid = /* @__PURE__ */ as(undefined);
-var void_ = /* @__PURE__ */ some2(undefined);
+var void_ = /* @__PURE__ */ some3(undefined);
 var flatMap = /* @__PURE__ */ dual(2, (self, f) => isNone2(self) ? none2() : f(self.value));
 var andThen = /* @__PURE__ */ dual(2, (self, f) => flatMap(self, (a) => {
   const b = isFunction(f) ? f(a) : f;
-  return isOption2(b) ? b : some2(b);
+  return isOption2(b) ? b : some3(b);
 }));
 var flatMapNullishOr = /* @__PURE__ */ dual(2, (self, f) => isNone2(self) ? none2() : fromNullishOr(f(self.value)));
 var flatten = /* @__PURE__ */ flatMap(identity);
@@ -1658,7 +1795,7 @@ var zipRight = /* @__PURE__ */ dual(2, (self, that) => flatMap(self, () => that)
 var zipLeft = /* @__PURE__ */ dual(2, (self, that) => tap(self, () => that));
 var composeK = /* @__PURE__ */ dual(2, (afb, bfc) => (a) => flatMap(afb(a), bfc));
 var tap = /* @__PURE__ */ dual(2, (self, f) => flatMap(self, (a) => map(f(a), () => a)));
-var product = (self, that) => isSome2(self) && isSome2(that) ? some2([self.value, that.value]) : none2();
+var product = (self, that) => isSome2(self) && isSome2(that) ? some3([self.value, that.value]) : none2();
 var productMany = (self, collection) => {
   if (isNone2(self)) {
     return none2();
@@ -1670,7 +1807,7 @@ var productMany = (self, collection) => {
     }
     out.push(o.value);
   }
-  return some2(out);
+  return some3(out);
 };
 var all = (input) => {
   if (Symbol.iterator in input) {
@@ -1681,7 +1818,7 @@ var all = (input) => {
       }
       out2.push(o.value);
     }
-    return some2(out2);
+    return some3(out2);
   }
   const out = {};
   for (const key of Object.keys(input)) {
@@ -1691,7 +1828,7 @@ var all = (input) => {
     }
     assignProperty(out, key, o.value);
   }
-  return some2(out);
+  return some3(out);
 };
 var zipWith = /* @__PURE__ */ dual(3, (self, that, f) => map(product(self, that), ([a, b]) => f(a, b)));
 var reduceCompact = /* @__PURE__ */ dual(3, (self, b, f) => {
@@ -1709,27 +1846,27 @@ var partitionMap = /* @__PURE__ */ dual(2, (self, f) => {
     return [none2(), none2()];
   }
   const e = f(self.value);
-  return isFailure(e) ? [some2(e.failure), none2()] : [none2(), some2(e.success)];
+  return isFailure(e) ? [some3(e.failure), none2()] : [none2(), some3(e.success)];
 });
 var filterMap = /* @__PURE__ */ dual(2, (self, f) => {
   if (isNone2(self)) {
     return none2();
   }
   const next = f(self.value);
-  return isSuccess(next) ? some2(next.success) : none2();
+  return isSuccess(next) ? some3(next.success) : none2();
 });
-var filter = /* @__PURE__ */ dual(2, (self, predicate) => isNone2(self) ? none2() : predicate(self.value) ? some2(self.value) : none2());
+var filter = /* @__PURE__ */ dual(2, (self, predicate) => isNone2(self) ? none2() : predicate(self.value) ? some3(self.value) : none2());
 var makeEquivalence = (isEquivalent) => make3((x, y) => isNone2(x) ? isNone2(y) : isNone2(y) ? false : isEquivalent(x.value, y.value));
 var makeOrder = (O) => make4((self, that) => isSome2(self) ? isSome2(that) ? O(self.value, that.value) : 1 : -1);
 var lift2 = (f) => dual(2, (self, that) => zipWith(self, that, f));
-var liftPredicate = /* @__PURE__ */ dual(2, (b, predicate) => predicate(b) ? some2(b) : none2());
+var liftPredicate = /* @__PURE__ */ dual(2, (b, predicate) => predicate(b) ? some3(b) : none2());
 var containsWith = (isEquivalent) => dual(2, (self, a) => isNone2(self) ? false : isEquivalent(self.value, a));
 var contains = /* @__PURE__ */ containsWith(/* @__PURE__ */ asEquivalence());
 var exists = /* @__PURE__ */ dual(2, (self, refinement) => isNone2(self) ? false : refinement(self.value));
 var bindTo2 = /* @__PURE__ */ bindTo(map);
 var let_2 = /* @__PURE__ */ let_(map);
 var bind2 = /* @__PURE__ */ bind(map, flatMap);
-var Do = /* @__PURE__ */ some2({});
+var Do = /* @__PURE__ */ some3({});
 var gen = (...args2) => {
   const f = args2.length === 1 ? args2[0] : args2[1].bind(args2[0]);
   const iterator = f();
@@ -1741,7 +1878,7 @@ var gen = (...args2) => {
     }
     state = iterator.next(current.value);
   }
-  return some2(state.value);
+  return some3(state.value);
 };
 function makeReducer(combiner) {
   return make2((self, that) => {
@@ -1749,19 +1886,19 @@ function makeReducer(combiner) {
       return that;
     if (isNone2(that))
       return self;
-    return some2(combiner.combine(self.value, that.value));
+    return some3(combiner.combine(self.value, that.value));
   }, none2());
 }
 function makeCombinerFailFast(combiner) {
   return make((self, that) => {
     if (isNone2(self) || isNone2(that))
       return none2();
-    return some2(combiner.combine(self.value, that.value));
+    return some3(combiner.combine(self.value, that.value));
   });
 }
 function makeReducerFailFast(reducer) {
   const combine2 = makeCombinerFailFast(reducer).combine;
-  const initialValue = some2(reducer.initialValue);
+  const initialValue = some3(reducer.initialValue);
   return make2(combine2, initialValue, (collection) => {
     let out = initialValue;
     for (const value of collection) {
@@ -1974,8 +2111,8 @@ var serviceNotFoundError = (service) => {
 var getOption = /* @__PURE__ */ dual(2, (self, service) => {
   const value = lookup(self, service.key);
   if (value !== notFound)
-    return some2(value);
-  return isReference(service) ? some2(getDefaultValue(service)) : none2();
+    return some3(value);
+  return isReference(service) ? some3(getDefaultValue(service)) : none2();
 });
 var merge = /* @__PURE__ */ dual(2, (self, that) => {
   if (self.mapUnsafe.size === 0)
@@ -2153,11 +2290,11 @@ var bind3 = /* @__PURE__ */ bind(map2, flatMap2);
 var bindTo3 = /* @__PURE__ */ bindTo(map2);
 var let_3 = /* @__PURE__ */ let_(map2);
 var transposeOption = (self) => {
-  return isNone(self) ? succeedNone : map2(self.value, some);
+  return isNone(self) ? succeedNone : map2(self.value, some2);
 };
-var transposeMapOption = /* @__PURE__ */ dual(2, (self, f) => isNone(self) ? succeedNone : map2(f(self.value), some));
+var transposeMapOption = /* @__PURE__ */ dual(2, (self, f) => isNone(self) ? succeedNone : map2(f(self.value), some2));
 var succeedNone = /* @__PURE__ */ succeed2(none);
-var succeedSome = (a) => succeed2(some(a));
+var succeedSome = (a) => succeed2(some2(a));
 var tap2 = /* @__PURE__ */ dual(2, (self, f) => {
   if (isSuccess2(self)) {
     f(self.success);
@@ -2166,7 +2303,7 @@ var tap2 = /* @__PURE__ */ dual(2, (self, f) => {
 });
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Tuple.js
-var makeEquivalence3 = Tuple;
+var makeEquivalence3 = Tuple2;
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Iterable.js
 var makeBy = (f, options) => {
@@ -2329,7 +2466,7 @@ var getUnsafe2 = /* @__PURE__ */ dual(2, (self, index) => {
   }
   return self[i];
 });
-var last = (self) => isReadonlyArrayNonEmpty(self) ? some2(lastNonEmpty(self)) : none2();
+var last = (self) => isReadonlyArrayNonEmpty(self) ? some3(lastNonEmpty(self)) : none2();
 var lastNonEmpty = (self) => self[self.length - 1];
 var takeWhile = /* @__PURE__ */ dual(2, (self, predicate) => {
   let i = 0;
@@ -2900,16 +3037,16 @@ var divide = /* @__PURE__ */ dual(2, (self, by) => {
   if (by === 0 || Object.is(by, -0))
     return none2();
   return match3(self, {
-    onMillis: (millis2) => some2(make6(millis2 / by)),
+    onMillis: (millis2) => some3(make6(millis2 / by)),
     onNanos: (nanos2) => {
       try {
-        return some2(make6(nanos2 / BigInt(by)));
+        return some3(make6(nanos2 / BigInt(by)));
       } catch {
         return none2();
       }
     },
-    onInfinity: () => some2(by > 0 ? infinity : negativeInfinity),
-    onNegativeInfinity: () => some2(by > 0 ? negativeInfinity : infinity)
+    onInfinity: () => some3(by > 0 ? infinity : negativeInfinity),
+    onNegativeInfinity: () => some3(by > 0 ? negativeInfinity : infinity)
   });
 });
 var divideUnsafe = /* @__PURE__ */ dual(2, (self, by) => {
@@ -3057,7 +3194,7 @@ var CombinerMin = /* @__PURE__ */ min(Order);
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Filter.js
 var toPredicate = (self) => (input) => !isFailure2(self(input));
 var has2 = (key) => (input) => input.has(key) ? succeed2(input) : fail2(input);
-var compose = /* @__PURE__ */ dual(2, (left, right) => (input) => {
+var compose2 = /* @__PURE__ */ dual(2, (left, right) => (input) => {
   const leftOut = left(input);
   if (isFailure2(leftOut))
     return leftOut;
@@ -3074,7 +3211,7 @@ var composePassthrough = /* @__PURE__ */ dual(2, (left, right) => (input) => {
 });
 var toOption = (self) => (input) => {
   const result = self(input);
-  return isFailure2(result) ? none2() : some2(result.success);
+  return isFailure2(result) ? none2() : some3(result.success);
 };
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Scheduler.js
@@ -4227,9 +4364,9 @@ var yieldNowWith = /* @__PURE__ */ makePrimitive({
   }
 });
 var yieldNow = /* @__PURE__ */ yieldNowWith(0);
-var succeedSome2 = (a) => succeed3(some2(a));
+var succeedSome2 = (a) => succeed3(some3(a));
 var succeedNone2 = /* @__PURE__ */ succeed3(/* @__PURE__ */ none2());
-var transposeOption2 = (self) => isNone2(self) ? succeedNone2 : map5(self.value, some2);
+var transposeOption2 = (self) => isNone2(self) ? succeedNone2 : map5(self.value, some3);
 var failCauseSync = (evaluate2) => suspend(() => failCause(internalCall(evaluate2)));
 var die = (defect) => exitDie(defect);
 var failSync = (error) => suspend(() => fail3(internalCall(error)));
@@ -4443,7 +4580,7 @@ var as2 = /* @__PURE__ */ dual(2, (self, value) => {
   const b = succeed3(value);
   return flatMap3(self, (_) => b);
 });
-var asSome = (self) => map5(self, some2);
+var asSome = (self) => map5(self, some3);
 var flip2 = (self) => matchEffect(self, {
   onFailure: succeed3,
   onSuccess: fail3
@@ -4607,11 +4744,11 @@ var exitAsVoidAll = (exits) => {
   }
   return failures.length === 0 ? exitVoid : exitFailCause(causeFromReasons(failures));
 };
-var exitGetSuccess = (self) => exitIsSuccess(self) ? some2(self.value) : none2();
-var exitGetCause = (self) => exitIsFailure(self) ? some2(self.cause) : none2();
+var exitGetSuccess = (self) => exitIsSuccess(self) ? some3(self.value) : none2();
+var exitGetCause = (self) => exitIsFailure(self) ? some3(self.cause) : none2();
 var exitFindErrorOption = (self) => {
   const error = exitFindError(self);
-  return isFailure2(error) ? none2() : some2(error.success);
+  return isFailure2(error) ? none2() : some3(error.success);
 };
 var service = (service2) => service2;
 var serviceOption = (service2) => withFiber((fiber2) => succeed3(getOption(fiber2.context, service2)));
@@ -4834,7 +4971,7 @@ var ignoreCause = /* @__PURE__ */ dual((args2) => isEffect(args2[0]), (self, opt
 });
 var option = (self) => match4(self, {
   onFailure: none2,
-  onSuccess: some2
+  onSuccess: some3
 });
 var result = (self) => matchEager(self, {
   onFailure: fail2,
@@ -5210,7 +5347,7 @@ var findFirst = /* @__PURE__ */ dual((args2) => isIterable(args2[0]) && !isEffec
 }));
 var findFirstLoop = (iterator, index, predicate, value) => flatMap3(predicate(value, index), (keep) => {
   if (keep) {
-    return succeed3(some2(value));
+    return succeed3(some3(value));
   }
   const next = iterator.next();
   if (!next.done) {
@@ -5228,7 +5365,7 @@ var findFirstFilter = /* @__PURE__ */ dual((args2) => isIterable(args2[0]) && !i
 }));
 var findFirstFilterLoop = (iterator, index, filter4, value) => flatMap3(filter4(value, index), (result2) => {
   if (isSuccess2(result2)) {
-    return succeed3(some2(result2.success));
+    return succeed3(some3(result2.success));
   }
   const next = iterator.next();
   if (!next.done) {
@@ -5766,11 +5903,11 @@ var noopSpan = (options) => Object.assign(Object.create(NoopSpanProto), options)
 var filterDisablePropagation = (span) => {
   if (!span)
     return none2();
-  return get(span.annotations, DisablePropagation) ? span._tag === "Span" ? filterDisablePropagation(getOrUndefined(span.parent)) : none2() : some2(span);
+  return get(span.annotations, DisablePropagation) ? span._tag === "Span" ? filterDisablePropagation(getOrUndefined(span.parent)) : none2() : some3(span);
 };
 var makeSpanUnsafe = (fiber2, name, options) => {
   const disablePropagation = !fiber2.getRef(TracerEnabled) || options?.annotations && get(options.annotations, DisablePropagation);
-  const parent = options?.parent !== undefined ? some2(options.parent) : options?.root ? none2() : filterDisablePropagation(fiber2.currentSpan);
+  const parent = options?.parent !== undefined ? some3(options.parent) : options?.root ? none2() : filterDisablePropagation(fiber2.currentSpan);
   let span;
   if (disablePropagation) {
     span = noopSpan({
@@ -6071,7 +6208,7 @@ var logLevelToOrder = (level) => {
       return Number.MAX_SAFE_INTEGER;
   }
 };
-var LogLevelOrder = /* @__PURE__ */ mapInput(Number2, logLevelToOrder);
+var LogLevelOrder = /* @__PURE__ */ mapInput2(Number2, logLevelToOrder);
 var isLogLevelGreaterThan = /* @__PURE__ */ isGreaterThan(LogLevelOrder);
 var CurrentLoggers = /* @__PURE__ */ Reference("effect/Loggers/CurrentLoggers", {
   defaultValue: () => new Set([defaultLogger, tracerLogger])
@@ -7323,7 +7460,7 @@ var offsetZoneRegExp = /^(?:GMT|[+-])/;
 var zoneFromString = (zone) => {
   if (offsetZoneRegExp.test(zone)) {
     const offset = parseOffset(zone);
-    return offset === null ? none2() : some2(zoneMakeOffset(offset));
+    return offset === null ? none2() : some3(zoneMakeOffset(offset));
   }
   return zoneMakeNamed(zone);
 };
@@ -7756,19 +7893,19 @@ var nextPow2 = (n) => {
 };
 var parse = (s) => {
   if (s === "NaN") {
-    return some2(NaN);
+    return some3(NaN);
   }
   if (s === "Infinity") {
-    return some2(Infinity);
+    return some3(Infinity);
   }
   if (s === "-Infinity") {
-    return some2(-Infinity);
+    return some3(-Infinity);
   }
   if (s.trim() === "") {
     return none2();
   }
   const n = Number3(s);
-  return Number3.isNaN(n) ? none2() : some2(n);
+  return Number3.isNaN(n) ? none2() : some3(n);
 };
 var ReducerMax = /* @__PURE__ */ make2((a, b) => Math.max(a, b), -Infinity);
 var ReducerMin = /* @__PURE__ */ make2((a, b) => Math.min(a, b), Infinity);
@@ -7915,7 +8052,7 @@ var repeatOrElse = /* @__PURE__ */ dual(3, (self, schedule, orElse3) => flatMap3
     meta = meta_;
   })), {
     disableYield: true
-  }), (error) => isDone(error) ? succeed3(error.value) : orElse3(error, meta.attempt === 0 ? none2() : some2(meta)));
+  }), (error) => isDone(error) ? succeed3(error.value) : orElse3(error, meta.attempt === 0 ? none2() : some3(meta)));
 }));
 var retryOrElse = /* @__PURE__ */ dual(3, (self, policy, orElse3) => flatMap3(toStepWithMetadata(policy), (step) => {
   let meta = CurrentMetadata2.defaultValue();
@@ -8227,7 +8364,7 @@ __export(exports_Metric, {
   snapshotUnsafe: () => snapshotUnsafe,
   snapshot: () => snapshot,
   modify: () => modify,
-  mapInput: () => mapInput2,
+  mapInput: () => mapInput3,
   linearBoundaries: () => linearBoundaries,
   isMetric: () => isMetric,
   histogram: () => histogram,
@@ -8564,7 +8701,7 @@ var counter = (name, options) => new CounterMetric(name, options);
 var gauge = (name, options) => new GaugeMetric(name, options);
 var frequency = (name, options) => new FrequencyMetric(name, options);
 var histogram = (name, options) => new HistogramMetric(name, options);
-var summary = (name, options) => mapInput2(summaryWithTimestamp(name, options), (input, context2) => [input, get(context2, ClockRef).currentTimeMillisUnsafe()]);
+var summary = (name, options) => mapInput3(summaryWithTimestamp(name, options), (input, context2) => [input, get(context2, ClockRef).currentTimeMillisUnsafe()]);
 var summaryWithTimestamp = (name, options) => new SummaryMetric(name, options);
 var timer = (name, options) => {
   const boundaries = isNotUndefined(options?.boundaries) ? options.boundaries : exponentialBoundaries({
@@ -8580,13 +8717,13 @@ var timer = (name, options) => {
     boundaries,
     attributes
   });
-  return mapInput2(metric, toMillis);
+  return mapInput3(metric, toMillis);
 };
 var value = (self) => flatMap3(context(), (context2) => sync(() => self.valueUnsafe(context2)));
 var modify = /* @__PURE__ */ dual(2, (self, input) => flatMap3(context(), (context2) => sync(() => self.modifyUnsafe(input, context2))));
 var update = /* @__PURE__ */ dual(2, (self, input) => contextWith((services) => sync(() => self.updateUnsafe(input, services))));
-var mapInput2 = /* @__PURE__ */ dual(2, (self, f) => new MetricTransform(self, (context2) => self.valueUnsafe(context2), (input, context2) => self.updateUnsafe(f(input, context2), context2), (input, context2) => self.modifyUnsafe(f(input, context2), context2)));
-var withConstantInput = /* @__PURE__ */ dual(2, (self, input) => mapInput2(self, () => input));
+var mapInput3 = /* @__PURE__ */ dual(2, (self, f) => new MetricTransform(self, (context2) => self.valueUnsafe(context2), (input, context2) => self.updateUnsafe(f(input, context2), context2), (input, context2) => self.modifyUnsafe(f(input, context2), context2)));
+var withConstantInput = /* @__PURE__ */ dual(2, (self, input) => mapInput3(self, () => input));
 var withAttributes = /* @__PURE__ */ dual(2, (self, attributes) => new MetricTransform(self, (context2) => self.valueUnsafe(addAttributesToContext(context2, attributes)), (input, context2) => self.updateUnsafe(input, addAttributesToContext(context2, attributes)), (input, context2) => self.modifyUnsafe(input, addAttributesToContext(context2, attributes))));
 var snapshot = /* @__PURE__ */ map5(/* @__PURE__ */ context(), (context2) => snapshotUnsafe(context2));
 var dump = /* @__PURE__ */ flatMap3(/* @__PURE__ */ context(), (context2) => {
@@ -9887,7 +10024,7 @@ var remainingUnsafe = (self) => {
   if (self.shutdownFlag.current) {
     return none2();
   }
-  return some2(self.subscription.size() + self.replayWindow.remaining);
+  return some3(self.subscription.size() + self.replayWindow.remaining);
 };
 var AbsentValue = /* @__PURE__ */ Symbol.for("effect/PubSub/AbsentValue");
 var addSubscribers = (subscribers, subscription, pollers) => {
@@ -11128,7 +11265,7 @@ var poll2 = (self) => suspend(() => {
     return succeed3(none2());
   }
   if (result3._tag === "Success") {
-    return succeed3(some2(result3.value));
+    return succeed3(some3(result3.value));
   }
   return succeed3(none2());
 });
@@ -11515,7 +11652,7 @@ var acquireUseRelease3 = (acquire, use2, release2) => fromTransformBracket(fnUnt
   let option3 = none2();
   yield* addFinalizerExit(forkedScope, (exit3) => isSome2(option3) ? release2(option3.value, exit3) : void_5);
   const value2 = yield* uninterruptible2(acquire);
-  option3 = some2(value2);
+  option3 = some3(value2);
   return yield* toTransform(use2(value2))(upstream, scope3);
 }));
 var fromArray = (array2) => fromPull(sync4(() => {
@@ -11535,7 +11672,7 @@ var fromIteratorArray = (iterator, chunkSize = DefaultChunkSize) => fromPull(syn
         if (buffer.length === 0) {
           return done2(state.value);
         }
-        done4 = some2(state.value);
+        done4 = some3(state.value);
         break;
       }
       buffer.push(state.value);
@@ -12115,7 +12252,7 @@ var splitLines = () => fromTransform((upstream, _scope) => sync4(() => {
       onSuccess: loop,
       onFailure: failCause4,
       onDone: (leftover) => {
-        done4 = some2(leftover);
+        done4 = some3(leftover);
         if (stringBuilder.length > 0 || midCRLF) {
           const last2 = stringBuilder;
           stringBuilder = "";
@@ -12701,13 +12838,13 @@ var empty8 = () => {
 };
 var get3 = /* @__PURE__ */ dual(2, (self, key) => {
   if (self.backing.has(key)) {
-    return some2(self.backing.get(key));
+    return some3(self.backing.get(key));
   } else if (isSimpleKey(key)) {
     return none2();
   }
   const refKey = referentialKeysCache.get(self);
   if (refKey !== undefined) {
-    return self.backing.has(refKey) ? some2(self.backing.get(refKey)) : none2();
+    return self.backing.has(refKey) ? some3(self.backing.get(refKey)) : none2();
   }
   const hash2 = hash(key);
   const bucket = self.buckets.get(hash2);
@@ -12723,7 +12860,7 @@ var getFromBucket = (self, bucket, key) => {
     if (equals(key, bucket[i])) {
       const refKey = bucket[i];
       referentialKeysCache.set(key, refKey);
-      return some2(self.backing.get(refKey));
+      return some3(self.backing.get(refKey));
     }
   }
   return none2();
@@ -13365,12 +13502,12 @@ var zipWithNext = (self) => mapAccumArray(self, none2, (acc, arr) => {
   let i = 0;
   if (acc._tag === "None") {
     i = 1;
-    acc = some2(arr[0]);
+    acc = some3(arr[0]);
   }
   const pairs = empty3();
   for (;i < arr.length; i++) {
     const value2 = acc.value;
-    acc = some2(arr[i]);
+    acc = some3(arr[i]);
     pairs.push([value2, acc]);
   }
   return [acc, pairs];
@@ -13384,7 +13521,7 @@ var zipWithPrevious = (self) => mapAccumArray(self, none2, (acc, arr) => {
   for (let i = 0;i < arr.length; i++) {
     const value2 = arr[i];
     pairs.push([acc, value2]);
-    acc = some2(arr[i]);
+    acc = some3(arr[i]);
   }
   return [acc, pairs];
 });
@@ -13397,16 +13534,16 @@ var zipWithPreviousAndNext = (self) => mapAccumArray(self, () => ({
   if (acc.current._tag === "None") {
     i = 1;
     current = arr[0];
-    acc.current = some2(current);
+    acc.current = some3(current);
   } else {
     current = acc.current.value;
   }
   const pairs = empty3();
   for (;i < arr.length; i++) {
     const element = arr[i];
-    acc.current = some2(element);
+    acc.current = some3(element);
     pairs.push([acc.prev, current, acc.current]);
-    acc.prev = some2(current);
+    acc.prev = some3(current);
     current = element;
   }
   return [acc, pairs];
@@ -13625,7 +13762,7 @@ var withExecutionPlan3 = /* @__PURE__ */ dual((args2) => isStream(args2[0]), (se
       if (preventFallbackOnPartialStream && receivedElements) {
         return fail11(error);
       }
-      lastError = some2(error);
+      lastError = some3(error);
       return loop;
     });
   });
@@ -14221,7 +14358,7 @@ var aggregateWithin = /* @__PURE__ */ dual(3, (self, sink, schedule4) => fromCha
   const catchSinkHalt = flatMap5(([value2, leftover_]) => {
     if (!sinkHasInput && buffer3.state._tag === "Done")
       return done2();
-    lastOutput = some2(value2);
+    lastOutput = some3(value2);
     leftover = leftover_;
     return succeed7(of(value2));
   });
@@ -15288,7 +15425,7 @@ var missing = /* @__PURE__ */ Symbol();
 var succeed10 = succeed4;
 var missingExit = /* @__PURE__ */ succeed10(missing);
 var sameExit = /* @__PURE__ */ succeed10(missing);
-var toOption2 = (value2) => value2 === missing ? none2() : some2(value2);
+var toOption2 = (value2) => value2 === missing ? none2() : some3(value2);
 var fromOptionExit = (option3) => option3._tag === "None" ? missingExit : succeed10(option3.value);
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/SchemaIssue.js
@@ -15853,7 +15990,7 @@ function transform(f) {
   return transformOptional(map(f));
 }
 function transformOrFail(f) {
-  return onSome((e, options) => f(e, options).pipe(mapEager2(some2)));
+  return onSome((e, options) => f(e, options).pipe(mapEager2(some3)));
 }
 function transformOptional(f) {
   return new Getter((oe) => succeed7(f(oe)));
@@ -15864,7 +16001,7 @@ function omit2() {
 function withDefault(defaultValue) {
   return new Getter((o) => {
     const filtered = filter(o, isNotUndefined);
-    return isSome2(filtered) ? succeed7(filtered) : mapEager2(defaultValue, some2);
+    return isSome2(filtered) ? succeed7(filtered) : mapEager2(defaultValue, some3);
   });
 }
 function String4() {
@@ -15884,7 +16021,7 @@ function trim2() {
 }
 function parseJson(options) {
   return onSome((input, parseOptions) => try_3({
-    try: () => some2(JSON.parse(input, options?.reviver)),
+    try: () => some3(JSON.parse(input, options?.reviver)),
     catch: () => new InvalidValue({
       expected: "a valid JSON string"
     }, input, parseOptions)
@@ -15897,7 +16034,7 @@ function stringifyJson(options) {
       if (output === undefined) {
         throw new TypeError("Value cannot be represented as JSON");
       }
-      return some2(output);
+      return some3(output);
     },
     catch: () => new InvalidValue({
       expected: "a JSON-serializable value"
@@ -16241,7 +16378,7 @@ var Equivalence4 = /* @__PURE__ */ make3((self, that) => {
 var equals3 = /* @__PURE__ */ dual(2, (self, that) => Equivalence4(self, that));
 var fromString = (s) => {
   if (s === "") {
-    return some2(zero2);
+    return some3(zero2);
   }
   let base;
   let exp;
@@ -16276,7 +16413,7 @@ var fromString = (s) => {
   if (!Number.isSafeInteger(scale2)) {
     return none2();
   }
-  return some2(make23(BigInt(digits), scale2));
+  return some3(make23(BigInt(digits), scale2));
 };
 var format6 = (n) => {
   const normalized = normalize(n);
@@ -16507,13 +16644,13 @@ function optionFromNullishOr(options) {
 }
 function optionFromOptionalKey() {
   return transformOptional2({
-    decode: some2,
+    decode: some3,
     encode: flatten
   });
 }
 function optionFromOptional() {
   return transformOptional2({
-    decode: (ot) => ot.pipe(filter(isNotUndefined), some2),
+    decode: (ot) => ot.pipe(filter(isNotUndefined), some3),
     encode: flatten
   });
 }
@@ -18611,7 +18748,7 @@ var unknownToStringTree = /* @__PURE__ */ new Link(StringTree, /* @__PURE__ */ p
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/Brand.js
 function nominal() {
   return Object.assign((input) => input, {
-    option: (input) => some2(input),
+    option: (input) => some3(input),
     result: (input) => succeed2(input),
     is: (_) => true
   });
@@ -19768,11 +19905,11 @@ var makeFile = /* @__PURE__ */ (() => {
           }
           this.position = position + BigInt(bytesRead);
           if (bytesRead === sizeNumber) {
-            return some2(buffer3);
+            return some3(buffer3);
           }
           const dst = Buffer.allocUnsafeSlow(bytesRead);
           buffer3.copy(dst, 0, 0, bytesRead);
-          return some2(dst);
+          return some3(dst);
         });
       });
     }
@@ -19886,7 +20023,7 @@ var makeFileInfo = (stat2) => ({
   uid: fromNullishOr(stat2.uid),
   gid: fromNullishOr(stat2.gid),
   size: Size(stat2.size),
-  blksize: stat2.blksize !== undefined ? some2(Size(stat2.blksize)) : none2(),
+  blksize: stat2.blksize !== undefined ? some3(Size(stat2.blksize)) : none2(),
   blocks: fromNullishOr(stat2.blocks)
 });
 var stat2 = /* @__PURE__ */ (() => {
@@ -20323,7 +20460,7 @@ __export(exports_Schema, {
   URLFromString: () => URLFromString,
   URL: () => URL2,
   TupleWithRest: () => TupleWithRest,
-  Tuple: () => Tuple2,
+  Tuple: () => Tuple3,
   Trimmed: () => Trimmed,
   Trim: () => Trim,
   Tree: () => Tree,
@@ -20343,7 +20480,7 @@ __export(exports_Schema, {
   TaggedClass: () => TaggedClass2,
   Symbol: () => Symbol3,
   StructWithRest: () => StructWithRest,
-  Struct: () => Struct,
+  Struct: () => Struct2,
   StringFromUriComponent: () => StringFromUriComponent,
   StringFromHex: () => StringFromHex,
   StringFromBase64Url: () => StringFromBase64Url,
@@ -20521,7 +20658,7 @@ var make32 = (type, mutable) => {
   graph.reverseAdjacency = new Map;
   graph.nextNodeIndex = 0;
   graph.nextEdgeIndex = 0;
-  graph.acyclic = some2(true);
+  graph.acyclic = some3(true);
   return graph;
 };
 var snapshot2 = (graph) => {
@@ -20654,7 +20791,7 @@ class LeafNode extends Node {
   }
   get(_shift, hash2, key) {
     if (this.hash === hash2 && equals(this.key, key)) {
-      return some2(this.value);
+      return some3(this.value);
     }
     return none2();
   }
@@ -20720,7 +20857,7 @@ class CollisionNode extends Node {
     }
     for (const [k, v] of this.entries) {
       if (equals(k, key)) {
-        return some2(v);
+        return some3(v);
       }
     }
     return none2();
@@ -21233,7 +21370,7 @@ var HashSetProto = {
     return hash(HashSetTypeId);
   },
   [symbol2](that) {
-    return isHashSet(that) && size7(this) === size7(that) && every2(this, (value2) => has5(that, value2));
+    return isHashSet(that) && size7(this) === size7(that) && every3(this, (value2) => has5(that, value2));
   },
   [Symbol.iterator]() {
     return keys3(keyMap(this));
@@ -21271,7 +21408,7 @@ var fromIterable7 = (values2) => {
 };
 var has5 = (self, value2) => has4(keyMap(self), value2);
 var size7 = (self) => size5(keyMap(self));
-var every2 = (self, predicate) => {
+var every3 = (self, predicate) => {
   for (const value2 of self) {
     if (!predicate(value2)) {
       return false;
@@ -21302,7 +21439,7 @@ function makeOption(schema) {
   return (input, options) => {
     const exit3 = runSyncExit2(parser(input, options));
     if (isSuccess4(exit3)) {
-      return some2(exit3.value);
+      return some3(exit3.value);
     }
     getSchemaIssueOrThrow(exit3.cause, "Option adapter can only return none for schema issues");
     return none2();
@@ -21427,7 +21564,7 @@ function asOption(parser) {
   return (input, options) => {
     const exit3 = parserExit(input, options);
     if (isSuccess4(exit3)) {
-      return some2(exit3.value);
+      return some3(exit3.value);
     }
     getSchemaIssueOrThrow(exit3.cause, "Option adapter can only return none for schema issues");
     return none2();
@@ -22122,7 +22259,7 @@ function base(ast, path) {
             return;
           }
           length++;
-          elementArbitraries.push(out2.map(some2));
+          elementArbitraries.push(out2.map(some3));
         }
         const minLength = ctx.constraint?.minLength ?? 0;
         const needsRest = isReadonlyArrayNonEmpty(rest) && minLength > length + optionals.length;
@@ -22135,7 +22272,7 @@ function base(ast, path) {
           }
           includedOptionals++;
           length++;
-          elementArbitraries.push(out2.map(some2));
+          elementArbitraries.push(out2.map(some3));
         }
         if (includedOptionals < optionalTarget) {
           return;
@@ -22179,7 +22316,7 @@ function base(ast, path) {
           arbitrary
         }) => {
           const out2 = arbitrary(fc, reset, recursionStack);
-          return isOptional(ast2) ? out2.chain((a) => fc.boolean().map((b) => b ? some2(a) : none2())) : out2.map(some2);
+          return isOptional(ast2) ? out2.chain((a) => fc.boolean().map((b) => b ? some3(a) : none2())) : out2.map(some3);
         });
         let out = fc.tuple(...elementArbitraries).map((elements2) => getSomes(takeWhile(elements2, isSome2)));
         if (isReadonlyArrayNonEmpty(rest)) {
@@ -24114,7 +24251,7 @@ class CheckNode {
     this.get = (s) => runChecks(checks, s);
   }
 }
-function compose2(a, b) {
+function compose3(a, b) {
   if (a.length === 0)
     return b;
   if (b.length === 0)
@@ -24153,13 +24290,13 @@ class OptionalImpl {
     return (s) => getOrElse3(flatMap2(this.getResult(s), (a) => this.replaceResult(f(a), s)), () => s);
   }
   compose(that) {
-    return make37(compose2(this.node, that.node));
+    return make37(compose3(this.node, that.node));
   }
   key(key) {
-    return make37(compose2(this.node, [new PathNode([key])]));
+    return make37(compose3(this.node, [new PathNode([key])]));
   }
   optionalKey(key) {
-    return make37(compose2(this.node, primitiveNode("Lens", (s) => s[key], (a, s) => {
+    return make37(compose3(this.node, primitiveNode("Lens", (s) => s[key], (a, s) => {
       const copy3 = cloneShallow(s);
       if (a === undefined) {
         if (Array.isArray(copy3) && typeof key === "number") {
@@ -24174,20 +24311,20 @@ class OptionalImpl {
     })));
   }
   check(...checks) {
-    return make37(compose2(this.node, [new CheckNode(checks)]));
+    return make37(compose3(this.node, [new CheckNode(checks)]));
   }
   refine(refinement, annotations2) {
-    return make37(compose2(this.node, [new CheckNode([makeFilterByGuard(refinement, annotations2)])]));
+    return make37(compose3(this.node, [new CheckNode([makeFilterByGuard(refinement, annotations2)])]));
   }
   tag(tag) {
     const err = fail2(new InvalidValue({
       expected: `${JSON.stringify(tag)} tag`
     }));
-    return make37(compose2(this.node, primitiveNode("Prism", (s) => s._tag === tag ? succeed2(s) : err, identity)));
+    return make37(compose3(this.node, primitiveNode("Prism", (s) => s._tag === tag ? succeed2(s) : err, identity)));
   }
   at(key, ..._rest) {
     const err = fail2(new Pointer([key], new MissingKey(undefined)));
-    return make37(compose2(this.node, primitiveNode("Optional", (s) => Object.hasOwn(s, key) ? succeed2(s[key]) : err, (a, s) => {
+    return make37(compose3(this.node, primitiveNode("Optional", (s) => Object.hasOwn(s, key) ? succeed2(s[key]) : err, (a, s) => {
       if (Object.hasOwn(s, key)) {
         const copy3 = cloneShallow(s);
         assignProperty(copy3, key, a);
@@ -24810,7 +24947,7 @@ function makeStruct(ast, fields) {
     }
   });
 }
-function Struct(fields) {
+function Struct2(fields) {
   return makeStruct(struct(fields, undefined), fields);
 }
 function fieldsAssign(fields) {
@@ -24838,7 +24975,7 @@ function encodeKeys(mapping) {
         reverseMapping[encodedKey] = k;
       }
     }
-    return Struct(fields).pipe(decodeTo2(self, transform2({
+    return Struct2(fields).pipe(decodeTo2(self, transform2({
       decode: renameKeys(reverseMapping),
       encode: renameKeys(appliedMapping)
     })));
@@ -24847,7 +24984,7 @@ function encodeKeys(mapping) {
 function extendTo(fields, derive) {
   return (self) => {
     const f = map3(self.fields, toType2);
-    const to = Struct({
+    const to = Struct2({
       ...f,
       ...fields
     });
@@ -24898,7 +25035,7 @@ function makeTuple(ast, elements) {
     }
   });
 }
-function Tuple2(elements) {
+function Tuple3(elements) {
   return makeTuple(tuple(elements), elements);
 }
 function TupleWithRest(schema, rest) {
@@ -25070,7 +25207,7 @@ function tagDefaultOmit(literal) {
   }));
 }
 function TaggedStruct(value4, fields) {
-  return Struct({
+  return Struct2({
     _tag: tag(value4),
     ...fields
   });
@@ -25209,7 +25346,7 @@ function isPattern2(regExp, annotations2) {
     ...annotations2
   });
 }
-var IsPatternPayload = /* @__PURE__ */ Struct({
+var IsPatternPayload = /* @__PURE__ */ Struct2({
   source: String6,
   flags: String6
 }).check(/* @__PURE__ */ makeFilter2((payload) => {
@@ -25283,7 +25420,7 @@ function isUUID(version, annotations2) {
     ...annotations2
   });
 }
-var isUUIDReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isUUID", /* @__PURE__ */ Struct({
+var isUUIDReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isUUID", /* @__PURE__ */ Struct2({
   version: /* @__PURE__ */ Union2([/* @__PURE__ */ Literals([1, 2, 3, 4, 5, 6, 7, 8]), Null2])
 }), ({
   annotations: annotations2,
@@ -25393,7 +25530,7 @@ function isStartsWith(startsWith, annotations2) {
     ...annotations2
   });
 }
-var isStartsWithReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isStartsWith", /* @__PURE__ */ Struct({
+var isStartsWithReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isStartsWith", /* @__PURE__ */ Struct2({
   startsWith: String6
 }), ({
   annotations: annotations2,
@@ -25424,7 +25561,7 @@ function isEndsWith(endsWith, annotations2) {
     ...annotations2
   });
 }
-var isEndsWithReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isEndsWith", /* @__PURE__ */ Struct({
+var isEndsWithReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isEndsWith", /* @__PURE__ */ Struct2({
   endsWith: String6
 }), ({
   annotations: annotations2,
@@ -25455,7 +25592,7 @@ function isIncludes(includes, annotations2) {
     ...annotations2
   });
 }
-var isIncludesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isIncludes", /* @__PURE__ */ Struct({
+var isIncludesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isIncludes", /* @__PURE__ */ Struct2({
   includes: String6
 }), ({
   annotations: annotations2,
@@ -25712,7 +25849,7 @@ var isGreaterThan6 = /* @__PURE__ */ makeIsGreaterThan({
     })
   })
 });
-var isGreaterThanReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThan", /* @__PURE__ */ Struct({
+var isGreaterThanReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThan", /* @__PURE__ */ Struct2({
   exclusiveMinimum: Finite
 }), ({
   annotations: annotations2,
@@ -25735,7 +25872,7 @@ var isGreaterThanOrEqualTo5 = /* @__PURE__ */ makeIsGreaterThanOrEqualTo({
     })
   })
 });
-var isGreaterThanOrEqualToReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualTo", /* @__PURE__ */ Struct({
+var isGreaterThanOrEqualToReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualTo", /* @__PURE__ */ Struct2({
   minimum: Finite
 }), ({
   annotations: annotations2,
@@ -25758,7 +25895,7 @@ var isLessThan6 = /* @__PURE__ */ makeIsLessThan({
     })
   })
 });
-var isLessThanReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThan", /* @__PURE__ */ Struct({
+var isLessThanReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThan", /* @__PURE__ */ Struct2({
   exclusiveMaximum: Finite
 }), ({
   annotations: annotations2,
@@ -25781,7 +25918,7 @@ var isLessThanOrEqualTo5 = /* @__PURE__ */ makeIsLessThanOrEqualTo({
     })
   })
 });
-var isLessThanOrEqualToReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualTo", /* @__PURE__ */ Struct({
+var isLessThanOrEqualToReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualTo", /* @__PURE__ */ Struct2({
   maximum: Finite
 }), ({
   annotations: annotations2,
@@ -25817,7 +25954,7 @@ var isBetween2 = /* @__PURE__ */ makeIsBetween({
     };
   }
 });
-var isBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetween", /* @__PURE__ */ Struct({
+var isBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetween", /* @__PURE__ */ Struct2({
   minimum: Finite,
   maximum: Finite,
   exclusiveMinimum: /* @__PURE__ */ optional2(/* @__PURE__ */ Literal2(true)),
@@ -25845,7 +25982,7 @@ var isMultipleOf = /* @__PURE__ */ makeIsMultipleOf({
     })
   })
 });
-var isMultipleOfReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMultipleOf", /* @__PURE__ */ Struct({
+var isMultipleOfReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMultipleOf", /* @__PURE__ */ Struct2({
   divisor: Finite
 }), ({
   annotations: annotations2,
@@ -26151,7 +26288,7 @@ function isMinLength(minLength, annotations2) {
     ...annotations2
   });
 }
-var isMinLengthReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinLength", /* @__PURE__ */ Struct({
+var isMinLengthReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinLength", /* @__PURE__ */ Struct2({
   minLength: Natural
 }), ({
   annotations: annotations2,
@@ -26189,7 +26326,7 @@ function isMaxLength(maxLength, annotations2) {
     ...annotations2
   });
 }
-var isMaxLengthReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxLength", /* @__PURE__ */ Struct({
+var isMaxLengthReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxLength", /* @__PURE__ */ Struct2({
   maxLength: Natural
 }), ({
   annotations: annotations2,
@@ -26235,7 +26372,7 @@ function isLengthBetween(minimum, maximum, annotations2) {
     ...annotations2
   });
 }
-var isLengthBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLengthBetween", /* @__PURE__ */ Struct({
+var isLengthBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLengthBetween", /* @__PURE__ */ Struct2({
   minimum: Natural,
   maximum: Natural
 }), ({
@@ -26265,7 +26402,7 @@ function isMinSize(minSize, annotations2) {
     ...annotations2
   });
 }
-var isMinSizeReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinSize", /* @__PURE__ */ Struct({
+var isMinSizeReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinSize", /* @__PURE__ */ Struct2({
   minSize: Natural
 }), ({
   annotations: annotations2,
@@ -26294,7 +26431,7 @@ function isMaxSize(maxSize, annotations2) {
     ...annotations2
   });
 }
-var isMaxSizeReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxSize", /* @__PURE__ */ Struct({
+var isMaxSizeReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxSize", /* @__PURE__ */ Struct2({
   maxSize: Natural
 }), ({
   annotations: annotations2,
@@ -26326,7 +26463,7 @@ function isSizeBetween(minimum, maximum, annotations2) {
     ...annotations2
   });
 }
-var isSizeBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isSizeBetween", /* @__PURE__ */ Struct({
+var isSizeBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isSizeBetween", /* @__PURE__ */ Struct2({
   minimum: Natural,
   maximum: Natural
 }), ({
@@ -26358,7 +26495,7 @@ function isMinProperties(minProperties, annotations2) {
     ...annotations2
   });
 }
-var isMinPropertiesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinProperties", /* @__PURE__ */ Struct({
+var isMinPropertiesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMinProperties", /* @__PURE__ */ Struct2({
   minProperties: Natural
 }), ({
   annotations: annotations2,
@@ -26389,7 +26526,7 @@ function isMaxProperties(maxProperties, annotations2) {
     ...annotations2
   });
 }
-var isMaxPropertiesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxProperties", /* @__PURE__ */ Struct({
+var isMaxPropertiesReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isMaxProperties", /* @__PURE__ */ Struct2({
   maxProperties: Natural
 }), ({
   annotations: annotations2,
@@ -26424,7 +26561,7 @@ function isPropertiesLengthBetween(minimum, maximum, annotations2) {
     ...annotations2
   });
 }
-var isPropertiesLengthBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isPropertiesLengthBetween", /* @__PURE__ */ Struct({
+var isPropertiesLengthBetweenReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isPropertiesLengthBetween", /* @__PURE__ */ Struct2({
   minimum: Natural,
   maximum: Natural
 }), ({
@@ -26507,7 +26644,7 @@ function Option(value4) {
         return succeedNone3;
       }
       return mapBothEager2(decodeUnknownEffect(value5)(input.value, options), {
-        onSuccess: some2,
+        onSuccess: some3,
         onFailure: (issue) => makeCompositeAtKey(ast, "value", issue, input, options)
       });
     }
@@ -26525,13 +26662,13 @@ function Option(value4) {
       importDeclarations: [`import * as Option from "effect/Option"`]
     }),
     expected: "Option",
-    toCodec: ([value5]) => link3()(Union2([Struct({
+    toCodec: ([value5]) => link3()(Union2([Struct2({
       _tag: Literal2("Some"),
       value: value5
-    }), Struct({
+    }), Struct2({
       _tag: Literal2("None")
     })]), transform2({
-      decode: (e) => e._tag === "None" ? none2() : some2(e.value),
+      decode: (e) => e._tag === "None" ? none2() : some3(e.value),
       encode: (o) => isSome2(o) ? {
         _tag: "Some",
         value: o.value
@@ -26541,7 +26678,7 @@ function Option(value4) {
     })),
     toArbitrary: ([value5]) => (fc, ctx) => {
       const terminal = fc.constant(none2());
-      const arbitrary = fc.oneof(terminal, value5.arbitrary.map(some2));
+      const arbitrary = fc.oneof(terminal, value5.arbitrary.map(some3));
       return withRecursion(fc, ctx, terminal, arbitrary);
     },
     toEquivalence: ([value5]) => makeEquivalence(value5),
@@ -26580,8 +26717,8 @@ function OptionFromOptionalNullOr(schema, options) {
   const onNoneEncoding = options === undefined ? "omit" : options.onNoneEncoding;
   const noneValue = onNoneEncoding === null ? null : undefined;
   return optional2(NullOr(schema)).pipe(decodeTo2(Option(toType2(schema)), transformOptional2({
-    decode: (oe) => oe.pipe(filter(isNotNullish), some2),
-    encode: onNoneEncoding === "omit" ? flatten : (ot) => some2(getOrElse(flatten(ot), () => noneValue))
+    decode: (oe) => oe.pipe(filter(isNotNullish), some3),
+    encode: onNoneEncoding === "omit" ? flatten : (ot) => some3(getOrElse(flatten(ot), () => noneValue))
   })));
 }
 function Result(success, failure) {
@@ -26614,10 +26751,10 @@ function Result(success, failure) {
       importDeclarations: [`import * as Result from "effect/Result"`]
     }),
     expected: "Result",
-    toCodec: ([success2, failure2]) => link3()(Union2([Struct({
+    toCodec: ([success2, failure2]) => link3()(Union2([Struct2({
       _tag: Literal2("Success"),
       success: success2
-    }), Struct({
+    }), Struct2({
       _tag: Literal2("Failure"),
       failure: failure2
     })]), transform2({
@@ -26778,13 +26915,13 @@ function CauseReason(error, defect) {
       importDeclarations: [`import * as Cause from "effect/Cause"`]
     }),
     expected: "Cause.Failure",
-    toCodec: ([error2, defect2]) => link3()(Union2([Struct({
+    toCodec: ([error2, defect2]) => link3()(Union2([Struct2({
       _tag: Literal2("Fail"),
       error: error2
-    }), Struct({
+    }), Struct2({
       _tag: Literal2("Die"),
       defect: defect2
-    }), Struct({
+    }), Struct2({
       _tag: Literal2("Interrupt"),
       fiberId: UndefinedOr(Finite)
     })]), transform2({
@@ -27017,10 +27154,10 @@ function Exit(value4, error, defect) {
       importDeclarations: [`import * as Exit from "effect/Exit"`]
     }),
     expected: "Exit",
-    toCodec: ([value5, error2, defect2]) => link3()(Union2([Struct({
+    toCodec: ([value5, error2, defect2]) => link3()(Union2([Struct2({
       _tag: Literal2("Success"),
       value: value5
-    }), Struct({
+    }), Struct2({
       _tag: Literal2("Failure"),
       cause: Cause(error2, defect2)
     })]), transform2({
@@ -27121,7 +27258,7 @@ function entriesArbitrary(fc, ctx, key, value4, fromIterable9) {
 }
 function ReadonlyMap(key, value4) {
   const schema = declareConstructor()([key, value4], ([key2, value5]) => {
-    const array3 = ArraySchema(Tuple2([key2, value5]));
+    const array3 = ArraySchema(Tuple3([key2, value5]));
     return (input, ast, options) => {
       if (input instanceof globalThis.Map) {
         return mapBothEager2(decodeUnknownEffect(array3)([...input], options), {
@@ -27143,7 +27280,7 @@ function ReadonlyMap(key, value4) {
       Type: `globalThis.ReadonlyMap<${typeParameters[0].Type}, ${typeParameters[1].Type}>`
     }),
     expected: "ReadonlyMap",
-    toCodec: ([key2, value5]) => link3()(ArraySchema(Tuple2([key2, value5])), transform2({
+    toCodec: ([key2, value5]) => link3()(ArraySchema(Tuple3([key2, value5])), transform2({
       decode: (e) => new globalThis.Map(e),
       encode: (map13) => [...map13.entries()]
     })),
@@ -27171,13 +27308,13 @@ var ReadonlyMapReviver = /* @__PURE__ */ makeDeclarationReviver("effect/schema/R
   return annotations2 === undefined ? schema : schema.annotate(annotations2);
 });
 function graphEncodedSchema(type, node, edge) {
-  return Struct({
+  return Struct2({
     type: Literal2(type),
-    nodes: ArraySchema(Struct({
+    nodes: ArraySchema(Struct2({
       index: Natural,
       data: node
     })),
-    edges: ArraySchema(Struct({
+    edges: ArraySchema(Struct2({
       index: Natural,
       source: Natural,
       target: Natural,
@@ -27327,7 +27464,7 @@ var GraphReviver = /* @__PURE__ */ makeDeclarationReviver("effect/schema/Graph",
 });
 function HashMap(key, value4) {
   const schema = declareConstructor()([key, value4], ([key2, value5]) => {
-    const entries3 = ArraySchema(Tuple2([key2, value5]));
+    const entries3 = ArraySchema(Tuple3([key2, value5]));
     return (input, ast, options) => {
       if (isHashMap2(input)) {
         return mapBothEager2(decodeUnknownEffect(entries3)(toEntries(input), options), {
@@ -27350,7 +27487,7 @@ function HashMap(key, value4) {
       importDeclarations: [`import * as HashMap from "effect/HashMap"`]
     }),
     expected: "HashMap",
-    toCodec: ([key2, value5]) => link3()(ArraySchema(Tuple2([key2, value5])), transform2({
+    toCodec: ([key2, value5]) => link3()(ArraySchema(Tuple3([key2, value5])), transform2({
       decode: fromIterable6,
       encode: toEntries
     })),
@@ -27537,7 +27674,7 @@ var RegExp3 = /* @__PURE__ */ instanceOf(globalThis.RegExp, {
     Type: `globalThis.RegExp`
   }),
   expected: "RegExp",
-  toCodecJson: () => link3()(Struct({
+  toCodecJson: () => link3()(Struct2({
     source: String6,
     flags: String6
   }), transformOrFail2({
@@ -27630,14 +27767,14 @@ var Duration = /* @__PURE__ */ declare(isDuration, {
     importDeclarations: [`import * as Duration from "effect/Duration"`]
   }),
   expected: "Duration",
-  toCodecJson: () => link3()(Union2([Struct({
+  toCodecJson: () => link3()(Union2([Struct2({
     _tag: Literal2("Infinity")
-  }), Struct({
+  }), Struct2({
     _tag: Literal2("NegativeInfinity")
-  }), Struct({
+  }), Struct2({
     _tag: Literal2("Nanos"),
     value: BigInt5
-  }), Struct({
+  }), Struct2({
     _tag: Literal2("Millis"),
     value: Int
   })]), transform2({
@@ -27788,7 +27925,7 @@ var File = /* @__PURE__ */ instanceOf(globalThis.File, {
     Type: `globalThis.File`
   }),
   expected: "File",
-  toCodecJson: () => link3()(Struct({
+  toCodecJson: () => link3()(Struct2({
     data: String6.check(isBase64()),
     type: String6,
     name: String6,
@@ -27833,10 +27970,10 @@ var FormData2 = /* @__PURE__ */ instanceOf(globalThis.FormData, {
     Type: `globalThis.FormData`
   }),
   expected: "FormData",
-  toCodecJson: () => link3()(ArraySchema(Tuple2([String6, Union2([Struct({
+  toCodecJson: () => link3()(ArraySchema(Tuple3([String6, Union2([Struct2({
     _tag: tag("String"),
     value: String6
-  }), Struct({
+  }), Struct2({
     _tag: tag("File"),
     value: File
   })])])), transformOrFail2({
@@ -27913,10 +28050,10 @@ var StringFromUriComponent = /* @__PURE__ */ String6.annotate({
   expected: "a URI component encoded string that will be decoded as a UTF-8 string"
 }).pipe(/* @__PURE__ */ decodeTo2(String6, stringFromUriComponent));
 var PropertyKey = /* @__PURE__ */ Union2([Finite, Symbol3, String6]);
-var StandardSchemaV1FailureResult = /* @__PURE__ */ Struct({
-  issues: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct({
+var StandardSchemaV1FailureResult = /* @__PURE__ */ Struct2({
+  issues: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct2({
     message: String6,
-    path: /* @__PURE__ */ optional2(/* @__PURE__ */ ArraySchema(/* @__PURE__ */ Union2([PropertyKey, /* @__PURE__ */ Struct({
+    path: /* @__PURE__ */ optional2(/* @__PURE__ */ ArraySchema(/* @__PURE__ */ Union2([PropertyKey, /* @__PURE__ */ Struct2({
       key: PropertyKey
     })])))
   }))
@@ -28134,7 +28271,7 @@ function makeClass(Inherited, identifier2, struct2, annotations2, proto) {
     }
     static extend(identifier3) {
       return (schema, annotations3) => {
-        const extension = isStruct(schema) ? schema : Struct(schema);
+        const extension = isStruct(schema) ? schema : Struct2(schema);
         const fields = {
           ...struct2.fields,
           ...extension.fields
@@ -28198,7 +28335,7 @@ function isStruct(schema) {
   return isSchema(schema);
 }
 var Class4 = (identifier2) => (schema, annotations2) => {
-  const struct2 = isStruct(schema) ? schema : Struct(schema);
+  const struct2 = isStruct(schema) ? schema : Struct2(schema);
   return makeClass(Class3, identifier2, struct2, annotations2, (identifier3) => ({
     toString() {
       return `${identifier3}(${format({
@@ -28219,7 +28356,7 @@ var TaggedClass2 = (identifier2) => {
   };
 };
 var Error4 = (identifier2) => (schema, annotations2) => {
-  const struct2 = isStruct(schema) ? schema : Struct(schema);
+  const struct2 = isStruct(schema) ? schema : Struct2(schema);
   const self = makeClass(Error2, identifier2, struct2, annotations2, (identifier3) => ({
     name: identifier3
   }));
@@ -28687,31 +28824,31 @@ var toCodecArrayFromSingleAST = /* @__PURE__ */ applyToSelfOrLastLinkEncodingIde
 function toCodecArrayFromSingleASTStep(ast) {
   return ast._tag === "Declaration" || ast._tag === "Arrays" || ast._tag === "Objects" || ast._tag === "Union" || ast._tag === "Suspend" ? ast.recur(toCodecArrayFromSingleAST) : ast;
 }
-var isGreaterThanDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanDate", /* @__PURE__ */ Struct({
+var isGreaterThanDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanDate", /* @__PURE__ */ Struct2({
   exclusiveMinimum: Date4
 }), ({
   annotations: annotations2,
   payload
 }) => isGreaterThanDate(payload.exclusiveMinimum, annotations2));
-var isGreaterThanOrEqualToDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualToDate", /* @__PURE__ */ Struct({
+var isGreaterThanOrEqualToDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualToDate", /* @__PURE__ */ Struct2({
   minimum: Date4
 }), ({
   annotations: annotations2,
   payload
 }) => isGreaterThanOrEqualToDate(payload.minimum, annotations2));
-var isLessThanDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanDate", /* @__PURE__ */ Struct({
+var isLessThanDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanDate", /* @__PURE__ */ Struct2({
   exclusiveMaximum: Date4
 }), ({
   annotations: annotations2,
   payload
 }) => isLessThanDate(payload.exclusiveMaximum, annotations2));
-var isLessThanOrEqualToDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualToDate", /* @__PURE__ */ Struct({
+var isLessThanOrEqualToDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualToDate", /* @__PURE__ */ Struct2({
   maximum: Date4
 }), ({
   annotations: annotations2,
   payload
 }) => isLessThanOrEqualToDate(payload.maximum, annotations2));
-var isBetweenDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetweenDate", /* @__PURE__ */ Struct({
+var isBetweenDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetweenDate", /* @__PURE__ */ Struct2({
   minimum: Date4,
   maximum: Date4,
   exclusiveMinimum: /* @__PURE__ */ optional2(/* @__PURE__ */ Literal2(true)),
@@ -28720,31 +28857,31 @@ var isBetweenDateReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBe
   annotations: annotations2,
   payload
 }) => isBetweenDate(payload, annotations2));
-var isGreaterThanBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanBigInt", /* @__PURE__ */ Struct({
+var isGreaterThanBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanBigInt", /* @__PURE__ */ Struct2({
   exclusiveMinimum: BigInt5
 }), ({
   annotations: annotations2,
   payload
 }) => isGreaterThanBigInt(payload.exclusiveMinimum, annotations2));
-var isGreaterThanOrEqualToBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualToBigInt", /* @__PURE__ */ Struct({
+var isGreaterThanOrEqualToBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isGreaterThanOrEqualToBigInt", /* @__PURE__ */ Struct2({
   minimum: BigInt5
 }), ({
   annotations: annotations2,
   payload
 }) => isGreaterThanOrEqualToBigInt(payload.minimum, annotations2));
-var isLessThanBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanBigInt", /* @__PURE__ */ Struct({
+var isLessThanBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanBigInt", /* @__PURE__ */ Struct2({
   exclusiveMaximum: BigInt5
 }), ({
   annotations: annotations2,
   payload
 }) => isLessThanBigInt(payload.exclusiveMaximum, annotations2));
-var isLessThanOrEqualToBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualToBigInt", /* @__PURE__ */ Struct({
+var isLessThanOrEqualToBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isLessThanOrEqualToBigInt", /* @__PURE__ */ Struct2({
   maximum: BigInt5
 }), ({
   annotations: annotations2,
   payload
 }) => isLessThanOrEqualToBigInt(payload.maximum, annotations2));
-var isBetweenBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetweenBigInt", /* @__PURE__ */ Struct({
+var isBetweenBigIntReviver = /* @__PURE__ */ makeFilterReviver("effect/schema/isBetweenBigInt", /* @__PURE__ */ Struct2({
   minimum: BigInt5,
   maximum: BigInt5,
   exclusiveMinimum: /* @__PURE__ */ optional2(/* @__PURE__ */ Literal2(true)),
@@ -28799,7 +28936,7 @@ var Json2 = /* @__PURE__ */ make39(/* @__PURE__ */ annotate2(Json, {
   })
 }));
 var JsonReviver = /* @__PURE__ */ makeFixedDeclarationReviver("effect/schema/Json", Json2);
-var JsonError = /* @__PURE__ */ Struct({
+var JsonError = /* @__PURE__ */ Struct2({
   message: String6,
   name: /* @__PURE__ */ optionalKey2(String6),
   stack: /* @__PURE__ */ optionalKey2(String6),
@@ -29031,10 +29168,10 @@ var Proto6 = {
   }
 };
 var identityPath = (path) => path;
-function makeProvider(load, mapInput3) {
+function makeProvider(load, mapInput4) {
   const self = Object.create(Proto6);
   self.load = load;
-  self.mapInput = mapInput3;
+  self.mapInput = mapInput4;
   return self;
 }
 function makeSource(get9, transform3) {
@@ -29242,7 +29379,7 @@ var resolveRecord = (results) => {
 var withDefault2 = /* @__PURE__ */ dual(2, (self, defaultValue) => {
   return make43((provider, pathPrefix) => mapEager2(evaluateAt(self, provider, pathPrefix), (resolution) => resolution._tag === "Absent" ? resolved(defaultValue, false) : resolution));
 });
-var option3 = (self) => self.pipe(map13(some2), withDefault2(none2()));
+var option3 = (self) => self.pipe(map13(some3), withDefault2(none2()));
 var unwrap5 = (wrapped) => {
   if (isConfig(wrapped))
     return wrapped;
@@ -30145,7 +30282,7 @@ var UrlParamsSchema = /* @__PURE__ */ declare(isUrlParams, {
   }),
   expected: "UrlParams",
   toEquivalence: () => Equivalence7,
-  toCodec: () => link3()(ArraySchema(Tuple2([String6, String6])), transform2({
+  toCodec: () => link3()(ArraySchema(Tuple3([String6, String6])), transform2({
     decode: make47,
     encode: (self) => self.params
   }))
@@ -30649,7 +30786,7 @@ var setUrlParam = /* @__PURE__ */ dual(3, (self, key, value4) => makeWith(self.m
 var setUrlParams = /* @__PURE__ */ dual(2, (self, input) => makeWith(self.method, self.url, setAll2(self.urlParams, input), self.hash, self.headers, self.body));
 var appendUrlParam = /* @__PURE__ */ dual(3, (self, key, value4) => makeWith(self.method, self.url, append3(self.urlParams, key, value4), self.hash, self.headers, self.body));
 var appendUrlParams = /* @__PURE__ */ dual(2, (self, input) => makeWith(self.method, self.url, appendAll3(self.urlParams, input), self.hash, self.headers, self.body));
-var setHash2 = /* @__PURE__ */ dual(2, (self, hash2) => makeWith(self.method, self.url, self.urlParams, some2(hash2), self.headers, self.body));
+var setHash2 = /* @__PURE__ */ dual(2, (self, hash2) => makeWith(self.method, self.url, self.urlParams, some3(hash2), self.headers, self.body));
 var removeHash = (self) => makeWith(self.method, self.url, self.urlParams, none2(), self.headers, self.body);
 var setBody = /* @__PURE__ */ dual(2, (self, body) => {
   return makeWith(self.method, self.url, self.urlParams, self.hash, updateHeaders(self.headers, body), body);
@@ -30670,7 +30807,7 @@ var bodyFile = /* @__PURE__ */ dual((args2) => isHttpClientRequest(args2[0]), (s
 function toUrl(self) {
   const r = make48(self.url, self.urlParams, getOrUndefined(self.hash));
   if (isSuccess2(r)) {
-    return some2(r.success);
+    return some3(r.success);
   }
   return none2();
 }
@@ -32414,7 +32551,7 @@ var StreamPart = (toolkit) => {
   return Union2([TextStartPart, TextDeltaPart, TextEndPart, ReasoningStartPart, ReasoningDeltaPart, ReasoningEndPart, ToolParamsStartPart, ToolParamsDeltaPart, ToolParamsEndPart, ToolApprovalRequestPart, FilePart, DocumentSourcePart, UrlSourcePart, ResponseMetadataPart, FinishPart, ErrorPart, ...toolCalls, ...toolResults]);
 };
 var ProviderMetadata = /* @__PURE__ */ Record(String6, /* @__PURE__ */ NullOr(Json2));
-var BasePart = /* @__PURE__ */ Struct({
+var BasePart = /* @__PURE__ */ Struct2({
   [PartTypeId]: /* @__PURE__ */ tag(PartTypeId).pipe(/* @__PURE__ */ withDecodingDefaultKey(/* @__PURE__ */ succeed7(PartTypeId), {
     encodingStrategy: "omit"
   })),
@@ -32426,21 +32563,21 @@ var makePart = (type, params) => ({
   type,
   metadata: params.metadata ?? {}
 });
-var TextPart = /* @__PURE__ */ Struct({
+var TextPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("text"),
   text: String6
 }).annotate({
   identifier: "TextPart"
 });
-var TextStartPart = /* @__PURE__ */ Struct({
+var TextStartPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("text-start"),
   id: String6
 }).annotate({
   identifier: "TextStartPart"
 });
-var TextDeltaPart = /* @__PURE__ */ Struct({
+var TextDeltaPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("text-delta"),
   id: String6,
@@ -32448,28 +32585,28 @@ var TextDeltaPart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "TextDeltaPart"
 });
-var TextEndPart = /* @__PURE__ */ Struct({
+var TextEndPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("text-end"),
   id: String6
 }).annotate({
   identifier: "TextEndPart"
 });
-var ReasoningPart = /* @__PURE__ */ Struct({
+var ReasoningPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("reasoning"),
   text: String6
 }).annotate({
   identifier: "ReasoningPart"
 });
-var ReasoningStartPart = /* @__PURE__ */ Struct({
+var ReasoningStartPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("reasoning-start"),
   id: String6
 }).annotate({
   identifier: "ReasoningStartPart"
 });
-var ReasoningDeltaPart = /* @__PURE__ */ Struct({
+var ReasoningDeltaPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("reasoning-delta"),
   id: String6,
@@ -32477,14 +32614,14 @@ var ReasoningDeltaPart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "ReasoningDeltaPart"
 });
-var ReasoningEndPart = /* @__PURE__ */ Struct({
+var ReasoningEndPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("reasoning-end"),
   id: String6
 }).annotate({
   identifier: "ReasoningEndPart"
 });
-var ToolParamsStartPart = /* @__PURE__ */ Struct({
+var ToolParamsStartPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("tool-params-start"),
   id: String6,
@@ -32493,7 +32630,7 @@ var ToolParamsStartPart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "ToolParamsStartPart"
 });
-var ToolParamsDeltaPart = /* @__PURE__ */ Struct({
+var ToolParamsDeltaPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("tool-params-delta"),
   id: String6,
@@ -32501,14 +32638,14 @@ var ToolParamsDeltaPart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "ToolParamsDeltaPart"
 });
-var ToolParamsEndPart = /* @__PURE__ */ Struct({
+var ToolParamsEndPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("tool-params-end"),
   id: String6
 }).annotate({
   identifier: "ToolParamsEndPart"
 });
-var ToolCallPart = (name, params) => Struct({
+var ToolCallPart = (name, params) => Struct2({
   ...BasePart.fields,
   type: Literal2("tool-call"),
   id: String6,
@@ -32527,7 +32664,7 @@ var ToolResultPart = (name, success, failure) => {
     isFailure: Boolean3,
     name: Literal2(name)
   };
-  const Decoded = Struct({
+  const Decoded = Struct2({
     ...Common,
     [PartTypeId]: Literal2(PartTypeId),
     result: ResultSchema,
@@ -32536,7 +32673,7 @@ var ToolResultPart = (name, success, failure) => {
     encodedResult: toEncoded2(ResultSchema),
     preliminary: Boolean3
   });
-  const Encoded = Struct({
+  const Encoded = Struct2({
     ...Common,
     result: toEncoded2(ResultSchema),
     providerExecuted: optional2(Boolean3),
@@ -32558,7 +32695,7 @@ var ToolResultPart = (name, success, failure) => {
   });
 };
 var toolResultPart = (params) => makePart("tool-result", params);
-var ToolApprovalRequestPart = /* @__PURE__ */ Struct({
+var ToolApprovalRequestPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("tool-approval-request"),
   approvalId: String6,
@@ -32567,7 +32704,7 @@ var ToolApprovalRequestPart = /* @__PURE__ */ Struct({
   identifier: "ToolApprovalRequestPart"
 });
 var toolApprovalRequestPart = (params) => makePart("tool-approval-request", params);
-var FilePart = /* @__PURE__ */ Struct({
+var FilePart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("file"),
   mediaType: String6,
@@ -32575,7 +32712,7 @@ var FilePart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "FilePart"
 });
-var DocumentSourcePart = /* @__PURE__ */ Struct({
+var DocumentSourcePart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("source"),
   sourceType: tag("document"),
@@ -32586,7 +32723,7 @@ var DocumentSourcePart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "DocumentSourcePart"
 });
-var UrlSourcePart = /* @__PURE__ */ Struct({
+var UrlSourcePart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("source"),
   sourceType: tag("url"),
@@ -32596,22 +32733,22 @@ var UrlSourcePart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "UrlSourcePart"
 });
-var HttpRequestDetails = /* @__PURE__ */ Struct({
+var HttpRequestDetails = /* @__PURE__ */ Struct2({
   method: Literals(["GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE"]),
   url: String6,
-  urlParams: ArraySchema(Tuple2([String6, String6])),
+  urlParams: ArraySchema(Tuple3([String6, String6])),
   hash: optional2(String6),
   headers: Record(String6, Union2([String6, Redacted(String6)]))
 }).annotate({
   identifier: "HttpRequestDetails"
 });
-var HttpResponseDetails = /* @__PURE__ */ Struct({
+var HttpResponseDetails = /* @__PURE__ */ Struct2({
   status: Int,
   headers: Record(String6, Union2([String6, Redacted(String6)]))
 }).annotate({
   identifier: "HttpResponseDetails"
 });
-var ResponseMetadataPart = /* @__PURE__ */ Struct({
+var ResponseMetadataPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("response-metadata"),
   id: optional2(String6),
@@ -32624,20 +32761,20 @@ var ResponseMetadataPart = /* @__PURE__ */ Struct({
 var FinishReason = /* @__PURE__ */ Literals(["stop", "length", "content-filter", "tool-calls", "error", "pause", "other", "unknown"]);
 
 class Usage extends (/* @__PURE__ */ Class4("effect/ai/AiResponse/Usage")({
-  inputTokens: /* @__PURE__ */ Struct({
+  inputTokens: /* @__PURE__ */ Struct2({
     uncached: /* @__PURE__ */ optional2(Int),
     total: /* @__PURE__ */ optional2(Int),
     cacheRead: /* @__PURE__ */ optional2(Int),
     cacheWrite: /* @__PURE__ */ optional2(Int)
   }),
-  outputTokens: /* @__PURE__ */ Struct({
+  outputTokens: /* @__PURE__ */ Struct2({
     total: /* @__PURE__ */ optional2(Int),
     text: /* @__PURE__ */ optional2(Int),
     reasoning: /* @__PURE__ */ optional2(Int)
   })
 })) {
 }
-var FinishPart = /* @__PURE__ */ Struct({
+var FinishPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("finish"),
   reason: FinishReason,
@@ -32646,7 +32783,7 @@ var FinishPart = /* @__PURE__ */ Struct({
 }).annotate({
   identifier: "FinishPart"
 });
-var ErrorPart = /* @__PURE__ */ Struct({
+var ErrorPart = /* @__PURE__ */ Struct2({
   ...BasePart.fields,
   type: tag("error"),
   error: Unknown2
@@ -32717,14 +32854,14 @@ ${suggestion}`;
   }
 }
 var ProviderMetadata2 = /* @__PURE__ */ Record(String6, /* @__PURE__ */ NullOr(MutableJson2));
-var UsageInfo = /* @__PURE__ */ Struct({
+var UsageInfo = /* @__PURE__ */ Struct2({
   promptTokens: optional2(Int),
   completionTokens: optional2(Int),
   totalTokens: optional2(Int)
 }).annotate({
   identifier: "UsageInfo"
 });
-var HttpContext = /* @__PURE__ */ Struct({
+var HttpContext = /* @__PURE__ */ Struct2({
   request: HttpRequestDetails,
   response: optional2(HttpResponseDetails),
   body: optional2(String6)
@@ -33199,7 +33336,7 @@ var make53 = () => acquireRelease2(sync4(() => makeUnsafe10(new Set, makeUnsafe2
   return interruptAll(fibers).pipe(into(set8.deferred));
 }));
 var internalFiberId = -1;
-var isInternalInterruption = /* @__PURE__ */ toPredicate(/* @__PURE__ */ compose(filterInterruptors, /* @__PURE__ */ has2(internalFiberId)));
+var isInternalInterruption = /* @__PURE__ */ toPredicate(/* @__PURE__ */ compose2(filterInterruptors, /* @__PURE__ */ has2(internalFiberId)));
 var addUnsafe2 = /* @__PURE__ */ dual((args2) => isFiberSet(args2[0]), (self, fiber3, options3) => {
   if (self.state._tag === "Closed") {
     fiber3.interruptUnsafe(internalFiberId);
@@ -33329,7 +33466,7 @@ __export(exports_Prompt, {
 var ProviderOptions = /* @__PURE__ */ Record(String6, /* @__PURE__ */ NullOr(Json2));
 var PartTypeId2 = "~effect/ai/Prompt/Part";
 var isPart2 = (u) => hasProperty(u, PartTypeId2);
-var BasePart2 = /* @__PURE__ */ Struct({
+var BasePart2 = /* @__PURE__ */ Struct2({
   [PartTypeId2]: /* @__PURE__ */ Literal2(PartTypeId2).pipe(/* @__PURE__ */ withDecodingDefaultKey(/* @__PURE__ */ succeed7(PartTypeId2), {
     encodingStrategy: "omit"
   })),
@@ -33341,7 +33478,7 @@ var makePart2 = (type, params) => ({
   type,
   options: params.options ?? {}
 });
-var TextPart2 = /* @__PURE__ */ Struct({
+var TextPart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("text"),
   text: String6
@@ -33349,7 +33486,7 @@ var TextPart2 = /* @__PURE__ */ Struct({
   identifier: "TextPart"
 });
 var textPart = (params) => makePart2("text", params);
-var ReasoningPart2 = /* @__PURE__ */ Struct({
+var ReasoningPart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("reasoning"),
   text: String6
@@ -33357,7 +33494,7 @@ var ReasoningPart2 = /* @__PURE__ */ Struct({
   identifier: "ReasoningPart"
 });
 var reasoningPart = (params) => makePart2("reasoning", params);
-var FilePart2 = /* @__PURE__ */ Struct({
+var FilePart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("file"),
   mediaType: String6,
@@ -33367,7 +33504,7 @@ var FilePart2 = /* @__PURE__ */ Struct({
   identifier: "FilePart"
 });
 var filePart = (params) => makePart2("file", params);
-var ToolCallPart2 = /* @__PURE__ */ Struct({
+var ToolCallPart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("tool-call"),
   id: String6,
@@ -33378,7 +33515,7 @@ var ToolCallPart2 = /* @__PURE__ */ Struct({
   identifier: "ToolCallPart"
 });
 var toolCallPart2 = (params) => makePart2("tool-call", params);
-var ToolResultPart2 = /* @__PURE__ */ Struct({
+var ToolResultPart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("tool-result"),
   id: String6,
@@ -33390,7 +33527,7 @@ var ToolResultPart2 = /* @__PURE__ */ Struct({
   identifier: "ToolResultPart"
 });
 var toolResultPart2 = (params) => makePart2("tool-result", params);
-var ToolApprovalResponsePart = /* @__PURE__ */ Struct({
+var ToolApprovalResponsePart = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("tool-approval-response"),
   approvalId: String6,
@@ -33400,7 +33537,7 @@ var ToolApprovalResponsePart = /* @__PURE__ */ Struct({
   identifier: "ToolApprovalResponsePart"
 });
 var toolApprovalResponsePart = (params) => makePart2("tool-approval-response", params);
-var ToolApprovalRequestPart2 = /* @__PURE__ */ Struct({
+var ToolApprovalRequestPart2 = /* @__PURE__ */ Struct2({
   ...BasePart2.fields,
   type: Literal2("tool-approval-request"),
   approvalId: String6,
@@ -33412,7 +33549,7 @@ var toolApprovalRequestPart2 = (params) => makePart2("tool-approval-request", pa
 var Part2 = /* @__PURE__ */ Union2([TextPart2, ReasoningPart2, FilePart2, ToolCallPart2, ToolResultPart2, ToolApprovalResponsePart, ToolApprovalRequestPart2]);
 var MessageTypeId = "~effect/ai/Prompt/Message";
 var isMessage = (u) => hasProperty(u, MessageTypeId);
-var BaseMessage = /* @__PURE__ */ Struct({
+var BaseMessage = /* @__PURE__ */ Struct2({
   [MessageTypeId]: /* @__PURE__ */ Literal2(MessageTypeId).pipe(/* @__PURE__ */ withDecodingDefaultKey(/* @__PURE__ */ succeed7(MessageTypeId), {
     encodingStrategy: "omit"
   })),
@@ -33430,7 +33567,7 @@ var ContentFromString = /* @__PURE__ */ String6.pipe(/* @__PURE__ */ decodeTo2(/
   })),
   encode: (content) => content[0].text
 })));
-var SystemMessage = /* @__PURE__ */ Struct({
+var SystemMessage = /* @__PURE__ */ Struct2({
   ...BaseMessage.fields,
   role: Literal2("system"),
   content: String6
@@ -33439,7 +33576,7 @@ var SystemMessage = /* @__PURE__ */ Struct({
 });
 var systemMessage = (params) => makeMessage("system", params);
 var UserMessagePart = /* @__PURE__ */ Union2([TextPart2, FilePart2]);
-var UserMessage = /* @__PURE__ */ Struct({
+var UserMessage = /* @__PURE__ */ Struct2({
   ...BaseMessage.fields,
   role: Literal2("user"),
   content: Union2([ContentFromString, ArraySchema(Union2([TextPart2, FilePart2]))])
@@ -33448,7 +33585,7 @@ var UserMessage = /* @__PURE__ */ Struct({
 });
 var userMessage = (params) => makeMessage("user", params);
 var AssistantMessagePart = /* @__PURE__ */ Union2([TextPart2, FilePart2, ReasoningPart2, ToolCallPart2, ToolResultPart2, ToolApprovalRequestPart2]);
-var AssistantMessage = /* @__PURE__ */ Struct({
+var AssistantMessage = /* @__PURE__ */ Struct2({
   ...BaseMessage.fields,
   role: Literal2("assistant"),
   content: Union2([ContentFromString, ArraySchema(Union2([TextPart2, FilePart2, ReasoningPart2, ToolCallPart2, ToolResultPart2, ToolApprovalRequestPart2]))])
@@ -33457,7 +33594,7 @@ var AssistantMessage = /* @__PURE__ */ Struct({
 });
 var assistantMessage = (params) => makeMessage("assistant", params);
 var ToolMessagePart = /* @__PURE__ */ Union2([ToolResultPart2, ToolApprovalResponsePart]);
-var ToolMessage = /* @__PURE__ */ Struct({
+var ToolMessage = /* @__PURE__ */ Struct2({
   ...BaseMessage.fields,
   role: Literal2("tool"),
   content: ArraySchema(Union2([ToolResultPart2, ToolApprovalResponsePart]))
@@ -33471,7 +33608,7 @@ var isPrompt = (u) => hasProperty(u, TypeId55);
 var $Prompt = /* @__PURE__ */ declare((u) => isPrompt(u), {
   identifier: "Prompt"
 });
-var Prompt = /* @__PURE__ */ Struct({
+var Prompt = /* @__PURE__ */ Struct2({
   content: ArraySchema(toEncoded2(Message))
 }).pipe(/* @__PURE__ */ decodeTo2($Prompt, /* @__PURE__ */ transformOrFail2({
   decode: (input, options3) => mapBothEager2(decodeEffect(ArraySchema(Message))(input.content), {
@@ -33754,7 +33891,7 @@ var make55 = /* @__PURE__ */ sync4(() => {
       if (partsAfterLastAssistant.length === 0) {
         return none3();
       }
-      return some2({
+      return some3({
         previousResponseId: responseId,
         prompt: fromMessages(partsAfterLastAssistant)
       });
@@ -39967,6 +40104,10 @@ class CodeExecutor extends exports_Context.Service()("@effect-agent/sandbox/Code
 // packages/sandbox/src/page-capture.ts
 var MAX_OUTPUT_BYTES2 = 8 * 1024 * 1024;
 var MAX_LINKS = 4096;
+var MAX_RESPONSE_FORMAT_BYTES = 64 * 1024;
+var MAX_RESPONSE_FORMAT_DEPTH = 32;
+var MAX_RESPONSE_FORMAT_NODES = 4096;
+var MAX_RESPONSE_FORMAT_COLLECTION_LENGTH = 256;
 var BoundedOutputText2 = exports_Schema.String.check(exports_Schema.isMaxLength(MAX_OUTPUT_BYTES2));
 var BoundedUrl = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var BoundedHtml = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(2 * 1024 * 1024));
@@ -39974,8 +40115,92 @@ var BoundedPrompt = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLeng
 var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
+var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
+var ResponseFormatPrimitive = exports_Schema.Literals([
+  "string",
+  "number",
+  "boolean",
+  "array",
+  "object",
+  "null",
+  "integer"
+]);
+var ResponseFormatPrimitiveList = exports_Schema.Array(ResponseFormatPrimitive).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(7), exports_Schema.isUnique());
+var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.StructWithRest(exports_Schema.Struct({
+  type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
+  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+  items: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  anyOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  oneOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  allOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
+}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]));
+var ResponseFormatDocument = exports_Schema.StructWithRest(exports_Schema.Struct({
+  type: exports_Schema.Literal("object"),
+  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
+  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
+}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]);
+var isResponseFormatDocument = exports_Schema.is(ResponseFormatDocument);
+var isBoundedResponseFormat = (input) => {
+  if (!exports_Predicate.isObject(input))
+    return false;
+  const pending = [
+    { value: input, depth: 0 }
+  ];
+  const visited = new WeakSet;
+  let nodes = 0;
+  let textUnits = 0;
+  try {
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (current === undefined || current.depth > MAX_RESPONSE_FORMAT_DEPTH || ++nodes > MAX_RESPONSE_FORMAT_NODES) {
+        return false;
+      }
+      const value4 = current.value;
+      if (value4 === null || typeof value4 === "boolean")
+        continue;
+      if (typeof value4 === "number") {
+        if (!Number.isFinite(value4))
+          return false;
+        continue;
+      }
+      if (typeof value4 === "string") {
+        textUnits += value4.length;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES)
+          return false;
+        continue;
+      }
+      if (!exports_Predicate.isObjectOrArray(value4) || visited.has(value4))
+        return false;
+      visited.add(value4);
+      const entries3 = Array.isArray(value4) ? value4.map((entry, index2) => [index2, entry]) : Object.entries(value4);
+      if (entries3.length > MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)
+        return false;
+      for (const [key, entry] of entries3) {
+        textUnits += typeof key === "string" ? key.length : 0;
+        if (textUnits > MAX_RESPONSE_FORMAT_BYTES)
+          return false;
+        pending.push({ value: entry, depth: current.depth + 1 });
+      }
+    }
+    if (!isResponseFormatDocument(input))
+      return false;
+    const encoded = JSON.stringify(input);
+    return exports_Encoding.encodeHex(encoded).length / 2 <= MAX_RESPONSE_FORMAT_BYTES;
+  } catch {
+    return false;
+  }
+};
+var PageCaptureResponseFormat = exports_Schema.declare(isBoundedResponseFormat, {
+  identifier: "@effect-agent/sandbox/PageCaptureResponseFormat",
+  description: "An object JSON Schema bounded to 64 KiB, depth 32, and 4096 nodes"
+});
 
 class PageUrlTarget extends exports_Schema.TaggedClass()("PageUrlTarget", {
   url: BoundedUrl
@@ -40001,7 +40226,7 @@ class CapturePageLinks extends exports_Schema.TaggedClass()("CapturePageLinks", 
 }
 
 class CapturePageStructured extends exports_Schema.TaggedClass()("CapturePageStructured", {
-  responseFormat: exports_Schema.Json,
+  responseFormat: PageCaptureResponseFormat,
   prompt: exports_Schema.optionalKey(BoundedPrompt)
 }) {
 }
@@ -40883,7 +41108,7 @@ var Proto18 = {
   setPayload(payloadSchema) {
     return makeProto3({
       _tag: this._tag,
-      payloadSchema: isSchema(payloadSchema) ? payloadSchema : Struct(payloadSchema),
+      payloadSchema: isSchema(payloadSchema) ? payloadSchema : Struct2(payloadSchema),
       successSchema: this.successSchema,
       errorSchema: this.errorSchema,
       defectSchema: this.defectSchema,
@@ -40955,7 +41180,7 @@ var make59 = (tag2, options3) => {
       }
     };
   } else {
-    payloadSchema = isSchema(options3?.payload) ? options3?.payload : options3?.payload ? Struct(options3?.payload) : Void2;
+    payloadSchema = isSchema(options3?.payload) ? options3?.payload : options3?.payload ? Struct2(options3?.payload) : Void2;
   }
   return makeProto3({
     _tag: tag2,
@@ -40983,38 +41208,38 @@ var optional3 = (schema3) => optionalKey2(schema3).pipe(decodeTo2(optional2(sche
 var RequestId = /* @__PURE__ */ Union2([String6, Finite]);
 var ProgressToken = /* @__PURE__ */ Union2([String6, Finite]);
 
-class RequestMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
-  _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
+class RequestMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
+  _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
     progressToken: /* @__PURE__ */ optional3(ProgressToken)
   }))
 }))) {
 }
 
-class ResultMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ResultMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, Json2))
 }))) {
 }
 
-class NotificationMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class NotificationMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, Json2))
 }))) {
 }
 var Cursor = String6;
 
-class PaginatedRequestMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class PaginatedRequestMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...RequestMeta.fields,
   cursor: /* @__PURE__ */ optional3(Cursor)
 }))) {
 }
 
-class PaginatedResultMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class PaginatedResultMeta extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResultMeta.fields,
   nextCursor: /* @__PURE__ */ optional3(Cursor)
 }))) {
 }
 var Role = /* @__PURE__ */ Literals(["user", "assistant"]);
 
-class Annotations extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class Annotations extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   audience: /* @__PURE__ */ optional3(/* @__PURE__ */ ArraySchema(Role)),
   priority: /* @__PURE__ */ optional3(/* @__PURE__ */ Finite.check(/* @__PURE__ */ isBetween2({
     minimum: 0,
@@ -41032,7 +41257,7 @@ class Icon extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/Icon")({
 })) {
 }
 
-class Implementation extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class Implementation extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   name: String6,
   title: /* @__PURE__ */ optional3(String6),
   version: String6,
@@ -41043,35 +41268,35 @@ class Implementation extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
 }
 
 class ClientCapabilities extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/ClientCapabilities")({
-  experimental: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, /* @__PURE__ */ Struct({}))),
+  experimental: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, /* @__PURE__ */ Struct2({}))),
   extensions: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(/* @__PURE__ */ TemplateLiteral2([String6, "/", String6]), Json2)),
-  roots: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
+  roots: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
     listChanged: /* @__PURE__ */ optional3(Boolean3)
   })),
-  sampling: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
-    context: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({})),
-    tools: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({}))
+  sampling: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
+    context: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({})),
+    tools: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({}))
   })),
-  elicitation: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
-    form: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({})),
-    url: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({}))
+  elicitation: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
+    form: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({})),
+    url: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({}))
   }))
 })) {
 }
 
-class ServerCapabilities extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
-  experimental: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, /* @__PURE__ */ Struct({}))),
+class ServerCapabilities extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
+  experimental: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, /* @__PURE__ */ Struct2({}))),
   extensions: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(/* @__PURE__ */ TemplateLiteral2([String6, "/", String6]), Json2)),
-  logging: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({})),
-  completions: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({})),
-  prompts: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
+  logging: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({})),
+  completions: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({})),
+  prompts: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
     listChanged: /* @__PURE__ */ optional3(Boolean3)
   })),
-  resources: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
+  resources: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
     subscribe: /* @__PURE__ */ optional3(Boolean3),
     listChanged: /* @__PURE__ */ optional3(Boolean3)
   })),
-  tools: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct({
+  tools: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2({
     listChanged: /* @__PURE__ */ optional3(Boolean3)
   }))
 }))) {
@@ -41127,7 +41352,7 @@ class InternalError extends (/* @__PURE__ */ Error4("effect/ai/McpSchema/Interna
   });
 }
 var McpError = /* @__PURE__ */ Union2([ParseError, InvalidRequest, MethodNotFound, InvalidParams, InternalError, McpErrorBase]);
-class InitializeResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class InitializeResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResultMeta.fields,
   protocolVersion: String6,
   capabilities: ServerCapabilities,
@@ -41192,20 +41417,20 @@ class ResourceTemplate extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/Res
 })) {
 }
 
-class ResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   uri: String6,
   mimeType: /* @__PURE__ */ optional3(String6),
   _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, Json2))
 }))) {
 }
 
-class TextResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class TextResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResourceContents.fields,
   text: String6
 }))) {
 }
 
-class BlobResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class BlobResourceContents extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResourceContents.fields,
   blob: Uint8ArrayFromBase64
 }))) {
@@ -41221,7 +41446,7 @@ class ListResourceTemplatesResult extends (/* @__PURE__ */ Class4("@effect/ai/Mc
   resourceTemplates: /* @__PURE__ */ ArraySchema(ResourceTemplate)
 })) {
 }
-class ReadResourceResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ReadResourceResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResultMeta.fields,
   contents: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Union2([TextResourceContents, BlobResourceContents]))
 }))) {
@@ -41237,7 +41462,7 @@ class ReadResource extends (/* @__PURE__ */ make59("resources/read", {
 })) {
 }
 class Subscribe extends (/* @__PURE__ */ make59("resources/subscribe", {
-  success: /* @__PURE__ */ Struct({}),
+  success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
     ...RequestMeta.fields,
@@ -41247,7 +41472,7 @@ class Subscribe extends (/* @__PURE__ */ make59("resources/subscribe", {
 }
 
 class Unsubscribe extends (/* @__PURE__ */ make59("resources/unsubscribe", {
-  success: /* @__PURE__ */ Struct({}),
+  success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
     ...RequestMeta.fields,
@@ -41264,7 +41489,7 @@ class ResourceUpdatedNotification extends (/* @__PURE__ */ make59("notifications
 })) {
 }
 
-class PromptArgument extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class PromptArgument extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   name: String6,
   title: /* @__PURE__ */ optional3(String6),
   description: /* @__PURE__ */ optional3(String6),
@@ -41282,7 +41507,7 @@ class Prompt2 extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/Prompt")({
 })) {
 }
 
-class TextContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class TextContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ tag("text"),
   text: String6,
   annotations: /* @__PURE__ */ optional3(Annotations),
@@ -41290,7 +41515,7 @@ class TextContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
 }))) {
 }
 
-class ImageContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ImageContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ tag("image"),
   data: Uint8ArrayFromBase64,
   mimeType: String6,
@@ -41299,7 +41524,7 @@ class ImageContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
 }))) {
 }
 
-class AudioContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class AudioContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ tag("audio"),
   data: Uint8ArrayFromBase64,
   mimeType: String6,
@@ -41308,7 +41533,7 @@ class AudioContent extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
 }))) {
 }
 
-class EmbeddedResource extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class EmbeddedResource extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ tag("resource"),
   resource: /* @__PURE__ */ Union2([TextResourceContents, BlobResourceContents]),
   annotations: /* @__PURE__ */ optional3(Annotations),
@@ -41316,14 +41541,14 @@ class EmbeddedResource extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct(
 }))) {
 }
 
-class ResourceLink extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ResourceLink extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...Resource2.fields,
   type: /* @__PURE__ */ tag("resource_link")
 }))) {
 }
 var ContentBlock = /* @__PURE__ */ Union2([TextContent, ImageContent, AudioContent, EmbeddedResource, ResourceLink]);
 
-class PromptMessage extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class PromptMessage extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   role: Role,
   content: ContentBlock
 }))) {
@@ -41352,7 +41577,7 @@ class GetPrompt extends (/* @__PURE__ */ make59("prompts/get", {
   }
 })) {
 }
-class ToolAnnotations extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ToolAnnotations extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   title: /* @__PURE__ */ optional3(String6),
   readOnlyHint: /* @__PURE__ */ optionalWithDefault(Boolean3, constFalse),
   destructiveHint: /* @__PURE__ */ optionalWithDefault(Boolean3, constTrue),
@@ -41360,7 +41585,7 @@ class ToolAnnotations extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
   openWorldHint: /* @__PURE__ */ optionalWithDefault(Boolean3, constTrue)
 }))) {
 }
-var ToolJsonSchema = /* @__PURE__ */ StructWithRest(/* @__PURE__ */ Struct({
+var ToolJsonSchema = /* @__PURE__ */ StructWithRest(/* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("object"),
   properties: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, /* @__PURE__ */ Record(String6, Json2))),
   required: /* @__PURE__ */ optional3(/* @__PURE__ */ ArraySchema(String6))
@@ -41408,13 +41633,13 @@ class SetLevel extends (/* @__PURE__ */ make59("logging/setLevel", {
     ...RequestMeta.fields,
     level: LoggingLevel
   },
-  success: /* @__PURE__ */ Struct({}),
+  success: /* @__PURE__ */ Struct2({}),
   error: McpError
 })) {
 }
 
 class LoggingMessageNotification extends (/* @__PURE__ */ make59("notifications/message", {
-  payload: /* @__PURE__ */ Struct({
+  payload: /* @__PURE__ */ Struct2({
     ...NotificationMeta.fields,
     level: LoggingLevel,
     logger: /* @__PURE__ */ optional3(String6),
@@ -41443,7 +41668,7 @@ class ToolResultContent extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/To
 }
 var SamplingMessageContentBlock = /* @__PURE__ */ Union2([TextContent, ImageContent, AudioContent, ToolUseContent, ToolResultContent]);
 
-class SamplingMessage extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class SamplingMessage extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   role: Role,
   content: /* @__PURE__ */ Union2([SamplingMessageContentBlock, /* @__PURE__ */ ArraySchema(SamplingMessageContentBlock)]),
   _meta: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, Json2))
@@ -41455,7 +41680,7 @@ class ToolChoice extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/ToolChoic
 })) {
 }
 
-class ModelHint extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class ModelHint extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   name: /* @__PURE__ */ optional3(String6)
 }))) {
 }
@@ -41491,21 +41716,21 @@ class CreateMessage extends (/* @__PURE__ */ make59("sampling/createMessage", {
   error: McpError,
   payload: {
     messages: /* @__PURE__ */ ArraySchema(SamplingMessage),
-    modelPreferences: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct(ModelPreferences.fields)),
+    modelPreferences: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2(ModelPreferences.fields)),
     systemPrompt: /* @__PURE__ */ optional3(String6),
     includeContext: /* @__PURE__ */ optional3(/* @__PURE__ */ Literals(["none", "thisServer", "allServers"])),
     temperature: /* @__PURE__ */ optional3(Finite),
     maxTokens: Int,
     stopSequences: /* @__PURE__ */ optional3(/* @__PURE__ */ ArraySchema(String6)),
     metadata: /* @__PURE__ */ optional3(/* @__PURE__ */ Record(String6, Unknown2)),
-    tools: /* @__PURE__ */ optional3(/* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct(Tool.fields))),
-    toolChoice: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct(ToolChoice.fields))
+    tools: /* @__PURE__ */ optional3(/* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct2(Tool.fields))),
+    toolChoice: /* @__PURE__ */ optional3(/* @__PURE__ */ Struct2(ToolChoice.fields))
   }
 })) {
 }
-class CompleteResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct({
+class CompleteResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2({
   ...ResultMeta.fields,
-  completion: /* @__PURE__ */ Struct({
+  completion: /* @__PURE__ */ Struct2({
     values: /* @__PURE__ */ ArraySchema(String6),
     total: /* @__PURE__ */ optional3(Int),
     hasMore: /* @__PURE__ */ optional3(Boolean3)
@@ -41561,7 +41786,7 @@ class TitledSingleSelectEnumSchema extends (/* @__PURE__ */ Class4("@effect/ai/M
   type: /* @__PURE__ */ tag("string"),
   title: /* @__PURE__ */ optional3(String6),
   description: /* @__PURE__ */ optional3(String6),
-  oneOf: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct({
+  oneOf: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct2({
     const: String6,
     title: String6
   })),
@@ -41576,7 +41801,7 @@ class UntitledMultiSelectEnumSchema extends (/* @__PURE__ */ Class4("@effect/ai/
   description: /* @__PURE__ */ optional3(String6),
   minItems: /* @__PURE__ */ optional3(Int),
   maxItems: /* @__PURE__ */ optional3(Int),
-  items: /* @__PURE__ */ Struct({
+  items: /* @__PURE__ */ Struct2({
     type: /* @__PURE__ */ tag("string"),
     enum: /* @__PURE__ */ ArraySchema(String6)
   }),
@@ -41590,8 +41815,8 @@ class TitledMultiSelectEnumSchema extends (/* @__PURE__ */ Class4("@effect/ai/Mc
   description: /* @__PURE__ */ optional3(String6),
   minItems: /* @__PURE__ */ optional3(Int),
   maxItems: /* @__PURE__ */ optional3(Int),
-  items: /* @__PURE__ */ Struct({
-    anyOf: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct({
+  items: /* @__PURE__ */ Struct2({
+    anyOf: /* @__PURE__ */ ArraySchema(/* @__PURE__ */ Struct2({
       const: String6,
       title: String6
     }))
@@ -41612,7 +41837,7 @@ class LegacyTitledEnumSchema extends (/* @__PURE__ */ Class4("@effect/ai/McpSche
 }
 var EnumSchema = /* @__PURE__ */ Union2([SingleSelectEnumSchema, MultiSelectEnumSchema, LegacyTitledEnumSchema]);
 var PrimitiveSchemaDefinition = /* @__PURE__ */ Union2([StringSchema, NumberSchema, BooleanSchema, EnumSchema]);
-var ElicitationFormSchema = /* @__PURE__ */ Struct({
+var ElicitationFormSchema = /* @__PURE__ */ Struct2({
   $schema: /* @__PURE__ */ optional3(String6),
   type: /* @__PURE__ */ tag("object"),
   properties: /* @__PURE__ */ Record(String6, PrimitiveSchemaDefinition),
@@ -43276,7 +43501,7 @@ var decode3 = (options3) => fromTransform((upstream, _scope) => sync4(() => {
 }));
 var decodeSchema = (schema3, options3) => pipeTo(decode3(options3), decode2(EventEncoded.pipe(decodeTo2(schema3)))());
 var decodeDataSchema = (schema3, options3) => {
-  const eventSchema = Struct({
+  const eventSchema = Struct2({
     ...EventEncoded.fields,
     data: fromJsonString2(schema3)
   });
@@ -43412,7 +43637,7 @@ function makeParser2(onParse, options3) {
   }
 }
 var BOM = "\uFEFF";
-var EventEncoded = /* @__PURE__ */ Struct({
+var EventEncoded = /* @__PURE__ */ Struct2({
   id: /* @__PURE__ */ optional2(String6),
   event: String6,
   data: String6
@@ -43435,7 +43660,7 @@ class AnthropicConfig extends (/* @__PURE__ */ Service()("@effect/ai-anthropic/A
 }
 
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/Generated.js
-var APIError = /* @__PURE__ */ Struct({
+var APIError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Internal server error"
@@ -43447,7 +43672,7 @@ var APIError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "APIError"
 });
-var AuthenticationError2 = /* @__PURE__ */ Struct({
+var AuthenticationError2 = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Authentication error"
@@ -43459,7 +43684,7 @@ var AuthenticationError2 = /* @__PURE__ */ Struct({
 }).annotate({
   title: "AuthenticationError"
 });
-var Base64PDFSource = /* @__PURE__ */ Struct({
+var Base64PDFSource = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data",
     format: "byte"
@@ -43476,7 +43701,7 @@ var Base64PDFSource = /* @__PURE__ */ Struct({
 var BashCodeExecutionToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "too_many_requests", "execution_time_exceeded", "output_file_too_large"]).annotate({
   title: "BashCodeExecutionToolResultErrorCode"
 });
-var BetaAPIError = /* @__PURE__ */ Struct({
+var BetaAPIError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Internal server error"
@@ -43488,7 +43713,7 @@ var BetaAPIError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "APIError"
 });
-var BetaAuthenticationError = /* @__PURE__ */ Struct({
+var BetaAuthenticationError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Authentication error"
@@ -43500,7 +43725,7 @@ var BetaAuthenticationError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "AuthenticationError"
 });
-var BetaBase64PDFSource = /* @__PURE__ */ Struct({
+var BetaBase64PDFSource = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data",
     format: "byte"
@@ -43517,7 +43742,7 @@ var BetaBase64PDFSource = /* @__PURE__ */ Struct({
 var BetaBashCodeExecutionToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "too_many_requests", "execution_time_exceeded", "output_file_too_large"]).annotate({
   title: "BashCodeExecutionToolResultErrorCode"
 });
-var BetaBillingError = /* @__PURE__ */ Struct({
+var BetaBillingError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Billing error"
@@ -43529,7 +43754,7 @@ var BetaBillingError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "BillingError"
 });
-var BetaCacheCreation = /* @__PURE__ */ Struct({
+var BetaCacheCreation = /* @__PURE__ */ Struct2({
   ephemeral_1h_input_tokens: Number6.annotate({
     title: "Ephemeral 1H Input Tokens",
     description: "The number of input tokens used to create the 1 hour cache entry.",
@@ -43546,7 +43771,7 @@ var BetaCacheCreation = /* @__PURE__ */ Struct({
 var BetaCodeExecutionToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "too_many_requests", "execution_time_exceeded"]).annotate({
   title: "CodeExecutionToolResultErrorCode"
 });
-var BetaCompactionContentBlockDelta = /* @__PURE__ */ Struct({
+var BetaCompactionContentBlockDelta = /* @__PURE__ */ Struct2({
   content: Union2([String6, Null2]).annotate({
     title: "Content"
   }),
@@ -43557,7 +43782,7 @@ var BetaCompactionContentBlockDelta = /* @__PURE__ */ Struct({
 }).annotate({
   title: "CompactionContentBlockDelta"
 });
-var BetaContentBlockStopEvent = /* @__PURE__ */ Struct({
+var BetaContentBlockStopEvent = /* @__PURE__ */ Struct2({
   index: Number6.annotate({
     title: "Index"
   }).check(isInt()),
@@ -43568,7 +43793,7 @@ var BetaContentBlockStopEvent = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ContentBlockStopEvent"
 });
-var BetaContextManagementResponse = /* @__PURE__ */ Struct({
+var BetaContextManagementResponse = /* @__PURE__ */ Struct2({
   original_input_tokens: Number6.annotate({
     title: "Original Input Tokens",
     description: "The original token count before context management was applied"
@@ -43576,7 +43801,7 @@ var BetaContextManagementResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ContextManagementResponse"
 });
-var BetaCreateSkillResponse = /* @__PURE__ */ Struct({
+var BetaCreateSkillResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -43615,7 +43840,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "CreateSkillResponse"
 });
-var BetaCreateSkillVersionResponse = /* @__PURE__ */ Struct({
+var BetaCreateSkillVersionResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -43662,7 +43887,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "CreateSkillVersionResponse"
 });
-var BetaDeleteMessageBatchResponse = /* @__PURE__ */ Struct({
+var BetaDeleteMessageBatchResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: "ID of the Message Batch."
@@ -43675,7 +43900,7 @@ var BetaDeleteMessageBatchResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "DeleteMessageBatchResponse"
 });
-var BetaDeleteSkillResponse = /* @__PURE__ */ Struct({
+var BetaDeleteSkillResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Unique identifier for the skill.
@@ -43690,7 +43915,7 @@ The format and length of IDs may change over time.`
 }).annotate({
   title: "DeleteSkillResponse"
 });
-var BetaDeleteSkillVersionResponse = /* @__PURE__ */ Struct({
+var BetaDeleteSkillVersionResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Version identifier for the skill.
@@ -43705,7 +43930,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "DeleteSkillVersionResponse"
 });
-var BetaDirectCaller = /* @__PURE__ */ Struct({
+var BetaDirectCaller = /* @__PURE__ */ Struct2({
   type: Literal2("direct").annotate({
     title: "Type"
   })
@@ -43713,7 +43938,7 @@ var BetaDirectCaller = /* @__PURE__ */ Struct({
   title: "DirectCaller",
   description: "Tool invocation directly from the model."
 });
-var BetaFileDeleteResponse = /* @__PURE__ */ Struct({
+var BetaFileDeleteResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: "ID of the deleted file."
@@ -43726,7 +43951,7 @@ var BetaFileDeleteResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "FileDeleteResponse"
 });
-var BetaFileMetadataSchema = /* @__PURE__ */ Struct({
+var BetaFileMetadataSchema = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "RFC 3339 datetime string representing when the file was created.",
@@ -43762,7 +43987,7 @@ The format and length of IDs may change over time.`
 }).annotate({
   title: "FileMetadataSchema"
 });
-var BetaGatewayTimeoutError = /* @__PURE__ */ Struct({
+var BetaGatewayTimeoutError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Request timeout"
@@ -43774,7 +43999,7 @@ var BetaGatewayTimeoutError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "GatewayTimeoutError"
 });
-var BetaGetSkillResponse = /* @__PURE__ */ Struct({
+var BetaGetSkillResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -43813,7 +44038,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "GetSkillResponse"
 });
-var BetaGetSkillVersionResponse = /* @__PURE__ */ Struct({
+var BetaGetSkillVersionResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -43860,7 +44085,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "GetSkillVersionResponse"
 });
-var BetaInputJsonContentBlockDelta = /* @__PURE__ */ Struct({
+var BetaInputJsonContentBlockDelta = /* @__PURE__ */ Struct2({
   partial_json: String6.annotate({
     title: "Partial Json"
   }),
@@ -43871,7 +44096,7 @@ var BetaInputJsonContentBlockDelta = /* @__PURE__ */ Struct({
 }).annotate({
   title: "InputJsonContentBlockDelta"
 });
-var BetaInvalidRequestError = /* @__PURE__ */ Struct({
+var BetaInvalidRequestError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Invalid request"
@@ -43883,7 +44108,7 @@ var BetaInvalidRequestError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "InvalidRequestError"
 });
-var BetaMessageBatch = /* @__PURE__ */ Struct({
+var BetaMessageBatch = /* @__PURE__ */ Struct2({
   archived_at: Union2([String6.annotate({
     format: "date-time"
   }), Null2]).annotate({
@@ -43924,7 +44149,7 @@ The format and length of IDs may change over time.`
     title: "Processing Status",
     description: "Processing status of the Message Batch."
   }),
-  request_counts: Struct({
+  request_counts: Struct2({
     canceled: Number6.annotate({
       title: "Canceled",
       description: `Number of requests in the Message Batch that have been canceled.
@@ -43974,7 +44199,7 @@ This is zero until processing of the entire Message Batch has ended.`,
 }).annotate({
   title: "MessageBatch"
 });
-var BetaMessageStopEvent = /* @__PURE__ */ Struct({
+var BetaMessageStopEvent = /* @__PURE__ */ Struct2({
   type: Literal2("message_stop").annotate({
     title: "Type",
     default: "message_stop"
@@ -43982,7 +44207,7 @@ var BetaMessageStopEvent = /* @__PURE__ */ Struct({
 }).annotate({
   title: "MessageStopEvent"
 });
-var BetaModelInfo = /* @__PURE__ */ Struct({
+var BetaModelInfo = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "RFC 3339 datetime string representing the time at which the model was released. May be set to an epoch value if the release date is unknown.",
@@ -44004,7 +44229,7 @@ var BetaModelInfo = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ModelInfo"
 });
-var BetaNotFoundError = /* @__PURE__ */ Struct({
+var BetaNotFoundError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Not found"
@@ -44016,7 +44241,7 @@ var BetaNotFoundError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "NotFoundError"
 });
-var BetaOverloadedError = /* @__PURE__ */ Struct({
+var BetaOverloadedError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Overloaded"
@@ -44028,7 +44253,7 @@ var BetaOverloadedError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "OverloadedError"
 });
-var BetaPermissionError = /* @__PURE__ */ Struct({
+var BetaPermissionError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Permission denied"
@@ -44040,7 +44265,7 @@ var BetaPermissionError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "PermissionError"
 });
-var BetaPlainTextSource = /* @__PURE__ */ Struct({
+var BetaPlainTextSource = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data"
   }),
@@ -44053,7 +44278,7 @@ var BetaPlainTextSource = /* @__PURE__ */ Struct({
 }).annotate({
   title: "PlainTextSource"
 });
-var BetaRateLimitError = /* @__PURE__ */ Struct({
+var BetaRateLimitError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Rate limited"
@@ -44065,7 +44290,7 @@ var BetaRateLimitError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "RateLimitError"
 });
-var BetaResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
+var BetaResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -44076,7 +44301,7 @@ var BetaResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionOutputBlock"
 });
-var BetaResponseCharLocationCitation = /* @__PURE__ */ Struct({
+var BetaResponseCharLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -44103,7 +44328,7 @@ var BetaResponseCharLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCharLocationCitation"
 });
-var BetaResponseCitationsConfig = /* @__PURE__ */ Struct({
+var BetaResponseCitationsConfig = /* @__PURE__ */ Struct2({
   enabled: Boolean3.annotate({
     title: "Enabled",
     default: false
@@ -44111,7 +44336,7 @@ var BetaResponseCitationsConfig = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCitationsConfig"
 });
-var BetaResponseClearThinking20251015Edit = /* @__PURE__ */ Struct({
+var BetaResponseClearThinking20251015Edit = /* @__PURE__ */ Struct2({
   cleared_input_tokens: Number6.annotate({
     title: "Cleared Input Tokens",
     description: "Number of input tokens cleared by this edit."
@@ -44128,7 +44353,7 @@ var BetaResponseClearThinking20251015Edit = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseClearThinking20251015Edit"
 });
-var BetaResponseClearToolUses20250919Edit = /* @__PURE__ */ Struct({
+var BetaResponseClearToolUses20250919Edit = /* @__PURE__ */ Struct2({
   cleared_input_tokens: Number6.annotate({
     title: "Cleared Input Tokens",
     description: "Number of input tokens cleared by this edit."
@@ -44145,7 +44370,7 @@ var BetaResponseClearToolUses20250919Edit = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseClearToolUses20250919Edit"
 });
-var BetaResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
+var BetaResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -44156,7 +44381,7 @@ var BetaResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionOutputBlock"
 });
-var BetaResponseCompactionBlock = /* @__PURE__ */ Struct({
+var BetaResponseCompactionBlock = /* @__PURE__ */ Struct2({
   content: Union2([String6, Null2]).annotate({
     title: "Content",
     description: "Summary of compacted content, or null if compaction failed"
@@ -44173,7 +44398,7 @@ When content is None, it indicates the compaction failed to produce a valid
 summary (e.g., malformed output from the model). Clients may round-trip
 compaction blocks with null content; the server treats them as no-ops.`
 });
-var BetaResponseContainerUploadBlock = /* @__PURE__ */ Struct({
+var BetaResponseContainerUploadBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -44185,7 +44410,7 @@ var BetaResponseContainerUploadBlock = /* @__PURE__ */ Struct({
   title: "ResponseContainerUploadBlock",
   description: "Response model for a file uploaded to the container."
 });
-var BetaResponseContentBlockLocationCitation = /* @__PURE__ */ Struct({
+var BetaResponseContentBlockLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -44212,7 +44437,7 @@ var BetaResponseContentBlockLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseContentBlockLocationCitation"
 });
-var BetaResponseMCPToolUseBlock = /* @__PURE__ */ Struct({
+var BetaResponseMCPToolUseBlock = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id"
   }).check(isPattern2(new RegExp("^[a-zA-Z0-9_-]+$"))),
@@ -44234,7 +44459,7 @@ var BetaResponseMCPToolUseBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseMCPToolUseBlock"
 });
-var BetaResponsePageLocationCitation = /* @__PURE__ */ Struct({
+var BetaResponsePageLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -44261,7 +44486,7 @@ var BetaResponsePageLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponsePageLocationCitation"
 });
-var BetaResponseRedactedThinkingBlock = /* @__PURE__ */ Struct({
+var BetaResponseRedactedThinkingBlock = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data"
   }),
@@ -44272,7 +44497,7 @@ var BetaResponseRedactedThinkingBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseRedactedThinkingBlock"
 });
-var BetaResponseSearchResultLocationCitation = /* @__PURE__ */ Struct({
+var BetaResponseSearchResultLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -44298,7 +44523,7 @@ var BetaResponseSearchResultLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseSearchResultLocationCitation"
 });
-var BetaResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struct2({
   is_file_update: Boolean3.annotate({
     title: "Is File Update"
   }),
@@ -44309,7 +44534,7 @@ var BetaResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struc
 }).annotate({
   title: "ResponseTextEditorCodeExecutionCreateResultBlock"
 });
-var BetaResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ Struct2({
   lines: Union2([ArraySchema(String6), Null2]).annotate({
     title: "Lines",
     default: null
@@ -44337,7 +44562,7 @@ var BetaResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ S
 }).annotate({
   title: "ResponseTextEditorCodeExecutionStrReplaceResultBlock"
 });
-var BetaResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct2({
   content: String6.annotate({
     title: "Content"
   }),
@@ -44363,7 +44588,7 @@ var BetaResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct(
 }).annotate({
   title: "ResponseTextEditorCodeExecutionViewResultBlock"
 });
-var BetaResponseThinkingBlock = /* @__PURE__ */ Struct({
+var BetaResponseThinkingBlock = /* @__PURE__ */ Struct2({
   signature: String6.annotate({
     title: "Signature"
   }),
@@ -44377,7 +44602,7 @@ var BetaResponseThinkingBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseThinkingBlock"
 });
-var BetaResponseToolReferenceBlock = /* @__PURE__ */ Struct({
+var BetaResponseToolReferenceBlock = /* @__PURE__ */ Struct2({
   tool_name: String6.annotate({
     title: "Tool Name"
   }).check(isMinLength(1)).check(isMaxLength(256)).check(isPattern2(new RegExp("^[a-zA-Z0-9_-]{1,256}$"))),
@@ -44388,7 +44613,7 @@ var BetaResponseToolReferenceBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolReferenceBlock"
 });
-var BetaResponseWebSearchResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseWebSearchResultBlock = /* @__PURE__ */ Struct2({
   encrypted_content: String6.annotate({
     title: "Encrypted Content"
   }),
@@ -44409,7 +44634,7 @@ var BetaResponseWebSearchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchResultBlock"
 });
-var BetaResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct({
+var BetaResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -44429,7 +44654,7 @@ var BetaResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchResultLocationCitation"
 });
-var BetaServerToolCaller = /* @__PURE__ */ Struct({
+var BetaServerToolCaller = /* @__PURE__ */ Struct2({
   tool_id: String6.annotate({
     title: "Tool Id"
   }).check(isPattern2(new RegExp("^srvtoolu_[a-zA-Z0-9_]+$"))),
@@ -44440,7 +44665,7 @@ var BetaServerToolCaller = /* @__PURE__ */ Struct({
   title: "ServerToolCaller",
   description: "Tool invocation generated by a server-side tool."
 });
-var BetaServerToolCaller_20260120 = /* @__PURE__ */ Struct({
+var BetaServerToolCaller_20260120 = /* @__PURE__ */ Struct2({
   tool_id: String6.annotate({
     title: "Tool Id"
   }).check(isPattern2(new RegExp("^srvtoolu_[a-zA-Z0-9_]+$"))),
@@ -44450,7 +44675,7 @@ var BetaServerToolCaller_20260120 = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ServerToolCaller_20260120"
 });
-var BetaServerToolUsage = /* @__PURE__ */ Struct({
+var BetaServerToolUsage = /* @__PURE__ */ Struct2({
   web_fetch_requests: Number6.annotate({
     title: "Web Fetch Requests",
     description: "The number of web fetch tool requests.",
@@ -44464,7 +44689,7 @@ var BetaServerToolUsage = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ServerToolUsage"
 });
-var BetaSignatureContentBlockDelta = /* @__PURE__ */ Struct({
+var BetaSignatureContentBlockDelta = /* @__PURE__ */ Struct2({
   signature: String6.annotate({
     title: "Signature"
   }),
@@ -44475,7 +44700,7 @@ var BetaSignatureContentBlockDelta = /* @__PURE__ */ Struct({
 }).annotate({
   title: "SignatureContentBlockDelta"
 });
-var BetaSkill = /* @__PURE__ */ Struct({
+var BetaSkill = /* @__PURE__ */ Struct2({
   skill_id: String6.annotate({
     title: "Skill Id",
     description: "Skill ID"
@@ -44492,7 +44717,7 @@ var BetaSkill = /* @__PURE__ */ Struct({
   title: "Skill",
   description: "A skill that was loaded in a container (response model)."
 });
-var BetaSkillVersion = /* @__PURE__ */ Struct({
+var BetaSkillVersion = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -44542,7 +44767,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 var BetaSpeed = /* @__PURE__ */ Literals(["standard", "fast"]).annotate({
   title: "Speed"
 });
-var BetaTextContentBlockDelta = /* @__PURE__ */ Struct({
+var BetaTextContentBlockDelta = /* @__PURE__ */ Struct2({
   text: String6.annotate({
     title: "Text"
   }),
@@ -44556,7 +44781,7 @@ var BetaTextContentBlockDelta = /* @__PURE__ */ Struct({
 var BetaTextEditorCodeExecutionToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "too_many_requests", "execution_time_exceeded", "file_not_found"]).annotate({
   title: "TextEditorCodeExecutionToolResultErrorCode"
 });
-var BetaThinkingContentBlockDelta = /* @__PURE__ */ Struct({
+var BetaThinkingContentBlockDelta = /* @__PURE__ */ Struct2({
   thinking: String6.annotate({
     title: "Thinking"
   }),
@@ -44576,7 +44801,7 @@ var BetaWebFetchToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_in
 var BetaWebSearchToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "max_uses_exceeded", "too_many_requests", "query_too_long", "request_too_large"]).annotate({
   title: "WebSearchToolResultErrorCode"
 });
-var Betaapi__schemas__skills__Skill = /* @__PURE__ */ Struct({
+var Betaapi__schemas__skills__Skill = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -44615,7 +44840,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "Skill"
 });
-var BillingError = /* @__PURE__ */ Struct({
+var BillingError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Billing error"
@@ -44627,7 +44852,7 @@ var BillingError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "BillingError"
 });
-var CacheCreation = /* @__PURE__ */ Struct({
+var CacheCreation = /* @__PURE__ */ Struct2({
   ephemeral_1h_input_tokens: Number6.annotate({
     title: "Ephemeral 1H Input Tokens",
     description: "The number of input tokens used to create the 1 hour cache entry.",
@@ -44644,7 +44869,7 @@ var CacheCreation = /* @__PURE__ */ Struct({
 var CodeExecutionToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input", "unavailable", "too_many_requests", "execution_time_exceeded"]).annotate({
   title: "CodeExecutionToolResultErrorCode"
 });
-var Container = /* @__PURE__ */ Struct({
+var Container = /* @__PURE__ */ Struct2({
   expires_at: String6.annotate({
     title: "Expires At",
     description: "The time at which the container will expire.",
@@ -44658,7 +44883,7 @@ var Container = /* @__PURE__ */ Struct({
   title: "Container",
   description: "Information about the container used in the request (for the code execution tool)"
 });
-var CountMessageTokensResponse = /* @__PURE__ */ Struct({
+var CountMessageTokensResponse = /* @__PURE__ */ Struct2({
   input_tokens: Number6.annotate({
     title: "Input Tokens",
     description: "The total number of tokens across the provided list of messages, system prompt, and tools."
@@ -44666,7 +44891,7 @@ var CountMessageTokensResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "CountMessageTokensResponse"
 });
-var CreateSkillResponse = /* @__PURE__ */ Struct({
+var CreateSkillResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -44705,7 +44930,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "CreateSkillResponse"
 });
-var CreateSkillVersionResponse = /* @__PURE__ */ Struct({
+var CreateSkillVersionResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -44752,7 +44977,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "CreateSkillVersionResponse"
 });
-var DeleteMessageBatchResponse = /* @__PURE__ */ Struct({
+var DeleteMessageBatchResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: "ID of the Message Batch."
@@ -44765,7 +44990,7 @@ var DeleteMessageBatchResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "DeleteMessageBatchResponse"
 });
-var DeleteSkillResponse = /* @__PURE__ */ Struct({
+var DeleteSkillResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Unique identifier for the skill.
@@ -44780,7 +45005,7 @@ The format and length of IDs may change over time.`
 }).annotate({
   title: "DeleteSkillResponse"
 });
-var DeleteSkillVersionResponse = /* @__PURE__ */ Struct({
+var DeleteSkillVersionResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Version identifier for the skill.
@@ -44795,7 +45020,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "DeleteSkillVersionResponse"
 });
-var DirectCaller = /* @__PURE__ */ Struct({
+var DirectCaller = /* @__PURE__ */ Struct2({
   type: Literal2("direct").annotate({
     title: "Type"
   })
@@ -44803,7 +45028,7 @@ var DirectCaller = /* @__PURE__ */ Struct({
   title: "DirectCaller",
   description: "Tool invocation directly from the model."
 });
-var FileDeleteResponse = /* @__PURE__ */ Struct({
+var FileDeleteResponse = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: "ID of the deleted file."
@@ -44816,7 +45041,7 @@ var FileDeleteResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "FileDeleteResponse"
 });
-var FileMetadataSchema = /* @__PURE__ */ Struct({
+var FileMetadataSchema = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "RFC 3339 datetime string representing when the file was created.",
@@ -44852,7 +45077,7 @@ The format and length of IDs may change over time.`
 }).annotate({
   title: "FileMetadataSchema"
 });
-var GatewayTimeoutError = /* @__PURE__ */ Struct({
+var GatewayTimeoutError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Request timeout"
@@ -44864,7 +45089,7 @@ var GatewayTimeoutError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "GatewayTimeoutError"
 });
-var GetSkillResponse = /* @__PURE__ */ Struct({
+var GetSkillResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -44903,7 +45128,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "GetSkillResponse"
 });
-var GetSkillVersionResponse = /* @__PURE__ */ Struct({
+var GetSkillVersionResponse = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -44950,7 +45175,7 @@ Each version is identified by a Unix epoch timestamp (e.g., "1759178010641129").
 }).annotate({
   title: "GetSkillVersionResponse"
 });
-var InvalidRequestError2 = /* @__PURE__ */ Struct({
+var InvalidRequestError2 = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Invalid request"
@@ -44962,7 +45187,7 @@ var InvalidRequestError2 = /* @__PURE__ */ Struct({
 }).annotate({
   title: "InvalidRequestError"
 });
-var MessageBatch = /* @__PURE__ */ Struct({
+var MessageBatch = /* @__PURE__ */ Struct2({
   archived_at: Union2([String6.annotate({
     format: "date-time"
   }), Null2]).annotate({
@@ -45003,7 +45228,7 @@ The format and length of IDs may change over time.`
     title: "Processing Status",
     description: "Processing status of the Message Batch."
   }),
-  request_counts: Struct({
+  request_counts: Struct2({
     canceled: Number6.annotate({
       title: "Canceled",
       description: `Number of requests in the Message Batch that have been canceled.
@@ -45053,7 +45278,7 @@ This is zero until processing of the entire Message Batch has ended.`,
 }).annotate({
   title: "MessageBatch"
 });
-var ModelInfo = /* @__PURE__ */ Struct({
+var ModelInfo = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "RFC 3339 datetime string representing the time at which the model was released. May be set to an epoch value if the release date is unknown.",
@@ -45075,7 +45300,7 @@ var ModelInfo = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ModelInfo"
 });
-var NotFoundError = /* @__PURE__ */ Struct({
+var NotFoundError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Not found"
@@ -45087,7 +45312,7 @@ var NotFoundError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "NotFoundError"
 });
-var OverloadedError = /* @__PURE__ */ Struct({
+var OverloadedError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Overloaded"
@@ -45099,7 +45324,7 @@ var OverloadedError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "OverloadedError"
 });
-var PermissionError = /* @__PURE__ */ Struct({
+var PermissionError = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Permission denied"
@@ -45111,7 +45336,7 @@ var PermissionError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "PermissionError"
 });
-var PlainTextSource = /* @__PURE__ */ Struct({
+var PlainTextSource = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data"
   }),
@@ -45124,7 +45349,7 @@ var PlainTextSource = /* @__PURE__ */ Struct({
 }).annotate({
   title: "PlainTextSource"
 });
-var RateLimitError2 = /* @__PURE__ */ Struct({
+var RateLimitError2 = /* @__PURE__ */ Struct2({
   message: String6.annotate({
     title: "Message",
     default: "Rate limited"
@@ -45136,7 +45361,7 @@ var RateLimitError2 = /* @__PURE__ */ Struct({
 }).annotate({
   title: "RateLimitError"
 });
-var ResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
+var ResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -45147,7 +45372,7 @@ var ResponseBashCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionOutputBlock"
 });
-var ResponseCharLocationCitation = /* @__PURE__ */ Struct({
+var ResponseCharLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -45174,7 +45399,7 @@ var ResponseCharLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCharLocationCitation"
 });
-var ResponseCitationsConfig = /* @__PURE__ */ Struct({
+var ResponseCitationsConfig = /* @__PURE__ */ Struct2({
   enabled: Boolean3.annotate({
     title: "Enabled",
     default: false
@@ -45182,7 +45407,7 @@ var ResponseCitationsConfig = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCitationsConfig"
 });
-var ResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
+var ResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -45193,7 +45418,7 @@ var ResponseCodeExecutionOutputBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionOutputBlock"
 });
-var ResponseContainerUploadBlock = /* @__PURE__ */ Struct({
+var ResponseContainerUploadBlock = /* @__PURE__ */ Struct2({
   file_id: String6.annotate({
     title: "File Id"
   }),
@@ -45205,7 +45430,7 @@ var ResponseContainerUploadBlock = /* @__PURE__ */ Struct({
   title: "ResponseContainerUploadBlock",
   description: "Response model for a file uploaded to the container."
 });
-var ResponseContentBlockLocationCitation = /* @__PURE__ */ Struct({
+var ResponseContentBlockLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -45232,7 +45457,7 @@ var ResponseContentBlockLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseContentBlockLocationCitation"
 });
-var ResponsePageLocationCitation = /* @__PURE__ */ Struct({
+var ResponsePageLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -45259,7 +45484,7 @@ var ResponsePageLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponsePageLocationCitation"
 });
-var ResponseRedactedThinkingBlock = /* @__PURE__ */ Struct({
+var ResponseRedactedThinkingBlock = /* @__PURE__ */ Struct2({
   data: String6.annotate({
     title: "Data"
   }),
@@ -45270,7 +45495,7 @@ var ResponseRedactedThinkingBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseRedactedThinkingBlock"
 });
-var ResponseSearchResultLocationCitation = /* @__PURE__ */ Struct({
+var ResponseSearchResultLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -45296,7 +45521,7 @@ var ResponseSearchResultLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseSearchResultLocationCitation"
 });
-var ResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struct({
+var ResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struct2({
   is_file_update: Boolean3.annotate({
     title: "Is File Update"
   }),
@@ -45307,7 +45532,7 @@ var ResponseTextEditorCodeExecutionCreateResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextEditorCodeExecutionCreateResultBlock"
 });
-var ResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ Struct({
+var ResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ Struct2({
   lines: Union2([ArraySchema(String6), Null2]).annotate({
     title: "Lines",
     default: null
@@ -45335,7 +45560,7 @@ var ResponseTextEditorCodeExecutionStrReplaceResultBlock = /* @__PURE__ */ Struc
 }).annotate({
   title: "ResponseTextEditorCodeExecutionStrReplaceResultBlock"
 });
-var ResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct({
+var ResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct2({
   content: String6.annotate({
     title: "Content"
   }),
@@ -45361,7 +45586,7 @@ var ResponseTextEditorCodeExecutionViewResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextEditorCodeExecutionViewResultBlock"
 });
-var ResponseThinkingBlock = /* @__PURE__ */ Struct({
+var ResponseThinkingBlock = /* @__PURE__ */ Struct2({
   signature: String6.annotate({
     title: "Signature"
   }),
@@ -45375,7 +45600,7 @@ var ResponseThinkingBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseThinkingBlock"
 });
-var ResponseToolReferenceBlock = /* @__PURE__ */ Struct({
+var ResponseToolReferenceBlock = /* @__PURE__ */ Struct2({
   tool_name: String6.annotate({
     title: "Tool Name"
   }).check(isMinLength(1)).check(isMaxLength(256)).check(isPattern2(new RegExp("^[a-zA-Z0-9_-]{1,256}$"))),
@@ -45386,7 +45611,7 @@ var ResponseToolReferenceBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolReferenceBlock"
 });
-var ResponseWebSearchResultBlock = /* @__PURE__ */ Struct({
+var ResponseWebSearchResultBlock = /* @__PURE__ */ Struct2({
   encrypted_content: String6.annotate({
     title: "Encrypted Content"
   }),
@@ -45407,7 +45632,7 @@ var ResponseWebSearchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchResultBlock"
 });
-var ResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct({
+var ResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct2({
   cited_text: String6.annotate({
     title: "Cited Text"
   }),
@@ -45427,7 +45652,7 @@ var ResponseWebSearchResultLocationCitation = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchResultLocationCitation"
 });
-var ServerToolCaller = /* @__PURE__ */ Struct({
+var ServerToolCaller = /* @__PURE__ */ Struct2({
   tool_id: String6.annotate({
     title: "Tool Id"
   }).check(isPattern2(new RegExp("^srvtoolu_[a-zA-Z0-9_]+$"))),
@@ -45438,7 +45663,7 @@ var ServerToolCaller = /* @__PURE__ */ Struct({
   title: "ServerToolCaller",
   description: "Tool invocation generated by a server-side tool."
 });
-var ServerToolCaller_20260120 = /* @__PURE__ */ Struct({
+var ServerToolCaller_20260120 = /* @__PURE__ */ Struct2({
   tool_id: String6.annotate({
     title: "Tool Id"
   }).check(isPattern2(new RegExp("^srvtoolu_[a-zA-Z0-9_]+$"))),
@@ -45448,7 +45673,7 @@ var ServerToolCaller_20260120 = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ServerToolCaller_20260120"
 });
-var ServerToolUsage = /* @__PURE__ */ Struct({
+var ServerToolUsage = /* @__PURE__ */ Struct2({
   web_fetch_requests: Number6.annotate({
     title: "Web Fetch Requests",
     description: "The number of web fetch tool requests.",
@@ -45462,7 +45687,7 @@ var ServerToolUsage = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ServerToolUsage"
 });
-var Skill = /* @__PURE__ */ Struct({
+var Skill = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill was created."
@@ -45501,7 +45726,7 @@ This represents the most recent version of the skill that has been created.`
 }).annotate({
   title: "Skill"
 });
-var SkillVersion = /* @__PURE__ */ Struct({
+var SkillVersion = /* @__PURE__ */ Struct2({
   created_at: String6.annotate({
     title: "Created At",
     description: "ISO 8601 timestamp of when the skill version was created."
@@ -45568,7 +45793,7 @@ var Model2 = /* @__PURE__ */ Union2([String6, Literals(["claude-sonnet-5", "clau
 
 See [models](https://docs.anthropic.com/en/docs/models-overview) for additional details and options.`
 });
-var ResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var ResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: BashCodeExecutionToolResultErrorCode,
   type: Literal2("bash_code_execution_tool_result_error").annotate({
     title: "Type",
@@ -45577,7 +45802,7 @@ var ResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionToolResultError"
 });
-var BetaResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaBashCodeExecutionToolResultErrorCode,
   type: Literal2("bash_code_execution_tool_result_error").annotate({
     title: "Type",
@@ -45586,7 +45811,7 @@ var BetaResponseBashCodeExecutionToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionToolResultError"
 });
-var BetaCompactionIterationUsage = /* @__PURE__ */ Struct({
+var BetaCompactionIterationUsage = /* @__PURE__ */ Struct2({
   cache_creation: Union2([BetaCacheCreation, Null2]).annotate({
     description: "Breakdown of cached tokens by TTL",
     default: null
@@ -45618,7 +45843,7 @@ var BetaCompactionIterationUsage = /* @__PURE__ */ Struct({
   title: "CompactionIterationUsage",
   description: "Token usage for a compaction iteration."
 });
-var BetaMessageIterationUsage = /* @__PURE__ */ Struct({
+var BetaMessageIterationUsage = /* @__PURE__ */ Struct2({
   cache_creation: Union2([BetaCacheCreation, Null2]).annotate({
     description: "Breakdown of cached tokens by TTL",
     default: null
@@ -45650,7 +45875,7 @@ var BetaMessageIterationUsage = /* @__PURE__ */ Struct({
   title: "MessageIterationUsage",
   description: "Token usage for a sampling iteration."
 });
-var BetaResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaCodeExecutionToolResultErrorCode,
   type: Literal2("code_execution_tool_result_error").annotate({
     title: "Type",
@@ -45659,7 +45884,7 @@ var BetaResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionToolResultError"
 });
-var BetaCountMessageTokensResponse = /* @__PURE__ */ Struct({
+var BetaCountMessageTokensResponse = /* @__PURE__ */ Struct2({
   context_management: Union2([BetaContextManagementResponse, Null2]).annotate({
     description: "Information about context management applied to the message."
   }),
@@ -45670,7 +45895,7 @@ var BetaCountMessageTokensResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "CountMessageTokensResponse"
 });
-var BetaFileListResponse = /* @__PURE__ */ Struct({
+var BetaFileListResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(BetaFileMetadataSchema).annotate({
     title: "Data",
     description: "List of file metadata objects."
@@ -45691,7 +45916,7 @@ var BetaFileListResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "FileListResponse"
 });
-var BetaListResponse_MessageBatch_ = /* @__PURE__ */ Struct({
+var BetaListResponse_MessageBatch_ = /* @__PURE__ */ Struct2({
   data: ArraySchema(BetaMessageBatch).annotate({
     title: "Data"
   }),
@@ -45710,7 +45935,7 @@ var BetaListResponse_MessageBatch_ = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListResponse[MessageBatch]"
 });
-var BetaListResponse_ModelInfo_ = /* @__PURE__ */ Struct({
+var BetaListResponse_ModelInfo_ = /* @__PURE__ */ Struct2({
   data: ArraySchema(BetaModelInfo).annotate({
     title: "Data"
   }),
@@ -45729,7 +45954,7 @@ var BetaListResponse_ModelInfo_ = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListResponse[ModelInfo]"
 });
-var BetaErrorResponse = /* @__PURE__ */ Struct({
+var BetaErrorResponse = /* @__PURE__ */ Struct2({
   error: Union2([BetaInvalidRequestError, BetaAuthenticationError, BetaBillingError, BetaPermissionError, BetaNotFoundError, BetaRateLimitError, BetaGatewayTimeoutError, BetaAPIError, BetaOverloadedError], {
     mode: "oneOf"
   }).annotate({
@@ -45746,7 +45971,7 @@ var BetaErrorResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ErrorResponse"
 });
-var BetaResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(BetaResponseBashCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -45766,7 +45991,7 @@ var BetaResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionResultBlock"
 });
-var BetaResponseDocumentBlock = /* @__PURE__ */ Struct({
+var BetaResponseDocumentBlock = /* @__PURE__ */ Struct2({
   citations: Union2([BetaResponseCitationsConfig, Null2]).annotate({
     description: "Citation configuration for the document",
     default: null
@@ -45788,7 +46013,7 @@ var BetaResponseDocumentBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseDocumentBlock"
 });
-var BetaResponseContextManagement = /* @__PURE__ */ Struct({
+var BetaResponseContextManagement = /* @__PURE__ */ Struct2({
   applied_edits: ArraySchema(Union2([BetaResponseClearToolUses20250919Edit, BetaResponseClearThinking20251015Edit], {
     mode: "oneOf"
   })).annotate({
@@ -45798,7 +46023,7 @@ var BetaResponseContextManagement = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseContextManagement"
 });
-var BetaResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(BetaResponseCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -45818,7 +46043,7 @@ var BetaResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionResultBlock"
 });
-var BetaResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(BetaResponseCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -45839,7 +46064,7 @@ var BetaResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct({
   title: "ResponseEncryptedCodeExecutionResultBlock",
   description: "Code execution result with encrypted stdout for PFC + web_search results."
 });
-var BetaResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct2({
   tool_references: ArraySchema(BetaResponseToolReferenceBlock).annotate({
     title: "Tool References"
   }),
@@ -45850,7 +46075,7 @@ var BetaResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolSearchResultBlock"
 });
-var BetaCitationsDelta = /* @__PURE__ */ Struct({
+var BetaCitationsDelta = /* @__PURE__ */ Struct2({
   citation: Union2([BetaResponseCharLocationCitation, BetaResponsePageLocationCitation, BetaResponseContentBlockLocationCitation, BetaResponseWebSearchResultLocationCitation, BetaResponseSearchResultLocationCitation], {
     mode: "oneOf"
   }).annotate({
@@ -45863,8 +46088,8 @@ var BetaCitationsDelta = /* @__PURE__ */ Struct({
 }).annotate({
   title: "CitationsDelta"
 });
-var BetaResponseMCPToolResultBlock = /* @__PURE__ */ Struct({
-  content: Union2([String6, ArraySchema(Struct({
+var BetaResponseMCPToolResultBlock = /* @__PURE__ */ Struct2({
+  content: Union2([String6, ArraySchema(Struct2({
     citations: Union2([ArraySchema(Union2([BetaResponseCharLocationCitation, BetaResponsePageLocationCitation, BetaResponseContentBlockLocationCitation, BetaResponseWebSearchResultLocationCitation, BetaResponseSearchResultLocationCitation], {
       mode: "oneOf"
     })), Null2]).annotate({
@@ -45900,7 +46125,7 @@ var BetaResponseMCPToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseMCPToolResultBlock"
 });
-var BetaResponseTextBlock = /* @__PURE__ */ Struct({
+var BetaResponseTextBlock = /* @__PURE__ */ Struct2({
   citations: optionalKey2(Union2([ArraySchema(Union2([BetaResponseCharLocationCitation, BetaResponsePageLocationCitation, BetaResponseContentBlockLocationCitation, BetaResponseWebSearchResultLocationCitation, BetaResponseSearchResultLocationCitation], {
     mode: "oneOf"
   })), Null2]).annotate({
@@ -45918,7 +46143,7 @@ var BetaResponseTextBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextBlock"
 });
-var BetaResponseServerToolUseBlock = /* @__PURE__ */ Struct({
+var BetaResponseServerToolUseBlock = /* @__PURE__ */ Struct2({
   caller: optionalKey2(Union2([BetaDirectCaller, BetaServerToolCaller, BetaServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -45940,7 +46165,7 @@ var BetaResponseServerToolUseBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseServerToolUseBlock"
 });
-var BetaResponseToolUseBlock = /* @__PURE__ */ Struct({
+var BetaResponseToolUseBlock = /* @__PURE__ */ Struct2({
   caller: optionalKey2(Union2([BetaDirectCaller, BetaServerToolCaller, BetaServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -45962,7 +46187,7 @@ var BetaResponseToolUseBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolUseBlock"
 });
-var BetaContainer = /* @__PURE__ */ Struct({
+var BetaContainer = /* @__PURE__ */ Struct2({
   expires_at: String6.annotate({
     title: "Expires At",
     description: "The time at which the container will expire.",
@@ -45981,7 +46206,7 @@ var BetaContainer = /* @__PURE__ */ Struct({
   title: "Container",
   description: "Information about the container used in the request (for the code execution tool)"
 });
-var BetaListSkillVersionsResponse = /* @__PURE__ */ Struct({
+var BetaListSkillVersionsResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(BetaSkillVersion).annotate({
     title: "Data",
     description: "List of skill versions."
@@ -45997,7 +46222,7 @@ var BetaListSkillVersionsResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListSkillVersionsResponse"
 });
-var BetaResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaTextEditorCodeExecutionToolResultErrorCode,
   error_message: Union2([String6, Null2]).annotate({
     title: "Error Message",
@@ -46010,7 +46235,7 @@ var BetaResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct(
 }).annotate({
   title: "ResponseTextEditorCodeExecutionToolResultError"
 });
-var BetaResponseToolSearchToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseToolSearchToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaToolSearchToolResultErrorCode,
   error_message: Union2([String6, Null2]).annotate({
     title: "Error Message",
@@ -46023,7 +46248,7 @@ var BetaResponseToolSearchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolResultError"
 });
-var BetaResponseWebFetchToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseWebFetchToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaWebFetchToolResultErrorCode,
   type: Literal2("web_fetch_tool_result_error").annotate({
     title: "Type",
@@ -46032,7 +46257,7 @@ var BetaResponseWebFetchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchToolResultError"
 });
-var BetaResponseWebSearchToolResultError = /* @__PURE__ */ Struct({
+var BetaResponseWebSearchToolResultError = /* @__PURE__ */ Struct2({
   error_code: BetaWebSearchToolResultErrorCode,
   type: Literal2("web_search_tool_result_error").annotate({
     title: "Type",
@@ -46041,7 +46266,7 @@ var BetaResponseWebSearchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchToolResultError"
 });
-var BetaListSkillsResponse = /* @__PURE__ */ Struct({
+var BetaListSkillsResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(Betaapi__schemas__skills__Skill).annotate({
     title: "Data",
     description: "List of skills."
@@ -46057,7 +46282,7 @@ var BetaListSkillsResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListSkillsResponse"
 });
-var ResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var ResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: CodeExecutionToolResultErrorCode,
   type: Literal2("code_execution_tool_result_error").annotate({
     title: "Type",
@@ -46066,7 +46291,7 @@ var ResponseCodeExecutionToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionToolResultError"
 });
-var FileListResponse = /* @__PURE__ */ Struct({
+var FileListResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(FileMetadataSchema).annotate({
     title: "Data",
     description: "List of file metadata objects."
@@ -46087,7 +46312,7 @@ var FileListResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "FileListResponse"
 });
-var ListResponse_MessageBatch_ = /* @__PURE__ */ Struct({
+var ListResponse_MessageBatch_ = /* @__PURE__ */ Struct2({
   data: ArraySchema(MessageBatch).annotate({
     title: "Data"
   }),
@@ -46106,7 +46331,7 @@ var ListResponse_MessageBatch_ = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListResponse[MessageBatch]"
 });
-var ListResponse_ModelInfo_ = /* @__PURE__ */ Struct({
+var ListResponse_ModelInfo_ = /* @__PURE__ */ Struct2({
   data: ArraySchema(ModelInfo).annotate({
     title: "Data"
   }),
@@ -46125,7 +46350,7 @@ var ListResponse_ModelInfo_ = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListResponse[ModelInfo]"
 });
-var ErrorResponse = /* @__PURE__ */ Struct({
+var ErrorResponse = /* @__PURE__ */ Struct2({
   error: Union2([InvalidRequestError2, AuthenticationError2, BillingError, PermissionError, NotFoundError, RateLimitError2, GatewayTimeoutError, APIError, OverloadedError], {
     mode: "oneOf"
   }).annotate({
@@ -46142,7 +46367,7 @@ var ErrorResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ErrorResponse"
 });
-var ResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var ResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(ResponseBashCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -46162,7 +46387,7 @@ var ResponseBashCodeExecutionResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionResultBlock"
 });
-var ResponseDocumentBlock = /* @__PURE__ */ Struct({
+var ResponseDocumentBlock = /* @__PURE__ */ Struct2({
   citations: Union2([ResponseCitationsConfig, Null2]).annotate({
     description: "Citation configuration for the document",
     default: null
@@ -46184,7 +46409,7 @@ var ResponseDocumentBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseDocumentBlock"
 });
-var ResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var ResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(ResponseCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -46204,7 +46429,7 @@ var ResponseCodeExecutionResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionResultBlock"
 });
-var ResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct({
+var ResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct2({
   content: ArraySchema(ResponseCodeExecutionOutputBlock).annotate({
     title: "Content"
   }),
@@ -46225,7 +46450,7 @@ var ResponseEncryptedCodeExecutionResultBlock = /* @__PURE__ */ Struct({
   title: "ResponseEncryptedCodeExecutionResultBlock",
   description: "Code execution result with encrypted stdout for PFC + web_search results."
 });
-var ResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct({
+var ResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct2({
   tool_references: ArraySchema(ResponseToolReferenceBlock).annotate({
     title: "Tool References"
   }),
@@ -46236,7 +46461,7 @@ var ResponseToolSearchToolSearchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolSearchResultBlock"
 });
-var ResponseTextBlock = /* @__PURE__ */ Struct({
+var ResponseTextBlock = /* @__PURE__ */ Struct2({
   citations: optionalKey2(Union2([ArraySchema(Union2([ResponseCharLocationCitation, ResponsePageLocationCitation, ResponseContentBlockLocationCitation, ResponseWebSearchResultLocationCitation, ResponseSearchResultLocationCitation], {
     mode: "oneOf"
   })), Null2]).annotate({
@@ -46254,7 +46479,7 @@ var ResponseTextBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextBlock"
 });
-var ResponseServerToolUseBlock = /* @__PURE__ */ Struct({
+var ResponseServerToolUseBlock = /* @__PURE__ */ Struct2({
   caller: Union2([DirectCaller, ServerToolCaller, ServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46279,7 +46504,7 @@ var ResponseServerToolUseBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseServerToolUseBlock"
 });
-var ResponseToolUseBlock = /* @__PURE__ */ Struct({
+var ResponseToolUseBlock = /* @__PURE__ */ Struct2({
   caller: Union2([DirectCaller, ServerToolCaller, ServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46304,7 +46529,7 @@ var ResponseToolUseBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolUseBlock"
 });
-var ListSkillsResponse = /* @__PURE__ */ Struct({
+var ListSkillsResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(Skill).annotate({
     title: "Data",
     description: "List of skills."
@@ -46320,7 +46545,7 @@ var ListSkillsResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListSkillsResponse"
 });
-var ListSkillVersionsResponse = /* @__PURE__ */ Struct({
+var ListSkillVersionsResponse = /* @__PURE__ */ Struct2({
   data: ArraySchema(SkillVersion).annotate({
     title: "Data",
     description: "List of skill versions."
@@ -46336,7 +46561,7 @@ var ListSkillVersionsResponse = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ListSkillVersionsResponse"
 });
-var ResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct({
+var ResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct2({
   error_code: TextEditorCodeExecutionToolResultErrorCode,
   error_message: Union2([String6, Null2]).annotate({
     title: "Error Message",
@@ -46349,7 +46574,7 @@ var ResponseTextEditorCodeExecutionToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextEditorCodeExecutionToolResultError"
 });
-var ResponseToolSearchToolResultError = /* @__PURE__ */ Struct({
+var ResponseToolSearchToolResultError = /* @__PURE__ */ Struct2({
   error_code: ToolSearchToolResultErrorCode,
   error_message: Union2([String6, Null2]).annotate({
     title: "Error Message",
@@ -46362,7 +46587,7 @@ var ResponseToolSearchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolResultError"
 });
-var ResponseWebFetchToolResultError = /* @__PURE__ */ Struct({
+var ResponseWebFetchToolResultError = /* @__PURE__ */ Struct2({
   error_code: WebFetchToolResultErrorCode,
   type: Literal2("web_fetch_tool_result_error").annotate({
     title: "Type",
@@ -46371,7 +46596,7 @@ var ResponseWebFetchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchToolResultError"
 });
-var ResponseWebSearchToolResultError = /* @__PURE__ */ Struct({
+var ResponseWebSearchToolResultError = /* @__PURE__ */ Struct2({
   error_code: WebSearchToolResultErrorCode,
   type: Literal2("web_search_tool_result_error").annotate({
     title: "Type",
@@ -46380,7 +46605,7 @@ var ResponseWebSearchToolResultError = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchToolResultError"
 });
-var CompletionResponse = /* @__PURE__ */ Struct({
+var CompletionResponse = /* @__PURE__ */ Struct2({
   completion: String6.annotate({
     title: "Completion",
     description: "The resulting completion up to and excluding the stop sequences."
@@ -46414,7 +46639,7 @@ Each entry represents one sampling iteration, with its own input/output token co
 - Understand token accumulation across server-side tool use loops`,
   default: null
 });
-var BetaResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([BetaResponseBashCodeExecutionToolResultError, BetaResponseBashCodeExecutionResultBlock]).annotate({
     title: "Content"
   }),
@@ -46428,7 +46653,7 @@ var BetaResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionToolResultBlock"
 });
-var BetaResponseWebFetchResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseWebFetchResultBlock = /* @__PURE__ */ Struct2({
   content: BetaResponseDocumentBlock,
   retrieved_at: Union2([String6, Null2]).annotate({
     title: "Retrieved At",
@@ -46446,7 +46671,7 @@ var BetaResponseWebFetchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchResultBlock"
 });
-var BetaResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([BetaResponseCodeExecutionToolResultError, BetaResponseCodeExecutionResultBlock, BetaResponseEncryptedCodeExecutionResultBlock]).annotate({
     title: "Content"
   }),
@@ -46460,7 +46685,7 @@ var BetaResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionToolResultBlock"
 });
-var BetaContentBlockDeltaEvent = /* @__PURE__ */ Struct({
+var BetaContentBlockDeltaEvent = /* @__PURE__ */ Struct2({
   delta: Union2([BetaTextContentBlockDelta, BetaInputJsonContentBlockDelta, BetaCitationsDelta, BetaThinkingContentBlockDelta, BetaSignatureContentBlockDelta, BetaCompactionContentBlockDelta], {
     mode: "oneOf"
   }).annotate({
@@ -46476,7 +46701,7 @@ var BetaContentBlockDeltaEvent = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ContentBlockDeltaEvent"
 });
-var BetaMessageDelta = /* @__PURE__ */ Struct({
+var BetaMessageDelta = /* @__PURE__ */ Struct2({
   container: optionalKey2(Union2([BetaContainer, Null2]).annotate({
     description: `Information about the container used in this request.
 
@@ -46494,7 +46719,7 @@ This will be non-null if a container tool (e.g. code execution) was used.`,
 }).annotate({
   title: "MessageDelta"
 });
-var BetaResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([BetaResponseTextEditorCodeExecutionToolResultError, BetaResponseTextEditorCodeExecutionViewResultBlock, BetaResponseTextEditorCodeExecutionCreateResultBlock, BetaResponseTextEditorCodeExecutionStrReplaceResultBlock]).annotate({
     title: "Content"
   }),
@@ -46508,7 +46733,7 @@ var BetaResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct(
 }).annotate({
   title: "ResponseTextEditorCodeExecutionToolResultBlock"
 });
-var BetaResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([BetaResponseToolSearchToolResultError, BetaResponseToolSearchToolSearchResultBlock]).annotate({
     title: "Content"
   }),
@@ -46522,7 +46747,7 @@ var BetaResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolResultBlock"
 });
-var BetaResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct2({
   caller: optionalKey2(Union2([BetaDirectCaller, BetaServerToolCaller, BetaServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46541,7 +46766,7 @@ var BetaResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchToolResultBlock"
 });
-var ResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([ResponseBashCodeExecutionToolResultError, ResponseBashCodeExecutionResultBlock]).annotate({
     title: "Content"
   }),
@@ -46555,7 +46780,7 @@ var ResponseBashCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseBashCodeExecutionToolResultBlock"
 });
-var ResponseWebFetchResultBlock = /* @__PURE__ */ Struct({
+var ResponseWebFetchResultBlock = /* @__PURE__ */ Struct2({
   content: ResponseDocumentBlock,
   retrieved_at: Union2([String6, Null2]).annotate({
     title: "Retrieved At",
@@ -46573,7 +46798,7 @@ var ResponseWebFetchResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchResultBlock"
 });
-var ResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([ResponseCodeExecutionToolResultError, ResponseCodeExecutionResultBlock, ResponseEncryptedCodeExecutionResultBlock]).annotate({
     title: "Content"
   }),
@@ -46587,7 +46812,7 @@ var ResponseCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseCodeExecutionToolResultBlock"
 });
-var ResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([ResponseTextEditorCodeExecutionToolResultError, ResponseTextEditorCodeExecutionViewResultBlock, ResponseTextEditorCodeExecutionCreateResultBlock, ResponseTextEditorCodeExecutionStrReplaceResultBlock]).annotate({
     title: "Content"
   }),
@@ -46601,7 +46826,7 @@ var ResponseTextEditorCodeExecutionToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseTextEditorCodeExecutionToolResultBlock"
 });
-var ResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct2({
   content: Union2([ResponseToolSearchToolResultError, ResponseToolSearchToolSearchResultBlock]).annotate({
     title: "Content"
   }),
@@ -46615,7 +46840,7 @@ var ResponseToolSearchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseToolSearchToolResultBlock"
 });
-var ResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct2({
   caller: Union2([DirectCaller, ServerToolCaller, ServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46637,7 +46862,7 @@ var ResponseWebSearchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebSearchToolResultBlock"
 });
-var BetaResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct({
+var BetaResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct2({
   caller: optionalKey2(Union2([BetaDirectCaller, BetaServerToolCaller, BetaServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46656,7 +46881,7 @@ var BetaResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchToolResultBlock"
 });
-var BetaMessageDeltaEvent = /* @__PURE__ */ Struct({
+var BetaMessageDeltaEvent = /* @__PURE__ */ Struct2({
   context_management: optionalKey2(Union2([BetaResponseContextManagement, Null2]).annotate({
     description: "Information about context management strategies applied during the request",
     default: null
@@ -46666,7 +46891,7 @@ var BetaMessageDeltaEvent = /* @__PURE__ */ Struct({
     title: "Type",
     default: "message_delta"
   }),
-  usage: Struct({
+  usage: Struct2({
     cache_creation_input_tokens: Union2([Number6.check(isInt()).check(isGreaterThanOrEqualTo5(0)), Null2]).annotate({
       title: "Cache Creation Input Tokens",
       description: "The cumulative number of input tokens used to create the cache entry.",
@@ -46698,7 +46923,7 @@ var BetaMessageDeltaEvent = /* @__PURE__ */ Struct({
 }).annotate({
   title: "MessageDeltaEvent"
 });
-var ResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct({
+var ResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct2({
   caller: Union2([DirectCaller, ServerToolCaller, ServerToolCaller_20260120], {
     mode: "oneOf"
   }).annotate({
@@ -46720,7 +46945,7 @@ var ResponseWebFetchToolResultBlock = /* @__PURE__ */ Struct({
 }).annotate({
   title: "ResponseWebFetchToolResultBlock"
 });
-var BetaContentBlockStartEvent = /* @__PURE__ */ Struct({
+var BetaContentBlockStartEvent = /* @__PURE__ */ Struct2({
   content_block: Union2([BetaResponseTextBlock, BetaResponseThinkingBlock, BetaResponseRedactedThinkingBlock, BetaResponseToolUseBlock, BetaResponseServerToolUseBlock, BetaResponseWebSearchToolResultBlock, BetaResponseWebFetchToolResultBlock, BetaResponseCodeExecutionToolResultBlock, BetaResponseBashCodeExecutionToolResultBlock, BetaResponseTextEditorCodeExecutionToolResultBlock, BetaResponseToolSearchToolResultBlock, BetaResponseMCPToolUseBlock, BetaResponseMCPToolResultBlock, BetaResponseContainerUploadBlock, BetaResponseCompactionBlock], {
     mode: "oneOf"
   }).annotate({
@@ -46742,7 +46967,7 @@ var BetaContentBlock = /* @__PURE__ */ Union2([BetaResponseTextBlock, BetaRespon
 var ContentBlock2 = /* @__PURE__ */ Union2([ResponseTextBlock, ResponseThinkingBlock, ResponseRedactedThinkingBlock, ResponseToolUseBlock, ResponseServerToolUseBlock, ResponseWebSearchToolResultBlock, ResponseWebFetchToolResultBlock, ResponseCodeExecutionToolResultBlock, ResponseBashCodeExecutionToolResultBlock, ResponseTextEditorCodeExecutionToolResultBlock, ResponseToolSearchToolResultBlock, ResponseContainerUploadBlock], {
   mode: "oneOf"
 });
-var BetaMessage = /* @__PURE__ */ Struct({
+var BetaMessage = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Unique object identifier.
@@ -46775,7 +47000,7 @@ The format and length of IDs may change over time.`
 This value will be a non-null string if one of your custom stop sequences was generated.`,
     default: null
   }),
-  usage: Struct({
+  usage: Struct2({
     cache_creation: Union2([BetaCacheCreation, Null2]).annotate({
       description: "Breakdown of cached tokens by TTL",
       default: null
@@ -46836,7 +47061,7 @@ This will be non-null if a container tool (e.g. code execution) was used.`,
 }).annotate({
   title: "Message"
 });
-var Message2 = /* @__PURE__ */ Struct({
+var Message2 = /* @__PURE__ */ Struct2({
   id: String6.annotate({
     title: "Id",
     description: `Unique object identifier.
@@ -46869,7 +47094,7 @@ The format and length of IDs may change over time.`
 This value will be a non-null string if one of your custom stop sequences was generated.`,
     default: null
   }),
-  usage: Struct({
+  usage: Struct2({
     cache_creation: Union2([CacheCreation, Null2]).annotate({
       description: "Breakdown of cached tokens by TTL",
       default: null
@@ -46919,7 +47144,7 @@ This will be non-null if a container tool (e.g. code execution) was used.`,
 }).annotate({
   title: "Message"
 });
-var BetaMessageStartEvent = /* @__PURE__ */ Struct({
+var BetaMessageStartEvent = /* @__PURE__ */ Struct2({
   message: BetaMessage,
   type: Literal2("message_start").annotate({
     title: "Type",
@@ -47488,9 +47713,9 @@ var AnthropicClientError = (tag2, cause, response) => new AnthropicClientErrorIm
 });
 
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/internal/errors.js
-var AnthropicErrorBody = /* @__PURE__ */ Struct({
+var AnthropicErrorBody = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("error"),
-  error: /* @__PURE__ */ Struct({
+  error: /* @__PURE__ */ Struct2({
     type: String6,
     message: String6
   })
@@ -47830,7 +48055,7 @@ var make61 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     HttpClientError: (error2) => mapHttpClientError(error2, "createMessage"),
     SchemaError: (error2) => fail7(mapSchemaError(error2, "createMessage"))
   }), withRedactedHeaders);
-  const PingEvent = Struct({
+  const PingEvent = Struct2({
     type: Literal2("ping")
   });
   const MessageEvent = Union2([PingEvent, BetaMessageStartEvent, BetaMessageDeltaEvent, BetaMessageStopEvent, BetaContentBlockStartEvent, BetaContentBlockDeltaEvent, BetaContentBlockStopEvent, BetaErrorResponse]);
@@ -50713,15 +50938,15 @@ var fromWebSocket = (acquire, options3) => withFiber2((fiber3) => {
 });
 
 // node_modules/.bun/@effect+ai-openai@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-openai/dist/internal/errors.js
-var OpenAiErrorBody = /* @__PURE__ */ Struct({
-  error: /* @__PURE__ */ Struct({
+var OpenAiErrorBody = /* @__PURE__ */ Struct2({
+  error: /* @__PURE__ */ Struct2({
     message: String6,
     type: /* @__PURE__ */ optional2(/* @__PURE__ */ NullOr(String6)),
     param: /* @__PURE__ */ optional2(/* @__PURE__ */ NullOr(String6)),
     code: /* @__PURE__ */ optional2(/* @__PURE__ */ NullOr(String6))
   })
 });
-var OpenAiCompatibleErrorBody = /* @__PURE__ */ Struct({
+var OpenAiCompatibleErrorBody = /* @__PURE__ */ Struct2({
   error: String6,
   code: /* @__PURE__ */ optional2(String6)
 });
@@ -51010,58 +51235,58 @@ class OpenAiConfig extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiC
 var UnknownRecord = /* @__PURE__ */ Record(String6, Unknown2);
 var ImageDetail = /* @__PURE__ */ Literals(["low", "high", "auto"]);
 var MessageStatus = /* @__PURE__ */ Literals(["in_progress", "completed", "incomplete"]);
-var InputTextContent = /* @__PURE__ */ Struct({
+var InputTextContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("input_text"),
   text: String6
 });
-var InputImageContent = /* @__PURE__ */ Struct({
+var InputImageContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("input_image"),
   image_url: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
   file_id: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
   detail: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(ImageDetail))
 });
-var InputFileContent = /* @__PURE__ */ Struct({
+var InputFileContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("input_file"),
   file_id: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
   filename: /* @__PURE__ */ optionalKey2(String6),
   file_url: /* @__PURE__ */ optionalKey2(String6),
   file_data: /* @__PURE__ */ optionalKey2(String6)
 });
-var SummaryTextContent = /* @__PURE__ */ Struct({
+var SummaryTextContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("summary_text"),
   text: String6
 });
-var ReasoningTextContent = /* @__PURE__ */ Struct({
+var ReasoningTextContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("reasoning_text"),
   text: String6
 });
-var RefusalContent = /* @__PURE__ */ Struct({
+var RefusalContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("refusal"),
   refusal: String6
 });
-var TextContent2 = /* @__PURE__ */ Struct({
+var TextContent2 = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("text"),
   text: String6
 });
-var ComputerScreenshotContent = /* @__PURE__ */ Struct({
+var ComputerScreenshotContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("computer_screenshot"),
   image_url: /* @__PURE__ */ NullOr(String6),
   file_id: /* @__PURE__ */ NullOr(String6)
 });
-var FileCitationAnnotation = /* @__PURE__ */ Struct({
+var FileCitationAnnotation = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("file_citation"),
   file_id: String6,
   index: Int,
   filename: String6
 });
-var UrlCitationAnnotation = /* @__PURE__ */ Struct({
+var UrlCitationAnnotation = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("url_citation"),
   url: String6,
   start_index: Int,
   end_index: Int,
   title: String6
 });
-var ContainerFileCitationAnnotation = /* @__PURE__ */ Struct({
+var ContainerFileCitationAnnotation = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("container_file_citation"),
   container_id: String6,
   file_id: String6,
@@ -51069,27 +51294,27 @@ var ContainerFileCitationAnnotation = /* @__PURE__ */ Struct({
   end_index: Int,
   filename: String6
 });
-var FilePathAnnotation = /* @__PURE__ */ Struct({
+var FilePathAnnotation = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("file_path"),
   file_id: String6,
   index: Int
 });
 var Annotation = /* @__PURE__ */ Union2([FileCitationAnnotation, UrlCitationAnnotation, ContainerFileCitationAnnotation, FilePathAnnotation]);
-var OutputTextContent = /* @__PURE__ */ Struct({
+var OutputTextContent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("output_text"),
   text: String6,
   annotations: /* @__PURE__ */ ArraySchema(Annotation),
   logprobs: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ ArraySchema(Unknown2))
 });
 var OutputMessageContent = /* @__PURE__ */ Union2([InputTextContent, OutputTextContent, TextContent2, SummaryTextContent, ReasoningTextContent, RefusalContent, InputImageContent, ComputerScreenshotContent, InputFileContent]);
-var OutputMessage = /* @__PURE__ */ Struct({
+var OutputMessage = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("message"),
   role: /* @__PURE__ */ Literal2("assistant"),
   content: /* @__PURE__ */ ArraySchema(OutputMessageContent),
   status: MessageStatus
 });
-var ReasoningItem = /* @__PURE__ */ Struct({
+var ReasoningItem = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("reasoning"),
   id: String6,
   encrypted_content: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
@@ -51097,7 +51322,7 @@ var ReasoningItem = /* @__PURE__ */ Struct({
   content: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ ArraySchema(ReasoningTextContent)),
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var FunctionCall = /* @__PURE__ */ Struct({
+var FunctionCall = /* @__PURE__ */ Struct2({
   id: /* @__PURE__ */ optionalKey2(String6),
   type: /* @__PURE__ */ Literal2("function_call"),
   call_id: String6,
@@ -51105,40 +51330,40 @@ var FunctionCall = /* @__PURE__ */ Struct({
   arguments: String6,
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var LocalShellCall = /* @__PURE__ */ Struct({
+var LocalShellCall = /* @__PURE__ */ Struct2({
   id: /* @__PURE__ */ optionalKey2(String6),
   type: /* @__PURE__ */ Literal2("local_shell_call"),
   call_id: String6,
   action: Unknown2,
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var ShellCall = /* @__PURE__ */ Struct({
+var ShellCall = /* @__PURE__ */ Struct2({
   id: /* @__PURE__ */ optionalKey2(String6),
   type: /* @__PURE__ */ Literal2("shell_call"),
   call_id: String6,
   action: Unknown2,
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var ResponseUsage = /* @__PURE__ */ StructWithRest(/* @__PURE__ */ Struct({
+var ResponseUsage = /* @__PURE__ */ StructWithRest(/* @__PURE__ */ Struct2({
   input_tokens: Int,
   output_tokens: Int,
   total_tokens: Int,
   input_tokens_details: /* @__PURE__ */ optionalKey2(Unknown2),
   output_tokens_details: /* @__PURE__ */ optionalKey2(Unknown2)
 }), [UnknownRecord]);
-var ApplyPatchOperation = /* @__PURE__ */ Struct({
+var ApplyPatchOperation = /* @__PURE__ */ Struct2({
   type: String6,
   path: String6,
   diff: /* @__PURE__ */ optionalKey2(String6)
 });
-var ApplyPatchCall = /* @__PURE__ */ Struct({
+var ApplyPatchCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("apply_patch_call"),
   call_id: String6,
   operation: ApplyPatchOperation,
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var CodeInterpreterCall = /* @__PURE__ */ Struct({
+var CodeInterpreterCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("code_interpreter_call"),
   code: /* @__PURE__ */ optionalKey2(String6),
@@ -51146,25 +51371,25 @@ var CodeInterpreterCall = /* @__PURE__ */ Struct({
   outputs: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ ArraySchema(Unknown2)),
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var ComputerCall = /* @__PURE__ */ Struct({
+var ComputerCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("computer_call"),
   status: /* @__PURE__ */ optionalKey2(MessageStatus)
 });
-var FileSearchCall = /* @__PURE__ */ Struct({
+var FileSearchCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("file_search_call"),
   status: /* @__PURE__ */ optionalKey2(String6),
   queries: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ ArraySchema(String6)),
   results: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(Unknown2))
 });
-var ImageGenerationCall = /* @__PURE__ */ Struct({
+var ImageGenerationCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("image_generation_call"),
   result: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
   status: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Literals(["in_progress", "completed", "generating", "failed"]))
 });
-var McpCall = /* @__PURE__ */ Struct({
+var McpCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("mcp_call"),
   approval_request_id: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6)),
@@ -51174,29 +51399,29 @@ var McpCall = /* @__PURE__ */ Struct({
   error: /* @__PURE__ */ optionalKey2(Unknown2),
   server_label: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(String6))
 });
-var McpListTools = /* @__PURE__ */ Struct({
+var McpListTools = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("mcp_list_tools")
 });
-var McpApprovalRequest = /* @__PURE__ */ Struct({
+var McpApprovalRequest = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("mcp_approval_request"),
   approval_request_id: /* @__PURE__ */ optionalKey2(String6),
   name: String6,
   arguments: Unknown2
 });
-var WebSearchCall = /* @__PURE__ */ Struct({
+var WebSearchCall = /* @__PURE__ */ Struct2({
   id: String6,
   type: /* @__PURE__ */ Literal2("web_search_call"),
   action: /* @__PURE__ */ optionalKey2(Unknown2),
   status: /* @__PURE__ */ optionalKey2(String6)
 });
 var OutputItem = /* @__PURE__ */ Union2([ApplyPatchCall, CodeInterpreterCall, ComputerCall, FileSearchCall, FunctionCall, ImageGenerationCall, LocalShellCall, McpCall, McpListTools, McpApprovalRequest, OutputMessage, ReasoningItem, ShellCall, WebSearchCall]);
-var ResponseError = /* @__PURE__ */ Struct({
+var ResponseError = /* @__PURE__ */ Struct2({
   code: String6,
   message: String6
 });
-var Response2 = /* @__PURE__ */ Struct({
+var Response2 = /* @__PURE__ */ Struct2({
   id: String6,
   object: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Literal2("response")),
   model: String6,
@@ -51204,44 +51429,44 @@ var Response2 = /* @__PURE__ */ Struct({
   output: /* @__PURE__ */ ArraySchema(OutputItem).pipe(/* @__PURE__ */ withDecodingDefault(/* @__PURE__ */ succeed7([]))),
   usage: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(ResponseUsage)),
   error: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(ResponseError)),
-  incomplete_details: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(/* @__PURE__ */ Struct({
+  incomplete_details: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ NullOr(/* @__PURE__ */ Struct2({
     reason: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Literals(["max_output_tokens", "content_filter"]))
   }))),
   service_tier: /* @__PURE__ */ optionalKey2(String6)
 });
-var ResponseCreatedEvent = /* @__PURE__ */ Struct({
+var ResponseCreatedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.created"),
   response: Response2,
   sequence_number: Int
 });
-var ResponseCompletedEvent = /* @__PURE__ */ Struct({
+var ResponseCompletedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.completed"),
   response: Response2,
   sequence_number: Int
 });
-var ResponseIncompleteEvent = /* @__PURE__ */ Struct({
+var ResponseIncompleteEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.incomplete"),
   response: Response2,
   sequence_number: Int
 });
-var ResponseFailedEvent = /* @__PURE__ */ Struct({
+var ResponseFailedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.failed"),
   response: Response2,
   sequence_number: Int
 });
-var ResponseOutputItemAddedEvent = /* @__PURE__ */ Struct({
+var ResponseOutputItemAddedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.output_item.added"),
   output_index: Int,
   sequence_number: Int,
   item: OutputItem
 });
-var ResponseOutputItemDoneEvent = /* @__PURE__ */ Struct({
+var ResponseOutputItemDoneEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.output_item.done"),
   output_index: Int,
   sequence_number: Int,
   item: OutputItem
 });
-var ResponseOutputTextDeltaEvent = /* @__PURE__ */ Struct({
+var ResponseOutputTextDeltaEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.output_text.delta"),
   item_id: String6,
   output_index: Int,
@@ -51250,7 +51475,7 @@ var ResponseOutputTextDeltaEvent = /* @__PURE__ */ Struct({
   sequence_number: Int,
   logprobs: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ ArraySchema(Unknown2))
 });
-var ResponseOutputTextAnnotationAddedEvent = /* @__PURE__ */ Struct({
+var ResponseOutputTextAnnotationAddedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.output_text.annotation.added"),
   item_id: String6,
   output_index: Int,
@@ -51259,7 +51484,7 @@ var ResponseOutputTextAnnotationAddedEvent = /* @__PURE__ */ Struct({
   sequence_number: Int,
   annotation: Annotation
 });
-var ResponseReasoningSummaryPartAddedEvent = /* @__PURE__ */ Struct({
+var ResponseReasoningSummaryPartAddedEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.reasoning_summary_part.added"),
   item_id: String6,
   output_index: Int,
@@ -51267,7 +51492,7 @@ var ResponseReasoningSummaryPartAddedEvent = /* @__PURE__ */ Struct({
   sequence_number: Int,
   part: SummaryTextContent
 });
-var ResponseReasoningSummaryPartDoneEvent = /* @__PURE__ */ Struct({
+var ResponseReasoningSummaryPartDoneEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.reasoning_summary_part.done"),
   item_id: String6,
   output_index: Int,
@@ -51275,7 +51500,7 @@ var ResponseReasoningSummaryPartDoneEvent = /* @__PURE__ */ Struct({
   sequence_number: Int,
   part: SummaryTextContent
 });
-var ResponseReasoningSummaryTextDeltaEvent = /* @__PURE__ */ Struct({
+var ResponseReasoningSummaryTextDeltaEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.reasoning_summary_text.delta"),
   item_id: String6,
   output_index: Int,
@@ -51283,56 +51508,56 @@ var ResponseReasoningSummaryTextDeltaEvent = /* @__PURE__ */ Struct({
   delta: String6,
   sequence_number: Int
 });
-var ResponseFunctionCallArgumentsDeltaEvent = /* @__PURE__ */ Struct({
+var ResponseFunctionCallArgumentsDeltaEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.function_call_arguments.delta"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   delta: String6
 });
-var ResponseFunctionCallArgumentsDoneEvent = /* @__PURE__ */ Struct({
+var ResponseFunctionCallArgumentsDoneEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.function_call_arguments.done"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   arguments: String6
 });
-var ResponseCodeInterpreterCallCodeDeltaEvent = /* @__PURE__ */ Struct({
+var ResponseCodeInterpreterCallCodeDeltaEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.code_interpreter_call_code.delta"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   delta: String6
 });
-var ResponseCodeInterpreterCallCodeDoneEvent = /* @__PURE__ */ Struct({
+var ResponseCodeInterpreterCallCodeDoneEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.code_interpreter_call_code.done"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   code: String6
 });
-var ResponseApplyPatchCallOperationDiffDeltaEvent = /* @__PURE__ */ Struct({
+var ResponseApplyPatchCallOperationDiffDeltaEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.apply_patch_call_operation_diff.delta"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   delta: String6
 });
-var ResponseApplyPatchCallOperationDiffDoneEvent = /* @__PURE__ */ Struct({
+var ResponseApplyPatchCallOperationDiffDoneEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.apply_patch_call_operation_diff.done"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   delta: /* @__PURE__ */ optionalKey2(String6)
 });
-var ResponseImageGenerationCallPartialImageEvent = /* @__PURE__ */ Struct({
+var ResponseImageGenerationCallPartialImageEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("response.image_generation_call.partial_image"),
   item_id: String6,
   output_index: Int,
   sequence_number: Int,
   partial_image_b64: String6
 });
-var ResponseErrorEvent = /* @__PURE__ */ Struct({
+var ResponseErrorEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("error"),
   code: /* @__PURE__ */ NullOr(String6),
   message: String6,
@@ -51346,16 +51571,16 @@ var UnknownResponseStreamEvent = /* @__PURE__ */ declare((value4) => hasProperty
   description: "Fallback for unknown future stream events"
 });
 var ResponseStreamEvent = /* @__PURE__ */ Union2([ResponseCreatedEvent, ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent, ResponseOutputTextDeltaEvent, ResponseOutputTextAnnotationAddedEvent, ResponseReasoningSummaryPartAddedEvent, ResponseReasoningSummaryPartDoneEvent, ResponseReasoningSummaryTextDeltaEvent, ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent, ResponseCodeInterpreterCallCodeDeltaEvent, ResponseCodeInterpreterCallCodeDoneEvent, ResponseApplyPatchCallOperationDiffDeltaEvent, ResponseApplyPatchCallOperationDiffDoneEvent, ResponseImageGenerationCallPartialImageEvent, ResponseErrorEvent, UnknownResponseStreamEvent]);
-var Embedding = /* @__PURE__ */ Struct({
+var Embedding = /* @__PURE__ */ Struct2({
   embedding: /* @__PURE__ */ Union2([/* @__PURE__ */ ArraySchema(Finite), String6]),
   index: Int,
   object: /* @__PURE__ */ optionalKey2(String6)
 });
-var CreateEmbeddingResponse = /* @__PURE__ */ Struct({
+var CreateEmbeddingResponse = /* @__PURE__ */ Struct2({
   data: /* @__PURE__ */ ArraySchema(Embedding),
   model: String6,
   object: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Literal2("list")),
-  usage: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Struct({
+  usage: /* @__PURE__ */ optionalKey2(/* @__PURE__ */ Struct2({
     prompt_tokens: Int,
     total_tokens: Int
   }))
@@ -51557,10 +51782,10 @@ var makeSocket = /* @__PURE__ */ gen4(function* () {
     }
   }).pipe(add(ResponseIdTracker, tracker));
 });
-var ErrorEvent = /* @__PURE__ */ Struct({
+var ErrorEvent = /* @__PURE__ */ Struct2({
   type: /* @__PURE__ */ Literal2("error"),
   status: /* @__PURE__ */ Int.pipe(/* @__PURE__ */ withDecodingDefault(/* @__PURE__ */ succeed7(500))),
-  error: /* @__PURE__ */ Struct({
+  error: /* @__PURE__ */ Struct2({
     type: String6,
     message: String6
   })

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -40116,6 +40116,8 @@ var BoundedSelector = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLe
 var BoundedPattern = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(1024));
 var BoundedMessage2 = exports_Schema.String.check(exports_Schema.isMaxLength(SANDBOX_DIAGNOSTIC_MAX_LENGTH));
 var BoundedSchemaProperty = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+var BoundedSchemaText = exports_Schema.String.check(exports_Schema.isMaxLength(8 * 1024));
+var BoundedSchemaReference = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(8 * 1024));
 var PositiveInt4 = exports_Schema.Int.check(exports_Schema.isGreaterThan(0));
 var BoundedTimeoutMillis = PositiveInt4.check(exports_Schema.isLessThanOrEqualTo(60000));
 var ResponseFormatPrimitive = exports_Schema.Literals([
@@ -40128,24 +40130,74 @@ var ResponseFormatPrimitive = exports_Schema.Literals([
   "integer"
 ]);
 var ResponseFormatPrimitiveList = exports_Schema.Array(ResponseFormatPrimitive).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(7), exports_Schema.isUnique());
-var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.StructWithRest(exports_Schema.Struct({
-  type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
-  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
-  items: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  anyOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  oneOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  allOf: exports_Schema.optionalKey(exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
-}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]));
-var ResponseFormatDocument = exports_Schema.StructWithRest(exports_Schema.Struct({
-  type: exports_Schema.Literal("object"),
-  properties: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
-  required: exports_Schema.optionalKey(exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
-  additionalProperties: exports_Schema.optionalKey(exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode])),
-  $defs: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH)))
-}), [exports_Schema.Record(exports_Schema.String, exports_Schema.Json)]);
+var ResponseFormatNode = exports_Schema.suspend(() => exports_Schema.Struct(responseFormatFields()).pipe(exports_Schema.annotate({ parseOptions: { onExcessProperty: "error" } })));
+var responseFormatFields = () => {
+  const boundedNodes = exports_Schema.Array(ResponseFormatNode).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH));
+  const boundedDefinitions = exports_Schema.Record(BoundedSchemaProperty, ResponseFormatNode).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH));
+  const boundedRequired = exports_Schema.Array(BoundedSchemaProperty).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique());
+  const subschema = exports_Schema.Union([exports_Schema.Boolean, ResponseFormatNode]);
+  return {
+    $schema: exports_Schema.optionalKey(BoundedSchemaReference),
+    $id: exports_Schema.optionalKey(BoundedSchemaReference),
+    $ref: exports_Schema.optionalKey(BoundedSchemaReference),
+    $anchor: exports_Schema.optionalKey(BoundedSchemaReference),
+    $dynamicRef: exports_Schema.optionalKey(BoundedSchemaReference),
+    $dynamicAnchor: exports_Schema.optionalKey(BoundedSchemaReference),
+    $comment: exports_Schema.optionalKey(BoundedSchemaText),
+    title: exports_Schema.optionalKey(BoundedSchemaText),
+    description: exports_Schema.optionalKey(BoundedSchemaText),
+    default: exports_Schema.optionalKey(exports_Schema.Json),
+    deprecated: exports_Schema.optionalKey(exports_Schema.Boolean),
+    readOnly: exports_Schema.optionalKey(exports_Schema.Boolean),
+    writeOnly: exports_Schema.optionalKey(exports_Schema.Boolean),
+    examples: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Json).check(exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+    type: exports_Schema.optionalKey(exports_Schema.Union([ResponseFormatPrimitive, ResponseFormatPrimitiveList])),
+    enum: exports_Schema.optionalKey(exports_Schema.Array(exports_Schema.Json).check(exports_Schema.isMinLength(1), exports_Schema.isMaxLength(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH), exports_Schema.isUnique())),
+    const: exports_Schema.optionalKey(exports_Schema.Json),
+    multipleOf: exports_Schema.optionalKey(exports_Schema.Finite.check(exports_Schema.isGreaterThan(0))),
+    maximum: exports_Schema.optionalKey(exports_Schema.Finite),
+    exclusiveMaximum: exports_Schema.optionalKey(exports_Schema.Finite),
+    minimum: exports_Schema.optionalKey(exports_Schema.Finite),
+    exclusiveMinimum: exports_Schema.optionalKey(exports_Schema.Finite),
+    maxLength: exports_Schema.optionalKey(exports_Schema.Natural),
+    minLength: exports_Schema.optionalKey(exports_Schema.Natural),
+    pattern: exports_Schema.optionalKey(BoundedSchemaText),
+    format: exports_Schema.optionalKey(BoundedSchemaText),
+    maxItems: exports_Schema.optionalKey(exports_Schema.Natural),
+    minItems: exports_Schema.optionalKey(exports_Schema.Natural),
+    uniqueItems: exports_Schema.optionalKey(exports_Schema.Boolean),
+    prefixItems: exports_Schema.optionalKey(boundedNodes),
+    items: exports_Schema.optionalKey(subschema),
+    additionalItems: exports_Schema.optionalKey(subschema),
+    unevaluatedItems: exports_Schema.optionalKey(subschema),
+    contains: exports_Schema.optionalKey(subschema),
+    minContains: exports_Schema.optionalKey(exports_Schema.Natural),
+    maxContains: exports_Schema.optionalKey(exports_Schema.Natural),
+    properties: exports_Schema.optionalKey(boundedDefinitions),
+    patternProperties: exports_Schema.optionalKey(boundedDefinitions),
+    required: exports_Schema.optionalKey(boundedRequired),
+    dependentRequired: exports_Schema.optionalKey(exports_Schema.Record(BoundedSchemaProperty, boundedRequired).check(exports_Schema.isMaxProperties(MAX_RESPONSE_FORMAT_COLLECTION_LENGTH))),
+    dependentSchemas: exports_Schema.optionalKey(boundedDefinitions),
+    additionalProperties: exports_Schema.optionalKey(subschema),
+    unevaluatedProperties: exports_Schema.optionalKey(subschema),
+    propertyNames: exports_Schema.optionalKey(subschema),
+    minProperties: exports_Schema.optionalKey(exports_Schema.Natural),
+    maxProperties: exports_Schema.optionalKey(exports_Schema.Natural),
+    anyOf: exports_Schema.optionalKey(boundedNodes),
+    oneOf: exports_Schema.optionalKey(boundedNodes),
+    allOf: exports_Schema.optionalKey(boundedNodes),
+    not: exports_Schema.optionalKey(subschema),
+    contentEncoding: exports_Schema.optionalKey(BoundedSchemaText),
+    contentMediaType: exports_Schema.optionalKey(BoundedSchemaText),
+    contentSchema: exports_Schema.optionalKey(subschema),
+    $defs: exports_Schema.optionalKey(boundedDefinitions),
+    definitions: exports_Schema.optionalKey(boundedDefinitions)
+  };
+};
+var ResponseFormatDocument = exports_Schema.Struct({
+  ...responseFormatFields(),
+  type: exports_Schema.Literal("object")
+}).pipe(exports_Schema.annotate({ parseOptions: { onExcessProperty: "error" } }));
 var isResponseFormatDocument = exports_Schema.is(ResponseFormatDocument);
 var isBoundedResponseFormat = (input) => {
   if (!exports_Predicate.isObject(input))

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -40416,13 +40416,15 @@ class PageCaptureRateLimitedError extends exports_Schema.TaggedError()("PageCapt
   implementation: SandboxImplementation,
   reason: exports_Schema.Literals(["rate", "quota"]),
   retryAfterMillis: exports_Schema.optionalKey(exports_Schema.Natural),
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 
 class PageCaptureNavigationError extends exports_Schema.TaggedError()("PageCaptureNavigationError", {
   implementation: SandboxImplementation,
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -40449,7 +40449,8 @@ class PageCaptureOutputLimitError extends exports_Schema.TaggedError()("PageCapt
 
 class PageCaptureProtocolError extends exports_Schema.TaggedError()("PageCaptureProtocolError", {
   implementation: SandboxImplementation,
-  message: BoundedMessage2
+  message: BoundedMessage2,
+  cause: exports_Schema.optionalKey(exports_Schema.Defect())
 }) {
 }
 var PageCaptureError = exports_Schema.Union([


### PR DESCRIPTION
## Summary

Give agents a browser tool that renders one allowed page and returns bounded Markdown, HTML, links, or schema-validated extracted data.

- [Platform-neutral `PageCapture` contract](https://github.com/danieljvdm/effect-agent/blob/a9c318bd8d06bdb2a8e1218c9f8d3423b9bec09b/packages/sandbox/src/page-capture.ts#L618) with typed requests, bounded response values, resource accounting, and provider-neutral errors.
- [Model-facing `WebCapture` tools](https://github.com/danieljvdm/effect-agent/blob/a9c318bd8d06bdb2a8e1218c9f8d3423b9bec09b/packages/capabilities/src/web-capture.ts#L362) with immutable HTTPS allowlists, fixed actions, fail-closed request validation, visible decoder requirements, and uncertain execution.
- [Cloudflare Browser Run adapter](https://github.com/danieljvdm/effect-agent/blob/a9c318bd8d06bdb2a8e1218c9f8d3423b9bec09b/packages/platform-cloudflare/src/browser-quick-action.ts#L193) that uses the pinned native Quick Action overloads, bounds streamed responses, propagates subrequest allowlists, cleans up interrupted readers, and strictly decodes the native response envelope.
- [Effect-native browser binding service](https://github.com/danieljvdm/effect-agent/blob/a9c318bd8d06bdb2a8e1218c9f8d3423b9bec09b/packages/platform-cloudflare/src/browser-quick-action.ts#L79) that keeps the native Promise boundary inside its Layer and keeps browser authority visible in the adapter requirement channel.
- [Typed inference-policy failure](https://github.com/danieljvdm/effect-agent/blob/a9c318bd8d06bdb2a8e1218c9f8d3423b9bec09b/packages/sandbox/src/page-capture.ts#L552) for Workers AI authorization and accounting refusals. Host diagnostics remain in the live cause and never enter model-visible output.
- Opt-in credentialed live integration, deployment and security specifications, a release changeset, and refreshed GitHub Action bundles.

## What went wrong

The original implementation had several boundary errors. It silently dropped malformed links, accepted arbitrary JSON as an extraction schema, trusted page-shaped JSON when deciding transport framing, captured decoder services ambiently, reused one URL schema for both navigation authority and returned data, and lost or exposed foreign provider diagnostics at typed error boundaries.

The Cloudflare adapter also declared its own `quickAction(action: string, options: Record<string, unknown>): Promise<Response>` shape. That hid drift from Cloudflare's action-specific option types and exposed a naked Promise in framework code. Workers AI policy returned the full `PageCaptureError` union, so a host could report a policy refusal as an unrelated navigation or protocol error. Manual `JSON.parse` branches and raw-body fallbacks accepted wire shapes that the native binding does not promise.

This PR now validates complete payloads through canonical Effect Schemas, separates navigation targets from captured links, preserves foreign causes only in host-visible typed fields, and uses fixed public messages. The binding Layer accepts Cloudflare's native `BrowserRun`, exposes action-specific Effect methods, and converts Promise rejection to `BrowserQuickActionRpcError`. The Workers AI service has one narrow policy error, which maps to `PageCaptureInferencePolicyError`. Successful native calls must return Cloudflare's documented JSON envelope.

## Architecture

```text
worker BrowserRun binding
  -> BrowserQuickActionBrowserBinding Layer
  -> Effect-native action client
  -> PageCapture adapter
  -> WebCapture tools
```

The sandbox package owns the platform-neutral port, request and result Schemas, and public error union. Capabilities owns the model-facing tools and fixed egress authority. The Cloudflare package owns the only Promise bridge and the native Quick Action types. Structured extraction uses a separate Layer that requires the host-owned Workers AI authorization and accounting service before the browser RPC runs.

The live REST smoke supplies a test-only `BrowserQuickActionClient` because it does not receive a Worker binding. That client converts REST responses to the same native response envelope before calling the production adapter.

## Evidence

A credentialed live run fetched [Linear pricing](https://linear.app/pricing) through one real Cloudflare markdown action and a real OpenAI agent:

```text
Model: gpt-5.6-luna
Reasoning effort: medium
Service tier: fast

Basic:    $10 per user/month, billed yearly
Business: $16 per user/month, billed yearly
Savings:   $6 per user/month
```

The three changed regression suites pass all 37 tests, including native option projection, strict envelope decoding, binding rejection, stream limits and interruption, inference-policy refusal, and model-output redaction. `vp run check` passes and the generated Action bundles are current.

Local handoff caveat: `vp run ready` passes its check phase, then fails in tests outside the changed browser suites. The failures are in PR work-order example fixtures, the PR-review CLI example, and a toolchain fixture where Bun cannot write to the sandbox temp directory. CI will rerun the full suite in its normal environment.

## Follow-ups

- [#151: prove the deployed Worker binding and separately authorized live structured extraction](https://github.com/danieljvdm/effect-agent/issues/151)
- [#150: add a production REST PageCapture adapter with Kitesurf](https://github.com/danieljvdm/effect-agent/issues/150)
- [#149: add scoped interactive browser sessions](https://github.com/danieljvdm/effect-agent/issues/149)
- [#153: add bounded screenshot, PDF, and snapshot capture](https://github.com/danieljvdm/effect-agent/issues/153)
- [#152: add policy-bound multi-page crawl jobs](https://github.com/danieljvdm/effect-agent/issues/152)
