### PR TITLE
feat: make terminal delivery budget-aware and durable

### DIFF
--- a/.changeset/reliable-terminal-delivery.md
+++ b/.changeset/reliable-terminal-delivery.md
@@ -7,5 +7,5 @@
 "@effect-agent/testing": patch
 ---
 
-Add crash-safe terminal delivery Tools, completion-capacity reservation, Run-scoped prompt provenance, and target-aware compaction.
-Persist priced per-call model usage through durable hosts and expose aggregate usage on Run settlements.
+Add crash-safe terminal delivery Tools and final model responses, completion-capacity reservation, Run-scoped prompt provenance, and target-aware compaction.
+Persist priced per-call model usage in the DN and DC assemblies and expose aggregate usage on Run settlements.

--- a/.changeset/reliable-terminal-delivery.md
+++ b/.changeset/reliable-terminal-delivery.md
@@ -1,0 +1,11 @@
+---
+"@effect-agent/core": minor
+"@effect-agent/engine": minor
+"@effect-agent/session": minor
+"@effect-agent/platform-node": minor
+"@effect-agent/platform-cloudflare": minor
+"@effect-agent/testing": patch
+---
+
+Add crash-safe terminal delivery Tools, completion-capacity reservation, Run-scoped prompt provenance, and target-aware compaction.
+Persist priced per-call model usage through durable hosts and expose aggregate usage on Run settlements.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -58,7 +58,8 @@ The single durable terminal outcome owed to an accepted Submission: `completed`,
 `aborted`. A failed Settlement always carries the framework's bounded generic diagnostic;
 completed joined work and every aborted Settlement may legitimately have no result. An ordinary
 completed Settlement may materialize the Definition-validated, Schema-encoded application run
-disposition stored in its exact canonical record.
+disposition stored in its exact canonical record. A Run Settlement may also carry its canonical
+aggregate model-usage and estimated-cost summary; joined Submissions do not duplicate it.
 
 ## Agent capabilities
 
@@ -96,6 +97,12 @@ but before an outcome is recorded, recovery records an unknown outcome and does 
 **Durable Tool**  
 An Effect AI Tool whose handler requires the framework's Durable Step service and divides external
 effects into named Steps. The handler may be re-entered after interruption.
+
+**Completion Tool**
+
+The single Definition-designated Tool whose successful singleton call projects through the Agent
+output Schema and completes the Run immediately. It remains an ordinary external side effect for
+authorization and durability; the designation adds terminal semantics, not exactly-once execution.
 
 **Step**  
 A deterministically named sub-operation within one Durable Tool Call. Its result is
@@ -169,7 +176,8 @@ and acceptable final output.
 Creation of a model-context summary or branch that reduces future prompt size without erasing
 canonical evidence. Physical record deletion is a separate retention operation. The engine
 compacts natively at the pre-Turn seam when the estimated next context exceeds the Context Token
-Limit. It prunes old Tool results, summarizes through one metered model call, and records
+Limit or would consume the Completion Reserve. It prunes old Tool results, summarizes through one
+metered model call, and records
 each compaction in the DN and DC assemblies as a canonical `CompactionCreated` record that
 projections fold
 (RUN-026). Host-supplied, digest-bound compaction artifacts remain a separate capability.
@@ -181,6 +189,11 @@ model-visible prompt, so eviction rebuilds it without making its artifact author
 The optional `AgentPolicy.contextTokenLimit` bound on one model call's live context, supplied by
 the host from its model choice. Distinct from `tokenBudget` (the cumulative runaway stop) and
 `costBudgetMicrousd` (spend).
+
+**Completion Reserve**
+
+The `AgentPolicy.completionReserveTokens` capacity withheld from research when a cumulative token
+budget is configured, so the Run can enter finalization before delivery becomes unaffordable.
 
 **Tool Result Bounds**  
 The `AgentPolicy.toolResultBounds` byte bound (default 50 KiB) applied once to every application

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -33445,7 +33445,7 @@ class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsag
   model: UsageIdentity,
   serviceTier: exports_Schema.optionalKey(UsageIdentity),
   pricingVersion: exports_Schema.optionalKey(UsageIdentity),
-  modelCalls: exports_Schema.Natural,
+  modelCalls: exports_Schema.Natural.check(exports_Schema.isGreaterThan(0)),
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: exports_Schema.Natural
@@ -38243,6 +38243,7 @@ var makeAgentSpawner = (parent, depth) => ({
 });
 var AgentRuntime = {
   decodeFinalOutput,
+  encodeRunDisposition,
   projectCompletionOutput,
   run: run4,
   start,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -37350,7 +37350,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
         }));
       }
-      if (overToolBudget && trace2.applicationToolCalls.length > 0 && !completionBatch) {
+      if (overToolBudget && trace2.applicationToolCalls.length > 0 && !(completionBatch && policy2.onExhaustion === "final-answer")) {
         return afterValidatedResponse(exports_Effect.gen(function* () {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
             limit: "tool-calls",
@@ -37612,7 +37612,7 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
     const continuation = toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options);
     return settledChildJoinCallIds === undefined ? continuation : enforceDurationDeadline(continuation, context3.durationDeadlineMillis, durationLimitError(policy2));
   };
-  if (overToolBudget && !completionBatch) {
+  if (overToolBudget && !(completionBatch && policy2.onExhaustion === "final-answer")) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
       limit: "tool-calls",
       message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -30073,6 +30073,7 @@ var Agent;
       ...options,
       id: exports_Schema.decodeSync(AgentId)(id2),
       metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata }),
+      completion: options.completion === undefined ? undefined : Object.freeze({ ...options.completion }),
       runDisposition: options.runDisposition === undefined ? undefined : Object.freeze({ ...options.runDisposition })
     });
   }
@@ -30163,6 +30164,14 @@ class ContextOverflowError extends exports_Schema.TaggedError()("ContextOverflow
   retried: exports_Schema.Boolean
 }) {
 }
+
+class ContextBudgetError extends exports_Schema.TaggedError()("ContextBudgetError", {
+  message: exports_Schema.String,
+  estimatedTokens: exports_Schema.Natural,
+  targetTokens: exports_Schema.Natural,
+  completionReserveTokens: exports_Schema.Natural
+}) {
+}
 var AgentError = exports_Schema.Union([
   AgentInputError,
   AgentOutputError,
@@ -30173,7 +30182,8 @@ var AgentError = exports_Schema.Union([
   AgentApprovalPending,
   ModelProtocolError,
   AgentInterrupted,
-  ContextOverflowError
+  ContextOverflowError,
+  ContextBudgetError
 ]);
 // packages/core/src/subagent.ts
 var DelegationDepth = exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(1));
@@ -30570,6 +30580,7 @@ var AgentPolicyFields = exports_Schema.Struct({
   repeatedFailureLimit: NonNegativeInt,
   onExhaustion: OnExhaustion,
   tokenBudget: exports_Schema.optionalKey(PositiveInt),
+  completionReserveTokens: NonNegativeInt,
   costBudgetMicrousd: exports_Schema.optionalKey(NonNegativeInt),
   contextTokenLimit: exports_Schema.optionalKey(PositiveInt),
   toolResultBounds: ToolResultBounds,
@@ -30579,6 +30590,10 @@ var AgentPolicyFields = exports_Schema.Struct({
 
 class AgentPolicy extends exports_Schema.Class("AgentPolicy")(AgentPolicyFields) {
   static make(input) {
+    const completionReserveTokens = input.completionReserveTokens ?? (input.tokenBudget === undefined ? 4096 : Math.min(4096, Math.floor(input.tokenBudget / 5)));
+    if (input.tokenBudget !== undefined && completionReserveTokens > input.tokenBudget) {
+      throw new Error("completionReserveTokens cannot exceed tokenBudget");
+    }
     return super.make({
       ...input,
       maxDuration: exports_Duration.fromInputUnsafe(input.maxDuration),
@@ -30586,6 +30601,7 @@ class AgentPolicy extends exports_Schema.Class("AgentPolicy")(AgentPolicyFields)
       onExhaustion: input.onExhaustion ?? "final-answer",
       toolResultBounds: input.toolResultBounds ?? ToolResultBounds.make({ maxBytes: 50 * 1024 }),
       runStatus: input.runStatus ?? "appended",
+      completionReserveTokens,
       compaction: input.compaction ?? CompactionPolicy.make()
     });
   }
@@ -33071,12 +33087,48 @@ var applySpanTransformer = (transformer, response, options) => {
     });
   }
 };
+// node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Model.js
+var exports_Model = {};
+__export(exports_Model, {
+  make: () => make53,
+  ProviderName: () => ProviderName,
+  ModelName: () => ModelName
+});
+var TypeId49 = "~effect/ai/Model";
+
+class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ProviderName")) {
+}
+
+class ModelName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ModelName")) {
+}
+var Proto11 = {
+  [TypeId49]: TypeId49,
+  ["~effect/Layer"]: {
+    _ROut: identity,
+    _E: identity,
+    _RIn: identity
+  },
+  get captureRequirements() {
+    const self = this;
+    return contextWith2((context3) => succeed6(provide2(self, succeedContext(context3))));
+  },
+  ...PipeInspectableProto,
+  toJSON() {
+    return {
+      _id: "effect/ai/Model",
+      provider: this.provider
+    };
+  }
+};
+var make53 = (provider, modelName, layer16) => Object.assign(Object.create(Proto11), {
+  provider
+}, merge3(layer16, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Tool.js
 var exports_Tool = {};
 __export(exports_Tool, {
   unsafeSecureJsonParse: () => unsafeSecureJsonParse,
   providerDefined: () => providerDefined,
-  make: () => make53,
+  make: () => make54,
   isUserDefined: () => isUserDefined,
   isProviderDefined: () => isProviderDefined,
   isEmptyParamsRecord: () => isEmptyParamsRecord,
@@ -33086,7 +33138,7 @@ __export(exports_Tool, {
   getJsonSchema: () => getJsonSchema,
   getDescription: () => getDescription,
   dynamic: () => dynamic,
-  TypeId: () => TypeId49,
+  TypeId: () => TypeId50,
   Title: () => Title,
   Strict: () => Strict,
   Readonly: () => Readonly,
@@ -33099,15 +33151,15 @@ __export(exports_Tool, {
   DynamicTypeId: () => DynamicTypeId,
   Destructive: () => Destructive
 });
-var TypeId49 = "~effect/ai/Tool";
+var TypeId50 = "~effect/ai/Tool";
 var ProviderDefinedTypeId = "~effect/ai/Tool/ProviderDefined";
 var DynamicTypeId = "~effect/ai/Tool/Dynamic";
-var isUserDefined = (u) => hasProperty(u, TypeId49) && !isProviderDefined(u) && !isDynamic(u);
+var isUserDefined = (u) => hasProperty(u, TypeId50) && !isProviderDefined(u) && !isDynamic(u);
 var isProviderDefined = (u) => hasProperty(u, ProviderDefinedTypeId);
 var isDynamic = (u) => hasProperty(u, DynamicTypeId);
 var clone2 = (self, overrides) => Object.assign(Object.create(Object.getPrototypeOf(self)), self, overrides);
-var Proto11 = {
-  [TypeId49]: {
+var Proto12 = {
+  [TypeId50]: {
     _Requirements: identity
   },
   pipe() {
@@ -33148,15 +33200,15 @@ var Proto11 = {
   }
 };
 var ProviderDefinedProto = {
-  ...Proto11,
+  ...Proto12,
   [ProviderDefinedTypeId]: ProviderDefinedTypeId
 };
 var DynamicProto = {
-  ...Proto11,
+  ...Proto12,
   [DynamicTypeId]: DynamicTypeId
 };
 var userDefinedProto = (options) => {
-  const self = Object.assign(Object.create(Proto11), options);
+  const self = Object.assign(Object.create(Proto12), options);
   self.id = `effect/ai/Tool/${options.name}`;
   return self;
 };
@@ -33169,7 +33221,7 @@ var dynamicProto = (options) => {
   self.id = `effect/ai/Tool/${options.name}`;
   return self;
 };
-var make53 = (name, options) => {
+var make54 = (name, options) => {
   const successSchema = options?.success ?? Void2;
   const failureSchema = options?.failure ?? Never2;
   return userDefinedProto({
@@ -33350,6 +33402,55 @@ class IdGenerator2 extends exports_Context.Service()("@effect-agent/core/IdGener
     nextRunId: exports_IdGenerator.defaultIdGenerator.generateId().pipe(exports_Effect.map((id2) => exports_Schema.decodeSync(RunId)(`run-${id2}`))),
     nextTurnId: exports_IdGenerator.defaultIdGenerator.generateId().pipe(exports_Effect.map((id2) => exports_Schema.decodeSync(TurnId)(`turn-${id2}`)))
   });
+}
+// packages/core/src/usage.ts
+var UsageIdentity = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+
+class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")({
+  total: exports_Schema.Natural,
+  uncached: exports_Schema.Natural,
+  cacheRead: exports_Schema.Natural,
+  cacheWrite: exports_Schema.Natural
+}) {
+}
+
+class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")({
+  total: exports_Schema.Natural,
+  text: exports_Schema.Natural,
+  reasoning: exports_Schema.Natural
+}) {
+}
+
+class ModelCallUsage extends exports_Schema.Class("@effect-agent/core/ModelCallUsage")({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: exports_Schema.optionalKey(UsageIdentity),
+  pricingVersion: exports_Schema.optionalKey(UsageIdentity),
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural
+}) {
+}
+
+class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsageGroup")({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: exports_Schema.optionalKey(UsageIdentity),
+  pricingVersion: exports_Schema.optionalKey(UsageIdentity),
+  modelCalls: exports_Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural
+}) {
+}
+
+class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")({
+  modelCalls: exports_Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural,
+  byModel: exports_Schema.Array(ModelUsageGroup)
+}) {
 }
 // packages/capabilities/src/redaction.ts
 var MAX_REDACTED_PREVIEW_BYTES = 8 * 1024;
@@ -35087,7 +35188,7 @@ var RunResumeUsageSchema = exports_Schema.Struct({
   lastInputTokens: exports_Schema.Natural,
   lastOutputTokens: exports_Schema.Natural,
   costMicrousd: exports_Schema.Natural
-}).check(exports_Schema.makeFilter((usage) => usage.lastInputTokens <= usage.inputTokens && usage.lastOutputTokens <= usage.outputTokens, {
+}).check(exports_Schema.makeFilter((usage2) => usage2.lastInputTokens <= usage2.inputTokens && usage2.lastOutputTokens <= usage2.outputTokens, {
   expected: "last-call token usage no greater than cumulative token usage"
 }));
 // packages/engine/src/run-events.ts
@@ -35189,31 +35290,31 @@ var schemaClassToolPartPreflight = (part, toolkit) => {
     return;
   }
 };
-var inspectModelResponsePartCapacity = (usage, part, limits, knownSafePrototypes = knownSafeModelResponsePrototypes) => exports_Effect.suspend(() => {
-  if (usage.responsePartCount >= limits.maxModelResponseParts) {
+var inspectModelResponsePartCapacity = (usage2, part, limits, knownSafePrototypes = knownSafeModelResponsePrototypes) => exports_Effect.suspend(() => {
+  if (usage2.responsePartCount >= limits.maxModelResponseParts) {
     return exports_Effect.fail(ModelProtocolError.make({
       message: `Model response exceeded the ${limits.maxModelResponseParts}-part response limit`
     }));
   }
-  const bytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage.responsePartBytes, knownSafePrototypes);
+  const bytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage2.responsePartBytes, knownSafePrototypes);
   return bytes === undefined ? exports_Effect.fail(ModelProtocolError.make({
     message: `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
   })) : exports_Effect.succeed(bytes);
 });
-var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart")(function* (part, toolkit, usage, limits) {
-  const directInputBytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage.responsePartBytes, knownSafeModelResponsePrototypes);
+var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart")(function* (part, toolkit, usage2, limits) {
+  const directInputBytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage2.responsePartBytes, knownSafeModelResponsePrototypes);
   if (directInputBytes === undefined) {
     const preflight = schemaClassToolPartPreflight(part, toolkit);
-    yield* inspectModelResponsePartCapacity(usage, preflight ?? part, limits);
+    yield* inspectModelResponsePartCapacity(usage2, preflight ?? part, limits);
   } else {
-    yield* inspectModelResponsePartCapacity(usage, part, limits);
+    yield* inspectModelResponsePartCapacity(usage2, part, limits);
   }
   const codec = exports_Schema.toCodecJson(exports_Response.StreamPart(toolkit));
   const encodingFailure = ModelProtocolError.make({
     message: "Model response part failed canonical encoding"
   });
   const encoded = yield* exports_Schema.encodeUnknownEffect(codec)(part).pipe(exports_Effect.mapError(() => encodingFailure));
-  const retainedBytes = yield* inspectModelResponsePartCapacity(usage, encoded, limits);
+  const retainedBytes = yield* inspectModelResponsePartCapacity(usage2, encoded, limits);
   const ownedEncoded = yield* exports_Effect.try({
     try: () => {
       if (typeof structuredCloneFunction !== "function") {
@@ -35232,15 +35333,15 @@ var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart"
   const ownedPart = yield* exports_Schema.decodeUnknownEffect(codec)(ownedEncoded).pipe(exports_Effect.mapError(() => decodingFailure));
   return { ownedPart, retainedBytes };
 });
-var consumeModelResponsePart = (usage, retainedBytes, limits) => exports_Effect.suspend(() => {
-  if (usage.responsePartCount >= limits.maxModelResponseParts || !Number.isSafeInteger(retainedBytes) || retainedBytes < 0 || retainedBytes > limits.maxModelResponseBytes - usage.responsePartBytes) {
+var consumeModelResponsePart = (usage2, retainedBytes, limits) => exports_Effect.suspend(() => {
+  if (usage2.responsePartCount >= limits.maxModelResponseParts || !Number.isSafeInteger(retainedBytes) || retainedBytes < 0 || retainedBytes > limits.maxModelResponseBytes - usage2.responsePartBytes) {
     return exports_Effect.fail(ModelProtocolError.make({
-      message: usage.responsePartCount >= limits.maxModelResponseParts ? `Model response exceeded the ${limits.maxModelResponseParts}-part response limit` : `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
+      message: usage2.responsePartCount >= limits.maxModelResponseParts ? `Model response exceeded the ${limits.maxModelResponseParts}-part response limit` : `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
     }));
   }
   return exports_Effect.sync(() => {
-    usage.responsePartCount += 1;
-    usage.responsePartBytes += retainedBytes;
+    usage2.responsePartCount += 1;
+    usage2.responsePartBytes += retainedBytes;
   });
 });
 var withSemaphorePermit = (semaphore, stream) => exports_Stream.scoped(exports_Stream.fromEffect(exports_Effect.acquireRelease(semaphore.take(1), (permits) => semaphore.release(permits).pipe(exports_Effect.asVoid))).pipe(exports_Stream.flatMap(() => stream)));
@@ -36022,23 +36123,57 @@ var outgoingModelPrompt = (policy2, context3, prepared, turn, declaredToolCalls)
     })
   ]);
 });
-var consumeUsage = (agent2, context3, usage, toolCallCount, options) => exports_Effect.gen(function* () {
-  if (usage === undefined) {
+var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => exports_Effect.gen(function* () {
+  if (usage2 === undefined) {
     return yield* AgentPolicyError.make({
       limit: "usage",
       message: "A completed model response did not report usage"
     });
   }
-  const inputTokens = Math.max(0, usage.inputTokens.total ?? (usage.inputTokens.uncached ?? 0) + (usage.inputTokens.cacheRead ?? 0) + (usage.inputTokens.cacheWrite ?? 0));
-  const outputTokens = Math.max(0, usage.outputTokens.total ?? (usage.outputTokens.text ?? 0) + (usage.outputTokens.reasoning ?? 0));
+  const natural = (value4) => value4 === undefined || !Number.isSafeInteger(value4) ? 0 : Math.max(0, value4);
+  const reportedUncached = natural(usage2.inputTokens.uncached);
+  const cacheRead = natural(usage2.inputTokens.cacheRead);
+  const cacheWrite = natural(usage2.inputTokens.cacheWrite);
+  const reportedText = natural(usage2.outputTokens.text);
+  const reasoning = natural(usage2.outputTokens.reasoning);
+  const inputTokens = Math.max(natural(usage2.inputTokens.total), reportedUncached + cacheRead + cacheWrite);
+  const outputTokens = Math.max(natural(usage2.outputTokens.total), reportedText + reasoning);
+  const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
+  const text = Math.max(reportedText, outputTokens - reasoning);
   const totalTokens = inputTokens + outputTokens;
-  const costMicrousd = options.estimateCostMicrousd === undefined ? 0 : yield* options.estimateCostMicrousd(usage);
+  const provider = yield* exports_Model.ProviderName;
+  const model = yield* exports_Model.ModelName;
+  const estimate = options.estimateCostMicrousd === undefined ? 0 : yield* options.estimateCostMicrousd(usage2, { provider, model, usage: usage2 });
+  const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
   if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
     return yield* AgentPolicyError.make({
       limit: "cost",
       message: "Model cost estimation must produce a non-negative integer number of microdollars"
     });
   }
+  const serviceTier = typeof estimate === "number" ? undefined : estimate.serviceTier;
+  const pricingVersion = typeof estimate === "number" ? undefined : estimate.pricingVersion;
+  const validPricingIdentity = (value4) => value4 === undefined || value4.length > 0 && value4.length <= 256;
+  if (!validPricingIdentity(serviceTier) || !validPricingIdentity(pricingVersion)) {
+    return yield* AgentPolicyError.make({
+      limit: "cost",
+      message: "Model cost estimation returned an invalid service tier or pricing version"
+    });
+  }
+  const modelUsage = ModelCallUsage.make({
+    provider,
+    model,
+    ...serviceTier === undefined ? {} : { serviceTier },
+    ...pricingVersion === undefined ? {} : { pricingVersion },
+    inputTokens: InputTokenUsage.make({
+      total: inputTokens,
+      uncached,
+      cacheRead,
+      cacheWrite
+    }),
+    outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
+    costMicrousd
+  });
   context3.modelCalls += 1;
   context3.inputTokens += inputTokens;
   context3.outputTokens += outputTokens;
@@ -36046,6 +36181,9 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options) => exports_
   context3.lastOutputTokens = outputTokens;
   context3.costMicrousd += costMicrousd;
   context3.lastCostMicrousd = costMicrousd;
+  if (options.durability !== undefined) {
+    yield* options.durability.noteTurnUsage({ turn, usage: modelUsage });
+  }
   const policy2 = agent2.definition.policy;
   const consumedTokens = context3.inputTokens + context3.outputTokens;
   const tokenBudget = policy2.tokenBudget;
@@ -36084,7 +36222,8 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options) => exports_
       totalTokens,
       toolCalls: toolCallCount,
       costMicrousd,
-      usage
+      usage: usage2,
+      modelUsage
     };
     yield* options.budget.consume(delta);
   }
@@ -36098,7 +36237,7 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options) => exports_
       limitValue: tokenBudget
     }));
   }
-  return { breach, warnings };
+  return { breach, warnings, modelUsage };
 });
 var eventBaseFor = exports_Effect.fnUntraced(function* (context3, terminal) {
   const ceiling = terminal ? context3.bufferLimits.maxRunEvents : context3.bufferLimits.maxRunEvents - 1;
@@ -36190,17 +36329,17 @@ var nextContextEstimate = (context3, view) => {
   return estimatePromptTokens(view);
 };
 var overflowText = (error2) => `${error2.message} ${error2.reason.message}`;
-var compactContext = (agent2, context3, source, turn, options, forceSummarize) => exports_Effect.gen(function* () {
+var compactContext = (agent2, context3, source, turn, options, targetTokens, forceSummarize, allowSummarize = true) => exports_Effect.gen(function* () {
   const policy2 = agent2.definition.policy;
   const state = context3.compaction;
   const events2 = [];
   const messages = source.content;
   const before = estimatePromptTokens(buildCompactedView(messages, state));
-  const limit = policy2.contextTokenLimit;
   const mode = policy2.compaction.mode;
+  const keepRecentTokens = targetTokens === undefined ? policy2.compaction.keepRecentTokens : Math.max(1, Math.min(policy2.compaction.keepRecentTokens, targetTokens));
   const commitDurable = (commit) => options.durability === undefined ? exports_Effect.void : options.durability.commitCompaction(commit);
   if (!forceSummarize && mode !== "summarize") {
-    const bound = choosePruneBound(messages, state, policy2.compaction.keepRecentTokens);
+    const bound = choosePruneBound(messages, state, keepRecentTokens);
     if (bound > state.clearedThrough) {
       state.clearedThrough = bound;
       state.lastViewLength = -1;
@@ -36218,15 +36357,15 @@ var compactContext = (agent2, context3, source, turn, options, forceSummarize) =
         tokensBeforeEstimate: before,
         tokensAfterEstimate: after2
       });
-      if (limit !== undefined && after2 <= limit) {
+      if (targetTokens !== undefined && after2 <= targetTokens) {
         return { events: events2 };
       }
     }
   }
-  if (mode === "prune" && !forceSummarize) {
+  if ((!allowSummarize || mode === "prune") && !forceSummarize) {
     return { events: events2 };
   }
-  const cut = chooseSummarizeCut(messages, state, policy2.compaction.keepRecentTokens);
+  const cut = chooseSummarizeCut(messages, state, keepRecentTokens);
   const covered = collectCoveredMessages(messages, state, cut);
   if (covered.length === 0) {
     return { events: events2 };
@@ -36263,17 +36402,9 @@ ${transcript}
   })));
   const wasFinalizing = context3.finalizing;
   context3.finalizing = true;
-  const consumed = yield* consumeUsage(agent2, context3, summaryUsage, 0, options).pipe(exports_Effect.ensuring(exports_Effect.sync(() => {
+  const consumed = yield* consumeUsage(agent2, context3, summaryUsage, 0, turn, options).pipe(exports_Effect.ensuring(exports_Effect.sync(() => {
     context3.finalizing = wasFinalizing;
   })));
-  if (options.durability !== undefined) {
-    yield* options.durability.noteTurnUsage({
-      turn,
-      inputTokens: context3.lastInputTokens,
-      outputTokens: context3.lastOutputTokens,
-      costMicrousd: context3.lastCostMicrousd
-    });
-  }
   events2.push(...consumed.warnings);
   const summaryText = pieces.join("").trim();
   const summary2 = summaryText.length === 0 ? "(no summary produced)" : summaryText;
@@ -36683,6 +36814,39 @@ var decodeFinalOutput = exports_Effect.fn("AgentRuntime.decodeFinalOutput")(func
   })));
   return { encoded: eventJson, decoded };
 });
+var encodeOutputCandidate = exports_Effect.fn("AgentRuntime.encodeOutputCandidate")(function* (agent2, candidate) {
+  const decoded = yield* exports_Schema.decodeUnknownEffect(agent2.definition.output)(candidate).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: cause.message
+  })));
+  const encoded = yield* exports_Schema.encodeUnknownEffect(agent2.definition.output)(decoded).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool output failed Schema encoding: ${cause.message}`
+  })));
+  const json = yield* exports_Schema.decodeUnknownEffect(exports_Schema.Json)(encoded).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool output did not encode as durable JSON: ${cause.message}`
+  })));
+  return { encoded: json, decoded };
+});
+var projectCompletionOutput = exports_Effect.fn("AgentRuntime.projectCompletionOutput")(function* (agent2, declaration, parameters, result4) {
+  const tool = agent2.definition.toolkit.tools[declaration.tool];
+  if (tool === undefined) {
+    return yield* ModelProtocolError.make({
+      message: `Agent completion declaration references unknown Tool ${declaration.tool}`
+    });
+  }
+  const decodedParameters = yield* exports_Schema.decodeUnknownEffect(tool.parametersSchema)(parameters).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool parameters failed canonical decoding: ${cause.message}`
+  })));
+  const decodedResult = yield* exports_Schema.decodeUnknownEffect(tool.successSchema)(result4).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool result failed canonical decoding: ${cause.message}`
+  })));
+  const projected = yield* exports_Effect.try({
+    try: () => declaration.project({ parameters: decodedParameters, result: decodedResult }),
+    catch: (cause) => AgentOutputError.make({
+      message: `Completion Tool projector failed: ${cause instanceof Error ? cause.message : String(cause)}`
+    })
+  });
+  return yield* encodeOutputCandidate(agent2, projected);
+});
 var encodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.encodeRunDisposition")(function* (declaration, output) {
   const selected = yield* exports_Effect.try({
     try: () => declaration.fromOutput(output),
@@ -36777,7 +36941,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
   }).pipe(exports_Effect.withLogSpan("AgentRuntime.model"))).pipe(exports_Stream.flatMap(exports_Stream.fromIterable));
   const policy2 = agent2.definition.policy;
   const bounds = effectiveRunBounds(policy2, options);
-  const finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > bounds.maxTurns || priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls || context3.tokenExhausted);
+  let finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > bounds.maxTurns || priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls || context3.tokenExhausted);
   if (finalAnswerOnly && context3.exhaustedDimension === undefined) {
     context3.exhaustedDimension = turn > bounds.maxTurns ? "turns" : priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls ? "tool-calls" : "tokens";
   }
@@ -36791,14 +36955,49 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
   const outputContractTokens = outputContractMessage === undefined ? 0 : estimatePromptTokens([
     exports_Prompt.makeMessage("system", { content: outputContractMessage })
   ]);
+  const derivedPrompt = yield* outgoingModelPrompt(policy2, context3, exports_Prompt.fromMessages([]), turn, priorToolCalls);
+  const derivedPromptTokens = outputContractTokens + estimatePromptTokens(derivedPrompt.content);
   let preEvents = [];
-  if (policy2.contextTokenLimit !== undefined && !context3.finalizing) {
+  if (!context3.finalizing) {
+    const consumedTokens = context3.inputTokens + context3.outputTokens;
+    const tokenCallTarget = policy2.tokenBudget === undefined || finalAnswerOnly ? undefined : Math.max(0, policy2.tokenBudget - consumedTokens - policy2.completionReserveTokens);
+    const contextCallTarget = policy2.contextTokenLimit;
+    const fullTarget = tokenCallTarget === undefined ? contextCallTarget : contextCallTarget === undefined ? tokenCallTarget : Math.min(tokenCallTarget, contextCallTarget);
+    const sourceTarget = fullTarget === undefined ? undefined : Math.max(0, fullTarget - derivedPromptTokens);
     const view = buildCompactedView(modelContext.prompt.content, context3.compaction);
-    const estimate = nextContextEstimate(context3, view);
-    if (estimate + outputContractTokens > policy2.contextTokenLimit && context3.compaction.lastCompactionTurn !== turn) {
+    const estimate = nextContextEstimate(context3, view) + derivedPromptTokens;
+    const contextPressure = contextCallTarget !== undefined && estimate > contextCallTarget;
+    const tokenPressure = tokenCallTarget !== undefined && estimate > tokenCallTarget;
+    if ((contextPressure || tokenPressure) && sourceTarget !== undefined && sourceTarget > 0 && context3.compaction.lastCompactionTurn !== turn) {
       context3.compaction.lastCompactionTurn = turn;
-      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options, false);
+      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options, sourceTarget, false, !tokenPressure);
       preEvents = outcome.events;
+    }
+    const prepared = buildCompactedView(modelContext.prompt.content, context3.compaction);
+    const preparedEstimate = nextContextEstimate(context3, prepared) + derivedPromptTokens;
+    if (context3.tokenExhausted) {
+      finalAnswerOnly = true;
+    }
+    const preparedTokenCallTarget = policy2.tokenBudget === undefined || finalAnswerOnly ? undefined : Math.max(0, policy2.tokenBudget - (context3.inputTokens + context3.outputTokens) - policy2.completionReserveTokens);
+    if (contextCallTarget !== undefined && preparedEstimate > contextCallTarget) {
+      return yield* ContextBudgetError.make({
+        message: `Compaction could not fit the next model prompt inside the ${contextCallTarget} token context target`,
+        estimatedTokens: preparedEstimate,
+        targetTokens: contextCallTarget,
+        completionReserveTokens: policy2.completionReserveTokens
+      });
+    }
+    if (preparedTokenCallTarget !== undefined && preparedEstimate > preparedTokenCallTarget) {
+      const error2 = AgentPolicyError.make({
+        limit: "tokens",
+        message: `The next research call would consume this Run's ${policy2.completionReserveTokens} token completion reserve`
+      });
+      if (policy2.onExhaustion === "fail") {
+        return yield* error2;
+      }
+      context3.tokenExhausted = true;
+      context3.exhaustedDimension ??= "tokens";
+      finalAnswerOnly = true;
     }
   }
   const compactedOutgoing = () => {
@@ -36810,14 +37009,20 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     prompt: outputContractMessage === undefined ? outgoing : insertOutputContract(outgoing, outputContractMessage),
     toolkit: agent2.definition.toolkit,
     disableToolCallResolution: true,
-    ...finalAnswerOnly ? { toolChoice: "none" } : {}
+    ...finalAnswerOnly ? agent2.definition.completion === undefined ? { toolChoice: "none" } : {
+      toolChoice: {
+        mode: "auto",
+        oneOf: [agent2.definition.completion.tool]
+      }
+    } : {}
   }), options.budget).pipe(exports_Stream.mapEffect((part) => ownModelResponsePart(part, agent2.definition.toolkit, trace2, context3.bufferLimits).pipe(exports_Effect.flatMap((owned) => eventsForPart(context3, turnId, turn, agent2.definition.toolkit.tools, trace2, owned.ownedPart, owned.retainedBytes)))), exports_Stream.flatMap(exports_Stream.fromIterable)))));
   const response = attempt(compactedOutgoing()).pipe(exports_Stream.catch((error2) => {
     if (!(error2 instanceof exports_AiError.AiError) || !isContextOverflowMessage(overflowText(error2))) {
       return exports_Stream.fail(error2);
     }
     const message = overflowText(error2);
-    if (trace2.parts.length > 0 || policy2.contextTokenLimit === undefined) {
+    const contextTokenLimit = policy2.contextTokenLimit;
+    if (trace2.parts.length > 0 || contextTokenLimit === undefined) {
       return exports_Stream.fail(ContextOverflowError.make({ message, retried: false }));
     }
     if (context3.compaction.overflowRetryTurn === turn) {
@@ -36826,10 +37031,20 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     context3.compaction.overflowRetryTurn = turn;
     context3.compaction.lastCompactionTurn = turn;
     return exports_Stream.unwrap(exports_Effect.gen(function* () {
-      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options, true).pipe(exports_Effect.mapError((inner) => inner instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(inner)) ? ContextOverflowError.make({
+      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options, Math.max(0, contextTokenLimit - derivedPromptTokens), true).pipe(exports_Effect.mapError((inner) => inner instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(inner)) ? ContextOverflowError.make({
         message: overflowText(inner),
         retried: true
       }) : inner));
+      const retryView = buildCompactedView(modelContext.prompt.content, context3.compaction);
+      const retryEstimate = nextContextEstimate(context3, retryView) + derivedPromptTokens;
+      if (retryEstimate > contextTokenLimit) {
+        return yield* ContextBudgetError.make({
+          message: `Overflow compaction could not fit the retry inside the ${contextTokenLimit} token context target`,
+          estimatedTokens: retryEstimate,
+          targetTokens: contextTokenLimit,
+          completionReserveTokens: policy2.completionReserveTokens
+        });
+      }
       const retried = attempt(compactedOutgoing()).pipe(exports_Stream.catch((again) => again instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(again)) ? exports_Stream.fail(ContextOverflowError.make({
         message: overflowText(again),
         retried: true
@@ -36855,9 +37070,17 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     if (hasProviderCalls && turnCompletion === undefined) {
       return failRunEventStream(ModelProtocolError.make({ message: "Model response omitted staged Turn completion" }));
     }
-    if (finalAnswerOnly && trace2.toolCalls.size > 0) {
+    const completionTool = agent2.definition.completion?.tool;
+    const declaresCompletion = completionTool !== undefined && trace2.applicationToolCalls.some((call) => call.name === completionTool);
+    if (declaresCompletion && trace2.toolCalls.size !== 1) {
       return failRunEventStream(ModelProtocolError.make({
-        message: `Model declared ${trace2.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion`
+        message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+      }));
+    }
+    const completionBatch = declaresCompletion && trace2.toolCalls.size === 1 && trace2.applicationToolCalls.length === 1;
+    if (finalAnswerOnly && trace2.toolCalls.size > 0 && !completionBatch) {
+      return failRunEventStream(ModelProtocolError.make({
+        message: completionTool === undefined ? `Model declared ${trace2.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion` : `Model declared ${trace2.toolCalls.size} non-completion Tool Call(s) after budget exhaustion`
       }));
     }
     const providerOnly = trace2.toolCalls.size > 0 && Array.from(trace2.toolCalls.values()).every(({ providerExecuted }) => providerExecuted);
@@ -36869,7 +37092,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     }
     const toolCalls = priorToolCalls + trace2.toolCalls.size;
     const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-    if (overToolBudget && policy2.onExhaustion === "fail") {
+    if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
       return failRunEventStream(AgentPolicyError.make({
         limit: "tool-calls",
         message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
@@ -36887,15 +37110,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
       ...additions
     ]);
     const afterValidatedResponse = (next2) => stagedResponse.pipe(exports_Stream.concat(exports_Stream.unwrap(exports_Effect.gen(function* () {
-      const consumed = yield* consumeUsage(agent2, context3, trace2.usage, trace2.toolCalls.size, options);
-      if (options.durability !== undefined) {
-        yield* options.durability.noteTurnUsage({
-          turn,
-          inputTokens: context3.lastInputTokens,
-          outputTokens: context3.lastOutputTokens,
-          costMicrousd: context3.lastCostMicrousd
-        });
-      }
+      const consumed = yield* consumeUsage(agent2, context3, trace2.usage, trace2.toolCalls.size, turn, options);
       const pre = [...consumed.warnings];
       if (!context3.warnedLimits.has("tool-calls") && nearingLimit(toolCalls + context3.programmaticToolCalls, bounds.maxToolCalls)) {
         context3.warnedLimits.add("tool-calls");
@@ -36930,7 +37145,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
             }))));
           }
         }
-        if (trace2.applicationToolCalls.length > 0) {
+        if (trace2.applicationToolCalls.length > 0 && !completionBatch) {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
             limit: "tokens",
             message: `Token budget exhausted: this Run's ${policy2.tokenBudget ?? 0} token budget was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
@@ -36984,13 +37199,14 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         }));
       }
       const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      if (turnsBlocked) {
+      const completionTurnAllowed = completionBatch;
+      if (turnsBlocked && !completionTurnAllowed) {
         return failRunEventStream(AgentPolicyError.make({
           limit: "turns",
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
         }));
       }
-      if (overToolBudget && trace2.applicationToolCalls.length > 0) {
+      if (overToolBudget && trace2.applicationToolCalls.length > 0 && !completionBatch) {
         return afterValidatedResponse(exports_Effect.gen(function* () {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
             limit: "tool-calls",
@@ -37061,6 +37277,33 @@ var toolBatchContinuation = (agent2, context3, trace2, prompt, turn, toolCalls, 
     ...promptFromTurnParts(trace2).content,
     toolMessage2
   ]);
+  const completion = agent2.definition.completion;
+  const completionResult = completion !== undefined && trace2.applicationToolCalls.length === 1 && orderedResults.length === 1 && orderedResults[0]?.name === completion.tool && orderedResults[0].isFailure === false ? orderedResults[0] : undefined;
+  if (completion !== undefined && completionResult !== undefined) {
+    const call = trace2.applicationCallDescriptors[0];
+    if (call === undefined) {
+      return failRunEventStream(ModelProtocolError.make({
+        message: `Completion Tool ${completion.tool} has no canonical call descriptor`
+      }));
+    }
+    const output = yield* projectCompletionOutput(agent2, completion, call.parameters, completionResult.encodedResult);
+    yield* advanceHistory(context3, history, options);
+    const bounds = effectiveRunBounds(agent2.definition.policy, options);
+    const exhausted = context3.tokenExhausted ? "tokens" : turn > bounds.maxTurns ? "turns" : toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls ? "tool-calls" : context3.exhaustedDimension;
+    if (exhausted !== undefined && context3.exhaustedDimension === undefined) {
+      context3.exhaustedDimension = exhausted;
+    }
+    const declaration = agent2.definition.runDisposition;
+    const runDisposition = exhausted !== undefined || declaration === undefined ? undefined : yield* encodeRunDisposition(agent2, output.decoded);
+    return exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
+      ...base2,
+      output: output.encoded,
+      ...runDisposition === undefined ? {} : { runDisposition },
+      turns: turn,
+      finishReason: exhausted === undefined ? "completed" : "budget-exhausted",
+      ...exhausted === undefined ? {} : { exhausted }
+    })));
+  }
   yield* advanceHistory(context3, history, options);
   const steering = yield* drainInputs(context3, options);
   const nextPrompt = yield* appendInputs(context3, history, steering, options);
@@ -37136,6 +37379,13 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
       executionClass: getToolExecutionClass(tool)
     });
   }
+  const completionTool = agent2.definition.completion?.tool;
+  if (completionTool !== undefined && trace2.applicationToolCalls.some((call) => call.name === completionTool) && trace2.toolCalls.size !== 1) {
+    return failRunEventStream(ModelProtocolError.make({
+      message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+    }));
+  }
+  const completionBatch = completionTool !== undefined && trace2.toolCalls.size === 1 && trace2.applicationToolCalls[0]?.name === completionTool;
   const settledIds = new Set;
   const settledInputs = yield* snapshotResumedSettledCalls(resume, declarationByCallId.size);
   for (const settledInput of settledInputs) {
@@ -37174,14 +37424,15 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
   const bounds = effectiveRunBounds(policy2, options);
   const toolCalls = trace2.toolCalls.size;
   const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-  if (overToolBudget && policy2.onExhaustion === "fail") {
+  if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "tool-calls",
       message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
     }));
   }
   const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-  if (turnsBlocked) {
+  const completionTurnAllowed = completionBatch;
+  if (turnsBlocked && !completionTurnAllowed) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "turns",
       message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
@@ -37218,7 +37469,7 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
     const continuation = toolBatchContinuation(agent2, context3, trace2, resumedPrompt, turn, toolCalls, options);
     return settledChildJoinCallIds === undefined ? continuation : enforceDurationDeadline(continuation, context3.durationDeadlineMillis, durationLimitError(policy2));
   };
-  if (overToolBudget) {
+  if (overToolBudget && !completionBatch) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace2, AgentPolicyError.make({
       limit: "tool-calls",
       message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
@@ -39199,7 +39450,7 @@ var toRunBudgetHook = (budget) => ({
     costMicrousd: delta.costMicrousd
   }).pipe(exports_Effect.mapError((error2) => BudgetAdapterError.make({
     message: `Engine usage delta is invalid: ${error2.message}`
-  })), exports_Effect.flatMap((usage) => budget.consume(usage)), exports_Effect.asVoid)
+  })), exports_Effect.flatMap((usage2) => budget.consume(usage2)), exports_Effect.asVoid)
 });
 var toRunConversationOptions = exports_Effect.fn("toRunConversationOptions")(function* (conversations, conversationId, runId) {
   const snapshot3 = yield* conversations.snapshot(conversationId);
@@ -39329,9 +39580,9 @@ function Stream(success, error2) {
 }
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/rpc/Rpc.js
-var TypeId50 = "~effect/rpc/Rpc";
-var Proto12 = {
-  [TypeId50]: TypeId50,
+var TypeId51 = "~effect/rpc/Rpc";
+var Proto13 = {
+  [TypeId51]: TypeId51,
   pipe() {
     return pipeArguments(this, arguments);
   },
@@ -39415,12 +39666,12 @@ var Proto12 = {
 };
 var makeProto3 = (options) => {
   function Rpc() {}
-  Object.setPrototypeOf(Rpc, Proto12);
+  Object.setPrototypeOf(Rpc, Proto13);
   Object.assign(Rpc, options);
   Rpc.key = `effect/rpc/Rpc/${options._tag}`;
   return Rpc;
 };
-var make54 = (tag2, options) => {
+var make55 = (tag2, options) => {
   const successSchema = options?.success ?? Void2;
   const errorSchema = options?.error ?? Never2;
   const defectSchema = options?.defect ?? Defect();
@@ -39613,7 +39864,7 @@ class InitializeResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2
 }))) {
 }
 
-class Initialize extends (/* @__PURE__ */ make54("initialize", {
+class Initialize extends (/* @__PURE__ */ make55("initialize", {
   success: InitializeResult,
   error: McpError,
   payload: {
@@ -39624,7 +39875,7 @@ class Initialize extends (/* @__PURE__ */ make54("initialize", {
   }
 })) {
 }
-class CancelledNotification extends (/* @__PURE__ */ make54("notifications/cancelled", {
+class CancelledNotification extends (/* @__PURE__ */ make55("notifications/cancelled", {
   payload: {
     ...NotificationMeta.fields,
     requestId: RequestId,
@@ -39633,7 +39884,7 @@ class CancelledNotification extends (/* @__PURE__ */ make54("notifications/cance
 })) {
 }
 
-class ProgressNotification extends (/* @__PURE__ */ make54("notifications/progress", {
+class ProgressNotification extends (/* @__PURE__ */ make55("notifications/progress", {
   payload: {
     ...NotificationMeta.fields,
     progressToken: ProgressToken,
@@ -39704,7 +39955,7 @@ class ReadResourceResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struc
 }))) {
 }
 
-class ReadResource extends (/* @__PURE__ */ make54("resources/read", {
+class ReadResource extends (/* @__PURE__ */ make55("resources/read", {
   success: ReadResourceResult,
   error: McpError,
   payload: {
@@ -39713,7 +39964,7 @@ class ReadResource extends (/* @__PURE__ */ make54("resources/read", {
   }
 })) {
 }
-class Subscribe extends (/* @__PURE__ */ make54("resources/subscribe", {
+class Subscribe extends (/* @__PURE__ */ make55("resources/subscribe", {
   success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
@@ -39723,7 +39974,7 @@ class Subscribe extends (/* @__PURE__ */ make54("resources/subscribe", {
 })) {
 }
 
-class Unsubscribe extends (/* @__PURE__ */ make54("resources/unsubscribe", {
+class Unsubscribe extends (/* @__PURE__ */ make55("resources/unsubscribe", {
   success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
@@ -39733,7 +39984,7 @@ class Unsubscribe extends (/* @__PURE__ */ make54("resources/unsubscribe", {
 })) {
 }
 
-class ResourceUpdatedNotification extends (/* @__PURE__ */ make54("notifications/resources/updated", {
+class ResourceUpdatedNotification extends (/* @__PURE__ */ make55("notifications/resources/updated", {
   payload: {
     ...NotificationMeta.fields,
     uri: String6
@@ -39818,7 +40069,7 @@ class GetPromptResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/GetP
 })) {
 }
 
-class GetPrompt extends (/* @__PURE__ */ make54("prompts/get", {
+class GetPrompt extends (/* @__PURE__ */ make55("prompts/get", {
   success: GetPromptResult,
   error: McpError,
   payload: {
@@ -39868,7 +40119,7 @@ class CallToolResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/CallT
 })) {
 }
 
-class CallTool extends (/* @__PURE__ */ make54("tools/call", {
+class CallTool extends (/* @__PURE__ */ make55("tools/call", {
   success: CallToolResult,
   error: McpError,
   payload: {
@@ -39880,7 +40131,7 @@ class CallTool extends (/* @__PURE__ */ make54("tools/call", {
 }
 var LoggingLevel = /* @__PURE__ */ Literals(["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"]);
 
-class SetLevel extends (/* @__PURE__ */ make54("logging/setLevel", {
+class SetLevel extends (/* @__PURE__ */ make55("logging/setLevel", {
   payload: {
     ...RequestMeta.fields,
     level: LoggingLevel
@@ -39890,7 +40141,7 @@ class SetLevel extends (/* @__PURE__ */ make54("logging/setLevel", {
 })) {
 }
 
-class LoggingMessageNotification extends (/* @__PURE__ */ make54("notifications/message", {
+class LoggingMessageNotification extends (/* @__PURE__ */ make55("notifications/message", {
   payload: /* @__PURE__ */ Struct2({
     ...NotificationMeta.fields,
     level: LoggingLevel,
@@ -39963,7 +40214,7 @@ class CreateMessageResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 })) {
 }
 
-class CreateMessage extends (/* @__PURE__ */ make54("sampling/createMessage", {
+class CreateMessage extends (/* @__PURE__ */ make55("sampling/createMessage", {
   success: CreateMessageResult,
   error: McpError,
   payload: {
@@ -40128,7 +40379,7 @@ class ElicitDeclineResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 }
 var ElicitResult = /* @__PURE__ */ Union2([ElicitAcceptResult, ElicitDeclineResult]);
 
-class Elicit extends (/* @__PURE__ */ make54("elicitation/create", {
+class Elicit extends (/* @__PURE__ */ make55("elicitation/create", {
   success: ElicitResult,
   error: McpError,
   payload: ElicitRequestParams
@@ -40674,7 +40925,7 @@ var reserveTransition = (ledger, request3) => {
   };
   return [ok(reservationView(reservationId, reservation)), next2];
 };
-var observeTransition = (ledger, reservationId, usage) => {
+var observeTransition = (ledger, reservationId, usage2) => {
   const reservation = ledger.reservations.get(reservationId);
   if (reservation === undefined) {
     return [fail13(SubagentReservationUnknown.make({ reservationId })), ledger];
@@ -40690,7 +40941,7 @@ var observeTransition = (ledger, reservationId, usage) => {
     ...parent.cumulativeOverrun
   };
   for (const spec of dimensionSpecs) {
-    const delta = usage[spec.key];
+    const delta = usage2[spec.key];
     if (delta === undefined) {
       continue;
     }
@@ -40804,8 +41055,8 @@ var SubagentReservationsMemoryLive = exports_Layer.effect(SubagentReservations, 
       const result4 = yield* exports_Ref.modify(state, (ledger) => reserveTransition(ledger, request3));
       return yield* resolve4(result4);
     }),
-    observe: exports_Effect.fn("SubagentReservations.observe")(function* (reservationId, usage) {
-      const result4 = yield* exports_Ref.modify(state, (ledger) => observeTransition(ledger, reservationId, usage));
+    observe: exports_Effect.fn("SubagentReservations.observe")(function* (reservationId, usage2) {
+      const result4 = yield* exports_Ref.modify(state, (ledger) => observeTransition(ledger, reservationId, usage2));
       return yield* resolve4(result4);
     }),
     beginRelease: exports_Effect.fn("SubagentReservations.beginRelease")(function* (reservationId) {
@@ -41001,10 +41252,10 @@ __export(exports_FetchHttpClient, {
 });
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/Headers.js
-var TypeId51 = /* @__PURE__ */ Symbol.for("~effect/http/Headers");
-var Proto13 = /* @__PURE__ */ Object.defineProperties(/* @__PURE__ */ Object.create(null), {
-  [TypeId51]: {
-    value: TypeId51
+var TypeId52 = /* @__PURE__ */ Symbol.for("~effect/http/Headers");
+var Proto14 = /* @__PURE__ */ Object.defineProperties(/* @__PURE__ */ Object.create(null), {
+  [TypeId52]: {
+    value: TypeId52
   },
   [symbolRedactable]: {
     value(context4) {
@@ -41033,20 +41284,20 @@ var Proto13 = /* @__PURE__ */ Object.defineProperties(/* @__PURE__ */ Object.cre
     value: BaseProto[NodeInspectSymbol]
   }
 });
-var make55 = (input) => Object.assign(Object.create(Proto13), input);
+var make56 = (input) => Object.assign(Object.create(Proto14), input);
 var Equivalence6 = /* @__PURE__ */ makeEquivalence4(/* @__PURE__ */ strictEqual());
-var empty14 = /* @__PURE__ */ Object.create(Proto13);
+var empty14 = /* @__PURE__ */ Object.create(Proto14);
 var fromInput2 = (input) => {
   if (input === undefined) {
     return empty14;
   } else if (Symbol.iterator in input) {
-    const out2 = Object.create(Proto13);
+    const out2 = Object.create(Proto14);
     for (const [k, v] of input) {
       out2[k.toLowerCase()] = v;
     }
     return out2;
   }
-  const out = Object.create(Proto13);
+  const out = Object.create(Proto14);
   for (const [k, v] of Object.entries(input)) {
     if (Array.isArray(v)) {
       out[k.toLowerCase()] = v.join(", ");
@@ -41056,23 +41307,23 @@ var fromInput2 = (input) => {
   }
   return out;
 };
-var fromRecordUnsafe = (input) => Object.setPrototypeOf(input, Proto13);
+var fromRecordUnsafe = (input) => Object.setPrototypeOf(input, Proto14);
 var set5 = /* @__PURE__ */ dual(3, (self, key, value4) => {
-  const out = make55(self);
+  const out = make56(self);
   out[key.toLowerCase()] = value4;
   return out;
 });
-var setAll = /* @__PURE__ */ dual(2, (self, headers) => make55({
+var setAll = /* @__PURE__ */ dual(2, (self, headers) => make56({
   ...self,
   ...fromInput2(headers)
 }));
 var merge7 = /* @__PURE__ */ dual(2, (self, headers) => {
-  const out = make55(self);
+  const out = make56(self);
   Object.assign(out, headers);
   return out;
 });
 var remove7 = /* @__PURE__ */ dual(2, (self, key) => {
-  const out = make55(self);
+  const out = make56(self);
   delete out[key.toLowerCase()];
   return out;
 });
@@ -41142,7 +41393,7 @@ __export(exports_HttpClient, {
   mapRequestEffect: () => mapRequestEffect,
   mapRequest: () => mapRequest,
   makeWith: () => makeWith2,
-  make: () => make59,
+  make: () => make60,
   layerMergedContext: () => layerMergedContext,
   isHttpClient: () => isHttpClient,
   head: () => head4,
@@ -41165,10 +41416,10 @@ __export(exports_HttpClient, {
 });
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/Cookies.js
-var TypeId52 = "~effect/http/Cookies";
+var TypeId53 = "~effect/http/Cookies";
 var CookieTypeId = "~effect/http/Cookies/Cookie";
-var Proto14 = {
-  [TypeId52]: TypeId52,
+var Proto15 = {
+  [TypeId53]: TypeId53,
   ...BaseProto,
   toJSON() {
     return {
@@ -41181,7 +41432,7 @@ var Proto14 = {
   }
 };
 var fromReadonlyRecord = (cookies) => {
-  const self = Object.create(Proto14);
+  const self = Object.create(Proto15);
   self.cookies = cookies;
   return self;
 };
@@ -41354,11 +41605,11 @@ var tryDecodeURIComponent = (str) => {
 };
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/UrlParams.js
-var TypeId53 = "~effect/http/UrlParams";
-var isUrlParams = (u) => hasProperty(u, TypeId53);
-var Proto15 = {
+var TypeId54 = "~effect/http/UrlParams";
+var isUrlParams = (u) => hasProperty(u, TypeId54);
+var Proto16 = {
   ...PipeInspectableProto,
-  [TypeId53]: TypeId53,
+  [TypeId54]: TypeId54,
   [Symbol.iterator]() {
     return this.params[Symbol.iterator]();
   },
@@ -41375,8 +41626,8 @@ var Proto15 = {
     return array(this.params.flat());
   }
 };
-var make56 = (params) => {
-  const self = Object.create(Proto15);
+var make57 = (params) => {
+  const self = Object.create(Proto16);
   self.params = params;
   return self;
 };
@@ -41394,7 +41645,7 @@ var fromInput3 = (input) => {
       out.push(parsed[i]);
     }
   }
-  return make56(out);
+  return make57(out);
 };
 var fromInputNested = (input) => {
   const entries3 = typeof input[Symbol.iterator] === "function" ? fromIterable2(input) : Object.entries(input);
@@ -41432,13 +41683,13 @@ var UrlParamsSchema = /* @__PURE__ */ declare(isUrlParams, {
   expected: "UrlParams",
   toEquivalence: () => Equivalence7,
   toCodec: () => link3()(ArraySchema(Tuple3([String6, String6])), transform2({
-    decode: make56,
+    decode: make57,
     encode: (self) => self.params
   }))
 });
-var empty15 = /* @__PURE__ */ make56([]);
-var set7 = /* @__PURE__ */ dual(3, (self, key, value4) => make56(append(filter3(self.params, ([k]) => k !== key), [key, String(value4)])));
-var transform3 = /* @__PURE__ */ dual(2, (self, f) => make56(f(self.params)));
+var empty15 = /* @__PURE__ */ make57([]);
+var set7 = /* @__PURE__ */ dual(3, (self, key, value4) => make57(append(filter3(self.params, ([k]) => k !== key), [key, String(value4)])));
+var transform3 = /* @__PURE__ */ dual(2, (self, f) => make57(f(self.params)));
 var setAll2 = /* @__PURE__ */ dual(2, (self, input) => {
   const out = fromInput3(input);
   const params = out.params;
@@ -41453,7 +41704,7 @@ var setAll2 = /* @__PURE__ */ dual(2, (self, input) => {
   }
   return out;
 });
-var append3 = /* @__PURE__ */ dual(3, (self, key, value4) => make56(append(self.params, [key, String(value4)])));
+var append3 = /* @__PURE__ */ dual(3, (self, key, value4) => make57(append(self.params, [key, String(value4)])));
 var appendAll3 = /* @__PURE__ */ dual(2, (self, input) => transform3(self, appendAll(fromInput3(input).params)));
 var toString = (input) => new URLSearchParams(fromInput3(input).params).toString();
 var toRecord = (self) => {
@@ -41479,17 +41730,17 @@ var schemaRecord = /* @__PURE__ */ UrlParamsSchema.pipe(/* @__PURE__ */ decodeTo
 })));
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpBody.js
-var TypeId54 = "~effect/http/HttpBody";
+var TypeId55 = "~effect/http/HttpBody";
 var HttpBodyErrorTypeId = "~effect/http/HttpBody/HttpBodyError";
 
 class HttpBodyError extends (/* @__PURE__ */ TaggedError2("HttpBodyError")) {
   [HttpBodyErrorTypeId] = HttpBodyErrorTypeId;
 }
 
-class Proto16 {
-  [TypeId54];
+class Proto17 {
+  [TypeId55];
   constructor() {
-    this[TypeId54] = TypeId54;
+    this[TypeId55] = TypeId55;
   }
   [NodeInspectSymbol]() {
     return this.toJSON();
@@ -41501,7 +41752,7 @@ class Proto16 {
   }
 }
 
-class Empty2 extends Proto16 {
+class Empty2 extends Proto17 {
   _tag = "Empty";
   toJSON() {
     return {
@@ -41512,7 +41763,7 @@ class Empty2 extends Proto16 {
 }
 var empty16 = /* @__PURE__ */ new Empty2;
 
-class Raw extends Proto16 {
+class Raw extends Proto17 {
   _tag = "Raw";
   body;
   contentType;
@@ -41535,7 +41786,7 @@ class Raw extends Proto16 {
 }
 var raw = (body, options) => new Raw(body, options?.contentType, options?.contentLength);
 
-class Uint8Array3 extends Proto16 {
+class Uint8Array3 extends Proto17 {
   _tag = "Uint8Array";
   body;
   contentType;
@@ -41582,7 +41833,7 @@ var jsonSchema = (schema3, options) => {
 };
 var urlParams = (urlParams2, contentType) => text(toString(fromInput3(urlParams2)), contentType ?? "application/x-www-form-urlencoded");
 
-class FormData3 extends Proto16 {
+class FormData3 extends Proto17 {
   _tag = "FormData";
   contentType = undefined;
   contentLength = undefined;
@@ -41624,7 +41875,7 @@ var formDataRecord = (entries3) => {
   return formData(data);
 };
 
-class Stream2 extends Proto16 {
+class Stream2 extends Proto17 {
   _tag = "Stream";
   stream;
   contentType;
@@ -41652,8 +41903,8 @@ var fileContentLength = (size9, options) => {
 var file = (path, options) => flatMap5(FileSystem, (fs) => map8(fs.stat(path), (info2) => stream2(fs.stream(path, options), options?.contentType, fileContentLength(info2.size, options))));
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpClientError.js
-var TypeId55 = "~effect/http/HttpClientError";
-var isHttpClientError = (u) => hasProperty(u, TypeId55);
+var TypeId56 = "~effect/http/HttpClientError";
+var isHttpClientError = (u) => hasProperty(u, TypeId56);
 
 class HttpClientError extends (/* @__PURE__ */ TaggedError2("HttpClientError")) {
   constructor(props) {
@@ -41666,7 +41917,7 @@ class HttpClientError extends (/* @__PURE__ */ TaggedError2("HttpClientError")) 
       super(props);
     }
   }
-  [TypeId55] = TypeId55;
+  [TypeId56] = TypeId56;
   get request() {
     return this.reason.request;
   }
@@ -41754,7 +42005,7 @@ __export(exports_HttpClientRequest, {
   options: () => options,
   modify: () => modify5,
   makeWith: () => makeWith,
-  make: () => make58,
+  make: () => make59,
   isHttpClientRequest: () => isHttpClientRequest,
   head: () => head3,
   get: () => get10,
@@ -41795,7 +42046,7 @@ var updateHeaders = (headers, body) => {
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/Url.js
 class UrlError extends (/* @__PURE__ */ TaggedError2("UrlError")) {
 }
-var make57 = (url2, params, hash2) => try_({
+var make58 = (url2, params, hash2) => try_({
   try: () => {
     const urlInstance = new URL(url2, baseUrl());
     for (let i = 0;i < params.params.length; i++) {
@@ -41821,10 +42072,10 @@ var baseUrl = () => {
 };
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpClientRequest.js
-var TypeId56 = "~effect/http/HttpClientRequest";
-var isHttpClientRequest = (u) => hasProperty(u, TypeId56);
-var Proto17 = {
-  [TypeId56]: TypeId56,
+var TypeId57 = "~effect/http/HttpClientRequest";
+var isHttpClientRequest = (u) => hasProperty(u, TypeId57);
+var Proto18 = {
+  [TypeId57]: TypeId57,
   ...BaseProto,
   toJSON() {
     return {
@@ -41842,7 +42093,7 @@ var Proto17 = {
   }
 };
 function makeWith(method, url2, urlParams2, hash2, headers, body) {
-  const self = Object.create(Proto17);
+  const self = Object.create(Proto18);
   self.method = method;
   self.url = url2;
   self.urlParams = urlParams2;
@@ -41852,19 +42103,19 @@ function makeWith(method, url2, urlParams2, hash2, headers, body) {
   return self;
 }
 var empty17 = /* @__PURE__ */ makeWith("GET", "", empty15, /* @__PURE__ */ none2(), empty14, empty16);
-var make58 = (method) => (url2, options) => modify5(empty17, {
+var make59 = (method) => (url2, options) => modify5(empty17, {
   method,
   url: url2,
   ...options ?? undefined
 });
-var get10 = /* @__PURE__ */ make58("GET");
-var post = /* @__PURE__ */ make58("POST");
-var patch = /* @__PURE__ */ make58("PATCH");
-var put = /* @__PURE__ */ make58("PUT");
-var del = /* @__PURE__ */ make58("DELETE");
-var head3 = /* @__PURE__ */ make58("HEAD");
-var options = /* @__PURE__ */ make58("OPTIONS");
-var trace2 = /* @__PURE__ */ make58("TRACE");
+var get10 = /* @__PURE__ */ make59("GET");
+var post = /* @__PURE__ */ make59("POST");
+var patch = /* @__PURE__ */ make59("PATCH");
+var put = /* @__PURE__ */ make59("PUT");
+var del = /* @__PURE__ */ make59("DELETE");
+var head3 = /* @__PURE__ */ make59("HEAD");
+var options = /* @__PURE__ */ make59("OPTIONS");
+var trace2 = /* @__PURE__ */ make59("TRACE");
 var modify5 = /* @__PURE__ */ dual(2, (self, options2) => {
   let result4 = self;
   if (options2.method) {
@@ -41954,7 +42205,7 @@ var bodyFormDataRecord = /* @__PURE__ */ dual(2, (self, entries3) => setBody(sel
 var bodyStream = /* @__PURE__ */ dual((args2) => isHttpClientRequest(args2[0]), (self, body, options2) => setBody(self, stream2(body, options2?.contentType, options2?.contentLength)));
 var bodyFile = /* @__PURE__ */ dual((args2) => isHttpClientRequest(args2[0]), (self, path, options2) => map8(file(path, options2), (body) => setBody(self, body)));
 function toUrl(self) {
-  const r = make57(self.url, self.urlParams, getOrUndefined(self.hash));
+  const r = make58(self.url, self.urlParams, getOrUndefined(self.hash));
   if (isSuccess2(r)) {
     return some3(r.success);
   }
@@ -41986,7 +42237,7 @@ var parseContentLength = (contentLength) => {
   return Number.isNaN(parsed) ? undefined : parsed;
 };
 var toWebResult = (self, options2) => {
-  const url2 = make57(self.url, self.urlParams, getOrUndefined(self.hash));
+  const url2 = make58(self.url, self.urlParams, getOrUndefined(self.hash));
   if (isFailure2(url2)) {
     return fail2(url2.failure);
   }
@@ -42050,11 +42301,11 @@ __export(exports_HttpClientResponse, {
   fromWeb: () => fromWeb2,
   filterStatusOk: () => filterStatusOk,
   filterStatus: () => filterStatus,
-  TypeId: () => TypeId58
+  TypeId: () => TypeId59
 });
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpIncomingMessage.js
-var TypeId57 = "~effect/http/HttpIncomingMessage";
+var TypeId58 = "~effect/http/HttpIncomingMessage";
 var schemaBodyJson2 = (schema3, options2) => {
   const decode2 = decodeEffect2(toCodecJson(schema3));
   const decodeJson = options2?.reviver === undefined ? undefined : decodeEffect2(fromJsonString2(toCodecJson(schema3), options2));
@@ -42092,7 +42343,7 @@ var inspect = (self, that) => {
 };
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpClientResponse.js
-var TypeId58 = "~effect/http/HttpClientResponse";
+var TypeId59 = "~effect/http/HttpClientResponse";
 var fromWeb2 = (request3, source) => new WebHttpClientResponse(request3, source);
 var schemaJson = (schema3, options2) => {
   const decode2 = decodeEffect2(toCodecJson(schema3).annotate({
@@ -42146,16 +42397,16 @@ var filterStatusOk = (self) => self.status >= 200 && self.status < 300 ? succeed
 }));
 
 class WebHttpClientResponse extends Class2 {
-  [TypeId57];
   [TypeId58];
+  [TypeId59];
   request;
   source;
   constructor(request3, source) {
     super();
     this.request = request3;
     this.source = source;
-    this[TypeId57] = TypeId57;
     this[TypeId58] = TypeId58;
+    this[TypeId59] = TypeId59;
   }
   toJSON() {
     return inspect(this, {
@@ -42271,8 +42522,8 @@ var toHeaders = (span2) => fromRecordUnsafe({
 });
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/http/HttpClient.js
-var TypeId59 = "~effect/http/HttpClient";
-var isHttpClient = (u) => hasProperty(u, TypeId59);
+var TypeId60 = "~effect/http/HttpClient";
+var isHttpClient = (u) => hasProperty(u, TypeId60);
 var HttpClient = /* @__PURE__ */ Service("effect/HttpClient");
 var accessor = (method) => (...args2) => flatMap5(HttpClient, (client) => client[method](...args2));
 var execute = /* @__PURE__ */ accessor("execute");
@@ -42293,7 +42544,7 @@ var filterOrFail4 = /* @__PURE__ */ dual(3, (self, f, orFailWith) => transformRe
 var filterStatus2 = /* @__PURE__ */ dual(2, (self, f) => transformResponse(self, flatMap5(filterStatus(f))));
 var filterStatusOk2 = /* @__PURE__ */ transformResponse(/* @__PURE__ */ flatMap5(filterStatusOk));
 var makeWith2 = (postprocess, preprocess) => {
-  const self = Object.create(Proto18);
+  const self = Object.create(Proto19);
   self.preprocess = preprocess;
   self.postprocess = postprocess;
   self.execute = function(request3) {
@@ -42301,8 +42552,8 @@ var makeWith2 = (postprocess, preprocess) => {
   };
   return self;
 };
-var Proto18 = {
-  [TypeId59]: TypeId59,
+var Proto19 = {
+  [TypeId60]: TypeId60,
   pipe() {
     return pipeArguments(this, arguments);
   },
@@ -42313,13 +42564,13 @@ var Proto18 = {
     };
   },
   .../* @__PURE__ */ Object.fromEntries(/* @__PURE__ */ allShort.map(([fullMethod, method]) => [method, function(url2, options3) {
-    return this.execute(make58(fullMethod)(url2, options3));
+    return this.execute(make59(fullMethod)(url2, options3));
   }]))
 };
-var make59 = (f) => makeWith2((effect2) => flatMap5(effect2, (request3) => withFiber2((fiber3) => {
+var make60 = (f) => makeWith2((effect2) => flatMap5(effect2, (request3) => withFiber2((fiber3) => {
   const scopedController = scopedRequests.get(request3);
   const controller = scopedController ?? new AbortController;
-  const urlResult = make57(request3.url, request3.urlParams, getOrUndefined(request3.hash));
+  const urlResult = make58(request3.url, request3.urlParams, getOrUndefined(request3.hash));
   if (isFailure2(urlResult)) {
     return fail6(new HttpClientError({
       reason: new InvalidUrlError({
@@ -42703,8 +42954,8 @@ class InterruptibleResponse {
     this.original = original;
     this.controller = controller;
   }
+  [TypeId59] = TypeId59;
   [TypeId58] = TypeId58;
-  [TypeId57] = TypeId57;
   applyInterrupt(effect2) {
     return suspend3(() => {
       responseRegistry.unregister(this.original);
@@ -42773,7 +43024,7 @@ var Fetch = /* @__PURE__ */ Reference("effect/http/FetchHttpClient/Fetch", {
 
 class RequestInit extends (/* @__PURE__ */ Service()("effect/http/FetchHttpClient/RequestInit")) {
 }
-var fetch = /* @__PURE__ */ make59((request3, url2, signal, fiber3) => {
+var fetch = /* @__PURE__ */ make60((request3, url2, signal, fiber3) => {
   const fetch2 = fiber3.getRef(Fetch);
   const options3 = getOrUndefined2(fiber3.context, RequestInit) ?? {};
   let headers = options3.headers ? merge7(fromInput2(options3.headers), request3.headers) : request3.headers;
@@ -46523,7 +46774,7 @@ var resolveReviewContinuityContext = exports_Effect.fn("resolveReviewContinuityC
   return { adjudications, priorFindingsOnScope };
 });
 var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function* () {
-  const { metadata, files, anchorFiles, fingerprint, usage } = context4;
+  const { metadata, files, anchorFiles, fingerprint, usage: usage2 } = context4;
   const executionContext = yield* ReviewExecutionContext;
   const adjudications = context4.adjudications ?? [];
   const adjudicatedIdentities = new Set(adjudications.map(adjudicationIdentity));
@@ -46625,7 +46876,7 @@ var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function
     headRef: metadata.headRef,
     modelLabel: options3.modelLabel,
     runUrl: options3.runUrl,
-    usage,
+    usage: usage2,
     fingerprint: skipFingerprint,
     inputCoverage,
     assurance,
@@ -46650,7 +46901,7 @@ var settleReviewRun = (core2, context4, options3) => exports_Effect.gen(function
     unreviewedPaths,
     plan,
     turns: core2.turns,
-    ...usage === undefined ? {} : { usage },
+    ...usage2 === undefined ? {} : { usage: usage2 },
     reviewMode: executionContext.mode,
     reviewReason: executionContext.reason,
     ...continuity.state === undefined ? {} : { state: continuity.state },
@@ -46690,14 +46941,14 @@ var executeReview = (binding, options3) => exports_Effect.gen(function* () {
     totalAnchorFiles: metadata.totalChangedFiles,
     events: events2
   });
-  const usage = yield* budget2.snapshot;
+  const usage2 = yield* budget2.snapshot;
   return yield* settleReviewRun({
     review,
     inputCoverage: assessment.inputCoverage,
     assurance: assessment.assurance,
     unreviewedPaths: assessment.unreviewedPaths,
     turns: result4.turns
-  }, { metadata, files, anchorFiles, fingerprint, usage, adjudications: continuity.adjudications }, options3);
+  }, { metadata, files, anchorFiles, fingerprint, usage: usage2, adjudications: continuity.adjudications }, options3);
 });
 var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* () {
   const source = yield* PullRequestSource;
@@ -46736,7 +46987,7 @@ var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* ()
     anchorFiles,
     totalAnchorFiles: metadata.totalChangedFiles
   });
-  const usage = yield* budget2.snapshot;
+  const usage2 = yield* budget2.snapshot;
   return yield* settleReviewRun({
     review: pipeline.review,
     inputCoverage,
@@ -46747,7 +46998,7 @@ var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* ()
       paths: pass.paths.slice(0, 12)
     })),
     turns: pipeline.turns
-  }, { metadata, files, anchorFiles, fingerprint, usage, adjudications: continuity.adjudications }, options3);
+  }, { metadata, files, anchorFiles, fingerprint, usage: usage2, adjudications: continuity.adjudications }, options3);
 });
 
 // packages/pr-review/src/internal/factory.ts
@@ -46780,7 +47031,7 @@ var makeReviewSnapshot = (ignore6) => provideIgnore(exports_Effect.gen(function*
     files: yield* source.anchorFiles
   };
 }), ignore6);
-var make60 = (options3) => {
+var make61 = (options3) => {
   const extraTools = options3.extraTools ?? EMPTY_TOOLS;
   requireReadonly(extraTools);
   const definition = Agent.define("pr-reviewer", {
@@ -46875,7 +47126,7 @@ var makeFanOut = (options3) => {
     }
   };
 };
-var PrReview = { make: make60, makeFanOut };
+var PrReview = { make: make61, makeFanOut };
 
 // packages/pr-review/src/internal/progress.ts
 var PROGRESS_COMMENT_MARKER_PREFIX = "<!-- effect-agent-pr-review progress";
@@ -47194,7 +47445,7 @@ var compactReviewLoggingLayer = exports_Layer.unwrap(exports_Effect.gen(function
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/AnthropicClient.js
 var exports_AnthropicClient = {};
 __export(exports_AnthropicClient, {
-  make: () => make62,
+  make: () => make63,
   layerConfig: () => layerConfig,
   layer: () => layer17,
   AnthropicClient: () => AnthropicClient
@@ -49540,7 +49791,7 @@ var WebSearchToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input
 });
 var StopReason = /* @__PURE__ */ Literals(["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "refusal"]);
 var BetaStopReason = /* @__PURE__ */ Literals(["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "compaction", "refusal", "model_context_window_exceeded"]);
-var Model2 = /* @__PURE__ */ Union2([String6, Literals(["claude-sonnet-5", "claude-fable-5", "claude-mythos-5", "claude-opus-4-8", "claude-opus-4-7", "claude-mythos-preview", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-opus-4-1", "claude-opus-4-1-20250805"])]).annotate({
+var Model = /* @__PURE__ */ Union2([String6, Literals(["claude-sonnet-5", "claude-fable-5", "claude-mythos-5", "claude-opus-4-8", "claude-opus-4-7", "claude-mythos-preview", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-opus-4-1", "claude-opus-4-1-20250805"])]).annotate({
   title: "Model",
   description: `The model that will complete your prompt.
 
@@ -50369,7 +50620,7 @@ var CompletionResponse = /* @__PURE__ */ Struct2({
 
 The format and length of IDs may change over time.`
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([String6, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"stop_sequence"`: we reached a stop sequence — either provided by you via the `stop_sequences` parameter, or a stop sequence built into the model\n* `"max_tokens"`: we exceeded `max_tokens_to_sample` or the model\'s maximum'
@@ -50741,7 +50992,7 @@ The format and length of IDs may change over time.`
     title: "Content",
     description: 'Content generated by the model.\n\nThis is an array of content blocks, each of which has a `type` that determines its shape.\n\nExample:\n\n```json\n[{"type": "text", "text": "Hi, I\'m Claude."}]\n```\n\nIf the request input `messages` ended with an `assistant` turn, then the response `content` will continue directly from that last turn. You can use this to constrain the model\'s output.\n\nFor example, if the input `messages` were:\n```json\n[\n  {"role": "user", "content": "What\'s the Greek name for Sun? (A) Sol (B) Helios (C) Sun"},\n  {"role": "assistant", "content": "The best answer is ("}\n]\n```\n\nThen the response `content` might be:\n\n```json\n[{"type": "text", "text": "B)"}]\n```'
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([BetaStopReason, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"end_turn"`: the model reached a natural stopping point\n* `"max_tokens"`: we exceeded the requested `max_tokens` or the model\'s maximum\n* `"stop_sequence"`: one of your provided custom `stop_sequences` was generated\n* `"tool_use"`: the model invoked one or more tools\n* `"pause_turn"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `"refusal"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.'
@@ -50835,7 +51086,7 @@ The format and length of IDs may change over time.`
     title: "Content",
     description: 'Content generated by the model.\n\nThis is an array of content blocks, each of which has a `type` that determines its shape.\n\nExample:\n\n```json\n[{"type": "text", "text": "Hi, I\'m Claude."}]\n```\n\nIf the request input `messages` ended with an `assistant` turn, then the response `content` will continue directly from that last turn. You can use this to constrain the model\'s output.\n\nFor example, if the input `messages` were:\n```json\n[\n  {"role": "user", "content": "What\'s the Greek name for Sun? (A) Sol (B) Helios (C) Sun"},\n  {"role": "assistant", "content": "The best answer is ("}\n]\n```\n\nThen the response `content` might be:\n\n```json\n[{"type": "text", "text": "B)"}]\n```'
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([StopReason, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"end_turn"`: the model reached a natural stopping point\n* `"max_tokens"`: we exceeded the requested `max_tokens` or the model\'s maximum\n* `"stop_sequence"`: one of your provided custom `stop_sequences` was generated\n* `"tool_use"`: the model invoked one or more tools\n* `"pause_turn"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `"refusal"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.'
@@ -50994,7 +51245,7 @@ var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet200 = BetaGetSkillVersio
 var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet4XX = BetaErrorResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete200 = BetaDeleteSkillVersionResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete4XX = BetaErrorResponse;
-var make61 = (httpClient, options3 = {}) => {
+var make62 = (httpClient, options3 = {}) => {
   const unexpectedStatus = (response) => flatMap5(orElseSucceed2(response.json, () => "Unexpected status code"), (description) => fail6(new HttpClientError({
     reason: new StatusCodeError({
       request: response.request,
@@ -51783,11 +52034,11 @@ var RedactedAnthropicHeaders = {
   AnthropicApiKey: "x-api-key"
 };
 var withRedactedHeaders = /* @__PURE__ */ updateService3(CurrentRedactedNames, /* @__PURE__ */ appendAll(/* @__PURE__ */ Object.values(RedactedAnthropicHeaders)));
-var make62 = /* @__PURE__ */ fnUntraced2(function* (options3) {
+var make63 = /* @__PURE__ */ fnUntraced2(function* (options3) {
   const baseClient = yield* HttpClient;
   const apiVersion = options3.apiVersion ?? "2023-06-01";
   const httpClient = baseClient.pipe(mapRequest((request3) => request3.pipe(prependUrl(options3.apiUrl ?? "https://api.anthropic.com"), isNotUndefined(options3.apiKey) ? setHeader(RedactedAnthropicHeaders.AnthropicApiKey, value3(options3.apiKey)) : identity, setHeader("anthropic-version", apiVersion), acceptJson)), isNotUndefined(options3.transformClient) ? options3.transformClient : identity);
-  const client = make61(httpClient, {
+  const client = make62(httpClient, {
     transformClient: fnUntraced2(function* (client2) {
       const config = yield* AnthropicConfig.getOrUndefined;
       if (isNotUndefined(config?.transformClient)) {
@@ -51841,12 +52092,12 @@ var make62 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createMessageStream
   });
 }, withRedactedHeaders);
-var layer17 = (options3) => effect(AnthropicClient, make62(options3));
+var layer17 = (options3) => effect(AnthropicClient, make63(options3));
 var layerConfig = (options3) => effect(AnthropicClient, gen4(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
   const apiVersion = isNotUndefined(options3?.apiVersion) ? yield* options3.apiVersion : undefined;
-  return yield* make62({
+  return yield* make63({
     apiKey,
     apiUrl,
     apiVersion,
@@ -52497,37 +52748,6 @@ function hoistAllOfDescriptions(schema3) {
 var supportedKeywords2 = /* @__PURE__ */ new Set(["$ref", "type", "title", "description", "enum", "const", "anyOf", "allOf", "properties", "required", "additionalProperties", "items", "pattern"]);
 var formats2 = /* @__PURE__ */ new Set(["date-time", "time", "date", "duration", "email", "hostname", "uri", "ipv4", "ipv6", "uuid"]);
 
-// node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Model.js
-var TypeId60 = "~effect/ai/Model";
-
-class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ProviderName")) {
-}
-
-class ModelName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ModelName")) {
-}
-var Proto19 = {
-  [TypeId60]: TypeId60,
-  ["~effect/Layer"]: {
-    _ROut: identity,
-    _E: identity,
-    _RIn: identity
-  },
-  get captureRequirements() {
-    const self = this;
-    return contextWith2((context4) => succeed6(provide2(self, succeedContext(context4))));
-  },
-  ...PipeInspectableProto,
-  toJSON() {
-    return {
-      _id: "effect/ai/Model",
-      provider: this.provider
-    };
-  }
-};
-var make63 = (provider, modelName, layer18) => Object.assign(Object.create(Proto19), {
-  provider
-}, merge3(layer18, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
-
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/AnthropicTelemetry.js
 var addAnthropicRequestAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.request", camelToSnake);
 var addAnthropicResponseAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.response", camelToSnake);
@@ -52568,7 +52788,7 @@ var formatIssue2 = /* @__PURE__ */ makeFormatterDefault();
 
 class Config extends (/* @__PURE__ */ Service()("@effect/ai-anthropic/AnthropicLanguageModel/Config")) {
 }
-var model = (model2, config) => make63("anthropic", model2, layer18({
+var model = (model2, config) => make53("anthropic", model2, layer18({
   model: model2,
   config
 }));
@@ -53623,7 +53843,7 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
   const mcpToolCalls = new Map;
   const serverToolCalls = new Map;
   const contentBlocks = new Map;
-  const usage = {
+  const usage2 = {
     inputTokens: 0,
     outputTokens: 0,
     cacheReadInputTokens: 0,
@@ -53637,9 +53857,9 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
         rawUsage = {
           ...event.message.usage
         };
-        usage.inputTokens = event.message.usage.input_tokens;
-        usage.cacheReadInputTokens = event.message.usage.cache_read_input_tokens ?? 0;
-        usage.cacheWriteInputTokens = event.message.usage.cache_creation_input_tokens ?? 0;
+        usage2.inputTokens = event.message.usage.input_tokens;
+        usage2.cacheReadInputTokens = event.message.usage.cache_read_input_tokens ?? 0;
+        usage2.cacheWriteInputTokens = event.message.usage.cache_creation_input_tokens ?? 0;
         if (isNotNullish(event.message.container)) {
           container = event.message.container;
         }
@@ -53703,15 +53923,15 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
           ...rawUsage,
           ...event.usage
         };
-        if (isNotNull(event.usage.input_tokens) && usage.inputTokens !== event.usage.input_tokens) {
-          usage.inputTokens = event.usage.input_tokens;
+        if (isNotNull(event.usage.input_tokens) && usage2.inputTokens !== event.usage.input_tokens) {
+          usage2.inputTokens = event.usage.input_tokens;
         }
-        usage.outputTokens = event.usage.output_tokens;
-        if (isNotNull(event.usage.cache_read_input_tokens) && usage.cacheReadInputTokens !== event.usage.cache_read_input_tokens) {
-          usage.cacheReadInputTokens = event.usage.cache_read_input_tokens;
+        usage2.outputTokens = event.usage.output_tokens;
+        if (isNotNull(event.usage.cache_read_input_tokens) && usage2.cacheReadInputTokens !== event.usage.cache_read_input_tokens) {
+          usage2.cacheReadInputTokens = event.usage.cache_read_input_tokens;
         }
-        if (isNotNull(event.usage.cache_creation_input_tokens) && usage.cacheWriteInputTokens !== event.usage.cache_creation_input_tokens) {
-          usage.cacheWriteInputTokens = event.usage.cache_creation_input_tokens;
+        if (isNotNull(event.usage.cache_creation_input_tokens) && usage2.cacheWriteInputTokens !== event.usage.cache_creation_input_tokens) {
+          usage2.cacheWriteInputTokens = event.usage.cache_creation_input_tokens;
         }
         if (isNotNullish(event.delta.container)) {
           container = event.delta.container;
@@ -53741,13 +53961,13 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
           reason: finishReason,
           usage: {
             inputTokens: {
-              uncached: usage.inputTokens,
-              total: usage.inputTokens + usage.cacheWriteInputTokens + usage.cacheReadInputTokens,
-              cacheRead: usage.cacheReadInputTokens,
-              cacheWrite: usage.cacheWriteInputTokens
+              uncached: usage2.inputTokens,
+              total: usage2.inputTokens + usage2.cacheWriteInputTokens + usage2.cacheReadInputTokens,
+              cacheRead: usage2.cacheReadInputTokens,
+              cacheWrite: usage2.cacheWriteInputTokens
             },
             outputTokens: {
-              total: usage.outputTokens,
+              total: usage2.outputTokens,
               text: undefined,
               reasoning: undefined
             }
@@ -55610,7 +55830,7 @@ var SharedModelIds = ModelIdsShared.members[1];
 
 class Config2 extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiLanguageModel/Config")) {
 }
-var model2 = (model3, config) => make63("openai", model3, layer20({
+var model2 = (model3, config) => make53("openai", model3, layer20({
   model: model3,
   config
 }));
@@ -57716,8 +57936,8 @@ var normalizeMcpToolCall = /* @__PURE__ */ fnUntraced2(function* ({
     params
   };
 });
-var getUsage = (usage) => {
-  if (isNullish(usage)) {
+var getUsage = (usage2) => {
+  if (isNullish(usage2)) {
     return {
       inputTokens: {
         uncached: undefined,
@@ -57732,11 +57952,11 @@ var getUsage = (usage) => {
       }
     };
   }
-  const inputTokens = usage.input_tokens;
-  const outputTokens = usage.output_tokens;
-  const cachedTokens = getUsageTokenDetail(usage.input_tokens_details, "cached_tokens") ?? 0;
-  const cacheWriteTokens = getUsageTokenDetail(usage.input_tokens_details, "cache_write_tokens");
-  const reasoningTokens = getUsageTokenDetail(usage.output_tokens_details, "reasoning_tokens") ?? 0;
+  const inputTokens = usage2.input_tokens;
+  const outputTokens = usage2.output_tokens;
+  const cachedTokens = getUsageTokenDetail(usage2.input_tokens_details, "cached_tokens") ?? 0;
+  const cacheWriteTokens = getUsageTokenDetail(usage2.input_tokens_details, "cache_write_tokens");
+  const reasoningTokens = getUsageTokenDetail(usage2.output_tokens_details, "reasoning_tokens") ?? 0;
   return {
     inputTokens: {
       uncached: inputTokens - cachedTokens,

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -36123,6 +36123,23 @@ var outgoingModelPrompt = (policy2, context3, prepared, turn, declaredToolCalls)
     })
   ]);
 });
+var ProviderUsage = exports_Schema.Struct({
+  inputTokens: exports_Schema.Struct({
+    uncached: exports_Schema.optional(exports_Schema.Natural),
+    total: exports_Schema.optional(exports_Schema.Natural),
+    cacheRead: exports_Schema.optional(exports_Schema.Natural),
+    cacheWrite: exports_Schema.optional(exports_Schema.Natural)
+  }),
+  outputTokens: exports_Schema.Struct({
+    total: exports_Schema.optional(exports_Schema.Natural),
+    text: exports_Schema.optional(exports_Schema.Natural),
+    reasoning: exports_Schema.optional(exports_Schema.Natural)
+  })
+});
+var invalidProviderUsage = () => ModelProtocolError.make({
+  message: "Model response usage fields and derived totals must be non-negative safe integers"
+});
+var decodeProviderUsageTotal = (value4) => exports_Schema.decodeUnknownEffect(exports_Schema.Natural)(value4).pipe(exports_Effect.mapError(() => invalidProviderUsage()));
 var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => exports_Effect.gen(function* () {
   if (usage2 === undefined) {
     return yield* AgentPolicyError.make({
@@ -36130,22 +36147,24 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
       message: "A completed model response did not report usage"
     });
   }
-  const natural = (value4) => value4 === undefined || !Number.isSafeInteger(value4) ? 0 : Math.max(0, value4);
-  const reportedUncached = natural(usage2.inputTokens.uncached);
-  const cacheRead = natural(usage2.inputTokens.cacheRead);
-  const cacheWrite = natural(usage2.inputTokens.cacheWrite);
-  const reportedText = natural(usage2.outputTokens.text);
-  const reasoning = natural(usage2.outputTokens.reasoning);
-  const inputTokens = Math.max(natural(usage2.inputTokens.total), reportedUncached + cacheRead + cacheWrite);
-  const outputTokens = Math.max(natural(usage2.outputTokens.total), reportedText + reasoning);
+  const providerUsage = yield* exports_Schema.decodeUnknownEffect(ProviderUsage)(usage2).pipe(exports_Effect.mapError(() => invalidProviderUsage()));
+  const reportedUncached = providerUsage.inputTokens.uncached ?? 0;
+  const cacheRead = providerUsage.inputTokens.cacheRead ?? 0;
+  const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
+  const reportedText = providerUsage.outputTokens.text ?? 0;
+  const reasoning = providerUsage.outputTokens.reasoning ?? 0;
+  const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
+  const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+  const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
+  const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
   const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
   const text = Math.max(reportedText, outputTokens - reasoning);
-  const totalTokens = inputTokens + outputTokens;
+  const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
   const provider = yield* exports_Model.ProviderName;
   const model = yield* exports_Model.ModelName;
   const estimate = options.estimateCostMicrousd === undefined ? 0 : yield* options.estimateCostMicrousd(usage2, { provider, model, usage: usage2 });
   const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
-  if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
+  if (!Number.isSafeInteger(costMicrousd) || costMicrousd < 0) {
     return yield* AgentPolicyError.make({
       limit: "cost",
       message: "Model cost estimation must produce a non-negative integer number of microdollars"
@@ -36174,9 +36193,12 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
     outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
     costMicrousd
   });
-  context3.modelCalls += 1;
-  context3.inputTokens += inputTokens;
-  context3.outputTokens += outputTokens;
+  const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
+  const cumulativeInputTokens = yield* decodeProviderUsageTotal(context3.inputTokens + inputTokens);
+  const cumulativeOutputTokens = yield* decodeProviderUsageTotal(context3.outputTokens + outputTokens);
+  context3.modelCalls = modelCalls;
+  context3.inputTokens = cumulativeInputTokens;
+  context3.outputTokens = cumulativeOutputTokens;
   context3.lastInputTokens = inputTokens;
   context3.lastOutputTokens = outputTokens;
   context3.costMicrousd += costMicrousd;
@@ -37092,7 +37114,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
     }
     const toolCalls = priorToolCalls + trace2.toolCalls.size;
     const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-    if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
+    if (overToolBudget && policy2.onExhaustion === "fail") {
       return failRunEventStream(AgentPolicyError.make({
         limit: "tool-calls",
         message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
@@ -37199,8 +37221,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options) => expo
         }));
       }
       const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      const completionTurnAllowed = completionBatch;
-      if (turnsBlocked && !completionTurnAllowed) {
+      if (turnsBlocked) {
         return failRunEventStream(AgentPolicyError.make({
           limit: "turns",
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
@@ -37424,15 +37445,14 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options) => exports_Stre
   const bounds = effectiveRunBounds(policy2, options);
   const toolCalls = trace2.toolCalls.size;
   const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-  if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
+  if (overToolBudget && policy2.onExhaustion === "fail") {
     return failRunEventStream(AgentPolicyError.make({
       limit: "tool-calls",
       message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
     }));
   }
   const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-  const completionTurnAllowed = completionBatch;
-  if (turnsBlocked && !completionTurnAllowed) {
+  if (turnsBlocked) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "turns",
       message: `Agent exceeded its ${bounds.maxTurns} Turn limit`

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -33451,14 +33451,25 @@ class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsag
   costMicrousd: exports_Schema.Natural
 }) {
 }
-
-class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")({
+var RunUsageSummaryFields = exports_Schema.Struct({
   modelCalls: exports_Schema.Natural,
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: exports_Schema.Natural,
   byModel: exports_Schema.Array(ModelUsageGroup)
-}) {
+}).check(exports_Schema.makeFilter((summary2) => {
+  const identities = summary2.byModel.map((group2) => JSON.stringify([
+    group2.provider,
+    group2.model,
+    group2.serviceTier ?? null,
+    group2.pricingVersion ?? null
+  ]));
+  return new Set(identities).size === identities.length && hasAdditiveTotal(summary2.modelCalls, summary2.byModel.map((group2) => group2.modelCalls)) && hasAdditiveTotal(summary2.inputTokens.total, summary2.byModel.map((group2) => group2.inputTokens.total)) && hasAdditiveTotal(summary2.inputTokens.uncached, summary2.byModel.map((group2) => group2.inputTokens.uncached)) && hasAdditiveTotal(summary2.inputTokens.cacheRead, summary2.byModel.map((group2) => group2.inputTokens.cacheRead)) && hasAdditiveTotal(summary2.inputTokens.cacheWrite, summary2.byModel.map((group2) => group2.inputTokens.cacheWrite)) && hasAdditiveTotal(summary2.outputTokens.total, summary2.byModel.map((group2) => group2.outputTokens.total)) && hasAdditiveTotal(summary2.outputTokens.text, summary2.byModel.map((group2) => group2.outputTokens.text)) && hasAdditiveTotal(summary2.outputTokens.reasoning, summary2.byModel.map((group2) => group2.outputTokens.reasoning)) && hasAdditiveTotal(summary2.costMicrousd, summary2.byModel.map((group2) => group2.costMicrousd));
+}, {
+  title: "Run usage totals equal unique per-model pricing groups within safe-integer accounting"
+}));
+
+class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")(RunUsageSummaryFields) {
 }
 var emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
 var emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
@@ -36240,11 +36251,26 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
   const reportedText = providerUsage.outputTokens.text ?? 0;
   const reasoning = providerUsage.outputTokens.reasoning ?? 0;
   const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
-  const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+  const reportedInputTotal = providerUsage.inputTokens.total;
+  const allInputComponentsReported = providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite !== undefined;
+  if (reportedInputTotal !== undefined && (reportedInputTotal < reportedInputComponents || allInputComponentsReported && reportedInputTotal !== reportedInputComponents)) {
+    return yield* invalidProviderUsage();
+  }
+  const inputTokens = reportedInputTotal ?? reportedInputComponents;
   const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
-  const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
-  const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
-  const text = Math.max(reportedText, outputTokens - reasoning);
+  const reportedOutputTotal = providerUsage.outputTokens.total;
+  const allOutputComponentsReported = providerUsage.outputTokens.text !== undefined && providerUsage.outputTokens.reasoning !== undefined;
+  if (reportedOutputTotal !== undefined && (reportedOutputTotal < reportedOutputComponents || allOutputComponentsReported && reportedOutputTotal !== reportedOutputComponents)) {
+    return yield* invalidProviderUsage();
+  }
+  const outputTokens = reportedOutputTotal ?? reportedOutputComponents;
+  const inputRemainder = inputTokens - reportedInputComponents;
+  const outputRemainder = outputTokens - reportedOutputComponents;
+  const uncached = reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+  const normalizedCacheRead = cacheRead + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead === undefined ? inputRemainder : 0);
+  const normalizedCacheWrite = cacheWrite + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite === undefined ? inputRemainder : 0);
+  const text = reportedText + (providerUsage.outputTokens.text === undefined ? outputRemainder : 0);
+  const normalizedReasoning = reasoning + (providerUsage.outputTokens.text !== undefined && providerUsage.outputTokens.reasoning === undefined ? outputRemainder : 0);
   const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
   const provider = yield* exports_Model.ProviderName;
   const model = yield* exports_Model.ModelName;
@@ -36273,10 +36299,14 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
     inputTokens: InputTokenUsage.make({
       total: inputTokens,
       uncached,
-      cacheRead,
-      cacheWrite
+      cacheRead: normalizedCacheRead,
+      cacheWrite: normalizedCacheWrite
     }),
-    outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
+    outputTokens: OutputTokenUsage.make({
+      total: outputTokens,
+      text,
+      reasoning: normalizedReasoning
+    }),
     costMicrousd
   });
   const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
@@ -38212,6 +38242,8 @@ var makeAgentSpawner = (parent, depth) => ({
   spawn: spawnWithParent(parent, depth)
 });
 var AgentRuntime = {
+  decodeFinalOutput,
+  projectCompletionOutput,
   run: run4,
   start,
   stream

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -33405,20 +33405,28 @@ class IdGenerator2 extends exports_Context.Service()("@effect-agent/core/IdGener
 }
 // packages/core/src/usage.ts
 var UsageIdentity = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
-
-class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")({
+var hasAdditiveTotal = (total, components) => {
+  const sum3 = components.reduce((accumulator, component) => accumulator + component, 0);
+  return Number.isSafeInteger(sum3) && total === sum3;
+};
+var InputTokenUsageFields = exports_Schema.Struct({
   total: exports_Schema.Natural,
   uncached: exports_Schema.Natural,
   cacheRead: exports_Schema.Natural,
   cacheWrite: exports_Schema.Natural
-}) {
-}
+}).check(exports_Schema.makeFilter((usage) => hasAdditiveTotal(usage.total, [usage.uncached, usage.cacheRead, usage.cacheWrite]), { title: "Input token total equals uncached, cache-read, and cache-write components" }));
 
-class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")({
+class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")(InputTokenUsageFields) {
+}
+var OutputTokenUsageFields = exports_Schema.Struct({
   total: exports_Schema.Natural,
   text: exports_Schema.Natural,
   reasoning: exports_Schema.Natural
-}) {
+}).check(exports_Schema.makeFilter((usage) => hasAdditiveTotal(usage.total, [usage.text, usage.reasoning]), {
+  title: "Output token total equals text and reasoning components"
+}));
+
+class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")(OutputTokenUsageFields) {
 }
 
 class ModelCallUsage extends exports_Schema.Class("@effect-agent/core/ModelCallUsage")({
@@ -33452,6 +33460,84 @@ class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageS
   byModel: exports_Schema.Array(ModelUsageGroup)
 }) {
 }
+var emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
+var emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
+
+class UsageAggregationError extends exports_Schema.TaggedError()("UsageAggregationError", {
+  field: exports_Schema.NonEmptyString,
+  message: exports_Schema.String
+}) {
+}
+var checkedAdd = (field, left, right) => {
+  const total = left + right;
+  return Number.isSafeInteger(left) && left >= 0 && Number.isSafeInteger(right) && right >= 0 && Number.isSafeInteger(total) ? exports_Effect.succeed(total) : exports_Effect.fail(UsageAggregationError.make({
+    field,
+    message: `Canonical usage aggregation exceeded the safe-integer range at ${field}`
+  }));
+};
+var summarizeModelUsage = exports_Effect.fn("summarizeModelUsage")(function* (calls) {
+  const inputTokens = emptyInputTokens();
+  const outputTokens = emptyOutputTokens();
+  const groups = new Map;
+  let modelCalls = 0;
+  let costMicrousd = 0;
+  for (const call of calls) {
+    modelCalls = yield* checkedAdd("modelCalls", modelCalls, 1);
+    inputTokens.total = yield* checkedAdd("inputTokens.total", inputTokens.total, call.inputTokens.total);
+    inputTokens.uncached = yield* checkedAdd("inputTokens.uncached", inputTokens.uncached, call.inputTokens.uncached);
+    inputTokens.cacheRead = yield* checkedAdd("inputTokens.cacheRead", inputTokens.cacheRead, call.inputTokens.cacheRead);
+    inputTokens.cacheWrite = yield* checkedAdd("inputTokens.cacheWrite", inputTokens.cacheWrite, call.inputTokens.cacheWrite);
+    outputTokens.total = yield* checkedAdd("outputTokens.total", outputTokens.total, call.outputTokens.total);
+    outputTokens.text = yield* checkedAdd("outputTokens.text", outputTokens.text, call.outputTokens.text);
+    outputTokens.reasoning = yield* checkedAdd("outputTokens.reasoning", outputTokens.reasoning, call.outputTokens.reasoning);
+    costMicrousd = yield* checkedAdd("costMicrousd", costMicrousd, call.costMicrousd);
+    const key = JSON.stringify([
+      call.provider,
+      call.model,
+      call.serviceTier ?? null,
+      call.pricingVersion ?? null
+    ]);
+    let group2 = groups.get(key);
+    if (group2 === undefined) {
+      group2 = {
+        provider: call.provider,
+        model: call.model,
+        ...call.serviceTier === undefined ? {} : { serviceTier: call.serviceTier },
+        ...call.pricingVersion === undefined ? {} : { pricingVersion: call.pricingVersion },
+        modelCalls: 0,
+        inputTokens: emptyInputTokens(),
+        outputTokens: emptyOutputTokens(),
+        costMicrousd: 0
+      };
+      groups.set(key, group2);
+    }
+    group2.modelCalls = yield* checkedAdd("byModel.modelCalls", group2.modelCalls, 1);
+    group2.inputTokens.total = yield* checkedAdd("byModel.inputTokens.total", group2.inputTokens.total, call.inputTokens.total);
+    group2.inputTokens.uncached = yield* checkedAdd("byModel.inputTokens.uncached", group2.inputTokens.uncached, call.inputTokens.uncached);
+    group2.inputTokens.cacheRead = yield* checkedAdd("byModel.inputTokens.cacheRead", group2.inputTokens.cacheRead, call.inputTokens.cacheRead);
+    group2.inputTokens.cacheWrite = yield* checkedAdd("byModel.inputTokens.cacheWrite", group2.inputTokens.cacheWrite, call.inputTokens.cacheWrite);
+    group2.outputTokens.total = yield* checkedAdd("byModel.outputTokens.total", group2.outputTokens.total, call.outputTokens.total);
+    group2.outputTokens.text = yield* checkedAdd("byModel.outputTokens.text", group2.outputTokens.text, call.outputTokens.text);
+    group2.outputTokens.reasoning = yield* checkedAdd("byModel.outputTokens.reasoning", group2.outputTokens.reasoning, call.outputTokens.reasoning);
+    group2.costMicrousd = yield* checkedAdd("byModel.costMicrousd", group2.costMicrousd, call.costMicrousd);
+  }
+  return RunUsageSummary.make({
+    modelCalls,
+    inputTokens: InputTokenUsage.make(inputTokens),
+    outputTokens: OutputTokenUsage.make(outputTokens),
+    costMicrousd,
+    byModel: [...groups.values()].map((group2) => ModelUsageGroup.make({
+      provider: group2.provider,
+      model: group2.model,
+      ...group2.serviceTier === undefined ? {} : { serviceTier: group2.serviceTier },
+      ...group2.pricingVersion === undefined ? {} : { pricingVersion: group2.pricingVersion },
+      modelCalls: group2.modelCalls,
+      inputTokens: InputTokenUsage.make(group2.inputTokens),
+      outputTokens: OutputTokenUsage.make(group2.outputTokens),
+      costMicrousd: group2.costMicrousd
+    }))
+  });
+});
 // packages/capabilities/src/redaction.ts
 var MAX_REDACTED_PREVIEW_BYTES = 8 * 1024;
 var MAX_REDACTION_NODES = 4096;
@@ -36196,12 +36282,19 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
   const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
   const cumulativeInputTokens = yield* decodeProviderUsageTotal(context3.inputTokens + inputTokens);
   const cumulativeOutputTokens = yield* decodeProviderUsageTotal(context3.outputTokens + outputTokens);
+  const cumulativeCostMicrousd = context3.costMicrousd + costMicrousd;
+  if (!Number.isSafeInteger(cumulativeCostMicrousd)) {
+    return yield* AgentPolicyError.make({
+      limit: "cost",
+      message: "Cumulative model cost exceeds safe-integer accounting capacity"
+    });
+  }
   context3.modelCalls = modelCalls;
   context3.inputTokens = cumulativeInputTokens;
   context3.outputTokens = cumulativeOutputTokens;
   context3.lastInputTokens = inputTokens;
   context3.lastOutputTokens = outputTokens;
-  context3.costMicrousd += costMicrousd;
+  context3.costMicrousd = cumulativeCostMicrousd;
   context3.lastCostMicrousd = costMicrousd;
   if (options.durability !== undefined) {
     yield* options.durability.noteTurnUsage({ turn, usage: modelUsage });

--- a/bun.lock
+++ b/bun.lock
@@ -187,7 +187,7 @@
     },
     "packages/capabilities": {
       "name": "@effect-agent/capabilities",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -203,7 +203,7 @@
     },
     "packages/core": {
       "name": "@effect-agent/core",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -214,7 +214,7 @@
     },
     "packages/effect-agent": {
       "name": "effect-agent",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -228,7 +228,7 @@
     },
     "packages/engine": {
       "name": "@effect-agent/engine",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "effect": "catalog:",
@@ -241,7 +241,7 @@
     },
     "packages/platform-cloudflare": {
       "name": "@effect-agent/platform-cloudflare",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -271,9 +271,10 @@
     },
     "packages/platform-node": {
       "name": "@effect-agent/platform-node",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
+        "@effect-agent/engine": "workspace:*",
         "@effect-agent/session": "workspace:*",
         "@effect-agent/storage-sqlite": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -282,7 +283,6 @@
       },
       "devDependencies": {
         "@effect-agent/capabilities": "workspace:*",
-        "@effect-agent/engine": "workspace:*",
         "@effect/vitest": "catalog:",
         "typescript": "catalog:",
         "vite-plus": "catalog:",
@@ -290,7 +290,7 @@
     },
     "packages/pr-review": {
       "name": "@effect-agent/pr-review",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect/ai-anthropic": "catalog:",
         "@effect/ai-openai": "catalog:",
@@ -306,7 +306,7 @@
     },
     "packages/sandbox": {
       "name": "@effect-agent/sandbox",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -317,7 +317,7 @@
     },
     "packages/sandbox-local": {
       "name": "@effect-agent/sandbox-local",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/sandbox": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -332,7 +332,7 @@
     },
     "packages/session": {
       "name": "@effect-agent/session",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -347,7 +347,7 @@
     },
     "packages/storage-cloudflare": {
       "name": "@effect-agent/storage-cloudflare",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/session": "workspace:*",
         "@effect/platform-browser": "catalog:",
@@ -366,7 +366,7 @@
     },
     "packages/storage-memory": {
       "name": "@effect-agent/storage-memory",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/session": "workspace:*",
@@ -381,7 +381,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@effect-agent/storage-sqlite",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/session": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -396,7 +396,7 @@
     },
     "packages/testing": {
       "name": "@effect-agent/testing",
-      "version": "0.1.0-beta.23",
+      "version": "0.1.0-beta.24",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -27,20 +27,22 @@ AgentPolicy.make({
   toolConcurrency: 4,
   repeatedFailureLimit: 3,
   tokenBudget: 80_000,
+  completionReserveTokens: 8_000,
   costBudgetMicrousd: 2_000_000,
   onExhaustion: "final-answer",
 });
 ```
 
-| Bound                  | What it limits                                       | On exhaustion                     |
-| ---------------------- | ---------------------------------------------------- | --------------------------------- |
-| `maxTurns`             | model requests per Run                               | `onExhaustion` resolves           |
-| `maxToolCalls`         | declared Tool Calls per Run (programmatic included)  | `onExhaustion` resolves           |
-| `maxDuration`          | logical-Run wall clock, including durable suspension | always fails typed                |
-| `tokenBudget`          | input + output tokens per Run                        | `onExhaustion` resolves (RUN-025) |
-| `costBudgetMicrousd`   | estimated cost per Run (needs a cost estimator)      | always fails typed                |
-| `repeatedFailureLimit` | consecutive terminal Tool failures                   | always fails typed                |
-| `toolConcurrency`      | parallel Tool Handlers per batch                     | concurrency gate                  |
+| Bound                     | What it limits                                       | On exhaustion                     |
+| ------------------------- | ---------------------------------------------------- | --------------------------------- |
+| `maxTurns`                | model requests per Run                               | `onExhaustion` resolves           |
+| `maxToolCalls`            | declared Tool Calls per Run (programmatic included)  | `onExhaustion` resolves           |
+| `maxDuration`             | logical-Run wall clock, including durable suspension | always fails typed                |
+| `tokenBudget`             | input + output tokens per Run                        | `onExhaustion` resolves (RUN-025) |
+| `completionReserveTokens` | capacity withheld from research for delivery         | enters finalization before spend  |
+| `costBudgetMicrousd`      | estimated cost per Run (needs a cost estimator)      | always fails typed                |
+| `repeatedFailureLimit`    | consecutive terminal Tool failures                   | always fails typed                |
+| `toolConcurrency`         | parallel Tool Handlers per batch                     | concurrency gate                  |
 
 A typed exhaustion failure is `AgentPolicyError` with a `limit` literal naming the exhausted limit.
 In the DN and DC assemblies a Run failed this way settles with that literal preserved as the
@@ -57,7 +59,8 @@ also applies once to the token budget under RUN-025.
 1. An over-budget declared Tool batch **never executes**. Every call settles as a synthetic
    failed result telling the model the budget is exhausted and to answer from what it already
    has. No handler runs; in the DN and DC assemblies the batch is never durably declared.
-2. Every subsequent model request forbids tool use (Effect AI `toolChoice: "none"`).
+2. Every subsequent model request forbids tool use (Effect AI `toolChoice: "none"`) unless the
+   Definition owns a completion Tool, in which case only that Tool remains available.
 3. Turn exhaustion admits exactly **one grace Turn** past `maxTurns`, under the same constraint.
    A second grace is structurally impossible.
 4. The Run settles _completed_ with `finishReason: "budget-exhausted"`, never a plain
@@ -67,17 +70,18 @@ also applies once to the token budget under RUN-025.
    distinguishes a truncated answer from an ordinary one and names the exhausted limit without
    the live event stream or message parsing.
 5. A model that declares a Tool Call under the constraint fails the Run typed
-   with `ModelProtocolError` under RUN-020. The Run does not enter a rejection loop.
+   with `ModelProtocolError` under RUN-020, except for the singleton Definition-owned completion
+   Tool in RUN-032. That Tool delivers and settles immediately without another summary turn.
 
 Synthetic rejections are exempt from `repeatedFailureLimit` folding: no handler ran, so a
 rejected four-call batch cannot trip a limit of three.
 
-**`"fail"`.** Exhaustion fails the Run before the exceeding work starts. Choose it for pipelines
-that must never accept a truncated answer. The repository's own PR reviewer pins it for review
-_children_, because every configured discovery
-and verification pass must settle exactly; a partial result would launder exhaustion into settled
-review assurance. Its separate input-coverage claim is host-derived and does not imply defect
-recall.
+**`"fail"`.** Exhaustion fails the Run typed before any declared application Handler starts,
+including a completion Tool. Choose fail mode for pipelines that must never accept a truncated
+answer or start a delivery side effect after a policy breach. The repository's own PR reviewer
+pins it for review _children_, because every configured discovery and verification pass must
+settle exactly; a partial result would launder exhaustion into settled review assurance. Its
+separate input-coverage claim is host-derived and does not imply defect recall.
 
 Duration, cost, and repeated-failure limits always fail the Run. Token exhaustion allows only one
 constrained final answer under RUN-025, so it cannot loop or spend without a bound.

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -78,8 +78,9 @@ described in [Agent definitions](/guide/agents): the over-budget batch settles s
 tool use is forbidden, and one grace Turn produces the final answer. The token dimension joins
 the same resolution: when cumulative usage crosses `tokenBudget`, a breaching response that
 already carries a decodable answer completes the Run directly, and otherwise the Run takes at
-most one constrained grace Turn (`toolChoice: "none"`; its usage is charged once and cannot
-re-trigger the breach). Either way the Run completes honestly:
+most one constrained grace Turn (`toolChoice: "none"`, or only the Definition-owned completion
+Tool; its usage is charged once and cannot re-trigger the breach). Either way the Run completes
+honestly:
 
 ```ts
 RunCompleted {
@@ -95,8 +96,9 @@ the budget-extension grant flow consumes when an orchestrator decides to re-dele
 larger allowance.
 
 `onExhaustion: "fail"` keeps every dimension fail-fast for pipelines that must never accept a
-truncated answer. Duration and cost breaches always fail typed because a grace call would extend
-the wall-clock limit or increase the bill.
+truncated answer. No declared application Handler, including a completion Tool, starts after the
+breach. Duration and cost breaches always fail typed because a grace call would extend the
+wall-clock limit or increase the bill.
 
 ## Compaction
 

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -34,12 +34,12 @@ callers receive the same value from `DurableAgentRuntime.awaitSettlement` and ca
 `AgentResultSchema` enforces the same boundary and rejects a `runDisposition` paired with
 `finishReason: "budget-exhausted"`.
 
-Under the default `onExhaustion: "final-answer"` policy, a Run that exhausts its Turn or Tool
-Call budget settles with one constrained final-answer Turn and reports it honestly as
+Under the default `onExhaustion: "final-answer"` policy, a Run that exhausts its Turn, Tool Call,
+or token budget settles with one constrained final-answer Turn and reports it honestly as
 `finishReason: "budget-exhausted"` (its `turns` count may exceed `maxTurns` by that one grace
-Turn). Duration, token, and cost exhaustion, pending approval, interruption, and failed output
-decoding are never successful finish reasons; with `onExhaustion: "fail"`, Turn and Tool Call
-exhaustion fail typed as well.
+Turn). Duration and cost exhaustion, pending approval, interruption, and failed output decoding
+are never successful finish reasons. With `onExhaustion: "fail"`, Turn, Tool Call, and token
+exhaustion fail typed before any declared application Handler starts.
 
 ## Observe semantic events
 

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -292,6 +292,13 @@ non-serializable Layer option and is deliberately outside `CloudflareDurableRunt
 That Schema continues to decode only scalar identities, cadences, limits, and storage gates before
 resources open.
 
+`NodeDurableRuntimeOptions.estimateCostMicrousd` and
+`CloudflareDurableRuntimeOptions.estimateCostMicrousd` install the deployment's closed pricing
+authority (RUN-035). It receives provider, model, and raw Effect AI usage and returns a
+non-negative microdollar estimate plus optional service-tier/pricing-version identity. The host
+captures it in `DurableRuntimeConfig`, so every replacement Attempt applies the same authority;
+configured `costBudgetMicrousd` policies fail typed when no estimator exists.
+
 Durable Object storage is the only correctness-critical store for that Conversation. In-memory
 object state is a cache because objects may stop unexpectedly. Alarm work is idempotent because
 alarms execute at least once.

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -202,7 +202,9 @@ The scheduler must classify recovery rather than blindly retry when failure occu
 
 Provider requests use a stable attempt operation ID when the provider supports it.
 Provider-returned text and reasoning deltas, signatures, redaction markers, usage,
-and metadata may be appended canonically as they arrive. A response becomes eligible
+and metadata may be appended canonically as they arrive. Every committed response records each
+completed model call separately, including compaction calls: provider, model, optional service
+tier/pricing version, cache splits, output splits, and estimated cost (RUN-035). A response becomes eligible
 for Tool execution or the next Prompt only after its completion record commits.
 
 If a worker dies mid-stream:
@@ -248,6 +250,16 @@ of its owning Run even before every call settles. If that Run instead terminates
 aborted without completing the batch, a later Run MUST NOT replay the orphan assistant Tool
 declaration or partial Tool results from that incomplete batch as model history. Instruction and
 user messages committed before the declaration remain visible.
+
+The first response of each Run also records the length of its evaluated instruction/wake prefix.
+That prefix remains canonical and visible to owner-Run recovery, but later Runs omit it from model
+input while preserving the conversational response and results (RUN-033).
+
+A Definition-owned completion Tool uses the same authorization, preparation, and settlement
+protocol as any external side effect. Its successful singleton result and a `RunCompleted` marker
+containing the Schema-projected output and exhaustion metadata commit in one atomic result batch.
+Recovery that observes that marker validates the matching declaration/result and proceeds directly
+to terminalization; it never invokes the model or Handler again (RUN-032).
 
 ## 11. Durable steps
 
@@ -323,6 +335,12 @@ from the already-classified Run failure; joined Submissions copy the host's cano
 byte-for-byte in both the live and recovery paths rather than rebuilding it from a Cause or
 message. The `SubmissionLedger` returns the same diagnostic as `Settlement.failure` on first
 finalization and every idempotent replay.
+
+Every Run settlement may carry its canonical `usageSummary`: model-call count, gross input/output
+breakdowns, total estimated microdollars, and deterministic per-model/tier groups (RUN-035). The
+summary is reserved and replayed with the exact settlement record and materialized by
+`awaitSettlement`; it is not reconstructed from the ledger's cached outcome. Joined Submissions
+omit an independent summary so one host Run's usage is not counted twice.
 
 Result-less cases are explicit by settlement family. A joined `completed` Submission has no
 independent output and may omit `result`; an `aborted` Submission always omits it because abort

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -313,7 +313,8 @@ a `completed` soft landing persists `finishReason: "budget-exhausted"` with the
 `{errorTag, message}` failure projection in `result`. Because the metadata rides the
 exact reserved record, it survives reservation replay, canonical append, recovery,
 and every later read unchanged. Decode is family-bound fail-closed: metadata on the
-wrong settlement family rejects. A `policyLimit` whose `result` does not carry the
+wrong settlement family rejects, and `finishReason: "budget-exhausted"` and `exhausted` must be
+present together or absent together. A `policyLimit` whose `result` does not carry the
 `AgentPolicyError` projection also rejects instead of becoming trusted audit history,
 and records persisted before the metadata existed decode with it absent (additive,
 schemaVersion 1).
@@ -342,7 +343,9 @@ Every Run settlement may carry its canonical `usageSummary`: model-call count, g
 breakdowns, total estimated microdollars, and deterministic per-model/tier groups (RUN-035). The
 summary is reserved and replayed with the exact settlement record and materialized by
 `awaitSettlement`; it is not reconstructed from the ledger's cached outcome. Joined Submissions
-omit an independent summary so one host Run's usage is not counted twice.
+omit an independent summary so one host Run's usage is not counted twice. Each canonical token
+total equals its recorded components, and cumulative token, model-call, and cost arithmetic is
+checked; an overflow fails typed before an invalid summary can be reserved.
 
 Result-less cases are explicit by settlement family. A joined `completed` Submission has no
 independent output and may omit `result`; an `aborted` Submission always omits it because abort

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -259,7 +259,9 @@ A Definition-owned completion Tool uses the same authorization, preparation, and
 protocol as any external side effect. Its successful singleton result and a `RunCompleted` marker
 containing the Schema-projected output and exhaustion metadata commit in one atomic result batch.
 Recovery that observes that marker validates the matching declaration/result and proceeds directly
-to terminalization; it never invokes the model or Handler again (RUN-032).
+to terminalization; it never invokes the model or Handler again (RUN-032). A budget-exhausted
+marker carries both `finishReason: "budget-exhausted"` and the `exhausted` dimension; a marker with
+only one fails Schema decoding.
 
 ## 11. Durable steps
 

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -255,11 +255,19 @@ The first response of each Run also records the length of its evaluated instruct
 That prefix remains canonical and visible to owner-Run recovery, but later Runs omit it from model
 input while preserving the conversational response and results (RUN-033).
 
+A successful no-tool final response and its `RunCompleted` marker commit in one atomic Turn batch.
+Recovery that observes the marker validates the matching response and proceeds directly to
+terminalization without invoking the model again. It re-decodes the canonical response through
+the Agent output Schema and requires the resulting durable output to match the marker; disagreement
+fails closed. Histories written before this additive marker remain valid and recover through the
+legacy response projection.
+
 A Definition-owned completion Tool uses the same authorization, preparation, and settlement
 protocol as any external side effect. Its successful singleton result and a `RunCompleted` marker
 containing the Schema-projected output and exhaustion metadata commit in one atomic result batch.
-Recovery that observes that marker validates the matching declaration/result and proceeds directly
-to terminalization; it never invokes the model or Handler again (RUN-032). A budget-exhausted
+Recovery that observes that marker re-decodes the canonical parameters/result, reapplies the
+Definition projector and Agent output Schema, and requires the durable output to match before
+terminalization; it never invokes the model or Handler again (RUN-032). A budget-exhausted
 marker carries both `finishReason: "budget-exhausted"` and the `exhausted` dimension; a marker with
 only one fails Schema decoding.
 
@@ -345,7 +353,8 @@ summary is reserved and replayed with the exact settlement record and materializ
 `awaitSettlement`; it is not reconstructed from the ledger's cached outcome. Joined Submissions
 omit an independent summary so one host Run's usage is not counted twice. Each canonical token
 total equals its recorded components, and cumulative token, model-call, and cost arithmetic is
-checked; an overflow fails typed before an invalid summary can be reserved.
+checked; an overflow fails typed before an invalid summary can be reserved. Per-model pricing
+identities are unique, and their checked component sums exactly match every top-level total.
 
 Result-less cases are explicit by settlement family. A joined `completed` Submission has no
 independent output and may omit `result`; an `aborted` Submission always omits it because abort

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -267,7 +267,9 @@ protocol as any external side effect. Its successful singleton result and a `Run
 containing the Schema-projected output and exhaustion metadata commit in one atomic result batch.
 Recovery that observes that marker re-decodes the canonical parameters/result, reapplies the
 Definition projector and Agent output Schema, and requires the durable output to match before
-terminalization; it never invokes the model or Handler again (RUN-032). A budget-exhausted
+terminalization. It counts every declared Tool Call, including provider-executed calls, before
+accepting the application completion Tool as the singleton batch; it never invokes the model or
+Handler again (RUN-032). A budget-exhausted
 marker carries both `finishReason: "budget-exhausted"` and the `exhausted` dimension; a marker with
 only one fails Schema decoding.
 

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -336,7 +336,9 @@ recovery; it does not derive it from cached outcome metadata. Decode is fail-clo
 valid only on a `completed` settlement with a `runId` and without
 `finishReason: "budget-exhausted"`. Failed, aborted, budget-exhausted, run-less joined,
 incomplete, and recovery-only outcomes cannot acquire one. The durable runtime never reconstructs
-this value from result prose or Tool records.
+this value from result prose or Tool records. When recovering the owning Run's canonical completion
+marker, however, it re-applies the Definition selector and Schema to the reconstructed typed output
+and requires that encoding to match the marker before terminalizing.
 
 Every `failed` canonical settlement carries exactly one generic failure diagnostic in `result`:
 `errorTag` is non-empty and at most 256 characters, and `message` is at most 16 KiB. No other

--- a/docs/spec/persistence.md
+++ b/docs/spec/persistence.md
@@ -149,14 +149,14 @@ The canonical log supports, at minimum:
 
 - conversation created/closed;
 - user, steering, and follow-up input;
-- model request metadata;
+- model request metadata and per-call normalized provider/model/tier/token/cost usage;
 - model text/reasoning deltas, completion, signature/redaction metadata, or structured item;
 - tool call requested, prepared, approved/rejected, settled, unknown;
 - compaction created/selected;
 - subagent requested/started/joined and child Parent Link;
-- run warning/failure;
+- run warning/failure and atomic terminal-Tool completion marker;
 - abort requested;
-- terminal outcome;
+- terminal outcome with aggregate Run usage;
 - repair annotations.
 
 Partial Tool-argument deltas, queue depth changes, heartbeats, and debug spans are

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -181,7 +181,9 @@ response identity, returned reasoning content, encrypted/signature fields, and p
 markers when Effect AI exposes them. Cached input remains billable gross usage; cache accounting is
 never interpreted as free tokens. Canonical input and output totals must equal the sums of their
 recorded components. Contradictory breakdowns and any aggregate that exceeds safe-integer
-accounting fail typed instead of being coerced or persisted.
+accounting fail typed instead of being coerced or persisted. A provider total below its explicit
+components rejects, as does any difference when all components were supplied; the framework
+classifies a remainder conservatively only when a component was genuinely omitted.
 
 The framework does not request or invent hidden reasoning. Partial Tool-argument
 deltas are live-only; the completed Tool Call is persisted.

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -179,7 +179,9 @@ identity, optional host-supplied service tier and pricing version, uncached/cach
 input, text/reasoning output, and estimated microdollar cost (RUN-035). It may additionally retain
 response identity, returned reasoning content, encrypted/signature fields, and provider redaction
 markers when Effect AI exposes them. Cached input remains billable gross usage; cache accounting is
-never interpreted as free tokens.
+never interpreted as free tokens. Canonical input and output totals must equal the sums of their
+recorded components. Contradictory breakdowns and any aggregate that exceeds safe-integer
+accounting fail typed instead of being coerced or persisted.
 
 The framework does not request or invent hidden reasoning. Partial Tool-argument
 deltas are live-only; the completed Tool Call is persisted.

--- a/docs/spec/providers.md
+++ b/docs/spec/providers.md
@@ -174,9 +174,12 @@ effect.
 
 ## 8. Provider metadata and reasoning
 
-The canonical Conversation may retain provider/model identity, response identity, usage, returned
-reasoning content, encrypted/signature fields, and provider redaction markers when Effect AI
-exposes them.
+The canonical Conversation retains normalized usage for each completed call: provider/model
+identity, optional host-supplied service tier and pricing version, uncached/cache-read/cache-write
+input, text/reasoning output, and estimated microdollar cost (RUN-035). It may additionally retain
+response identity, returned reasoning content, encrypted/signature fields, and provider redaction
+markers when Effect AI exposes them. Cached input remains billable gross usage; cache accounting is
+never interpreted as free tokens.
 
 The framework does not request or invent hidden reasoning. Partial Tool-argument
 deltas are live-only; the completed Tool Call is persisted.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -650,7 +650,9 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   aggregation overflow fails with
   `ModelProtocolError` before cost estimation or budget consumption. A recovery usage seed obeys
   the same integer bound, with last-call token counts no greater than cumulative totals; invalid
-  seeds fail before Run input hooks or external execution.
+  seeds fail before Run input hooks or external execution. A reported provider total must not be
+  smaller than its explicit components and must equal them when every component is present;
+  only genuinely omitted components may receive an inferred remainder.
 - **RUN-024:** With policy `runStatus: "appended"`, every outgoing model request carries a
   derived run-status message showing Turns, Tool Calls, tokens, and elapsed time; the
   message is never persisted as canonical history.
@@ -702,14 +704,17 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   including after budget exhaustion under `onExhaustion: "final-answer"`, without a
   private-summary model turn. Fail mode rejects exhausted delivery before its Handler starts,
   mixed completion batches fail before any Handler, and durable recovery never repeats a
-  canonically settled call.
+  canonically settled call. Recovery re-decodes the canonical parameters/result, reapplies the
+  projector and output Schema, and requires the reconstructed durable output to match its marker.
   Durable no-tool completion likewise commits its final response and completion marker atomically,
-  so recovery terminalizes without issuing a duplicate model request.
+  so recovery re-decodes and matches that response before terminalizing without a duplicate model
+  request.
 - **RUN-033:** A first response marks its evaluated instruction/wake prefix as Run-scoped.
   Recovery of that Run retains it, while later Runs omit only that marked prefix and preserve the
   remaining assistant/tool conversation. The recorded prefix length must be smaller than the
-  recorded message count so at least the response remains; out-of-bounds provenance fails Schema
-  decoding, while unmarked legacy records retain their full projection.
+  recorded message count, every prefixed message must be system or user input, and at least the
+  response must remain. Invalid provenance fails Schema decoding, while unmarked legacy records
+  retain their full projection.
 - **RUN-034:** Before provider I/O the engine reserves `completionReserveTokens` and admits a
   research call only when its estimated complete prompt plus that reserve fits the remaining gross
   token budget. Context or token pressure invokes target-aware compaction; an unreachable target
@@ -721,3 +726,5 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   `costBudgetMicrousd` is enforced across Attempts, and every Run settlement carries an aggregate
   usage summary without double-counting joined Submissions. Any component, token, model-call, or
   cost aggregation that would exceed safe-integer accounting fails typed before settlement.
+  Summary pricing identities are unique, and every top-level total exactly equals the checked sum
+  of its per-model groups.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -67,9 +67,8 @@ Stop Policy evaluation (step 16) enforces the finite Agent Policy at the Turn se
 next model request. Turn and Tool Call limits bound the work itself: work that would exceed them
 never starts. How exhaustion resolves is policy-selected via `onExhaustion`:
 
-- `"fail"` fails the Run typed (`AgentPolicyError`) at the seam. Its sole delivery exception is
-  an already-declared, authorized singleton completion Tool (RUN-032): discarding that call would
-  lose the typed terminal result after the model response has already spent the budget.
+- `"fail"` fails the Run typed (`AgentPolicyError`) at the seam before any declared application
+  Handler starts.
 - `"final-answer"` (the default) gives the model one constrained settlement opportunity. An
   over-budget declared Tool batch never executes a handler and is never durably declared as a
   pending batch; every open call settles synthetically as a model-visible failed result carrying
@@ -100,10 +99,9 @@ typed projector from the Tool's decoded parameters and successful result to the 
 (RUN-032). The completion call must be the only call in its batch. After authorization and the
 ordinary durable Tool protocol succeed, the engine Schema-validates the projected output and
 completes immediately: it does not ask the model for a private summary. A completion batch may run
-after a token, Turn, or Tool-call limit is crossed, including under `onExhaustion: "fail"`, and its
-completion preserves the honest `budget-exhausted` metadata. This exception applies only to the
-already-declared delivery batch; it does not grant another research or model Turn. Mixed batches
-fail before any Handler starts.
+after a token, Turn, or Tool-call limit is crossed under `onExhaustion: "final-answer"`, and its
+completion preserves the honest `budget-exhausted` metadata. Fail mode rejects the batch before
+its Handler starts. Mixed batches fail before any Handler starts.
 
 `maxDuration` bounds wall clock for one logical Run, not one process Attempt and not cumulative
 worker-active time. In the durable assemblies the clock starts when the Submission's initial
@@ -632,12 +630,10 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   batch never executes a handler and is never durably declared: every open call settles
   synthetically as a model-visible failed result exempt from repeated-failure folding,
   subsequent model requests forbid tool use, and the Run completes with
-  `finishReason: "budget-exhausted"`. Under `"fail"` the Run fails typed before the batch starts,
-  except for the already-declared singleton completion Tool defined by RUN-032.
+  `finishReason: "budget-exhausted"`. Under `"fail"` the Run fails typed before the batch starts.
 - **RUN-019:** Turn exhaustion under `"final-answer"` admits exactly one grace Turn past
   `maxTurns`, with tool use forbidden; the pending batch at the final permitted Turn executes
-  normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam unless
-  that Turn already declared the singleton completion Tool defined by RUN-032.
+  normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam.
 - **RUN-020:** Final-answer Turns are fail-closed: a model that declares any Tool Call under a
   `toolChoice: "none"` request fails the Run typed.
 - **RUN-021:** Per-Run allowances are tightening-only: the effective Turn/Tool-Call limit is the
@@ -649,9 +645,11 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   original byte size, and provider-executed results are exempt.
 - **RUN-023:** The engine accounts cache-read and cache-write input tokens distinctly from
   uncached input and tracks the most recent call's input/output tokens as the live-context
-  estimate, both visible through the budget hook. A recovery usage seed must contain non-negative
-  safe integers with last-call token counts no greater than cumulative totals; invalid seeds fail
-  before Run input hooks or external execution.
+  estimate, both visible through the budget hook. Every present provider token field and each
+  derived total must be a non-negative safe integer; malformed usage fails with
+  `ModelProtocolError` before cost estimation or budget consumption. A recovery usage seed obeys
+  the same integer bound, with last-call token counts no greater than cumulative totals; invalid
+  seeds fail before Run input hooks or external execution.
 - **RUN-024:** With policy `runStatus: "appended"`, every outgoing model request carries a
   derived run-status message showing Turns, Tool Calls, tokens, and elapsed time; the
   message is never persisted as canonical history.
@@ -700,8 +698,12 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   resumed denial writes no new preparation.
 - **RUN-032:** An Agent Definition may designate one singleton completion Tool and a typed output
   projector. A successful authorized call Schema-validates and completes the Run immediately,
-  including after budget exhaustion, without a private-summary model turn; mixed completion
-  batches fail before any Handler, and durable recovery never repeats a canonically settled call.
+  including after budget exhaustion under `onExhaustion: "final-answer"`, without a
+  private-summary model turn. Fail mode rejects exhausted delivery before its Handler starts,
+  mixed completion batches fail before any Handler, and durable recovery never repeats a
+  canonically settled call.
+  Durable no-tool completion likewise commits its final response and completion marker atomically,
+  so recovery terminalizes without issuing a duplicate model request.
 - **RUN-033:** A first response marks its evaluated instruction/wake prefix as Run-scoped.
   Recovery of that Run retains it, while later Runs omit only that marked prefix and preserve the
   remaining assistant/tool conversation; unmarked legacy records retain their full projection.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -407,8 +407,9 @@ and exempt from re-triggering breach). Either
 way the Run settles as `RunCompleted` with `finishReason: "budget-exhausted"` and
 `exhausted: "tokens"`. A grace-Turn response that declares any Tool call other than the permitted
 singleton completion Tool fails typed (`ModelProtocolError`, RUN-020). Under
-`onExhaustion: "fail"`, a token breach remains fatal and no declared application Handler starts.
-A `maxDuration` breach always fails because a grace call would extend wall clock past the contract.
+`onExhaustion: "fail"`, a token breach remains fatal and no
+declared application Handler starts. A `maxDuration` breach always fails because a grace call
+would extend wall clock past the contract.
 
 After these steps the engine appends the model-visible final-output contract to the produced
 Model Input (RUN-028): one framework-owned system message carrying the JSON Schema derived from
@@ -454,7 +455,9 @@ output prose or infers disposition from Tool events. When the application select
 typed error retains the original value in its Schema-safe diagnostic `cause`; the terminal event
 uses a fixed non-sensitive message and never serializes that foreign cause. The public
 `AgentResultSchema` independently rejects a disposition on `finishReason: "budget-exhausted"`, so
-untrusted serialized results cannot bypass the event-reducer invariant.
+untrusted serialized results cannot bypass the event-reducer invariant. Durable recovery re-applies
+the selector and Schema to the reconstructed output and rejects a completion marker whose encoded
+disposition differs or appears where the live seam would omit it.
 
 Raw provider chunks are never mixed into the stable event union.
 
@@ -632,10 +635,12 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   subsequent model requests forbid tool use, and the Run completes with
   `finishReason: "budget-exhausted"`. Under `"fail"` the Run fails typed before the batch starts.
 - **RUN-019:** Turn exhaustion under `"final-answer"` admits exactly one grace Turn past
-  `maxTurns`, with tool use forbidden; the pending batch at the final permitted Turn executes
-  normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam.
+  `maxTurns`, with Tool use limited to the permitted singleton completion Tool; the pending batch
+  at the final permitted Turn executes normally, and no second grace Turn exists. Under `"fail"`
+  the Run fails typed at the seam.
 - **RUN-020:** Final-answer Turns are fail-closed: a model that declares any Tool Call under a
-  `toolChoice: "none"` request fails the Run typed.
+  `toolChoice: "none"` request, or any call other than the permitted singleton completion Tool
+  when that Tool is constrained, fails the Run typed.
 - **RUN-021:** Per-Run allowances are tightening-only: the effective Turn/Tool-Call limit is the
   minimum of the Agent Policy bound and the normalized allowance, never more, and the
   `onExhaustion` resolution applies at the effective limit.
@@ -705,7 +710,8 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   private-summary model turn. Fail mode rejects exhausted delivery before its Handler starts,
   mixed completion batches fail before any Handler, and durable recovery never repeats a
   canonically settled call. Recovery re-decodes the canonical parameters/result, reapplies the
-  projector and output Schema, and requires the reconstructed durable output to match its marker.
+  projector, output Schema, and any ordinary run-disposition selector, and requires the
+  reconstructed durable values to match their marker.
   Durable no-tool completion likewise commits its final response and completion marker atomically,
   so recovery re-decodes and matches that response before terminalizing without a duplicate model
   request.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -646,7 +646,8 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
 - **RUN-023:** The engine accounts cache-read and cache-write input tokens distinctly from
   uncached input and tracks the most recent call's input/output tokens as the live-context
   estimate, both visible through the budget hook. Every present provider token field and each
-  derived total must be a non-negative safe integer; malformed usage fails with
+  derived or cumulative total must be a non-negative safe integer; malformed usage or live
+  aggregation overflow fails with
   `ModelProtocolError` before cost estimation or budget consumption. A recovery usage seed obeys
   the same integer bound, with last-call token counts no greater than cumulative totals; invalid
   seeds fail before Run input hooks or external execution.
@@ -706,13 +707,17 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   so recovery terminalizes without issuing a duplicate model request.
 - **RUN-033:** A first response marks its evaluated instruction/wake prefix as Run-scoped.
   Recovery of that Run retains it, while later Runs omit only that marked prefix and preserve the
-  remaining assistant/tool conversation; unmarked legacy records retain their full projection.
+  remaining assistant/tool conversation. The recorded prefix length must be smaller than the
+  recorded message count so at least the response remains; out-of-bounds provenance fails Schema
+  decoding, while unmarked legacy records retain their full projection.
 - **RUN-034:** Before provider I/O the engine reserves `completionReserveTokens` and admits a
   research call only when its estimated complete prompt plus that reserve fits the remaining gross
   token budget. Context or token pressure invokes target-aware compaction; an unreachable target
   fails locally with `ContextBudgetError`, and token pressure otherwise enters finalization early.
 - **RUN-035:** Each completed model call normalizes and durably records provider, model, optional
   service tier/pricing version, uncached/cache-read/cache-write input, text/reasoning output, and
-  estimated microdollar cost. Cached tokens remain part of gross token budgeting, durable hosts
-  expose the estimator, `costBudgetMicrousd` is enforced across Attempts, and every Run settlement
-  carries an aggregate usage summary without double-counting joined Submissions.
+  estimated microdollar cost. Every canonical input or output total exactly equals its component
+  sum. Cached tokens remain part of gross token budgeting, durable hosts expose the estimator,
+  `costBudgetMicrousd` is enforced across Attempts, and every Run settlement carries an aggregate
+  usage summary without double-counting joined Submissions. Any component, token, model-call, or
+  cost aggregation that would exceed safe-integer accounting fails typed before settlement.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -67,14 +67,16 @@ Stop Policy evaluation (step 16) enforces the finite Agent Policy at the Turn se
 next model request. Turn and Tool Call limits bound the work itself: work that would exceed them
 never starts. How exhaustion resolves is policy-selected via `onExhaustion`:
 
-- `"fail"` fails the Run typed (`AgentPolicyError`) at the seam, exactly the pre-RUN-018
-  behavior.
+- `"fail"` fails the Run typed (`AgentPolicyError`) at the seam. Its sole delivery exception is
+  an already-declared, authorized singleton completion Tool (RUN-032): discarding that call would
+  lose the typed terminal result after the model response has already spent the budget.
 - `"final-answer"` (the default) gives the model one constrained settlement opportunity. An
   over-budget declared Tool batch never executes a handler and is never durably declared as a
   pending batch; every open call settles synthetically as a model-visible failed result carrying
   the encoded policy failure, exempt from repeated-failure folding. Every subsequent model
-  request forbids tool use (`toolChoice: "none"`), and Turn exhaustion admits exactly one grace
-  Turn past `maxTurns` under the same constraint. A Run that settles this way completes with
+  request either forbids tool use (`toolChoice: "none"`) or advertises only the Definition-owned
+  completion Tool. Turn exhaustion admits exactly one grace Turn past `maxTurns` under the same
+  constraint. A Run that settles this way completes with
   `finishReason: "budget-exhausted"` (RUN-011), and a model that declares a Tool Call under the
   constraint fails the Run typed (`ModelProtocolError`, RUN-020).
 
@@ -92,6 +94,16 @@ Call outcomes fold into one consecutive-failure counter in declaration order, an
 Call success resets it, and reaching `repeatedFailureLimit` fails the Run with the typed policy
 failure (`limit: "repeated-failures"`). A `repeatedFailureLimit` of `0` disables the bound.
 Budget-rejected synthetic settlements neither advance nor reset that counter.
+
+An Agent Definition may designate one Toolkit member as its completion Tool and provide a pure,
+typed projector from the Tool's decoded parameters and successful result to the Agent output
+(RUN-032). The completion call must be the only call in its batch. After authorization and the
+ordinary durable Tool protocol succeed, the engine Schema-validates the projected output and
+completes immediately: it does not ask the model for a private summary. A completion batch may run
+after a token, Turn, or Tool-call limit is crossed, including under `onExhaustion: "fail"`, and its
+completion preserves the honest `budget-exhausted` metadata. This exception applies only to the
+already-declared delivery batch; it does not grant another research or model Turn. Mixed batches
+fail before any Handler starts.
 
 `maxDuration` bounds wall clock for one logical Run, not one process Attempt and not cumulative
 worker-active time. In the durable assemblies the clock starts when the Submission's initial
@@ -300,9 +312,12 @@ Context preparation:
 5. Compact with the engine-native policy if required.
 6. Append derived run status and the final-output contract and produce normalized Model Input.
 
-Official prior history remains the exact prefix of the newly materialized Run history. Evaluated
-instructions and the current decoded input append after that prefix; a new Run must never prepend,
-rewrite, or reorder already-official messages.
+Official prior history remains canonical and append-only. Each first response marks the leading
+messages contributed only by that Run's evaluated instructions and wake input. Recovery of the
+owning Run retains that prefix, while every later Run omits it from model input and keeps the
+assistant/tool conversational remainder (RUN-033). Records without provenance retain their full
+legacy projection. Current instructions and decoded input append after the projected prior
+history; no projection rewrites or reorders canonical records.
 
 `RunContextPreparation` is a generic Effect service, not a Conversation store. Its optional prompt
 hook receives stable Run/Turn identities, the immutable source `Prompt`, and the rendered
@@ -321,10 +336,14 @@ canonical records.
 Step 4 is implemented from policy plus observed usage. The engine tracks the most recent model
 call's provider-reported input and output tokens as the live-context estimate, and estimates the
 next call's context as that value plus a chars/4 approximation of parts appended since (the whole
-prompt on the first call). Cache-read and cache-write input tokens are accounted distinctly from
-uncached input and forwarded through the budget hook. `AgentPolicy.contextTokenLimit`, when
-present, bounds one call's live context; `tokenBudget` remains the cumulative runaway stop; spend
-belongs to `costBudgetMicrousd`.
+prompt on the first call). Before provider I/O it also accounts for the derived run-status and
+output-contract messages and withholds `AgentPolicy.completionReserveTokens` from research. The
+admission condition is therefore `estimated next call + completion reserve <= remaining token
+budget` (RUN-034). If it does not hold, the engine compacts or enters final-answer mode before the
+research call; `onExhaustion: "fail"` fails typed at that seam. Cache-read and cache-write input
+tokens remain distinct but both count toward gross token use. `AgentPolicy.contextTokenLimit`,
+when present, bounds one call's live context; `tokenBudget` remains the cumulative runaway stop;
+spend belongs to `costBudgetMicrousd`.
 
 ### Tool result bounds
 
@@ -344,8 +363,9 @@ message is derived at prompt-assembly time and is never persisted as canonical h
 
 ### Compaction
 
-Step 5 runs at the pre-Turn seam, synchronously, when the estimated next context exceeds
-`contextTokenLimit`, per `AgentPolicy.compaction`:
+Step 5 runs at the pre-Turn seam, synchronously, when either the next context exceeds
+`contextTokenLimit` or `estimated next call + completion reserve` exceeds remaining
+`tokenBudget`, per `AgentPolicy.compaction`:
 
 1. **Prune** (`clear-tool-results`): application Tool results older than the protected
    `keepRecentTokens` tail are replaced with `"[tool result cleared by compaction]"`, preserving
@@ -365,8 +385,11 @@ shared estimator, and limits coverage to prior Runs. The owning Run's records ar
 because its first response record carries the evaluated
 instructions and input. The engine's in-memory rebuild is therefore a view that may cover more
 than the record; the record is canonical. A threshold compaction with no prior-Run records to
-cover commits no record and applies only in-view. Compaction appends or emits a summary representation and
-preserves the source history; failed compaction leaves the original history authoritative.
+cover commits no record and applies only in-view. After pruning or summarizing, the engine
+re-estimates the complete outgoing prompt. If the target remains unreachable it fails locally with
+`ContextBudgetError` and never sends a request it already knows cannot fit (RUN-034). Compaction
+appends or emits a summary representation and preserves the source history; failed compaction
+leaves the original history authoritative.
 Host-supplied, digest-bound compaction artifacts remain available through the capabilities layer
 ([capabilities §6](./capabilities.md)). They shape each model request through
 `RunContextPreparation`; unlike `CompactionCreated`, the supplied artifact itself is not canonical
@@ -377,15 +400,17 @@ and is recomputed after restart from the canonical source.
 Crossing 80% of a configured budget dimension emits a `BudgetWarning` Run Event once per
 dimension (RUN-025). Turn and Tool Call exhaustion resolve through the Stop Policy's
 `onExhaustion` machinery in section 3 and RUN-018 through RUN-020. Token exhaustion is a
-post-response check and joins the same resolution. Under the default `"final-answer"`, a breaching response that
+pre-call reserve and post-response gross check, and joins the same resolution. Under the default
+`"final-answer"`, a breaching response that
 already carries a decodable final answer at a stop completes the Run directly with that answer
 and no extra call, and otherwise the Run takes at most one constrained grace Turn
-(`toolChoice: "none"`; its usage is consumed once and exempt from re-triggering breach). Either
+(`toolChoice: "none"`, or only the Definition-owned completion Tool; its usage is consumed once
+and exempt from re-triggering breach). Either
 way the Run settles as `RunCompleted` with `finishReason: "budget-exhausted"` and
-`exhausted: "tokens"`. A grace-Turn response that declares Tool calls fails typed
-(`ModelProtocolError`, RUN-020); under `onExhaustion: "fail"` token breach keeps the fail-fast
-contract with `AgentPolicyError`. A `maxDuration` breach always fails because a grace call would
-extend wall clock past the contract.
+`exhausted: "tokens"`. A grace-Turn response that declares any Tool call other than the permitted
+singleton completion Tool fails typed (`ModelProtocolError`, RUN-020). Under
+`onExhaustion: "fail"`, a token breach remains fatal and no declared application Handler starts.
+A `maxDuration` breach always fails because a grace call would extend wall clock past the contract.
 
 After these steps the engine appends the model-visible final-output contract to the produced
 Model Input (RUN-028): one framework-owned system message carrying the JSON Schema derived from
@@ -581,12 +606,13 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
 - **RUN-011:** Budget exhaustion cannot masquerade as success, and its dimension survives
   durably typed. A Run that settles through final-answer resolution after Turn, Tool Call, or
   token exhaustion carries `finishReason: "budget-exhausted"` and the `exhausted` dimension
-  marker, never `"model-stop"`, on the live terminal event and on the durable
-  `SubmissionSettled` record; `onExhaustion: "fail"` fails typed before any successful stop,
-  and a Run failed by `AgentPolicyError` settles with the typed `limit` preserved as the
+  marker on the live terminal event and durable `SubmissionSettled` record, never `"model-stop"`.
+  `onExhaustion: "fail"` fails typed before any exhausted application Handler starts. A Run failed
+  by `AgentPolicyError` settles with the typed `limit` preserved as the
   durable record's `policyLimit`. Consumers never reconstruct either dimension from message
-  text. The metadata is family-bound fail-closed: `exhausted` decodes only alongside
-  `finishReason: "budget-exhausted"` on a `completed` settlement, `policyLimit` only on a
+  text. The metadata is family-bound fail-closed: `finishReason: "budget-exhausted"` and
+  `exhausted` must either both be present on a `completed` settlement or both be absent;
+  `policyLimit` is valid only on a
   `failed` settlement whose recorded failure projection is the `AgentPolicyError` it names, and
   histories persisted before the dimensions became durable decode with the metadata absent.
 - **RUN-012:** Provider SDK types do not enter Conversation records; Effect AI Prompt and Response
@@ -606,11 +632,12 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   batch never executes a handler and is never durably declared: every open call settles
   synthetically as a model-visible failed result exempt from repeated-failure folding,
   subsequent model requests forbid tool use, and the Run completes with
-  `finishReason: "budget-exhausted"`. Under `"fail"` the Run fails typed before the batch
-  starts.
+  `finishReason: "budget-exhausted"`. Under `"fail"` the Run fails typed before the batch starts,
+  except for the already-declared singleton completion Tool defined by RUN-032.
 - **RUN-019:** Turn exhaustion under `"final-answer"` admits exactly one grace Turn past
   `maxTurns`, with tool use forbidden; the pending batch at the final permitted Turn executes
-  normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam.
+  normally, and no second grace Turn exists. Under `"fail"` the Run fails typed at the seam unless
+  that Turn already declared the singleton completion Tool defined by RUN-032.
 - **RUN-020:** Final-answer Turns are fail-closed: a model that declares any Tool Call under a
   `toolChoice: "none"` request fails the Run typed.
 - **RUN-021:** Per-Run allowances are tightening-only: the effective Turn/Tool-Call limit is the
@@ -632,9 +659,11 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   The token dimension participates in the `onExhaustion` resolution: under `"final-answer"`, a
   token-breaching response that already carries decodable
   final output settles directly, and otherwise the Run takes at most one constrained grace Turn
-  (`toolChoice: "none"`, its usage consumed once and exempt from re-triggering breach),
+  (`toolChoice: "none"`, or only the Definition-owned completion Tool; its usage consumed once
+  and exempt from re-triggering breach),
   completing with `finishReason: "budget-exhausted"` and `exhausted: "tokens"`; under `"fail"`
-  token breach stays fatal. Duration and cost remain hard limits in both modes.
+  a token breach stays fatal and no application Handler starts. Duration and cost remain hard
+  rails in both modes.
 - **RUN-026:** When the estimated next model-call context exceeds policy `contextTokenLimit`,
   including the reserved size of the model-visible output contract the engine appends after
   preparation under RUN-028, the engine compacts at the pre-Turn boundary. It prunes old Tool
@@ -669,3 +698,19 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   descriptor; denial fails typed and settles accepted work terminally without the denied Attempt
   starting a Handler or creating a new side effect. Fresh denial writes no prepared record, and
   resumed denial writes no new preparation.
+- **RUN-032:** An Agent Definition may designate one singleton completion Tool and a typed output
+  projector. A successful authorized call Schema-validates and completes the Run immediately,
+  including after budget exhaustion, without a private-summary model turn; mixed completion
+  batches fail before any Handler, and durable recovery never repeats a canonically settled call.
+- **RUN-033:** A first response marks its evaluated instruction/wake prefix as Run-scoped.
+  Recovery of that Run retains it, while later Runs omit only that marked prefix and preserve the
+  remaining assistant/tool conversation; unmarked legacy records retain their full projection.
+- **RUN-034:** Before provider I/O the engine reserves `completionReserveTokens` and admits a
+  research call only when its estimated complete prompt plus that reserve fits the remaining gross
+  token budget. Context or token pressure invokes target-aware compaction; an unreachable target
+  fails locally with `ContextBudgetError`, and token pressure otherwise enters finalization early.
+- **RUN-035:** Each completed model call normalizes and durably records provider, model, optional
+  service tier/pricing version, uncached/cache-read/cache-write input, text/reasoning output, and
+  estimated microdollar cost. Cached tokens remain part of gross token budgeting, durable hosts
+  expose the estimator, `costBudgetMicrousd` is enforced across Attempts, and every Run settlement
+  carries an aggregate usage summary without double-counting joined Submissions.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -710,8 +710,9 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   private-summary model turn. Fail mode rejects exhausted delivery before its Handler starts,
   mixed completion batches fail before any Handler, and durable recovery never repeats a
   canonically settled call. Recovery re-decodes the canonical parameters/result, reapplies the
-  projector, output Schema, and any ordinary run-disposition selector, and requires the
-  reconstructed durable values to match their marker.
+  projector, output Schema, and any ordinary run-disposition selector, counts provider-executed
+  calls when enforcing the singleton batch, and requires the reconstructed durable values to
+  match their marker.
   Durable no-tool completion likewise commits its final response and completion marker atomically,
   so recovery re-decodes and matches that response before terminalizing without a duplicate model
   request.

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -94,9 +94,11 @@ Generated command sequences cover:
 - completion-reserve admission and unreachable compaction targets;
 - singleton completion Tool success, mixed-batch rejection, strict fail-mode admission, and crash
   recovery after result commit;
-- malformed provider usage rejection before cost estimation or budget consumption;
-- Run-scoped prompt provenance across owner recovery and later Runs;
-- durable cache-split/model/tier/cost usage and settlement aggregation;
+- malformed or non-additive provider usage rejection before cost estimation or budget consumption;
+- Run-scoped prompt provenance across owner recovery and later Runs, including prefix bounds;
+- durable cache-split/model/tier/cost usage and settlement aggregation, including checked token and
+  cost overflow;
+- paired budget-exhaustion metadata on live completion markers and durable settlements;
 - child-agent completion/interruption;
 - budget exhaustion;
 - subscriber backpressure;

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -97,8 +97,10 @@ Generated command sequences cover:
 - malformed or non-additive provider usage rejection before cost estimation or budget consumption;
 - Run-scoped prompt provenance across owner recovery and later Runs, including prefix bounds;
 - durable cache-split/model/tier/cost usage and settlement aggregation, including checked token and
-  cost overflow;
+  cost overflow, unique pricing groups, and exact group-to-summary agreement;
 - paired budget-exhaustion metadata on live completion markers and durable settlements;
+- recovered no-Tool and completion-Tool markers revalidated against their canonical response or
+  Tool result under hostile-store substitution;
 - child-agent completion/interruption;
 - budget exhaustion;
 - subscriber backpressure;

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -91,6 +91,10 @@ Generated command sequences cover:
 - steering and follow-up races;
 - approval timing;
 - compaction success/failure;
+- completion-reserve admission and unreachable compaction targets;
+- singleton completion Tool success, mixed-batch rejection, and crash recovery after result commit;
+- Run-scoped prompt provenance across owner recovery and later Runs;
+- durable cache-split/model/tier/cost usage and settlement aggregation;
 - child-agent completion/interruption;
 - budget exhaustion;
 - subscriber backpressure;

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -92,7 +92,9 @@ Generated command sequences cover:
 - approval timing;
 - compaction success/failure;
 - completion-reserve admission and unreachable compaction targets;
-- singleton completion Tool success, mixed-batch rejection, and crash recovery after result commit;
+- singleton completion Tool success, mixed-batch rejection, strict fail-mode admission, and crash
+  recovery after result commit;
+- malformed provider usage rejection before cost estimation or budget consumption;
 - Run-scoped prompt provenance across owner recovery and later Runs;
 - durable cache-split/model/tier/cost usage and settlement aggregation;
 - child-agent completion/interruption;

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -99,8 +99,8 @@ Generated command sequences cover:
 - durable cache-split/model/tier/cost usage and settlement aggregation, including checked token and
   cost overflow, unique pricing groups, and exact group-to-summary agreement;
 - paired budget-exhaustion metadata on live completion markers and durable settlements;
-- recovered no-Tool and completion-Tool markers revalidated against their canonical response or
-  Tool result under hostile-store substitution;
+- recovered no-Tool and completion-Tool markers revalidated against their canonical response,
+  Tool result, and output-derived run disposition under hostile-store substitution;
 - child-agent completion/interruption;
 - budget exhaustion;
 - subscriber backpressure;

--- a/examples/demo/src/demo/general-chat.test.ts
+++ b/examples/demo/src/demo/general-chat.test.ts
@@ -4,11 +4,12 @@ import type {
   AgentInputError,
   AgentOutputError,
   AgentPolicyError,
+  AgentToolAuthorizationDenied,
+  ContextBudgetError,
   ContextOverflowError,
   IdGenerator,
   ModelProtocolError,
 } from "@effect-agent/core";
-import { type AgentToolAuthorizationDenied } from "@effect-agent/core";
 import {
   AgentRuntime,
   type AgentChildPending,
@@ -51,6 +52,7 @@ type ExpectedFailure =
   | AgentInputError
   | AgentOutputError
   | AgentPolicyError
+  | ContextBudgetError
   | ContextOverflowError
   | ModelProtocolError
   | AgentApprovalDenied

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -30,6 +30,30 @@ export interface RunDispositionDeclaration<Output, DispositionSchema extends Sch
   readonly fromOutput: (output: Output) => unknown;
 }
 
+/** Values available to a Definition-owned completion Tool projector after canonical decoding. */
+export interface CompletionProjectionInput<Parameters = unknown, Result = unknown> {
+  readonly parameters: Parameters;
+  readonly result: Result;
+}
+
+/** One application Tool whose successful canonical result can complete its owning Agent. */
+export interface CompletionToolDeclaration<
+  Parameters = unknown,
+  Result = unknown,
+  Output = unknown,
+> {
+  readonly tool: string;
+  readonly project: (input: CompletionProjectionInput<Parameters, Result>) => Output;
+}
+
+type CompletionToolFor<ToolkitValue extends Toolkit.Any, Output> = {
+  readonly [Name in keyof ToolkitValue["tools"] & string]: CompletionToolDeclaration<
+    Tool.Parameters<ToolkitValue["tools"][Name]>,
+    Tool.Success<ToolkitValue["tools"][Name]>,
+    Output
+  > & { readonly tool: Name };
+}[keyof ToolkitValue["tools"] & string];
+
 /** Immutable, model-agnostic schemas, behavior, tools, and bounds for an agent. */
 export interface Definition<
   InputSchema extends Schema.Top,
@@ -50,6 +74,8 @@ export interface Definition<
   readonly toolkit: ToolkitValue;
   /** Finite execution bounds enforced by the runtime. */
   readonly policy: AgentPolicy;
+  /** Optional successful Tool result that projects directly to the Agent output and settles. */
+  readonly completion?: CompletionToolDeclaration | undefined;
   readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
@@ -70,6 +96,7 @@ export interface DefinitionOptions<
   readonly instructions: Instructions;
   readonly toolkit: ToolkitValue;
   readonly policy: AgentPolicy;
+  readonly completion?: CompletionToolFor<ToolkitValue, OutputSchema["Type"]> | undefined;
   readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
@@ -181,6 +208,7 @@ export namespace Agent {
     | DefinitionValue["input"]["DecodingServices"]
     | DefinitionValue["input"]["EncodingServices"]
     | DefinitionValue["output"]["DecodingServices"]
+    | DefinitionValue["output"]["EncodingServices"]
     | RunDispositionSchemaOf<DefinitionValue>["DecodingServices"]
     | RunDispositionSchemaOf<DefinitionValue>["EncodingServices"];
 
@@ -240,6 +268,7 @@ export namespace Agent {
       readonly instructions: unknown;
       readonly toolkit: Toolkit.Any;
       readonly policy: AgentPolicy;
+      readonly completion?: CompletionToolDeclaration | undefined;
       readonly runDisposition?: RunDispositionDeclaration<never, Schema.Top> | undefined;
       readonly description?: string | undefined;
       readonly metadata?: Readonly<Record<string, string>> | undefined;
@@ -249,6 +278,8 @@ export namespace Agent {
       ...options,
       id: S.decodeSync(AgentId)(id),
       metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata }),
+      completion:
+        options.completion === undefined ? undefined : Object.freeze({ ...options.completion }),
       runDisposition:
         options.runDisposition === undefined
           ? undefined

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -205,6 +205,7 @@ export namespace Agent {
     | EffectServices<InstructionEffect<DefinitionValue["instructions"], Input<DefinitionValue>>>
     | Tool.HandlersFor<Tools<DefinitionValue>>
     | Tool.HandlerServices<Tools<DefinitionValue>[keyof Tools<DefinitionValue>]>
+    | Tool.SuccessSchema<Tools<DefinitionValue>[keyof Tools<DefinitionValue>]>["DecodingServices"]
     | DefinitionValue["input"]["DecodingServices"]
     | DefinitionValue["input"]["EncodingServices"]
     | DefinitionValue["output"]["DecodingServices"]

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -122,6 +122,17 @@ export class ContextOverflowError extends Schema.TaggedError<ContextOverflowErro
   },
 ) {}
 
+/** Local context preparation could not fit a legal prompt inside its target before provider I/O. */
+export class ContextBudgetError extends Schema.TaggedError<ContextBudgetError>()(
+  "ContextBudgetError",
+  {
+    message: Schema.String,
+    estimatedTokens: Schema.Natural,
+    targetTokens: Schema.Natural,
+    completionReserveTokens: Schema.Natural,
+  },
+) {}
+
 /** Schema for framework-owned agent errors; application and Effect AI failures remain separate. */
 export const AgentError = Schema.Union([
   AgentInputError,
@@ -134,5 +145,6 @@ export const AgentError = Schema.Union([
   ModelProtocolError,
   AgentInterrupted,
   ContextOverflowError,
+  ContextBudgetError,
 ]);
 export type AgentError = typeof AgentError.Type;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./policy.ts";
 export * from "./services.ts";
 export * from "./subagent.ts";
 export * from "./tool-result.ts";
+export * from "./usage.ts";

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -56,6 +56,8 @@ const AgentPolicyFields = Schema.Struct({
   repeatedFailureLimit: NonNegativeInt,
   onExhaustion: OnExhaustion,
   tokenBudget: Schema.optionalKey(PositiveInt),
+  /** Tokens withheld from research calls so one final delivery call remains admissible. */
+  completionReserveTokens: NonNegativeInt,
   costBudgetMicrousd: Schema.optionalKey(NonNegativeInt),
   /** Per-model-call live-context bound; crossing it triggers compaction rather than failure. */
   contextTokenLimit: Schema.optionalKey(PositiveInt),
@@ -75,6 +77,7 @@ export type AgentPolicyInput = Readonly<
     | "toolResultBounds"
     | "runStatus"
     | "compaction"
+    | "completionReserveTokens"
   > & {
     /** Finite, positive wall-clock duration accepted in any Effect Duration input form. */
     readonly maxDuration: Duration.Input;
@@ -86,6 +89,8 @@ export type AgentPolicyInput = Readonly<
     readonly toolResultBounds?: ToolResultBounds;
     /** Whether a derived run-status message is appended to each model call; defaults to `"appended"`. */
     readonly runStatus?: AgentPolicyFields["runStatus"];
+    /** Tokens reserved for final delivery; defaults to 20% of tokenBudget, capped at 4,096. */
+    readonly completionReserveTokens?: number;
     /** Compaction strategy applied when `contextTokenLimit` is crossed; defaults documented on `CompactionPolicy`. */
     readonly compaction?: CompactionPolicy;
   }
@@ -95,6 +100,14 @@ export type AgentPolicyInput = Readonly<
 export class AgentPolicy extends Schema.Class<AgentPolicy>("AgentPolicy")(AgentPolicyFields) {
   /** Normalize and validate finite policy bounds, throwing on invalid input. */
   static override make(input: AgentPolicyInput): AgentPolicy {
+    const completionReserveTokens =
+      input.completionReserveTokens ??
+      (input.tokenBudget === undefined
+        ? 4_096
+        : Math.min(4_096, Math.floor(input.tokenBudget / 5)));
+    if (input.tokenBudget !== undefined && completionReserveTokens > input.tokenBudget) {
+      throw new Error("completionReserveTokens cannot exceed tokenBudget");
+    }
     return super.make({
       ...input,
       maxDuration: Duration.fromInputUnsafe(input.maxDuration),
@@ -102,6 +115,7 @@ export class AgentPolicy extends Schema.Class<AgentPolicy>("AgentPolicy")(AgentP
       onExhaustion: input.onExhaustion ?? "final-answer",
       toolResultBounds: input.toolResultBounds ?? ToolResultBounds.make({ maxBytes: 50 * 1024 }),
       runStatus: input.runStatus ?? "appended",
+      completionReserveTokens,
       compaction: input.compaction ?? CompactionPolicy.make(),
     });
   }

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -66,16 +66,74 @@ export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
   costMicrousd: Schema.Natural,
 }) {}
 
-/** Settlement aggregate included with a terminal Run settlement. */
-export class RunUsageSummary extends Schema.Class<RunUsageSummary>(
-  "@effect-agent/core/RunUsageSummary",
-)({
+const RunUsageSummaryFields = Schema.Struct({
   modelCalls: Schema.Natural,
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: Schema.Natural,
   byModel: Schema.Array(ModelUsageGroup),
-}) {}
+}).check(
+  Schema.makeFilter(
+    (summary) => {
+      const identities = summary.byModel.map((group) =>
+        JSON.stringify([
+          group.provider,
+          group.model,
+          group.serviceTier ?? null,
+          group.pricingVersion ?? null,
+        ]),
+      );
+      return (
+        new Set(identities).size === identities.length &&
+        hasAdditiveTotal(
+          summary.modelCalls,
+          summary.byModel.map((group) => group.modelCalls),
+        ) &&
+        hasAdditiveTotal(
+          summary.inputTokens.total,
+          summary.byModel.map((group) => group.inputTokens.total),
+        ) &&
+        hasAdditiveTotal(
+          summary.inputTokens.uncached,
+          summary.byModel.map((group) => group.inputTokens.uncached),
+        ) &&
+        hasAdditiveTotal(
+          summary.inputTokens.cacheRead,
+          summary.byModel.map((group) => group.inputTokens.cacheRead),
+        ) &&
+        hasAdditiveTotal(
+          summary.inputTokens.cacheWrite,
+          summary.byModel.map((group) => group.inputTokens.cacheWrite),
+        ) &&
+        hasAdditiveTotal(
+          summary.outputTokens.total,
+          summary.byModel.map((group) => group.outputTokens.total),
+        ) &&
+        hasAdditiveTotal(
+          summary.outputTokens.text,
+          summary.byModel.map((group) => group.outputTokens.text),
+        ) &&
+        hasAdditiveTotal(
+          summary.outputTokens.reasoning,
+          summary.byModel.map((group) => group.outputTokens.reasoning),
+        ) &&
+        hasAdditiveTotal(
+          summary.costMicrousd,
+          summary.byModel.map((group) => group.costMicrousd),
+        )
+      );
+    },
+    {
+      title:
+        "Run usage totals equal unique per-model pricing groups within safe-integer accounting",
+    },
+  ),
+);
+
+/** Settlement aggregate included with a terminal Run settlement. */
+export class RunUsageSummary extends Schema.Class<RunUsageSummary>(
+  "@effect-agent/core/RunUsageSummary",
+)(RunUsageSummaryFields) {}
 
 interface MutableUsageGroup {
   readonly provider: string;

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -60,7 +60,7 @@ export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
   model: UsageIdentity,
   serviceTier: Schema.optionalKey(UsageIdentity),
   pricingVersion: Schema.optionalKey(UsageIdentity),
-  modelCalls: Schema.Natural,
+  modelCalls: Schema.Natural.check(Schema.isGreaterThan(0)),
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: Schema.Natural,

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -1,25 +1,43 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 const UsageIdentity = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 
-/** Provider-reported input-token components for one completed model call. */
-export class InputTokenUsage extends Schema.Class<InputTokenUsage>(
-  "@effect-agent/core/InputTokenUsage",
-)({
+const hasAdditiveTotal = (total: number, components: ReadonlyArray<number>): boolean => {
+  const sum = components.reduce((accumulator, component) => accumulator + component, 0);
+  return Number.isSafeInteger(sum) && total === sum;
+};
+
+const InputTokenUsageFields = Schema.Struct({
   total: Schema.Natural,
   uncached: Schema.Natural,
   cacheRead: Schema.Natural,
   cacheWrite: Schema.Natural,
-}) {}
+}).check(
+  Schema.makeFilter(
+    (usage) => hasAdditiveTotal(usage.total, [usage.uncached, usage.cacheRead, usage.cacheWrite]),
+    { title: "Input token total equals uncached, cache-read, and cache-write components" },
+  ),
+);
+
+/** Provider-reported input-token components for one completed model call. */
+export class InputTokenUsage extends Schema.Class<InputTokenUsage>(
+  "@effect-agent/core/InputTokenUsage",
+)(InputTokenUsageFields) {}
+
+const OutputTokenUsageFields = Schema.Struct({
+  total: Schema.Natural,
+  text: Schema.Natural,
+  reasoning: Schema.Natural,
+}).check(
+  Schema.makeFilter((usage) => hasAdditiveTotal(usage.total, [usage.text, usage.reasoning]), {
+    title: "Output token total equals text and reasoning components",
+  }),
+);
 
 /** Provider-reported output-token components for one completed model call. */
 export class OutputTokenUsage extends Schema.Class<OutputTokenUsage>(
   "@effect-agent/core/OutputTokenUsage",
-)({
-  total: Schema.Natural,
-  text: Schema.Natural,
-  reasoning: Schema.Natural,
-}) {}
+)(OutputTokenUsageFields) {}
 
 /** Canonical, provider-independent accounting for one completed model call. */
 export class ModelCallUsage extends Schema.Class<ModelCallUsage>(
@@ -78,22 +96,83 @@ interface MutableUsageGroup {
 const emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
 const emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
 
+/** Canonical usage could not be aggregated without exceeding safe-integer accounting. */
+export class UsageAggregationError extends Schema.TaggedError<UsageAggregationError>()(
+  "UsageAggregationError",
+  {
+    field: Schema.NonEmptyString,
+    message: Schema.String,
+  },
+) {}
+
+const checkedAdd = (
+  field: string,
+  left: number,
+  right: number,
+): Effect.Effect<number, UsageAggregationError> => {
+  const total = left + right;
+  return Number.isSafeInteger(left) &&
+    left >= 0 &&
+    Number.isSafeInteger(right) &&
+    right >= 0 &&
+    Number.isSafeInteger(total)
+    ? Effect.succeed(total)
+    : Effect.fail(
+        UsageAggregationError.make({
+          field,
+          message: `Canonical usage aggregation exceeded the safe-integer range at ${field}`,
+        }),
+      );
+};
+
 /** Deterministically aggregate canonical per-call usage without making cached tokens free. */
-export const summarizeModelUsage = (calls: ReadonlyArray<ModelCallUsage>): RunUsageSummary => {
+export const summarizeModelUsage = Effect.fn("summarizeModelUsage")(function* (
+  calls: ReadonlyArray<ModelCallUsage>,
+): Effect.fn.Return<RunUsageSummary, UsageAggregationError> {
   const inputTokens = emptyInputTokens();
   const outputTokens = emptyOutputTokens();
   const groups = new Map<string, MutableUsageGroup>();
+  let modelCalls = 0;
   let costMicrousd = 0;
 
   for (const call of calls) {
-    inputTokens.total += call.inputTokens.total;
-    inputTokens.uncached += call.inputTokens.uncached;
-    inputTokens.cacheRead += call.inputTokens.cacheRead;
-    inputTokens.cacheWrite += call.inputTokens.cacheWrite;
-    outputTokens.total += call.outputTokens.total;
-    outputTokens.text += call.outputTokens.text;
-    outputTokens.reasoning += call.outputTokens.reasoning;
-    costMicrousd += call.costMicrousd;
+    modelCalls = yield* checkedAdd("modelCalls", modelCalls, 1);
+    inputTokens.total = yield* checkedAdd(
+      "inputTokens.total",
+      inputTokens.total,
+      call.inputTokens.total,
+    );
+    inputTokens.uncached = yield* checkedAdd(
+      "inputTokens.uncached",
+      inputTokens.uncached,
+      call.inputTokens.uncached,
+    );
+    inputTokens.cacheRead = yield* checkedAdd(
+      "inputTokens.cacheRead",
+      inputTokens.cacheRead,
+      call.inputTokens.cacheRead,
+    );
+    inputTokens.cacheWrite = yield* checkedAdd(
+      "inputTokens.cacheWrite",
+      inputTokens.cacheWrite,
+      call.inputTokens.cacheWrite,
+    );
+    outputTokens.total = yield* checkedAdd(
+      "outputTokens.total",
+      outputTokens.total,
+      call.outputTokens.total,
+    );
+    outputTokens.text = yield* checkedAdd(
+      "outputTokens.text",
+      outputTokens.text,
+      call.outputTokens.text,
+    );
+    outputTokens.reasoning = yield* checkedAdd(
+      "outputTokens.reasoning",
+      outputTokens.reasoning,
+      call.outputTokens.reasoning,
+    );
+    costMicrousd = yield* checkedAdd("costMicrousd", costMicrousd, call.costMicrousd);
 
     const key = JSON.stringify([
       call.provider,
@@ -115,19 +194,51 @@ export const summarizeModelUsage = (calls: ReadonlyArray<ModelCallUsage>): RunUs
       };
       groups.set(key, group);
     }
-    group.modelCalls += 1;
-    group.inputTokens.total += call.inputTokens.total;
-    group.inputTokens.uncached += call.inputTokens.uncached;
-    group.inputTokens.cacheRead += call.inputTokens.cacheRead;
-    group.inputTokens.cacheWrite += call.inputTokens.cacheWrite;
-    group.outputTokens.total += call.outputTokens.total;
-    group.outputTokens.text += call.outputTokens.text;
-    group.outputTokens.reasoning += call.outputTokens.reasoning;
-    group.costMicrousd += call.costMicrousd;
+    group.modelCalls = yield* checkedAdd("byModel.modelCalls", group.modelCalls, 1);
+    group.inputTokens.total = yield* checkedAdd(
+      "byModel.inputTokens.total",
+      group.inputTokens.total,
+      call.inputTokens.total,
+    );
+    group.inputTokens.uncached = yield* checkedAdd(
+      "byModel.inputTokens.uncached",
+      group.inputTokens.uncached,
+      call.inputTokens.uncached,
+    );
+    group.inputTokens.cacheRead = yield* checkedAdd(
+      "byModel.inputTokens.cacheRead",
+      group.inputTokens.cacheRead,
+      call.inputTokens.cacheRead,
+    );
+    group.inputTokens.cacheWrite = yield* checkedAdd(
+      "byModel.inputTokens.cacheWrite",
+      group.inputTokens.cacheWrite,
+      call.inputTokens.cacheWrite,
+    );
+    group.outputTokens.total = yield* checkedAdd(
+      "byModel.outputTokens.total",
+      group.outputTokens.total,
+      call.outputTokens.total,
+    );
+    group.outputTokens.text = yield* checkedAdd(
+      "byModel.outputTokens.text",
+      group.outputTokens.text,
+      call.outputTokens.text,
+    );
+    group.outputTokens.reasoning = yield* checkedAdd(
+      "byModel.outputTokens.reasoning",
+      group.outputTokens.reasoning,
+      call.outputTokens.reasoning,
+    );
+    group.costMicrousd = yield* checkedAdd(
+      "byModel.costMicrousd",
+      group.costMicrousd,
+      call.costMicrousd,
+    );
   }
 
   return RunUsageSummary.make({
-    modelCalls: calls.length,
+    modelCalls,
     inputTokens: InputTokenUsage.make(inputTokens),
     outputTokens: OutputTokenUsage.make(outputTokens),
     costMicrousd,
@@ -144,4 +255,4 @@ export const summarizeModelUsage = (calls: ReadonlyArray<ModelCallUsage>): RunUs
       }),
     ),
   });
-};
+});

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -48,7 +48,7 @@ export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
   costMicrousd: Schema.Natural,
 }) {}
 
-/** Durable aggregate included with a terminal Run settlement. */
+/** Settlement aggregate included with a terminal Run settlement. */
 export class RunUsageSummary extends Schema.Class<RunUsageSummary>(
   "@effect-agent/core/RunUsageSummary",
 )({

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -1,0 +1,147 @@
+import { Schema } from "effect";
+
+const UsageIdentity = Schema.NonEmptyString.check(Schema.isMaxLength(256));
+
+/** Provider-reported input-token components for one completed model call. */
+export class InputTokenUsage extends Schema.Class<InputTokenUsage>(
+  "@effect-agent/core/InputTokenUsage",
+)({
+  total: Schema.Natural,
+  uncached: Schema.Natural,
+  cacheRead: Schema.Natural,
+  cacheWrite: Schema.Natural,
+}) {}
+
+/** Provider-reported output-token components for one completed model call. */
+export class OutputTokenUsage extends Schema.Class<OutputTokenUsage>(
+  "@effect-agent/core/OutputTokenUsage",
+)({
+  total: Schema.Natural,
+  text: Schema.Natural,
+  reasoning: Schema.Natural,
+}) {}
+
+/** Canonical, provider-independent accounting for one completed model call. */
+export class ModelCallUsage extends Schema.Class<ModelCallUsage>(
+  "@effect-agent/core/ModelCallUsage",
+)({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: Schema.optionalKey(UsageIdentity),
+  pricingVersion: Schema.optionalKey(UsageIdentity),
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: Schema.Natural,
+}) {}
+
+/** Settlement-sized aggregate for calls sharing one pricing identity. */
+export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
+  "@effect-agent/core/ModelUsageGroup",
+)({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: Schema.optionalKey(UsageIdentity),
+  pricingVersion: Schema.optionalKey(UsageIdentity),
+  modelCalls: Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: Schema.Natural,
+}) {}
+
+/** Durable aggregate included with a terminal Run settlement. */
+export class RunUsageSummary extends Schema.Class<RunUsageSummary>(
+  "@effect-agent/core/RunUsageSummary",
+)({
+  modelCalls: Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: Schema.Natural,
+  byModel: Schema.Array(ModelUsageGroup),
+}) {}
+
+interface MutableUsageGroup {
+  readonly provider: string;
+  readonly model: string;
+  readonly serviceTier?: string | undefined;
+  readonly pricingVersion?: string | undefined;
+  modelCalls: number;
+  inputTokens: {
+    total: number;
+    uncached: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  outputTokens: { total: number; text: number; reasoning: number };
+  costMicrousd: number;
+}
+
+const emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
+const emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
+
+/** Deterministically aggregate canonical per-call usage without making cached tokens free. */
+export const summarizeModelUsage = (calls: ReadonlyArray<ModelCallUsage>): RunUsageSummary => {
+  const inputTokens = emptyInputTokens();
+  const outputTokens = emptyOutputTokens();
+  const groups = new Map<string, MutableUsageGroup>();
+  let costMicrousd = 0;
+
+  for (const call of calls) {
+    inputTokens.total += call.inputTokens.total;
+    inputTokens.uncached += call.inputTokens.uncached;
+    inputTokens.cacheRead += call.inputTokens.cacheRead;
+    inputTokens.cacheWrite += call.inputTokens.cacheWrite;
+    outputTokens.total += call.outputTokens.total;
+    outputTokens.text += call.outputTokens.text;
+    outputTokens.reasoning += call.outputTokens.reasoning;
+    costMicrousd += call.costMicrousd;
+
+    const key = JSON.stringify([
+      call.provider,
+      call.model,
+      call.serviceTier ?? null,
+      call.pricingVersion ?? null,
+    ]);
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = {
+        provider: call.provider,
+        model: call.model,
+        ...(call.serviceTier === undefined ? {} : { serviceTier: call.serviceTier }),
+        ...(call.pricingVersion === undefined ? {} : { pricingVersion: call.pricingVersion }),
+        modelCalls: 0,
+        inputTokens: emptyInputTokens(),
+        outputTokens: emptyOutputTokens(),
+        costMicrousd: 0,
+      };
+      groups.set(key, group);
+    }
+    group.modelCalls += 1;
+    group.inputTokens.total += call.inputTokens.total;
+    group.inputTokens.uncached += call.inputTokens.uncached;
+    group.inputTokens.cacheRead += call.inputTokens.cacheRead;
+    group.inputTokens.cacheWrite += call.inputTokens.cacheWrite;
+    group.outputTokens.total += call.outputTokens.total;
+    group.outputTokens.text += call.outputTokens.text;
+    group.outputTokens.reasoning += call.outputTokens.reasoning;
+    group.costMicrousd += call.costMicrousd;
+  }
+
+  return RunUsageSummary.make({
+    modelCalls: calls.length,
+    inputTokens: InputTokenUsage.make(inputTokens),
+    outputTokens: OutputTokenUsage.make(outputTokens),
+    costMicrousd,
+    byModel: [...groups.values()].map((group) =>
+      ModelUsageGroup.make({
+        provider: group.provider,
+        model: group.model,
+        ...(group.serviceTier === undefined ? {} : { serviceTier: group.serviceTier }),
+        ...(group.pricingVersion === undefined ? {} : { pricingVersion: group.pricingVersion }),
+        modelCalls: group.modelCalls,
+        inputTokens: InputTokenUsage.make(group.inputTokens),
+        outputTokens: OutputTokenUsage.make(group.outputTokens),
+        costMicrousd: group.costMicrousd,
+      }),
+    ),
+  });
+};

--- a/packages/core/test/agent-types.test.ts
+++ b/packages/core/test/agent-types.test.ts
@@ -50,6 +50,12 @@ const SearchAvailability = Tool.make("search_availability", {
 });
 const TravelTools = Toolkit.make(SearchAvailability);
 
+const PostMessage = Tool.make("post_message", {
+  parameters: Schema.Struct({ message: Schema.String }),
+  success: Schema.Struct({ messageId: Schema.String }),
+});
+const DeliveryTools = Toolkit.make(PostMessage);
+
 const model = Model.make(
   "scripted",
   "type-proof",
@@ -106,6 +112,26 @@ const dispositionDefinition = Agent.define("disposition-type-proof", {
   runDisposition: {
     schema: RunDisposition,
     fromOutput: (output) => output.runDisposition,
+  },
+});
+
+const terminalDefinition = Agent.define("terminal-type-proof", {
+  input: Schema.Struct({ destination: Schema.String }),
+  output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+  instructions: "Deliver the final message.",
+  toolkit: DeliveryTools,
+  policy: AgentPolicy.make({
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+  completion: {
+    tool: "post_message",
+    project: ({ parameters, result }) => ({
+      message: parameters.message,
+      messageId: result.messageId,
+    }),
   },
 });
 
@@ -213,6 +239,7 @@ describe("Agent type inference", () => {
     expect(declaredRunDispositionFailureProof).toBe(true);
     expect(runDispositionFailureProof).toBe(true);
     expect(Object.isFrozen(dispositionDefinition.runDisposition)).toBe(true);
+    expect(Object.isFrozen(terminalDefinition.completion)).toBe(true);
     expect(agent.definition).toBe(definition);
     expect(agent.model).toBe(model);
     expect(Object.isFrozen(definition)).toBe(true);

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -116,6 +116,21 @@ describe("core schemas", () => {
     ).toBe("Failure");
     expect(
       Schema.decodeUnknownExit(RunUsageSummary)({
+        ...summary,
+        byModel: [
+          { ...group, costMicrousd: 0 },
+          {
+            ...group,
+            model: "zero-call-cost",
+            modelCalls: 0,
+            inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 0, text: 0, reasoning: 0 },
+          },
+        ],
+      })._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RunUsageSummary)({
         modelCalls: 2,
         inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
         outputTokens: { total: 0, text: 0, reasoning: 0 },

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -30,7 +30,10 @@ import {
   ConversationId,
   DelegationId,
   IdGenerator,
+  InputTokenUsage,
+  ModelCallUsage,
   ModelProtocolError,
+  OutputTokenUsage,
   ReceiptId,
   RunCompleted,
   RunEvent,
@@ -38,17 +41,78 @@ import {
   RunStarted,
   SettlementId,
   SubagentParentLink,
+  summarizeModelUsage,
   ToolCallDeclared,
   ToolCallId,
   ToolResultBounds,
   TruncatedToolResult,
   TurnId,
+  UsageAggregationError,
 } from "../src/index.ts";
 
 // Core is platform-neutral: no TextEncoder in its lib; hex length halves to UTF-8 bytes.
 const utf8Bytes = (value: string): number => Encoding.encodeHex(value).length / 2;
 
 describe("core schemas", () => {
+  it("RUN-035: rejects non-additive canonical token breakdowns", () => {
+    expect(
+      Schema.decodeUnknownExit(InputTokenUsage)({
+        total: 0,
+        uncached: 0,
+        cacheRead: 100,
+        cacheWrite: 0,
+      })._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(OutputTokenUsage)({ total: 1, text: 1, reasoning: 1 })._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(ModelCallUsage)({
+        provider: "test",
+        model: "test-model",
+        inputTokens: { total: 3, uncached: 1, cacheRead: 1, cacheWrite: 1 },
+        outputTokens: { total: 3, text: 2, reasoning: 1 },
+        costMicrousd: 0,
+      })._tag,
+    ).toBe("Success");
+  });
+
+  it("RUN-035: aggregates usage through a typed safe-integer overflow boundary", () => {
+    const call = (inputTokens: number, costMicrousd: number) =>
+      ModelCallUsage.make({
+        provider: "test",
+        model: "test-model",
+        inputTokens: InputTokenUsage.make({
+          total: inputTokens,
+          uncached: inputTokens,
+          cacheRead: 0,
+          cacheWrite: 0,
+        }),
+        outputTokens: OutputTokenUsage.make({ total: 0, text: 0, reasoning: 0 }),
+        costMicrousd,
+      });
+
+    const inputOverflow = Effect.runSync(
+      Effect.flip(summarizeModelUsage([call(Number.MAX_SAFE_INTEGER, 0), call(1, 0)])),
+    );
+    expect(inputOverflow).toBeInstanceOf(UsageAggregationError);
+    expect(inputOverflow.field).toBe("inputTokens.total");
+
+    const costOverflow = Effect.runSync(
+      Effect.flip(summarizeModelUsage([call(0, Number.MAX_SAFE_INTEGER), call(0, 1)])),
+    );
+    expect(costOverflow).toBeInstanceOf(UsageAggregationError);
+    expect(costOverflow.field).toBe("costMicrousd");
+
+    const summary = Effect.runSync(summarizeModelUsage([call(2, 3), call(5, 7)]));
+    expect(summary).toMatchObject({
+      modelCalls: 2,
+      inputTokens: { total: 7, uncached: 7, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 0, text: 0, reasoning: 0 },
+      costMicrousd: 10,
+    });
+  });
+
   it("decodes distinct non-empty branded identifiers", () => {
     expect(Schema.decodeSync(AgentId)("travel-planner")).toBe("travel-planner");
     expect(Schema.decodeSync(DelegationId)("delegate-research")).toBe("delegate-research");

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -81,6 +81,7 @@ describe("core schemas", () => {
     expect(policy.maxDuration).toEqual(Duration.seconds(30));
     expect(policy.repeatedFailureLimit).toBe(3);
     expect(policy.tokenBudget).toBe(1_000);
+    expect(policy.completionReserveTokens).toBe(200);
     expect(policy.costBudgetMicrousd).toBe(10_000);
     expect(() =>
       AgentPolicy.make({
@@ -439,6 +440,7 @@ describe("context-economics policy", () => {
     expect(policy.compaction.keepRecentTokens).toBe(20_000);
     expect(policy.compaction.mode).toBe("prune-then-summarize");
     expect(policy.contextTokenLimit).toBeUndefined();
+    expect(policy.completionReserveTokens).toBe(4_096);
 
     const custom = AgentPolicy.make({
       maxTurns: 2,
@@ -473,6 +475,16 @@ describe("context-economics policy", () => {
     expect(() => ToolResultBounds.make({ maxBytes: 0 })).toThrow();
     expect(() => CompactionPolicy.make({ keepRecentTokens: 0 })).toThrow();
     expect(() => CompactionPolicy.make({ keepRecentTokens: 2.5 })).toThrow();
+    expect(() =>
+      AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 1,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+        tokenBudget: 100,
+        completionReserveTokens: 101,
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -37,6 +37,7 @@ import {
   ReceiptId,
   RunCompleted,
   RunEvent,
+  RunUsageSummary,
   RunId,
   RunStarted,
   SettlementId,
@@ -75,6 +76,68 @@ describe("core schemas", () => {
         costMicrousd: 0,
       })._tag,
     ).toBe("Success");
+
+    const group = {
+      provider: "test",
+      model: "test-model",
+      modelCalls: 1,
+      inputTokens: { total: 3, uncached: 1, cacheRead: 1, cacheWrite: 1 },
+      outputTokens: { total: 3, text: 2, reasoning: 1 },
+      costMicrousd: 5,
+    } as const;
+    const summary = {
+      modelCalls: 1,
+      inputTokens: group.inputTokens,
+      outputTokens: group.outputTokens,
+      costMicrousd: group.costMicrousd,
+      byModel: [group],
+    } as const;
+    expect(Schema.decodeUnknownExit(RunUsageSummary)(summary)._tag).toBe("Success");
+    expect(Schema.decodeUnknownExit(RunUsageSummary)({ ...summary, modelCalls: 0 })._tag).toBe(
+      "Failure",
+    );
+    expect(
+      Schema.decodeUnknownExit(RunUsageSummary)({
+        ...summary,
+        inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+      })._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RunUsageSummary)({
+        ...summary,
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      })._tag,
+    ).toBe("Failure");
+    expect(Schema.decodeUnknownExit(RunUsageSummary)({ ...summary, costMicrousd: 0 })._tag).toBe(
+      "Failure",
+    );
+    expect(
+      Schema.decodeUnknownExit(RunUsageSummary)({ ...summary, byModel: [group, group] })._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RunUsageSummary)({
+        modelCalls: 2,
+        inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+        costMicrousd: Number.MAX_SAFE_INTEGER,
+        byModel: [
+          {
+            ...group,
+            model: "large-cost",
+            inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 0, text: 0, reasoning: 0 },
+            costMicrousd: Number.MAX_SAFE_INTEGER,
+          },
+          {
+            ...group,
+            model: "overflow-cost",
+            inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 0, text: 0, reasoning: 0 },
+            costMicrousd: 1,
+          },
+        ],
+      })._tag,
+    ).toBe("Failure");
   });
 
   it("RUN-035: aggregates usage through a typed safe-integer overflow boundary", () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2518,8 +2518,7 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         limit: "tokens",
         message: `Agent exceeded its ${tokenBudget} token budget`,
       });
-      // Fail-fast token breaches keep the pre-soft-landing contract: no
-      // budget-hook charge, warning event, or application Handler.
+      // Fail mode rejects before any declared application Handler starts.
       if (policy.onExhaustion === "fail") {
         return yield* breach;
       }
@@ -2869,14 +2868,7 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
     );
     const wasFinalizing = context.finalizing;
     context.finalizing = true;
-    const consumed = yield* consumeUsage(
-      agent,
-      context,
-      summaryUsage,
-      0,
-      turn,
-      options,
-    ).pipe(
+    const consumed = yield* consumeUsage(agent, context, summaryUsage, 0, turn, options).pipe(
       Effect.ensuring(
         Effect.sync(() => {
           context.finalizing = wasFinalizing;
@@ -6506,10 +6498,12 @@ export const withTerminalDefectEvent = <E, R>(
  * in the returned Effect or Stream. The interpreter owns no shared service or
  * Layer state. The two output helpers are the canonical revalidation seams for
  * durable session adapters; they apply the same Schemas and projector as live
- * execution without invoking a Model or Tool Handler.
+ * execution without invoking a Model or Tool Handler. The disposition helper
+ * likewise reapplies the Definition selector and Schema.
  */
 export const AgentRuntime = {
   decodeFinalOutput,
+  encodeRunDisposition,
   projectCompletionOutput,
   run,
   start,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4371,7 +4371,11 @@ const makeTurn = <
             // commit shape and recovery replays it like any no-tool Turn. The
             // rejected Turn's usage is still charged via
             // `afterValidatedResponse` because the Run continues.
-            if (overToolBudget && trace.applicationToolCalls.length > 0 && !completionBatch) {
+            if (
+              overToolBudget &&
+              trace.applicationToolCalls.length > 0 &&
+              !(completionBatch && policy.onExhaustion === "final-answer")
+            ) {
               return afterValidatedResponse(
                 Effect.gen(function* () {
                   const rejection = yield* settleRejectedBatch(
@@ -4921,7 +4925,7 @@ const makeResumeTurn = <
       // results stand verbatim, only open calls get the synthetic failure,
       // and no handler starts. Once the synthetic settlements commit, the
       // pending batch is complete and recovery offers no further resume.
-      if (overToolBudget && !completionBatch) {
+      if (overToolBudget && !(completionBatch && policy.onExhaustion === "final-answer")) {
         const rejection = yield* settleRejectedBatch(
           context,
           turnId,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -14,16 +14,20 @@ import {
   BudgetWarning,
   unserializableToolResult,
   CompactionPerformed,
+  ContextBudgetError,
   ContextOverflowError,
+  type CompletionToolDeclaration,
   ConversationId,
   type Definition,
   DelegationDepth,
   type DelegationId,
   IdGenerator,
+  InputTokenUsage,
   type InstructionSource,
   isDelegationToolName,
   type RunDispositionDeclaration,
   ModelStarted,
+  ModelCallUsage,
   ModelProtocolError,
   ReasoningDelta,
   ReceiptId,
@@ -52,6 +56,7 @@ import {
   type ToolResultBounds,
   TurnCompleted,
   TurnStarted,
+  OutputTokenUsage,
   type TurnId,
 } from "@effect-agent/core";
 import type { Take } from "effect";
@@ -77,7 +82,7 @@ import {
   type Tool,
   AiError,
   LanguageModel,
-  type Model,
+  Model,
   Prompt,
   Response,
   Toolkit,
@@ -266,6 +271,7 @@ export type AgentRuntimeFailure<
 > =
   | Agent.Failure<AgentValue>
   | AgentPolicyError
+  | ContextBudgetError
   | ContextOverflowError
   | ModelProtocolError
   | AgentApprovalDenied
@@ -2300,9 +2306,14 @@ const outgoingModelPrompt = (
 
 /** Usage accounting outcome of one completed model response (RUN-025). */
 interface ConsumedUsage {
-  /** A finalize-eligible budget breach; fail-fast breaches never reach the caller. */
+  /**
+   * A finalize-eligible budget breach. Fail-fast breaches do not reach the
+   * caller unless this response declared the singleton completion Tool: that
+   * already-paid delivery response is allowed to finish RUN-032.
+   */
   readonly breach: AgentPolicyError | undefined;
   readonly warnings: ReadonlyArray<RunEvent>;
+  readonly modelUsage: ModelCallUsage;
 }
 
 const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>(
@@ -2310,11 +2321,12 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
   context: RunContext,
   usage: Response.Usage | undefined,
   toolCallCount: number,
+  turn: number,
   options: RunOptions<HookError, HookRequirements>,
 ): Effect.Effect<
   ConsumedUsage,
   AgentPolicyError | ModelProtocolError | HookError,
-  HookRequirements
+  HookRequirements | Model.ProviderName | Model.ModelName
 > =>
   Effect.gen(function* () {
     if (usage === undefined) {
@@ -2323,27 +2335,64 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         message: "A completed model response did not report usage",
       });
     }
+    const natural = (value: number | undefined): number =>
+      value === undefined || !Number.isSafeInteger(value) ? 0 : Math.max(0, value);
+    const reportedUncached = natural(usage.inputTokens.uncached);
+    const cacheRead = natural(usage.inputTokens.cacheRead);
+    const cacheWrite = natural(usage.inputTokens.cacheWrite);
+    const reportedText = natural(usage.outputTokens.text);
+    const reasoning = natural(usage.outputTokens.reasoning);
+    // Gross token accounting never discounts cache activity. A provider's
+    // aggregate may be absent or narrower than its reported components.
     const inputTokens = Math.max(
-      0,
-      usage.inputTokens.total ??
-        (usage.inputTokens.uncached ?? 0) +
-          (usage.inputTokens.cacheRead ?? 0) +
-          (usage.inputTokens.cacheWrite ?? 0),
+      natural(usage.inputTokens.total),
+      reportedUncached + cacheRead + cacheWrite,
     );
-    const outputTokens = Math.max(
-      0,
-      usage.outputTokens.total ??
-        (usage.outputTokens.text ?? 0) + (usage.outputTokens.reasoning ?? 0),
-    );
+    const outputTokens = Math.max(natural(usage.outputTokens.total), reportedText + reasoning);
+    // When a provider reports only aggregates, classify the unexplained input
+    // conservatively as uncached and non-reasoning output as text. This keeps
+    // each persisted breakdown additive instead of silently inventing a free,
+    // unclassified token bucket.
+    const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
+    const text = Math.max(reportedText, outputTokens - reasoning);
     const totalTokens = inputTokens + outputTokens;
-    const costMicrousd =
-      options.estimateCostMicrousd === undefined ? 0 : yield* options.estimateCostMicrousd(usage);
+    const provider = yield* Model.ProviderName;
+    const model = yield* Model.ModelName;
+    const estimate =
+      options.estimateCostMicrousd === undefined
+        ? 0
+        : yield* options.estimateCostMicrousd(usage, { provider, model, usage });
+    const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
     if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
       return yield* AgentPolicyError.make({
         limit: "cost",
         message: "Model cost estimation must produce a non-negative integer number of microdollars",
       });
     }
+    const serviceTier = typeof estimate === "number" ? undefined : estimate.serviceTier;
+    const pricingVersion = typeof estimate === "number" ? undefined : estimate.pricingVersion;
+    const validPricingIdentity = (value: string | undefined): boolean =>
+      value === undefined || (value.length > 0 && value.length <= 256);
+    if (!validPricingIdentity(serviceTier) || !validPricingIdentity(pricingVersion)) {
+      return yield* AgentPolicyError.make({
+        limit: "cost",
+        message: "Model cost estimation returned an invalid service tier or pricing version",
+      });
+    }
+    const modelUsage = ModelCallUsage.make({
+      provider,
+      model,
+      ...(serviceTier === undefined ? {} : { serviceTier }),
+      ...(pricingVersion === undefined ? {} : { pricingVersion }),
+      inputTokens: InputTokenUsage.make({
+        total: inputTokens,
+        uncached,
+        cacheRead,
+        cacheWrite,
+      }),
+      outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
+      costMicrousd,
+    });
     context.modelCalls += 1;
     context.inputTokens += inputTokens;
     context.outputTokens += outputTokens;
@@ -2351,6 +2400,13 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
     context.lastOutputTokens = outputTokens;
     context.costMicrousd += costMicrousd;
     context.lastCostMicrousd = costMicrousd;
+
+    if (options.durability !== undefined) {
+      // Stage before enforcing hard rails: a response that spends past the
+      // cost/token budget still becomes auditable in its canonical Turn and
+      // terminal settlement.
+      yield* options.durability.noteTurnUsage({ turn, usage: modelUsage });
+    }
 
     const policy = agent.definition.policy;
     const consumedTokens = context.inputTokens + context.outputTokens;
@@ -2366,8 +2422,8 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         limit: "tokens",
         message: `Agent exceeded its ${tokenBudget} token budget`,
       });
-      // Fail-fast token breaches keep the pre-soft-landing contract exactly: no
-      // budget-hook charge and no warning event on the failing response.
+      // Fail-fast token breaches keep the pre-soft-landing contract: no
+      // budget-hook charge, warning event, or application Handler.
       if (policy.onExhaustion === "fail") {
         return yield* breach;
       }
@@ -2404,6 +2460,7 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         toolCalls: toolCallCount,
         costMicrousd,
         usage,
+        modelUsage,
       };
       yield* options.budget.consume(delta);
     }
@@ -2423,7 +2480,7 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         }),
       );
     }
-    return { breach, warnings };
+    return { breach, warnings, modelUsage };
   });
 
 // `Effect.fnUntraced`: this helper runs for every streamed Response Part, so a
@@ -2605,8 +2662,8 @@ interface CompactionOutcome {
  * summarizer call's usage is consumed like any other model call, with
  * `context.finalizing` held during its accounting so a budget breach
  * surfaces at the next response's check instead of recursing into finalize
- * mid-compaction; its usage is deliberately not staged for resume re-seed
- * (only canonical response records carry usage).
+ * mid-compaction. Durable coordinators stage it as a distinct call in the
+ * same canonical Turn as the response that follows.
  */
 const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirements>(
   agent: AgentValue,
@@ -2614,11 +2671,13 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
   source: Prompt.Prompt,
   turn: number,
   options: RunOptions<HookError, HookRequirements>,
+  targetTokens: number | undefined,
   forceSummarize: boolean,
+  allowSummarize = true,
 ): Effect.Effect<
   CompactionOutcome,
   AgentPolicyError | ModelProtocolError | AiError.AiError | HookError,
-  HookRequirements | LanguageModel.LanguageModel
+  HookRequirements | LanguageModel.LanguageModel | Model.ProviderName | Model.ModelName
 > =>
   Effect.gen(function* () {
     const policy = agent.definition.policy;
@@ -2626,14 +2685,17 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
     const events: Array<RunEvent> = [];
     const messages = source.content;
     const before = estimatePromptTokens(buildCompactedView(messages, state));
-    const limit = policy.contextTokenLimit;
     const mode = policy.compaction.mode;
+    const keepRecentTokens =
+      targetTokens === undefined
+        ? policy.compaction.keepRecentTokens
+        : Math.max(1, Math.min(policy.compaction.keepRecentTokens, targetTokens));
 
     const commitDurable = (commit: RunCompactionCommit) =>
       options.durability === undefined ? Effect.void : options.durability.commitCompaction(commit);
 
     if (!forceSummarize && mode !== "summarize") {
-      const bound = choosePruneBound(messages, state, policy.compaction.keepRecentTokens);
+      const bound = choosePruneBound(messages, state, keepRecentTokens);
       if (bound > state.clearedThrough) {
         state.clearedThrough = bound;
         state.lastViewLength = -1;
@@ -2653,19 +2715,20 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
           tokensBeforeEstimate: before,
           tokensAfterEstimate: after,
         });
-        if (limit !== undefined && after <= limit) {
+        if (targetTokens !== undefined && after <= targetTokens) {
           return { events };
         }
       }
     }
-    if (mode === "prune" && !forceSummarize) {
-      // Pruning may legitimately reclaim nothing (a single protected result):
-      // the Turn proceeds anyway — the provider may still accept, and the
-      // RUN-027 overflow path is the typed backstop when it does not.
+    if ((!allowSummarize || mode === "prune") && !forceSummarize) {
+      // Pruning may legitimately reclaim nothing (for example, one protected
+      // result). The caller re-estimates the rebuilt prompt and either enters
+      // finalization or fails locally; known-over-target work never reaches
+      // the provider.
       return { events };
     }
 
-    const cut = chooseSummarizeCut(messages, state, policy.compaction.keepRecentTokens);
+    const cut = chooseSummarizeCut(messages, state, keepRecentTokens);
     const covered = collectCoveredMessages(messages, state, cut);
     if (covered.length === 0) {
       return { events };
@@ -2710,24 +2773,20 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
     );
     const wasFinalizing = context.finalizing;
     context.finalizing = true;
-    const consumed = yield* consumeUsage(agent, context, summaryUsage, 0, options).pipe(
+    const consumed = yield* consumeUsage(
+      agent,
+      context,
+      summaryUsage,
+      0,
+      turn,
+      options,
+    ).pipe(
       Effect.ensuring(
         Effect.sync(() => {
           context.finalizing = wasFinalizing;
         }),
       ),
     );
-    if (options.durability !== undefined) {
-      // The summarizer's spend must survive ownership changes: it stages into
-      // the same canonical Turn as the Turn's own response, and the session
-      // accumulates both (RUN-023).
-      yield* options.durability.noteTurnUsage({
-        turn,
-        inputTokens: context.lastInputTokens,
-        outputTokens: context.lastOutputTokens,
-        costMicrousd: context.lastCostMicrousd,
-      });
-    }
     events.push(...consumed.warnings);
     const summaryText = pieces.join("").trim();
     const summary = summaryText.length === 0 ? "(no summary produced)" : summaryText;
@@ -3286,6 +3345,68 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
   return { encoded: eventJson, decoded };
 });
 
+const encodeOutputCandidate = Effect.fn("AgentRuntime.encodeOutputCandidate")(function* <
+  AgentValue extends Agent.Any,
+>(agent: AgentValue, candidate: unknown) {
+  const decoded = yield* Schema.decodeUnknownEffect(agent.definition.output)(candidate).pipe(
+    Effect.mapError((cause) =>
+      AgentOutputError.make({
+        message: cause.message,
+      }),
+    ),
+  );
+  const encoded = yield* Schema.encodeUnknownEffect(agent.definition.output)(decoded).pipe(
+    Effect.mapError((cause) =>
+      AgentOutputError.make({
+        message: `Completion Tool output failed Schema encoding: ${cause.message}`,
+      }),
+    ),
+  );
+  const json = yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
+    Effect.mapError((cause) =>
+      AgentOutputError.make({
+        message: `Completion Tool output did not encode as durable JSON: ${cause.message}`,
+      }),
+    ),
+  );
+  return { encoded: json, decoded };
+});
+
+const projectCompletionOutput = Effect.fn("AgentRuntime.projectCompletionOutput")(function* <
+  AgentValue extends Agent.Any,
+>(agent: AgentValue, declaration: CompletionToolDeclaration, parameters: unknown, result: unknown) {
+  const tool = agent.definition.toolkit.tools[declaration.tool];
+  if (tool === undefined) {
+    return yield* ModelProtocolError.make({
+      message: `Agent completion declaration references unknown Tool ${declaration.tool}`,
+    });
+  }
+  const decodedParameters = yield* Schema.decodeUnknownEffect(tool.parametersSchema)(
+    parameters,
+  ).pipe(
+    Effect.mapError((cause) =>
+      AgentOutputError.make({
+        message: `Completion Tool parameters failed canonical decoding: ${cause.message}`,
+      }),
+    ),
+  );
+  const decodedResult = yield* Schema.decodeUnknownEffect(tool.successSchema)(result).pipe(
+    Effect.mapError((cause) =>
+      AgentOutputError.make({
+        message: `Completion Tool result failed canonical decoding: ${cause.message}`,
+      }),
+    ),
+  );
+  const projected = yield* Effect.try({
+    try: () => declaration.project({ parameters: decodedParameters, result: decodedResult }),
+    catch: (cause) =>
+      AgentOutputError.make({
+        message: `Completion Tool projector failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      }),
+  });
+  return yield* encodeOutputCandidate(agent, projected);
+});
+
 const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDisposition")(function* <
   Output,
   DispositionSchema extends Schema.Top,
@@ -3518,8 +3639,8 @@ const makeTurn = <
         }).pipe(Effect.withLogSpan("AgentRuntime.model")),
       ).pipe(Stream.flatMap(Stream.fromIterable));
 
-      // Final-answer mode (RUN-018/RUN-019, extended to the token dimension
-      // by RUN-025 to the token dimension): once the Turn, Tool Call, or token budget is
+      // Final-answer mode (RUN-018/RUN-019, extended to tokens by RUN-025):
+      // once the Turn, Tool Call, or token budget is
       // exhausted, the model keeps its toolkit declaration but may not call
       // it. Turn and Tool Call conditions are pure derivations of committed
       // state (`turn`, `priorToolCalls`, `programmaticToolCalls`); the token
@@ -3530,7 +3651,7 @@ const makeTurn = <
       // path byte-for-byte.
       const policy = agent.definition.policy;
       const bounds = effectiveRunBounds(policy, options);
-      const finalAnswerOnly =
+      let finalAnswerOnly =
         policy.onExhaustion !== "fail" &&
         (turn > bounds.maxTurns ||
           priorToolCalls + context.programmaticToolCalls > bounds.maxToolCalls ||
@@ -3556,27 +3677,52 @@ const makeTurn = <
         );
       }
       // The output contract (RUN-028) rides every outgoing request after
-      // compaction, so the window calculation reserves its estimated size the
-      // same way Tool-schema overhead is provider-side reality: the view must
-      // fit the limit WITH the contract the engine will append.
+      // compaction, so the view must fit the limit with the contract the
+      // engine will append.
       const outputContractTokens =
         outputContractMessage === undefined
           ? 0
           : estimatePromptTokens([
               Prompt.makeMessage("system", { content: outputContractMessage }),
             ]);
+      const derivedPrompt = yield* outgoingModelPrompt(
+        policy,
+        context,
+        Prompt.fromMessages([]),
+        turn,
+        priorToolCalls,
+      );
+      const derivedPromptTokens =
+        outputContractTokens + estimatePromptTokens(derivedPrompt.content);
       let preEvents: ReadonlyArray<RunEvent> = [];
-      if (policy.contextTokenLimit !== undefined && !context.finalizing) {
+      if (!context.finalizing) {
+        const consumedTokens = context.inputTokens + context.outputTokens;
+        const tokenCallTarget =
+          policy.tokenBudget === undefined || finalAnswerOnly
+            ? undefined
+            : Math.max(0, policy.tokenBudget - consumedTokens - policy.completionReserveTokens);
+        const contextCallTarget = policy.contextTokenLimit;
+        const fullTarget =
+          tokenCallTarget === undefined
+            ? contextCallTarget
+            : contextCallTarget === undefined
+              ? tokenCallTarget
+              : Math.min(tokenCallTarget, contextCallTarget);
+        const sourceTarget =
+          fullTarget === undefined ? undefined : Math.max(0, fullTarget - derivedPromptTokens);
         const view = buildCompactedView(modelContext.prompt.content, context.compaction);
-        const estimate = nextContextEstimate(context, view);
+        const estimate = nextContextEstimate(context, view) + derivedPromptTokens;
+        const contextPressure = contextCallTarget !== undefined && estimate > contextCallTarget;
+        const tokenPressure = tokenCallTarget !== undefined && estimate > tokenCallTarget;
         if (
-          estimate + outputContractTokens > policy.contextTokenLimit &&
+          (contextPressure || tokenPressure) &&
+          sourceTarget !== undefined &&
+          sourceTarget > 0 &&
           context.compaction.lastCompactionTurn !== turn
         ) {
-          // Loop guard: at most one threshold compaction per Turn. If the
-          // post-compaction estimate still exceeds the limit the Turn
-          // proceeds anyway — the provider may accept, and RUN-027 overflow
-          // recovery is the typed backstop when it does not.
+          // Loop guard: at most one threshold compaction per Turn. The target
+          // is checked below before provider I/O, so a non-progressing pass
+          // fails typed rather than relying on a provider rejection.
           context.compaction.lastCompactionTurn = turn;
           const outcome = yield* compactContext(
             agent,
@@ -3584,9 +3730,48 @@ const makeTurn = <
             modelContext.prompt,
             turn,
             options,
+            sourceTarget,
             false,
+            !tokenPressure,
           );
           preEvents = outcome.events;
+        }
+        const prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
+        const preparedEstimate = nextContextEstimate(context, prepared) + derivedPromptTokens;
+        // A summarizing compaction is itself a priced model call. Recompute
+        // admission from its reported usage instead of carrying the stale
+        // pre-compaction balance into the research call that follows.
+        if (context.tokenExhausted) {
+          finalAnswerOnly = true;
+        }
+        const preparedTokenCallTarget =
+          policy.tokenBudget === undefined || finalAnswerOnly
+            ? undefined
+            : Math.max(
+                0,
+                policy.tokenBudget -
+                  (context.inputTokens + context.outputTokens) -
+                  policy.completionReserveTokens,
+              );
+        if (contextCallTarget !== undefined && preparedEstimate > contextCallTarget) {
+          return yield* ContextBudgetError.make({
+            message: `Compaction could not fit the next model prompt inside the ${contextCallTarget} token context target`,
+            estimatedTokens: preparedEstimate,
+            targetTokens: contextCallTarget,
+            completionReserveTokens: policy.completionReserveTokens,
+          });
+        }
+        if (preparedTokenCallTarget !== undefined && preparedEstimate > preparedTokenCallTarget) {
+          const error = AgentPolicyError.make({
+            limit: "tokens",
+            message: `The next research call would consume this Run's ${policy.completionReserveTokens} token completion reserve`,
+          });
+          if (policy.onExhaustion === "fail") {
+            return yield* error;
+          }
+          context.tokenExhausted = true;
+          context.exhaustedDimension ??= "tokens";
+          finalAnswerOnly = true;
         }
       }
       /** The model-visible view of the Turn basis under current compaction state. */
@@ -3611,7 +3796,16 @@ const makeTurn = <
                       : insertOutputContract(outgoing, outputContractMessage),
                   toolkit: agent.definition.toolkit,
                   disableToolCallResolution: true,
-                  ...(finalAnswerOnly ? { toolChoice: "none" as const } : {}),
+                  ...(finalAnswerOnly
+                    ? agent.definition.completion === undefined
+                      ? { toolChoice: "none" as const }
+                      : {
+                          toolChoice: {
+                            mode: "auto" as const,
+                            oneOf: [agent.definition.completion.tool],
+                          },
+                        }
+                    : {}),
                 }),
                 options.budget,
               ).pipe(
@@ -3660,7 +3854,8 @@ const makeTurn = <
               return Stream.fail(error);
             }
             const message = overflowText(error);
-            if (trace.parts.length > 0 || policy.contextTokenLimit === undefined) {
+            const contextTokenLimit = policy.contextTokenLimit;
+            if (trace.parts.length > 0 || contextTokenLimit === undefined) {
               return Stream.fail(ContextOverflowError.make({ message, retried: false }));
             }
             if (context.compaction.overflowRetryTurn === turn) {
@@ -3681,6 +3876,7 @@ const makeTurn = <
                   modelContext.prompt,
                   turn,
                   options,
+                  Math.max(0, contextTokenLimit - derivedPromptTokens),
                   true,
                 ).pipe(
                   Effect.mapError(
@@ -3694,6 +3890,19 @@ const makeTurn = <
                         : inner,
                   ),
                 );
+                const retryView = buildCompactedView(
+                  modelContext.prompt.content,
+                  context.compaction,
+                );
+                const retryEstimate = nextContextEstimate(context, retryView) + derivedPromptTokens;
+                if (retryEstimate > contextTokenLimit) {
+                  return yield* ContextBudgetError.make({
+                    message: `Overflow compaction could not fit the retry inside the ${contextTokenLimit} token context target`,
+                    estimatedTokens: retryEstimate,
+                    targetTokens: contextTokenLimit,
+                    completionReserveTokens: policy.completionReserveTokens,
+                  });
+                }
                 // The retried call is outside the outer catch: a second
                 // classified overflow converts here, typed, no retry.
                 const retried: TurnStream = attempt(compactedOutgoing()).pipe(
@@ -3743,14 +3952,32 @@ const makeTurn = <
               ModelProtocolError.make({ message: "Model response omitted staged Turn completion" }),
             );
           }
-          // Fail-closed (RUN-020): a final-answer Turn requested with
-          // `toolChoice: "none"`, so any declared call — application or
-          // provider-executed — is a protocol violation, never another
-          // rejection round.
-          if (finalAnswerOnly && trace.toolCalls.size > 0) {
+          const completionTool = agent.definition.completion?.tool;
+          const declaresCompletion =
+            completionTool !== undefined &&
+            trace.applicationToolCalls.some((call) => call.name === completionTool);
+          if (declaresCompletion && trace.toolCalls.size !== 1) {
             return failRunEventStream(
               ModelProtocolError.make({
-                message: `Model declared ${trace.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion`,
+                message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`,
+              }),
+            );
+          }
+          const completionBatch =
+            declaresCompletion &&
+            trace.toolCalls.size === 1 &&
+            trace.applicationToolCalls.length === 1;
+          // Fail-closed (RUN-020): final-answer mode advertises either no
+          // Tool or exactly the Definition-owned completion Tool. Any other
+          // declaration is a protocol violation, never another rejection
+          // round.
+          if (finalAnswerOnly && trace.toolCalls.size > 0 && !completionBatch) {
+            return failRunEventStream(
+              ModelProtocolError.make({
+                message:
+                  completionTool === undefined
+                    ? `Model declared ${trace.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion`
+                    : `Model declared ${trace.toolCalls.size} non-completion Tool Call(s) after budget exhaustion`,
               }),
             );
           }
@@ -3769,7 +3996,7 @@ const makeTurn = <
           }
           const toolCalls = priorToolCalls + trace.toolCalls.size;
           const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
-          if (overToolBudget && policy.onExhaustion === "fail") {
+          if (overToolBudget && policy.onExhaustion === "fail" && !completionBatch) {
             return failRunEventStream(
               AgentPolicyError.make({
                 limit: "tool-calls",
@@ -3837,16 +4064,9 @@ const makeTurn = <
                       context,
                       trace.usage,
                       trace.toolCalls.size,
+                      turn,
                       options,
                     );
-                    if (options.durability !== undefined) {
-                      yield* options.durability.noteTurnUsage({
-                        turn,
-                        inputTokens: context.lastInputTokens,
-                        outputTokens: context.lastOutputTokens,
-                        costMicrousd: context.lastCostMicrousd,
-                      });
-                    }
                     const pre: Array<RunEvent> = [...consumed.warnings];
                     if (
                       !context.warnedLimits.has("tool-calls") &&
@@ -3908,7 +4128,7 @@ const makeTurn = <
                           );
                         }
                       }
-                      if (trace.applicationToolCalls.length > 0) {
+                      if (trace.applicationToolCalls.length > 0 && !completionBatch) {
                         // RUN-025 joins the RUN-018 synthetic-settlement path:
                         // the token-breaching batch never executes a handler,
                         // and `tokenExhausted` (stamped by `consumeUsage`)
@@ -4037,7 +4257,8 @@ const makeTurn = <
             }
             const turnsBlocked =
               policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-            if (turnsBlocked) {
+            const completionTurnAllowed = completionBatch;
+            if (turnsBlocked && !completionTurnAllowed) {
               return failRunEventStream(
                 AgentPolicyError.make({
                   limit: "turns",
@@ -4054,7 +4275,7 @@ const makeTurn = <
             // commit shape and recovery replays it like any no-tool Turn. The
             // rejected Turn's usage is still charged via
             // `afterValidatedResponse` because the Run continues.
-            if (overToolBudget && trace.applicationToolCalls.length > 0) {
+            if (overToolBudget && trace.applicationToolCalls.length > 0 && !completionBatch) {
               return afterValidatedResponse(
                 Effect.gen(function* () {
                   const rejection = yield* settleRejectedBatch(
@@ -4246,6 +4467,60 @@ const toolBatchContinuation = <
         ...promptFromTurnParts(trace).content,
         toolMessage,
       ]);
+      const completion = agent.definition.completion;
+      const completionResult =
+        completion !== undefined &&
+        trace.applicationToolCalls.length === 1 &&
+        orderedResults.length === 1 &&
+        orderedResults[0]?.name === completion.tool &&
+        orderedResults[0].isFailure === false
+          ? orderedResults[0]
+          : undefined;
+      if (completion !== undefined && completionResult !== undefined) {
+        const call = trace.applicationCallDescriptors[0];
+        if (call === undefined) {
+          return failRunEventStream(
+            ModelProtocolError.make({
+              message: `Completion Tool ${completion.tool} has no canonical call descriptor`,
+            }),
+          );
+        }
+        const output = yield* projectCompletionOutput(
+          agent,
+          completion,
+          call.parameters,
+          completionResult.encodedResult,
+        );
+        yield* advanceHistory(context, history, options);
+        const bounds = effectiveRunBounds(agent.definition.policy, options);
+        const exhausted = context.tokenExhausted
+          ? "tokens"
+          : turn > bounds.maxTurns
+            ? "turns"
+            : toolCalls + context.programmaticToolCalls > bounds.maxToolCalls
+              ? "tool-calls"
+              : context.exhaustedDimension;
+        if (exhausted !== undefined && context.exhaustedDimension === undefined) {
+          context.exhaustedDimension = exhausted;
+        }
+        const declaration = agent.definition.runDisposition;
+        const runDisposition =
+          exhausted !== undefined || declaration === undefined
+            ? undefined
+            : yield* encodeRunDisposition(agent, output.decoded);
+        return Stream.fromEffect(
+          Effect.map(eventBase(context), (base) =>
+            RunCompleted.make({
+              ...base,
+              output: output.encoded,
+              ...(runDisposition === undefined ? {} : { runDisposition }),
+              turns: turn,
+              finishReason: exhausted === undefined ? "completed" : "budget-exhausted",
+              ...(exhausted === undefined ? {} : { exhausted }),
+            }),
+          ),
+        );
+      }
       yield* advanceHistory(context, history, options);
       const steering = yield* drainInputs(context, options);
       const nextPrompt = yield* appendInputs(context, history, steering, options);
@@ -4389,6 +4664,22 @@ const makeResumeTurn = <
           executionClass: getToolExecutionClass(tool),
         });
       }
+      const completionTool = agent.definition.completion?.tool;
+      if (
+        completionTool !== undefined &&
+        trace.applicationToolCalls.some((call) => call.name === completionTool) &&
+        trace.toolCalls.size !== 1
+      ) {
+        return failRunEventStream(
+          ModelProtocolError.make({
+            message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`,
+          }),
+        );
+      }
+      const completionBatch =
+        completionTool !== undefined &&
+        trace.toolCalls.size === 1 &&
+        trace.applicationToolCalls[0]?.name === completionTool;
       const settledIds = new Set<string>();
       const settledInputs = yield* snapshotResumedSettledCalls(resume, declarationByCallId.size);
       for (const settledInput of settledInputs) {
@@ -4442,7 +4733,7 @@ const makeResumeTurn = <
       const bounds = effectiveRunBounds(policy, options);
       const toolCalls = trace.toolCalls.size;
       const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
-      if (overToolBudget && policy.onExhaustion === "fail") {
+      if (overToolBudget && policy.onExhaustion === "fail" && !completionBatch) {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "tool-calls",
@@ -4452,7 +4743,8 @@ const makeResumeTurn = <
       }
       const turnsBlocked =
         policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      if (turnsBlocked) {
+      const completionTurnAllowed = completionBatch;
+      if (turnsBlocked && !completionTurnAllowed) {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "turns",
@@ -4534,7 +4826,7 @@ const makeResumeTurn = <
       // results stand verbatim, only open calls get the synthetic failure,
       // and no handler starts. Once the synthetic settlements commit, the
       // pending batch is complete and recovery offers no further resume.
-      if (overToolBudget) {
+      if (overToolBudget && !completionBatch) {
         const rejection = yield* settleRejectedBatch(
           context,
           turnId,
@@ -4700,8 +4992,7 @@ const stream = <
       };
       // Restored totals can already breach the token budget (runtime spec §9):
       // the resumed Attempt must never issue an unconstrained external call.
-      // "fail" rejects before any model call or resumed handler runs;
-      // "final-answer" starts already constrained via the one-shot flag.
+      // "fail" rejects before any model call or resumed handler runs.
       if (resumeUsage !== undefined) {
         // Cost is an unconditional hard rail with no grace call in either
         // exhaustion mode (runtime spec §3): a resume whose seeded spend

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2306,15 +2306,35 @@ const outgoingModelPrompt = (
 
 /** Usage accounting outcome of one completed model response (RUN-025). */
 interface ConsumedUsage {
-  /**
-   * A finalize-eligible budget breach. Fail-fast breaches do not reach the
-   * caller unless this response declared the singleton completion Tool: that
-   * already-paid delivery response is allowed to finish RUN-032.
-   */
+  /** A finalize-eligible budget breach under `onExhaustion: "final-answer"`. */
   readonly breach: AgentPolicyError | undefined;
   readonly warnings: ReadonlyArray<RunEvent>;
   readonly modelUsage: ModelCallUsage;
 }
+
+const ProviderUsage = Schema.Struct({
+  inputTokens: Schema.Struct({
+    uncached: Schema.optional(Schema.Natural),
+    total: Schema.optional(Schema.Natural),
+    cacheRead: Schema.optional(Schema.Natural),
+    cacheWrite: Schema.optional(Schema.Natural),
+  }),
+  outputTokens: Schema.Struct({
+    total: Schema.optional(Schema.Natural),
+    text: Schema.optional(Schema.Natural),
+    reasoning: Schema.optional(Schema.Natural),
+  }),
+});
+
+const invalidProviderUsage = () =>
+  ModelProtocolError.make({
+    message: "Model response usage fields and derived totals must be non-negative safe integers",
+  });
+
+const decodeProviderUsageTotal = (value: number): Effect.Effect<number, ModelProtocolError> =>
+  Schema.decodeUnknownEffect(Schema.Natural)(value).pipe(
+    Effect.mapError(() => invalidProviderUsage()),
+  );
 
 const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>(
   agent: AgentValue,
@@ -2335,27 +2355,29 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         message: "A completed model response did not report usage",
       });
     }
-    const natural = (value: number | undefined): number =>
-      value === undefined || !Number.isSafeInteger(value) ? 0 : Math.max(0, value);
-    const reportedUncached = natural(usage.inputTokens.uncached);
-    const cacheRead = natural(usage.inputTokens.cacheRead);
-    const cacheWrite = natural(usage.inputTokens.cacheWrite);
-    const reportedText = natural(usage.outputTokens.text);
-    const reasoning = natural(usage.outputTokens.reasoning);
+    const providerUsage = yield* Schema.decodeUnknownEffect(ProviderUsage)(usage).pipe(
+      Effect.mapError(() => invalidProviderUsage()),
+    );
+    const reportedUncached = providerUsage.inputTokens.uncached ?? 0;
+    const cacheRead = providerUsage.inputTokens.cacheRead ?? 0;
+    const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
+    const reportedText = providerUsage.outputTokens.text ?? 0;
+    const reasoning = providerUsage.outputTokens.reasoning ?? 0;
     // Gross token accounting never discounts cache activity. A provider's
     // aggregate may be absent or narrower than its reported components.
-    const inputTokens = Math.max(
-      natural(usage.inputTokens.total),
+    const reportedInputComponents = yield* decodeProviderUsageTotal(
       reportedUncached + cacheRead + cacheWrite,
     );
-    const outputTokens = Math.max(natural(usage.outputTokens.total), reportedText + reasoning);
+    const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+    const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
+    const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
     // When a provider reports only aggregates, classify the unexplained input
     // conservatively as uncached and non-reasoning output as text. This keeps
     // each persisted breakdown additive instead of silently inventing a free,
     // unclassified token bucket.
     const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
     const text = Math.max(reportedText, outputTokens - reasoning);
-    const totalTokens = inputTokens + outputTokens;
+    const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
     const provider = yield* Model.ProviderName;
     const model = yield* Model.ModelName;
     const estimate =
@@ -2363,7 +2385,7 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         ? 0
         : yield* options.estimateCostMicrousd(usage, { provider, model, usage });
     const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
-    if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
+    if (!Number.isSafeInteger(costMicrousd) || costMicrousd < 0) {
       return yield* AgentPolicyError.make({
         limit: "cost",
         message: "Model cost estimation must produce a non-negative integer number of microdollars",
@@ -2393,9 +2415,16 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
       outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
       costMicrousd,
     });
-    context.modelCalls += 1;
-    context.inputTokens += inputTokens;
-    context.outputTokens += outputTokens;
+    const modelCalls = yield* decodeProviderUsageTotal(context.modelCalls + 1);
+    const cumulativeInputTokens = yield* decodeProviderUsageTotal(
+      context.inputTokens + inputTokens,
+    );
+    const cumulativeOutputTokens = yield* decodeProviderUsageTotal(
+      context.outputTokens + outputTokens,
+    );
+    context.modelCalls = modelCalls;
+    context.inputTokens = cumulativeInputTokens;
+    context.outputTokens = cumulativeOutputTokens;
     context.lastInputTokens = inputTokens;
     context.lastOutputTokens = outputTokens;
     context.costMicrousd += costMicrousd;
@@ -3996,7 +4025,7 @@ const makeTurn = <
           }
           const toolCalls = priorToolCalls + trace.toolCalls.size;
           const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
-          if (overToolBudget && policy.onExhaustion === "fail" && !completionBatch) {
+          if (overToolBudget && policy.onExhaustion === "fail") {
             return failRunEventStream(
               AgentPolicyError.make({
                 limit: "tool-calls",
@@ -4257,8 +4286,7 @@ const makeTurn = <
             }
             const turnsBlocked =
               policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-            const completionTurnAllowed = completionBatch;
-            if (turnsBlocked && !completionTurnAllowed) {
+            if (turnsBlocked) {
               return failRunEventStream(
                 AgentPolicyError.make({
                   limit: "turns",
@@ -4733,7 +4761,7 @@ const makeResumeTurn = <
       const bounds = effectiveRunBounds(policy, options);
       const toolCalls = trace.toolCalls.size;
       const overToolBudget = toolCalls + context.programmaticToolCalls > bounds.maxToolCalls;
-      if (overToolBudget && policy.onExhaustion === "fail" && !completionBatch) {
+      if (overToolBudget && policy.onExhaustion === "fail") {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "tool-calls",
@@ -4743,8 +4771,7 @@ const makeResumeTurn = <
       }
       const turnsBlocked =
         policy.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      const completionTurnAllowed = completionBatch;
-      if (turnsBlocked && !completionTurnAllowed) {
+      if (turnsBlocked) {
         return failRunEventStream(
           AgentPolicyError.make({
             limit: "turns",

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -297,12 +297,20 @@ export type EngineProvidedToolServices =
   | ToolBroker
   | ToolSpanTelemetry;
 
+/** Schema services needed to reconstruct a completion Tool's canonical Agent output. */
+export type AgentCompletionProjectionRequirements<AgentValue extends Agent.Any> =
+  | AgentValue["definition"]["output"]["DecodingServices"]
+  | AgentValue["definition"]["output"]["EncodingServices"]
+  | Tool.ParametersSchema<Agent.ToolUnion<AgentValue>>["DecodingServices"]
+  | Tool.SuccessSchema<Agent.ToolUnion<AgentValue>>["DecodingServices"];
+
 /**
  * Inferred agent services plus the runtime's identity-generation authority.
  * Engine-provided Tool handler services are excluded because the interpreter
  * supplies them itself, bound to the current Run's identity. Output decoding
- * services stay listed unexcluded: `run`/`start` re-decode the terminal
- * output outside the Run stream's provision boundary.
+ * and completion-projection Schema services stay listed unexcluded:
+ * `run`/`start` re-decode terminal output and durable recovery re-decodes
+ * canonical completion Tool parameters/results outside the handler boundary.
  */
 export type AgentRuntimeRequirements<
   AgentValue extends Agent.Any,
@@ -310,6 +318,7 @@ export type AgentRuntimeRequirements<
   InstructionRequirements = never,
 > =
   | Exclude<Agent.Requirements<AgentValue>, EngineProvidedToolServices>
+  | AgentCompletionProjectionRequirements<AgentValue>
   | AgentValue["definition"]["output"]["DecodingServices"]
   | IdGenerator
   | HookRequirements
@@ -2363,20 +2372,67 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
     const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
     const reportedText = providerUsage.outputTokens.text ?? 0;
     const reasoning = providerUsage.outputTokens.reasoning ?? 0;
-    // Gross token accounting never discounts cache activity. A provider's
-    // aggregate may be absent or narrower than its reported components.
+    // Gross token accounting never discounts cache activity. An omitted
+    // aggregate is derived from present components; an omitted component may
+    // receive the aggregate remainder. Explicitly contradictory fields fail.
     const reportedInputComponents = yield* decodeProviderUsageTotal(
       reportedUncached + cacheRead + cacheWrite,
     );
-    const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+    const reportedInputTotal = providerUsage.inputTokens.total;
+    const allInputComponentsReported =
+      providerUsage.inputTokens.uncached !== undefined &&
+      providerUsage.inputTokens.cacheRead !== undefined &&
+      providerUsage.inputTokens.cacheWrite !== undefined;
+    if (
+      reportedInputTotal !== undefined &&
+      (reportedInputTotal < reportedInputComponents ||
+        (allInputComponentsReported && reportedInputTotal !== reportedInputComponents))
+    ) {
+      return yield* invalidProviderUsage();
+    }
+    const inputTokens = reportedInputTotal ?? reportedInputComponents;
     const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
-    const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
+    const reportedOutputTotal = providerUsage.outputTokens.total;
+    const allOutputComponentsReported =
+      providerUsage.outputTokens.text !== undefined &&
+      providerUsage.outputTokens.reasoning !== undefined;
+    if (
+      reportedOutputTotal !== undefined &&
+      (reportedOutputTotal < reportedOutputComponents ||
+        (allOutputComponentsReported && reportedOutputTotal !== reportedOutputComponents))
+    ) {
+      return yield* invalidProviderUsage();
+    }
+    const outputTokens = reportedOutputTotal ?? reportedOutputComponents;
     // When a provider reports only aggregates, classify the unexplained input
-    // conservatively as uncached and non-reasoning output as text. This keeps
-    // each persisted breakdown additive instead of silently inventing a free,
-    // unclassified token bucket.
-    const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
-    const text = Math.max(reportedText, outputTokens - reasoning);
+    // conservatively as uncached and non-reasoning output as text when those
+    // fields are absent. If either was explicit, assign the remainder to the
+    // first genuinely omitted component so no provider-supplied value changes.
+    const inputRemainder = inputTokens - reportedInputComponents;
+    const outputRemainder = outputTokens - reportedOutputComponents;
+    const uncached =
+      reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+    const normalizedCacheRead =
+      cacheRead +
+      (providerUsage.inputTokens.uncached !== undefined &&
+      providerUsage.inputTokens.cacheRead === undefined
+        ? inputRemainder
+        : 0);
+    const normalizedCacheWrite =
+      cacheWrite +
+      (providerUsage.inputTokens.uncached !== undefined &&
+      providerUsage.inputTokens.cacheRead !== undefined &&
+      providerUsage.inputTokens.cacheWrite === undefined
+        ? inputRemainder
+        : 0);
+    const text =
+      reportedText + (providerUsage.outputTokens.text === undefined ? outputRemainder : 0);
+    const normalizedReasoning =
+      reasoning +
+      (providerUsage.outputTokens.text !== undefined &&
+      providerUsage.outputTokens.reasoning === undefined
+        ? outputRemainder
+        : 0);
     const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
     const provider = yield* Model.ProviderName;
     const model = yield* Model.ModelName;
@@ -2409,10 +2465,14 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
       inputTokens: InputTokenUsage.make({
         total: inputTokens,
         uncached,
-        cacheRead,
-        cacheWrite,
+        cacheRead: normalizedCacheRead,
+        cacheWrite: normalizedCacheWrite,
       }),
-      outputTokens: OutputTokenUsage.make({ total: outputTokens, text, reasoning }),
+      outputTokens: OutputTokenUsage.make({
+        total: outputTokens,
+        text,
+        reasoning: normalizedReasoning,
+      }),
       costMicrousd,
     });
     const modelCalls = yield* decodeProviderUsageTotal(context.modelCalls + 1);
@@ -3410,7 +3470,16 @@ const encodeOutputCandidate = Effect.fn("AgentRuntime.encodeOutputCandidate")(fu
 
 const projectCompletionOutput = Effect.fn("AgentRuntime.projectCompletionOutput")(function* <
   AgentValue extends Agent.Any,
->(agent: AgentValue, declaration: CompletionToolDeclaration, parameters: unknown, result: unknown) {
+>(
+  agent: AgentValue,
+  declaration: CompletionToolDeclaration,
+  parameters: unknown,
+  result: unknown,
+): Effect.fn.Return<
+  { readonly encoded: Schema.Json; readonly decoded: Agent.Output<AgentValue> },
+  AgentOutputError | ModelProtocolError,
+  AgentCompletionProjectionRequirements<AgentValue>
+> {
   const tool = agent.definition.toolkit.tools[declaration.tool];
   if (tool === undefined) {
     return yield* ModelProtocolError.make({
@@ -6435,9 +6504,13 @@ export const withTerminalDefectEvent = <E, R>(
  *
  * The bound Model is provided locally; all remaining requirements stay visible
  * in the returned Effect or Stream. The interpreter owns no shared service or
- * Layer state.
+ * Layer state. The two output helpers are the canonical revalidation seams for
+ * durable session adapters; they apply the same Schemas and projector as live
+ * execution without invoking a Model or Tool Handler.
  */
 export const AgentRuntime = {
+  decodeFinalOutput,
+  projectCompletionOutput,
   run,
   start,
   stream,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2422,12 +2422,19 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
     const cumulativeOutputTokens = yield* decodeProviderUsageTotal(
       context.outputTokens + outputTokens,
     );
+    const cumulativeCostMicrousd = context.costMicrousd + costMicrousd;
+    if (!Number.isSafeInteger(cumulativeCostMicrousd)) {
+      return yield* AgentPolicyError.make({
+        limit: "cost",
+        message: "Cumulative model cost exceeds safe-integer accounting capacity",
+      });
+    }
     context.modelCalls = modelCalls;
     context.inputTokens = cumulativeInputTokens;
     context.outputTokens = cumulativeOutputTokens;
     context.lastInputTokens = inputTokens;
     context.lastOutputTokens = outputTokens;
-    context.costMicrousd += costMicrousd;
+    context.costMicrousd = cumulativeCostMicrousd;
     context.lastCostMicrousd = costMicrousd;
 
     if (options.durability !== undefined) {

--- a/packages/engine/src/run-options.ts
+++ b/packages/engine/src/run-options.ts
@@ -5,6 +5,7 @@ import type {
   DelegationId,
   ReceiptId,
   RunId,
+  ModelCallUsage,
   SubagentParentLink,
   SubmissionId,
   ToolCallId,
@@ -128,7 +129,35 @@ export interface RunUsageDelta {
   readonly toolCalls: number;
   readonly costMicrousd: number;
   readonly usage: Response.Usage;
+  /** Present for model-call deltas; absent for programmatic Tool-only charges. */
+  readonly modelUsage?: ModelCallUsage | undefined;
 }
+
+/** Stable pricing identity returned alongside a host's microdollar estimate. */
+export interface RunCostEstimate {
+  readonly costMicrousd: number;
+  readonly serviceTier?: string | undefined;
+  readonly pricingVersion?: string | undefined;
+}
+
+/** A number preserves the original estimator API; the object form adds pricing provenance. */
+export type RunCostEstimateValue = number | RunCostEstimate;
+
+/** Model identity presented beside the legacy raw-usage estimator argument. */
+export interface RunCostEstimateRequest {
+  readonly provider: string;
+  readonly model: string;
+  readonly usage: Response.Usage;
+}
+
+/**
+ * Host-owned price lookup; durable hosts close every dependency before installing it. Raw usage
+ * remains the first argument for source and runtime compatibility with the original estimator API.
+ */
+export type RunCostEstimator<Error = never, Requirements = never> = (
+  usage: Response.Usage,
+  request: RunCostEstimateRequest,
+) => Effect.Effect<RunCostEstimateValue, Error, Requirements>;
 
 /**
  * Dependency-neutral hierarchical budget hook. A typed failure at a Turn-seam
@@ -247,10 +276,7 @@ export interface RunCompactionCommit {
 /** One completed model call's provider-reported usage, staged for the Turn's canonical commit. */
 export interface RunTurnUsage {
   readonly turn: number;
-  readonly inputTokens: number;
-  readonly outputTokens: number;
-  /** Estimated spend of the staged call; recovery re-seeds the cost budget from it. */
-  readonly costMicrousd: number;
+  readonly usage: ModelCallUsage;
 }
 
 /**
@@ -633,9 +659,7 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
    */
   readonly turnAllowance?: number | undefined;
   /** Required when the core policy declares `costBudgetMicrousd`. */
-  readonly estimateCostMicrousd?:
-    | ((usage: Response.Usage) => Effect.Effect<number, HookError, HookRequirements>)
-    | undefined;
+  readonly estimateCostMicrousd?: RunCostEstimator<HookError, HookRequirements> | undefined;
   readonly scheduling?: RunSchedulingHook | undefined;
   /** Optional tightening-only overrides for the engine's finite in-memory buffer ceilings. */
   readonly bufferLimits?: RunBufferLimits | undefined;

--- a/packages/engine/test/compaction.test.ts
+++ b/packages/engine/test/compaction.test.ts
@@ -2,6 +2,7 @@ import {
   Agent,
   AgentPolicy,
   CompactionPolicy,
+  ContextBudgetError,
   ContextOverflowError,
   ConversationId,
   IdGenerator,
@@ -69,6 +70,7 @@ const toolCallParts = (
 interface CapturedRequest {
   readonly prompt: Prompt.Prompt;
   readonly toolCount: number;
+  readonly toolChoice: unknown;
 }
 
 type ScriptEntry = ReadonlyArray<Response.StreamPartEncoded> | { readonly fail: string };
@@ -92,7 +94,11 @@ const scriptedModel = (script: ReadonlyArray<ScriptEntry>) => {
         generateText: () => Effect.succeed([]),
         streamText: (request) => {
           const index = Math.min(requests.length, script.length - 1);
-          requests.push({ prompt: request.prompt, toolCount: request.tools.length });
+          requests.push({
+            prompt: request.prompt,
+            toolCount: request.tools.length,
+            toolChoice: request.toolChoice,
+          });
           const entry = script[index];
           if (entry === undefined) return Stream.empty;
           if ("fail" in entry) return Stream.fail(overflowFailure(entry.fail));
@@ -228,11 +234,11 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
         "maximum context window reached",
       ];
       for (const text of positives) {
-        expect(isContextOverflowMessage(text), text).toBe(true);
+        expect(isContextOverflowMessage(text)).toBe(true);
       }
       const negatives = ["rate limit exceeded", "invalid api key", "content filtered", ""];
       for (const text of negatives) {
-        expect(isContextOverflowMessage(text), text).toBe(false);
+        expect(isContextOverflowMessage(text)).toBe(false);
       }
     }),
   );
@@ -317,6 +323,69 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
           performed[0]?.tokensBeforeEstimate ?? 0,
         );
       }),
+  );
+
+  it.effect(
+    "RUN-034: cumulative token pressure compacts before it spends the completion reserve",
+    () =>
+      Effect.gen(function* () {
+        const policy = AgentPolicy.make({
+          ...basePolicy,
+          tokenBudget: 2_000,
+          completionReserveTokens: 500,
+          compaction: CompactionPolicy.make({ keepRecentTokens: 200, mode: "prune" }),
+        });
+        const { exit, requests, events } = yield* driveRun({
+          policy,
+          script: [
+            toolCallParts("s1", "search", {}, usageOf(100, 5)),
+            toolCallParts("s2", "search", {}, usageOf(700, 5)),
+            finalParts('{"answer":"done"}', usageOf(200, 5)),
+          ],
+          results: ["old".repeat(1_000), "recent"],
+        });
+
+        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(requests).toHaveLength(3);
+        const finalRequest = requests[2];
+        if (finalRequest === undefined) throw new Error("expected a final request");
+        expect(toolResultValues(finalRequest.prompt)).toEqual([CLEARED_TOOL_RESULT, "recent"]);
+        expect(compactionEvents(events).map((event) => event.kind)).toContain("clear-tool-results");
+      }),
+  );
+
+  it.effect("RUN-034: summarizer usage is charged before admitting the post-compaction call", () =>
+    Effect.gen(function* () {
+      const policy = AgentPolicy.make({
+        ...basePolicy,
+        tokenBudget: 12_000,
+        completionReserveTokens: 1_000,
+        contextTokenLimit: 1_500,
+        compaction: CompactionPolicy.make({ keepRecentTokens: 300, mode: "summarize" }),
+      });
+      const { exit, requests, events } = yield* driveRun({
+        policy,
+        script: [
+          toolCallParts("s1", "search", {}, usageOf(100, 5)),
+          toolCallParts("s2", "search", {}, usageOf(1_300, 5)),
+          finalParts("Goal: preserve delivery capacity", usageOf(9_600, 100)),
+          finalParts('{"answer":"delivered"}', usageOf(50, 10)),
+        ],
+        results: ["a".repeat(4_000), "b".repeat(4_000)],
+      });
+
+      expect(requests).toHaveLength(4);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(requests[3]?.toolChoice).toBe("none");
+      expect(
+        events.some(
+          (event) =>
+            event._tag === "RunCompleted" &&
+            event.finishReason === "budget-exhausted" &&
+            event.exhausted === "tokens",
+        ),
+      ).toBe(true);
+    }),
   );
 
   // -------------------------------------------------------- RUN-026 summarize
@@ -414,7 +483,7 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
       }),
   );
 
-  it.effect("RUN-026: mode prune proceeds past the limit without a summarizer call", () =>
+  it.effect("RUN-034: mode prune fails typed when protected context cannot reach the target", () =>
     Effect.gen(function* () {
       const policy = AgentPolicy.make({
         ...basePolicy,
@@ -430,24 +499,23 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
         results: ["small"],
       });
 
-      expect(Exit.isSuccess(exit)).toBe(true);
-      expect(requests).toHaveLength(2);
-      const second = requests[1];
-      if (second === undefined) throw new Error("expected a second model request");
-      expect(toolResultValues(second.prompt)).toEqual(["small"]);
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = failureFrom(exit);
+      expect(failure).toBeInstanceOf(ContextBudgetError);
+      expect(requests).toHaveLength(1);
       expect(compactionEvents(events)).toHaveLength(0);
     }),
   );
 
   it.effect(
-    "RUN-028: the window reserves the output contract's size — the same view compacts with a large contract and stays whole without one",
+    "RUN-028: the context target includes the output contract and fails before provider I/O when the protected tail cannot fit",
     () =>
       Effect.gen(function* () {
         // The contract is appended to every outgoing request AFTER the window
         // check, so the estimate must reserve its size: a view comfortably
         // under the limit still compacts when view + contract crosses it.
         const paddedOutput = Schema.Struct({ answer: Schema.String }).annotate({
-          description: "p".repeat(32_000),
+          description: "p".repeat(12_000),
         });
         const policy = AgentPolicy.make({
           ...basePolicy,
@@ -455,6 +523,7 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
           compaction: CompactionPolicy.make({ keepRecentTokens: 200, mode: "prune" }),
         });
         const bigResult = "r".repeat(6_000);
+        const recentResult = "s".repeat(8_000);
 
         const reserved = yield* driveRunWith(paddedOutput, {
           policy,
@@ -463,16 +532,13 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
             toolCallParts("s2", "search", {}, usageOf(200, 5)),
             finalParts('{"answer":"done"}', usageOf(300, 5)),
           ],
-          results: [bigResult, "small"],
+          results: [bigResult, recentResult],
         });
-        expect(Exit.isSuccess(reserved.exit)).toBe(true);
-        // The big first-turn result was cleared before the final request even
-        // though the view alone (~2k tokens) is far below the 5k limit.
-        expect(compactionEvents(reserved.events).length).toBeGreaterThanOrEqual(1);
-        const finalRequest = reserved.requests.at(-1);
-        if (finalRequest === undefined) throw new Error("expected a final model request");
-        expect(toolResultValues(finalRequest.prompt)).toContain(CLEARED_TOOL_RESULT);
-        expect(toolResultValues(finalRequest.prompt)).not.toContain(bigResult);
+        expect(Exit.isFailure(reserved.exit)).toBe(true);
+        expect(failureFrom(reserved.exit)).toBeInstanceOf(ContextBudgetError);
+        // The contract plus the protected newest result cannot reach the
+        // target, so the next provider request never starts.
+        expect(reserved.requests.length).toBeLessThan(3);
 
         // Control: an unrenderable output Schema produces no contract, so the
         // identical view under the identical limit never compacts.
@@ -485,7 +551,7 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
               toolCallParts("s2", "search", {}, usageOf(200, 5)),
               finalParts('["first",1,"last"]', usageOf(300, 5)),
             ],
-            results: [bigResult, "small"],
+            results: [bigResult, recentResult],
           },
         );
         expect(Exit.isSuccess(control.exit)).toBe(true);
@@ -576,6 +642,31 @@ layer(identifiers)("engine compaction and overflow recovery", (it) => {
       if (failure instanceof ContextOverflowError) {
         expect(failure.retried).toBe(true);
       }
+    }),
+  );
+
+  it.effect("RUN-034: overflow compaction fails locally when its summary cannot reach target", () =>
+    Effect.gen(function* () {
+      const policy = AgentPolicy.make({
+        ...basePolicy,
+        contextTokenLimit: 20_000,
+        compaction: CompactionPolicy.make({ keepRecentTokens: 300, mode: "summarize" }),
+      });
+      const { exit, requests } = yield* driveRun({
+        policy,
+        script: [
+          toolCallParts("s1", "search", {}, usageOf(100, 5)),
+          toolCallParts("s2", "search", {}, usageOf(200, 5)),
+          { fail: "maximum context length exceeded" },
+          finalParts(`Goal: ${"summary".repeat(20_000)}`, usageOf(20, 10)),
+        ],
+        results: ["a".repeat(4_000), "b".repeat(4_000)],
+      });
+
+      expect(failureFrom(exit)).toBeInstanceOf(ContextBudgetError);
+      // Two research calls, the rejected call, and one summarizer call. The
+      // engine never sends a retry it already knows exceeds the target.
+      expect(requests).toHaveLength(4);
     }),
   );
 

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -143,6 +143,12 @@ const SearchTool = Tool.make("search", {
 });
 const searchToolkit = Toolkit.make(SearchTool);
 
+const PostMessageTool = Tool.make("post_message", {
+  parameters: Schema.Struct({ message: Schema.String }),
+  success: Schema.Struct({ messageId: Schema.String }),
+});
+const postMessageToolkit = Toolkit.make(PostMessageTool);
+
 const answerOutput = Schema.Struct({ answer: Schema.String });
 
 layer(identifiers)("context economics — bounding, tracking, status, exhaustion", (it) => {
@@ -326,7 +332,16 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
         expect(observed[0]?.inputTokens).toBe(9);
         expect(observed[0]?.usage.inputTokens.cacheRead).toBe(3);
         expect(observed[0]?.usage.inputTokens.cacheWrite).toBe(4);
+        expect(observed[0]?.modelUsage).toMatchObject({
+          provider: "scripted",
+          model: "context-economics",
+          inputTokens: { total: 9, uncached: 2, cacheRead: 3, cacheWrite: 4 },
+        });
         expect(observed[1]?.inputTokens).toBe(150);
+        expect(observed[1]?.modelUsage).toMatchObject({
+          inputTokens: { total: 150, uncached: 150, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 5, text: 5, reasoning: 0 },
+        });
 
         // The second request's status message reflects the FIRST call's input,
         // not the cumulative total.
@@ -436,11 +451,11 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 10,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 100,
+            tokenBudget: 10_000,
           }),
         });
         const { model, requests } = scriptedModel([
-          toolCallParts("s1", "search", {}, usageOf(70, 15)),
+          toolCallParts("s1", "search", {}, usageOf(7_000, 1_500)),
           finalParts('{"answer":"done"}', usageOf(1, 1)),
         ]);
         const toolLayer = searchToolkit.toLayer({ search: () => Effect.succeed("found") });
@@ -454,7 +469,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
         if (first === undefined || second === undefined) throw new Error("expected two requests");
         expect(promptText(first.prompt)).not.toContain("WARNING:");
         expect(messageText(second.prompt.content.at(-1)!)).toBe(
-          "<run-status>turn 2/10 · tool-calls 1/10 · tokens 85/100 · last-context 70 · elapsed 0s/30s · WARNING: approaching limits — converge and deliver your final result now.</run-status>",
+          "<run-status>turn 2/10 · tool-calls 1/10 · tokens 8500/10000 · last-context 7000 · elapsed 0s/30s · WARNING: approaching limits — converge and deliver your final result now.</run-status>",
         );
       }),
   );
@@ -496,13 +511,13 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 10,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 100,
+            tokenBudget: 10_000,
           }),
         });
         const { model } = scriptedModel([
-          toolCallParts("s1", "search", {}, usageOf(50, 10)),
-          toolCallParts("s2", "search", {}, usageOf(25, 0)),
-          finalParts('{"answer":"done"}', usageOf(5, 0)),
+          toolCallParts("s1", "search", {}, usageOf(800, 200)),
+          toolCallParts("s2", "search", {}, usageOf(7_500, 0)),
+          finalParts('{"answer":"done"}', usageOf(500, 0)),
         ]);
         const toolLayer = searchToolkit.toLayer({ search: () => Effect.succeed("found") });
 
@@ -514,7 +529,11 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
 
         const warnings = (yield* Ref.get(events)).filter((event) => event._tag === "BudgetWarning");
         expect(warnings).toHaveLength(1);
-        expect(warnings[0]).toMatchObject({ limit: "tokens", consumed: 85, limitValue: 100 });
+        expect(warnings[0]).toMatchObject({
+          limit: "tokens",
+          consumed: 8_500,
+          limitValue: 10_000,
+        });
       }),
   );
 
@@ -617,12 +636,12 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 5,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 10,
+            tokenBudget: 10_000,
           }),
         });
         const { model, requests } = scriptedModel([
-          toolCallParts("s1", "search", {}, usageOf(9, 4)),
-          finalParts('{"answer":"partial"}', usageOf(3, 1)),
+          toolCallParts("s1", "search", {}, usageOf(9_000, 4_000)),
+          finalParts('{"answer":"partial"}', usageOf(3_000, 1_000)),
         ]);
         const toolLayer = searchToolkit.toLayer({
           search: () => Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("found")),
@@ -674,6 +693,169 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
         const completed = observed.find((event) => event._tag === "RunCompleted");
         expect(completed).toMatchObject({
           output: { answer: "partial" },
+          finishReason: "budget-exhausted",
+          exhausted: "tokens",
+        });
+      }),
+  );
+
+  it.effect(
+    "RUN-032: an authorized completion Tool settles immediately when its response crosses the token budget",
+    () =>
+      Effect.gen(function* () {
+        const handlerStarts = yield* Ref.make(0);
+        const definition = Agent.define("token-exhausted-terminal-tool", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+          instructions: "Deliver the final answer with post_message.",
+          toolkit: postMessageToolkit,
+          policy: AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 5,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            tokenBudget: 10_000,
+            onExhaustion: "fail",
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ parameters, result }) => ({
+              message: parameters.message,
+              messageId: result.messageId,
+            }),
+          },
+        });
+        const { model, requests } = scriptedModel([
+          toolCallParts(
+            "delivery-1",
+            "post_message",
+            { message: "delivered" },
+            usageOf(9_000, 4_000),
+          ),
+          finalParts('{"message":"private summary","messageId":"wrong"}'),
+        ]);
+        const toolLayer = postMessageToolkit.toLayer({
+          post_message: () =>
+            Ref.update(handlerStarts, (count) => count + 1).pipe(
+              Effect.as({ messageId: "message-1" }),
+            ),
+        });
+
+        const result = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+          question: "deliver",
+        }).pipe(Effect.provide(toolLayer));
+
+        expect(requests).toHaveLength(1);
+        expect(yield* Ref.get(handlerStarts)).toBe(1);
+        expect(result).toMatchObject({
+          output: { message: "delivered", messageId: "message-1" },
+          finishReason: "budget-exhausted",
+          exhausted: "tokens",
+        });
+      }),
+  );
+
+  it.effect("RUN-032: a completion Tool must be the singleton declared batch", () =>
+    Effect.gen(function* () {
+      const mixedToolkit = Toolkit.make(PostMessageTool, SearchTool);
+      const handlerStarts = yield* Ref.make(0);
+      const definition = Agent.define("mixed-terminal-tool-batch", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+        instructions: "Deliver exactly once.",
+        toolkit: mixedToolkit,
+        policy: AgentPolicy.make({
+          maxTurns: 5,
+          maxToolCalls: 5,
+          maxDuration: "30 seconds",
+          toolConcurrency: 2,
+        }),
+        completion: {
+          tool: "post_message",
+          project: ({ parameters, result }) => ({
+            message: parameters.message,
+            messageId: result.messageId,
+          }),
+        },
+      });
+      const { model, requests } = scriptedModel([
+        [
+          {
+            type: "tool-call",
+            id: "delivery-mixed",
+            name: "post_message",
+            params: { message: "must not send" },
+            providerExecuted: false,
+          },
+          {
+            type: "tool-call",
+            id: "search-mixed",
+            name: "search",
+            params: {},
+            providerExecuted: false,
+          },
+          { type: "finish", reason: "tool-calls", usage: usageOf(10, 5) },
+        ],
+      ]);
+      const toolLayer = mixedToolkit.toLayer({
+        post_message: () =>
+          Ref.update(handlerStarts, (count) => count + 1).pipe(
+            Effect.as({ messageId: "must-not-exist" }),
+          ),
+        search: () =>
+          Ref.update(handlerStarts, (count) => count + 1).pipe(Effect.as("must-not-run")),
+      });
+
+      const exit = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+        question: "deliver",
+      }).pipe(Effect.provide(toolLayer), Effect.exit);
+
+      expect(failureFrom(exit)).toBeInstanceOf(ModelProtocolError);
+      expect(requests).toHaveLength(1);
+      expect(yield* Ref.get(handlerStarts)).toBe(0);
+    }),
+  );
+
+  it.effect(
+    "RUN-034: completion reserve enters delivery mode before a research call can consume it",
+    () =>
+      Effect.gen(function* () {
+        const definition = Agent.define("completion-reserve-terminal-tool", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+          instructions: `Research only while delivery capacity remains. ${"context ".repeat(100)}`,
+          toolkit: postMessageToolkit,
+          policy: AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 5,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            tokenBudget: 10_000,
+            completionReserveTokens: 9_800,
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ parameters, result }) => ({
+              message: parameters.message,
+              messageId: result.messageId,
+            }),
+          },
+        });
+        const { model, requests } = scriptedModel([
+          toolCallParts("delivery-1", "post_message", { message: "reserved" }, usageOf(50, 10)),
+        ]);
+        const toolLayer = postMessageToolkit.toLayer({
+          post_message: () => Effect.succeed({ messageId: "message-reserved" }),
+        });
+
+        const result = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+          question: "deliver",
+        }).pipe(Effect.provide(toolLayer));
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.toolChoice).toEqual({ mode: "auto", oneOf: ["post_message"] });
+        expect(result).toMatchObject({
+          output: { message: "reserved", messageId: "message-reserved" },
           finishReason: "budget-exhausted",
           exhausted: "tokens",
         });
@@ -839,7 +1021,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 5,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 10,
+            tokenBudget: 10_000,
           }),
         });
         const { model } = scriptedModel([
@@ -872,12 +1054,12 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 5,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 10,
+            tokenBudget: 10_000,
           }),
         });
         const { model } = scriptedModel([
-          toolCallParts("s1", "search", {}, usageOf(9, 4)),
-          finalParts("not json", usageOf(1, 1)),
+          toolCallParts("s1", "search", {}, usageOf(9_000, 4_000)),
+          finalParts("not json", usageOf(1_000, 1_000)),
         ]);
         const toolLayer = searchToolkit.toLayer({ search: () => Effect.succeed("found") });
 
@@ -925,6 +1107,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
 
   it.effect("RUN-025: a simultaneous token and cost breach fails typed on the cost rail", () =>
     Effect.gen(function* () {
+      const estimatedInputTokens = yield* Ref.make<number | undefined>(undefined);
       const definition = Agent.define("both-breach", {
         input: Schema.Struct({ question: Schema.String }),
         output: answerOutput,
@@ -943,11 +1126,15 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
       const exit = yield* AgentRuntime.run(
         Agent.withModel(definition, model),
         { question: "q" },
-        { estimateCostMicrousd: () => Effect.succeed(2_000) },
+        {
+          estimateCostMicrousd: (usage) =>
+            Ref.set(estimatedInputTokens, usage.inputTokens.total).pipe(Effect.as(2_000)),
+        },
       ).pipe(Effect.exit);
       const failure = failureFrom(exit);
       expect(failure).toBeInstanceOf(AgentPolicyError);
       expect((failure as AgentPolicyError).limit).toBe("cost");
+      expect(yield* Ref.get(estimatedInputTokens)).toBe(150);
     }),
   );
 
@@ -1380,7 +1567,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxToolCalls: 2,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            tokenBudget: 100,
+            tokenBudget: 10_000,
           }),
         });
         const { model } = scriptedModel([
@@ -1403,7 +1590,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             { type: "text-start", id: "answer" },
             { type: "text-delta", id: "answer", delta: '{"answer":"hosted"}' },
             { type: "text-end", id: "answer" },
-            { type: "finish", reason: "stop", usage: usageOf(150, 10) },
+            { type: "finish", reason: "stop", usage: usageOf(15_000, 1_000) },
           ],
         ]);
         const result = yield* AgentRuntime.run(Agent.withModel(definition, model), {

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -28,6 +28,7 @@ import {
   AgentRuntime,
   formatRunStatus,
   type RunDurabilityHook,
+  type RunTurnResume,
   type RunUsageDelta,
 } from "../src/index.ts";
 
@@ -37,16 +38,18 @@ const identifiers = Layer.succeed(IdGenerator, {
   nextTurnId: Effect.succeed(Schema.decodeSync(TurnId)("turn-1")),
 });
 
-const emptyUsage = { inputTokens: {}, outputTokens: {} };
+type FinishUsage = Extract<Response.StreamPartEncoded, { readonly type: "finish" }>["usage"];
 
-const usageOf = (input: number, output: number) => ({
+const emptyUsage: FinishUsage = { inputTokens: {}, outputTokens: {} };
+
+const usageOf = (input: number, output: number): FinishUsage => ({
   inputTokens: { total: input },
   outputTokens: { total: output },
 });
 
 const finalParts = (
   text: string,
-  usage: typeof emptyUsage | ReturnType<typeof usageOf> = emptyUsage,
+  usage: FinishUsage = emptyUsage,
 ): ReadonlyArray<Response.StreamPartEncoded> => [
   { type: "text-start", id: "answer" },
   { type: "text-delta", id: "answer", delta: text },
@@ -58,7 +61,7 @@ const toolCallParts = (
   id: string,
   name: string,
   params: Record<string, unknown>,
-  usage: typeof emptyUsage | ReturnType<typeof usageOf> = emptyUsage,
+  usage: FinishUsage = emptyUsage,
 ): ReadonlyArray<Response.StreamPartEncoded> => [
   { type: "tool-call", id, name, params, providerExecuted: false },
   { type: "finish", reason: "tool-calls", usage },
@@ -349,6 +352,59 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
         if (second === undefined) throw new Error("expected a second model request");
         expect(promptText(second.prompt)).toContain("last-context 9");
       }),
+  );
+
+  it.effect("RUN-023: rejects malformed provider token usage instead of counting it as zero", () =>
+    Effect.gen(function* () {
+      const estimatorCalls = yield* Ref.make(0);
+      const definition = Agent.define("invalid-provider-usage", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: answerOutput,
+        instructions: "Answer.",
+        toolkit: Toolkit.empty,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const malformed: ReadonlyArray<FinishUsage> = [
+        { inputTokens: { total: -1 }, outputTokens: {} },
+        { inputTokens: { uncached: -1 }, outputTokens: {} },
+        { inputTokens: { cacheRead: -1 }, outputTokens: {} },
+        { inputTokens: { cacheWrite: -1 }, outputTokens: {} },
+        { inputTokens: {}, outputTokens: { total: -1 } },
+        { inputTokens: {}, outputTokens: { text: -1 } },
+        { inputTokens: {}, outputTokens: { reasoning: -1 } },
+        // Effect AI rejects non-integers and unsafe integers before this seam.
+        // This pair proves that individually valid fields cannot overflow a
+        // derived total and escape accounting.
+        {
+          inputTokens: {
+            uncached: Number.MAX_SAFE_INTEGER,
+            cacheRead: Number.MAX_SAFE_INTEGER,
+          },
+          outputTokens: {},
+        },
+      ];
+
+      for (const usage of malformed) {
+        const { model, requests } = scriptedModel([finalParts('{"answer":"invalid"}', usage)]);
+        const exit = yield* AgentRuntime.run(
+          Agent.withModel(definition, model),
+          { question: "q" },
+          {
+            estimateCostMicrousd: () =>
+              Ref.update(estimatorCalls, (count) => count + 1).pipe(Effect.as(0)),
+          },
+        ).pipe(Effect.exit);
+
+        expect(failureFrom(exit)).toBeInstanceOf(ModelProtocolError);
+        expect(requests).toHaveLength(1);
+      }
+      expect(yield* Ref.get(estimatorCalls)).toBe(0);
+    }),
   );
 
   // ---------------------------------------------------------------- RUN-024
@@ -700,7 +756,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
   );
 
   it.effect(
-    "RUN-032: an authorized completion Tool settles immediately when its response crosses the token budget",
+    "RUN-032: final-answer mode lets an authorized completion Tool settle when its response crosses the token budget",
     () =>
       Effect.gen(function* () {
         const handlerStarts = yield* Ref.make(0);
@@ -715,7 +771,6 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
             maxDuration: "30 seconds",
             toolConcurrency: 1,
             tokenBudget: 10_000,
-            onExhaustion: "fail",
           }),
           completion: {
             tool: "post_message",
@@ -755,6 +810,225 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
       }),
   );
 
+  it.effect(
+    "RUN-032: fail mode rejects a token-breaching completion Tool before its handler starts",
+    () =>
+      Effect.gen(function* () {
+        const handlerStarts = yield* Ref.make(0);
+        const definition = Agent.define("token-exhausted-terminal-tool-fail", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+          instructions: "Deliver the final answer with post_message.",
+          toolkit: postMessageToolkit,
+          policy: AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 5,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            tokenBudget: 10_000,
+            onExhaustion: "fail",
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ parameters, result }) => ({
+              message: parameters.message,
+              messageId: result.messageId,
+            }),
+          },
+        });
+        const { model, requests } = scriptedModel([
+          toolCallParts(
+            "delivery-fail",
+            "post_message",
+            { message: "must not deliver" },
+            usageOf(9_000, 4_000),
+          ),
+        ]);
+        const toolLayer = postMessageToolkit.toLayer({
+          post_message: () =>
+            Ref.update(handlerStarts, (count) => count + 1).pipe(
+              Effect.as({ messageId: "must-not-exist" }),
+            ),
+        });
+
+        const exit = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+          question: "deliver",
+        }).pipe(Effect.provide(toolLayer), Effect.exit);
+        const failure = failureFrom(exit);
+
+        expect(failure).toBeInstanceOf(AgentPolicyError);
+        expect((failure as AgentPolicyError).limit).toBe("tokens");
+        expect(requests).toHaveLength(1);
+        expect(yield* Ref.get(handlerStarts)).toBe(0);
+      }),
+  );
+
+  it.effect("RUN-032: fail mode does not exempt a completion Tool from the Turn limit", () =>
+    Effect.gen(function* () {
+      const handlerStarts = yield* Ref.make(0);
+      const definition = Agent.define("turn-exhausted-terminal-tool-fail", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+        instructions: "Deliver the final answer with post_message.",
+        toolkit: postMessageToolkit,
+        policy: AgentPolicy.make({
+          maxTurns: 1,
+          maxToolCalls: 5,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+          onExhaustion: "fail",
+        }),
+        completion: {
+          tool: "post_message",
+          project: ({ parameters, result }) => ({
+            message: parameters.message,
+            messageId: result.messageId,
+          }),
+        },
+      });
+      const { model } = scriptedModel([
+        toolCallParts("delivery-turn-fail", "post_message", { message: "must not deliver" }),
+      ]);
+      const toolLayer = postMessageToolkit.toLayer({
+        post_message: () =>
+          Ref.update(handlerStarts, (count) => count + 1).pipe(
+            Effect.as({ messageId: "must-not-exist" }),
+          ),
+      });
+
+      const exit = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+        question: "deliver",
+      }).pipe(Effect.provide(toolLayer), Effect.exit);
+      const failure = failureFrom(exit);
+
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect((failure as AgentPolicyError).limit).toBe("turns");
+      expect(yield* Ref.get(handlerStarts)).toBe(0);
+    }),
+  );
+
+  it.effect("RUN-032: fail mode does not exempt a completion Tool from the Tool Call limit", () =>
+    Effect.gen(function* () {
+      const SearchThenPost = Toolkit.make(SearchTool, PostMessageTool);
+      const searchStarts = yield* Ref.make(0);
+      const deliveryStarts = yield* Ref.make(0);
+      const definition = Agent.define("tool-exhausted-terminal-tool-fail", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+        instructions: "Research, then deliver the final answer with post_message.",
+        toolkit: SearchThenPost,
+        policy: AgentPolicy.make({
+          maxTurns: 5,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+          onExhaustion: "fail",
+        }),
+        completion: {
+          tool: "post_message",
+          project: ({ parameters, result }) => ({
+            message: parameters.message,
+            messageId: result.messageId,
+          }),
+        },
+      });
+      const { model, requests } = scriptedModel([
+        toolCallParts("search-before-delivery", "search", {}),
+        toolCallParts("delivery-tool-fail", "post_message", {
+          message: "must not deliver",
+        }),
+      ]);
+      const toolLayer = SearchThenPost.toLayer({
+        search: () => Ref.update(searchStarts, (count) => count + 1).pipe(Effect.as("found")),
+        post_message: () =>
+          Ref.update(deliveryStarts, (count) => count + 1).pipe(
+            Effect.as({ messageId: "must-not-exist" }),
+          ),
+      });
+
+      const exit = yield* AgentRuntime.run(Agent.withModel(definition, model), {
+        question: "deliver",
+      }).pipe(Effect.provide(toolLayer), Effect.exit);
+      const failure = failureFrom(exit);
+
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect((failure as AgentPolicyError).limit).toBe("tool-calls");
+      expect(requests).toHaveLength(2);
+      expect(yield* Ref.get(searchStarts)).toBe(1);
+      expect(yield* Ref.get(deliveryStarts)).toBe(0);
+    }),
+  );
+
+  it.effect(
+    "RUN-032: fail mode rejects an over-budget resumed completion Tool before its handler starts",
+    () =>
+      Effect.gen(function* () {
+        const handlerStarts = yield* Ref.make(0);
+        const definition = Agent.define("resume-token-exhausted-terminal-tool-fail", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+          instructions: "Deliver the final answer with post_message.",
+          toolkit: postMessageToolkit,
+          policy: AgentPolicy.make({
+            maxTurns: 5,
+            maxToolCalls: 5,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            tokenBudget: 100,
+            onExhaustion: "fail",
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ parameters, result }) => ({
+              message: parameters.message,
+              messageId: result.messageId,
+            }),
+          },
+        });
+        const { model, requests } = scriptedModel([finalParts('{"message":"never"}')]);
+        const toolLayer = postMessageToolkit.toLayer({
+          post_message: () =>
+            Ref.update(handlerStarts, (count) => count + 1).pipe(
+              Effect.as({ messageId: "must-not-exist" }),
+            ),
+        });
+        const resume: RunTurnResume = {
+          turn: 1,
+          turnId: Schema.decodeSync(TurnId)("turn-resumed-delivery"),
+          calls: [
+            {
+              id: "delivery-resumed-fail",
+              name: "post_message",
+              params: { message: "must not deliver" },
+            },
+          ],
+          settled: [],
+        };
+
+        const exit = yield* AgentRuntime.run(
+          Agent.withModel(definition, model),
+          { question: "deliver" },
+          {
+            resume,
+            resumeUsage: {
+              modelCalls: 1,
+              inputTokens: 90,
+              outputTokens: 20,
+              lastInputTokens: 90,
+              lastOutputTokens: 20,
+              costMicrousd: 0,
+            },
+          },
+        ).pipe(Effect.provide(toolLayer), Effect.exit);
+        const failure = failureFrom(exit);
+
+        expect(failure).toBeInstanceOf(AgentPolicyError);
+        expect((failure as AgentPolicyError).limit).toBe("tokens");
+        expect(requests).toHaveLength(0);
+        expect(yield* Ref.get(handlerStarts)).toBe(0);
+      }),
+  );
+
   it.effect("RUN-032: a completion Tool must be the singleton declared batch", () =>
     Effect.gen(function* () {
       const mixedToolkit = Toolkit.make(PostMessageTool, SearchTool);
@@ -762,7 +1036,7 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
       const definition = Agent.define("mixed-terminal-tool-batch", {
         input: Schema.Struct({ question: Schema.String }),
         output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
-        instructions: "Deliver exactly once.",
+        instructions: "Deliver the final message.",
         toolkit: mixedToolkit,
         policy: AgentPolicy.make({
           maxTurns: 5,

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -1412,6 +1412,46 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
     }),
   );
 
+  it.effect("RUN-035: cumulative model cost fails typed before safe-integer overflow", () =>
+    Effect.gen(function* () {
+      const estimatorCalls = yield* Ref.make(0);
+      const definition = Agent.define("cost-overflow", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: answerOutput,
+        instructions: "Search, then answer.",
+        toolkit: searchToolkit,
+        policy: AgentPolicy.make({
+          maxTurns: 3,
+          maxToolCalls: 2,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const { model } = scriptedModel([
+        toolCallParts("cost-search", "search", {}),
+        finalParts('{"answer":"done"}'),
+      ]);
+      const toolLayer = searchToolkit.toLayer({ search: () => Effect.succeed("found") });
+
+      const exit = yield* AgentRuntime.run(
+        Agent.withModel(definition, model),
+        { question: "q" },
+        {
+          estimateCostMicrousd: () =>
+            Ref.modify(estimatorCalls, (count) => [
+              count === 0 ? Number.MAX_SAFE_INTEGER : 1,
+              count + 1,
+            ]),
+        },
+      ).pipe(Effect.provide(toolLayer), Effect.exit);
+      const failure = failureFrom(exit);
+
+      expect(failure).toBeInstanceOf(AgentPolicyError);
+      expect((failure as AgentPolicyError).limit).toBe("cost");
+      expect(yield* Ref.get(estimatorCalls)).toBe(2);
+    }),
+  );
+
   it.effect("RUN-022: an unserializable Tool result becomes the fail-closed sentinel", () =>
     Effect.gen(function* () {
       const UnknownTool = Tool.make("emitUnknown", {

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -387,6 +387,14 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
           },
           outputTokens: {},
         },
+        // Reported totals cannot contradict explicitly reported components.
+        { inputTokens: { total: 0, cacheRead: 100 }, outputTokens: {} },
+        {
+          inputTokens: { total: 200, uncached: 50, cacheRead: 50, cacheWrite: 0 },
+          outputTokens: {},
+        },
+        { inputTokens: {}, outputTokens: { total: 0, text: 100 } },
+        { inputTokens: {}, outputTokens: { total: 200, text: 50, reasoning: 50 } },
       ];
 
       for (const usage of malformed) {
@@ -404,6 +412,46 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
         expect(requests).toHaveLength(1);
       }
       expect(yield* Ref.get(estimatorCalls)).toBe(0);
+    }),
+  );
+
+  it.effect("RUN-023: assigns aggregate remainders only to omitted provider components", () =>
+    Effect.gen(function* () {
+      const deltas = yield* Ref.make<ReadonlyArray<RunUsageDelta>>([]);
+      const definition = Agent.define("provider-usage-remainder", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: answerOutput,
+        instructions: "Answer.",
+        toolkit: Toolkit.empty,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const { model } = scriptedModel([
+        finalParts('{"answer":"done"}', {
+          inputTokens: { total: 100, uncached: 20, cacheRead: 30 },
+          outputTokens: { total: 20, text: 5 },
+        }),
+      ]);
+
+      yield* AgentRuntime.run(
+        Agent.withModel(definition, model),
+        { question: "q" },
+        {
+          budget: {
+            guard: (effect) => effect,
+            consume: (delta) => Ref.update(deltas, (all) => [...all, delta]),
+          },
+        },
+      );
+
+      expect((yield* Ref.get(deltas))[0]?.modelUsage).toMatchObject({
+        inputTokens: { total: 100, uncached: 20, cacheRead: 30, cacheWrite: 50 },
+        outputTokens: { total: 20, text: 5, reasoning: 15 },
+      });
     }),
   );
 

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -1,5 +1,5 @@
 import { ConversationId } from "@effect-agent/core";
-import type { RunContextPreparation } from "@effect-agent/engine";
+import type { RunContextPreparation, RunCostEstimator } from "@effect-agent/engine";
 import { RunContextPreparationPassthrough } from "@effect-agent/engine";
 import {
   AgentBindingResolver,
@@ -80,6 +80,8 @@ export interface CloudflareDurableRuntimeOptions {
   readonly leaseRenewalInterval?: number | undefined;
   /** Milliseconds; default 500. */
   readonly abortPollInterval?: number | undefined;
+  /** Deployment-owned pricing authority used by durable cost budgets and settlements. */
+  readonly estimateCostMicrousd?: RunCostEstimator | undefined;
   /** Milliseconds; default 25. */
   readonly observationPollInterval?: number | undefined;
   /** Bytes; default just under the 2 MB platform value limit. */
@@ -359,6 +361,9 @@ export class CloudflareDurableRuntime {
             settlementPollInterval: Duration.millis(config.settlementPollInterval),
             leaseRenewalInterval: Duration.millis(config.leaseRenewalInterval),
             abortPollInterval: Duration.millis(config.abortPollInterval),
+            ...(options.estimateCostMicrousd === undefined
+              ? {}
+              : { estimateCostMicrousd: options.estimateCostMicrousd }),
           }),
         );
 

--- a/packages/platform-cloudflare/test/travel-planner-dc.test.ts
+++ b/packages/platform-cloudflare/test/travel-planner-dc.test.ts
@@ -250,6 +250,7 @@ describe("DC Travel Planner — baseline settlement", () => {
       "ToolCallSettled",
       "ToolCallSettled",
       "ModelResponseRecorded",
+      "RunCompleted",
       "SubmissionSettled",
     ]);
     const settled = settledPayloadOf(records);

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@effect-agent/core": "workspace:*",
+    "@effect-agent/engine": "workspace:*",
     "@effect-agent/session": "workspace:*",
     "@effect-agent/storage-sqlite": "workspace:*",
     "@effect/platform-node": "catalog:",
@@ -34,7 +35,6 @@
   },
   "devDependencies": {
     "@effect-agent/capabilities": "workspace:*",
-    "@effect-agent/engine": "workspace:*",
     "@effect/vitest": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"

--- a/packages/platform-node/src/layers.ts
+++ b/packages/platform-node/src/layers.ts
@@ -1,7 +1,8 @@
 import type { SubmissionId } from "@effect-agent/core";
 import type { RunCostEstimator } from "@effect-agent/engine";
-import type { ConversationStore, WakeScheduler } from "@effect-agent/session";
 import {
+  type ConversationStore,
+  type WakeScheduler,
   AgentBindingResolver,
   DEFAULT_OWNERSHIP_LEASE_DURATION,
   DeploymentId,

--- a/packages/platform-node/src/layers.ts
+++ b/packages/platform-node/src/layers.ts
@@ -1,4 +1,5 @@
 import type { SubmissionId } from "@effect-agent/core";
+import type { RunCostEstimator } from "@effect-agent/engine";
 import type { ConversationStore, WakeScheduler } from "@effect-agent/session";
 import {
   AgentBindingResolver,
@@ -105,6 +106,8 @@ export interface NodeDurableRuntimeOptions {
   readonly leaseRenewalInterval?: number | undefined;
   /** Milliseconds; default 500. */
   readonly abortPollInterval?: number | undefined;
+  /** Deployment-owned pricing authority used by durable cost budgets and settlements. */
+  readonly estimateCostMicrousd?: RunCostEstimator | undefined;
   /** Milliseconds; default 5000. */
   readonly busyTimeout?: number | undefined;
   /** Milliseconds; default 25. */
@@ -191,22 +194,22 @@ const sqliteStorageConfigLayer: Layer.Layer<SqliteStorageConfig, never, NodeDura
   );
 
 /** Session coordinator configuration derived from the single validated Node configuration. */
-const durableRuntimeConfigLayer: Layer.Layer<
-  DurableRuntimeConfig,
-  never,
-  NodeDurableRuntimeConfig
-> = Layer.effect(DurableRuntimeConfig)(
-  Effect.gen(function* () {
-    const config = yield* NodeDurableRuntimeConfig;
-    return DurableRuntimeConfig.make({
-      deploymentId: config.deploymentId,
-      producerId: config.producerId,
-      settlementPollInterval: Duration.millis(config.settlementPollInterval),
-      leaseRenewalInterval: Duration.millis(config.leaseRenewalInterval),
-      abortPollInterval: Duration.millis(config.abortPollInterval),
-    });
-  }),
-);
+const durableRuntimeConfigLayer = (
+  estimateCostMicrousd: RunCostEstimator | undefined,
+): Layer.Layer<DurableRuntimeConfig, never, NodeDurableRuntimeConfig> =>
+  Layer.effect(DurableRuntimeConfig)(
+    Effect.gen(function* () {
+      const config = yield* NodeDurableRuntimeConfig;
+      return DurableRuntimeConfig.make({
+        deploymentId: config.deploymentId,
+        producerId: config.producerId,
+        settlementPollInterval: Duration.millis(config.settlementPollInterval),
+        leaseRenewalInterval: Duration.millis(config.leaseRenewalInterval),
+        abortPollInterval: Duration.millis(config.abortPollInterval),
+        ...(estimateCostMicrousd === undefined ? {} : { estimateCostMicrousd }),
+      });
+    }),
+  );
 
 /** Wake fallback-scan cadence derived from the single validated Node configuration. */
 const wakeSchedulerConfigLayer: Layer.Layer<
@@ -376,7 +379,11 @@ export class NodeDurableRuntime {
         );
         return DurableAgentRuntime.layer.pipe(
           Layer.provideMerge(
-            Layer.mergeAll(ports, durableRuntimeConfigLayer, bindingResolverLayer),
+            Layer.mergeAll(
+              ports,
+              durableRuntimeConfigLayer(options.estimateCostMicrousd),
+              bindingResolverLayer,
+            ),
           ),
           Layer.provide(
             Layer.mergeAll(wakeSchedulerConfigLayer, runtimeFailpointLayer, reconcilerLayer),

--- a/packages/platform-node/test/crash/crash.test.ts
+++ b/packages/platform-node/test/crash/crash.test.ts
@@ -600,7 +600,7 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
     );
 
     it.effect(
-      "kill before settlement reservation: the outcome is recomputed and settles exactly once",
+      "kill before settlement reservation: canonical completion avoids another model call and settles once",
       () =>
         withCrashSite((site) =>
           Effect.gen(function* () {
@@ -632,11 +632,13 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
                 expect(settlements).toHaveLength(1);
                 expect(settlements[0]?.outcome).toBe("completed");
 
-                // D6: the model was re-invoked (a visible duplicate Turn), never re-settled.
+                // The response and Run completion committed atomically before
+                // reservation, so recovery terminalizes without another model call.
                 const records = yield* readLog(conversation);
                 expect(
                   logTags(records).filter((tag) => tag === "ModelResponseRecorded"),
-                ).toHaveLength(2);
+                ).toHaveLength(1);
+                expect(logTags(records).filter((tag) => tag === "RunCompleted")).toHaveLength(1);
                 expect(logTags(records).filter((tag) => tag === "SubmissionSettled")).toHaveLength(
                   1,
                 );

--- a/packages/platform-node/test/layers.test.ts
+++ b/packages/platform-node/test/layers.test.ts
@@ -1,7 +1,7 @@
 import { Agent, AgentPolicy, ConversationId } from "@effect-agent/core";
 import type { SubmissionId } from "@effect-agent/core";
-import type { AgentBindingResolver } from "@effect-agent/session";
 import {
+  type AgentBindingResolver,
   AdmissionRequest,
   ClaimRequest,
   ConversationRead,
@@ -359,6 +359,7 @@ describe("NodeDurableRuntime", () => {
               "ConversationCreated",
               "UserInputRecorded",
               "ModelResponseRecorded",
+              "RunCompleted",
               "SubmissionSettled",
               "RepairAnnotated",
             ]);

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -3121,64 +3121,122 @@ const make = Effect.gen(function* () {
           readonly modelUsage: ReadonlyArray<ModelCallUsage>;
         }
       >();
-      const currentUsageSummary = (): RunUsageSummary => {
-        const stagedCalls = [...stagedUsage.values()].flatMap((usage) => usage.modelUsage);
-        const detailedCalls = [...journal.usage.modelUsage, ...stagedCalls];
-        const detailed = summarizeModelUsage(detailedCalls);
-        const inputTokens =
-          journal.usage.inputTokens +
-          [...stagedUsage.values()].reduce((total, usage) => total + usage.inputTokens, 0);
-        const outputTokens =
-          journal.usage.outputTokens +
-          [...stagedUsage.values()].reduce((total, usage) => total + usage.outputTokens, 0);
-        const costMicrousd =
-          journal.usage.costMicrousd +
-          [...stagedUsage.values()].reduce((total, usage) => total + usage.costMicrousd, 0);
-        const modelCalls = journal.usage.modelCalls + stagedCalls.length;
-        const legacyCalls = modelCalls - detailed.modelCalls;
-        const legacyInput = inputTokens - detailed.inputTokens.total;
-        const legacyOutput = outputTokens - detailed.outputTokens.total;
-        const legacyCost = costMicrousd - detailed.costMicrousd;
-        const legacyGroup =
-          legacyCalls <= 0
-            ? []
-            : [
-                ModelUsageGroup.make({
-                  provider: "unknown",
-                  model: "legacy-record",
-                  modelCalls: legacyCalls,
-                  inputTokens: InputTokenUsage.make({
-                    total: Math.max(0, legacyInput),
-                    uncached: Math.max(0, legacyInput),
-                    cacheRead: 0,
-                    cacheWrite: 0,
+      const checkedUsageTotal = (
+        field: string,
+        value: number,
+      ): Effect.Effect<number, RunJournalError> =>
+        Schema.decodeUnknownEffect(Schema.Natural)(value).pipe(
+          Effect.mapError((cause) =>
+            RunJournalError.make({
+              message: `Run usage summary exceeds safe-integer bounds at ${field}`,
+              cause,
+            }),
+          ),
+        );
+      const addUsageTotal = (field: string, left: number, right: number) =>
+        checkedUsageTotal(field, left + right);
+      const subtractUsageTotal = (field: string, left: number, right: number) =>
+        checkedUsageTotal(field, left - right);
+      const currentUsageSummary = (): Effect.Effect<RunUsageSummary, RunJournalError> =>
+        Effect.gen(function* () {
+          const stagedCalls = [...stagedUsage.values()].flatMap((usage) => usage.modelUsage);
+          const detailedCalls = [...journal.usage.modelUsage, ...stagedCalls];
+          const detailed = yield* summarizeModelUsage(detailedCalls).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({
+                message: "Run detailed usage exceeds safe-integer accounting bounds",
+                cause,
+              }),
+            ),
+          );
+          let inputTokens = journal.usage.inputTokens;
+          let outputTokens = journal.usage.outputTokens;
+          let costMicrousd = journal.usage.costMicrousd;
+          for (const usage of stagedUsage.values()) {
+            inputTokens = yield* addUsageTotal("inputTokens", inputTokens, usage.inputTokens);
+            outputTokens = yield* addUsageTotal("outputTokens", outputTokens, usage.outputTokens);
+            costMicrousd = yield* addUsageTotal("costMicrousd", costMicrousd, usage.costMicrousd);
+          }
+          const modelCalls = yield* addUsageTotal(
+            "modelCalls",
+            journal.usage.modelCalls,
+            stagedCalls.length,
+          );
+          const legacyCalls = yield* subtractUsageTotal(
+            "legacy.modelCalls",
+            modelCalls,
+            detailed.modelCalls,
+          );
+          const legacyInput = yield* subtractUsageTotal(
+            "legacy.inputTokens",
+            inputTokens,
+            detailed.inputTokens.total,
+          );
+          const legacyOutput = yield* subtractUsageTotal(
+            "legacy.outputTokens",
+            outputTokens,
+            detailed.outputTokens.total,
+          );
+          const legacyCost = yield* subtractUsageTotal(
+            "legacy.costMicrousd",
+            costMicrousd,
+            detailed.costMicrousd,
+          );
+          if (legacyCalls === 0 && (legacyInput !== 0 || legacyOutput !== 0 || legacyCost !== 0)) {
+            return yield* RunJournalError.make({
+              message: "Run aggregate usage has legacy totals without a legacy model call",
+            });
+          }
+          const legacyGroup =
+            legacyCalls === 0
+              ? []
+              : [
+                  ModelUsageGroup.make({
+                    provider: "unknown",
+                    model: "legacy-record",
+                    modelCalls: legacyCalls,
+                    inputTokens: InputTokenUsage.make({
+                      total: legacyInput,
+                      uncached: legacyInput,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    }),
+                    outputTokens: OutputTokenUsage.make({
+                      total: legacyOutput,
+                      text: legacyOutput,
+                      reasoning: 0,
+                    }),
+                    costMicrousd: legacyCost,
                   }),
-                  outputTokens: OutputTokenUsage.make({
-                    total: Math.max(0, legacyOutput),
-                    text: Math.max(0, legacyOutput),
-                    reasoning: 0,
-                  }),
-                  costMicrousd: Math.max(0, legacyCost),
-                }),
-              ];
-        return RunUsageSummary.make({
-          modelCalls,
-          inputTokens: InputTokenUsage.make({
-            total: inputTokens,
-            // Legacy aggregate inputs are conservatively classified as uncached.
-            uncached: detailed.inputTokens.uncached + Math.max(0, legacyInput),
-            cacheRead: detailed.inputTokens.cacheRead,
-            cacheWrite: detailed.inputTokens.cacheWrite,
-          }),
-          outputTokens: OutputTokenUsage.make({
-            total: outputTokens,
-            text: detailed.outputTokens.text + Math.max(0, legacyOutput),
-            reasoning: detailed.outputTokens.reasoning,
-          }),
-          costMicrousd,
-          byModel: [...detailed.byModel, ...legacyGroup],
+                ];
+          const uncached = yield* addUsageTotal(
+            "inputTokens.uncached",
+            detailed.inputTokens.uncached,
+            legacyInput,
+          );
+          const text = yield* addUsageTotal(
+            "outputTokens.text",
+            detailed.outputTokens.text,
+            legacyOutput,
+          );
+          return RunUsageSummary.make({
+            modelCalls,
+            inputTokens: InputTokenUsage.make({
+              total: inputTokens,
+              // Legacy aggregate inputs are conservatively classified as uncached.
+              uncached,
+              cacheRead: detailed.inputTokens.cacheRead,
+              cacheWrite: detailed.inputTokens.cacheWrite,
+            }),
+            outputTokens: OutputTokenUsage.make({
+              total: outputTokens,
+              text,
+              reasoning: detailed.outputTokens.reasoning,
+            }),
+            costMicrousd,
+            byModel: [...detailed.byModel, ...legacyGroup],
+          });
         });
-      };
       const recordedCompletion = records.find(
         (envelope) => envelope.record.recordId === runCompletedRecordId(runId),
       )?.record.payload;
@@ -3235,7 +3293,7 @@ const make = Effect.gen(function* () {
           ...(recordedCompletion.exhausted === undefined
             ? {}
             : { exhausted: recordedCompletion.exhausted }),
-          usageSummary: currentUsageSummary(),
+          usageSummary: yield* currentUsageSummary(),
         };
       }
       // RUN-026: durable compaction covers only records of PRIOR Runs — never

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -780,13 +780,18 @@ interface DeclaredApplicationCall {
   readonly params: unknown;
 }
 
+interface DeclaredToolCalls {
+  readonly total: number;
+  readonly application: Array<DeclaredApplicationCall>;
+}
+
 /**
- * Pure extraction of a Turn's declared application Tool Calls from the canonical (encoded)
- * `ModelResponseRecorded.messages` value. Provider-executed calls are the provider's own
- * responsibility and never enter the durable prepared/settled protocol.
+ * Pure inspection of every Tool Call declared in one canonical response. Provider-executed calls
+ * count toward the batch singleton invariant even though only application calls enter the durable
+ * prepared/settled protocol.
  */
-const declaredApplicationCalls = Effect.fn("DurableAgentRuntime.declaredApplicationCalls")(
-  (messages: PersistedJson): Effect.Effect<Array<DeclaredApplicationCall>, RunJournalError> =>
+const declaredToolCalls = Effect.fn("DurableAgentRuntime.declaredToolCalls")(
+  (messages: PersistedJson): Effect.Effect<DeclaredToolCalls, RunJournalError> =>
     decodePrompt(messages).pipe(
       Effect.mapError((cause) =>
         RunJournalError.make({
@@ -795,17 +800,27 @@ const declaredApplicationCalls = Effect.fn("DurableAgentRuntime.declaredApplicat
         }),
       ),
       Effect.map((prompt) => {
-        const calls: Array<DeclaredApplicationCall> = [];
+        let total = 0;
+        const application: Array<DeclaredApplicationCall> = [];
         for (const message of prompt.content) {
           if (message.role !== "assistant") continue;
           for (const part of message.content) {
-            if (part.type !== "tool-call" || part.providerExecuted) continue;
-            calls.push({ id: part.id, name: part.name, params: part.params });
+            if (part.type !== "tool-call") continue;
+            total += 1;
+            if (!part.providerExecuted) {
+              application.push({ id: part.id, name: part.name, params: part.params });
+            }
           }
         }
-        return calls;
+        return { total, application };
       }),
     ),
+);
+
+/** Application calls alone drive durable preparation, settlement, and batch resume. */
+const declaredApplicationCalls = Effect.fn("DurableAgentRuntime.declaredApplicationCalls")(
+  (messages: PersistedJson): Effect.Effect<Array<DeclaredApplicationCall>, RunJournalError> =>
+    declaredToolCalls(messages).pipe(Effect.map(({ application }) => application)),
 );
 
 /** Rebuild the exact JSON text that the engine decoded from one terminal no-Tool response. */
@@ -3320,7 +3335,8 @@ const make = Effect.gen(function* () {
             message: `Run ${runId} has a terminal completion marker without a response`,
           });
         }
-        const calls = yield* declaredApplicationCalls(response.messages);
+        const declared = yield* declaredToolCalls(response.messages);
+        const calls = declared.application;
         let expectedOutput: {
           readonly encoded: Schema.Json;
           readonly decoded: OutputSchema["Type"];
@@ -3339,6 +3355,7 @@ const make = Effect.gen(function* () {
                 )?.record.payload;
           if (
             completion === undefined ||
+            declared.total !== 1 ||
             calls.length !== 1 ||
             call?.name !== completion.tool ||
             settled?._tag !== "ToolCallSettled" ||

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -33,6 +33,7 @@ import {
   RunContextPreparationPassthrough,
   type RunContextPreparationError,
   type AgentRuntimeRequirements,
+  type AgentCompletionProjectionRequirements,
   type ChildEstablishStatus,
   type RunApprovalHook,
   type RunContextHook,
@@ -605,7 +606,9 @@ export const DurableApprovalResolver: Context.Reference<RunApprovalHook<never, n
 export type DurableWorkerRequirements<
   AgentValue extends Agent.Any,
   InstructionRequirements = never,
-> = Exclude<AgentRuntimeRequirements<AgentValue, never, InstructionRequirements>, IdGenerator>;
+> =
+  | Exclude<AgentRuntimeRequirements<AgentValue, never, InstructionRequirements>, IdGenerator>
+  | AgentCompletionProjectionRequirements<AgentValue>;
 
 export interface DurableRuntimeConfigOptions {
   readonly deploymentId: DeploymentId;
@@ -798,6 +801,29 @@ const declaredApplicationCalls = Effect.fn("DurableAgentRuntime.declaredApplicat
           }
         }
         return calls;
+      }),
+    ),
+);
+
+/** Rebuild the exact JSON text that the engine decoded from one terminal no-Tool response. */
+const terminalAssistantText = Effect.fn("DurableAgentRuntime.terminalAssistantText")(
+  (messages: PersistedJson): Effect.Effect<string, RunJournalError> =>
+    decodePrompt(messages).pipe(
+      Effect.mapError((cause) =>
+        RunJournalError.make({
+          message: "ModelResponseRecorded messages are not Schema-encoded Prompt messages",
+          cause,
+        }),
+      ),
+      Effect.map((prompt) => {
+        let text = "";
+        for (const message of prompt.content) {
+          if (message.role !== "assistant") continue;
+          for (const part of message.content) {
+            if (part.type === "text") text += part.text;
+          }
+        }
+        return text;
       }),
     ),
 );
@@ -3187,28 +3213,60 @@ const make = Effect.gen(function* () {
               message: "Run aggregate usage has legacy totals without a legacy model call",
             });
           }
-          const legacyGroup =
-            legacyCalls === 0
-              ? []
-              : [
-                  ModelUsageGroup.make({
-                    provider: "unknown",
-                    model: "legacy-record",
-                    modelCalls: legacyCalls,
-                    inputTokens: InputTokenUsage.make({
-                      total: legacyInput,
-                      uncached: legacyInput,
-                      cacheRead: 0,
-                      cacheWrite: 0,
-                    }),
-                    outputTokens: OutputTokenUsage.make({
-                      total: legacyOutput,
-                      text: legacyOutput,
-                      reasoning: 0,
-                    }),
-                    costMicrousd: legacyCost,
-                  }),
-                ];
+          const byModel = [...detailed.byModel];
+          if (legacyCalls > 0) {
+            const existingIndex = byModel.findIndex(
+              (group) =>
+                group.provider === "unknown" &&
+                group.model === "legacy-record" &&
+                group.serviceTier === undefined &&
+                group.pricingVersion === undefined,
+            );
+            const existing = existingIndex < 0 ? undefined : byModel[existingIndex];
+            const legacyGroup = ModelUsageGroup.make({
+              provider: "unknown",
+              model: "legacy-record",
+              modelCalls: yield* addUsageTotal(
+                "byModel.modelCalls",
+                existing?.modelCalls ?? 0,
+                legacyCalls,
+              ),
+              inputTokens: InputTokenUsage.make({
+                total: yield* addUsageTotal(
+                  "byModel.inputTokens.total",
+                  existing?.inputTokens.total ?? 0,
+                  legacyInput,
+                ),
+                uncached: yield* addUsageTotal(
+                  "byModel.inputTokens.uncached",
+                  existing?.inputTokens.uncached ?? 0,
+                  legacyInput,
+                ),
+                cacheRead: existing?.inputTokens.cacheRead ?? 0,
+                cacheWrite: existing?.inputTokens.cacheWrite ?? 0,
+              }),
+              outputTokens: OutputTokenUsage.make({
+                total: yield* addUsageTotal(
+                  "byModel.outputTokens.total",
+                  existing?.outputTokens.total ?? 0,
+                  legacyOutput,
+                ),
+                text: yield* addUsageTotal(
+                  "byModel.outputTokens.text",
+                  existing?.outputTokens.text ?? 0,
+                  legacyOutput,
+                ),
+                reasoning: existing?.outputTokens.reasoning ?? 0,
+              }),
+              costMicrousd: yield* addUsageTotal(
+                "byModel.costMicrousd",
+                existing?.costMicrousd ?? 0,
+                legacyCost,
+              ),
+            });
+            if (existingIndex < 0) byModel.push(legacyGroup);
+            else byModel[existingIndex] = legacyGroup;
+          }
           const uncached = yield* addUsageTotal(
             "inputTokens.uncached",
             detailed.inputTokens.uncached,
@@ -3234,7 +3292,7 @@ const make = Effect.gen(function* () {
               reasoning: detailed.outputTokens.reasoning,
             }),
             costMicrousd,
-            byModel: [...detailed.byModel, ...legacyGroup],
+            byModel,
           });
         });
       const recordedCompletion = records.find(
@@ -3246,7 +3304,6 @@ const make = Effect.gen(function* () {
             message: `Run ${runId} has an invalid terminal completion marker`,
           });
         }
-        const completion = agent.definition.completion;
         const response = [...records]
           .reverse()
           .find(
@@ -3254,31 +3311,83 @@ const make = Effect.gen(function* () {
               envelope.record.payload._tag === "ModelResponseRecorded" &&
               envelope.record.payload.runId === runId,
           )?.record.payload;
-        if (completion === undefined || response?._tag !== "ModelResponseRecorded") {
+        if (response?._tag !== "ModelResponseRecorded") {
           return yield* RunJournalError.make({
-            message: `Run ${runId} has a terminal completion marker without a completion declaration and response`,
+            message: `Run ${runId} has a terminal completion marker without a response`,
           });
         }
         const calls = yield* declaredApplicationCalls(response.messages);
-        const call = calls[0];
-        const settled =
-          call === undefined
-            ? undefined
-            : records.find(
-                (envelope) =>
-                  envelope.record.payload._tag === "ToolCallSettled" &&
-                  envelope.record.payload.runId === runId &&
-                  envelope.record.payload.toolCallId === call.id,
-              )?.record.payload;
-        if (
-          calls.length !== 1 ||
-          call?.name !== completion.tool ||
-          settled?._tag !== "ToolCallSettled" ||
-          settled.toolName !== completion.tool ||
-          settled.isFailure
-        ) {
+        let expectedOutput: Schema.Json;
+        if (calls.length > 0) {
+          const completion = agent.definition.completion;
+          const call = calls[0];
+          const settled =
+            call === undefined
+              ? undefined
+              : records.find(
+                  (envelope) =>
+                    envelope.record.payload._tag === "ToolCallSettled" &&
+                    envelope.record.payload.runId === runId &&
+                    envelope.record.payload.toolCallId === call.id,
+                )?.record.payload;
+          if (
+            completion === undefined ||
+            calls.length !== 1 ||
+            call?.name !== completion.tool ||
+            settled?._tag !== "ToolCallSettled" ||
+            settled.toolName !== completion.tool ||
+            settled.isFailure
+          ) {
+            return yield* RunJournalError.make({
+              message: `Run ${runId} has a terminal completion marker without one successful declared completion Tool result`,
+            });
+          }
+          expectedOutput = (yield* AgentRuntime.projectCompletionOutput(
+            agent,
+            completion,
+            call.params,
+            settled.result,
+          ).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({
+                message: `Run ${runId} completion Tool output failed recovery projection`,
+                cause,
+              }),
+            ),
+          )).encoded;
+        } else {
+          const responseText = yield* terminalAssistantText(response.messages);
+          expectedOutput = (yield* AgentRuntime.decodeFinalOutput(agent, responseText).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({
+                message: `Run ${runId} final response output failed recovery decoding`,
+                cause,
+              }),
+            ),
+          )).encoded;
+        }
+        const boundedExpectedOutput = yield* decodePersisted(expectedOutput).pipe(
+          Effect.mapError((cause) =>
+            RunJournalError.make({
+              message: `Run ${runId} reconstructed output exceeds canonical persistence bounds`,
+              cause,
+            }),
+          ),
+        );
+        const [expectedOutputDigest, recordedOutputDigest] = yield* Effect.all([
+          withCrypto(digestJson(boundedExpectedOutput)),
+          withCrypto(digestJson(recordedCompletion.output)),
+        ]).pipe(
+          Effect.mapError((cause) =>
+            RunJournalError.make({
+              message: `Run ${runId} completion output comparison failed`,
+              cause,
+            }),
+          ),
+        );
+        if (expectedOutputDigest !== recordedOutputDigest) {
           return yield* RunJournalError.make({
-            message: `Run ${runId} has a terminal completion marker without one successful declared completion Tool result`,
+            message: `Run ${runId} terminal completion output disagrees with its canonical response or Tool result`,
           });
         }
         return {

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -1,15 +1,21 @@
+import type { ModelCallUsage } from "@effect-agent/core";
 import {
   AgentApprovalPending,
   AgentInputError,
   ConversationId,
   DelegationDepth,
   IdGenerator,
+  InputTokenUsage,
+  ModelUsageGroup,
   isDelegationToolName,
   PolicyLimit,
   ReceiptId,
+  RunUsageSummary,
   SubagentParentLink,
   SubmissionId,
+  summarizeModelUsage,
   ToolCallId,
+  OutputTokenUsage,
   type Agent,
   type AgentId,
   type AttemptId,
@@ -30,6 +36,7 @@ import {
   type ChildEstablishStatus,
   type RunApprovalHook,
   type RunContextHook,
+  type RunCostEstimator,
   type RunDurabilityHook,
   type RunInputCommand,
   type RunInputHook,
@@ -222,6 +229,7 @@ import {
   modelResponseInterruptedRecordId,
   modelResponseRecordId,
   projectRunJournal,
+  runCompletedRecordId,
   runIdForSubmission,
   subagentJoinBatchId,
   subagentJoinedRecordId,
@@ -608,6 +616,8 @@ export interface DurableRuntimeConfigOptions {
   readonly leaseRenewalInterval?: Duration.Duration | undefined;
   /** Active-Run abort-intent poll cadence (default 500ms). */
   readonly abortPollInterval?: Duration.Duration | undefined;
+  /** Deployment-owned model pricing authority, captured for every recoverable Run. */
+  readonly estimateCostMicrousd?: RunCostEstimator | undefined;
 }
 
 /** Deployment-scoped identity and liveness cadences for the durable coordinator. */
@@ -619,6 +629,7 @@ export class DurableRuntimeConfig extends Context.Service<
     readonly settlementPollInterval: Duration.Duration;
     readonly leaseRenewalInterval: Duration.Duration;
     readonly abortPollInterval: Duration.Duration;
+    readonly estimateCostMicrousd?: RunCostEstimator | undefined;
   }
 >()("@effect-agent/session/DurableRuntimeConfig") {
   static make(options: DurableRuntimeConfigOptions): (typeof DurableRuntimeConfig)["Service"] {
@@ -628,6 +639,9 @@ export class DurableRuntimeConfig extends Context.Service<
       settlementPollInterval: options.settlementPollInterval ?? Duration.millis(500),
       leaseRenewalInterval: options.leaseRenewalInterval ?? Duration.seconds(10),
       abortPollInterval: options.abortPollInterval ?? Duration.millis(500),
+      ...(options.estimateCostMicrousd === undefined
+        ? {}
+        : { estimateCostMicrousd: options.estimateCostMicrousd }),
     };
   }
 
@@ -647,14 +661,16 @@ type AttemptOutcome =
       readonly finishReason?: "budget-exhausted";
       /** The dimension that bound; set exactly alongside `finishReason` (RUN-011). */
       readonly exhausted?: ExhaustedLimit;
+      readonly usageSummary?: RunUsageSummary;
     }
   | {
       readonly _tag: "failed";
       readonly result: SettlementFailureDiagnostic;
       /** The typed limit of an `AgentPolicyError` failure; absent otherwise (RUN-011). */
       readonly policyLimit?: PolicyLimit;
+      readonly usageSummary?: RunUsageSummary;
     }
-  | { readonly _tag: "aborted" };
+  | { readonly _tag: "aborted"; readonly usageSummary?: RunUsageSummary };
 
 /**
  * What one `runModel` pass produced: a terminal `AttemptOutcome` for terminalization, a
@@ -895,14 +911,19 @@ const make = Effect.gen(function* () {
       payload.submissionId !== settlement.submissionId ||
       payload.settlementId !== settlement.settlementId ||
       payload.receiptId !== settlement.receiptId ||
-      payload.outcome !== settlement.outcome ||
-      settlement.outcome !== "completed" ||
-      payload.runDisposition === undefined
+      payload.outcome !== settlement.outcome
     ) {
       return Settlement.make(common);
     }
-    return Settlement.make({
+    const canonical = {
       ...common,
+      ...(payload.usageSummary === undefined ? {} : { usageSummary: payload.usageSummary }),
+    };
+    if (settlement.outcome !== "completed" || payload.runDisposition === undefined) {
+      return Settlement.make(canonical);
+    }
+    return Settlement.make({
+      ...canonical,
       runDisposition: payload.runDisposition,
     });
   };
@@ -2108,6 +2129,7 @@ const make = Effect.gen(function* () {
         ...(outcome._tag === "failed" && outcome.policyLimit !== undefined
           ? { policyLimit: outcome.policyLimit }
           : {}),
+        ...(outcome.usageSummary === undefined ? {} : { usageSummary: outcome.usageSummary }),
       }),
     ).pipe(Effect.orDie);
     const record = yield* makeEnvelope(submissionSettlementRecordId(submissionId), payload);
@@ -3096,8 +3118,126 @@ const make = Effect.gen(function* () {
           readonly inputTokens: number;
           readonly outputTokens: number;
           readonly costMicrousd: number;
+          readonly modelUsage: ReadonlyArray<ModelCallUsage>;
         }
       >();
+      const currentUsageSummary = (): RunUsageSummary => {
+        const stagedCalls = [...stagedUsage.values()].flatMap((usage) => usage.modelUsage);
+        const detailedCalls = [...journal.usage.modelUsage, ...stagedCalls];
+        const detailed = summarizeModelUsage(detailedCalls);
+        const inputTokens =
+          journal.usage.inputTokens +
+          [...stagedUsage.values()].reduce((total, usage) => total + usage.inputTokens, 0);
+        const outputTokens =
+          journal.usage.outputTokens +
+          [...stagedUsage.values()].reduce((total, usage) => total + usage.outputTokens, 0);
+        const costMicrousd =
+          journal.usage.costMicrousd +
+          [...stagedUsage.values()].reduce((total, usage) => total + usage.costMicrousd, 0);
+        const modelCalls = journal.usage.modelCalls + stagedCalls.length;
+        const legacyCalls = modelCalls - detailed.modelCalls;
+        const legacyInput = inputTokens - detailed.inputTokens.total;
+        const legacyOutput = outputTokens - detailed.outputTokens.total;
+        const legacyCost = costMicrousd - detailed.costMicrousd;
+        const legacyGroup =
+          legacyCalls <= 0
+            ? []
+            : [
+                ModelUsageGroup.make({
+                  provider: "unknown",
+                  model: "legacy-record",
+                  modelCalls: legacyCalls,
+                  inputTokens: InputTokenUsage.make({
+                    total: Math.max(0, legacyInput),
+                    uncached: Math.max(0, legacyInput),
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  }),
+                  outputTokens: OutputTokenUsage.make({
+                    total: Math.max(0, legacyOutput),
+                    text: Math.max(0, legacyOutput),
+                    reasoning: 0,
+                  }),
+                  costMicrousd: Math.max(0, legacyCost),
+                }),
+              ];
+        return RunUsageSummary.make({
+          modelCalls,
+          inputTokens: InputTokenUsage.make({
+            total: inputTokens,
+            // Legacy aggregate inputs are conservatively classified as uncached.
+            uncached: detailed.inputTokens.uncached + Math.max(0, legacyInput),
+            cacheRead: detailed.inputTokens.cacheRead,
+            cacheWrite: detailed.inputTokens.cacheWrite,
+          }),
+          outputTokens: OutputTokenUsage.make({
+            total: outputTokens,
+            text: detailed.outputTokens.text + Math.max(0, legacyOutput),
+            reasoning: detailed.outputTokens.reasoning,
+          }),
+          costMicrousd,
+          byModel: [...detailed.byModel, ...legacyGroup],
+        });
+      };
+      const recordedCompletion = records.find(
+        (envelope) => envelope.record.recordId === runCompletedRecordId(runId),
+      )?.record.payload;
+      if (recordedCompletion !== undefined) {
+        if (recordedCompletion._tag !== "RunCompleted" || recordedCompletion.runId !== runId) {
+          return yield* RunJournalError.make({
+            message: `Run ${runId} has an invalid terminal completion marker`,
+          });
+        }
+        const completion = agent.definition.completion;
+        const response = [...records]
+          .reverse()
+          .find(
+            (envelope) =>
+              envelope.record.payload._tag === "ModelResponseRecorded" &&
+              envelope.record.payload.runId === runId,
+          )?.record.payload;
+        if (completion === undefined || response?._tag !== "ModelResponseRecorded") {
+          return yield* RunJournalError.make({
+            message: `Run ${runId} has a terminal completion marker without a completion declaration and response`,
+          });
+        }
+        const calls = yield* declaredApplicationCalls(response.messages);
+        const call = calls[0];
+        const settled =
+          call === undefined
+            ? undefined
+            : records.find(
+                (envelope) =>
+                  envelope.record.payload._tag === "ToolCallSettled" &&
+                  envelope.record.payload.runId === runId &&
+                  envelope.record.payload.toolCallId === call.id,
+              )?.record.payload;
+        if (
+          calls.length !== 1 ||
+          call?.name !== completion.tool ||
+          settled?._tag !== "ToolCallSettled" ||
+          settled.toolName !== completion.tool ||
+          settled.isFailure
+        ) {
+          return yield* RunJournalError.make({
+            message: `Run ${runId} has a terminal completion marker without one successful declared completion Tool result`,
+          });
+        }
+        return {
+          _tag: "completed" as const,
+          result: recordedCompletion.output,
+          ...(recordedCompletion.runDisposition === undefined
+            ? {}
+            : { runDisposition: recordedCompletion.runDisposition }),
+          ...(recordedCompletion.finishReason === undefined
+            ? {}
+            : { finishReason: recordedCompletion.finishReason }),
+          ...(recordedCompletion.exhausted === undefined
+            ? {}
+            : { exhausted: recordedCompletion.exhausted }),
+          usageSummary: currentUsageSummary(),
+        };
+      }
       // RUN-026: durable compaction covers only records of PRIOR Runs — never
       // the appending Run's own records — so the owner's instruction/input
       // messages survive every projection and the resume-splice arithmetic
@@ -3335,6 +3475,9 @@ const make = Effect.gen(function* () {
                   producerId: config.producerId,
                   deploymentId: config.deploymentId,
                   createdAt,
+                  ...(canonicalTurn === 1 && pendingSlice.length > 0
+                    ? { runScopedPrefixLength: pendingSlice.length }
+                    : {}),
                   usage: stagedUsage.get(canonicalTurn),
                 }),
               );
@@ -3452,9 +3595,10 @@ const make = Effect.gen(function* () {
             const key = turnOffset + usage.turn;
             const prior = stagedUsage.get(key);
             stagedUsage.set(key, {
-              inputTokens: (prior?.inputTokens ?? 0) + usage.inputTokens,
-              outputTokens: (prior?.outputTokens ?? 0) + usage.outputTokens,
-              costMicrousd: (prior?.costMicrousd ?? 0) + usage.costMicrousd,
+              inputTokens: (prior?.inputTokens ?? 0) + usage.usage.inputTokens.total,
+              outputTokens: (prior?.outputTokens ?? 0) + usage.usage.outputTokens.total,
+              costMicrousd: (prior?.costMicrousd ?? 0) + usage.usage.costMicrousd,
+              modelUsage: [...(prior?.modelUsage ?? []), usage.usage],
             });
           }),
         commitCompaction: (commit) =>
@@ -4256,6 +4400,9 @@ const make = Effect.gen(function* () {
               },
             }),
         ...(preparedContext === undefined ? {} : { context: preparedContext }),
+        ...(config.estimateCostMicrousd === undefined
+          ? {}
+          : { estimateCostMicrousd: config.estimateCostMicrousd }),
         ...(journal.committedTurns === 0 ? {} : { resumeUsage: journal.usage }),
       };
 
@@ -4284,6 +4431,7 @@ const make = Effect.gen(function* () {
           // Already-canonical per-call settles (late settles from the resolution path, or
           // resume-injected results) are excluded by record identity.
           const remaining: Array<Prompt.Message> = [];
+          const resultParts: Array<Prompt.ToolResultPart> = [];
           let toolParts = 0;
           for (const message of appended) {
             if (message.role !== "tool") {
@@ -4297,9 +4445,31 @@ const make = Effect.gen(function* () {
             );
             if (parts.length === 0) continue;
             toolParts += parts.length;
+            resultParts.push(...parts);
             remaining.push(Prompt.makeMessage("tool", { content: parts }));
           }
           if (toolParts > 0) {
+            const completion = agent.definition.completion;
+            const completionPart = resultParts[0];
+            const runCompletion =
+              completion !== undefined &&
+              resultParts.length === 1 &&
+              completionPart?.name === completion.tool &&
+              completionPart.isFailure !== true &&
+              state.completedOutput !== undefined
+                ? {
+                    output: state.completedOutput,
+                    ...(state.completedRunDisposition === undefined
+                      ? {}
+                      : { runDisposition: state.completedRunDisposition }),
+                    ...(state.completedFinishReason === undefined
+                      ? {}
+                      : { finishReason: state.completedFinishReason }),
+                    ...(state.completedExhausted === undefined
+                      ? {}
+                      : { exhausted: state.completedExhausted }),
+                  }
+                : undefined;
             const batch = yield* turnResultsBatch({
               runId,
               turn: canonicalTurn,
@@ -4308,6 +4478,7 @@ const make = Effect.gen(function* () {
               producerId: config.producerId,
               deploymentId: config.deploymentId,
               createdAt,
+              ...(runCompletion === undefined ? {} : { runCompletion }),
             });
             yield* appendBatch(ctx, batch);
             for (const record of batch.records) knownIds.add(record.recordId);
@@ -4315,6 +4486,10 @@ const make = Effect.gen(function* () {
           }
         } else {
           // No durable response commit: the P4 single-batch shape (no-tool Turns).
+          const runScopedPrefixLength =
+            canonicalTurn === 1
+              ? appended.findIndex((message) => message.role === "assistant")
+              : -1;
           const batch = yield* withCrypto(
             turnCanonicalBatch({
               runId,
@@ -4324,6 +4499,7 @@ const make = Effect.gen(function* () {
               producerId: config.producerId,
               deploymentId: config.deploymentId,
               createdAt,
+              ...(runScopedPrefixLength > 0 ? { runScopedPrefixLength } : {}),
               usage: stagedUsage.get(canonicalTurn),
             }),
           );
@@ -4398,15 +4574,16 @@ const make = Effect.gen(function* () {
             }));
           }
           case "RunCompleted": {
-            return commitPendingTurn.pipe(
-              Effect.andThen(
-                recordCompleted(
-                  event.output,
-                  event.finishReason,
-                  event.exhausted,
-                  event.runDisposition,
-                ),
-              ),
+            return recordCompleted(
+              event.output,
+              event.finishReason,
+              event.exhausted,
+              event.runDisposition,
+            ).pipe(
+              // The terminal state is available while the result batch is
+              // built, so its RunCompleted marker commits atomically with the
+              // successful completion Tool result.
+              Effect.andThen(commitPendingTurn),
             );
           }
           case "RunFailed": {
@@ -4623,8 +4800,16 @@ const make = Effect.gen(function* () {
 
       if (result._tag === "suspendedRun") return approvalSuspension(result.toolCallId);
       if (result._tag === "suspendedChildRun") return childSuspension(result.children);
-      if (result._tag === "aborted") return abortedRunPhase;
-      if (result._tag === "failedRun") return result.outcome;
+      if (result._tag === "aborted") {
+        return abortedRunPhase(yield* currentUsageSummary());
+      }
+      if (result._tag === "failedRun") {
+        const failed: RunPhaseOutcome = {
+          ...result.outcome,
+          usageSummary: yield* currentUsageSummary(),
+        };
+        return failed;
+      }
       const state = yield* Ref.get(stateRef);
       if (state.completedOutput === undefined) {
         return yield* LedgerError.make({
@@ -4644,6 +4829,7 @@ const make = Effect.gen(function* () {
         ...(state.completedFinishReason === undefined || state.completedExhausted === undefined
           ? {}
           : { exhausted: state.completedExhausted }),
+        usageSummary: yield* currentUsageSummary(),
       };
       return completed;
     });

--- a/packages/session/src/durable-runtime.ts
+++ b/packages/session/src/durable-runtime.ts
@@ -1,5 +1,5 @@
-import type { ModelCallUsage } from "@effect-agent/core";
 import {
+  type ModelCallUsage,
   AgentApprovalPending,
   AgentInputError,
   ConversationId,
@@ -698,7 +698,10 @@ const childSuspension = (children: AgentChildPending["children"]): RunPhaseOutco
   children,
 });
 
-const abortedRunPhase: RunPhaseOutcome = { _tag: "aborted" };
+const abortedRunPhase = (usageSummary: RunUsageSummary): RunPhaseOutcome => ({
+  _tag: "aborted",
+  usageSummary,
+});
 
 /**
  * Internal marker separating coordinator infrastructure failures (fencing, storage, failpoints —
@@ -3017,8 +3020,9 @@ const make = Effect.gen(function* () {
    * the response messages, creating the durability §15 provably-safe window), the durable
    * approval preflight (§2.6 — recorded decisions replay deterministically, unresolved requests
    * become canonical and suspend the Attempt), an optional PREPARED batch (before any handler
-   * starts), and a RESULTS batch at the next TurnStarted/RunCompleted/RunFailed seam. No-tool
-   * Turns keep the exact P4 single-batch shape. When the journal ends mid-batch,
+   * starts), and a RESULTS batch at the next TurnStarted/RunCompleted/RunFailed seam. A completed
+   * no-tool Turn atomically adds its `RunCompleted` marker to the P4 single-batch shape. When the
+   * journal ends mid-batch,
    * `RunOptions.resume` replays the declared batch without re-invoking the model (§2.4).
    */
   const runModel = <
@@ -3317,7 +3321,10 @@ const make = Effect.gen(function* () {
           });
         }
         const calls = yield* declaredApplicationCalls(response.messages);
-        let expectedOutput: Schema.Json;
+        let expectedOutput: {
+          readonly encoded: Schema.Json;
+          readonly decoded: OutputSchema["Type"];
+        };
         if (calls.length > 0) {
           const completion = agent.definition.completion;
           const call = calls[0];
@@ -3342,7 +3349,7 @@ const make = Effect.gen(function* () {
               message: `Run ${runId} has a terminal completion marker without one successful declared completion Tool result`,
             });
           }
-          expectedOutput = (yield* AgentRuntime.projectCompletionOutput(
+          expectedOutput = yield* AgentRuntime.projectCompletionOutput(
             agent,
             completion,
             call.params,
@@ -3354,19 +3361,19 @@ const make = Effect.gen(function* () {
                 cause,
               }),
             ),
-          )).encoded;
+          );
         } else {
           const responseText = yield* terminalAssistantText(response.messages);
-          expectedOutput = (yield* AgentRuntime.decodeFinalOutput(agent, responseText).pipe(
+          expectedOutput = yield* AgentRuntime.decodeFinalOutput(agent, responseText).pipe(
             Effect.mapError((cause) =>
               RunJournalError.make({
                 message: `Run ${runId} final response output failed recovery decoding`,
                 cause,
               }),
             ),
-          )).encoded;
+          );
         }
-        const boundedExpectedOutput = yield* decodePersisted(expectedOutput).pipe(
+        const boundedExpectedOutput = yield* decodePersisted(expectedOutput.encoded).pipe(
           Effect.mapError((cause) =>
             RunJournalError.make({
               message: `Run ${runId} reconstructed output exceeds canonical persistence bounds`,
@@ -3389,6 +3396,54 @@ const make = Effect.gen(function* () {
           return yield* RunJournalError.make({
             message: `Run ${runId} terminal completion output disagrees with its canonical response or Tool result`,
           });
+        }
+        const expectedRunDisposition =
+          recordedCompletion.finishReason === "budget-exhausted"
+            ? undefined
+            : yield* AgentRuntime.encodeRunDisposition(agent, expectedOutput.decoded).pipe(
+                Effect.mapError((cause) =>
+                  RunJournalError.make({
+                    message: `Run ${runId} run disposition failed recovery projection`,
+                    cause,
+                  }),
+                ),
+              );
+        if (
+          (expectedRunDisposition === undefined) !==
+          (recordedCompletion.runDisposition === undefined)
+        ) {
+          return yield* RunJournalError.make({
+            message: `Run ${runId} terminal run disposition disagrees with its reconstructed output`,
+          });
+        }
+        if (
+          expectedRunDisposition !== undefined &&
+          recordedCompletion.runDisposition !== undefined
+        ) {
+          const boundedExpectedRunDisposition = yield* decodePersisted(expectedRunDisposition).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({
+                message: `Run ${runId} reconstructed run disposition exceeds canonical persistence bounds`,
+                cause,
+              }),
+            ),
+          );
+          const [expectedRunDispositionDigest, recordedRunDispositionDigest] = yield* Effect.all([
+            withCrypto(digestJson(boundedExpectedRunDisposition)),
+            withCrypto(digestJson(recordedCompletion.runDisposition)),
+          ]).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({
+                message: `Run ${runId} run disposition comparison failed`,
+                cause,
+              }),
+            ),
+          );
+          if (expectedRunDispositionDigest !== recordedRunDispositionDigest) {
+            return yield* RunJournalError.make({
+              message: `Run ${runId} terminal run disposition disagrees with its reconstructed output`,
+            });
+          }
         }
         return {
           _tag: "completed" as const,
@@ -4582,6 +4637,21 @@ const make = Effect.gen(function* () {
         const canonicalTurn = turnOffset + state.pendingTurn.turn;
         const createdAt = yield* nowUtc;
         let committedLen = history.content.length;
+        const completedRun =
+          state.completedOutput === undefined
+            ? undefined
+            : {
+                output: state.completedOutput,
+                ...(state.completedRunDisposition === undefined
+                  ? {}
+                  : { runDisposition: state.completedRunDisposition }),
+                ...(state.completedFinishReason === undefined
+                  ? {}
+                  : { finishReason: state.completedFinishReason }),
+                ...(state.completedExhausted === undefined
+                  ? {}
+                  : { exhausted: state.completedExhausted }),
+              };
         if (knownIds.has(modelResponseRecordId(runId, canonicalTurn))) {
           // The response is already durable (commit 1 of the split shape): only the results
           // batch remains. The slice is [response messages…, tool message, trailing input…]:
@@ -4623,19 +4693,8 @@ const make = Effect.gen(function* () {
               resultParts.length === 1 &&
               completionPart?.name === completion.tool &&
               completionPart.isFailure !== true &&
-              state.completedOutput !== undefined
-                ? {
-                    output: state.completedOutput,
-                    ...(state.completedRunDisposition === undefined
-                      ? {}
-                      : { runDisposition: state.completedRunDisposition }),
-                    ...(state.completedFinishReason === undefined
-                      ? {}
-                      : { finishReason: state.completedFinishReason }),
-                    ...(state.completedExhausted === undefined
-                      ? {}
-                      : { exhausted: state.completedExhausted }),
-                  }
+              completedRun !== undefined
+                ? completedRun
                 : undefined;
             const batch = yield* turnResultsBatch({
               runId,
@@ -4667,6 +4726,7 @@ const make = Effect.gen(function* () {
               deploymentId: config.deploymentId,
               createdAt,
               ...(runScopedPrefixLength > 0 ? { runScopedPrefixLength } : {}),
+              ...(completedRun === undefined ? {} : { runCompletion: completedRun }),
               usage: stagedUsage.get(canonicalTurn),
             }),
           );
@@ -4747,9 +4807,9 @@ const make = Effect.gen(function* () {
               event.exhausted,
               event.runDisposition,
             ).pipe(
-              // The terminal state is available while the result batch is
-              // built, so its RunCompleted marker commits atomically with the
-              // successful completion Tool result.
+              // The terminal state is available while the final canonical
+              // batch is built, so its RunCompleted marker commits atomically
+              // with either the no-tool response or the completion Tool result.
               Effect.andThen(commitPendingTurn),
             );
           }

--- a/packages/session/src/ledger.ts
+++ b/packages/session/src/ledger.ts
@@ -3,11 +3,13 @@ import {
   AttemptId,
   ConversationId,
   ReceiptId,
+  RunUsageSummary,
   SettlementId,
   SubmissionId,
   ToolCallId,
 } from "@effect-agent/core";
-import { Context, Duration, Effect, Option, Schema, Stream } from "effect";
+import type { Option, Stream } from "effect";
+import { Context, Duration, Effect, Schema } from "effect";
 
 import {
   AbortRequested,
@@ -348,6 +350,8 @@ const SettlementFields = Schema.Struct({
   outcome: SettlementOutcome,
   /** Schema-encoded application disposition materialized from the exact canonical reservation. */
   runDisposition: Schema.optionalKey(PersistedJson),
+  /** Canonical aggregate of model usage and estimated spend for this Run. */
+  usageSummary: Schema.optionalKey(RunUsageSummary),
   /** Present exactly for `failed`; its Schema rejects excess keys before canonical projection. */
   failure: Schema.optionalKey(SettlementFailureDiagnostic),
   settledAt: Schema.DateTimeUtcFromString,

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -218,9 +218,12 @@ export class ToolCallSettled extends Schema.TaggedClass<ToolCallSettled>(
  * Turn boundary so a recovering Attempt can rebuild the next Prompt from canonical records alone.
  * `messagesDigest` pins the exact encoded content.
  */
-export class ModelResponseRecorded extends Schema.TaggedClass<ModelResponseRecorded>(
-  "@effect-agent/session/ModelResponseRecorded",
-)("ModelResponseRecorded", {
+const PersistedPromptMessages = Schema.Struct({
+  content: Schema.Array(Schema.Json),
+});
+const isPersistedPromptMessages = Schema.is(PersistedPromptMessages);
+
+const ModelResponseRecordedFields = Schema.Struct({
   runId: RunId,
   turnId: TurnId,
   turn: TurnNumber,
@@ -243,7 +246,19 @@ export class ModelResponseRecorded extends Schema.TaggedClass<ModelResponseRecor
   outputTokens: Schema.optionalKey(Schema.Natural),
   /** Estimated spend staged with the usage; recovery re-seeds the cost budget (RUN-023). */
   costMicrousd: Schema.optionalKey(Schema.Natural),
-}) {}
+}).check(
+  Schema.makeFilter(
+    (response) =>
+      response.runScopedPrefixLength === undefined ||
+      (isPersistedPromptMessages(response.messages) &&
+        response.runScopedPrefixLength < response.messages.content.length),
+    { title: "Run-scoped Prompt prefix leaves at least one recorded response message" },
+  ),
+);
+
+export class ModelResponseRecorded extends Schema.TaggedClass<ModelResponseRecorded>(
+  "@effect-agent/session/ModelResponseRecorded",
+)("ModelResponseRecorded", ModelResponseRecordedFields) {}
 
 /**
  * One approved uncertain/idempotent ordinary Tool Call made durable BEFORE any handler starts
@@ -499,7 +514,7 @@ const isSettlementFailureDiagnostic = Schema.is(SettlementFailureDiagnostic);
 
 const hasValidSettlementFamily = (settled: typeof RawSubmissionSettled.Type): boolean =>
   (settled.finishReason === undefined || settled.outcome === "completed") &&
-  (settled.exhausted === undefined || settled.finishReason === "budget-exhausted") &&
+  (settled.finishReason === undefined) === (settled.exhausted === undefined) &&
   (settled.usageSummary === undefined || settled.runId !== undefined) &&
   (settled.runDisposition === undefined ||
     (settled.outcome === "completed" &&

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -16,6 +16,7 @@ import {
   TurnId,
 } from "@effect-agent/core";
 import { Encoding, Schema } from "effect";
+import { Prompt } from "effect/unstable/ai";
 
 const identifier = <const Name extends string>(name: Name) =>
   Schema.NonEmptyString.pipe(Schema.brand(`@effect-agent/session/${name}`));
@@ -218,9 +219,7 @@ export class ToolCallSettled extends Schema.TaggedClass<ToolCallSettled>(
  * Turn boundary so a recovering Attempt can rebuild the next Prompt from canonical records alone.
  * `messagesDigest` pins the exact encoded content.
  */
-const PersistedPromptMessages = Schema.Struct({
-  content: Schema.Array(Schema.Json),
-});
+const PersistedPromptMessages = Schema.toEncoded(Prompt.Prompt);
 const isPersistedPromptMessages = Schema.is(PersistedPromptMessages);
 
 const ModelResponseRecordedFields = Schema.Struct({
@@ -251,8 +250,14 @@ const ModelResponseRecordedFields = Schema.Struct({
     (response) =>
       response.runScopedPrefixLength === undefined ||
       (isPersistedPromptMessages(response.messages) &&
-        response.runScopedPrefixLength < response.messages.content.length),
-    { title: "Run-scoped Prompt prefix leaves at least one recorded response message" },
+        response.runScopedPrefixLength < response.messages.content.length &&
+        response.messages.content
+          .slice(0, response.runScopedPrefixLength)
+          .every((message) => message.role === "system" || message.role === "user")),
+    {
+      title:
+        "Run-scoped Prompt prefix contains only instruction/wake messages and leaves one response",
+    },
   ),
 );
 

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -424,7 +424,7 @@ export class RunFailed extends Schema.TaggedClass<RunFailed>("@effect-agent/sess
 const RunCompletedFields = Schema.Struct({
   runId: RunId,
   output: PersistedJson,
-  /** Application disposition captured with an ordinary terminal Tool completion. */
+  /** Application disposition captured with an ordinary completion. */
   runDisposition: Schema.optionalKey(PersistedJson),
   /** Honest soft-landing marker, present exactly when `exhausted` is present. */
   finishReason: Schema.optionalKey(Schema.Literal("budget-exhausted")),

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -406,13 +406,14 @@ const RunCompletedFields = Schema.Struct({
   output: PersistedJson,
   /** Application disposition captured with an ordinary terminal Tool completion. */
   runDisposition: Schema.optionalKey(PersistedJson),
-  /** Honest soft-landing marker captured atomically with the terminal Tool result. */
+  /** Honest soft-landing marker, present exactly when `exhausted` is present. */
   finishReason: Schema.optionalKey(Schema.Literal("budget-exhausted")),
+  /** Budget dimension paired with `finishReason` on a soft landing. */
   exhausted: Schema.optionalKey(ExhaustedLimit),
 }).check(
   Schema.makeFilter(
     (completed) =>
-      (completed.exhausted === undefined || completed.finishReason === "budget-exhausted") &&
+      (completed.finishReason === undefined) === (completed.exhausted === undefined) &&
       (completed.runDisposition === undefined || completed.finishReason === undefined),
     { title: "Run completion metadata matches its terminal family" },
   ),

--- a/packages/session/src/records.ts
+++ b/packages/session/src/records.ts
@@ -6,6 +6,8 @@ import {
   ExhaustedLimit,
   PolicyLimit,
   ReceiptId,
+  ModelCallUsage,
+  RunUsageSummary,
   RunId,
   SettlementId,
   SubagentParentLink,
@@ -225,12 +227,18 @@ export class ModelResponseRecorded extends Schema.TaggedClass<ModelResponseRecor
   messages: PersistedJson,
   messagesDigest: Digest,
   /**
-   * Per-call provider usage (RUN-023), present for records committed after
-   * the context-economics arc. Totals are what budget re-seeding needs; cache splits are
-   * deliberately not persisted — snapshot fidelity is host-side, and the
-   * canonical log stays minimal. Absent fields re-seed as zero (dev-data
-   * policy: old records under-count rather than fail).
+   * Number of leading messages that belong only to this Run's evaluated instructions and wake
+   * input. They remain canonical and are visible while recovering this Run, but later Runs omit
+   * them from their model-facing history. Records without this field retain their full history.
    */
+  runScopedPrefixLength: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+  /**
+   * Exact normalized usage for every model call staged into this Turn. A
+   * summarizer and the Turn response are distinct entries. Absent on legacy
+   * records, whose aggregate totals below retain the old resume behavior.
+   */
+  modelUsage: Schema.optionalKey(Schema.Array(ModelCallUsage)),
+  /** Aggregate compatibility fields used by older projections. */
   inputTokens: Schema.optionalKey(Schema.Natural),
   outputTokens: Schema.optionalKey(Schema.Natural),
   /** Estimated spend staged with the usage; recovery re-seeds the cost budget (RUN-023). */
@@ -393,12 +401,26 @@ export class RunFailed extends Schema.TaggedClass<RunFailed>("@effect-agent/sess
   },
 ) {}
 
-export class RunCompleted extends Schema.TaggedClass<RunCompleted>(
-  "@effect-agent/session/RunCompleted",
-)("RunCompleted", {
+const RunCompletedFields = Schema.Struct({
   runId: RunId,
   output: PersistedJson,
-}) {}
+  /** Application disposition captured with an ordinary terminal Tool completion. */
+  runDisposition: Schema.optionalKey(PersistedJson),
+  /** Honest soft-landing marker captured atomically with the terminal Tool result. */
+  finishReason: Schema.optionalKey(Schema.Literal("budget-exhausted")),
+  exhausted: Schema.optionalKey(ExhaustedLimit),
+}).check(
+  Schema.makeFilter(
+    (completed) =>
+      (completed.exhausted === undefined || completed.finishReason === "budget-exhausted") &&
+      (completed.runDisposition === undefined || completed.finishReason === undefined),
+    { title: "Run completion metadata matches its terminal family" },
+  ),
+);
+
+export class RunCompleted extends Schema.TaggedClass<RunCompleted>(
+  "@effect-agent/session/RunCompleted",
+)("RunCompleted", RunCompletedFields) {}
 
 export class RepairAnnotated extends Schema.TaggedClass<RepairAnnotated>(
   "@effect-agent/session/RepairAnnotated",
@@ -465,6 +487,8 @@ const RawSubmissionSettled = Schema.Struct({
    * before the limit became durable (additive, schemaVersion 1).
    */
   policyLimit: Schema.optionalKey(PolicyLimit),
+  /** Canonical aggregate of all priced model calls made by this Run. */
+  usageSummary: Schema.optionalKey(RunUsageSummary),
 });
 
 const isPolicyFailureProjection = Schema.is(
@@ -475,6 +499,7 @@ const isSettlementFailureDiagnostic = Schema.is(SettlementFailureDiagnostic);
 const hasValidSettlementFamily = (settled: typeof RawSubmissionSettled.Type): boolean =>
   (settled.finishReason === undefined || settled.outcome === "completed") &&
   (settled.exhausted === undefined || settled.finishReason === "budget-exhausted") &&
+  (settled.usageSummary === undefined || settled.runId !== undefined) &&
   (settled.runDisposition === undefined ||
     (settled.outcome === "completed" &&
       settled.finishReason === undefined &&

--- a/packages/session/src/run-journal.ts
+++ b/packages/session/src/run-journal.ts
@@ -1,6 +1,16 @@
-import { ConversationId, RunId, ToolCallId, TurnId, type SubmissionId } from "@effect-agent/core";
+import {
+  ConversationId,
+  ModelCallUsage,
+  RunId,
+  summarizeModelUsage,
+  ToolCallId,
+  TurnId,
+  type ExhaustedLimit,
+  type SubmissionId,
+} from "@effect-agent/core";
 import { CLEARED_TOOL_RESULT, COMPACTION_SUMMARY_PREFIX } from "@effect-agent/engine";
-import { Crypto, Effect, Schema, type DateTime } from "effect";
+import type { Crypto } from "effect";
+import { Effect, Schema, type DateTime } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
 import { digestJson, type DigestError } from "./digest.ts";
@@ -12,6 +22,7 @@ import {
   PersistedJson,
   RecordEnvelope,
   RecordId,
+  RunCompleted,
   ToolCallSettled,
   type CanonicalRecordEnvelope,
   type DeploymentId,
@@ -103,6 +114,10 @@ export const compactionBatchId = (
 /** Deterministic canonical record identity of one Turn's `ModelResponseRecorded` record. */
 export const modelResponseRecordId = (runId: RunId, turn: number): RecordId =>
   decodeRecordId(`model-response:${runId}:${turn}`);
+
+/** Terminal Tool completion marker committed atomically with its settled Tool result. */
+export const runCompletedRecordId = (runId: RunId): RecordId =>
+  decodeRecordId(`run-completed:${runId}`);
 
 /** Deterministic canonical record identity of one Turn's `ToolCallSettled` record. */
 export const toolCallSettledRecordId = (
@@ -329,6 +344,8 @@ export interface RunJournalUsage {
   readonly lastOutputTokens: number;
   /** Cumulative persisted spend of the projected Run's committed calls (RUN-023). */
   readonly costMicrousd: number;
+  /** Canonical per-call detail used for settlement aggregation and recovery. */
+  readonly modelUsage: ReadonlyArray<ModelCallUsage>;
 }
 
 export interface RunJournalProjection {
@@ -341,6 +358,47 @@ export interface RunJournalProjection {
   /** Summed per-call usage of the projected Run's committed responses; zeros for records predating usage capture. */
   readonly usage: RunJournalUsage;
 }
+
+interface ProjectedResponseUsage {
+  readonly modelCalls: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly costMicrousd: number;
+  readonly modelUsage: ReadonlyArray<ModelCallUsage>;
+}
+
+const projectedResponseUsage = (
+  response: ModelResponseRecorded,
+): Effect.Effect<ProjectedResponseUsage, RunJournalError> => {
+  const calls = response.modelUsage;
+  if (calls === undefined) {
+    return Effect.succeed({
+      modelCalls: 1,
+      inputTokens: response.inputTokens ?? 0,
+      outputTokens: response.outputTokens ?? 0,
+      costMicrousd: response.costMicrousd ?? 0,
+      modelUsage: [],
+    });
+  }
+  if (calls.length === 0) {
+    return Effect.fail(journalError("A canonical modelUsage list must not be empty"));
+  }
+  const summary = summarizeModelUsage(calls);
+  if (
+    (response.inputTokens !== undefined && response.inputTokens !== summary.inputTokens.total) ||
+    (response.outputTokens !== undefined && response.outputTokens !== summary.outputTokens.total) ||
+    (response.costMicrousd !== undefined && response.costMicrousd !== summary.costMicrousd)
+  ) {
+    return Effect.fail(journalError("Canonical detailed and aggregate model usage disagree"));
+  }
+  return Effect.succeed({
+    modelCalls: summary.modelCalls,
+    inputTokens: summary.inputTokens.total,
+    outputTokens: summary.outputTokens.total,
+    costMicrousd: summary.costMicrousd,
+    modelUsage: calls,
+  });
+};
 
 interface FoldState {
   readonly all: Array<Prompt.Message>;
@@ -503,6 +561,7 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     state = { ...state, all: [...state.all, message], before: [...state.before, message] };
   };
 
+  const modelUsage: Array<ModelCallUsage> = [];
   const usage = {
     modelCalls: 0,
     inputTokens: 0,
@@ -510,6 +569,7 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     lastInputTokens: 0,
     lastOutputTokens: 0,
     costMicrousd: 0,
+    modelUsage,
   };
   let usageTurn = 0;
 
@@ -569,14 +629,16 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
       // into the summary (the append side never covers the owner, but stay
       // fail-safe if it ever did).
       if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {
-        usage.modelCalls += 1;
-        usage.inputTokens += payload.inputTokens ?? 0;
-        usage.outputTokens += payload.outputTokens ?? 0;
-        usage.costMicrousd += payload.costMicrousd ?? 0;
+        const responseUsage = yield* projectedResponseUsage(payload);
+        usage.modelCalls += responseUsage.modelCalls;
+        usage.inputTokens += responseUsage.inputTokens;
+        usage.outputTokens += responseUsage.outputTokens;
+        usage.costMicrousd += responseUsage.costMicrousd;
+        usage.modelUsage.push(...responseUsage.modelUsage);
         if (payload.turn > usageTurn) {
           usageTurn = payload.turn;
-          usage.lastInputTokens = payload.inputTokens ?? 0;
-          usage.lastOutputTokens = payload.outputTokens ?? 0;
+          usage.lastInputTokens = responseUsage.inputTokens;
+          usage.lastOutputTokens = responseUsage.outputTokens;
         }
       }
       continue;
@@ -610,20 +672,26 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     }
     const forRun = payload.runId === ownerRunId;
     if (forRun) {
-      usage.modelCalls += 1;
-      usage.inputTokens += payload.inputTokens ?? 0;
-      usage.outputTokens += payload.outputTokens ?? 0;
-      usage.costMicrousd += payload.costMicrousd ?? 0;
+      const responseUsage = yield* projectedResponseUsage(payload);
+      usage.modelCalls += responseUsage.modelCalls;
+      usage.inputTokens += responseUsage.inputTokens;
+      usage.outputTokens += responseUsage.outputTokens;
+      usage.costMicrousd += responseUsage.costMicrousd;
+      usage.modelUsage.push(...responseUsage.modelUsage);
       if (payload.turn > usageTurn) {
         usageTurn = payload.turn;
-        usage.lastInputTokens = payload.inputTokens ?? 0;
-        usage.lastOutputTokens = payload.outputTokens ?? 0;
+        usage.lastInputTokens = responseUsage.inputTokens;
+        usage.lastOutputTokens = responseUsage.outputTokens;
       }
     }
+    const modelVisible =
+      !forRun && payload.runScopedPrefixLength !== undefined
+        ? Prompt.fromMessages(messages.content.slice(payload.runScopedPrefixLength))
+        : messages;
     const visibleMessages =
       !forRun && incompleteToolTurns.has(envelope.record.recordId)
-        ? withoutApplicationToolCallMessages(messages)
-        : messages.content;
+        ? withoutApplicationToolCallMessages(modelVisible)
+        : modelVisible.content;
     state = {
       ...state,
       all: [...state.all, ...visibleMessages],
@@ -692,18 +760,31 @@ export interface TurnCommitInput {
   readonly producerId: ProducerId;
   readonly deploymentId: DeploymentId;
   readonly createdAt: DateTime.Utc;
+  /** Leading instruction/wake messages that stay canonical but are hidden from later Runs. */
+  readonly runScopedPrefixLength?: number | undefined;
+  /** Terminal Tool output committed atomically with this Turn's result batch. */
+  readonly runCompletion?:
+    | {
+        readonly output: PersistedJson;
+        readonly runDisposition?: PersistedJson | undefined;
+        readonly finishReason?: "budget-exhausted" | undefined;
+        readonly exhausted?: ExhaustedLimit | undefined;
+      }
+    | undefined;
   /** Per-call provider usage staged by the engine's `noteTurnUsage` (RUN-023). */
   readonly usage?:
     | {
         readonly inputTokens: number;
         readonly outputTokens: number;
         readonly costMicrousd?: number | undefined;
+        readonly modelUsage?: ReadonlyArray<ModelCallUsage> | undefined;
       }
     | undefined;
 }
 
 const decodePersistedJson = Schema.decodeUnknownEffect(PersistedJson);
 const encodePrompt = Schema.encodeEffect(Prompt.Prompt);
+const decodeModelUsage = Schema.decodeUnknownEffect(Schema.Array(ModelCallUsage));
 
 const requireCanonicalTurn = (turn: number): Effect.Effect<void, RunJournalError> =>
   !Number.isInteger(turn) || turn <= 0
@@ -738,6 +819,21 @@ const modelResponseRecord = Effect.fn("RunJournal.modelResponseRecord")(function
   if (promptMessages.length === 0) {
     return yield* journalError(`Turn ${input.turn} appended no model-visible Prompt messages`);
   }
+  const runScopedPrefixLength = input.runScopedPrefixLength;
+  if (
+    runScopedPrefixLength !== undefined &&
+    (input.turn !== 1 ||
+      !Number.isSafeInteger(runScopedPrefixLength) ||
+      runScopedPrefixLength <= 0 ||
+      runScopedPrefixLength >= promptMessages.length ||
+      promptMessages
+        .slice(0, runScopedPrefixLength)
+        .some((message) => message.role !== "system" && message.role !== "user"))
+  ) {
+    return yield* journalError(
+      "Run-scoped Prompt provenance must identify a non-empty system/user prefix of Turn 1 before its assistant response",
+    );
+  }
   const encodedMessages = yield* encodePrompt(Prompt.fromMessages([...promptMessages])).pipe(
     Effect.mapError((cause) => journalError("Turn Prompt messages failed to encode", cause)),
   );
@@ -747,6 +843,26 @@ const modelResponseRecord = Effect.fn("RunJournal.modelResponseRecord")(function
     ),
   );
   const messagesDigest = yield* digestJson(messages);
+  const modelUsage =
+    input.usage?.modelUsage === undefined
+      ? undefined
+      : yield* decodeModelUsage(input.usage.modelUsage).pipe(
+          Effect.mapError((cause) => journalError("Turn model usage failed to decode", cause)),
+        );
+  if (modelUsage !== undefined) {
+    if (modelUsage.length === 0) {
+      return yield* journalError("Turn model usage must contain at least one completed call");
+    }
+    const summary = summarizeModelUsage(modelUsage);
+    if (
+      input.usage === undefined ||
+      input.usage.inputTokens !== summary.inputTokens.total ||
+      input.usage.outputTokens !== summary.outputTokens.total ||
+      (input.usage.costMicrousd ?? 0) !== summary.costMicrousd
+    ) {
+      return yield* journalError("Turn detailed and aggregate model usage disagree");
+    }
+  }
   return RecordEnvelope.make({
     recordId: modelResponseRecordId(input.runId, input.turn),
     family: "conversation",
@@ -759,6 +875,8 @@ const modelResponseRecord = Effect.fn("RunJournal.modelResponseRecord")(function
       turn: input.turn,
       messages,
       messagesDigest,
+      ...(runScopedPrefixLength === undefined ? {} : { runScopedPrefixLength }),
+      ...(modelUsage === undefined ? {} : { modelUsage }),
       ...(input.usage === undefined
         ? {}
         : {
@@ -874,9 +992,37 @@ export const turnResultsBatch = Effect.fn("RunJournal.turnResultsBatch")(functio
   if (first === undefined) {
     return yield* journalError(`Turn ${input.turn} has no terminal Tool results to commit`);
   }
+  if (input.runCompletion !== undefined && toolRecords.length !== 1) {
+    return yield* journalError("A terminal Tool completion requires exactly one settled result");
+  }
+  const completionRecord =
+    input.runCompletion === undefined
+      ? []
+      : [
+          RecordEnvelope.make({
+            recordId: runCompletedRecordId(input.runId),
+            family: "conversation",
+            schemaVersion: 1,
+            createdAt: input.createdAt,
+            deploymentId: input.deploymentId,
+            payload: RunCompleted.make({
+              runId: input.runId,
+              output: input.runCompletion.output,
+              ...(input.runCompletion.runDisposition === undefined
+                ? {}
+                : { runDisposition: input.runCompletion.runDisposition }),
+              ...(input.runCompletion.finishReason === undefined
+                ? {}
+                : { finishReason: input.runCompletion.finishReason }),
+              ...(input.runCompletion.exhausted === undefined
+                ? {}
+                : { exhausted: input.runCompletion.exhausted }),
+            }),
+          }),
+        ];
   return CanonicalBatch.make({
     batchId: turnResultsBatchId(input.runId, input.turn),
     producerId: input.producerId,
-    records: [first, ...toolRecords.slice(1)],
+    records: [first, ...toolRecords.slice(1), ...completionRecord],
   });
 });

--- a/packages/session/src/run-journal.ts
+++ b/packages/session/src/run-journal.ts
@@ -9,8 +9,7 @@ import {
   type SubmissionId,
 } from "@effect-agent/core";
 import { CLEARED_TOOL_RESULT, COMPACTION_SUMMARY_PREFIX } from "@effect-agent/engine";
-import type { Crypto } from "effect";
-import { Effect, Schema, type DateTime } from "effect";
+import { type Crypto, Effect, Schema, type DateTime } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
 import { digestJson, type DigestError } from "./digest.ts";
@@ -811,7 +810,7 @@ export interface TurnCommitInput {
   readonly createdAt: DateTime.Utc;
   /** Leading instruction/wake messages that stay canonical but are hidden from later Runs. */
   readonly runScopedPrefixLength?: number | undefined;
-  /** Terminal Tool output committed atomically with this Turn's result batch. */
+  /** Terminal output committed atomically with this Turn's final canonical batch. */
   readonly runCompletion?:
     | {
         readonly output: PersistedJson;
@@ -980,15 +979,39 @@ const toolSettledRecords = Effect.fn("RunJournal.toolSettledRecords")(function* 
   return toolRecords;
 });
 
+const runCompletionRecord = (input: TurnCommitInput): RecordEnvelope | undefined =>
+  input.runCompletion === undefined
+    ? undefined
+    : RecordEnvelope.make({
+        recordId: runCompletedRecordId(input.runId),
+        family: "conversation",
+        schemaVersion: 1,
+        createdAt: input.createdAt,
+        deploymentId: input.deploymentId,
+        payload: RunCompleted.make({
+          runId: input.runId,
+          output: input.runCompletion.output,
+          ...(input.runCompletion.runDisposition === undefined
+            ? {}
+            : { runDisposition: input.runCompletion.runDisposition }),
+          ...(input.runCompletion.finishReason === undefined
+            ? {}
+            : { finishReason: input.runCompletion.finishReason }),
+          ...(input.runCompletion.exhausted === undefined
+            ? {}
+            : { exhausted: input.runCompletion.exhausted }),
+        }),
+      });
+
 /**
  * Pure per-Turn canonical batch builder (TurnCompleted seam fold, D6/D8): one
  * `ModelResponseRecorded` record plus one `ToolCallSettled` record per terminal Tool result, all
  * under the WP0-style deterministic identities, committed as ONE atomic batch. The same input
  * always yields byte-identical content, so an in-Attempt append retry is an honest batch replay.
  *
- * Phase 5 keeps this exact shape for Turns that declare no application Tool calls (decision
- * point 6: P4 histories replay byte-identically); tool-declaring Turns split into
- * `turnResponseBatch` + `turnResultsBatch`.
+ * Phase 5 keeps this shape for Turns that declare no application Tool calls; their terminal
+ * `RunCompleted` marker joins the response in this same atomic batch. Tool-declaring Turns split
+ * into `turnResponseBatch` + `turnResultsBatch`.
  */
 export const turnCanonicalBatch = Effect.fn("RunJournal.turnCanonicalBatch")(function* (
   input: TurnCommitInput,
@@ -997,10 +1020,14 @@ export const turnCanonicalBatch = Effect.fn("RunJournal.turnCanonicalBatch")(fun
   const { promptMessages, toolParts } = splitTurnMessages(input.appended);
   const modelResponse = yield* modelResponseRecord(input, promptMessages);
   const toolRecords = yield* toolSettledRecords(input, toolParts);
+  const completionRecord = runCompletionRecord(input);
   return CanonicalBatch.make({
     batchId: turnBatchId(input.runId, input.turn),
     producerId: input.producerId,
-    records: [modelResponse, ...toolRecords],
+    records:
+      completionRecord === undefined
+        ? [modelResponse, ...toolRecords]
+        : [modelResponse, ...toolRecords, completionRecord],
   });
 });
 
@@ -1046,34 +1073,13 @@ export const turnResultsBatch = Effect.fn("RunJournal.turnResultsBatch")(functio
   if (input.runCompletion !== undefined && toolRecords.length !== 1) {
     return yield* journalError("A terminal Tool completion requires exactly one settled result");
   }
-  const completionRecord =
-    input.runCompletion === undefined
-      ? []
-      : [
-          RecordEnvelope.make({
-            recordId: runCompletedRecordId(input.runId),
-            family: "conversation",
-            schemaVersion: 1,
-            createdAt: input.createdAt,
-            deploymentId: input.deploymentId,
-            payload: RunCompleted.make({
-              runId: input.runId,
-              output: input.runCompletion.output,
-              ...(input.runCompletion.runDisposition === undefined
-                ? {}
-                : { runDisposition: input.runCompletion.runDisposition }),
-              ...(input.runCompletion.finishReason === undefined
-                ? {}
-                : { finishReason: input.runCompletion.finishReason }),
-              ...(input.runCompletion.exhausted === undefined
-                ? {}
-                : { exhausted: input.runCompletion.exhausted }),
-            }),
-          }),
-        ];
+  const completionRecord = runCompletionRecord(input);
   return CanonicalBatch.make({
     batchId: turnResultsBatchId(input.runId, input.turn),
     producerId: input.producerId,
-    records: [first, ...toolRecords.slice(1), ...completionRecord],
+    records:
+      completionRecord === undefined
+        ? [first, ...toolRecords.slice(1)]
+        : [first, ...toolRecords.slice(1), completionRecord],
   });
 });

--- a/packages/session/src/run-journal.ts
+++ b/packages/session/src/run-journal.ts
@@ -369,36 +369,53 @@ interface ProjectedResponseUsage {
 
 const projectedResponseUsage = (
   response: ModelResponseRecorded,
-): Effect.Effect<ProjectedResponseUsage, RunJournalError> => {
-  const calls = response.modelUsage;
-  if (calls === undefined) {
-    return Effect.succeed({
-      modelCalls: 1,
-      inputTokens: response.inputTokens ?? 0,
-      outputTokens: response.outputTokens ?? 0,
-      costMicrousd: response.costMicrousd ?? 0,
-      modelUsage: [],
-    });
-  }
-  if (calls.length === 0) {
-    return Effect.fail(journalError("A canonical modelUsage list must not be empty"));
-  }
-  const summary = summarizeModelUsage(calls);
-  if (
-    (response.inputTokens !== undefined && response.inputTokens !== summary.inputTokens.total) ||
-    (response.outputTokens !== undefined && response.outputTokens !== summary.outputTokens.total) ||
-    (response.costMicrousd !== undefined && response.costMicrousd !== summary.costMicrousd)
-  ) {
-    return Effect.fail(journalError("Canonical detailed and aggregate model usage disagree"));
-  }
-  return Effect.succeed({
-    modelCalls: summary.modelCalls,
-    inputTokens: summary.inputTokens.total,
-    outputTokens: summary.outputTokens.total,
-    costMicrousd: summary.costMicrousd,
-    modelUsage: calls,
+): Effect.Effect<ProjectedResponseUsage, RunJournalError> =>
+  Effect.gen(function* () {
+    const calls = response.modelUsage;
+    if (calls === undefined) {
+      return {
+        modelCalls: 1,
+        inputTokens: response.inputTokens ?? 0,
+        outputTokens: response.outputTokens ?? 0,
+        costMicrousd: response.costMicrousd ?? 0,
+        modelUsage: [],
+      };
+    }
+    if (calls.length === 0) {
+      return yield* journalError("A canonical modelUsage list must not be empty");
+    }
+    const summary = yield* summarizeModelUsage(calls).pipe(
+      Effect.mapError((cause) =>
+        journalError("Canonical model usage exceeds accounting bounds", cause),
+      ),
+    );
+    if (
+      (response.inputTokens !== undefined && response.inputTokens !== summary.inputTokens.total) ||
+      (response.outputTokens !== undefined &&
+        response.outputTokens !== summary.outputTokens.total) ||
+      (response.costMicrousd !== undefined && response.costMicrousd !== summary.costMicrousd)
+    ) {
+      return yield* journalError("Canonical detailed and aggregate model usage disagree");
+    }
+    return {
+      modelCalls: summary.modelCalls,
+      inputTokens: summary.inputTokens.total,
+      outputTokens: summary.outputTokens.total,
+      costMicrousd: summary.costMicrousd,
+      modelUsage: calls,
+    };
   });
-};
+
+const addProjectedUsage = (
+  field: string,
+  left: number,
+  right: number,
+): Effect.Effect<number, RunJournalError> =>
+  Schema.decodeUnknownEffect(Schema.Natural)(left + right).pipe(
+    Effect.mapError((cause) =>
+      journalError(`Canonical projected usage exceeds safe-integer bounds at ${field}`, cause),
+    ),
+  );
 
 interface FoldState {
   readonly all: Array<Prompt.Message>;
@@ -630,10 +647,26 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
       // fail-safe if it ever did).
       if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {
         const responseUsage = yield* projectedResponseUsage(payload);
-        usage.modelCalls += responseUsage.modelCalls;
-        usage.inputTokens += responseUsage.inputTokens;
-        usage.outputTokens += responseUsage.outputTokens;
-        usage.costMicrousd += responseUsage.costMicrousd;
+        usage.modelCalls = yield* addProjectedUsage(
+          "modelCalls",
+          usage.modelCalls,
+          responseUsage.modelCalls,
+        );
+        usage.inputTokens = yield* addProjectedUsage(
+          "inputTokens",
+          usage.inputTokens,
+          responseUsage.inputTokens,
+        );
+        usage.outputTokens = yield* addProjectedUsage(
+          "outputTokens",
+          usage.outputTokens,
+          responseUsage.outputTokens,
+        );
+        usage.costMicrousd = yield* addProjectedUsage(
+          "costMicrousd",
+          usage.costMicrousd,
+          responseUsage.costMicrousd,
+        );
         usage.modelUsage.push(...responseUsage.modelUsage);
         if (payload.turn > usageTurn) {
           usageTurn = payload.turn;
@@ -673,10 +706,26 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     const forRun = payload.runId === ownerRunId;
     if (forRun) {
       const responseUsage = yield* projectedResponseUsage(payload);
-      usage.modelCalls += responseUsage.modelCalls;
-      usage.inputTokens += responseUsage.inputTokens;
-      usage.outputTokens += responseUsage.outputTokens;
-      usage.costMicrousd += responseUsage.costMicrousd;
+      usage.modelCalls = yield* addProjectedUsage(
+        "modelCalls",
+        usage.modelCalls,
+        responseUsage.modelCalls,
+      );
+      usage.inputTokens = yield* addProjectedUsage(
+        "inputTokens",
+        usage.inputTokens,
+        responseUsage.inputTokens,
+      );
+      usage.outputTokens = yield* addProjectedUsage(
+        "outputTokens",
+        usage.outputTokens,
+        responseUsage.outputTokens,
+      );
+      usage.costMicrousd = yield* addProjectedUsage(
+        "costMicrousd",
+        usage.costMicrousd,
+        responseUsage.costMicrousd,
+      );
       usage.modelUsage.push(...responseUsage.modelUsage);
       if (payload.turn > usageTurn) {
         usageTurn = payload.turn;
@@ -853,7 +902,9 @@ const modelResponseRecord = Effect.fn("RunJournal.modelResponseRecord")(function
     if (modelUsage.length === 0) {
       return yield* journalError("Turn model usage must contain at least one completed call");
     }
-    const summary = summarizeModelUsage(modelUsage);
+    const summary = yield* summarizeModelUsage(modelUsage).pipe(
+      Effect.mapError((cause) => journalError("Turn model usage exceeds accounting bounds", cause)),
+    );
     if (
       input.usage === undefined ||
       input.usage.inputTokens !== summary.inputTokens.total ||

--- a/packages/session/test/run-journal.test.ts
+++ b/packages/session/test/run-journal.test.ts
@@ -117,6 +117,12 @@ const completionTurnAppended: ReadonlyArray<Prompt.Message> = [
   }),
 ];
 
+const finalTurnAppended: ReadonlyArray<Prompt.Message> = [
+  Prompt.makeMessage("assistant", {
+    content: [Prompt.makePart("text", { text: '{"answer":"Booked."}' })],
+  }),
+];
+
 const turnInput = (
   appended: ReadonlyArray<Prompt.Message>,
   turn = 1,
@@ -226,6 +232,27 @@ describe("run journal batch split (plan §2.1)", () => {
         expect(splitProjection.committedTurns).toBe(singleProjection.committedTurns);
         expect(splitProjection.prompt).toEqual(singleProjection.prompt);
         expect(splitProjection.historyBefore).toEqual(singleProjection.historyBefore);
+      }),
+    );
+
+    it.effect("commits a no-tool final response and Run completion marker atomically", () =>
+      Effect.gen(function* () {
+        const batch = yield* turnCanonicalBatch({
+          ...turnInput(finalTurnAppended),
+          runCompletion: {
+            output: { answer: "Booked." },
+          },
+        });
+
+        expect(batch.records.map((record) => record.recordId)).toEqual([
+          modelResponseRecordId(RUN_ID, 1),
+          runCompletedRecordId(RUN_ID),
+        ]);
+        expect(batch.records[1]?.payload).toMatchObject({
+          _tag: "RunCompleted",
+          runId: RUN_ID,
+          output: { answer: "Booked." },
+        });
       }),
     );
 

--- a/packages/session/test/run-journal.test.ts
+++ b/packages/session/test/run-journal.test.ts
@@ -18,6 +18,7 @@ import {
   modelResponseRecordId,
   promptFromCanonicalRecords,
   projectRunJournal,
+  runCompletedRecordId,
   runIdForSubmission,
   subagentJoinBatchId,
   subagentJoinedRecordId,
@@ -92,6 +93,30 @@ const toolTurnAppended: ReadonlyArray<Prompt.Message> = [
   }),
 ];
 
+const completionTurnAppended: ReadonlyArray<Prompt.Message> = [
+  Prompt.makeMessage("assistant", {
+    content: [
+      Prompt.makePart("tool-call", {
+        id: "call-1",
+        name: "post_message",
+        params: { message: "Your flight is booked." },
+        providerExecuted: false,
+      }),
+    ],
+  }),
+  Prompt.makeMessage("tool", {
+    content: [
+      Prompt.makePart("tool-result", {
+        id: "call-1",
+        name: "post_message",
+        result: { messageId: "message-42" },
+        isFailure: false,
+        providerExecuted: false,
+      }),
+    ],
+  }),
+];
+
 const turnInput = (
   appended: ReadonlyArray<Prompt.Message>,
   turn = 1,
@@ -126,6 +151,22 @@ const envelopesOf = (batches: ReadonlyArray<CanonicalBatch>): Array<CanonicalRec
   }
   return envelopes;
 };
+
+const textOfPrompt = (prompt: Prompt.Prompt): string =>
+  prompt.content
+    .map((message) =>
+      typeof message.content === "string"
+        ? message.content
+        : message.content.map((part) => (part.type === "text" ? part.text : "")).join(""),
+    )
+    .join("\n");
+
+const resultsOfPrompt = (prompt: Prompt.Prompt): ReadonlyArray<unknown> =>
+  prompt.content.flatMap((message) =>
+    message.role === "tool"
+      ? message.content.filter((part) => part.type === "tool-result").map((part) => part.result)
+      : [],
+  );
 
 const auditRecord = (
   recordId: string,
@@ -185,6 +226,29 @@ describe("run journal batch split (plan §2.1)", () => {
         expect(splitProjection.committedTurns).toBe(singleProjection.committedTurns);
         expect(splitProjection.prompt).toEqual(singleProjection.prompt);
         expect(splitProjection.historyBefore).toEqual(singleProjection.historyBefore);
+      }),
+    );
+
+    it.effect("commits a terminal Tool result and Run completion marker atomically", () =>
+      Effect.gen(function* () {
+        const results = yield* turnResultsBatch({
+          ...turnInput(completionTurnAppended),
+          runCompletion: {
+            output: { deliveredMessageId: "message-42" },
+            runDisposition: { channel: "support" },
+          },
+        });
+
+        expect(results.records.map((record) => record.recordId)).toEqual([
+          toolCallSettledRecordId(RUN_ID, 1, CALL_ONE),
+          runCompletedRecordId(RUN_ID),
+        ]);
+        expect(results.records[1]?.payload).toMatchObject({
+          _tag: "RunCompleted",
+          runId: RUN_ID,
+          output: { deliveredMessageId: "message-42" },
+          runDisposition: { channel: "support" },
+        });
       }),
     );
 
@@ -396,6 +460,47 @@ describe("run journal batch split (plan §2.1)", () => {
           ),
         ).toEqual([CALL_ONE]);
       }),
+    );
+
+    it.effect(
+      "RUN-033: keeps run-scoped instructions canonical while excluding them from later model prompts",
+      () =>
+        Effect.gen(function* () {
+          const firstResponse = yield* turnResponseBatch({
+            ...turnInput(toolTurnAppended),
+            runScopedPrefixLength: 2,
+          });
+          const firstResults = yield* turnResultsBatch(turnInput(toolTurnAppended));
+          const conversationalTurn: ReadonlyArray<Prompt.Message> = [
+            Prompt.makeMessage("user", {
+              content: [
+                Prompt.makePart("text", { text: "Please mention the cancellation terms." }),
+              ],
+            }),
+            Prompt.makeMessage("assistant", {
+              content: [
+                Prompt.makePart("text", { text: '{"answer":"Cancellation terms added."}' }),
+              ],
+            }),
+          ];
+          const secondResponse = yield* turnResponseBatch(turnInput(conversationalTurn, 2));
+          const records = envelopesOf([firstResponse, firstResults, secondResponse]);
+
+          const recovering = yield* projectRunJournal(records, RUN_ID);
+          expect(textOfPrompt(recovering.prompt)).toContain("Answer as JSON.");
+          expect(textOfPrompt(recovering.prompt)).toContain("book?");
+
+          const later = yield* projectRunJournal(records, LATER_RUN_ID);
+          const laterText = textOfPrompt(later.historyBefore);
+          expect(laterText).not.toContain("Answer as JSON.");
+          expect(laterText).not.toContain("book?");
+          expect(laterText).toContain("Please mention the cancellation terms.");
+          expect(laterText).toContain("Cancellation terms added.");
+          expect(resultsOfPrompt(later.historyBefore)).toEqual([
+            { bookingRef: "flight-42" },
+            { bookingRef: "lodging-7" },
+          ]);
+        }),
     );
 
     it.effect("projects prepared/unknown/step/approval/resolution records transparently", () =>
@@ -943,6 +1048,7 @@ describe("engine compaction records and projection (RUN-026)", () => {
           lastInputTokens: 250,
           lastOutputTokens: 20,
           costMicrousd: 0,
+          modelUsage: [],
         });
       }),
     );

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -393,6 +393,41 @@ describe("phase 4 durable canonical payloads", () => {
     }
   });
 
+  it("RUN-011: requires both budget fields on a RunCompleted marker", () => {
+    const envelope = (payload: unknown): unknown => ({
+      recordId: "record-run-completed-budget",
+      family: "conversation",
+      schemaVersion: 1,
+      createdAt: "2026-07-29T12:00:00.000Z",
+      deploymentId: "test-deployment",
+      payload,
+    });
+    const completed = {
+      _tag: "RunCompleted",
+      runId: "run-budget-completed",
+      output: { answer: "partial" },
+    } as const;
+
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({
+          ...completed,
+          finishReason: "budget-exhausted",
+          exhausted: "tokens",
+        }),
+      )._tag,
+    ).toBe("Success");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({ ...completed, finishReason: "budget-exhausted" }),
+      )._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(envelope({ ...completed, exhausted: "tokens" }))
+        ._tag,
+    ).toBe("Failure");
+  });
+
   it("RUN-011: round-trips typed budget metadata and decodes legacy settlements without it", () => {
     const payloads = [
       // A completed soft landing persists the finishReason with its typed dimension.

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -407,15 +407,31 @@ describe("phase 4 durable canonical payloads", () => {
       messages: {
         content: [
           { role: "system", content: "Run instructions" },
+          { role: "user", content: "Run wake input" },
           { role: "assistant", content: "Answer" },
         ],
       },
     } as const;
 
     expect(
-      Schema.decodeUnknownExit(RecordEnvelope)(envelope({ ...response, runScopedPrefixLength: 1 }))
+      Schema.decodeUnknownExit(RecordEnvelope)(envelope({ ...response, runScopedPrefixLength: 2 }))
         ._tag,
     ).toBe("Success");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({
+          ...response,
+          messages: {
+            content: [
+              { role: "system", content: "Run instructions" },
+              { role: "assistant", content: "Not wake input" },
+              { role: "assistant", content: "Answer" },
+            ],
+          },
+          runScopedPrefixLength: 2,
+        }),
+      )._tag,
+    ).toBe("Failure");
     expect(
       Schema.decodeUnknownExit(RecordEnvelope)(
         envelope({ ...response, runScopedPrefixLength: response.messages.content.length }),

--- a/packages/session/test/session.test.ts
+++ b/packages/session/test/session.test.ts
@@ -393,7 +393,42 @@ describe("phase 4 durable canonical payloads", () => {
     }
   });
 
-  it("RUN-011: requires both budget fields on a RunCompleted marker", () => {
+  it("RUN-033: bounds a Run-scoped prefix to the recorded Prompt messages", () => {
+    const envelope = (payload: unknown): unknown => ({
+      recordId: "record-run-scoped-prefix",
+      family: "conversation",
+      schemaVersion: 1,
+      createdAt: "2026-07-29T12:00:00.000Z",
+      deploymentId: "test-deployment",
+      payload,
+    });
+    const response = {
+      ...encodedModelResponseRecorded,
+      messages: {
+        content: [
+          { role: "system", content: "Run instructions" },
+          { role: "assistant", content: "Answer" },
+        ],
+      },
+    } as const;
+
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(envelope({ ...response, runScopedPrefixLength: 1 }))
+        ._tag,
+    ).toBe("Success");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({ ...response, runScopedPrefixLength: response.messages.content.length }),
+      )._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({ ...response, runScopedPrefixLength: response.messages.content.length + 1 }),
+      )._tag,
+    ).toBe("Failure");
+  });
+
+  it("RUN-011: requires both budget fields on completion markers and settlements", () => {
     const envelope = (payload: unknown): unknown => ({
       recordId: "record-run-completed-budget",
       family: "conversation",
@@ -426,9 +461,29 @@ describe("phase 4 durable canonical payloads", () => {
       Schema.decodeUnknownExit(RecordEnvelope)(envelope({ ...completed, exhausted: "tokens" }))
         ._tag,
     ).toBe("Failure");
+
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({
+          ...encodedSubmissionSettled,
+          finishReason: "budget-exhausted",
+          exhausted: "tokens",
+        }),
+      )._tag,
+    ).toBe("Success");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({ ...encodedSubmissionSettled, finishReason: "budget-exhausted" }),
+      )._tag,
+    ).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(RecordEnvelope)(
+        envelope({ ...encodedSubmissionSettled, exhausted: "tokens" }),
+      )._tag,
+    ).toBe("Failure");
   });
 
-  it("RUN-011: round-trips typed budget metadata and decodes legacy settlements without it", () => {
+  it("RUN-011: round-trips typed budget metadata and settlements without budget metadata", () => {
     const payloads = [
       // A completed soft landing persists the finishReason with its typed dimension.
       {
@@ -443,8 +498,8 @@ describe("phase 4 durable canonical payloads", () => {
         result: { errorTag: "AgentPolicyError", message: "Agent exceeded its 100 token budget" },
         policyLimit: "tokens",
       } as const,
-      // Histories persisted before the dimension became durable carry the finishReason alone.
-      { ...encodedSubmissionSettled, finishReason: "budget-exhausted" } as const,
+      // Histories persisted before budget metadata retain both fields as absent.
+      encodedSubmissionSettled,
     ];
     for (const [index, payload] of payloads.entries()) {
       const record = decodeRecord(`record-run011-${index}`, payload);

--- a/packages/storage-cloudflare/src/do-conversation-store.ts
+++ b/packages/storage-cloudflare/src/do-conversation-store.ts
@@ -56,8 +56,8 @@ import {
   DoStorageConfigValue,
 } from "./do-storage-config.ts";
 import { DoStorageFailpoint, type DoStorageFailpointHandler } from "./do-storage-failpoint.ts";
-import type { DoStorageCompatibilityError } from "./errors.ts";
 import {
+  type DoStorageCompatibilityError,
   DoAppendConflict,
   DoCheckpointConflict,
   DoFenceRejected,

--- a/packages/storage-cloudflare/src/do-journal.ts
+++ b/packages/storage-cloudflare/src/do-journal.ts
@@ -4,8 +4,8 @@ import { Effect, Schema } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlError } from "effect/unstable/sql/SqlError";
 
-import type { DoStorageFailpointError } from "./errors.ts";
 import {
+  type DoStorageFailpointError,
   DoAppendConflict,
   DoCheckpointConflict,
   DoFenceRejected,

--- a/packages/storage-memory/src/memory-ledger.ts
+++ b/packages/storage-memory/src/memory-ledger.ts
@@ -1,5 +1,5 @@
-import type { ToolCallId } from "@effect-agent/core";
 import {
+  type ToolCallId,
   AttemptId,
   ReceiptId,
   SubmissionId,
@@ -7,8 +7,8 @@ import {
   type ConversationId,
   type SettlementId,
 } from "@effect-agent/core";
-import type { ParentLinkage } from "@effect-agent/session";
 import {
+  type ParentLinkage,
   AbortCommand,
   AdmissionAdmitted,
   AdmissionConflict,

--- a/packages/storage-sqlite/src/sqlite-conversation-store.ts
+++ b/packages/storage-sqlite/src/sqlite-conversation-store.ts
@@ -43,8 +43,8 @@ import {
 } from "effect";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
 
-import type { SqliteStorageCompatibilityError } from "./errors.ts";
 import {
+  type SqliteStorageCompatibilityError,
   SqliteAppendConflict,
   SqliteCheckpointConflict,
   SqliteFenceRejected,

--- a/packages/testing/src/fixtures/travel-planner/phase2.ts
+++ b/packages/testing/src/fixtures/travel-planner/phase2.ts
@@ -86,7 +86,7 @@ export const TravelPlannerPhase2 = Agent.define("travel-planner-phase-2", {
     maxToolCalls: 4,
     maxDuration: "30 seconds",
     toolConcurrency: 3,
-    tokenBudget: 2_048,
+    tokenBudget: 4_096,
   }),
   description:
     "Build a review-only itinerary and require approval before creating a temporary hold.",

--- a/packages/testing/src/fixtures/travel-planner/phase6.ts
+++ b/packages/testing/src/fixtures/travel-planner/phase6.ts
@@ -920,8 +920,46 @@ export const phase6TravelPlannerGoldenEvidence: Schema.Json = [
     },
   },
   {
-    batchId: "submission-settlement:{submissionId}",
+    batchId: "turn:run:{submissionId}:2",
     sequence: 8,
+    record: {
+      recordId: "run-completed:run:{submissionId}",
+      family: "conversation",
+      schemaVersion: 1,
+      createdAt: "{timestamp}",
+      deploymentId: "{deploymentId}",
+      payload: {
+        _tag: "RunCompleted",
+        runId: "run:{submissionId}",
+        output: {
+          itineraries: [
+            {
+              title: "Westward light, eastbound overnight",
+              route: "San Francisco → London",
+              dates: "14–19 September 2026",
+              flight: "EA 218 · nonstop · SFO 18:40 → LHR 13:05+1",
+              lodging: "Bloomsbury House · refundable studio · 4 nights",
+              activities: ["British Museum timed entry", "Thames evening walk"],
+              estimatedTotalCents: 284000,
+              currency: "USD",
+              quoteId: "quote-sfo-lhr-001",
+              assumptions: [
+                "Two travelers sharing one studio",
+                "Quote is read-only availability, not a reservation",
+              ],
+              unresolvedConstraints: [
+                "Traveler names and accessibility requests are intentionally omitted",
+              ],
+              nextAction: "review",
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    batchId: "submission-settlement:{submissionId}",
+    sequence: 9,
     record: {
       recordId: "settlement:{submissionId}",
       family: "conversation",

--- a/packages/testing/src/fixtures/travel-planner/phase6.ts
+++ b/packages/testing/src/fixtures/travel-planner/phase6.ts
@@ -719,6 +719,25 @@ export const phase6TravelPlannerGoldenEvidence: Schema.Json = [
         turn: 1,
         inputTokens: 128,
         outputTokens: 96,
+        runScopedPrefixLength: 2,
+        modelUsage: [
+          {
+            provider: "scripted",
+            model: "travel-planner-phase-4",
+            inputTokens: {
+              total: 128,
+              uncached: 128,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 96,
+              text: 96,
+              reasoning: 0,
+            },
+            costMicrousd: 0,
+          },
+        ],
         messages: {
           content: [
             {
@@ -868,6 +887,24 @@ export const phase6TravelPlannerGoldenEvidence: Schema.Json = [
         turn: 2,
         inputTokens: 128,
         outputTokens: 96,
+        modelUsage: [
+          {
+            provider: "scripted",
+            model: "travel-planner-phase-4",
+            inputTokens: {
+              total: 128,
+              uncached: 128,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 96,
+              text: 96,
+              reasoning: 0,
+            },
+            costMicrousd: 0,
+          },
+        ],
         messages: {
           content: [
             {
@@ -918,6 +955,40 @@ export const phase6TravelPlannerGoldenEvidence: Schema.Json = [
                 "Traveler names and accessibility requests are intentionally omitted",
               ],
               nextAction: "review",
+            },
+          ],
+        },
+        usageSummary: {
+          modelCalls: 2,
+          inputTokens: {
+            total: 256,
+            uncached: 256,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: {
+            total: 192,
+            text: 192,
+            reasoning: 0,
+          },
+          costMicrousd: 0,
+          byModel: [
+            {
+              provider: "scripted",
+              model: "travel-planner-phase-4",
+              modelCalls: 2,
+              inputTokens: {
+                total: 256,
+                uncached: 256,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: {
+                total: 192,
+                text: 192,
+                reasoning: 0,
+              },
+              costMicrousd: 0,
             },
           ],
         },

--- a/packages/testing/test/durable-join.test.ts
+++ b/packages/testing/test/durable-join.test.ts
@@ -236,6 +236,7 @@ layer(testLayer)("DUR P5 joining/joined queued input (plan §2.5)", (it) => {
         "UserInputRecorded",
         "UserInputRecorded",
         "ModelResponseRecorded",
+        "RunCompleted",
         "SubmissionSettled",
         "SubmissionSettled",
       ]);

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -1,4 +1,3 @@
-import type { IdGenerator } from "@effect-agent/core";
 import {
   Agent,
   AgentPolicy,
@@ -10,7 +9,6 @@ import {
   type IdGenerator,
 } from "@effect-agent/core";
 import { COMPACTION_SUMMARY_PREFIX, ToolExecutionClass } from "@effect-agent/engine";
-import type { AdmissionConflict, FenceRejected, SettlementConflict } from "@effect-agent/session";
 import {
   AbortCommand,
   ApprovalDecisionCommand,
@@ -48,6 +46,7 @@ import {
   promptFromCanonicalRecords,
   replayConversation,
   recoveryRepairRecordId,
+  runCompletedRecordId,
   runIdForSubmission,
   submissionInputRecordId,
   submissionSettlementRecordId,
@@ -321,6 +320,50 @@ const corruptedCompletionBaseLayer = Layer.mergeAll(
 
 const corruptedCompletionTestLayer = DurableAgentRuntime.layer.pipe(
   Layer.provideMerge(corruptedCompletionBaseLayer),
+);
+
+const corruptRunDispositionEnvelope = (
+  envelope: CanonicalRecordEnvelope,
+): CanonicalRecordEnvelope => {
+  const payload = envelope.record.payload;
+  if (payload._tag !== "RunCompleted" || payload.runDisposition === undefined) return envelope;
+  return CanonicalRecordEnvelope.make({
+    ...envelope,
+    record: RecordEnvelope.make({
+      ...envelope.record,
+      payload: RunCompleted.make({
+        runId: payload.runId,
+        output: payload.output,
+        runDisposition: "hostile-replacement",
+        ...(payload.finishReason === undefined ? {} : { finishReason: payload.finishReason }),
+        ...(payload.exhausted === undefined ? {} : { exhausted: payload.exhausted }),
+      }),
+    }),
+  });
+};
+
+const corruptedRunDispositionStoreLayer = Layer.effect(
+  ConversationStore,
+  Effect.gen(function* () {
+    const inner = yield* ConversationStore;
+    return ConversationStore.of({
+      ...inner,
+      read: (request) => inner.read(request).pipe(Stream.map(corruptRunDispositionEnvelope)),
+    });
+  }),
+).pipe(Layer.provide(MemoryConversationStoreLive));
+
+const corruptedRunDispositionTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      MemorySubmissionLedgerLive,
+      corruptedRunDispositionStoreLayer,
+      WakeScheduler.layerNoop,
+      DurableRuntimeFailpoint.layerTest,
+      ToolReconciler.uncertain,
+      configLayer,
+    ).pipe(Layer.provideMerge(NodeCrypto.layer)),
+  ),
 );
 
 const pricedConfigLayer = DurableRuntimeConfig.layer({
@@ -1030,6 +1073,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
         "ModelResponseRecorded",
         "ToolCallSettled",
         "ModelResponseRecorded",
+        "RunCompleted",
         "SubmissionSettled",
       ]);
       expect(records.map((envelope) => envelope.record.recordId)).toEqual([
@@ -1038,6 +1082,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
         modelResponseRecordId(runId, 1),
         `tool-settled:${runId}:1:search-1`,
         modelResponseRecordId(runId, 2),
+        runCompletedRecordId(runId),
         submissionSettlementRecordId(submissionId),
       ]);
 
@@ -1119,6 +1164,49 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(decodedDisposition).toBe("application-complete");
         }
       }),
+  );
+
+  it.effect("recovers a canonically completed no-tool Turn without another model call", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel((call) =>
+        call === 0
+          ? finalParts('{"answer":"Committed once."}')
+          : finalParts('{"answer":"Wrong duplicate call."}'),
+      );
+      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const conversation = "conversation-final-turn-recovery";
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: "complete once?" },
+        submitOptions(conversation, "final-turn-recovery-1"),
+      );
+
+      yield* armFailpoint("turn:after-canonical-append");
+      const crashed = yield* Effect.exit(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      expect(scripted.prompts).toHaveLength(1);
+      yield* clearFailpoint;
+
+      const settled = yield* runtime.processConversation(agent, decodeConversationId(conversation));
+      expect(settled).toHaveLength(1);
+      expect(settled[0]?.outcome).toBe("completed");
+      expect(yield* runtime.awaitSettlement(receipt)).toEqual(settled[0]);
+      expect(scripted.prompts).toHaveLength(1);
+
+      const payloads = (yield* readLog(conversation)).map((envelope) => envelope.record.payload);
+      expect(payloads.filter((payload) => payload._tag === "ModelResponseRecorded")).toHaveLength(
+        1,
+      );
+      expect(payloads.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(1);
+      expect(payloads.at(-1)).toMatchObject({
+        _tag: "SubmissionSettled",
+        outcome: "completed",
+        result: { answer: "Committed once." },
+      });
+    }),
   );
 
   it.effect(
@@ -1429,6 +1517,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           "ToolCallSettled",
           "ToolCallSettled",
           "ModelResponseRecorded",
+          "RunCompleted",
           "SubmissionSettled",
         ]);
         // Exact synthetic settlements: identities in declaration order, each
@@ -2579,6 +2668,37 @@ layer(corruptedCompletionTestLayer)("RUN-032 recovered completion validation", (
       );
       expect(failureTag(recovered)).toBe("RunJournalError");
       expect(yield* Ref.get(handlerCalls)).toBe(1);
+      expect(scripted.prompts).toHaveLength(1);
+    }),
+  );
+});
+
+layer(corruptedRunDispositionTestLayer)("RUN-029 recovered run disposition validation", (it) => {
+  it.effect("rejects a marker whose disposition disagrees with its reconstructed output", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel(() =>
+        finalParts('{"answer":"done","runDisposition":"application-complete"}'),
+      );
+      const agent = Agent.withModel(dispositionDefinition, scripted.model);
+      const conversation = "conversation-hostile-run-disposition";
+
+      yield* runtime.submit(
+        agent,
+        { question: "validate disposition recovery" },
+        submitOptions(conversation, "hostile-run-disposition-1"),
+      );
+      yield* armFailpoint("turn:after-canonical-append");
+      const crashed = yield* Effect.exit(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      yield* clearFailpoint;
+
+      const recovered = yield* Effect.exit(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      expect(failureTag(recovered)).toBe("RunJournalError");
       expect(scripted.prompts).toHaveLength(1);
     }),
   );

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -1,3 +1,4 @@
+import type { IdGenerator } from "@effect-agent/core";
 import {
   Agent,
   AgentPolicy,
@@ -9,6 +10,7 @@ import {
   type IdGenerator,
 } from "@effect-agent/core";
 import { COMPACTION_SUMMARY_PREFIX, ToolExecutionClass } from "@effect-agent/engine";
+import type { AdmissionConflict, FenceRejected, SettlementConflict } from "@effect-agent/session";
 import {
   AbortCommand,
   ApprovalDecisionCommand,
@@ -260,6 +262,33 @@ const baseLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeCrypto.layer));
 
 const testLayer = DurableAgentRuntime.layer.pipe(Layer.provideMerge(baseLayer));
+
+const pricedConfigLayer = DurableRuntimeConfig.layer({
+  deploymentId: Schema.decodeSync(DeploymentId)("deployment-priced"),
+  producerId: Schema.decodeSync(ProducerId)("producer-priced"),
+  settlementPollInterval: Duration.millis(100),
+  leaseRenewalInterval: Duration.seconds(5),
+  abortPollInterval: Duration.millis(100),
+  estimateCostMicrousd: () =>
+    Effect.succeed({
+      costMicrousd: 1_200,
+      serviceTier: "priority",
+      pricingVersion: "prices-2026-08-24",
+    }),
+});
+
+const pricedTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      MemorySubmissionLedgerLive,
+      MemoryConversationStoreLive,
+      WakeScheduler.layerNoop,
+      DurableRuntimeFailpoint.layerTest,
+      ToolReconciler.uncertain,
+      pricedConfigLayer,
+    ).pipe(Layer.provideMerge(NodeCrypto.layer)),
+  ),
+);
 
 const untrustedSettlementLedgerLayer = Layer.effect(
   SubmissionLedger,
@@ -960,11 +989,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
         expect(settled.result).toEqual({ answer: "Found." });
       }
 
-      // The canonical journal alone rebuilds the exact model-visible prompt.
+      // A later Run sees conversational history without replaying this Run's
+      // evaluated instruction/input prefix.
       const prompt = yield* promptFromCanonicalRecords(records);
       expect(prompt.content.map((message) => message.role)).toEqual([
-        "system",
-        "user",
         "assistant",
         "tool",
         "assistant",
@@ -1030,6 +1058,181 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           const decodedDisposition = yield* Schema.decodeUnknownEffect(RunDisposition)(disposition);
           expect(decodedDisposition).toBe("application-complete");
         }
+      }),
+  );
+
+  it.effect(
+    "RUN-032 recovers a canonically settled completion Tool without another model call or side effect",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const PostMessage = Tool.make("post_message", {
+          parameters: Schema.Struct({ message: Schema.String }),
+          success: Schema.Struct({ messageId: Schema.String }),
+        });
+        const tools = Toolkit.make(PostMessage);
+        const definition = Agent.define("durable-terminal-delivery", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ messageId: Schema.String, delivered: Schema.Boolean }),
+          instructions: "Deliver through post_message.",
+          toolkit: tools,
+          policy: AgentPolicy.make({
+            maxTurns: 3,
+            maxToolCalls: 2,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ result }) => ({ messageId: result.messageId, delivered: true }),
+          },
+        });
+        const scripted = yield* makeScriptedModel((call) =>
+          call === 0
+            ? [
+                {
+                  type: "tool-call",
+                  id: "delivery-1",
+                  name: "post_message",
+                  params: { message: "Delivered once" },
+                  providerExecuted: false,
+                },
+                { type: "finish", reason: "tool-calls", usage },
+              ]
+            : finalParts('{"messageId":"wrong-second-call","delivered":false}'),
+        );
+        const handlerCalls = yield* Ref.make(0);
+        const toolLayer = tools.toLayer({
+          post_message: () =>
+            Ref.updateAndGet(handlerCalls, (count) => count + 1).pipe(
+              Effect.as({ messageId: "message-1" }),
+            ),
+        });
+        const agent = Agent.withModel(definition, scripted.model);
+        const conversation = "conversation-terminal-delivery-recovery";
+
+        yield* runtime.submit(
+          agent,
+          { question: "deliver?" },
+          submitOptions(conversation, "terminal-delivery-1"),
+        );
+        yield* armFailpoint("turn:after-results-append");
+        const crashed = yield* Effect.exit(
+          runtime
+            .processConversation(agent, decodeConversationId(conversation))
+            .pipe(Effect.provide(toolLayer)),
+        );
+        expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+        expect(yield* Ref.get(handlerCalls)).toBe(1);
+        expect(scripted.prompts).toHaveLength(1);
+        yield* clearFailpoint;
+
+        const settled = yield* runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer));
+        expect(settled).toHaveLength(1);
+        expect(settled[0]?.outcome).toBe("completed");
+        expect(yield* Ref.get(handlerCalls)).toBe(1);
+        expect(scripted.prompts).toHaveLength(1);
+        const payloads = (yield* readLog(conversation)).map((envelope) => envelope.record.payload);
+        expect(payloads.filter((payload) => payload._tag === "ModelResponseRecorded")).toHaveLength(
+          1,
+        );
+        expect(payloads.at(-1)).toMatchObject({
+          _tag: "SubmissionSettled",
+          outcome: "completed",
+          result: { messageId: "message-1", delivered: true },
+        });
+      }),
+  );
+
+  it.effect(
+    "RUN-032 resumes an over-token completion delivery under fail mode after the response commit",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const PostMessage = Tool.make("post_message", {
+          parameters: Schema.Struct({ message: Schema.String }),
+          success: Schema.Struct({ messageId: Schema.String }),
+        });
+        const tools = Toolkit.make(PostMessage);
+        const definition = Agent.define("durable-over-token-delivery", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ messageId: Schema.String, delivered: Schema.Boolean }),
+          instructions: "Deliver through post_message.",
+          toolkit: tools,
+          policy: AgentPolicy.make({
+            maxTurns: 3,
+            maxToolCalls: 2,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            tokenBudget: 1_000,
+            completionReserveTokens: 100,
+            onExhaustion: "fail",
+          }),
+          completion: {
+            tool: "post_message",
+            project: ({ result }) => ({ messageId: result.messageId, delivered: true }),
+          },
+        });
+        const scripted = yield* makeScriptedModel(() => [
+          {
+            type: "tool-call",
+            id: "over-token-delivery-1",
+            name: "post_message",
+            params: { message: "Delivered after recovery" },
+            providerExecuted: false,
+          },
+          {
+            type: "finish",
+            reason: "tool-calls",
+            usage: {
+              inputTokens: { total: 900 },
+              outputTokens: { total: 200 },
+            },
+          },
+        ]);
+        const handlerCalls = yield* Ref.make(0);
+        const toolLayer = tools.toLayer({
+          post_message: () =>
+            Ref.updateAndGet(handlerCalls, (count) => count + 1).pipe(
+              Effect.as({ messageId: "recovered-message-1" }),
+            ),
+        });
+        const agent = Agent.withModel(definition, scripted.model);
+        const conversation = "conversation-over-token-terminal-delivery";
+
+        yield* runtime.submit(
+          agent,
+          { question: "deliver?" },
+          submitOptions(conversation, "over-token-terminal-delivery-1"),
+        );
+        yield* armFailpoint("turn:after-response-append");
+        const crashed = yield* Effect.exit(
+          runtime
+            .processConversation(agent, decodeConversationId(conversation))
+            .pipe(Effect.provide(toolLayer)),
+        );
+        expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+        expect(yield* Ref.get(handlerCalls)).toBe(0);
+        expect(scripted.prompts).toHaveLength(1);
+        yield* clearFailpoint;
+
+        const settled = yield* runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer));
+        expect(settled).toHaveLength(1);
+        expect(settled[0]?.outcome).toBe("completed");
+        expect(yield* Ref.get(handlerCalls)).toBe(1);
+        expect(scripted.prompts).toHaveLength(1);
+        const payloads = (yield* readLog(conversation)).map((envelope) => envelope.record.payload);
+        expect(payloads.at(-1)).toMatchObject({
+          _tag: "SubmissionSettled",
+          outcome: "completed",
+          finishReason: "budget-exhausted",
+          exhausted: "tokens",
+          result: { messageId: "recovered-message-1", delivered: true },
+        });
       }),
   );
 
@@ -1211,13 +1414,10 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           });
         }
 
-        // The canonical journal alone rebuilds the exact model-visible prompt,
-        // rejected batch included: the tool message carries one failed result
-        // per rejected call in declaration order.
+        // A later Run sees the rejected batch as conversational history but
+        // not this Run's evaluated instruction/input prefix.
         const prompt = yield* promptFromCanonicalRecords(records);
         expect(prompt.content.map((message) => message.role)).toEqual([
-          "system",
-          "user",
           "assistant",
           "tool",
           "assistant",
@@ -2275,7 +2475,9 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
 
         // Submission 1: an ordinary tool Run leaves prior-Run records to cover.
         const first = yield* makeScriptedModel((call) =>
-          call === 0 ? toolCallParts : finalParts('{"answer":"Found the sea."}'),
+          call === 0
+            ? toolCallParts
+            : finalParts(JSON.stringify({ answer: `Found the sea. ${"PAD".repeat(1_000)}` })),
         );
         yield* runtime.submit(
           Agent.withModel(searchDefinition, first.model),
@@ -2303,7 +2505,7 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
             maxToolCalls: 2,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            contextTokenLimit: 50,
+            contextTokenLimit: 500,
             compaction: CompactionPolicy.make({ keepRecentTokens: 10, mode: "summarize" }),
           }),
         });
@@ -2395,7 +2597,7 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
         const probeLayer = probeTools.toLayer({
           probe: () =>
             Ref.getAndUpdate(calls, (count) => count + 1).pipe(
-              Effect.map((count) => (count === 0 ? "small" : "PAD".repeat(2_000))),
+              Effect.map((count) => (count === 0 ? "OLD".repeat(3_000) : "PAD".repeat(2_000))),
             ),
         });
         const prior = yield* makeScriptedModel((call) =>
@@ -2428,7 +2630,7 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
             maxToolCalls: 2,
             maxDuration: "30 seconds",
             toolConcurrency: 1,
-            contextTokenLimit: 50,
+            contextTokenLimit: 3_000,
             compaction: CompactionPolicy.make({ keepRecentTokens: 400, mode: "summarize" }),
           }),
         });
@@ -2479,7 +2681,9 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
 
       // Submission 1 leaves prior-Run records for the compactor to cover.
       const first = yield* makeScriptedModel((call) =>
-        call === 0 ? toolCallParts : finalParts('{"answer":"Found the sea."}'),
+        call === 0
+          ? toolCallParts
+          : finalParts(JSON.stringify({ answer: `Found the sea. ${"PAD".repeat(1_000)}` })),
       );
       yield* runtime.submit(
         Agent.withModel(searchDefinition, first.model),
@@ -2504,7 +2708,7 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
           maxToolCalls: 2,
           maxDuration: "30 seconds",
           toolConcurrency: 1,
-          contextTokenLimit: 50,
+          contextTokenLimit: 500,
           compaction: CompactionPolicy.make({ keepRecentTokens: 10, mode: "summarize" }),
         }),
       });
@@ -2557,14 +2761,14 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
           maxToolCalls: 2,
           maxDuration: "30 seconds",
           toolConcurrency: 1,
-          tokenBudget: 100,
+          tokenBudget: 1_000,
           onExhaustion: "fail",
         }),
       });
       const scripted = yield* makeScriptedModel((call) =>
         call === 0
-          ? toolCallPartsWithUsage(usageOf(90, 5))
-          : finalPartsWithUsage('{"answer":"cheap"}', usageOf(20, 5)),
+          ? toolCallPartsWithUsage(usageOf(900, 50))
+          : finalPartsWithUsage('{"answer":"cheap"}', usageOf(200, 50)),
       );
       const agent = Agent.withModel(reseedDefinition, scripted.model);
       yield* runtime.submit(
@@ -2587,9 +2791,9 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
       const settled = yield* runtime
         .processConversation(agent, decodeConversationId(conversation))
         .pipe(Effect.provide(searchToolLayer));
-      // 90+5 committed tokens re-seed the resumed Attempt; the 25-token Turn 2
-      // breaches the 100-token budget. Without re-seeding this Run would
-      // complete (25 < 100) — the failed settlement IS the re-seed proof.
+      // 950 committed tokens re-seed the resumed Attempt. The completion
+      // reserve is already unavailable, so recovery fails before another
+      // unconstrained model call; without re-seeding it would continue.
       expect(settled).toHaveLength(1);
       expect(settled[0]?.outcome).toBe("failed");
 
@@ -2603,8 +2807,8 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
       if (payload === undefined || payload._tag !== "ModelResponseRecorded") {
         throw new Error("expected the Turn 1 response record");
       }
-      expect(payload.inputTokens).toBe(90);
-      expect(payload.outputTokens).toBe(5);
+      expect(payload.inputTokens).toBe(900);
+      expect(payload.outputTokens).toBe(50);
     }),
   );
 });
@@ -2883,6 +3087,89 @@ layer(testLayer)("RUN-011 durable typed budget settlement", (it) => {
             result: { errorTag: "AgentPolicyError" },
           });
         }
+      }),
+  );
+});
+
+layer(pricedTestLayer)("RUN-035 durable cost accounting", (it) => {
+  it.effect(
+    "persists cache splits and pricing identity, enforces cost, and settles with usage",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const definition = Agent.define("durable-priced-usage", {
+          input: Schema.Struct({ question: Schema.String }),
+          output: Schema.Struct({ answer: Schema.String }),
+          instructions: "Answer immediately.",
+          toolkit: Toolkit.empty,
+          policy: AgentPolicy.make({
+            maxTurns: 3,
+            maxToolCalls: 2,
+            maxDuration: "30 seconds",
+            toolConcurrency: 1,
+            costBudgetMicrousd: 1_000,
+          }),
+        });
+        const meteredUsage = {
+          inputTokens: { total: 10, uncached: 7, cacheRead: 2, cacheWrite: 1 },
+          outputTokens: { total: 10, text: 6, reasoning: 4 },
+        };
+        const scripted = yield* makeScriptedModel(() => [
+          { type: "text-start", id: "answer" },
+          { type: "text-delta", id: "answer", delta: '{"answer":"priced"}' },
+          { type: "text-end", id: "answer" },
+          { type: "finish", reason: "stop", usage: meteredUsage },
+        ]);
+        const agent = Agent.withModel(definition, scripted.model);
+        const conversation = "conversation-priced-usage";
+
+        yield* runtime.submit(
+          agent,
+          { question: "cost?" },
+          submitOptions(conversation, "priced-usage-1"),
+        );
+        const settlements = yield* runtime.processConversation(
+          agent,
+          decodeConversationId(conversation),
+        );
+        const settlement = settlements[0];
+        expect(settlement?.outcome).toBe("failed");
+        expect(settlement?.usageSummary).toMatchObject({
+          modelCalls: 1,
+          inputTokens: meteredUsage.inputTokens,
+          outputTokens: meteredUsage.outputTokens,
+          costMicrousd: 1_200,
+          byModel: [
+            {
+              provider: "scripted",
+              model: "durable-test",
+              serviceTier: "priority",
+              pricingVersion: "prices-2026-08-24",
+              modelCalls: 1,
+            },
+          ],
+        });
+
+        const payloads = (yield* readLog(conversation)).map((envelope) => envelope.record.payload);
+        const response = payloads.find((payload) => payload._tag === "ModelResponseRecorded");
+        expect(response?.modelUsage).toEqual([
+          {
+            provider: "scripted",
+            model: "durable-test",
+            serviceTier: "priority",
+            pricingVersion: "prices-2026-08-24",
+            inputTokens: meteredUsage.inputTokens,
+            outputTokens: meteredUsage.outputTokens,
+            costMicrousd: 1_200,
+          },
+        ]);
+        const settled = payloads.at(-1);
+        expect(settled).toMatchObject({
+          _tag: "SubmissionSettled",
+          outcome: "failed",
+          policyLimit: "cost",
+          usageSummary: settlement?.usageSummary,
+        });
       }),
   );
 });

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -26,7 +26,9 @@ import {
   DurableRuntimeFailpointError,
   DurableRuntimeFailpointTestControl,
   IdempotencyKey,
+  ModelResponseRecorded,
   ObservationOffset,
+  PersistedJson,
   Principal,
   ProducerId,
   QueueSequence,
@@ -320,6 +322,76 @@ const corruptedCompletionBaseLayer = Layer.mergeAll(
 
 const corruptedCompletionTestLayer = DurableAgentRuntime.layer.pipe(
   Layer.provideMerge(corruptedCompletionBaseLayer),
+);
+
+const injectProviderExecutedCall = (messages: Schema.Json): Schema.Json => {
+  const prompt = Schema.decodeUnknownSync(Prompt.Prompt)(messages);
+  return Schema.decodeUnknownSync(PersistedJson)(
+    Schema.encodeSync(Prompt.Prompt)(
+      Prompt.fromMessages([
+        ...prompt.content,
+        Prompt.makeMessage("assistant", {
+          content: [
+            Prompt.makePart("tool-call", {
+              id: "hostile-provider-call",
+              name: "HostedSearch",
+              params: { query: "hidden" },
+              providerExecuted: true,
+            }),
+          ],
+        }),
+      ]),
+    ),
+  );
+};
+
+const injectProviderCallEnvelope = (envelope: CanonicalRecordEnvelope): CanonicalRecordEnvelope => {
+  const payload = envelope.record.payload;
+  if (payload._tag !== "ModelResponseRecorded") return envelope;
+  return CanonicalRecordEnvelope.make({
+    ...envelope,
+    record: RecordEnvelope.make({
+      ...envelope.record,
+      payload: ModelResponseRecorded.make({
+        runId: payload.runId,
+        turnId: payload.turnId,
+        turn: payload.turn,
+        messages: injectProviderExecutedCall(payload.messages),
+        messagesDigest: payload.messagesDigest,
+        ...(payload.runScopedPrefixLength === undefined
+          ? {}
+          : { runScopedPrefixLength: payload.runScopedPrefixLength }),
+        ...(payload.modelUsage === undefined ? {} : { modelUsage: payload.modelUsage }),
+        ...(payload.inputTokens === undefined ? {} : { inputTokens: payload.inputTokens }),
+        ...(payload.outputTokens === undefined ? {} : { outputTokens: payload.outputTokens }),
+        ...(payload.costMicrousd === undefined ? {} : { costMicrousd: payload.costMicrousd }),
+      }),
+    }),
+  });
+};
+
+const injectedProviderCallStoreLayer = Layer.effect(
+  ConversationStore,
+  Effect.gen(function* () {
+    const inner = yield* ConversationStore;
+    return ConversationStore.of({
+      ...inner,
+      read: (request) => inner.read(request).pipe(Stream.map(injectProviderCallEnvelope)),
+    });
+  }),
+).pipe(Layer.provide(MemoryConversationStoreLive));
+
+const injectedProviderCallTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      MemorySubmissionLedgerLive,
+      injectedProviderCallStoreLayer,
+      WakeScheduler.layerNoop,
+      DurableRuntimeFailpoint.layerTest,
+      ToolReconciler.uncertain,
+      configLayer,
+    ).pipe(Layer.provideMerge(NodeCrypto.layer)),
+  ),
 );
 
 const corruptRunDispositionEnvelope = (
@@ -2650,6 +2722,78 @@ layer(corruptedCompletionTestLayer)("RUN-032 recovered completion validation", (
         agent,
         { question: "validate delivery recovery" },
         submitOptions(conversation, "hostile-tool-completion-1"),
+      );
+      yield* armFailpoint("turn:after-results-append");
+      const crashed = yield* Effect.exit(
+        runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer)),
+      );
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      expect(yield* Ref.get(handlerCalls)).toBe(1);
+      yield* clearFailpoint;
+
+      const recovered = yield* Effect.exit(
+        runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer)),
+      );
+      expect(failureTag(recovered)).toBe("RunJournalError");
+      expect(yield* Ref.get(handlerCalls)).toBe(1);
+      expect(scripted.prompts).toHaveLength(1);
+    }),
+  );
+});
+
+layer(injectedProviderCallTestLayer)("RUN-032 recovered completion singleton validation", (it) => {
+  it.effect("rejects a completion marker mixed with a provider-executed Tool Call", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const PostMessage = Tool.make("post_message", {
+        parameters: Schema.Struct({ message: Schema.String }),
+        success: Schema.Struct({ messageId: Schema.String }),
+      });
+      const tools = Toolkit.make(PostMessage);
+      const definition = Agent.define("hostile-mixed-terminal-delivery", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: DeliveryCompletionOutput,
+        instructions: "Deliver through post_message.",
+        toolkit: tools,
+        policy: AgentPolicy.make({
+          maxTurns: 3,
+          maxToolCalls: 2,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+        completion: {
+          tool: "post_message",
+          project: ({ result }) => ({ messageId: result.messageId, delivered: true }),
+        },
+      });
+      const scripted = yield* makeScriptedModel(() => [
+        {
+          type: "tool-call",
+          id: "mixed-delivery-1",
+          name: "post_message",
+          params: { message: "canonical delivery" },
+          providerExecuted: false,
+        },
+        { type: "finish", reason: "tool-calls", usage },
+      ]);
+      const handlerCalls = yield* Ref.make(0);
+      const toolLayer = tools.toLayer({
+        post_message: () =>
+          Ref.updateAndGet(handlerCalls, (count) => count + 1).pipe(
+            Effect.as({ messageId: "canonical-message" }),
+          ),
+      });
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-hostile-mixed-tool-completion";
+
+      yield* runtime.submit(
+        agent,
+        { question: "validate singleton recovery" },
+        submitOptions(conversation, "hostile-mixed-tool-completion-1"),
       );
       yield* armFailpoint("turn:after-results-append");
       const crashed = yield* Effect.exit(

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -33,7 +33,9 @@ import {
   ProducerId,
   QueueSequence,
   Receipt,
+  RecordEnvelope,
   RecoverySnapshotRequest,
+  RunCompleted,
   Settlement,
   SubmissionLedger,
   SubmissionLookupById,
@@ -262,6 +264,64 @@ const baseLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeCrypto.layer));
 
 const testLayer = DurableAgentRuntime.layer.pipe(Layer.provideMerge(baseLayer));
+
+const AnswerCompletionOutput = Schema.Struct({ answer: Schema.String });
+const DeliveryCompletionOutput = Schema.Struct({
+  messageId: Schema.String,
+  delivered: Schema.Boolean,
+});
+const isAnswerCompletionOutput = Schema.is(AnswerCompletionOutput);
+const isDeliveryCompletionOutput = Schema.is(DeliveryCompletionOutput);
+
+const corruptCompletionOutput = (output: Schema.Json): Schema.Json => {
+  if (isAnswerCompletionOutput(output)) return { answer: "hostile replacement" };
+  if (isDeliveryCompletionOutput(output)) {
+    return { messageId: "hostile-replacement", delivered: output.delivered };
+  }
+  return output;
+};
+
+const corruptCompletionEnvelope = (envelope: CanonicalRecordEnvelope): CanonicalRecordEnvelope => {
+  const payload = envelope.record.payload;
+  if (payload._tag !== "RunCompleted") return envelope;
+  return CanonicalRecordEnvelope.make({
+    ...envelope,
+    record: RecordEnvelope.make({
+      ...envelope.record,
+      payload: RunCompleted.make({
+        runId: payload.runId,
+        output: corruptCompletionOutput(payload.output),
+        ...(payload.runDisposition === undefined ? {} : { runDisposition: payload.runDisposition }),
+        ...(payload.finishReason === undefined ? {} : { finishReason: payload.finishReason }),
+        ...(payload.exhausted === undefined ? {} : { exhausted: payload.exhausted }),
+      }),
+    }),
+  });
+};
+
+const corruptedCompletionStoreLayer = Layer.effect(
+  ConversationStore,
+  Effect.gen(function* () {
+    const inner = yield* ConversationStore;
+    return ConversationStore.of({
+      ...inner,
+      read: (request) => inner.read(request).pipe(Stream.map(corruptCompletionEnvelope)),
+    });
+  }),
+).pipe(Layer.provide(MemoryConversationStoreLive));
+
+const corruptedCompletionBaseLayer = Layer.mergeAll(
+  MemorySubmissionLedgerLive,
+  corruptedCompletionStoreLayer,
+  WakeScheduler.layerNoop,
+  DurableRuntimeFailpoint.layerTest,
+  ToolReconciler.uncertain,
+  configLayer,
+).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const corruptedCompletionTestLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(corruptedCompletionBaseLayer),
+);
 
 const pricedConfigLayer = DurableRuntimeConfig.layer({
   deploymentId: Schema.decodeSync(DeploymentId)("deployment-priced"),
@@ -2423,6 +2483,105 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
       }),
     );
   });
+});
+
+layer(corruptedCompletionTestLayer)("RUN-032 recovered completion validation", (it) => {
+  it.effect("rejects a no-Tool marker whose output disagrees with its canonical response", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"canonical"}'));
+      const agent = Agent.withModel(plannerDefinition, scripted.model);
+      const conversation = "conversation-hostile-no-tool-completion";
+
+      yield* runtime.submit(
+        agent,
+        { question: "validate recovery" },
+        submitOptions(conversation, "hostile-no-tool-completion-1"),
+      );
+      yield* armFailpoint("turn:after-canonical-append");
+      const crashed = yield* Effect.exit(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      yield* clearFailpoint;
+
+      const recovered = yield* Effect.exit(
+        runtime.processConversation(agent, decodeConversationId(conversation)),
+      );
+      expect(failureTag(recovered)).toBe("RunJournalError");
+      expect(scripted.prompts).toHaveLength(1);
+    }),
+  );
+
+  it.effect("rejects a completion-Tool marker that disagrees with its canonical result", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const PostMessage = Tool.make("post_message", {
+        parameters: Schema.Struct({ message: Schema.String }),
+        success: Schema.Struct({ messageId: Schema.String }),
+      });
+      const tools = Toolkit.make(PostMessage);
+      const definition = Agent.define("hostile-terminal-delivery", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: DeliveryCompletionOutput,
+        instructions: "Deliver through post_message.",
+        toolkit: tools,
+        policy: AgentPolicy.make({
+          maxTurns: 3,
+          maxToolCalls: 2,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+        completion: {
+          tool: "post_message",
+          project: ({ result }) => ({ messageId: result.messageId, delivered: true }),
+        },
+      });
+      const scripted = yield* makeScriptedModel(() => [
+        {
+          type: "tool-call",
+          id: "hostile-delivery-1",
+          name: "post_message",
+          params: { message: "canonical delivery" },
+          providerExecuted: false,
+        },
+        { type: "finish", reason: "tool-calls", usage },
+      ]);
+      const handlerCalls = yield* Ref.make(0);
+      const toolLayer = tools.toLayer({
+        post_message: () =>
+          Ref.updateAndGet(handlerCalls, (count) => count + 1).pipe(
+            Effect.as({ messageId: "canonical-message" }),
+          ),
+      });
+      const agent = Agent.withModel(definition, scripted.model);
+      const conversation = "conversation-hostile-tool-completion";
+
+      yield* runtime.submit(
+        agent,
+        { question: "validate delivery recovery" },
+        submitOptions(conversation, "hostile-tool-completion-1"),
+      );
+      yield* armFailpoint("turn:after-results-append");
+      const crashed = yield* Effect.exit(
+        runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer)),
+      );
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      expect(yield* Ref.get(handlerCalls)).toBe(1);
+      yield* clearFailpoint;
+
+      const recovered = yield* Effect.exit(
+        runtime
+          .processConversation(agent, decodeConversationId(conversation))
+          .pipe(Effect.provide(toolLayer)),
+      );
+      expect(failureTag(recovered)).toBe("RunJournalError");
+      expect(yield* Ref.get(handlerCalls)).toBe(1);
+      expect(scripted.prompts).toHaveLength(1);
+    }),
+  );
 });
 
 layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -1147,7 +1147,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
   );
 
   it.effect(
-    "RUN-032 resumes an over-token completion delivery under fail mode after the response commit",
+    "RUN-032 resumes an over-token completion delivery under final-answer mode after the response commit",
     () =>
       Effect.gen(function* () {
         const runtime = yield* DurableAgentRuntime;
@@ -1168,7 +1168,6 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
             toolConcurrency: 1,
             tokenBudget: 1_000,
             completionReserveTokens: 100,
-            onExhaustion: "fail",
           }),
           completion: {
             tool: "post_message",

--- a/packages/testing/test/durable-tools.test.ts
+++ b/packages/testing/test/durable-tools.test.ts
@@ -39,7 +39,6 @@ import {
   runIdForSubmission,
   toolCallPreparedRecordId,
   toolStepSettledRecordId,
-  type CanonicalRecordEnvelope,
   type DurableRuntimeFailpointLocation,
   type DurableSubmitOptions,
   type PreparedToolCallEvidence,
@@ -468,6 +467,7 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
         "ToolCallPrepared",
         "ToolCallSettled",
         "ModelResponseRecorded",
+        "RunCompleted",
         "SubmissionSettled",
       ]);
       const byId = new Map(
@@ -530,6 +530,7 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
         "ModelResponseRecorded",
         "ToolCallSettled",
         "ModelResponseRecorded",
+        "RunCompleted",
         "SubmissionSettled",
       ]);
       // The response/results split still applies (application calls exist), only preparation

--- a/packages/testing/test/durable-tools.test.ts
+++ b/packages/testing/test/durable-tools.test.ts
@@ -39,6 +39,7 @@ import {
   runIdForSubmission,
   toolCallPreparedRecordId,
   toolStepSettledRecordId,
+  type CanonicalRecordEnvelope,
   type DurableRuntimeFailpointLocation,
   type DurableSubmitOptions,
   type PreparedToolCallEvidence,
@@ -488,11 +489,10 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
         expect(prepared.toolName).toBe("book");
       }
 
-      // The canonical journal alone still rebuilds the exact model-visible prompt.
+      // The canonical journal rebuilds the next-Run prompt without replaying the prior Run's
+      // instruction and wake prefix.
       const prompt = yield* promptFromCanonicalRecords(records);
       expect(prompt.content.map((message) => message.role)).toEqual([
-        "system",
-        "user",
         "assistant",
         "tool",
         "assistant",
@@ -1082,11 +1082,10 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
         ).toHaveLength(2);
 
         // The audit tags stay prompt-transparent: the journal replays one contiguous tool
-        // message for the Turn regardless of the late per-call settles.
+        // message for the Turn regardless of the late per-call settles, while omitting the
+        // prior Run's instruction and wake prefix.
         const prompt = yield* promptFromCanonicalRecords(records);
         expect(prompt.content.map((message) => message.role)).toEqual([
-          "system",
-          "user",
           "assistant",
           "tool",
           "assistant",
@@ -1455,8 +1454,6 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
       ).toHaveLength(1);
       const prompt = yield* promptFromCanonicalRecords(records);
       expect(prompt.content.map((message) => message.role)).toEqual([
-        "system",
-        "user",
         "assistant",
         "tool",
         "assistant",

--- a/packages/testing/test/travel-planner-phase4.test.ts
+++ b/packages/testing/test/travel-planner-phase4.test.ts
@@ -136,6 +136,7 @@ const RUN_TAGS = [
   "ToolCallSettled",
   "ToolCallSettled",
   "ModelResponseRecorded",
+  "RunCompleted",
 ] as const;
 
 describe("TEST-014 P4 durable Travel Planner profile (DN) — supplier booking is NOT claimed safely replayable (P5 scope)", () => {

--- a/packages/testing/test/travel-planner-phase5.test.ts
+++ b/packages/testing/test/travel-planner-phase5.test.ts
@@ -1156,6 +1156,7 @@ describe("TEST-014 P5 Travel Planner on the DN SQLite assembly", () => {
             "ToolStepSettled",
             "ToolCallSettled",
             "ModelResponseRecorded",
+            "RunCompleted",
             "SubmissionSettled",
           ]);
 

--- a/packages/testing/test/travel-planner-phase5.test.ts
+++ b/packages/testing/test/travel-planner-phase5.test.ts
@@ -1177,12 +1177,10 @@ describe("TEST-014 P5 Travel Planner on the DN SQLite assembly", () => {
             ).toBe(1);
           }
 
-          // The canonical journal alone rebuilds the model-visible prompt (encoded params are
-          // Prompt-valid, the P4 Struct workaround is unnecessary).
+          // The canonical journal rebuilds the next-Run prompt without the prior instruction/wake
+          // prefix (encoded params remain Prompt-valid; the P4 Struct workaround is unnecessary).
           const prompt = yield* promptFromCanonicalRecords(records);
           expect(prompt.content.map((message) => message.role)).toEqual([
-            "system",
-            "user",
             "assistant",
             "tool",
             "assistant",

--- a/packages/testing/test/travel-planner.compile.test.ts
+++ b/packages/testing/test/travel-planner.compile.test.ts
@@ -4,6 +4,7 @@ import {
   type AgentInputError,
   type AgentOutputError,
   type AgentPolicyError,
+  type ContextBudgetError,
   type ContextOverflowError,
   type IdGenerator,
   type ModelProtocolError,
@@ -62,6 +63,7 @@ type ExpectedFailure =
   | AgentInputError
   | AgentOutputError
   | AgentPolicyError
+  | ContextBudgetError
   | ContextOverflowError
   | ModelProtocolError
   | AgentApprovalDenied

--- a/packages/testing/test/travel-planner.compile.test.ts
+++ b/packages/testing/test/travel-planner.compile.test.ts
@@ -9,6 +9,7 @@ import {
   type IdGenerator,
   type ModelProtocolError,
   Agent,
+  AgentPolicy,
   type AgentToolAuthorizationDenied,
 } from "@effect-agent/core";
 import {
@@ -17,8 +18,9 @@ import {
   type AgentRuntimeFailure,
   type AgentRuntimeRequirements,
 } from "@effect-agent/engine";
-import { type Effect, type Scope } from "effect";
-import { type AiError, Model, type Tool, type Toolkit } from "effect/unstable/ai";
+import type { DurableWorkerRequirements } from "@effect-agent/session";
+import { Context, Effect, Schema, SchemaGetter, type Scope } from "effect";
+import { type AiError, Model, Tool, Toolkit } from "effect/unstable/ai";
 import { describe, expect, it } from "vite-plus/test";
 
 import type {
@@ -45,6 +47,42 @@ type Assert<Value extends true> = Value;
 const model = Model.make("scripted", "travel-planner-type-proof", ScriptedModel.layer([]));
 const agent = Agent.withModel(TravelPlanner, model);
 const program = AgentRuntime.run(agent, phase1Trip);
+
+class CompletionResultDecoder extends Context.Service<
+  CompletionResultDecoder,
+  { readonly validate: (value: string) => string }
+>()("@effect-agent/testing/CompletionResultDecoder") {}
+
+const ContextualCompletionResult = Schema.String.pipe(
+  Schema.decode({
+    decode: SchemaGetter.transformOrFail((value) =>
+      Effect.map(CompletionResultDecoder, ({ validate }) => validate(value)),
+    ),
+    encode: SchemaGetter.transform((value) => value),
+  }),
+);
+const Complete = Tool.make("complete", {
+  parameters: Schema.Struct({ answer: Schema.String }),
+  success: ContextualCompletionResult,
+});
+const completionToolkit = Toolkit.make(Complete);
+const completionDefinition = Agent.define("completion-requirements-proof", {
+  input: Schema.Struct({ question: Schema.String }),
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: "Complete through the Tool.",
+  toolkit: completionToolkit,
+  policy: AgentPolicy.make({
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+  completion: {
+    tool: "complete",
+    project: ({ result }) => ({ answer: result }),
+  },
+});
+const completionAgent = Agent.withModel(completionDefinition, model);
 
 type ExpectedRequirements =
   | FlightCatalog
@@ -77,6 +115,12 @@ type PublicRequirementsProof = Assert<
   Equal<AgentRuntimeRequirements<typeof agent> | Scope.Scope, ExpectedRequirements>
 >;
 type PublicFailureProof = Assert<Equal<AgentRuntimeFailure<typeof agent>, ExpectedFailure>>;
+type CompletionRuntimeRequirementsProof = Assert<
+  CompletionResultDecoder extends AgentRuntimeRequirements<typeof completionAgent> ? true : false
+>;
+type CompletionDurableRequirementsProof = Assert<
+  CompletionResultDecoder extends DurableWorkerRequirements<typeof completionAgent> ? true : false
+>;
 
 describe("TEST-009 P1 Travel Planner public-contract inference", () => {
   it("preserves Tool and instruction failures and requirements in Run E/R", () => {
@@ -84,17 +128,23 @@ describe("TEST-009 P1 Travel Planner public-contract inference", () => {
     const failureProof: FailureProof = true;
     const publicRequirementsProof: PublicRequirementsProof = true;
     const publicFailureProof: PublicFailureProof = true;
+    const completionRuntimeRequirementsProof: CompletionRuntimeRequirementsProof = true;
+    const completionDurableRequirementsProof: CompletionDurableRequirementsProof = true;
 
     expect({
       requirementsProof,
       failureProof,
       publicRequirementsProof,
       publicFailureProof,
+      completionRuntimeRequirementsProof,
+      completionDurableRequirementsProof,
     }).toEqual({
       requirementsProof: true,
       failureProof: true,
       publicRequirementsProof: true,
       publicFailureProof: true,
+      completionRuntimeRequirementsProof: true,
+      completionDurableRequirementsProof: true,
     });
   });
 });

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -35307,14 +35307,25 @@ class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsag
   costMicrousd: exports_Schema.Natural
 }) {
 }
-
-class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")({
+var RunUsageSummaryFields = exports_Schema.Struct({
   modelCalls: exports_Schema.Natural,
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: exports_Schema.Natural,
   byModel: exports_Schema.Array(ModelUsageGroup)
-}) {
+}).check(exports_Schema.makeFilter((summary2) => {
+  const identities = summary2.byModel.map((group2) => JSON.stringify([
+    group2.provider,
+    group2.model,
+    group2.serviceTier ?? null,
+    group2.pricingVersion ?? null
+  ]));
+  return new Set(identities).size === identities.length && hasAdditiveTotal(summary2.modelCalls, summary2.byModel.map((group2) => group2.modelCalls)) && hasAdditiveTotal(summary2.inputTokens.total, summary2.byModel.map((group2) => group2.inputTokens.total)) && hasAdditiveTotal(summary2.inputTokens.uncached, summary2.byModel.map((group2) => group2.inputTokens.uncached)) && hasAdditiveTotal(summary2.inputTokens.cacheRead, summary2.byModel.map((group2) => group2.inputTokens.cacheRead)) && hasAdditiveTotal(summary2.inputTokens.cacheWrite, summary2.byModel.map((group2) => group2.inputTokens.cacheWrite)) && hasAdditiveTotal(summary2.outputTokens.total, summary2.byModel.map((group2) => group2.outputTokens.total)) && hasAdditiveTotal(summary2.outputTokens.text, summary2.byModel.map((group2) => group2.outputTokens.text)) && hasAdditiveTotal(summary2.outputTokens.reasoning, summary2.byModel.map((group2) => group2.outputTokens.reasoning)) && hasAdditiveTotal(summary2.costMicrousd, summary2.byModel.map((group2) => group2.costMicrousd));
+}, {
+  title: "Run usage totals equal unique per-model pricing groups within safe-integer accounting"
+}));
+
+class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")(RunUsageSummaryFields) {
 }
 var emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
 var emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
@@ -38091,11 +38102,26 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
   const reportedText = providerUsage.outputTokens.text ?? 0;
   const reasoning = providerUsage.outputTokens.reasoning ?? 0;
   const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
-  const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+  const reportedInputTotal = providerUsage.inputTokens.total;
+  const allInputComponentsReported = providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite !== undefined;
+  if (reportedInputTotal !== undefined && (reportedInputTotal < reportedInputComponents || allInputComponentsReported && reportedInputTotal !== reportedInputComponents)) {
+    return yield* invalidProviderUsage();
+  }
+  const inputTokens = reportedInputTotal ?? reportedInputComponents;
   const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
-  const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
-  const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
-  const text2 = Math.max(reportedText, outputTokens - reasoning);
+  const reportedOutputTotal = providerUsage.outputTokens.total;
+  const allOutputComponentsReported = providerUsage.outputTokens.text !== undefined && providerUsage.outputTokens.reasoning !== undefined;
+  if (reportedOutputTotal !== undefined && (reportedOutputTotal < reportedOutputComponents || allOutputComponentsReported && reportedOutputTotal !== reportedOutputComponents)) {
+    return yield* invalidProviderUsage();
+  }
+  const outputTokens = reportedOutputTotal ?? reportedOutputComponents;
+  const inputRemainder = inputTokens - reportedInputComponents;
+  const outputRemainder = outputTokens - reportedOutputComponents;
+  const uncached = reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+  const normalizedCacheRead = cacheRead + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead === undefined ? inputRemainder : 0);
+  const normalizedCacheWrite = cacheWrite + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite === undefined ? inputRemainder : 0);
+  const text2 = reportedText + (providerUsage.outputTokens.text === undefined ? outputRemainder : 0);
+  const normalizedReasoning = reasoning + (providerUsage.outputTokens.text !== undefined && providerUsage.outputTokens.reasoning === undefined ? outputRemainder : 0);
   const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
   const provider = yield* exports_Model.ProviderName;
   const model = yield* exports_Model.ModelName;
@@ -38124,10 +38150,14 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
     inputTokens: InputTokenUsage.make({
       total: inputTokens,
       uncached,
-      cacheRead,
-      cacheWrite
+      cacheRead: normalizedCacheRead,
+      cacheWrite: normalizedCacheWrite
     }),
-    outputTokens: OutputTokenUsage.make({ total: outputTokens, text: text2, reasoning }),
+    outputTokens: OutputTokenUsage.make({
+      total: outputTokens,
+      text: text2,
+      reasoning: normalizedReasoning
+    }),
     costMicrousd
   });
   const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
@@ -40063,6 +40093,8 @@ var makeAgentSpawner = (parent, depth) => ({
   spawn: spawnWithParent(parent, depth)
 });
 var AgentRuntime = {
+  decodeFinalOutput,
+  projectCompletionOutput,
   run: run4,
   start,
   stream: stream3

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -37974,6 +37974,23 @@ var outgoingModelPrompt = (policy2, context3, prepared, turn, declaredToolCalls)
     })
   ]);
 });
+var ProviderUsage = exports_Schema.Struct({
+  inputTokens: exports_Schema.Struct({
+    uncached: exports_Schema.optional(exports_Schema.Natural),
+    total: exports_Schema.optional(exports_Schema.Natural),
+    cacheRead: exports_Schema.optional(exports_Schema.Natural),
+    cacheWrite: exports_Schema.optional(exports_Schema.Natural)
+  }),
+  outputTokens: exports_Schema.Struct({
+    total: exports_Schema.optional(exports_Schema.Natural),
+    text: exports_Schema.optional(exports_Schema.Natural),
+    reasoning: exports_Schema.optional(exports_Schema.Natural)
+  })
+});
+var invalidProviderUsage = () => ModelProtocolError.make({
+  message: "Model response usage fields and derived totals must be non-negative safe integers"
+});
+var decodeProviderUsageTotal = (value4) => exports_Schema.decodeUnknownEffect(exports_Schema.Natural)(value4).pipe(exports_Effect.mapError(() => invalidProviderUsage()));
 var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => exports_Effect.gen(function* () {
   if (usage2 === undefined) {
     return yield* AgentPolicyError.make({
@@ -37981,22 +37998,24 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
       message: "A completed model response did not report usage"
     });
   }
-  const natural = (value4) => value4 === undefined || !Number.isSafeInteger(value4) ? 0 : Math.max(0, value4);
-  const reportedUncached = natural(usage2.inputTokens.uncached);
-  const cacheRead = natural(usage2.inputTokens.cacheRead);
-  const cacheWrite = natural(usage2.inputTokens.cacheWrite);
-  const reportedText = natural(usage2.outputTokens.text);
-  const reasoning = natural(usage2.outputTokens.reasoning);
-  const inputTokens = Math.max(natural(usage2.inputTokens.total), reportedUncached + cacheRead + cacheWrite);
-  const outputTokens = Math.max(natural(usage2.outputTokens.total), reportedText + reasoning);
+  const providerUsage = yield* exports_Schema.decodeUnknownEffect(ProviderUsage)(usage2).pipe(exports_Effect.mapError(() => invalidProviderUsage()));
+  const reportedUncached = providerUsage.inputTokens.uncached ?? 0;
+  const cacheRead = providerUsage.inputTokens.cacheRead ?? 0;
+  const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
+  const reportedText = providerUsage.outputTokens.text ?? 0;
+  const reasoning = providerUsage.outputTokens.reasoning ?? 0;
+  const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
+  const inputTokens = Math.max(providerUsage.inputTokens.total ?? 0, reportedInputComponents);
+  const reportedOutputComponents = yield* decodeProviderUsageTotal(reportedText + reasoning);
+  const outputTokens = Math.max(providerUsage.outputTokens.total ?? 0, reportedOutputComponents);
   const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
   const text2 = Math.max(reportedText, outputTokens - reasoning);
-  const totalTokens = inputTokens + outputTokens;
+  const totalTokens = yield* decodeProviderUsageTotal(inputTokens + outputTokens);
   const provider = yield* exports_Model.ProviderName;
   const model = yield* exports_Model.ModelName;
   const estimate = options3.estimateCostMicrousd === undefined ? 0 : yield* options3.estimateCostMicrousd(usage2, { provider, model, usage: usage2 });
   const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
-  if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
+  if (!Number.isSafeInteger(costMicrousd) || costMicrousd < 0) {
     return yield* AgentPolicyError.make({
       limit: "cost",
       message: "Model cost estimation must produce a non-negative integer number of microdollars"
@@ -38025,9 +38044,12 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
     outputTokens: OutputTokenUsage.make({ total: outputTokens, text: text2, reasoning }),
     costMicrousd
   });
-  context3.modelCalls += 1;
-  context3.inputTokens += inputTokens;
-  context3.outputTokens += outputTokens;
+  const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
+  const cumulativeInputTokens = yield* decodeProviderUsageTotal(context3.inputTokens + inputTokens);
+  const cumulativeOutputTokens = yield* decodeProviderUsageTotal(context3.outputTokens + outputTokens);
+  context3.modelCalls = modelCalls;
+  context3.inputTokens = cumulativeInputTokens;
+  context3.outputTokens = cumulativeOutputTokens;
   context3.lastInputTokens = inputTokens;
   context3.lastOutputTokens = outputTokens;
   context3.costMicrousd += costMicrousd;
@@ -38943,7 +38965,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
     }
     const toolCalls = priorToolCalls + trace3.toolCalls.size;
     const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-    if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
+    if (overToolBudget && policy2.onExhaustion === "fail") {
       return failRunEventStream(AgentPolicyError.make({
         limit: "tool-calls",
         message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
@@ -39050,8 +39072,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
         }));
       }
       const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      const completionTurnAllowed = completionBatch;
-      if (turnsBlocked && !completionTurnAllowed) {
+      if (turnsBlocked) {
         return failRunEventStream(AgentPolicyError.make({
           limit: "turns",
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
@@ -39275,15 +39296,14 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options3) => exports_Str
   const bounds = effectiveRunBounds(policy2, options3);
   const toolCalls = trace3.toolCalls.size;
   const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-  if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
+  if (overToolBudget && policy2.onExhaustion === "fail") {
     return failRunEventStream(AgentPolicyError.make({
       limit: "tool-calls",
       message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
     }));
   }
   const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-  const completionTurnAllowed = completionBatch;
-  if (turnsBlocked && !completionTurnAllowed) {
+  if (turnsBlocked) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "turns",
       message: `Agent exceeded its ${bounds.maxTurns} Turn limit`

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -35261,20 +35261,28 @@ class IdGenerator2 extends exports_Context.Service()("@effect-agent/core/IdGener
 }
 // packages/core/src/usage.ts
 var UsageIdentity = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
-
-class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")({
+var hasAdditiveTotal = (total, components) => {
+  const sum3 = components.reduce((accumulator, component) => accumulator + component, 0);
+  return Number.isSafeInteger(sum3) && total === sum3;
+};
+var InputTokenUsageFields = exports_Schema.Struct({
   total: exports_Schema.Natural,
   uncached: exports_Schema.Natural,
   cacheRead: exports_Schema.Natural,
   cacheWrite: exports_Schema.Natural
-}) {
-}
+}).check(exports_Schema.makeFilter((usage) => hasAdditiveTotal(usage.total, [usage.uncached, usage.cacheRead, usage.cacheWrite]), { title: "Input token total equals uncached, cache-read, and cache-write components" }));
 
-class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")({
+class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")(InputTokenUsageFields) {
+}
+var OutputTokenUsageFields = exports_Schema.Struct({
   total: exports_Schema.Natural,
   text: exports_Schema.Natural,
   reasoning: exports_Schema.Natural
-}) {
+}).check(exports_Schema.makeFilter((usage) => hasAdditiveTotal(usage.total, [usage.text, usage.reasoning]), {
+  title: "Output token total equals text and reasoning components"
+}));
+
+class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")(OutputTokenUsageFields) {
 }
 
 class ModelCallUsage extends exports_Schema.Class("@effect-agent/core/ModelCallUsage")({
@@ -35308,6 +35316,84 @@ class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageS
   byModel: exports_Schema.Array(ModelUsageGroup)
 }) {
 }
+var emptyInputTokens = () => ({ total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 });
+var emptyOutputTokens = () => ({ total: 0, text: 0, reasoning: 0 });
+
+class UsageAggregationError extends exports_Schema.TaggedError()("UsageAggregationError", {
+  field: exports_Schema.NonEmptyString,
+  message: exports_Schema.String
+}) {
+}
+var checkedAdd = (field, left, right) => {
+  const total = left + right;
+  return Number.isSafeInteger(left) && left >= 0 && Number.isSafeInteger(right) && right >= 0 && Number.isSafeInteger(total) ? exports_Effect.succeed(total) : exports_Effect.fail(UsageAggregationError.make({
+    field,
+    message: `Canonical usage aggregation exceeded the safe-integer range at ${field}`
+  }));
+};
+var summarizeModelUsage = exports_Effect.fn("summarizeModelUsage")(function* (calls) {
+  const inputTokens = emptyInputTokens();
+  const outputTokens = emptyOutputTokens();
+  const groups = new Map;
+  let modelCalls = 0;
+  let costMicrousd = 0;
+  for (const call of calls) {
+    modelCalls = yield* checkedAdd("modelCalls", modelCalls, 1);
+    inputTokens.total = yield* checkedAdd("inputTokens.total", inputTokens.total, call.inputTokens.total);
+    inputTokens.uncached = yield* checkedAdd("inputTokens.uncached", inputTokens.uncached, call.inputTokens.uncached);
+    inputTokens.cacheRead = yield* checkedAdd("inputTokens.cacheRead", inputTokens.cacheRead, call.inputTokens.cacheRead);
+    inputTokens.cacheWrite = yield* checkedAdd("inputTokens.cacheWrite", inputTokens.cacheWrite, call.inputTokens.cacheWrite);
+    outputTokens.total = yield* checkedAdd("outputTokens.total", outputTokens.total, call.outputTokens.total);
+    outputTokens.text = yield* checkedAdd("outputTokens.text", outputTokens.text, call.outputTokens.text);
+    outputTokens.reasoning = yield* checkedAdd("outputTokens.reasoning", outputTokens.reasoning, call.outputTokens.reasoning);
+    costMicrousd = yield* checkedAdd("costMicrousd", costMicrousd, call.costMicrousd);
+    const key = JSON.stringify([
+      call.provider,
+      call.model,
+      call.serviceTier ?? null,
+      call.pricingVersion ?? null
+    ]);
+    let group2 = groups.get(key);
+    if (group2 === undefined) {
+      group2 = {
+        provider: call.provider,
+        model: call.model,
+        ...call.serviceTier === undefined ? {} : { serviceTier: call.serviceTier },
+        ...call.pricingVersion === undefined ? {} : { pricingVersion: call.pricingVersion },
+        modelCalls: 0,
+        inputTokens: emptyInputTokens(),
+        outputTokens: emptyOutputTokens(),
+        costMicrousd: 0
+      };
+      groups.set(key, group2);
+    }
+    group2.modelCalls = yield* checkedAdd("byModel.modelCalls", group2.modelCalls, 1);
+    group2.inputTokens.total = yield* checkedAdd("byModel.inputTokens.total", group2.inputTokens.total, call.inputTokens.total);
+    group2.inputTokens.uncached = yield* checkedAdd("byModel.inputTokens.uncached", group2.inputTokens.uncached, call.inputTokens.uncached);
+    group2.inputTokens.cacheRead = yield* checkedAdd("byModel.inputTokens.cacheRead", group2.inputTokens.cacheRead, call.inputTokens.cacheRead);
+    group2.inputTokens.cacheWrite = yield* checkedAdd("byModel.inputTokens.cacheWrite", group2.inputTokens.cacheWrite, call.inputTokens.cacheWrite);
+    group2.outputTokens.total = yield* checkedAdd("byModel.outputTokens.total", group2.outputTokens.total, call.outputTokens.total);
+    group2.outputTokens.text = yield* checkedAdd("byModel.outputTokens.text", group2.outputTokens.text, call.outputTokens.text);
+    group2.outputTokens.reasoning = yield* checkedAdd("byModel.outputTokens.reasoning", group2.outputTokens.reasoning, call.outputTokens.reasoning);
+    group2.costMicrousd = yield* checkedAdd("byModel.costMicrousd", group2.costMicrousd, call.costMicrousd);
+  }
+  return RunUsageSummary.make({
+    modelCalls,
+    inputTokens: InputTokenUsage.make(inputTokens),
+    outputTokens: OutputTokenUsage.make(outputTokens),
+    costMicrousd,
+    byModel: [...groups.values()].map((group2) => ModelUsageGroup.make({
+      provider: group2.provider,
+      model: group2.model,
+      ...group2.serviceTier === undefined ? {} : { serviceTier: group2.serviceTier },
+      ...group2.pricingVersion === undefined ? {} : { pricingVersion: group2.pricingVersion },
+      modelCalls: group2.modelCalls,
+      inputTokens: InputTokenUsage.make(group2.inputTokens),
+      outputTokens: OutputTokenUsage.make(group2.outputTokens),
+      costMicrousd: group2.costMicrousd
+    }))
+  });
+});
 // packages/capabilities/src/redaction.ts
 var MAX_REDACTED_PREVIEW_BYTES = 8 * 1024;
 var MAX_REDACTION_NODES = 4096;
@@ -38047,12 +38133,19 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
   const modelCalls = yield* decodeProviderUsageTotal(context3.modelCalls + 1);
   const cumulativeInputTokens = yield* decodeProviderUsageTotal(context3.inputTokens + inputTokens);
   const cumulativeOutputTokens = yield* decodeProviderUsageTotal(context3.outputTokens + outputTokens);
+  const cumulativeCostMicrousd = context3.costMicrousd + costMicrousd;
+  if (!Number.isSafeInteger(cumulativeCostMicrousd)) {
+    return yield* AgentPolicyError.make({
+      limit: "cost",
+      message: "Cumulative model cost exceeds safe-integer accounting capacity"
+    });
+  }
   context3.modelCalls = modelCalls;
   context3.inputTokens = cumulativeInputTokens;
   context3.outputTokens = cumulativeOutputTokens;
   context3.lastInputTokens = inputTokens;
   context3.lastOutputTokens = outputTokens;
-  context3.costMicrousd += costMicrousd;
+  context3.costMicrousd = cumulativeCostMicrousd;
   context3.lastCostMicrousd = costMicrousd;
   if (options3.durability !== undefined) {
     yield* options3.durability.noteTurnUsage({ turn, usage: modelUsage });

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -35301,7 +35301,7 @@ class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsag
   model: UsageIdentity,
   serviceTier: exports_Schema.optionalKey(UsageIdentity),
   pricingVersion: exports_Schema.optionalKey(UsageIdentity),
-  modelCalls: exports_Schema.Natural,
+  modelCalls: exports_Schema.Natural.check(exports_Schema.isGreaterThan(0)),
   inputTokens: InputTokenUsage,
   outputTokens: OutputTokenUsage,
   costMicrousd: exports_Schema.Natural
@@ -40094,6 +40094,7 @@ var makeAgentSpawner = (parent, depth) => ({
 });
 var AgentRuntime = {
   decodeFinalOutput,
+  encodeRunDisposition,
   projectCompletionOutput,
   run: run4,
   start,

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -39201,7 +39201,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
         }));
       }
-      if (overToolBudget && trace3.applicationToolCalls.length > 0 && !completionBatch) {
+      if (overToolBudget && trace3.applicationToolCalls.length > 0 && !(completionBatch && policy2.onExhaustion === "final-answer")) {
         return afterValidatedResponse(exports_Effect.gen(function* () {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace3, AgentPolicyError.make({
             limit: "tool-calls",
@@ -39463,7 +39463,7 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options3) => exports_Str
     const continuation = toolBatchContinuation(agent2, context3, trace3, resumedPrompt, turn, toolCalls, options3);
     return settledChildJoinCallIds === undefined ? continuation : enforceDurationDeadline(continuation, context3.durationDeadlineMillis, durationLimitError(policy2));
   };
-  if (overToolBudget && !completionBatch) {
+  if (overToolBudget && !(completionBatch && policy2.onExhaustion === "final-answer")) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace3, AgentPolicyError.make({
       limit: "tool-calls",
       message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -31929,6 +31929,7 @@ var Agent;
       ...options3,
       id: exports_Schema.decodeSync(AgentId)(id2),
       metadata: options3.metadata === undefined ? undefined : Object.freeze({ ...options3.metadata }),
+      completion: options3.completion === undefined ? undefined : Object.freeze({ ...options3.completion }),
       runDisposition: options3.runDisposition === undefined ? undefined : Object.freeze({ ...options3.runDisposition })
     });
   }
@@ -32019,6 +32020,14 @@ class ContextOverflowError extends exports_Schema.TaggedError()("ContextOverflow
   retried: exports_Schema.Boolean
 }) {
 }
+
+class ContextBudgetError extends exports_Schema.TaggedError()("ContextBudgetError", {
+  message: exports_Schema.String,
+  estimatedTokens: exports_Schema.Natural,
+  targetTokens: exports_Schema.Natural,
+  completionReserveTokens: exports_Schema.Natural
+}) {
+}
 var AgentError = exports_Schema.Union([
   AgentInputError,
   AgentOutputError,
@@ -32029,7 +32038,8 @@ var AgentError = exports_Schema.Union([
   AgentApprovalPending,
   ModelProtocolError,
   AgentInterrupted,
-  ContextOverflowError
+  ContextOverflowError,
+  ContextBudgetError
 ]);
 // packages/core/src/subagent.ts
 var DelegationDepth = exports_Schema.Int.check(exports_Schema.isGreaterThanOrEqualTo(1));
@@ -32426,6 +32436,7 @@ var AgentPolicyFields = exports_Schema.Struct({
   repeatedFailureLimit: NonNegativeInt,
   onExhaustion: OnExhaustion,
   tokenBudget: exports_Schema.optionalKey(PositiveInt),
+  completionReserveTokens: NonNegativeInt,
   costBudgetMicrousd: exports_Schema.optionalKey(NonNegativeInt),
   contextTokenLimit: exports_Schema.optionalKey(PositiveInt),
   toolResultBounds: ToolResultBounds,
@@ -32435,6 +32446,10 @@ var AgentPolicyFields = exports_Schema.Struct({
 
 class AgentPolicy extends exports_Schema.Class("AgentPolicy")(AgentPolicyFields) {
   static make(input) {
+    const completionReserveTokens = input.completionReserveTokens ?? (input.tokenBudget === undefined ? 4096 : Math.min(4096, Math.floor(input.tokenBudget / 5)));
+    if (input.tokenBudget !== undefined && completionReserveTokens > input.tokenBudget) {
+      throw new Error("completionReserveTokens cannot exceed tokenBudget");
+    }
     return super.make({
       ...input,
       maxDuration: exports_Duration.fromInputUnsafe(input.maxDuration),
@@ -32442,6 +32457,7 @@ class AgentPolicy extends exports_Schema.Class("AgentPolicy")(AgentPolicyFields)
       onExhaustion: input.onExhaustion ?? "final-answer",
       toolResultBounds: input.toolResultBounds ?? ToolResultBounds.make({ maxBytes: 50 * 1024 }),
       runStatus: input.runStatus ?? "appended",
+      completionReserveTokens,
       compaction: input.compaction ?? CompactionPolicy.make()
     });
   }
@@ -34927,12 +34943,48 @@ var applySpanTransformer = (transformer, response, options3) => {
     });
   }
 };
+// node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Model.js
+var exports_Model = {};
+__export(exports_Model, {
+  make: () => make58,
+  ProviderName: () => ProviderName,
+  ModelName: () => ModelName
+});
+var TypeId57 = "~effect/ai/Model";
+
+class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ProviderName")) {
+}
+
+class ModelName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ModelName")) {
+}
+var Proto17 = {
+  [TypeId57]: TypeId57,
+  ["~effect/Layer"]: {
+    _ROut: identity,
+    _E: identity,
+    _RIn: identity
+  },
+  get captureRequirements() {
+    const self = this;
+    return contextWith2((context3) => succeed7(provide2(self, succeedContext(context3))));
+  },
+  ...PipeInspectableProto,
+  toJSON() {
+    return {
+      _id: "effect/ai/Model",
+      provider: this.provider
+    };
+  }
+};
+var make58 = (provider, modelName, layer17) => Object.assign(Object.create(Proto17), {
+  provider
+}, merge3(layer17, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Tool.js
 var exports_Tool = {};
 __export(exports_Tool, {
   unsafeSecureJsonParse: () => unsafeSecureJsonParse,
   providerDefined: () => providerDefined,
-  make: () => make58,
+  make: () => make59,
   isUserDefined: () => isUserDefined,
   isProviderDefined: () => isProviderDefined,
   isEmptyParamsRecord: () => isEmptyParamsRecord,
@@ -34942,7 +34994,7 @@ __export(exports_Tool, {
   getJsonSchema: () => getJsonSchema,
   getDescription: () => getDescription,
   dynamic: () => dynamic,
-  TypeId: () => TypeId57,
+  TypeId: () => TypeId58,
   Title: () => Title,
   Strict: () => Strict,
   Readonly: () => Readonly,
@@ -34955,15 +35007,15 @@ __export(exports_Tool, {
   DynamicTypeId: () => DynamicTypeId,
   Destructive: () => Destructive
 });
-var TypeId57 = "~effect/ai/Tool";
+var TypeId58 = "~effect/ai/Tool";
 var ProviderDefinedTypeId = "~effect/ai/Tool/ProviderDefined";
 var DynamicTypeId = "~effect/ai/Tool/Dynamic";
-var isUserDefined = (u) => hasProperty(u, TypeId57) && !isProviderDefined(u) && !isDynamic(u);
+var isUserDefined = (u) => hasProperty(u, TypeId58) && !isProviderDefined(u) && !isDynamic(u);
 var isProviderDefined = (u) => hasProperty(u, ProviderDefinedTypeId);
 var isDynamic = (u) => hasProperty(u, DynamicTypeId);
 var clone2 = (self, overrides) => Object.assign(Object.create(Object.getPrototypeOf(self)), self, overrides);
-var Proto17 = {
-  [TypeId57]: {
+var Proto18 = {
+  [TypeId58]: {
     _Requirements: identity
   },
   pipe() {
@@ -35004,15 +35056,15 @@ var Proto17 = {
   }
 };
 var ProviderDefinedProto = {
-  ...Proto17,
+  ...Proto18,
   [ProviderDefinedTypeId]: ProviderDefinedTypeId
 };
 var DynamicProto = {
-  ...Proto17,
+  ...Proto18,
   [DynamicTypeId]: DynamicTypeId
 };
 var userDefinedProto = (options3) => {
-  const self = Object.assign(Object.create(Proto17), options3);
+  const self = Object.assign(Object.create(Proto18), options3);
   self.id = `effect/ai/Tool/${options3.name}`;
   return self;
 };
@@ -35025,7 +35077,7 @@ var dynamicProto = (options3) => {
   self.id = `effect/ai/Tool/${options3.name}`;
   return self;
 };
-var make58 = (name, options3) => {
+var make59 = (name, options3) => {
   const successSchema = options3?.success ?? Void2;
   const failureSchema = options3?.failure ?? Never2;
   return userDefinedProto({
@@ -35206,6 +35258,55 @@ class IdGenerator2 extends exports_Context.Service()("@effect-agent/core/IdGener
     nextRunId: exports_IdGenerator.defaultIdGenerator.generateId().pipe(exports_Effect.map((id2) => exports_Schema.decodeSync(RunId)(`run-${id2}`))),
     nextTurnId: exports_IdGenerator.defaultIdGenerator.generateId().pipe(exports_Effect.map((id2) => exports_Schema.decodeSync(TurnId)(`turn-${id2}`)))
   });
+}
+// packages/core/src/usage.ts
+var UsageIdentity = exports_Schema.NonEmptyString.check(exports_Schema.isMaxLength(256));
+
+class InputTokenUsage extends exports_Schema.Class("@effect-agent/core/InputTokenUsage")({
+  total: exports_Schema.Natural,
+  uncached: exports_Schema.Natural,
+  cacheRead: exports_Schema.Natural,
+  cacheWrite: exports_Schema.Natural
+}) {
+}
+
+class OutputTokenUsage extends exports_Schema.Class("@effect-agent/core/OutputTokenUsage")({
+  total: exports_Schema.Natural,
+  text: exports_Schema.Natural,
+  reasoning: exports_Schema.Natural
+}) {
+}
+
+class ModelCallUsage extends exports_Schema.Class("@effect-agent/core/ModelCallUsage")({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: exports_Schema.optionalKey(UsageIdentity),
+  pricingVersion: exports_Schema.optionalKey(UsageIdentity),
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural
+}) {
+}
+
+class ModelUsageGroup extends exports_Schema.Class("@effect-agent/core/ModelUsageGroup")({
+  provider: UsageIdentity,
+  model: UsageIdentity,
+  serviceTier: exports_Schema.optionalKey(UsageIdentity),
+  pricingVersion: exports_Schema.optionalKey(UsageIdentity),
+  modelCalls: exports_Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural
+}) {
+}
+
+class RunUsageSummary extends exports_Schema.Class("@effect-agent/core/RunUsageSummary")({
+  modelCalls: exports_Schema.Natural,
+  inputTokens: InputTokenUsage,
+  outputTokens: OutputTokenUsage,
+  costMicrousd: exports_Schema.Natural,
+  byModel: exports_Schema.Array(ModelUsageGroup)
+}) {
 }
 // packages/capabilities/src/redaction.ts
 var MAX_REDACTED_PREVIEW_BYTES = 8 * 1024;
@@ -36938,7 +37039,7 @@ var RunResumeUsageSchema = exports_Schema.Struct({
   lastInputTokens: exports_Schema.Natural,
   lastOutputTokens: exports_Schema.Natural,
   costMicrousd: exports_Schema.Natural
-}).check(exports_Schema.makeFilter((usage) => usage.lastInputTokens <= usage.inputTokens && usage.lastOutputTokens <= usage.outputTokens, {
+}).check(exports_Schema.makeFilter((usage2) => usage2.lastInputTokens <= usage2.inputTokens && usage2.lastOutputTokens <= usage2.outputTokens, {
   expected: "last-call token usage no greater than cumulative token usage"
 }));
 // packages/engine/src/run-events.ts
@@ -37040,31 +37141,31 @@ var schemaClassToolPartPreflight = (part, toolkit) => {
     return;
   }
 };
-var inspectModelResponsePartCapacity = (usage, part, limits, knownSafePrototypes = knownSafeModelResponsePrototypes) => exports_Effect.suspend(() => {
-  if (usage.responsePartCount >= limits.maxModelResponseParts) {
+var inspectModelResponsePartCapacity = (usage2, part, limits, knownSafePrototypes = knownSafeModelResponsePrototypes) => exports_Effect.suspend(() => {
+  if (usage2.responsePartCount >= limits.maxModelResponseParts) {
     return exports_Effect.fail(ModelProtocolError.make({
       message: `Model response exceeded the ${limits.maxModelResponseParts}-part response limit`
     }));
   }
-  const bytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage.responsePartBytes, knownSafePrototypes);
+  const bytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage2.responsePartBytes, knownSafePrototypes);
   return bytes === undefined ? exports_Effect.fail(ModelProtocolError.make({
     message: `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
   })) : exports_Effect.succeed(bytes);
 });
-var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart")(function* (part, toolkit, usage, limits) {
-  const directInputBytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage.responsePartBytes, knownSafeModelResponsePrototypes);
+var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart")(function* (part, toolkit, usage2, limits) {
+  const directInputBytes = boundedValueFootprint(part, limits.maxModelResponseBytes - usage2.responsePartBytes, knownSafeModelResponsePrototypes);
   if (directInputBytes === undefined) {
     const preflight = schemaClassToolPartPreflight(part, toolkit);
-    yield* inspectModelResponsePartCapacity(usage, preflight ?? part, limits);
+    yield* inspectModelResponsePartCapacity(usage2, preflight ?? part, limits);
   } else {
-    yield* inspectModelResponsePartCapacity(usage, part, limits);
+    yield* inspectModelResponsePartCapacity(usage2, part, limits);
   }
   const codec = exports_Schema.toCodecJson(exports_Response.StreamPart(toolkit));
   const encodingFailure = ModelProtocolError.make({
     message: "Model response part failed canonical encoding"
   });
   const encoded = yield* exports_Schema.encodeUnknownEffect(codec)(part).pipe(exports_Effect.mapError(() => encodingFailure));
-  const retainedBytes = yield* inspectModelResponsePartCapacity(usage, encoded, limits);
+  const retainedBytes = yield* inspectModelResponsePartCapacity(usage2, encoded, limits);
   const ownedEncoded = yield* exports_Effect.try({
     try: () => {
       if (typeof structuredCloneFunction !== "function") {
@@ -37083,15 +37184,15 @@ var ownModelResponsePart = exports_Effect.fn("AgentRuntime.ownModelResponsePart"
   const ownedPart = yield* exports_Schema.decodeUnknownEffect(codec)(ownedEncoded).pipe(exports_Effect.mapError(() => decodingFailure));
   return { ownedPart, retainedBytes };
 });
-var consumeModelResponsePart = (usage, retainedBytes, limits) => exports_Effect.suspend(() => {
-  if (usage.responsePartCount >= limits.maxModelResponseParts || !Number.isSafeInteger(retainedBytes) || retainedBytes < 0 || retainedBytes > limits.maxModelResponseBytes - usage.responsePartBytes) {
+var consumeModelResponsePart = (usage2, retainedBytes, limits) => exports_Effect.suspend(() => {
+  if (usage2.responsePartCount >= limits.maxModelResponseParts || !Number.isSafeInteger(retainedBytes) || retainedBytes < 0 || retainedBytes > limits.maxModelResponseBytes - usage2.responsePartBytes) {
     return exports_Effect.fail(ModelProtocolError.make({
-      message: usage.responsePartCount >= limits.maxModelResponseParts ? `Model response exceeded the ${limits.maxModelResponseParts}-part response limit` : `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
+      message: usage2.responsePartCount >= limits.maxModelResponseParts ? `Model response exceeded the ${limits.maxModelResponseParts}-part response limit` : `Model response exceeded the ${limits.maxModelResponseBytes}-byte retained response limit`
     }));
   }
   return exports_Effect.sync(() => {
-    usage.responsePartCount += 1;
-    usage.responsePartBytes += retainedBytes;
+    usage2.responsePartCount += 1;
+    usage2.responsePartBytes += retainedBytes;
   });
 });
 var withSemaphorePermit = (semaphore, stream3) => exports_Stream.scoped(exports_Stream.fromEffect(exports_Effect.acquireRelease(semaphore.take(1), (permits) => semaphore.release(permits).pipe(exports_Effect.asVoid))).pipe(exports_Stream.flatMap(() => stream3)));
@@ -37873,23 +37974,57 @@ var outgoingModelPrompt = (policy2, context3, prepared, turn, declaredToolCalls)
     })
   ]);
 });
-var consumeUsage = (agent2, context3, usage, toolCallCount, options3) => exports_Effect.gen(function* () {
-  if (usage === undefined) {
+var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => exports_Effect.gen(function* () {
+  if (usage2 === undefined) {
     return yield* AgentPolicyError.make({
       limit: "usage",
       message: "A completed model response did not report usage"
     });
   }
-  const inputTokens = Math.max(0, usage.inputTokens.total ?? (usage.inputTokens.uncached ?? 0) + (usage.inputTokens.cacheRead ?? 0) + (usage.inputTokens.cacheWrite ?? 0));
-  const outputTokens = Math.max(0, usage.outputTokens.total ?? (usage.outputTokens.text ?? 0) + (usage.outputTokens.reasoning ?? 0));
+  const natural = (value4) => value4 === undefined || !Number.isSafeInteger(value4) ? 0 : Math.max(0, value4);
+  const reportedUncached = natural(usage2.inputTokens.uncached);
+  const cacheRead = natural(usage2.inputTokens.cacheRead);
+  const cacheWrite = natural(usage2.inputTokens.cacheWrite);
+  const reportedText = natural(usage2.outputTokens.text);
+  const reasoning = natural(usage2.outputTokens.reasoning);
+  const inputTokens = Math.max(natural(usage2.inputTokens.total), reportedUncached + cacheRead + cacheWrite);
+  const outputTokens = Math.max(natural(usage2.outputTokens.total), reportedText + reasoning);
+  const uncached = Math.max(reportedUncached, inputTokens - cacheRead - cacheWrite);
+  const text2 = Math.max(reportedText, outputTokens - reasoning);
   const totalTokens = inputTokens + outputTokens;
-  const costMicrousd = options3.estimateCostMicrousd === undefined ? 0 : yield* options3.estimateCostMicrousd(usage);
+  const provider = yield* exports_Model.ProviderName;
+  const model = yield* exports_Model.ModelName;
+  const estimate = options3.estimateCostMicrousd === undefined ? 0 : yield* options3.estimateCostMicrousd(usage2, { provider, model, usage: usage2 });
+  const costMicrousd = typeof estimate === "number" ? estimate : estimate.costMicrousd;
   if (!Number.isInteger(costMicrousd) || costMicrousd < 0) {
     return yield* AgentPolicyError.make({
       limit: "cost",
       message: "Model cost estimation must produce a non-negative integer number of microdollars"
     });
   }
+  const serviceTier = typeof estimate === "number" ? undefined : estimate.serviceTier;
+  const pricingVersion = typeof estimate === "number" ? undefined : estimate.pricingVersion;
+  const validPricingIdentity = (value4) => value4 === undefined || value4.length > 0 && value4.length <= 256;
+  if (!validPricingIdentity(serviceTier) || !validPricingIdentity(pricingVersion)) {
+    return yield* AgentPolicyError.make({
+      limit: "cost",
+      message: "Model cost estimation returned an invalid service tier or pricing version"
+    });
+  }
+  const modelUsage = ModelCallUsage.make({
+    provider,
+    model,
+    ...serviceTier === undefined ? {} : { serviceTier },
+    ...pricingVersion === undefined ? {} : { pricingVersion },
+    inputTokens: InputTokenUsage.make({
+      total: inputTokens,
+      uncached,
+      cacheRead,
+      cacheWrite
+    }),
+    outputTokens: OutputTokenUsage.make({ total: outputTokens, text: text2, reasoning }),
+    costMicrousd
+  });
   context3.modelCalls += 1;
   context3.inputTokens += inputTokens;
   context3.outputTokens += outputTokens;
@@ -37897,6 +38032,9 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options3) => exports
   context3.lastOutputTokens = outputTokens;
   context3.costMicrousd += costMicrousd;
   context3.lastCostMicrousd = costMicrousd;
+  if (options3.durability !== undefined) {
+    yield* options3.durability.noteTurnUsage({ turn, usage: modelUsage });
+  }
   const policy2 = agent2.definition.policy;
   const consumedTokens = context3.inputTokens + context3.outputTokens;
   const tokenBudget = policy2.tokenBudget;
@@ -37935,7 +38073,8 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options3) => exports
       totalTokens,
       toolCalls: toolCallCount,
       costMicrousd,
-      usage
+      usage: usage2,
+      modelUsage
     };
     yield* options3.budget.consume(delta);
   }
@@ -37949,7 +38088,7 @@ var consumeUsage = (agent2, context3, usage, toolCallCount, options3) => exports
       limitValue: tokenBudget
     }));
   }
-  return { breach, warnings };
+  return { breach, warnings, modelUsage };
 });
 var eventBaseFor = exports_Effect.fnUntraced(function* (context3, terminal) {
   const ceiling = terminal ? context3.bufferLimits.maxRunEvents : context3.bufferLimits.maxRunEvents - 1;
@@ -38041,17 +38180,17 @@ var nextContextEstimate = (context3, view) => {
   return estimatePromptTokens(view);
 };
 var overflowText = (error2) => `${error2.message} ${error2.reason.message}`;
-var compactContext = (agent2, context3, source, turn, options3, forceSummarize) => exports_Effect.gen(function* () {
+var compactContext = (agent2, context3, source, turn, options3, targetTokens, forceSummarize, allowSummarize = true) => exports_Effect.gen(function* () {
   const policy2 = agent2.definition.policy;
   const state = context3.compaction;
   const events2 = [];
   const messages = source.content;
   const before = estimatePromptTokens(buildCompactedView(messages, state));
-  const limit = policy2.contextTokenLimit;
   const mode = policy2.compaction.mode;
+  const keepRecentTokens = targetTokens === undefined ? policy2.compaction.keepRecentTokens : Math.max(1, Math.min(policy2.compaction.keepRecentTokens, targetTokens));
   const commitDurable = (commit) => options3.durability === undefined ? exports_Effect.void : options3.durability.commitCompaction(commit);
   if (!forceSummarize && mode !== "summarize") {
-    const bound = choosePruneBound(messages, state, policy2.compaction.keepRecentTokens);
+    const bound = choosePruneBound(messages, state, keepRecentTokens);
     if (bound > state.clearedThrough) {
       state.clearedThrough = bound;
       state.lastViewLength = -1;
@@ -38069,15 +38208,15 @@ var compactContext = (agent2, context3, source, turn, options3, forceSummarize) 
         tokensBeforeEstimate: before,
         tokensAfterEstimate: after2
       });
-      if (limit !== undefined && after2 <= limit) {
+      if (targetTokens !== undefined && after2 <= targetTokens) {
         return { events: events2 };
       }
     }
   }
-  if (mode === "prune" && !forceSummarize) {
+  if ((!allowSummarize || mode === "prune") && !forceSummarize) {
     return { events: events2 };
   }
-  const cut = chooseSummarizeCut(messages, state, policy2.compaction.keepRecentTokens);
+  const cut = chooseSummarizeCut(messages, state, keepRecentTokens);
   const covered = collectCoveredMessages(messages, state, cut);
   if (covered.length === 0) {
     return { events: events2 };
@@ -38114,17 +38253,9 @@ ${transcript}
   })));
   const wasFinalizing = context3.finalizing;
   context3.finalizing = true;
-  const consumed = yield* consumeUsage(agent2, context3, summaryUsage, 0, options3).pipe(exports_Effect.ensuring(exports_Effect.sync(() => {
+  const consumed = yield* consumeUsage(agent2, context3, summaryUsage, 0, turn, options3).pipe(exports_Effect.ensuring(exports_Effect.sync(() => {
     context3.finalizing = wasFinalizing;
   })));
-  if (options3.durability !== undefined) {
-    yield* options3.durability.noteTurnUsage({
-      turn,
-      inputTokens: context3.lastInputTokens,
-      outputTokens: context3.lastOutputTokens,
-      costMicrousd: context3.lastCostMicrousd
-    });
-  }
   events2.push(...consumed.warnings);
   const summaryText = pieces.join("").trim();
   const summary2 = summaryText.length === 0 ? "(no summary produced)" : summaryText;
@@ -38534,6 +38665,39 @@ var decodeFinalOutput = exports_Effect.fn("AgentRuntime.decodeFinalOutput")(func
   })));
   return { encoded: eventJson, decoded };
 });
+var encodeOutputCandidate = exports_Effect.fn("AgentRuntime.encodeOutputCandidate")(function* (agent2, candidate) {
+  const decoded = yield* exports_Schema.decodeUnknownEffect(agent2.definition.output)(candidate).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: cause.message
+  })));
+  const encoded = yield* exports_Schema.encodeUnknownEffect(agent2.definition.output)(decoded).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool output failed Schema encoding: ${cause.message}`
+  })));
+  const json2 = yield* exports_Schema.decodeUnknownEffect(exports_Schema.Json)(encoded).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool output did not encode as durable JSON: ${cause.message}`
+  })));
+  return { encoded: json2, decoded };
+});
+var projectCompletionOutput = exports_Effect.fn("AgentRuntime.projectCompletionOutput")(function* (agent2, declaration, parameters, result4) {
+  const tool = agent2.definition.toolkit.tools[declaration.tool];
+  if (tool === undefined) {
+    return yield* ModelProtocolError.make({
+      message: `Agent completion declaration references unknown Tool ${declaration.tool}`
+    });
+  }
+  const decodedParameters = yield* exports_Schema.decodeUnknownEffect(tool.parametersSchema)(parameters).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool parameters failed canonical decoding: ${cause.message}`
+  })));
+  const decodedResult = yield* exports_Schema.decodeUnknownEffect(tool.successSchema)(result4).pipe(exports_Effect.mapError((cause) => AgentOutputError.make({
+    message: `Completion Tool result failed canonical decoding: ${cause.message}`
+  })));
+  const projected = yield* exports_Effect.try({
+    try: () => declaration.project({ parameters: decodedParameters, result: decodedResult }),
+    catch: (cause) => AgentOutputError.make({
+      message: `Completion Tool projector failed: ${cause instanceof Error ? cause.message : String(cause)}`
+    })
+  });
+  return yield* encodeOutputCandidate(agent2, projected);
+});
 var encodeRunDispositionCandidate = exports_Effect.fn("AgentRuntime.encodeRunDisposition")(function* (declaration, output) {
   const selected = yield* exports_Effect.try({
     try: () => declaration.fromOutput(output),
@@ -38628,7 +38792,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
   }).pipe(exports_Effect.withLogSpan("AgentRuntime.model"))).pipe(exports_Stream.flatMap(exports_Stream.fromIterable));
   const policy2 = agent2.definition.policy;
   const bounds = effectiveRunBounds(policy2, options3);
-  const finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > bounds.maxTurns || priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls || context3.tokenExhausted);
+  let finalAnswerOnly = policy2.onExhaustion !== "fail" && (turn > bounds.maxTurns || priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls || context3.tokenExhausted);
   if (finalAnswerOnly && context3.exhaustedDimension === undefined) {
     context3.exhaustedDimension = turn > bounds.maxTurns ? "turns" : priorToolCalls + context3.programmaticToolCalls > bounds.maxToolCalls ? "tool-calls" : "tokens";
   }
@@ -38642,14 +38806,49 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
   const outputContractTokens = outputContractMessage === undefined ? 0 : estimatePromptTokens([
     exports_Prompt.makeMessage("system", { content: outputContractMessage })
   ]);
+  const derivedPrompt = yield* outgoingModelPrompt(policy2, context3, exports_Prompt.fromMessages([]), turn, priorToolCalls);
+  const derivedPromptTokens = outputContractTokens + estimatePromptTokens(derivedPrompt.content);
   let preEvents = [];
-  if (policy2.contextTokenLimit !== undefined && !context3.finalizing) {
+  if (!context3.finalizing) {
+    const consumedTokens = context3.inputTokens + context3.outputTokens;
+    const tokenCallTarget = policy2.tokenBudget === undefined || finalAnswerOnly ? undefined : Math.max(0, policy2.tokenBudget - consumedTokens - policy2.completionReserveTokens);
+    const contextCallTarget = policy2.contextTokenLimit;
+    const fullTarget = tokenCallTarget === undefined ? contextCallTarget : contextCallTarget === undefined ? tokenCallTarget : Math.min(tokenCallTarget, contextCallTarget);
+    const sourceTarget = fullTarget === undefined ? undefined : Math.max(0, fullTarget - derivedPromptTokens);
     const view = buildCompactedView(modelContext.prompt.content, context3.compaction);
-    const estimate = nextContextEstimate(context3, view);
-    if (estimate + outputContractTokens > policy2.contextTokenLimit && context3.compaction.lastCompactionTurn !== turn) {
+    const estimate = nextContextEstimate(context3, view) + derivedPromptTokens;
+    const contextPressure = contextCallTarget !== undefined && estimate > contextCallTarget;
+    const tokenPressure = tokenCallTarget !== undefined && estimate > tokenCallTarget;
+    if ((contextPressure || tokenPressure) && sourceTarget !== undefined && sourceTarget > 0 && context3.compaction.lastCompactionTurn !== turn) {
       context3.compaction.lastCompactionTurn = turn;
-      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options3, false);
+      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options3, sourceTarget, false, !tokenPressure);
       preEvents = outcome.events;
+    }
+    const prepared = buildCompactedView(modelContext.prompt.content, context3.compaction);
+    const preparedEstimate = nextContextEstimate(context3, prepared) + derivedPromptTokens;
+    if (context3.tokenExhausted) {
+      finalAnswerOnly = true;
+    }
+    const preparedTokenCallTarget = policy2.tokenBudget === undefined || finalAnswerOnly ? undefined : Math.max(0, policy2.tokenBudget - (context3.inputTokens + context3.outputTokens) - policy2.completionReserveTokens);
+    if (contextCallTarget !== undefined && preparedEstimate > contextCallTarget) {
+      return yield* ContextBudgetError.make({
+        message: `Compaction could not fit the next model prompt inside the ${contextCallTarget} token context target`,
+        estimatedTokens: preparedEstimate,
+        targetTokens: contextCallTarget,
+        completionReserveTokens: policy2.completionReserveTokens
+      });
+    }
+    if (preparedTokenCallTarget !== undefined && preparedEstimate > preparedTokenCallTarget) {
+      const error2 = AgentPolicyError.make({
+        limit: "tokens",
+        message: `The next research call would consume this Run's ${policy2.completionReserveTokens} token completion reserve`
+      });
+      if (policy2.onExhaustion === "fail") {
+        return yield* error2;
+      }
+      context3.tokenExhausted = true;
+      context3.exhaustedDimension ??= "tokens";
+      finalAnswerOnly = true;
     }
   }
   const compactedOutgoing = () => {
@@ -38661,14 +38860,20 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
     prompt: outputContractMessage === undefined ? outgoing : insertOutputContract(outgoing, outputContractMessage),
     toolkit: agent2.definition.toolkit,
     disableToolCallResolution: true,
-    ...finalAnswerOnly ? { toolChoice: "none" } : {}
+    ...finalAnswerOnly ? agent2.definition.completion === undefined ? { toolChoice: "none" } : {
+      toolChoice: {
+        mode: "auto",
+        oneOf: [agent2.definition.completion.tool]
+      }
+    } : {}
   }), options3.budget).pipe(exports_Stream.mapEffect((part) => ownModelResponsePart(part, agent2.definition.toolkit, trace3, context3.bufferLimits).pipe(exports_Effect.flatMap((owned) => eventsForPart(context3, turnId, turn, agent2.definition.toolkit.tools, trace3, owned.ownedPart, owned.retainedBytes)))), exports_Stream.flatMap(exports_Stream.fromIterable)))));
   const response = attempt(compactedOutgoing()).pipe(exports_Stream.catch((error2) => {
     if (!(error2 instanceof exports_AiError.AiError) || !isContextOverflowMessage(overflowText(error2))) {
       return exports_Stream.fail(error2);
     }
     const message = overflowText(error2);
-    if (trace3.parts.length > 0 || policy2.contextTokenLimit === undefined) {
+    const contextTokenLimit = policy2.contextTokenLimit;
+    if (trace3.parts.length > 0 || contextTokenLimit === undefined) {
       return exports_Stream.fail(ContextOverflowError.make({ message, retried: false }));
     }
     if (context3.compaction.overflowRetryTurn === turn) {
@@ -38677,10 +38882,20 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
     context3.compaction.overflowRetryTurn = turn;
     context3.compaction.lastCompactionTurn = turn;
     return exports_Stream.unwrap(exports_Effect.gen(function* () {
-      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options3, true).pipe(exports_Effect.mapError((inner) => inner instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(inner)) ? ContextOverflowError.make({
+      const outcome = yield* compactContext(agent2, context3, modelContext.prompt, turn, options3, Math.max(0, contextTokenLimit - derivedPromptTokens), true).pipe(exports_Effect.mapError((inner) => inner instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(inner)) ? ContextOverflowError.make({
         message: overflowText(inner),
         retried: true
       }) : inner));
+      const retryView = buildCompactedView(modelContext.prompt.content, context3.compaction);
+      const retryEstimate = nextContextEstimate(context3, retryView) + derivedPromptTokens;
+      if (retryEstimate > contextTokenLimit) {
+        return yield* ContextBudgetError.make({
+          message: `Overflow compaction could not fit the retry inside the ${contextTokenLimit} token context target`,
+          estimatedTokens: retryEstimate,
+          targetTokens: contextTokenLimit,
+          completionReserveTokens: policy2.completionReserveTokens
+        });
+      }
       const retried = attempt(compactedOutgoing()).pipe(exports_Stream.catch((again) => again instanceof exports_AiError.AiError && isContextOverflowMessage(overflowText(again)) ? exports_Stream.fail(ContextOverflowError.make({
         message: overflowText(again),
         retried: true
@@ -38706,9 +38921,17 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
     if (hasProviderCalls && turnCompletion === undefined) {
       return failRunEventStream(ModelProtocolError.make({ message: "Model response omitted staged Turn completion" }));
     }
-    if (finalAnswerOnly && trace3.toolCalls.size > 0) {
+    const completionTool = agent2.definition.completion?.tool;
+    const declaresCompletion = completionTool !== undefined && trace3.applicationToolCalls.some((call) => call.name === completionTool);
+    if (declaresCompletion && trace3.toolCalls.size !== 1) {
       return failRunEventStream(ModelProtocolError.make({
-        message: `Model declared ${trace3.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion`
+        message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+      }));
+    }
+    const completionBatch = declaresCompletion && trace3.toolCalls.size === 1 && trace3.applicationToolCalls.length === 1;
+    if (finalAnswerOnly && trace3.toolCalls.size > 0 && !completionBatch) {
+      return failRunEventStream(ModelProtocolError.make({
+        message: completionTool === undefined ? `Model declared ${trace3.toolCalls.size} Tool Call(s) under toolChoice "none" after budget exhaustion` : `Model declared ${trace3.toolCalls.size} non-completion Tool Call(s) after budget exhaustion`
       }));
     }
     const providerOnly = trace3.toolCalls.size > 0 && Array.from(trace3.toolCalls.values()).every(({ providerExecuted }) => providerExecuted);
@@ -38720,7 +38943,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
     }
     const toolCalls = priorToolCalls + trace3.toolCalls.size;
     const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-    if (overToolBudget && policy2.onExhaustion === "fail") {
+    if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
       return failRunEventStream(AgentPolicyError.make({
         limit: "tool-calls",
         message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
@@ -38738,15 +38961,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
       ...additions
     ]);
     const afterValidatedResponse = (next2) => stagedResponse.pipe(exports_Stream.concat(exports_Stream.unwrap(exports_Effect.gen(function* () {
-      const consumed = yield* consumeUsage(agent2, context3, trace3.usage, trace3.toolCalls.size, options3);
-      if (options3.durability !== undefined) {
-        yield* options3.durability.noteTurnUsage({
-          turn,
-          inputTokens: context3.lastInputTokens,
-          outputTokens: context3.lastOutputTokens,
-          costMicrousd: context3.lastCostMicrousd
-        });
-      }
+      const consumed = yield* consumeUsage(agent2, context3, trace3.usage, trace3.toolCalls.size, turn, options3);
       const pre = [...consumed.warnings];
       if (!context3.warnedLimits.has("tool-calls") && nearingLimit(toolCalls + context3.programmaticToolCalls, bounds.maxToolCalls)) {
         context3.warnedLimits.add("tool-calls");
@@ -38781,7 +38996,7 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
             }))));
           }
         }
-        if (trace3.applicationToolCalls.length > 0) {
+        if (trace3.applicationToolCalls.length > 0 && !completionBatch) {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace3, AgentPolicyError.make({
             limit: "tokens",
             message: `Token budget exhausted: this Run's ${policy2.tokenBudget ?? 0} token budget was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
@@ -38835,13 +39050,14 @@ var makeTurn = (agent2, context3, prompt, turn, priorToolCalls, options3) => exp
         }));
       }
       const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-      if (turnsBlocked) {
+      const completionTurnAllowed = completionBatch;
+      if (turnsBlocked && !completionTurnAllowed) {
         return failRunEventStream(AgentPolicyError.make({
           limit: "turns",
           message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
         }));
       }
-      if (overToolBudget && trace3.applicationToolCalls.length > 0) {
+      if (overToolBudget && trace3.applicationToolCalls.length > 0 && !completionBatch) {
         return afterValidatedResponse(exports_Effect.gen(function* () {
           const rejection = yield* settleRejectedBatch(context3, turnId, trace3, AgentPolicyError.make({
             limit: "tool-calls",
@@ -38912,6 +39128,33 @@ var toolBatchContinuation = (agent2, context3, trace3, prompt, turn, toolCalls, 
     ...promptFromTurnParts(trace3).content,
     toolMessage2
   ]);
+  const completion = agent2.definition.completion;
+  const completionResult = completion !== undefined && trace3.applicationToolCalls.length === 1 && orderedResults.length === 1 && orderedResults[0]?.name === completion.tool && orderedResults[0].isFailure === false ? orderedResults[0] : undefined;
+  if (completion !== undefined && completionResult !== undefined) {
+    const call = trace3.applicationCallDescriptors[0];
+    if (call === undefined) {
+      return failRunEventStream(ModelProtocolError.make({
+        message: `Completion Tool ${completion.tool} has no canonical call descriptor`
+      }));
+    }
+    const output = yield* projectCompletionOutput(agent2, completion, call.parameters, completionResult.encodedResult);
+    yield* advanceHistory(context3, history, options3);
+    const bounds = effectiveRunBounds(agent2.definition.policy, options3);
+    const exhausted = context3.tokenExhausted ? "tokens" : turn > bounds.maxTurns ? "turns" : toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls ? "tool-calls" : context3.exhaustedDimension;
+    if (exhausted !== undefined && context3.exhaustedDimension === undefined) {
+      context3.exhaustedDimension = exhausted;
+    }
+    const declaration = agent2.definition.runDisposition;
+    const runDisposition = exhausted !== undefined || declaration === undefined ? undefined : yield* encodeRunDisposition(agent2, output.decoded);
+    return exports_Stream.fromEffect(exports_Effect.map(eventBase(context3), (base2) => RunCompleted.make({
+      ...base2,
+      output: output.encoded,
+      ...runDisposition === undefined ? {} : { runDisposition },
+      turns: turn,
+      finishReason: exhausted === undefined ? "completed" : "budget-exhausted",
+      ...exhausted === undefined ? {} : { exhausted }
+    })));
+  }
   yield* advanceHistory(context3, history, options3);
   const steering = yield* drainInputs(context3, options3);
   const nextPrompt = yield* appendInputs(context3, history, steering, options3);
@@ -38987,6 +39230,13 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options3) => exports_Str
       executionClass: getToolExecutionClass(tool)
     });
   }
+  const completionTool = agent2.definition.completion?.tool;
+  if (completionTool !== undefined && trace3.applicationToolCalls.some((call) => call.name === completionTool) && trace3.toolCalls.size !== 1) {
+    return failRunEventStream(ModelProtocolError.make({
+      message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+    }));
+  }
+  const completionBatch = completionTool !== undefined && trace3.toolCalls.size === 1 && trace3.applicationToolCalls[0]?.name === completionTool;
   const settledIds = new Set;
   const settledInputs = yield* snapshotResumedSettledCalls(resume, declarationByCallId.size);
   for (const settledInput of settledInputs) {
@@ -39025,14 +39275,15 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options3) => exports_Str
   const bounds = effectiveRunBounds(policy2, options3);
   const toolCalls = trace3.toolCalls.size;
   const overToolBudget = toolCalls + context3.programmaticToolCalls > bounds.maxToolCalls;
-  if (overToolBudget && policy2.onExhaustion === "fail") {
+  if (overToolBudget && policy2.onExhaustion === "fail" && !completionBatch) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "tool-calls",
       message: `Agent exceeded its ${bounds.maxToolCalls} Tool Call limit`
     }));
   }
   const turnsBlocked = policy2.onExhaustion === "fail" ? turn >= bounds.maxTurns : turn > bounds.maxTurns;
-  if (turnsBlocked) {
+  const completionTurnAllowed = completionBatch;
+  if (turnsBlocked && !completionTurnAllowed) {
     return failRunEventStream(AgentPolicyError.make({
       limit: "turns",
       message: `Agent exceeded its ${bounds.maxTurns} Turn limit`
@@ -39069,7 +39320,7 @@ var makeResumeTurn = (agent2, context3, prompt, resume, options3) => exports_Str
     const continuation = toolBatchContinuation(agent2, context3, trace3, resumedPrompt, turn, toolCalls, options3);
     return settledChildJoinCallIds === undefined ? continuation : enforceDurationDeadline(continuation, context3.durationDeadlineMillis, durationLimitError(policy2));
   };
-  if (overToolBudget) {
+  if (overToolBudget && !completionBatch) {
     const rejection = yield* settleRejectedBatch(context3, turnId, trace3, AgentPolicyError.make({
       limit: "tool-calls",
       message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`
@@ -41166,9 +41417,9 @@ function Stream2(success, error2) {
 }
 
 // node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/rpc/Rpc.js
-var TypeId58 = "~effect/rpc/Rpc";
-var Proto18 = {
-  [TypeId58]: TypeId58,
+var TypeId59 = "~effect/rpc/Rpc";
+var Proto19 = {
+  [TypeId59]: TypeId59,
   pipe() {
     return pipeArguments(this, arguments);
   },
@@ -41252,12 +41503,12 @@ var Proto18 = {
 };
 var makeProto3 = (options3) => {
   function Rpc() {}
-  Object.setPrototypeOf(Rpc, Proto18);
+  Object.setPrototypeOf(Rpc, Proto19);
   Object.assign(Rpc, options3);
   Rpc.key = `effect/rpc/Rpc/${options3._tag}`;
   return Rpc;
 };
-var make59 = (tag2, options3) => {
+var make60 = (tag2, options3) => {
   const successSchema = options3?.success ?? Void2;
   const errorSchema = options3?.error ?? Never2;
   const defectSchema = options3?.defect ?? Defect();
@@ -41450,7 +41701,7 @@ class InitializeResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struct2
 }))) {
 }
 
-class Initialize extends (/* @__PURE__ */ make59("initialize", {
+class Initialize extends (/* @__PURE__ */ make60("initialize", {
   success: InitializeResult,
   error: McpError,
   payload: {
@@ -41461,7 +41712,7 @@ class Initialize extends (/* @__PURE__ */ make59("initialize", {
   }
 })) {
 }
-class CancelledNotification extends (/* @__PURE__ */ make59("notifications/cancelled", {
+class CancelledNotification extends (/* @__PURE__ */ make60("notifications/cancelled", {
   payload: {
     ...NotificationMeta.fields,
     requestId: RequestId,
@@ -41470,7 +41721,7 @@ class CancelledNotification extends (/* @__PURE__ */ make59("notifications/cance
 })) {
 }
 
-class ProgressNotification extends (/* @__PURE__ */ make59("notifications/progress", {
+class ProgressNotification extends (/* @__PURE__ */ make60("notifications/progress", {
   payload: {
     ...NotificationMeta.fields,
     progressToken: ProgressToken,
@@ -41541,7 +41792,7 @@ class ReadResourceResult extends (/* @__PURE__ */ Opaque()(/* @__PURE__ */ Struc
 }))) {
 }
 
-class ReadResource extends (/* @__PURE__ */ make59("resources/read", {
+class ReadResource extends (/* @__PURE__ */ make60("resources/read", {
   success: ReadResourceResult,
   error: McpError,
   payload: {
@@ -41550,7 +41801,7 @@ class ReadResource extends (/* @__PURE__ */ make59("resources/read", {
   }
 })) {
 }
-class Subscribe extends (/* @__PURE__ */ make59("resources/subscribe", {
+class Subscribe extends (/* @__PURE__ */ make60("resources/subscribe", {
   success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
@@ -41560,7 +41811,7 @@ class Subscribe extends (/* @__PURE__ */ make59("resources/subscribe", {
 })) {
 }
 
-class Unsubscribe extends (/* @__PURE__ */ make59("resources/unsubscribe", {
+class Unsubscribe extends (/* @__PURE__ */ make60("resources/unsubscribe", {
   success: /* @__PURE__ */ Struct2({}),
   error: McpError,
   payload: {
@@ -41570,7 +41821,7 @@ class Unsubscribe extends (/* @__PURE__ */ make59("resources/unsubscribe", {
 })) {
 }
 
-class ResourceUpdatedNotification extends (/* @__PURE__ */ make59("notifications/resources/updated", {
+class ResourceUpdatedNotification extends (/* @__PURE__ */ make60("notifications/resources/updated", {
   payload: {
     ...NotificationMeta.fields,
     uri: String6
@@ -41655,7 +41906,7 @@ class GetPromptResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/GetP
 })) {
 }
 
-class GetPrompt extends (/* @__PURE__ */ make59("prompts/get", {
+class GetPrompt extends (/* @__PURE__ */ make60("prompts/get", {
   success: GetPromptResult,
   error: McpError,
   payload: {
@@ -41705,7 +41956,7 @@ class CallToolResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/CallT
 })) {
 }
 
-class CallTool extends (/* @__PURE__ */ make59("tools/call", {
+class CallTool extends (/* @__PURE__ */ make60("tools/call", {
   success: CallToolResult,
   error: McpError,
   payload: {
@@ -41717,7 +41968,7 @@ class CallTool extends (/* @__PURE__ */ make59("tools/call", {
 }
 var LoggingLevel = /* @__PURE__ */ Literals(["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"]);
 
-class SetLevel extends (/* @__PURE__ */ make59("logging/setLevel", {
+class SetLevel extends (/* @__PURE__ */ make60("logging/setLevel", {
   payload: {
     ...RequestMeta.fields,
     level: LoggingLevel
@@ -41727,7 +41978,7 @@ class SetLevel extends (/* @__PURE__ */ make59("logging/setLevel", {
 })) {
 }
 
-class LoggingMessageNotification extends (/* @__PURE__ */ make59("notifications/message", {
+class LoggingMessageNotification extends (/* @__PURE__ */ make60("notifications/message", {
   payload: /* @__PURE__ */ Struct2({
     ...NotificationMeta.fields,
     level: LoggingLevel,
@@ -41800,7 +42051,7 @@ class CreateMessageResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 })) {
 }
 
-class CreateMessage extends (/* @__PURE__ */ make59("sampling/createMessage", {
+class CreateMessage extends (/* @__PURE__ */ make60("sampling/createMessage", {
   success: CreateMessageResult,
   error: McpError,
   payload: {
@@ -41965,7 +42216,7 @@ class ElicitDeclineResult extends (/* @__PURE__ */ Class4("@effect/ai/McpSchema/
 }
 var ElicitResult = /* @__PURE__ */ Union2([ElicitAcceptResult, ElicitDeclineResult]);
 
-class Elicit extends (/* @__PURE__ */ make59("elicitation/create", {
+class Elicit extends (/* @__PURE__ */ make60("elicitation/create", {
   success: ElicitResult,
   error: McpError,
   payload: ElicitRequestParams
@@ -42511,7 +42762,7 @@ var reserveTransition = (ledger, request3) => {
   };
   return [ok(reservationView(reservationId, reservation)), next2];
 };
-var observeTransition = (ledger, reservationId, usage) => {
+var observeTransition = (ledger, reservationId, usage2) => {
   const reservation = ledger.reservations.get(reservationId);
   if (reservation === undefined) {
     return [fail14(SubagentReservationUnknown.make({ reservationId })), ledger];
@@ -42527,7 +42778,7 @@ var observeTransition = (ledger, reservationId, usage) => {
     ...parent.cumulativeOverrun
   };
   for (const spec of dimensionSpecs) {
-    const delta = usage[spec.key];
+    const delta = usage2[spec.key];
     if (delta === undefined) {
       continue;
     }
@@ -42641,8 +42892,8 @@ var SubagentReservationsMemoryLive = exports_Layer.effect(SubagentReservations, 
       const result4 = yield* exports_Ref.modify(state, (ledger) => reserveTransition(ledger, request3));
       return yield* resolve4(result4);
     }),
-    observe: exports_Effect.fn("SubagentReservations.observe")(function* (reservationId, usage) {
-      const result4 = yield* exports_Ref.modify(state, (ledger) => observeTransition(ledger, reservationId, usage));
+    observe: exports_Effect.fn("SubagentReservations.observe")(function* (reservationId, usage2) {
+      const result4 = yield* exports_Ref.modify(state, (ledger) => observeTransition(ledger, reservationId, usage2));
       return yield* resolve4(result4);
     }),
     beginRelease: exports_Effect.fn("SubagentReservations.beginRelease")(function* (reservationId) {
@@ -43530,7 +43781,7 @@ var localGitWorkOrderHostLayer = (config) => exports_Layer.effect(WorkOrderHost,
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/AnthropicClient.js
 var exports_AnthropicClient = {};
 __export(exports_AnthropicClient, {
-  make: () => make61,
+  make: () => make62,
   layerConfig: () => layerConfig,
   layer: () => layer17,
   AnthropicClient: () => AnthropicClient
@@ -45876,7 +46127,7 @@ var WebSearchToolResultErrorCode = /* @__PURE__ */ Literals(["invalid_tool_input
 });
 var StopReason = /* @__PURE__ */ Literals(["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "refusal"]);
 var BetaStopReason = /* @__PURE__ */ Literals(["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "compaction", "refusal", "model_context_window_exceeded"]);
-var Model2 = /* @__PURE__ */ Union2([String6, Literals(["claude-sonnet-5", "claude-fable-5", "claude-mythos-5", "claude-opus-4-8", "claude-opus-4-7", "claude-mythos-preview", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-opus-4-1", "claude-opus-4-1-20250805"])]).annotate({
+var Model = /* @__PURE__ */ Union2([String6, Literals(["claude-sonnet-5", "claude-fable-5", "claude-mythos-5", "claude-opus-4-8", "claude-opus-4-7", "claude-mythos-preview", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-opus-4-1", "claude-opus-4-1-20250805"])]).annotate({
   title: "Model",
   description: `The model that will complete your prompt.
 
@@ -46705,7 +46956,7 @@ var CompletionResponse = /* @__PURE__ */ Struct2({
 
 The format and length of IDs may change over time.`
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([String6, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"stop_sequence"`: we reached a stop sequence — either provided by you via the `stop_sequences` parameter, or a stop sequence built into the model\n* `"max_tokens"`: we exceeded `max_tokens_to_sample` or the model\'s maximum'
@@ -47077,7 +47328,7 @@ The format and length of IDs may change over time.`
     title: "Content",
     description: 'Content generated by the model.\n\nThis is an array of content blocks, each of which has a `type` that determines its shape.\n\nExample:\n\n```json\n[{"type": "text", "text": "Hi, I\'m Claude."}]\n```\n\nIf the request input `messages` ended with an `assistant` turn, then the response `content` will continue directly from that last turn. You can use this to constrain the model\'s output.\n\nFor example, if the input `messages` were:\n```json\n[\n  {"role": "user", "content": "What\'s the Greek name for Sun? (A) Sol (B) Helios (C) Sun"},\n  {"role": "assistant", "content": "The best answer is ("}\n]\n```\n\nThen the response `content` might be:\n\n```json\n[{"type": "text", "text": "B)"}]\n```'
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([BetaStopReason, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"end_turn"`: the model reached a natural stopping point\n* `"max_tokens"`: we exceeded the requested `max_tokens` or the model\'s maximum\n* `"stop_sequence"`: one of your provided custom `stop_sequences` was generated\n* `"tool_use"`: the model invoked one or more tools\n* `"pause_turn"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `"refusal"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.'
@@ -47171,7 +47422,7 @@ The format and length of IDs may change over time.`
     title: "Content",
     description: 'Content generated by the model.\n\nThis is an array of content blocks, each of which has a `type` that determines its shape.\n\nExample:\n\n```json\n[{"type": "text", "text": "Hi, I\'m Claude."}]\n```\n\nIf the request input `messages` ended with an `assistant` turn, then the response `content` will continue directly from that last turn. You can use this to constrain the model\'s output.\n\nFor example, if the input `messages` were:\n```json\n[\n  {"role": "user", "content": "What\'s the Greek name for Sun? (A) Sol (B) Helios (C) Sun"},\n  {"role": "assistant", "content": "The best answer is ("}\n]\n```\n\nThen the response `content` might be:\n\n```json\n[{"type": "text", "text": "B)"}]\n```'
   }),
-  model: Model2,
+  model: Model,
   stop_reason: Union2([StopReason, Null2]).annotate({
     title: "Stop Reason",
     description: 'The reason that we stopped.\n\nThis may be one the following values:\n* `"end_turn"`: the model reached a natural stopping point\n* `"max_tokens"`: we exceeded the requested `max_tokens` or the model\'s maximum\n* `"stop_sequence"`: one of your provided custom `stop_sequences` was generated\n* `"tool_use"`: the model invoked one or more tools\n* `"pause_turn"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `"refusal"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.'
@@ -47330,7 +47581,7 @@ var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet200 = BetaGetSkillVersio
 var BetaGetSkillVersionV1SkillsSkillIdVersionsVersionGet4XX = BetaErrorResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete200 = BetaDeleteSkillVersionResponse;
 var BetaDeleteSkillVersionV1SkillsSkillIdVersionsVersionDelete4XX = BetaErrorResponse;
-var make60 = (httpClient, options3 = {}) => {
+var make61 = (httpClient, options3 = {}) => {
   const unexpectedStatus = (response) => flatMap5(orElseSucceed2(response.json, () => "Unexpected status code"), (description) => fail7(new HttpClientError({
     reason: new StatusCodeError({
       request: response.request,
@@ -48119,11 +48370,11 @@ var RedactedAnthropicHeaders = {
   AnthropicApiKey: "x-api-key"
 };
 var withRedactedHeaders = /* @__PURE__ */ updateService3(CurrentRedactedNames, /* @__PURE__ */ appendAll(/* @__PURE__ */ Object.values(RedactedAnthropicHeaders)));
-var make61 = /* @__PURE__ */ fnUntraced2(function* (options3) {
+var make62 = /* @__PURE__ */ fnUntraced2(function* (options3) {
   const baseClient = yield* HttpClient;
   const apiVersion = options3.apiVersion ?? "2023-06-01";
   const httpClient = baseClient.pipe(mapRequest((request3) => request3.pipe(prependUrl(options3.apiUrl ?? "https://api.anthropic.com"), isNotUndefined(options3.apiKey) ? setHeader(RedactedAnthropicHeaders.AnthropicApiKey, value3(options3.apiKey)) : identity, setHeader("anthropic-version", apiVersion), acceptJson)), isNotUndefined(options3.transformClient) ? options3.transformClient : identity);
-  const client = make60(httpClient, {
+  const client = make61(httpClient, {
     transformClient: fnUntraced2(function* (client2) {
       const config = yield* AnthropicConfig.getOrUndefined;
       if (isNotUndefined(config?.transformClient)) {
@@ -48177,12 +48428,12 @@ var make61 = /* @__PURE__ */ fnUntraced2(function* (options3) {
     createMessageStream
   });
 }, withRedactedHeaders);
-var layer17 = (options3) => effect(AnthropicClient, make61(options3));
+var layer17 = (options3) => effect(AnthropicClient, make62(options3));
 var layerConfig = (options3) => effect(AnthropicClient, gen4(function* () {
   const apiKey = isNotUndefined(options3?.apiKey) ? yield* options3.apiKey : undefined;
   const apiUrl = isNotUndefined(options3?.apiUrl) ? yield* options3.apiUrl : undefined;
   const apiVersion = isNotUndefined(options3?.apiVersion) ? yield* options3.apiVersion : undefined;
-  return yield* make61({
+  return yield* make62({
     apiKey,
     apiUrl,
     apiVersion,
@@ -48833,37 +49084,6 @@ function hoistAllOfDescriptions(schema3) {
 var supportedKeywords2 = /* @__PURE__ */ new Set(["$ref", "type", "title", "description", "enum", "const", "anyOf", "allOf", "properties", "required", "additionalProperties", "items", "pattern"]);
 var formats2 = /* @__PURE__ */ new Set(["date-time", "time", "date", "duration", "email", "hostname", "uri", "ipv4", "ipv6", "uuid"]);
 
-// node_modules/.bun/effect@4.0.0-rc.110/node_modules/effect/dist/unstable/ai/Model.js
-var TypeId59 = "~effect/ai/Model";
-
-class ProviderName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ProviderName")) {
-}
-
-class ModelName extends (/* @__PURE__ */ Service()("effect/unstable/ai/Model/ModelName")) {
-}
-var Proto19 = {
-  [TypeId59]: TypeId59,
-  ["~effect/Layer"]: {
-    _ROut: identity,
-    _E: identity,
-    _RIn: identity
-  },
-  get captureRequirements() {
-    const self = this;
-    return contextWith2((context4) => succeed7(provide2(self, succeedContext(context4))));
-  },
-  ...PipeInspectableProto,
-  toJSON() {
-    return {
-      _id: "effect/ai/Model",
-      provider: this.provider
-    };
-  }
-};
-var make62 = (provider, modelName, layer18) => Object.assign(Object.create(Proto19), {
-  provider
-}, merge3(layer18, succeedContext(ProviderName.context(provider).pipe(add(ModelName, modelName)))));
-
 // node_modules/.bun/@effect+ai-anthropic@4.0.0-rc.110+1d1b44bb2cb1f9cf/node_modules/@effect/ai-anthropic/dist/AnthropicTelemetry.js
 var addAnthropicRequestAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.request", camelToSnake);
 var addAnthropicResponseAttributes = /* @__PURE__ */ addSpanAttributes("gen_ai.anthropic.response", camelToSnake);
@@ -48904,7 +49124,7 @@ var formatIssue2 = /* @__PURE__ */ makeFormatterDefault();
 
 class Config extends (/* @__PURE__ */ Service()("@effect/ai-anthropic/AnthropicLanguageModel/Config")) {
 }
-var model = (model2, config) => make62("anthropic", model2, layer18({
+var model = (model2, config) => make58("anthropic", model2, layer18({
   model: model2,
   config
 }));
@@ -49959,7 +50179,7 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
   const mcpToolCalls = new Map;
   const serverToolCalls = new Map;
   const contentBlocks = new Map;
-  const usage = {
+  const usage2 = {
     inputTokens: 0,
     outputTokens: 0,
     cacheReadInputTokens: 0,
@@ -49973,9 +50193,9 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
         rawUsage = {
           ...event.message.usage
         };
-        usage.inputTokens = event.message.usage.input_tokens;
-        usage.cacheReadInputTokens = event.message.usage.cache_read_input_tokens ?? 0;
-        usage.cacheWriteInputTokens = event.message.usage.cache_creation_input_tokens ?? 0;
+        usage2.inputTokens = event.message.usage.input_tokens;
+        usage2.cacheReadInputTokens = event.message.usage.cache_read_input_tokens ?? 0;
+        usage2.cacheWriteInputTokens = event.message.usage.cache_creation_input_tokens ?? 0;
         if (isNotNullish(event.message.container)) {
           container = event.message.container;
         }
@@ -50039,15 +50259,15 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
           ...rawUsage,
           ...event.usage
         };
-        if (isNotNull(event.usage.input_tokens) && usage.inputTokens !== event.usage.input_tokens) {
-          usage.inputTokens = event.usage.input_tokens;
+        if (isNotNull(event.usage.input_tokens) && usage2.inputTokens !== event.usage.input_tokens) {
+          usage2.inputTokens = event.usage.input_tokens;
         }
-        usage.outputTokens = event.usage.output_tokens;
-        if (isNotNull(event.usage.cache_read_input_tokens) && usage.cacheReadInputTokens !== event.usage.cache_read_input_tokens) {
-          usage.cacheReadInputTokens = event.usage.cache_read_input_tokens;
+        usage2.outputTokens = event.usage.output_tokens;
+        if (isNotNull(event.usage.cache_read_input_tokens) && usage2.cacheReadInputTokens !== event.usage.cache_read_input_tokens) {
+          usage2.cacheReadInputTokens = event.usage.cache_read_input_tokens;
         }
-        if (isNotNull(event.usage.cache_creation_input_tokens) && usage.cacheWriteInputTokens !== event.usage.cache_creation_input_tokens) {
-          usage.cacheWriteInputTokens = event.usage.cache_creation_input_tokens;
+        if (isNotNull(event.usage.cache_creation_input_tokens) && usage2.cacheWriteInputTokens !== event.usage.cache_creation_input_tokens) {
+          usage2.cacheWriteInputTokens = event.usage.cache_creation_input_tokens;
         }
         if (isNotNullish(event.delta.container)) {
           container = event.delta.container;
@@ -50077,13 +50297,13 @@ var makeStreamResponse = /* @__PURE__ */ fnUntraced2(function* ({
           reason: finishReason,
           usage: {
             inputTokens: {
-              uncached: usage.inputTokens,
-              total: usage.inputTokens + usage.cacheWriteInputTokens + usage.cacheReadInputTokens,
-              cacheRead: usage.cacheReadInputTokens,
-              cacheWrite: usage.cacheWriteInputTokens
+              uncached: usage2.inputTokens,
+              total: usage2.inputTokens + usage2.cacheWriteInputTokens + usage2.cacheReadInputTokens,
+              cacheRead: usage2.cacheReadInputTokens,
+              cacheWrite: usage2.cacheWriteInputTokens
             },
             outputTokens: {
-              total: usage.outputTokens,
+              total: usage2.outputTokens,
               text: undefined,
               reasoning: undefined
             }
@@ -51946,7 +52166,7 @@ var SharedModelIds = ModelIdsShared.members[1];
 
 class Config2 extends (/* @__PURE__ */ Service()("@effect/ai-openai/OpenAiLanguageModel/Config")) {
 }
-var model2 = (model3, config) => make62("openai", model3, layer20({
+var model2 = (model3, config) => make58("openai", model3, layer20({
   model: model3,
   config
 }));
@@ -54052,8 +54272,8 @@ var normalizeMcpToolCall = /* @__PURE__ */ fnUntraced2(function* ({
     params
   };
 });
-var getUsage = (usage) => {
-  if (isNullish(usage)) {
+var getUsage = (usage2) => {
+  if (isNullish(usage2)) {
     return {
       inputTokens: {
         uncached: undefined,
@@ -54068,11 +54288,11 @@ var getUsage = (usage) => {
       }
     };
   }
-  const inputTokens = usage.input_tokens;
-  const outputTokens = usage.output_tokens;
-  const cachedTokens = getUsageTokenDetail(usage.input_tokens_details, "cached_tokens") ?? 0;
-  const cacheWriteTokens = getUsageTokenDetail(usage.input_tokens_details, "cache_write_tokens");
-  const reasoningTokens = getUsageTokenDetail(usage.output_tokens_details, "reasoning_tokens") ?? 0;
+  const inputTokens = usage2.input_tokens;
+  const outputTokens = usage2.output_tokens;
+  const cachedTokens = getUsageTokenDetail(usage2.input_tokens_details, "cached_tokens") ?? 0;
+  const cacheWriteTokens = getUsageTokenDetail(usage2.input_tokens_details, "cache_write_tokens");
+  const reasoningTokens = getUsageTokenDetail(usage2.output_tokens_details, "reasoning_tokens") ?? 0;
   return {
     inputTokens: {
       uncached: inputTokens - cachedTokens,


### PR DESCRIPTION
## Summary

- Let an Agent declare one typed completion Tool. A successful call projects the Tool result and settles immediately; under the default `final-answer` policy it can be the sole grace delivery after token, Turn, or Tool Call exhaustion, while `fail` remains strictly fail-fast.
- Reserve delivery capacity before research, compact against the remaining gross token budget, and keep prior Run instruction and wake prefixes out of future prompts without deleting canonical history.
- Validate provider usage instead of coercing malformed fields to zero. Persist cached input, uncached input, output, model, tier, and estimated cost usage in the DN and DC assemblies; settlements include an aggregate usage summary.
- Fail closed when usage totals disagree, prompt provenance could remove conversation, or a recovered completion marker disagrees with its canonical response or Tool result.

## What went wrong

The runtime treated every Tool call as intermediate work. After a delivery Tool succeeded, it still asked the model for a private final answer. Budget checks also ran after responses, so the research call that consumed the last delivery tokens had already happened. Durable prompt reconstruction replayed every prior Run's evaluated instructions, while persisted usage discarded provider cache and pricing detail.

This change makes completion explicit in the Agent definition, admits only that singleton Tool during finalization, and commits its successful result with the Run completion marker. Pre-call admission now reserves completion tokens and re-evaluates the balance after compaction. Run-scoped prompt provenance and detailed usage records preserve audit history without replaying stale instructions or losing cost data.

Review follow-ups keep every `onExhaustion: "fail"` dimension strict; reject malformed, contradictory, non-additive, or overflowing usage before it can affect budgets; require unique pricing identities and exact summary/group agreement; validate persisted prefix roles; pair durable budget markers; re-run the Agent output Schema or completion projector before accepting a recovered marker; and count provider-executed calls when revalidating completion singletons.

## Architecture

- [Typed completion declaration](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/core/src/agent.ts)
- [Canonical usage schemas and checked aggregation](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/core/src/usage.ts)
- [Provider validation, completion projection, reserve, compaction, and delivery](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/engine/src/index.ts)
- [Prompt provenance and settlement schemas](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/session/src/records.ts)
- [Durable recovery revalidation and checked usage projection](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/session/src/durable-runtime.ts)
- [Normative runtime requirements](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/docs/spec/runtime.md)

## Evidence

- [Core schema regressions](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/core/test/core.test.ts) cover additive token records, exact summary/group agreement, duplicate identities, and safe-integer overflow.
- [Engine regressions](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/engine/test/context-economics.test.ts) cover malformed and contradictory provider usage, omitted-component remainder allocation, strict fail-mode admission, terminal delivery, singleton enforcement, and live cumulative cost overflow.
- [Durable schema regressions](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/session/test/session.test.ts) reject prefixes containing response messages, out-of-bounds prefixes, and one-sided budget markers.
- [Hostile-store recovery regressions](https://github.com/danieljvdm/effect-agent/blob/5f93c64b4c1596762953cb9ddce0aa460161d222/packages/testing/test/durable-runtime.test.ts) prove both no-Tool and completion-Tool output substitution fail closed without another model or Handler invocation.
- `vp run check`, `vp run test`, and `vp run build` pass across the full workspace, including real-process and Cloudflare eviction/failpoint matrices.
