### PR TITLE
fix(pr-review): keep incremental retries path-bound

### DIFF
--- a/.changeset/path-bound-review-retries.md
+++ b/.changeset/path-bound-review-retries.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Keep each failed incremental review stage attached to its own unchanged paths so unrelated leftovers no longer widen model scope. Reopen discovery only for paths whose candidate verification must be regenerated.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -43553,6 +43553,7 @@ var fullReviewSelection = (input) => ({
   reason: input.reason,
   files: input.files,
   affectedPaths: input.files.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]),
+  retryPasses: [],
   retryPaths: [],
   retryStages: [],
   totalFiles: input.totalFiles,
@@ -43610,35 +43611,46 @@ var incrementalFromDelta = (input) => {
   }
   const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
   const retryOnly = new Set;
-  const retryStages = new Set;
   for (const path of carriedPaths) {
     if (affectedPaths.has(path))
       continue;
     retryOnly.add(path);
-    for (const pass of input.priorState.unreviewedPasses) {
-      if (pass.paths.includes(path))
-        retryStages.add(pass.stage);
+  }
+  const retryPathsByStage = new Map;
+  const representedRetryPaths = new Set;
+  for (const pass of input.priorState.unreviewedPasses) {
+    for (const path of pass.paths) {
+      if (!retryOnly.has(path))
+        continue;
+      const paths = retryPathsByStage.get(pass.stage) ?? new Set;
+      paths.add(path);
+      retryPathsByStage.set(pass.stage, paths);
+      representedRetryPaths.add(path);
     }
   }
-  if (retryStages.has("verification") && !retryStages.has("discovery") && !retryStages.has("specialist")) {
-    retryStages.add("discovery");
-    retryStages.add("specialist");
+  for (const path of retryOnly) {
+    if (representedRetryPaths.has(path))
+      continue;
+    retryOnly.delete(path);
+    affectedPaths.add(path);
   }
-  if (retryOnly.size > 0 && retryStages.size === 0) {
-    for (const path of retryOnly)
-      affectedPaths.add(path);
-    retryStages.add("discovery");
-    retryStages.add("specialist");
-    retryStages.add("verification");
-  }
+  const retryPasses = ["discovery", "specialist", "verification"].flatMap((stage) => {
+    const paths = [...retryPathsByStage.get(stage) ?? []].filter((path) => retryOnly.has(path)).sort();
+    return Array.from({ length: Math.ceil(paths.length / 12) }, (_, index2) => StoredUnreviewedPass.make({
+      stage,
+      paths: paths.slice(index2 * 12, (index2 + 1) * 12)
+    }));
+  });
+  const retryPaths = [...retryOnly].sort();
+  const retryStages = [...new Set(retryPasses.map((pass) => pass.stage))];
   for (const file2 of input.fullFiles) {
     const needed = affectedPaths.has(file2.path) || file2.previousPath !== undefined && affectedPaths.has(file2.previousPath) || retryOnly.has(file2.path) || file2.previousPath !== undefined && retryOnly.has(file2.previousPath);
     if (needed)
       selectedByPath.set(file2.path, file2);
   }
   const selectedFiles = [...selectedByPath.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
-  const leftoverCount = [...retryOnly].filter((path) => !affectedPaths.has(path)).length;
-  const carriedReason = leftoverCount > 0 ? `; retrying ${leftoverCount} unchanged leftover path(s) without rediscovery` : carriedPaths.length > 0 ? `; retrying ${carriedPaths.length} carried unreviewed path(s)` : "";
+  const leftoverCount = retryPaths.length;
+  const carriedReason = leftoverCount > 0 ? `; retrying ${leftoverCount} unchanged leftover path(s) by recorded failed stage` : carriedPaths.length > 0 ? `; retrying ${carriedPaths.length} carried unreviewed path(s)` : "";
   const concernPathCount = affectedPaths.size - initialAffectedCount;
   const concernReason = concernPathCount === 0 ? "" : `; reopening ${concernPathCount} related concern path(s) for context`;
   return {
@@ -43646,8 +43658,9 @@ var incrementalFromDelta = (input) => {
     reason: `${input.reason}${carriedReason}${concernReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
-    retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),
-    retryStages: [...retryStages].sort(),
+    retryPasses,
+    retryPaths,
+    retryStages,
     totalFiles: selectedFiles.length,
     baselineSha: input.priorState.reviewedHeadSha,
     priorState: input.priorState,
@@ -45150,9 +45163,31 @@ var remapPlanUnitIds = (plan, offset) => {
   });
 };
 var scheduleFanOutWork = (input) => {
-  const retryPathSet = new Set(input.retry?.paths ?? []);
-  const retryStages = new Set(input.retry?.stages ?? []);
-  if (retryPathSet.size === 0) {
+  const requestedRetryPasses = input.retry?.passes ?? input.retry?.stages?.map((stage) => ({ stage, paths: input.retry?.paths ?? [] })) ?? [];
+  const requestedStagesByPath = new Map;
+  for (const pass of requestedRetryPasses) {
+    for (const path of pass.paths) {
+      const stages = requestedStagesByPath.get(path) ?? new Set;
+      stages.add(pass.stage);
+      requestedStagesByPath.set(path, stages);
+    }
+  }
+  const canonicalPathByKnownPath = new Map;
+  const retryStagesByPath = new Map;
+  for (const file2 of input.files) {
+    canonicalPathByKnownPath.set(file2.path, file2.path);
+    if (file2.previousPath !== undefined) {
+      canonicalPathByKnownPath.set(file2.previousPath, file2.path);
+    }
+    const requested = [
+      requestedStagesByPath.get(file2.path),
+      ...file2.previousPath === undefined ? [] : [requestedStagesByPath.get(file2.previousPath)]
+    ];
+    const stages = new Set(requested.flatMap((entry) => [...entry ?? []]));
+    if (stages.size > 0)
+      retryStagesByPath.set(file2.path, stages);
+  }
+  if (retryStagesByPath.size === 0) {
     const plan2 = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
     const passesByUnit2 = new Map;
     for (const pass of plan2.discoveryPasses) {
@@ -45160,50 +45195,71 @@ var scheduleFanOutWork = (input) => {
       passes.push(pass);
       passesByUnit2.set(pass.unitId, passes);
     }
-    return { plan: plan2, passesByUnit: passesByUnit2, overflowRetryPaths: [] };
+    return { plan: plan2, passesByUnit: passesByUnit2, overflowRetryPasses: [] };
   }
-  const freshFiles = input.files.filter((file2) => !retryPathSet.has(file2.path));
-  const retryFiles = input.files.filter((file2) => retryPathSet.has(file2.path));
-  const freshPlan = planReviewUnits(freshFiles, { totalChangedFiles: input.totalChangedFiles });
-  const retryPlan = remapPlanUnitIds(planReviewUnits(retryFiles, { totalChangedFiles: input.totalChangedFiles }), freshPlan.units.length);
-  const acceptedFresh = freshPlan.units.slice(0, MAX_REVIEW_UNITS);
-  const acceptedRetry = retryPlan.units.slice(0, Math.max(0, MAX_REVIEW_UNITS - acceptedFresh.length));
-  const overflowRetryPaths = retryPlan.units.slice(acceptedRetry.length).flatMap((unit) => [...unit.paths]);
-  const retryPassFilter = (pass) => {
-    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
-    return retryStages.has(stage);
+  const discoveryStagesFor = (stages) => {
+    if (stages.has("verification"))
+      return ["discovery", "specialist"];
+    return [
+      ...stages.has("discovery") ? ["discovery"] : [],
+      ...stages.has("specialist") ? ["specialist"] : []
+    ];
   };
-  const acceptedRetryIds = new Set(acceptedRetry.map((unit) => unit.unitId));
-  let retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId) && retryPassFilter(pass));
-  if (retryStages.has("verification") && !retryStages.has("discovery") && !retryStages.has("specialist")) {
-    retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId));
+  const freshFiles = input.files.filter((file2) => !retryStagesByPath.has(file2.path));
+  const retryGroups = new Map;
+  for (const file2 of input.files) {
+    const retryStages = retryStagesByPath.get(file2.path);
+    if (retryStages === undefined)
+      continue;
+    const stages = discoveryStagesFor(retryStages);
+    const key = stages.join("|");
+    const group2 = retryGroups.get(key) ?? { stages, files: [] };
+    group2.files.push(file2);
+    retryGroups.set(key, group2);
   }
-  const acceptedFreshIds = new Set(acceptedFresh.map((unit) => unit.unitId));
-  const freshPasses = freshPlan.discoveryPasses.filter((pass) => acceptedFreshIds.has(pass.unitId));
-  const discoveryPasses = [...freshPasses, ...retryPasses];
+  const batches = [
+    ...freshFiles.length === 0 ? [] : [{ stages: ["discovery", "specialist"], files: freshFiles }],
+    ...[...retryGroups.entries()].sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0).map(([, group2]) => group2)
+  ];
+  const subplans = [];
+  const acceptedUnits = [];
+  const rejectedUnits = [];
+  const discoveryPasses = [];
+  for (const batch of batches) {
+    const batchPlan = remapPlanUnitIds(planReviewUnits(batch.files, { totalChangedFiles: batch.files.length }), acceptedUnits.length);
+    subplans.push(batchPlan);
+    const accepted = batchPlan.units.slice(0, Math.max(0, MAX_REVIEW_UNITS - acceptedUnits.length));
+    acceptedUnits.push(...accepted);
+    rejectedUnits.push(...batchPlan.units.slice(accepted.length));
+    const acceptedIds = new Set(accepted.map((unit) => unit.unitId));
+    discoveryPasses.push(...batchPlan.discoveryPasses.filter((pass) => {
+      const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+      return acceptedIds.has(pass.unitId) && batch.stages.includes(stage);
+    }));
+  }
+  const acceptedPaths = new Set(acceptedUnits.flatMap((unit) => unit.paths));
+  const incompletePlannedPaths = new Set([
+    ...subplans.flatMap((plan2) => plan2.partialEvidencePaths),
+    ...subplans.flatMap((plan2) => plan2.unassignedPaths),
+    ...rejectedUnits.flatMap((unit) => unit.paths)
+  ]);
+  const partialEvidencePaths = [...incompletePlannedPaths].filter((path) => acceptedPaths.has(path)).sort();
+  const unassignedPaths = [...incompletePlannedPaths].filter((path) => !acceptedPaths.has(path)).sort();
+  const rejectedEvidenceShards = rejectedUnits.flatMap((unit) => unit.evidenceShards);
+  const undiffablePaths = [...new Set(subplans.flatMap((plan2) => plan2.undiffablePaths))].sort();
   const plan = ReviewUnitPlan.make({
     totalFiles: input.files.length,
-    truncated: freshPlan.truncated || retryPlan.truncated,
-    units: [...acceptedFresh, ...acceptedRetry],
+    truncated: input.files.length < input.totalChangedFiles,
+    units: acceptedUnits,
     discoveryPasses,
-    undiffablePaths: [
-      ...new Set([...freshPlan.undiffablePaths, ...retryPlan.undiffablePaths])
-    ].sort(),
-    partialEvidencePaths: [
-      ...new Set([...freshPlan.partialEvidencePaths, ...retryPlan.partialEvidencePaths])
-    ].sort(),
-    unassignedEvidenceShardCount: freshPlan.unassignedEvidenceShardCount + retryPlan.unassignedEvidenceShardCount,
+    undiffablePaths,
+    partialEvidencePaths,
+    unassignedEvidenceShardCount: subplans.reduce((total, item) => total + item.unassignedEvidenceShardCount, 0) + rejectedEvidenceShards.length,
     unassignedEvidenceShardIds: [
-      ...freshPlan.unassignedEvidenceShardIds,
-      ...retryPlan.unassignedEvidenceShardIds
+      ...subplans.flatMap((item) => item.unassignedEvidenceShardIds),
+      ...rejectedEvidenceShards.map((shard) => shard.shardId)
     ].slice(0, MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS),
-    unassignedPaths: [
-      ...new Set([
-        ...freshPlan.unassignedPaths,
-        ...retryPlan.unassignedPaths,
-        ...overflowRetryPaths
-      ])
-    ].sort()
+    unassignedPaths
   });
   const passesByUnit = new Map;
   for (const pass of discoveryPasses) {
@@ -45211,10 +45267,33 @@ var scheduleFanOutWork = (input) => {
     passes.push(pass);
     passesByUnit.set(pass.unitId, passes);
   }
-  return { plan, passesByUnit, overflowRetryPaths };
+  const incompletePaths = new Set([
+    ...partialEvidencePaths,
+    ...unassignedPaths,
+    ...undiffablePaths
+  ]);
+  const overflowRetryPathsByStage = new Map;
+  for (const pass of requestedRetryPasses) {
+    for (const path of pass.paths) {
+      const canonicalPath = canonicalPathByKnownPath.get(path);
+      if (canonicalPath === undefined || !incompletePaths.has(canonicalPath))
+        continue;
+      const paths = overflowRetryPathsByStage.get(pass.stage) ?? new Set;
+      paths.add(canonicalPath);
+      overflowRetryPathsByStage.set(pass.stage, paths);
+    }
+  }
+  const overflowRetryPasses = ["discovery", "specialist", "verification"].flatMap((stage) => {
+    const paths = [...overflowRetryPathsByStage.get(stage) ?? []].sort();
+    return Array.from({ length: Math.ceil(paths.length / MAX_UNIT_FILES) }, (_, index2) => ({
+      stage,
+      paths: paths.slice(index2 * MAX_UNIT_FILES, (index2 + 1) * MAX_UNIT_FILES)
+    }));
+  });
+  return { plan, passesByUnit, overflowRetryPasses };
 };
 var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
-  const { plan, passesByUnit, overflowRetryPaths } = scheduleFanOutWork(input);
+  const { plan, passesByUnit, overflowRetryPasses } = scheduleFanOutWork(input);
   const outcomes = yield* exports_Effect.forEach(plan.units, (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input), { concurrency: REVIEW_UNIT_CONCURRENCY });
   const failedPasses = outcomes.flatMap((outcome) => outcome.failedPasses);
   const unsettledCandidates = outcomes.reduce((total, outcome) => total + outcome.unsettledCandidates, 0);
@@ -45273,7 +45352,7 @@ var runFanOutReview = (binding, input) => exports_Effect.gen(function* () {
     ].sort(),
     unreviewedPasses: [
       ...outcomes.flatMap((outcome) => outcome.unreviewedPasses),
-      ...overflowRetryPaths.length === 0 ? [] : ((input.retry?.stages.length) ? input.retry.stages : ["discovery", "specialist", "verification"]).map((stage) => ({ stage, paths: overflowRetryPaths }))
+      ...overflowRetryPasses
     ],
     turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0)
   };
@@ -46532,16 +46611,19 @@ var executeFanOutReview = (binding, options3) => exports_Effect.gen(function* ()
   const budget2 = yield* makeUsageBudget(options3.limits ?? fanOutReviewBudgetLimits);
   const totalFiles = executionContext.totalFiles;
   const continuity = yield* resolveReviewContinuityContext();
+  const retryPasses = executionContext.retryPasses ?? executionContext.retryStages.map((stage) => ({
+    stage,
+    paths: executionContext.retryPaths
+  }));
   const pipeline = yield* runFanOutReview(binding, {
     files,
     anchorFiles,
     totalChangedFiles: totalFiles,
     maxFindings: options3.maxFindings,
     budget: toRunBudgetHook(budget2),
-    ...executionContext.retryPaths.length > 0 ? {
+    ...retryPasses.length > 0 ? {
       retry: {
-        paths: executionContext.retryPaths,
-        stages: executionContext.retryStages
+        passes: retryPasses
       }
     } : {},
     ...continuity.adjudications.length > 0 || continuity.priorFindingsOnScope.length > 0 ? {

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -140,13 +140,14 @@ completed run that can be signed advances the authenticated incremental baseline
 that stays failed carries its paths forward as retryable scope inside the state instead of
 freezing the baseline, and only a fully settled state authorizes skip-unchanged. A rewritten
 head that is no longer a git ancestor stays incremental when a two-dot tree comparison can
-name the current PR paths whose contents changed. Unchanged leftovers retry only the failed
-pass and keep their stored findings. The package exports `./testing` for fixture sources, a collecting
-publisher, and prompt-keyed scripted models. It exports `./action` and `./cli` as platform-node host
-entrypoints. It consumes the `effect-agent` umbrella as the first package-level consumer. Deployment class E
-only; review posting is never claimed exactly-once. Its built-in OpenAI host configuration accepts
-the single explicit service tier `fast`, includes it in the model profile fingerprint, and rejects
-that provider-specific setting when Anthropic is selected.
+name the current PR paths whose contents changed; unchanged leftovers keep failed stages bound
+to their exact paths and retain stored findings. Failed verification reopens discovery only for
+its owning paths because candidate payloads are not persisted. The package exports `./testing` for
+fixture sources, a collecting publisher, and prompt-keyed scripted models. It exports `./action`
+and `./cli` as platform-node host entrypoints. It consumes the `effect-agent` umbrella as the first
+package-level consumer. Deployment class E only; review posting is never claimed exactly-once. Its
+built-in OpenAI host configuration accepts the single explicit service tier `fast`, includes it in
+the model profile fingerprint, and rejects that provider-specific setting when Anthropic is selected.
 
 ### `@effect-agent/testing`
 

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -364,13 +364,15 @@ shards rather than silently truncated; every unit receives a fresh specialist di
 with deterministic host-classified risk categories directing its focus;
 a defect missed by general discovery can still become a candidate; and an independent verifier
 rejects an unsupported candidate before host-side publication. Failed or exhausted discovery and
-verification passes remain visible, leave candidates unsettled, emit no authenticated continuity
-state, and cannot produce a successful Action conclusion. Incremental fixtures prove that newly
-affected paths invalidate carried findings while unchanged findings remain active. Confirmed
-non-anchored concerns retain their host-validated evidence paths; changing or deleting any one
-invalidates the old concern and reopens the remaining current paths for context, while legacy
-pathless concern state forces a full review. Explicit final mode discards prior assurance scope and
-plans fresh discovery over the complete bounded diff.
+verification passes remain visible, leave candidates unsettled, advance authenticated continuity
+state with exact failed-stage ownership, and cannot produce a successful Action conclusion.
+Incremental fixtures prove that newly affected paths invalidate carried findings while unchanged
+findings remain active, and that different failed stages stay attached to their own unchanged
+paths. A failed verification may regenerate candidates through fresh discovery, but only for its
+own paths. Confirmed non-anchored concerns retain their host-validated evidence paths; changing or
+deleting any one invalidates the old concern and reopens the remaining current paths for context,
+while legacy pathless concern state forces a full review. Explicit final mode discards prior
+assurance scope and plans fresh discovery over the complete bounded diff.
 Overflow fixtures preserve every affected path and the exact unassigned-shard count while bounding
 identifier diagnostics. Extra or duplicate delegation declarations cannot hide behind an expected
 work ID, equivalent cross-pass candidates are verified once, and an empty plan settles without

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -185,8 +185,10 @@ gate.
 ## Action and CLI
 
 The prebuilt GitHub Action handles signed incremental state, fail-closed scope selection, sticky
-progress, stale-review retirement, and final audits. See its [setup and behavior guide](../../action/README.md)
-and [input reference](../../action/action.yml). Custom hosts can import `runReviewAction` from
+progress, stale-review retirement, and final audits. Failed stages remain attached to their exact
+unchanged paths; failed verification reopens discovery only for its paths because candidates are
+not persisted. See its [setup and behavior guide](../../action/README.md) and
+[input reference](../../action/action.yml). Custom hosts can import `runReviewAction` from
 `@effect-agent/pr-review/action`.
 
 Run the CLI with

--- a/packages/pr-review/src/internal/fan-out.ts
+++ b/packages/pr-review/src/internal/fan-out.ts
@@ -403,13 +403,20 @@ export interface FanOutPipelineInput {
   /** Shared run budget observed by every child pass. */
   readonly budget?: RunBudgetHook<BudgetExceeded | BudgetAdapterError> | undefined;
   /**
-   * Unchanged leftover paths from a prior failed pass. Those units retry only
-   * the recorded stages — no second general discovery on files nobody touched.
+   * Unchanged leftovers from prior failed passes. Every stage stays attached
+   * to its own paths; failed verification reopens both discovery perspectives
+   * for only those paths because candidate payloads are not persisted.
    */
   readonly retry?:
     | {
-        readonly paths: ReadonlyArray<string>;
-        readonly stages: ReadonlyArray<FailedReviewPass["stage"]>;
+        readonly passes?: ReadonlyArray<{
+          readonly stage: FailedReviewPass["stage"];
+          readonly paths: ReadonlyArray<string>;
+        }>;
+        /** @deprecated Pass path-bound `passes`; this flat form cannot preserve ownership. */
+        readonly paths?: ReadonlyArray<string>;
+        /** @deprecated Pass path-bound `passes`; this flat form cannot preserve ownership. */
+        readonly stages?: ReadonlyArray<FailedReviewPass["stage"]>;
       }
     | undefined;
   /**
@@ -840,11 +847,38 @@ const scheduleFanOutWork = (
 ): {
   readonly plan: ReviewUnitPlan;
   readonly passesByUnit: Map<string, ReadonlyArray<ReviewDiscoveryPass>>;
-  readonly overflowRetryPaths: ReadonlyArray<string>;
+  readonly overflowRetryPasses: ReadonlyArray<{
+    readonly stage: FailedReviewPass["stage"];
+    readonly paths: ReadonlyArray<string>;
+  }>;
 } => {
-  const retryPathSet = new Set(input.retry?.paths ?? []);
-  const retryStages = new Set(input.retry?.stages ?? []);
-  if (retryPathSet.size === 0) {
+  const requestedRetryPasses =
+    input.retry?.passes ??
+    input.retry?.stages?.map((stage) => ({ stage, paths: input.retry?.paths ?? [] })) ??
+    [];
+  const requestedStagesByPath = new Map<string, Set<FailedReviewPass["stage"]>>();
+  for (const pass of requestedRetryPasses) {
+    for (const path of pass.paths) {
+      const stages = requestedStagesByPath.get(path) ?? new Set<FailedReviewPass["stage"]>();
+      stages.add(pass.stage);
+      requestedStagesByPath.set(path, stages);
+    }
+  }
+  const canonicalPathByKnownPath = new Map<string, string>();
+  const retryStagesByPath = new Map<string, Set<FailedReviewPass["stage"]>>();
+  for (const file of input.files) {
+    canonicalPathByKnownPath.set(file.path, file.path);
+    if (file.previousPath !== undefined) {
+      canonicalPathByKnownPath.set(file.previousPath, file.path);
+    }
+    const requested = [
+      requestedStagesByPath.get(file.path),
+      ...(file.previousPath === undefined ? [] : [requestedStagesByPath.get(file.previousPath)]),
+    ];
+    const stages = new Set(requested.flatMap((entry) => [...(entry ?? [])]));
+    if (stages.size > 0) retryStagesByPath.set(file.path, stages);
+  }
+  if (retryStagesByPath.size === 0) {
     const plan = planReviewUnits(input.files, { totalChangedFiles: input.totalChangedFiles });
     const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
     for (const pass of plan.discoveryPasses) {
@@ -852,65 +886,96 @@ const scheduleFanOutWork = (
       passes.push(pass);
       passesByUnit.set(pass.unitId, passes);
     }
-    return { plan, passesByUnit, overflowRetryPaths: [] };
+    return { plan, passesByUnit, overflowRetryPasses: [] };
   }
-  const freshFiles = input.files.filter((file) => !retryPathSet.has(file.path));
-  const retryFiles = input.files.filter((file) => retryPathSet.has(file.path));
-  const freshPlan = planReviewUnits(freshFiles, { totalChangedFiles: input.totalChangedFiles });
-  const retryPlan = remapPlanUnitIds(
-    planReviewUnits(retryFiles, { totalChangedFiles: input.totalChangedFiles }),
-    freshPlan.units.length,
-  );
-  const acceptedFresh = freshPlan.units.slice(0, MAX_REVIEW_UNITS);
-  const acceptedRetry = retryPlan.units.slice(
-    0,
-    Math.max(0, MAX_REVIEW_UNITS - acceptedFresh.length),
-  );
-  const overflowRetryPaths = retryPlan.units
-    .slice(acceptedRetry.length)
-    .flatMap((unit) => [...unit.paths]);
-  const retryPassFilter = (pass: ReviewDiscoveryPass): boolean => {
-    const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
-    return retryStages.has(stage);
+
+  type DiscoveryStage = "discovery" | "specialist";
+  const discoveryStagesFor = (
+    stages: ReadonlySet<FailedReviewPass["stage"]>,
+  ): ReadonlyArray<DiscoveryStage> => {
+    if (stages.has("verification")) return ["discovery", "specialist"];
+    return [
+      ...(stages.has("discovery") ? (["discovery"] as const) : []),
+      ...(stages.has("specialist") ? (["specialist"] as const) : []),
+    ];
   };
-  const acceptedRetryIds = new Set(acceptedRetry.map((unit) => unit.unitId));
-  let retryPasses = retryPlan.discoveryPasses.filter(
-    (pass) => acceptedRetryIds.has(pass.unitId) && retryPassFilter(pass),
-  );
-  if (
-    retryStages.has("verification") &&
-    !retryStages.has("discovery") &&
-    !retryStages.has("specialist")
-  ) {
-    retryPasses = retryPlan.discoveryPasses.filter((pass) => acceptedRetryIds.has(pass.unitId));
+  const freshFiles = input.files.filter((file) => !retryStagesByPath.has(file.path));
+  const retryGroups = new Map<
+    string,
+    { readonly stages: ReadonlyArray<DiscoveryStage>; readonly files: Array<ChangedFile> }
+  >();
+  for (const file of input.files) {
+    const retryStages = retryStagesByPath.get(file.path);
+    if (retryStages === undefined) continue;
+    const stages = discoveryStagesFor(retryStages);
+    const key = stages.join("|");
+    const group = retryGroups.get(key) ?? { stages, files: [] };
+    group.files.push(file);
+    retryGroups.set(key, group);
   }
-  const acceptedFreshIds = new Set(acceptedFresh.map((unit) => unit.unitId));
-  const freshPasses = freshPlan.discoveryPasses.filter((pass) => acceptedFreshIds.has(pass.unitId));
-  const discoveryPasses = [...freshPasses, ...retryPasses];
+
+  const batches: ReadonlyArray<{
+    readonly stages: ReadonlyArray<DiscoveryStage>;
+    readonly files: ReadonlyArray<ChangedFile>;
+  }> = [
+    ...(freshFiles.length === 0
+      ? []
+      : [{ stages: ["discovery", "specialist"] as const, files: freshFiles }]),
+    ...[...retryGroups.entries()]
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([, group]) => group),
+  ];
+  const subplans: Array<ReviewUnitPlan> = [];
+  const acceptedUnits: Array<ReviewUnit> = [];
+  const rejectedUnits: Array<ReviewUnit> = [];
+  const discoveryPasses: Array<ReviewDiscoveryPass> = [];
+  for (const batch of batches) {
+    const batchPlan = remapPlanUnitIds(
+      planReviewUnits(batch.files, { totalChangedFiles: batch.files.length }),
+      acceptedUnits.length,
+    );
+    subplans.push(batchPlan);
+    const accepted = batchPlan.units.slice(0, Math.max(0, MAX_REVIEW_UNITS - acceptedUnits.length));
+    acceptedUnits.push(...accepted);
+    rejectedUnits.push(...batchPlan.units.slice(accepted.length));
+    const acceptedIds = new Set(accepted.map((unit) => unit.unitId));
+    discoveryPasses.push(
+      ...batchPlan.discoveryPasses.filter((pass) => {
+        const stage = pass.perspective === "risk-specialist" ? "specialist" : "discovery";
+        return acceptedIds.has(pass.unitId) && batch.stages.includes(stage);
+      }),
+    );
+  }
+
+  const acceptedPaths = new Set(acceptedUnits.flatMap((unit) => unit.paths));
+  const incompletePlannedPaths = new Set([
+    ...subplans.flatMap((plan) => plan.partialEvidencePaths),
+    ...subplans.flatMap((plan) => plan.unassignedPaths),
+    ...rejectedUnits.flatMap((unit) => unit.paths),
+  ]);
+  const partialEvidencePaths = [...incompletePlannedPaths]
+    .filter((path) => acceptedPaths.has(path))
+    .sort();
+  const unassignedPaths = [...incompletePlannedPaths]
+    .filter((path) => !acceptedPaths.has(path))
+    .sort();
+  const rejectedEvidenceShards = rejectedUnits.flatMap((unit) => unit.evidenceShards);
+  const undiffablePaths = [...new Set(subplans.flatMap((plan) => plan.undiffablePaths))].sort();
   const plan = ReviewUnitPlan.make({
     totalFiles: input.files.length,
-    truncated: freshPlan.truncated || retryPlan.truncated,
-    units: [...acceptedFresh, ...acceptedRetry],
+    truncated: input.files.length < input.totalChangedFiles,
+    units: acceptedUnits,
     discoveryPasses,
-    undiffablePaths: [
-      ...new Set([...freshPlan.undiffablePaths, ...retryPlan.undiffablePaths]),
-    ].sort(),
-    partialEvidencePaths: [
-      ...new Set([...freshPlan.partialEvidencePaths, ...retryPlan.partialEvidencePaths]),
-    ].sort(),
+    undiffablePaths,
+    partialEvidencePaths,
     unassignedEvidenceShardCount:
-      freshPlan.unassignedEvidenceShardCount + retryPlan.unassignedEvidenceShardCount,
+      subplans.reduce((total, item) => total + item.unassignedEvidenceShardCount, 0) +
+      rejectedEvidenceShards.length,
     unassignedEvidenceShardIds: [
-      ...freshPlan.unassignedEvidenceShardIds,
-      ...retryPlan.unassignedEvidenceShardIds,
+      ...subplans.flatMap((item) => item.unassignedEvidenceShardIds),
+      ...rejectedEvidenceShards.map((shard) => shard.shardId),
     ].slice(0, MAX_REPORTED_UNASSIGNED_EVIDENCE_SHARDS),
-    unassignedPaths: [
-      ...new Set([
-        ...freshPlan.unassignedPaths,
-        ...retryPlan.unassignedPaths,
-        ...overflowRetryPaths,
-      ]),
-    ].sort(),
+    unassignedPaths,
   });
   const passesByUnit = new Map<string, Array<ReviewDiscoveryPass>>();
   for (const pass of discoveryPasses) {
@@ -918,7 +983,31 @@ const scheduleFanOutWork = (
     passes.push(pass);
     passesByUnit.set(pass.unitId, passes);
   }
-  return { plan, passesByUnit, overflowRetryPaths };
+  const incompletePaths = new Set([
+    ...partialEvidencePaths,
+    ...unassignedPaths,
+    ...undiffablePaths,
+  ]);
+  const overflowRetryPathsByStage = new Map<FailedReviewPass["stage"], Set<string>>();
+  for (const pass of requestedRetryPasses) {
+    for (const path of pass.paths) {
+      const canonicalPath = canonicalPathByKnownPath.get(path);
+      if (canonicalPath === undefined || !incompletePaths.has(canonicalPath)) continue;
+      const paths = overflowRetryPathsByStage.get(pass.stage) ?? new Set<string>();
+      paths.add(canonicalPath);
+      overflowRetryPathsByStage.set(pass.stage, paths);
+    }
+  }
+  const overflowRetryPasses = (["discovery", "specialist", "verification"] as const).flatMap(
+    (stage) => {
+      const paths = [...(overflowRetryPathsByStage.get(stage) ?? [])].sort();
+      return Array.from({ length: Math.ceil(paths.length / MAX_UNIT_FILES) }, (_, index) => ({
+        stage,
+        paths: paths.slice(index * MAX_UNIT_FILES, (index + 1) * MAX_UNIT_FILES),
+      }));
+    },
+  );
+  return { plan, passesByUnit, overflowRetryPasses };
 };
 
 /**
@@ -932,7 +1021,7 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
   input: FanOutPipelineInput,
 ) =>
   Effect.gen(function* () {
-    const { plan, passesByUnit, overflowRetryPaths } = scheduleFanOutWork(input);
+    const { plan, passesByUnit, overflowRetryPasses } = scheduleFanOutWork(input);
     const outcomes = yield* Effect.forEach(
       plan.units,
       (unit) => reviewUnit(binding, unit, passesByUnit.get(unit.unitId) ?? [], input),
@@ -1052,12 +1141,7 @@ export const runFanOutReview = <Provider, ModelProvides, ModelRequires>(
       ].sort(),
       unreviewedPasses: [
         ...outcomes.flatMap((outcome) => outcome.unreviewedPasses),
-        ...(overflowRetryPaths.length === 0
-          ? []
-          : (input.retry?.stages.length
-              ? input.retry.stages
-              : (["discovery", "specialist", "verification"] as const)
-            ).map((stage) => ({ stage, paths: overflowRetryPaths }))),
+        ...overflowRetryPasses,
       ],
       turns: outcomes.reduce((total, outcome) => total + outcome.turns, 0),
     } satisfies FanOutPipelineOutcome;

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -131,11 +131,11 @@ export const MAX_STORED_UNREVIEWED_PATHS = 100;
 /** Failed-pass records stored beside the leftover paths; one per unit stage. */
 export const MAX_STORED_UNREVIEWED_PASSES = 24;
 
-/** Stages a leftover path may need retried without a second general discovery. */
+/** Stages a leftover path may need retried on the next incremental run. */
 export const UnreviewedStage = Schema.Literals(["discovery", "specialist", "verification"]);
 export type UnreviewedStage = typeof UnreviewedStage.Type;
 
-/** One failed fan-out pass whose paths should be retried, not rediscovered. */
+/** One failed fan-out pass whose stage remains attached to its exact paths. */
 export class StoredUnreviewedPass extends Schema.Class<StoredUnreviewedPass>(
   "@effect-agent/pr-review/StoredUnreviewedPass",
 )({
@@ -403,9 +403,12 @@ export interface ReviewSelection {
   /** Paths whose changes invalidate prior findings, including paths reverted out of the PR. */
   readonly affectedPaths: ReadonlyArray<string>;
   /**
-   * Leftover paths whose contents did not change. Fan-out retries only the
-   * recorded failed stages on these paths and keeps their stored findings.
+   * Failed stages attached to the unchanged paths that own them. Verification
+   * retries reopen discovery for only their paths because candidates are not
+   * persisted in review state.
    */
+  readonly retryPasses?: ReadonlyArray<StoredUnreviewedPass>;
+  /** Flattened summaries retained for diagnostics and compatibility. */
   readonly retryPaths: ReadonlyArray<string>;
   readonly retryStages: ReadonlyArray<UnreviewedStage>;
   readonly totalFiles: number;
@@ -429,6 +432,7 @@ export const fullReviewSelection = (input: {
   affectedPaths: input.files.flatMap((file) =>
     file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
   ),
+  retryPasses: [],
   retryPaths: [],
   retryStages: [],
   totalFiles: input.totalFiles,
@@ -519,28 +523,43 @@ const incrementalFromDelta = (input: {
   }
   const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
   const retryOnly = new Set<string>();
-  const retryStages = new Set<UnreviewedStage>();
   for (const path of carriedPaths) {
     if (affectedPaths.has(path)) continue;
     retryOnly.add(path);
-    for (const pass of input.priorState.unreviewedPasses) {
-      if (pass.paths.includes(path)) retryStages.add(pass.stage);
+  }
+
+  const retryPathsByStage = new Map<UnreviewedStage, Set<string>>();
+  const representedRetryPaths = new Set<string>();
+  for (const pass of input.priorState.unreviewedPasses) {
+    for (const path of pass.paths) {
+      if (!retryOnly.has(path)) continue;
+      const paths = retryPathsByStage.get(pass.stage) ?? new Set<string>();
+      paths.add(path);
+      retryPathsByStage.set(pass.stage, paths);
+      representedRetryPaths.add(path);
     }
   }
-  if (
-    retryStages.has("verification") &&
-    !retryStages.has("discovery") &&
-    !retryStages.has("specialist")
-  ) {
-    retryStages.add("discovery");
-    retryStages.add("specialist");
+  // Some continuity gaps (capacity overflow, partial evidence, legacy state)
+  // have no failed-pass record. They conservatively re-enter fresh discovery
+  // instead of inheriting another path's unrelated failed stage.
+  for (const path of retryOnly) {
+    if (representedRetryPaths.has(path)) continue;
+    retryOnly.delete(path);
+    affectedPaths.add(path);
   }
-  if (retryOnly.size > 0 && retryStages.size === 0) {
-    for (const path of retryOnly) affectedPaths.add(path);
-    retryStages.add("discovery");
-    retryStages.add("specialist");
-    retryStages.add("verification");
-  }
+  const retryPasses = (["discovery", "specialist", "verification"] as const).flatMap((stage) => {
+    const paths = [...(retryPathsByStage.get(stage) ?? [])]
+      .filter((path) => retryOnly.has(path))
+      .sort();
+    return Array.from({ length: Math.ceil(paths.length / 12) }, (_, index) =>
+      StoredUnreviewedPass.make({
+        stage,
+        paths: paths.slice(index * 12, (index + 1) * 12),
+      }),
+    );
+  });
+  const retryPaths = [...retryOnly].sort();
+  const retryStages = [...new Set(retryPasses.map((pass) => pass.stage))];
   for (const file of input.fullFiles) {
     const needed =
       affectedPaths.has(file.path) ||
@@ -552,10 +571,10 @@ const incrementalFromDelta = (input: {
   const selectedFiles = [...selectedByPath.values()].sort((left, right) =>
     left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
   );
-  const leftoverCount = [...retryOnly].filter((path) => !affectedPaths.has(path)).length;
+  const leftoverCount = retryPaths.length;
   const carriedReason =
     leftoverCount > 0
-      ? `; retrying ${leftoverCount} unchanged leftover path(s) without rediscovery`
+      ? `; retrying ${leftoverCount} unchanged leftover path(s) by recorded failed stage`
       : carriedPaths.length > 0
         ? `; retrying ${carriedPaths.length} carried unreviewed path(s)`
         : "";
@@ -569,8 +588,9 @@ const incrementalFromDelta = (input: {
     reason: `${input.reason}${carriedReason}${concernReason}`,
     files: selectedFiles,
     affectedPaths: [...affectedPaths].sort(),
-    retryPaths: [...retryOnly].filter((path) => !affectedPaths.has(path)).sort(),
-    retryStages: [...retryStages].sort(),
+    retryPasses,
+    retryPaths,
+    retryStages,
     totalFiles: selectedFiles.length,
     baselineSha: input.priorState.reviewedHeadSha,
     priorState: input.priorState,

--- a/packages/pr-review/src/internal/run.ts
+++ b/packages/pr-review/src/internal/run.ts
@@ -553,17 +553,22 @@ export const executeFanOutReview = <Provider, ModelProvides, ModelRequires>(
     const budget = yield* makeUsageBudget(options.limits ?? fanOutReviewBudgetLimits);
     const totalFiles = executionContext.totalFiles;
     const continuity = yield* resolveReviewContinuityContext();
+    const retryPasses =
+      executionContext.retryPasses ??
+      executionContext.retryStages.map((stage) => ({
+        stage,
+        paths: executionContext.retryPaths,
+      }));
     const pipeline = yield* runFanOutReview(binding, {
       files,
       anchorFiles,
       totalChangedFiles: totalFiles,
       maxFindings: options.maxFindings,
       budget: toRunBudgetHook(budget),
-      ...(executionContext.retryPaths.length > 0
+      ...(retryPasses.length > 0
         ? {
             retry: {
-              paths: executionContext.retryPaths,
-              stages: executionContext.retryStages,
+              passes: retryPasses,
             },
           }
         : {}),

--- a/packages/pr-review/test/pr-review-fanout.test.ts
+++ b/packages/pr-review/test/pr-review-fanout.test.ts
@@ -194,6 +194,17 @@ const report = (workId: string, value: FileReviewReport): OfflineUnitScript => (
   outcomes: [{ _tag: "report", report: value }],
 });
 
+const emptyDiscoveryReport = (workId: string, unitId: string): FileReviewReport =>
+  FileReviewReport.make({
+    phase: "discovery",
+    workId,
+    unitId,
+    findings: [],
+    concerns: [],
+    fileSummaries: [],
+    assessments: [],
+  });
+
 /** Run the host-scheduled pipeline offline over the fixture pull request. */
 const runOfflineFanOut = (script: {
   readonly children: ReadonlyArray<OfflineUnitScript>;
@@ -206,6 +217,10 @@ const runOfflineFanOut = (script: {
         readonly stages: ReadonlyArray<"discovery" | "specialist" | "verification">;
       }
     | undefined;
+  readonly retryPasses?: ReadonlyArray<{
+    readonly stage: "discovery" | "specialist" | "verification";
+    readonly paths: ReadonlyArray<string>;
+  }>;
 }) =>
   Effect.gen(function* () {
     const fixture = script.fixture ?? highRiskFixture;
@@ -220,6 +235,13 @@ const runOfflineFanOut = (script: {
         webCryptoReviewStateAuthenticatorLayer(Redacted.make("offline-assurance-secret")),
       ),
     );
+    const retryPasses =
+      script.retryPasses ??
+      script.retry?.stages.map((stage) => ({ stage, paths: script.retry?.paths ?? [] })) ??
+      [];
+    const retryPaths = [...new Set(retryPasses.flatMap((pass) => pass.paths))];
+    const retryStages = [...new Set(retryPasses.map((pass) => pass.stage))];
+    const isIncremental = retryPasses.length > 0;
     const program = executeFanOutReview(childBinding, {
       post: true,
       applyVerdict: false,
@@ -237,15 +259,15 @@ const runOfflineFanOut = (script: {
         ),
       ),
       Effect.provideService(ReviewExecutionContext, {
-        mode: script.retry === undefined ? "full" : "incremental",
-        reason:
-          script.retry === undefined
-            ? "offline full-diff assurance fixture"
-            : "offline leftover-pass retry fixture",
+        mode: isIncremental ? "incremental" : "full",
+        reason: isIncremental
+          ? "offline leftover-pass retry fixture"
+          : "offline full-diff assurance fixture",
         files: reviewFiles,
-        affectedPaths: script.retry === undefined ? reviewFiles.map((file) => file.path) : [],
-        retryPaths: script.retry?.paths ?? [],
-        retryStages: script.retry?.stages ?? [],
+        affectedPaths: isIncremental ? [] : reviewFiles.map((file) => file.path),
+        retryPasses,
+        retryPaths,
+        retryStages,
         totalFiles: reviewFiles.length,
         baselineSha: undefined,
         priorState: undefined,
@@ -975,6 +997,85 @@ describe("host-scheduled discovery and verification pipeline", () => {
       expect(result.outcome.review.findings).toEqual([supportedFinding]);
       expect(result.outcome.unreviewedPaths).toEqual([]);
       expect(result.outcome.state?.unreviewedPasses).toEqual([]);
+    }),
+  );
+
+  it.effect("keeps failed retry stages attached to their own unchanged paths", () =>
+    Effect.gen(function* () {
+      const authenticationPath = highRiskFiles[0]!.path;
+      const eventPath = highRiskFiles[1]!.path;
+      const result = yield* runOfflineFanOut({
+        retryPasses: [
+          { stage: "discovery", paths: [authenticationPath] },
+          { stage: "specialist", paths: [eventPath] },
+        ],
+        children: [
+          report("unit-001-general", emptyDiscoveryReport("unit-001-general", "unit-001")),
+          report("unit-001-specialist", emptyDiscoveryReport("unit-001-specialist", "unit-001")),
+          report("unit-002-specialist", emptyDiscoveryReport("unit-002-specialist", "unit-002")),
+        ],
+      });
+
+      const generalPrompt = result.childPrompts.find((prompt) =>
+        prompt.includes("for unit-001-general in host-planned unit"),
+      );
+      const specialistPrompt = result.childPrompts.find((prompt) =>
+        prompt.includes("for unit-002-specialist in host-planned unit"),
+      );
+
+      expect(result.childCalls).toBe(2);
+      expect(generalPrompt).toContain(authenticationPath);
+      expect(generalPrompt).not.toContain(eventPath);
+      expect(specialistPrompt).toContain(eventPath);
+      expect(specialistPrompt).not.toContain(authenticationPath);
+      expect(result.outcome.assurance).toMatchObject({
+        status: "settled",
+        requiredGeneralDiscoveryPasses: 1,
+        completedGeneralDiscoveryPasses: 1,
+        requiredSpecialistPasses: 1,
+        completedSpecialistPasses: 1,
+      });
+    }),
+  );
+
+  it.effect("regenerates candidates only for the paths whose verification failed", () =>
+    Effect.gen(function* () {
+      const authenticationPath = highRiskFiles[0]!.path;
+      const eventPath = highRiskFiles[1]!.path;
+      const result = yield* runOfflineFanOut({
+        retryPasses: [
+          { stage: "verification", paths: [authenticationPath] },
+          { stage: "specialist", paths: [eventPath] },
+        ],
+        children: [
+          report("unit-001-general", emptyDiscoveryReport("unit-001-general", "unit-001")),
+          report("unit-001-specialist", emptyDiscoveryReport("unit-001-specialist", "unit-001")),
+          report("unit-002-specialist", emptyDiscoveryReport("unit-002-specialist", "unit-002")),
+        ],
+      });
+
+      const verificationRetryPrompts = result.childPrompts.filter((prompt) =>
+        prompt.includes("in host-planned unit unit-001"),
+      );
+      const specialistRetryPrompt = result.childPrompts.find((prompt) =>
+        prompt.includes("for unit-002-specialist in host-planned unit"),
+      );
+
+      expect(result.childCalls).toBe(3);
+      expect(verificationRetryPrompts).toHaveLength(2);
+      for (const prompt of verificationRetryPrompts) {
+        expect(prompt).toContain(authenticationPath);
+        expect(prompt).not.toContain(eventPath);
+      }
+      expect(specialistRetryPrompt).toContain(eventPath);
+      expect(specialistRetryPrompt).not.toContain(authenticationPath);
+      expect(result.outcome.assurance).toMatchObject({
+        status: "settled",
+        requiredGeneralDiscoveryPasses: 1,
+        completedGeneralDiscoveryPasses: 1,
+        requiredSpecialistPasses: 2,
+        completedSpecialistPasses: 2,
+      });
     }),
   );
 

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -409,9 +409,41 @@ describe("review state", () => {
       "src/corrective.ts",
     ]);
     expect(selection.affectedPaths).not.toContain("src/accepted.ts");
+    expect(selection.retryPasses).toEqual([
+      StoredUnreviewedPass.make({ stage: "specialist", paths: ["src/accepted.ts"] }),
+    ]);
     expect(selection.retryPaths).toEqual(["src/accepted.ts"]);
     expect(selection.retryStages).toEqual(["specialist"]);
-    expect(selection.reason).toContain("without rediscovery");
+    expect(selection.reason).toContain("by recorded failed stage");
+  });
+
+  it("preserves different failed stages for different unchanged paths", () => {
+    const queuedFile = ChangedFile.make({
+      path: "src/queued.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 1,
+      patch: "@@ -1 +1 @@\n-old\n+queued",
+    });
+    const carryingState = ReviewState.make({
+      ...priorState,
+      unreviewedPaths: ["src/accepted.ts", "src/queued.ts"],
+      unreviewedPasses: [
+        StoredUnreviewedPass.make({ stage: "discovery", paths: ["src/accepted.ts"] }),
+        StoredUnreviewedPass.make({ stage: "specialist", paths: ["src/queued.ts"] }),
+      ],
+      settled: false,
+    });
+    const selection = select({
+      current: PullRequestMetadata.make({ ...metadata, totalChangedFiles: 3 }),
+      fullFiles: [acceptedFile, correctiveFile, queuedFile],
+      priorState: carryingState,
+    });
+
+    expect(selection.retryPasses).toEqual([
+      StoredUnreviewedPass.make({ stage: "discovery", paths: ["src/accepted.ts"] }),
+      StoredUnreviewedPass.make({ stage: "specialist", paths: ["src/queued.ts"] }),
+    ]);
   });
 
   it("reviews only content-changed PR paths after a rewritten head", () => {


### PR DESCRIPTION
## Summary

- Preserve the exact `{ stage, paths }` relationship from authenticated continuity state through review selection and fan-out scheduling.
- Group unchanged retries by their required discovery stages so one failed path cannot widen another path. Verification retries regenerate candidates through both discovery perspectives, but only for their owning paths.
- Preserve legacy flat retry input and overflow continuity, update the package contract and docs, add a changeset, and rebuild the vendored Action.

## What went wrong

`ReviewState` already stored each failed pass with its exact paths, but `ReviewSelection` flattened those records into a union of paths and a separate union of stages. The scheduler then applied every stage in that union to every carried path. Mixed failures therefore caused unrelated files to enter model prompts and spend the shared run budget outside their required retry scope. The behavior was visible in [this kommunikasie review run](https://github.com/reve-ai/kommunikasie/actions/runs/32770654736/job/97570016913).

## Architecture

- [Continuity selection](https://github.com/danieljvdm/effect-agent/blob/9fb15a1fa3bf4e4bad52030bfe0215143c684e6d/packages/pr-review/src/internal/review-state.ts#L524-L562) retains path ownership and sends unrepresented carry back through fresh discovery.
- [Fan-out scheduling](https://github.com/danieljvdm/effect-agent/blob/9fb15a1fa3bf4e4bad52030bfe0215143c684e6d/packages/pr-review/src/internal/fan-out.ts#L845-L1010) canonicalizes renamed paths, groups identical retry requirements, and preserves exact stage ownership through overflow.
- [Regression coverage](https://github.com/danieljvdm/effect-agent/blob/9fb15a1fa3bf4e4bad52030bfe0215143c684e6d/packages/pr-review/test/pr-review-fanout.test.ts#L1003-L1080) pins mixed discovery/specialist scope and verification candidate regeneration.

## Evidence

- Red: the mixed-stage regression failed on the old scheduler because the general prompt for `authenticate.ts` also contained unrelated `parse-event.ts` scope.
- Green: the regression passes with exact prompt membership; the path/stage continuity and verification-only retry cases also pass.
- `@effect-agent/pr-review`: 188 tests passed and 1 skipped; package check and build passed.
- Repository static checks completed with 0 errors; docs build, package-purity verification, Action build/check, formatting, and `git diff --check` passed.
- The aggregate `vp run ready` reached package type checks but Vite+ intermittently failed to spawn the `@effect-agent/sandbox-local` TypeScript task with `Invalid argument (os error 22)`; that exact package check passed immediately when run in isolation.