### PR TITLE
fix(pr-review): compare rewritten heads by tree snapshots

### DIFF
--- a/.changeset/bounded-rewritten-head-snapshots.md
+++ b/.changeset/bounded-rewritten-head-snapshots.md
@@ -1,0 +1,8 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Keep incremental reviews scoped after amended or force-pushed heads by comparing complete Git tree
+snapshots across bounded PR paths, then hydrating changed paths from the current full PR records.
+Fall back to a full review with an observable reason when either snapshot is unavailable, malformed,
+or truncated.

--- a/action/README.md
+++ b/action/README.md
@@ -75,8 +75,15 @@ Only a terminal marker from `review-author`, pinned to the reviewed commit and s
 secret, may narrow scope. The default author is `github-actions[bot]`; custom GitHub App tokens
 require `<app-slug>[bot]`. The marker is capped at 24,000 characters. Missing, invalid, or oversized
 state and incompatible PR or profile identity force a full review. After state passes those checks,
-an unavailable, truncated, or non-ancestor three-dot comparison may use a two-dot content
-comparison to identify changed PR paths. `skip-unchanged: "true"` is the default.
+an unavailable, truncated, or non-ancestor three-dot lineage comparison may use direct Git commit
+tree snapshots. The action compares blob identity, path presence, file mode, and object type only
+for the bounded current-PR and stored-continuity path set, then hydrates selected paths from the
+current full PR file records. Missing, malformed, or truncated snapshots force a full review and
+appear in `review-reason`. `skip-unchanged: "true"` is the default.
+
+The rewritten-head path does not use GitHub's three-dot comparison as a content delta: that route
+starts at the merge base and can expand an amended pull request back to its full diff. GitHub REST
+does not provide the two-dot comparison spelling as an alternative.
 
 The workflow needs `contents: read` and `pull-requests: write`, but not `checks: write`.
 Fingerprints compare text, not runtime meaning, so use `review-mode: final` when a base change needs

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -43548,6 +43548,15 @@ class ReviewHeadComparison extends exports_Schema.Class("@effect-agent/pr-review
   truncated: exports_Schema.Boolean
 }) {
 }
+var MAX_TREE_COMPARISON_PATHS = 750;
+
+class ReviewTreeComparison extends exports_Schema.Class("@effect-agent/pr-review/ReviewTreeComparison")({
+  baseSha: GitCommitSha,
+  headSha: GitCommitSha,
+  changedPaths: exports_Schema.Array(ChangedPath).check(exports_Schema.isMaxLength(MAX_TREE_COMPARISON_PATHS)),
+  truncated: exports_Schema.Boolean
+}) {
+}
 var fullReviewSelection = (input) => ({
   mode: "full",
   reason: input.reason,
@@ -43583,10 +43592,7 @@ var validateReviewState = (state, current, profileFingerprint) => {
 var filePaths = (file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath];
 var incrementalFromDelta = (input) => {
   const currentPaths = new Set(input.fullFiles.flatMap(filePaths));
-  const affectedPaths = new Set([
-    ...input.deltaFiles.flatMap(filePaths),
-    ...input.extraAffectedPaths ?? []
-  ]);
+  const affectedPaths = new Set([...input.deltaPaths, ...input.extraAffectedPaths ?? []]);
   const initialAffectedCount = affectedPaths.size;
   let expanded = true;
   while (expanded) {
@@ -43604,11 +43610,6 @@ var incrementalFromDelta = (input) => {
     }
   }
   const selectedByPath = new Map;
-  for (const file2 of input.deltaFiles) {
-    if (currentPaths.has(file2.path) || file2.previousPath !== undefined && currentPaths.has(file2.previousPath)) {
-      selectedByPath.set(file2.path, file2);
-    }
-  }
   const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
   const retryOnly = new Set;
   for (const path of carriedPaths) {
@@ -43701,25 +43702,32 @@ var selectReviewRange = (input) => {
       baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
     }
     return incrementalFromDelta({
-      current: input.current,
       fullFiles: input.fullFiles,
       profileFingerprint: input.profileFingerprint,
       priorState: input.priorState,
-      deltaFiles: comparison.files,
+      deltaPaths: comparison.files.flatMap(filePaths),
       extraAffectedPaths: extraAffected,
       reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`
     });
   }
   const contentComparison = input.contentComparison;
-  if (contentComparison !== undefined && !contentComparison.truncated) {
+  if (contentComparison !== undefined) {
+    if (contentComparison.baseSha !== input.priorState.reviewedHeadSha || contentComparison.headSha !== input.current.headSha) {
+      return full("the rewritten-head tree snapshot comparison did not match the requested heads");
+    }
+    if (contentComparison.truncated) {
+      return full("the rewritten-head tree snapshot comparison was truncated");
+    }
     return incrementalFromDelta({
-      current: input.current,
       fullFiles: input.fullFiles,
       profileFingerprint: input.profileFingerprint,
       priorState: input.priorState,
-      deltaFiles: contentComparison.files,
+      deltaPaths: contentComparison.changedPaths,
       reason: `rewritten history; contents changed since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}`
     });
+  }
+  if (input.contentComparisonFailure !== undefined) {
+    return full(`the rewritten-head tree snapshot comparison failed: ${input.contentComparisonFailure.slice(0, 2048)}`);
   }
   if (comparison === undefined)
     return full("the incremental head comparison was unavailable");
@@ -45904,6 +45912,23 @@ var GitHubCompareWire = exports_Schema.Struct({
   merge_base_commit: exports_Schema.Struct({ sha: exports_Schema.String }),
   files: GitHubFilesPageWire
 });
+var GitHubGitCommitWire = exports_Schema.Struct({
+  sha: GitCommitSha,
+  tree: exports_Schema.Struct({ sha: GitCommitSha })
+});
+var GitHubTreeEntryWire = exports_Schema.Struct({
+  path: exports_Schema.String.check(exports_Schema.isMaxLength(4096)),
+  mode: exports_Schema.String.check(exports_Schema.isMaxLength(6)),
+  type: exports_Schema.Literals(["blob", "tree", "commit"]),
+  sha: GitCommitSha
+});
+var MAX_RECURSIVE_TREE_ENTRIES = 1e5;
+var GitHubTreeWire = exports_Schema.Struct({
+  sha: GitCommitSha,
+  tree: exports_Schema.Array(GitHubTreeEntryWire).check(exports_Schema.isMaxLength(MAX_RECURSIVE_TREE_ENTRIES)),
+  truncated: exports_Schema.Boolean
+});
+var TreeComparisonPaths = exports_Schema.Array(ChangedPath).check(exports_Schema.isMaxLength(MAX_TREE_COMPARISON_PATHS));
 var MAX_PRIOR_REVIEW_PAGES = 5;
 var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.gen(function* () {
   const target = yield* GitHubReviewTarget;
@@ -45914,6 +45939,13 @@ var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.
   const asLookupFailure = (error2) => PriorReviewLookupFailure.make({
     reason: `${error2._tag}: ${error2.message ?? "request failed"}`.slice(0, 2048)
   });
+  const asTreeLookupFailure = (operation) => (error2) => PriorReviewLookupFailure.make({
+    reason: `${operation}: ${error2._tag}: ${error2.message ?? "request failed"}`.slice(0, 2048)
+  });
+  const decodeLookupJson = (schema3, operation) => {
+    const decode2 = exports_Schema.decodeUnknownEffect(schema3);
+    return (response) => response.json.pipe(exports_Effect.mapError(asTreeLookupFailure(operation)), exports_Effect.flatMap((body) => decode2(body).pipe(exports_Effect.mapError(asTreeLookupFailure(operation)))));
+  };
   const readMarkers = (authenticator) => exports_Effect.gen(function* () {
     const perPage = 100;
     let latest = exports_Option.none();
@@ -45950,8 +45982,8 @@ var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.
     }
     return { latestFingerprint: latest, latestState };
   }).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
-  const compareCommits = (baseSha, headSha, separator) => exports_Effect.gen(function* () {
-    const response = yield* exports_HttpClient.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}${separator}${encodeURIComponent(headSha)}`).pipe(exports_HttpClientRequest.acceptJson), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asLookupFailure));
+  const compareCommits = (baseSha, headSha) => exports_Effect.gen(function* () {
+    const response = yield* exports_HttpClient.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`).pipe(exports_HttpClientRequest.acceptJson), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asLookupFailure));
     const wire = yield* response.json.pipe(exports_Effect.mapError(asLookupFailure), exports_Effect.flatMap((body) => exports_Schema.decodeUnknownEffect(GitHubCompareWire)(body).pipe(exports_Effect.mapError(asLookupFailure))));
     const files = wire.files.map(toChangedFile);
     return ReviewHeadComparison.make({
@@ -45963,21 +45995,73 @@ var gitHubPriorReviewsLayer = exports_Layer.effect(PriorReviews)(exports_Effect.
       truncated: files.length >= MAX_CHANGED_FILES
     });
   }).pipe(exports_Effect.provideService(exports_HttpClient.HttpClient, client));
-  const compareTrees = (baseSha, headSha) => compareCommits(baseSha, headSha, "..").pipe(exports_Effect.map((comparison) => ReviewHeadComparison.make({
-    status: comparison.status === "identical" ? "identical" : "ahead",
-    baseSha,
-    headSha,
-    mergeBaseSha: baseSha,
-    files: comparison.files,
-    truncated: comparison.truncated
-  })));
+  const readTreeSnapshot = exports_Effect.fn("PriorReviews.readTreeSnapshot")(function* (commitSha) {
+    const commitResponse = yield* client.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/git/commits/${encodeURIComponent(commitSha)}`).pipe(exports_HttpClientRequest.acceptJson), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asTreeLookupFailure("get Git commit")));
+    const commit = yield* decodeLookupJson(GitHubGitCommitWire, "decode Git commit")(commitResponse);
+    if (commit.sha !== commitSha) {
+      return yield* PriorReviewLookupFailure.make({
+        reason: `GitHub returned commit ${commit.sha} for requested snapshot ${commitSha}`
+      });
+    }
+    const treeResponse = yield* client.execute(withCommonHeaders(exports_HttpClientRequest.get(`${target.apiUrl}/repos/${target.repository}/git/trees/${encodeURIComponent(commit.tree.sha)}`).pipe(exports_HttpClientRequest.acceptJson, exports_HttpClientRequest.setUrlParams({ recursive: "1" })), target.token)).pipe(exports_Effect.flatMap(exports_HttpClientResponse.filterStatusOk), exports_Effect.mapError(asTreeLookupFailure("get recursive Git tree")));
+    const tree = yield* decodeLookupJson(GitHubTreeWire, "decode recursive Git tree")(treeResponse);
+    if (tree.sha !== commit.tree.sha) {
+      return yield* PriorReviewLookupFailure.make({
+        reason: `GitHub returned tree ${tree.sha} for requested tree ${commit.tree.sha}`
+      });
+    }
+    const entries3 = new Map;
+    for (const entry of tree.tree) {
+      if (entries3.has(entry.path)) {
+        return yield* PriorReviewLookupFailure.make({
+          reason: `GitHub returned duplicate path '${entry.path}' in tree ${tree.sha}`
+        });
+      }
+      entries3.set(entry.path, entry);
+    }
+    return { entries: entries3, truncated: tree.truncated };
+  });
+  const compareTrees = exports_Effect.fn("PriorReviews.compareTrees")(function* (baseSha, headSha, paths) {
+    const decodeSha = exports_Schema.decodeUnknownEffect(GitCommitSha);
+    const [validatedBaseSha, validatedHeadSha, validatedPaths] = yield* exports_Effect.all([
+      decodeSha(baseSha),
+      decodeSha(headSha),
+      exports_Schema.decodeUnknownEffect(TreeComparisonPaths)(paths)
+    ]).pipe(exports_Effect.mapError(asTreeLookupFailure("validate tree comparison request")));
+    const uniquePaths2 = [...new Set(validatedPaths)].sort();
+    const { base: base2, head: head5 } = yield* exports_Effect.all({
+      base: readTreeSnapshot(validatedBaseSha),
+      head: readTreeSnapshot(validatedHeadSha)
+    }, { concurrency: 2 });
+    if (base2.truncated || head5.truncated) {
+      return ReviewTreeComparison.make({
+        baseSha: validatedBaseSha,
+        headSha: validatedHeadSha,
+        changedPaths: [],
+        truncated: true
+      });
+    }
+    const changedPaths = uniquePaths2.filter((path) => {
+      const before = base2.entries.get(path);
+      const after = head5.entries.get(path);
+      if (before === undefined || after === undefined)
+        return before !== after;
+      return before.sha !== after.sha || before.mode !== after.mode || before.type !== after.type;
+    });
+    return ReviewTreeComparison.make({
+      baseSha: validatedBaseSha,
+      headSha: validatedHeadSha,
+      changedPaths,
+      truncated: false
+    });
+  });
   return PriorReviews.of({
     latestFingerprint: readMarkers(exports_Option.none()).pipe(exports_Effect.map((markers) => markers.latestFingerprint)),
     latestState: exports_Effect.gen(function* () {
       const authenticator = yield* ReviewStateAuthenticator;
       return yield* readMarkers(exports_Option.some(authenticator)).pipe(exports_Effect.map((markers) => markers.latestState));
     }),
-    compareHeads: (baseSha, headSha) => compareCommits(baseSha, headSha, "..."),
+    compareHeads: compareCommits,
     compareTrees
   });
 }));
@@ -58041,6 +58125,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
       let comparison;
       let baseComparison;
       let contentComparison;
+      let contentComparisonFailure;
       if ((options3.reviewMode ?? "incremental") === "incremental" && recovered.state !== undefined) {
         if (recovered.state.reviewedHeadSha === metadata.headSha) {
           comparison = ReviewHeadComparison.make({
@@ -58074,15 +58159,28 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           }
         }
         if (recovered.state.reviewedHeadSha !== metadata.headSha && (comparison === undefined || !isLineageAncestor(comparison, recovered.state, metadata.headSha))) {
-          contentComparison = yield* history.compareTrees(recovered.state.reviewedHeadSha, metadata.headSha).pipe(exports_Effect.orElseSucceed(() => {
-            return;
-          }));
-          if (contentComparison !== undefined && reviewer.filterFiles !== undefined) {
-            contentComparison = ReviewHeadComparison.make({
-              ...contentComparison,
-              files: reviewer.filterFiles(contentComparison.files)
-            });
+          const comparisonPaths = new Set(fullFiles.flatMap((file2) => file2.previousPath === undefined ? [file2.path] : [file2.path, file2.previousPath]));
+          for (const finding of recovered.state.unresolvedFindings) {
+            comparisonPaths.add(finding.path);
           }
+          for (const concern of recovered.state.unresolvedConcerns) {
+            for (const path of concern.evidencePaths ?? [])
+              comparisonPaths.add(path);
+          }
+          for (const path of recovered.state.unreviewedPaths)
+            comparisonPaths.add(path);
+          const treeResult = yield* history.compareTrees(recovered.state.reviewedHeadSha, metadata.headSha, [...comparisonPaths]).pipe(exports_Effect.match({
+            onFailure: (failure) => ({
+              comparison: undefined,
+              failure: failure.reason
+            }),
+            onSuccess: (treeComparison) => ({
+              comparison: treeComparison,
+              failure: undefined
+            })
+          }));
+          contentComparison = treeResult.comparison;
+          contentComparisonFailure = treeResult.failure;
         }
       }
       selection = {
@@ -58095,6 +58193,7 @@ var runReviewAction = (reviewer, options3 = {}) => exports_Effect.gen(function* 
           comparison,
           baseComparison,
           contentComparison,
+          contentComparisonFailure,
           lookupFailure: recovered.failure
         }),
         stateAuthenticator

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -45916,12 +45916,27 @@ var GitHubGitCommitWire = exports_Schema.Struct({
   sha: GitCommitSha,
   tree: exports_Schema.Struct({ sha: GitCommitSha })
 });
-var GitHubTreeEntryWire = exports_Schema.Struct({
+var GitHubTreeEntryFields = {
   path: exports_Schema.String.check(exports_Schema.isMaxLength(4096)),
-  mode: exports_Schema.String.check(exports_Schema.isMaxLength(6)),
-  type: exports_Schema.Literals(["blob", "tree", "commit"]),
   sha: GitCommitSha
-});
+};
+var GitHubTreeEntryWire = exports_Schema.Union([
+  exports_Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: exports_Schema.Literals(["100644", "100755", "120000"]),
+    type: exports_Schema.Literal("blob")
+  }),
+  exports_Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: exports_Schema.Literal("040000"),
+    type: exports_Schema.Literal("tree")
+  }),
+  exports_Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: exports_Schema.Literal("160000"),
+    type: exports_Schema.Literal("commit")
+  })
+]);
 var MAX_RECURSIVE_TREE_ENTRIES = 1e5;
 var GitHubTreeWire = exports_Schema.Struct({
   sha: GitCommitSha,

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -191,6 +191,11 @@ not persisted. See its [setup and behavior guide](../../action/README.md) and
 [input reference](../../action/action.yml). Custom hosts can import `runReviewAction` from
 `@effect-agent/pr-review/action`.
 
+For an amended or force-pushed head, the GitHub adapter compares complete commit tree snapshots
+across a bounded PR and continuity path set. Selection then uses the current full PR records, so
+patches and rename metadata remain intact. An unavailable, malformed, or truncated tree falls back
+to the full PR and records the cause in the review reason.
+
 Run the CLI with
 `bun src/cli.ts --repo owner/name --pr 123 [--post] [--provider anthropic] [--service-tier fast] [--fan-out]`.
 

--- a/packages/pr-review/src/action.ts
+++ b/packages/pr-review/src/action.ts
@@ -32,6 +32,7 @@ import {
   ReviewExecutionContext,
   ReviewHeadComparison,
   ReviewStateAuthenticator,
+  type ReviewTreeComparison,
   isLineageAncestor,
   type ReviewMode,
   type ReviewState,
@@ -604,7 +605,8 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
         }
         let comparison: ReviewHeadComparison | undefined;
         let baseComparison: ReviewHeadComparison | undefined;
-        let contentComparison: ReviewHeadComparison | undefined;
+        let contentComparison: ReviewTreeComparison | undefined;
+        let contentComparisonFailure: string | undefined;
         if (
           (options.reviewMode ?? "incremental") === "incremental" &&
           recovered.state !== undefined
@@ -645,15 +647,34 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
             (comparison === undefined ||
               !isLineageAncestor(comparison, recovered.state, metadata.headSha))
           ) {
-            contentComparison = yield* history
-              .compareTrees(recovered.state.reviewedHeadSha, metadata.headSha)
-              .pipe(Effect.orElseSucceed(() => undefined));
-            if (contentComparison !== undefined && reviewer.filterFiles !== undefined) {
-              contentComparison = ReviewHeadComparison.make({
-                ...contentComparison,
-                files: reviewer.filterFiles(contentComparison.files),
-              });
+            const comparisonPaths = new Set(
+              fullFiles.flatMap((file) =>
+                file.previousPath === undefined ? [file.path] : [file.path, file.previousPath],
+              ),
+            );
+            for (const finding of recovered.state.unresolvedFindings) {
+              comparisonPaths.add(finding.path);
             }
+            for (const concern of recovered.state.unresolvedConcerns) {
+              for (const path of concern.evidencePaths ?? []) comparisonPaths.add(path);
+            }
+            for (const path of recovered.state.unreviewedPaths) comparisonPaths.add(path);
+            const treeResult = yield* history
+              .compareTrees(recovered.state.reviewedHeadSha, metadata.headSha, [...comparisonPaths])
+              .pipe(
+                Effect.match({
+                  onFailure: (failure) => ({
+                    comparison: undefined,
+                    failure: failure.reason,
+                  }),
+                  onSuccess: (treeComparison) => ({
+                    comparison: treeComparison,
+                    failure: undefined,
+                  }),
+                }),
+              );
+            contentComparison = treeResult.comparison;
+            contentComparisonFailure = treeResult.failure;
           }
         }
         selection = {
@@ -666,6 +687,7 @@ export const runReviewAction = <E, R, FingerprintE = never, FingerprintR = never
             comparison,
             baseComparison,
             contentComparison,
+            contentComparisonFailure,
             lookupFailure: recovered.failure,
           }),
           stateAuthenticator,

--- a/packages/pr-review/src/internal/fixtures.ts
+++ b/packages/pr-review/src/internal/fixtures.ts
@@ -8,7 +8,7 @@ import {
   ReviewPublisher,
 } from "./github.ts";
 import type { ReviewPublicationPlan } from "./render.ts";
-import type { ReviewHeadComparison, ReviewState } from "./review-state.ts";
+import type { ReviewHeadComparison, ReviewState, ReviewTreeComparison } from "./review-state.ts";
 import {
   MAX_CHANGED_FILES,
   MAX_FILE_CHARS,
@@ -120,7 +120,7 @@ export const staticPriorReviews = (
   options: {
     readonly state?: Option.Option<ReviewState> | undefined;
     readonly comparison?: ReviewHeadComparison | undefined;
-    readonly treeComparison?: ReviewHeadComparison | undefined;
+    readonly treeComparison?: ReviewTreeComparison | undefined;
   } = {},
 ): PriorReviews["Service"] =>
   PriorReviews.of({
@@ -142,7 +142,7 @@ export const staticPriorReviewsLayer = (
   options: {
     readonly state?: Option.Option<ReviewState> | undefined;
     readonly comparison?: ReviewHeadComparison | undefined;
-    readonly treeComparison?: ReviewHeadComparison | undefined;
+    readonly treeComparison?: ReviewTreeComparison | undefined;
   } = {},
 ): Layer.Layer<PriorReviews> =>
   Layer.succeed(PriorReviews)(staticPriorReviews(fingerprint, options));

--- a/packages/pr-review/src/internal/github.ts
+++ b/packages/pr-review/src/internal/github.ts
@@ -925,12 +925,28 @@ const GitHubGitCommitWire = Schema.Struct({
   tree: Schema.Struct({ sha: GitCommitSha }),
 });
 
-const GitHubTreeEntryWire = Schema.Struct({
+const GitHubTreeEntryFields = {
   path: Schema.String.check(Schema.isMaxLength(4_096)),
-  mode: Schema.String.check(Schema.isMaxLength(6)),
-  type: Schema.Literals(["blob", "tree", "commit"]),
   sha: GitCommitSha,
-});
+} as const;
+
+const GitHubTreeEntryWire = Schema.Union([
+  Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: Schema.Literals(["100644", "100755", "120000"]),
+    type: Schema.Literal("blob"),
+  }),
+  Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: Schema.Literal("040000"),
+    type: Schema.Literal("tree"),
+  }),
+  Schema.Struct({
+    ...GitHubTreeEntryFields,
+    mode: Schema.Literal("160000"),
+    type: Schema.Literal("commit"),
+  }),
+]);
 
 const MAX_RECURSIVE_TREE_ENTRIES = 100_000;
 const GitHubTreeWire = Schema.Struct({

--- a/packages/pr-review/src/internal/github.ts
+++ b/packages/pr-review/src/internal/github.ts
@@ -11,7 +11,7 @@ import {
   ReviewAdjudicationFailure,
   ReviewAdjudicationHost,
 } from "./adjudication.ts";
-import { ChangedFile } from "./diff.ts";
+import { ChangedFile, ChangedPath } from "./diff.ts";
 import { extractFingerprint } from "./fingerprint.ts";
 import type { ReviewPublicationPlan } from "./render.ts";
 import {
@@ -21,8 +21,11 @@ import {
   ReviewRetirementHost,
 } from "./retirement.ts";
 import {
+  GitCommitSha,
+  MAX_TREE_COMPARISON_PATHS,
   ReviewHeadComparison,
   ReviewStateAuthenticator,
+  ReviewTreeComparison,
   type ReviewState,
 } from "./review-state.ts";
 import {
@@ -884,14 +887,15 @@ export class PriorReviews extends Context.Service<
       headSha: string,
     ) => Effect.Effect<ReviewHeadComparison, PriorReviewLookupFailure>;
     /**
-     * Two-dot tree comparison (`base..head`). Used when the reviewed head is
-     * not a git ancestor so a rebase or amend can still name the paths whose
-     * blob contents actually changed.
+     * Compare complete commit tree snapshots for a bounded path allowlist.
+     * Used when the reviewed head is not a git ancestor after a rebase,
+     * amend, or force-push.
      */
     readonly compareTrees: (
       baseSha: string,
       headSha: string,
-    ) => Effect.Effect<ReviewHeadComparison, PriorReviewLookupFailure>;
+      paths: ReadonlyArray<string>,
+    ) => Effect.Effect<ReviewTreeComparison, PriorReviewLookupFailure>;
   }
 >()("@effect-agent/pr-review/PriorReviews") {}
 
@@ -916,6 +920,29 @@ const GitHubCompareWire = Schema.Struct({
   files: GitHubFilesPageWire,
 });
 
+const GitHubGitCommitWire = Schema.Struct({
+  sha: GitCommitSha,
+  tree: Schema.Struct({ sha: GitCommitSha }),
+});
+
+const GitHubTreeEntryWire = Schema.Struct({
+  path: Schema.String.check(Schema.isMaxLength(4_096)),
+  mode: Schema.String.check(Schema.isMaxLength(6)),
+  type: Schema.Literals(["blob", "tree", "commit"]),
+  sha: GitCommitSha,
+});
+
+const MAX_RECURSIVE_TREE_ENTRIES = 100_000;
+const GitHubTreeWire = Schema.Struct({
+  sha: GitCommitSha,
+  tree: Schema.Array(GitHubTreeEntryWire).check(Schema.isMaxLength(MAX_RECURSIVE_TREE_ENTRIES)),
+  truncated: Schema.Boolean,
+});
+
+const TreeComparisonPaths = Schema.Array(ChangedPath).check(
+  Schema.isMaxLength(MAX_TREE_COMPARISON_PATHS),
+);
+
 /** Reviews are paged chronologically; scanning stays bounded. */
 const MAX_PRIOR_REVIEW_PAGES = 5;
 
@@ -935,6 +962,24 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
       PriorReviewLookupFailure.make({
         reason: `${error._tag}: ${error.message ?? "request failed"}`.slice(0, 2_048),
       });
+    const asTreeLookupFailure =
+      (operation: string) => (error: { readonly _tag: string; readonly message?: string }) =>
+        PriorReviewLookupFailure.make({
+          reason: `${operation}: ${error._tag}: ${error.message ?? "request failed"}`.slice(
+            0,
+            2_048,
+          ),
+        });
+    const decodeLookupJson = <S extends Schema.Top>(schema: S, operation: string) => {
+      const decode = Schema.decodeUnknownEffect(schema);
+      return (response: HttpClientResponse.HttpClientResponse) =>
+        response.json.pipe(
+          Effect.mapError(asTreeLookupFailure(operation)),
+          Effect.flatMap((body) =>
+            decode(body).pipe(Effect.mapError(asTreeLookupFailure(operation))),
+          ),
+        );
+    };
     const readMarkers = (authenticator: Option.Option<ReviewStateAuthenticator["Service"]>) =>
       Effect.gen(function* () {
         const perPage = 100;
@@ -995,12 +1040,12 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
         }
         return { latestFingerprint: latest, latestState };
       }).pipe(Effect.provideService(HttpClient.HttpClient, client));
-    const compareCommits = (baseSha: string, headSha: string, separator: "..." | "..") =>
+    const compareCommits = (baseSha: string, headSha: string) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.execute(
           withCommonHeaders(
             HttpClientRequest.get(
-              `${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}${separator}${encodeURIComponent(headSha)}`,
+              `${target.apiUrl}/repos/${target.repository}/compare/${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`,
             ).pipe(HttpClientRequest.acceptJson),
             target.token,
           ),
@@ -1023,21 +1068,107 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
           truncated: files.length >= MAX_CHANGED_FILES,
         });
       }).pipe(Effect.provideService(HttpClient.HttpClient, client));
-    const compareTrees = (baseSha: string, headSha: string) =>
-      compareCommits(baseSha, headSha, "..").pipe(
-        Effect.map((comparison) =>
-          ReviewHeadComparison.make({
-            // This is a content snapshot, not a lineage claim. Selection
-            // intersects these files with the current PR path set.
-            status: comparison.status === "identical" ? "identical" : "ahead",
-            baseSha,
-            headSha,
-            mergeBaseSha: baseSha,
-            files: comparison.files,
-            truncated: comparison.truncated,
-          }),
-        ),
+    const readTreeSnapshot = Effect.fn("PriorReviews.readTreeSnapshot")(function* (
+      commitSha: string,
+    ) {
+      const commitResponse = yield* client
+        .execute(
+          withCommonHeaders(
+            HttpClientRequest.get(
+              `${target.apiUrl}/repos/${target.repository}/git/commits/${encodeURIComponent(commitSha)}`,
+            ).pipe(HttpClientRequest.acceptJson),
+            target.token,
+          ),
+        )
+        .pipe(
+          Effect.flatMap(HttpClientResponse.filterStatusOk),
+          Effect.mapError(asTreeLookupFailure("get Git commit")),
+        );
+      const commit = yield* decodeLookupJson(
+        GitHubGitCommitWire,
+        "decode Git commit",
+      )(commitResponse);
+      if (commit.sha !== commitSha) {
+        return yield* PriorReviewLookupFailure.make({
+          reason: `GitHub returned commit ${commit.sha} for requested snapshot ${commitSha}`,
+        });
+      }
+      const treeResponse = yield* client
+        .execute(
+          withCommonHeaders(
+            HttpClientRequest.get(
+              `${target.apiUrl}/repos/${target.repository}/git/trees/${encodeURIComponent(commit.tree.sha)}`,
+            ).pipe(
+              HttpClientRequest.acceptJson,
+              HttpClientRequest.setUrlParams({ recursive: "1" }),
+            ),
+            target.token,
+          ),
+        )
+        .pipe(
+          Effect.flatMap(HttpClientResponse.filterStatusOk),
+          Effect.mapError(asTreeLookupFailure("get recursive Git tree")),
+        );
+      const tree = yield* decodeLookupJson(
+        GitHubTreeWire,
+        "decode recursive Git tree",
+      )(treeResponse);
+      if (tree.sha !== commit.tree.sha) {
+        return yield* PriorReviewLookupFailure.make({
+          reason: `GitHub returned tree ${tree.sha} for requested tree ${commit.tree.sha}`,
+        });
+      }
+      const entries = new Map<string, typeof GitHubTreeEntryWire.Type>();
+      for (const entry of tree.tree) {
+        if (entries.has(entry.path)) {
+          return yield* PriorReviewLookupFailure.make({
+            reason: `GitHub returned duplicate path '${entry.path}' in tree ${tree.sha}`,
+          });
+        }
+        entries.set(entry.path, entry);
+      }
+      return { entries, truncated: tree.truncated } as const;
+    });
+    const compareTrees = Effect.fn("PriorReviews.compareTrees")(function* (
+      baseSha: string,
+      headSha: string,
+      paths: ReadonlyArray<string>,
+    ) {
+      const decodeSha = Schema.decodeUnknownEffect(GitCommitSha);
+      const [validatedBaseSha, validatedHeadSha, validatedPaths] = yield* Effect.all([
+        decodeSha(baseSha),
+        decodeSha(headSha),
+        Schema.decodeUnknownEffect(TreeComparisonPaths)(paths),
+      ]).pipe(Effect.mapError(asTreeLookupFailure("validate tree comparison request")));
+      const uniquePaths = [...new Set(validatedPaths)].sort();
+      const { base, head } = yield* Effect.all(
+        {
+          base: readTreeSnapshot(validatedBaseSha),
+          head: readTreeSnapshot(validatedHeadSha),
+        },
+        { concurrency: 2 },
       );
+      if (base.truncated || head.truncated) {
+        return ReviewTreeComparison.make({
+          baseSha: validatedBaseSha,
+          headSha: validatedHeadSha,
+          changedPaths: [],
+          truncated: true,
+        });
+      }
+      const changedPaths = uniquePaths.filter((path) => {
+        const before = base.entries.get(path);
+        const after = head.entries.get(path);
+        if (before === undefined || after === undefined) return before !== after;
+        return before.sha !== after.sha || before.mode !== after.mode || before.type !== after.type;
+      });
+      return ReviewTreeComparison.make({
+        baseSha: validatedBaseSha,
+        headSha: validatedHeadSha,
+        changedPaths,
+        truncated: false,
+      });
+    });
     return PriorReviews.of({
       latestFingerprint: readMarkers(Option.none()).pipe(
         Effect.map((markers) => markers.latestFingerprint),
@@ -1048,7 +1179,7 @@ export const gitHubPriorReviewsLayer: Layer.Layer<
           Effect.map((markers) => markers.latestState),
         );
       }),
-      compareHeads: (baseSha, headSha) => compareCommits(baseSha, headSha, "..."),
+      compareHeads: compareCommits,
       compareTrees,
     });
   }),

--- a/packages/pr-review/src/internal/review-state.ts
+++ b/packages/pr-review/src/internal/review-state.ts
@@ -395,6 +395,23 @@ export class ReviewHeadComparison extends Schema.Class<ReviewHeadComparison>(
   truncated: Schema.Boolean,
 }) {}
 
+/**
+ * Current and previous paths for 300 PR files plus bounded stored continuity
+ * paths. The live adapter refuses a larger snapshot-comparison request.
+ */
+export const MAX_TREE_COMPARISON_PATHS = 750;
+
+/** A direct comparison of two complete commit tree snapshots. */
+export class ReviewTreeComparison extends Schema.Class<ReviewTreeComparison>(
+  "@effect-agent/pr-review/ReviewTreeComparison",
+)({
+  baseSha: GitCommitSha,
+  headSha: GitCommitSha,
+  changedPaths: Schema.Array(ChangedPath).check(Schema.isMaxLength(MAX_TREE_COMPARISON_PATHS)),
+  /** True when GitHub returned either recursive tree incompletely. */
+  truncated: Schema.Boolean,
+}) {}
+
 /** Internal review selection applied as a decorator over the full PR source. */
 export interface ReviewSelection {
   readonly mode: ReviewScopeMode;
@@ -482,19 +499,15 @@ const filePaths = (file: ChangedFile): ReadonlyArray<string> =>
   file.previousPath === undefined ? [file.path] : [file.path, file.previousPath];
 
 const incrementalFromDelta = (input: {
-  readonly current: PullRequestMetadata;
   readonly fullFiles: ReadonlyArray<ChangedFile>;
   readonly profileFingerprint: string;
   readonly priorState: ReviewState;
-  readonly deltaFiles: ReadonlyArray<ChangedFile>;
+  readonly deltaPaths: ReadonlyArray<string>;
   readonly extraAffectedPaths?: ReadonlyArray<string> | undefined;
   readonly reason: string;
 }): ReviewSelection => {
   const currentPaths = new Set(input.fullFiles.flatMap(filePaths));
-  const affectedPaths = new Set([
-    ...input.deltaFiles.flatMap(filePaths),
-    ...(input.extraAffectedPaths ?? []),
-  ]);
+  const affectedPaths = new Set([...input.deltaPaths, ...(input.extraAffectedPaths ?? [])]);
   const initialAffectedCount = affectedPaths.size;
   // Reopen every current path needed to reassess a concern touched by this
   // delta. Repeat to a fixed point because two concerns may overlap on a path.
@@ -513,14 +526,6 @@ const incrementalFromDelta = (input: {
     }
   }
   const selectedByPath = new Map<string, ChangedFile>();
-  for (const file of input.deltaFiles) {
-    if (
-      currentPaths.has(file.path) ||
-      (file.previousPath !== undefined && currentPaths.has(file.previousPath))
-    ) {
-      selectedByPath.set(file.path, file);
-    }
-  }
   const carriedPaths = input.priorState.unreviewedPaths.filter((path) => currentPaths.has(path));
   const retryOnly = new Set<string>();
   for (const path of carriedPaths) {
@@ -608,11 +613,12 @@ export const selectReviewRange = (input: {
   readonly comparison: ReviewHeadComparison | undefined;
   readonly baseComparison?: ReviewHeadComparison | undefined;
   /**
-   * Two-dot tree comparison used when the reviewed head is not a git ancestor
-   * (rebase, amend, force-push). Intersected with the current PR path set so
-   * main-drift outside the pull request never re-enters scope.
+   * Direct commit-tree snapshot comparison used when the reviewed head is not
+   * a git ancestor. Selection hydrates these paths from the current PR files.
    */
-  readonly contentComparison?: ReviewHeadComparison | undefined;
+  readonly contentComparison?: ReviewTreeComparison | undefined;
+  /** Why the direct snapshot comparison could not produce complete evidence. */
+  readonly contentComparisonFailure?: string | undefined;
   readonly lookupFailure?: string | undefined;
 }): ReviewSelection => {
   const full = (reason: string) =>
@@ -654,25 +660,37 @@ export const selectReviewRange = (input: {
       baseReason = `; base advanced from ${input.priorState.baseSha.slice(0, 7)} and overlapping PR paths were included`;
     }
     return incrementalFromDelta({
-      current: input.current,
       fullFiles: input.fullFiles,
       profileFingerprint: input.profileFingerprint,
       priorState: input.priorState,
-      deltaFiles: comparison.files,
+      deltaPaths: comparison.files.flatMap(filePaths),
       extraAffectedPaths: extraAffected,
       reason: `changes since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}${baseReason}`,
     });
   }
   const contentComparison = input.contentComparison;
-  if (contentComparison !== undefined && !contentComparison.truncated) {
+  if (contentComparison !== undefined) {
+    if (
+      contentComparison.baseSha !== input.priorState.reviewedHeadSha ||
+      contentComparison.headSha !== input.current.headSha
+    ) {
+      return full("the rewritten-head tree snapshot comparison did not match the requested heads");
+    }
+    if (contentComparison.truncated) {
+      return full("the rewritten-head tree snapshot comparison was truncated");
+    }
     return incrementalFromDelta({
-      current: input.current,
       fullFiles: input.fullFiles,
       profileFingerprint: input.profileFingerprint,
       priorState: input.priorState,
-      deltaFiles: contentComparison.files,
+      deltaPaths: contentComparison.changedPaths,
       reason: `rewritten history; contents changed since reviewed head ${input.priorState.reviewedHeadSha.slice(0, 7)}`,
     });
+  }
+  if (input.contentComparisonFailure !== undefined) {
+    return full(
+      `the rewritten-head tree snapshot comparison failed: ${input.contentComparisonFailure.slice(0, 2_048)}`,
+    );
   }
   if (comparison === undefined) return full("the incremental head comparison was unavailable");
   if (comparison.truncated) return full("the incremental comparison exceeded GitHub's file bound");

--- a/packages/pr-review/test/action.test.ts
+++ b/packages/pr-review/test/action.test.ts
@@ -39,6 +39,7 @@ import {
   ReviewInputCoverage,
   ReviewRunOutcome,
   ReviewState,
+  ReviewTreeComparison,
   PullRequestSource,
   StoredReviewFinding,
   UnsupportedServiceTierProvider,
@@ -1037,12 +1038,10 @@ describe("runReviewAction", () => {
               files: [changed, untouched],
               truncated: false,
             }),
-            treeComparison: ReviewHeadComparison.make({
-              status: "ahead",
+            treeComparison: ReviewTreeComparison.make({
               baseSha: reviewedHeadSha,
               headSha: currentHeadSha,
-              mergeBaseSha: reviewedHeadSha,
-              files: [changed],
+              changedPaths: [changed.path],
               truncated: false,
             }),
           }),
@@ -1054,7 +1053,7 @@ describe("runReviewAction", () => {
     }),
   );
 
-  it.effect("reviews a rebased head when the effective patch changed", () =>
+  it.effect("makes an unavailable rewritten-head snapshot visible in full-review scope", () =>
     Effect.gen(function* () {
       const harness = yield* actionHarness(
         JSON.stringify({
@@ -1093,12 +1092,16 @@ describe("runReviewAction", () => {
         lastReviewMode: "full",
       });
       const invoked = yield* Ref.make(0);
+      const reviewReasons = yield* Ref.make<ReadonlyArray<string>>([]);
       const result = yield* runReviewAction(
         {
           run: () =>
-            Ref.update(invoked, (count) => count + 1).pipe(
-              Effect.map(() => fakeOutcome("comment")),
-            ),
+            Effect.gen(function* () {
+              const selection = yield* ReviewExecutionContext;
+              yield* Ref.update(invoked, (count) => count + 1);
+              yield* Ref.update(reviewReasons, (reasons) => [...reasons, selection.reason]);
+              return fakeOutcome("comment");
+            }),
           fingerprint: Effect.succeed("c".repeat(64)),
           profileFingerprint: Effect.succeed(profileFingerprint),
           snapshot: Effect.succeed({ metadata, files: [] }),
@@ -1111,6 +1114,9 @@ describe("runReviewAction", () => {
 
       expect(result._tag).toBe("Completed");
       expect(yield* Ref.get(invoked)).toBe(1);
+      expect(yield* Ref.get(reviewReasons)).toEqual([
+        "the rewritten-head tree snapshot comparison failed: no fixture tree comparison",
+      ]);
       expect(yield* Ref.get(harness.written)).toContain("skipped=false");
     }),
   );

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -142,6 +142,8 @@ describe("GitHub prior reviews", () => {
                 entry("src/previous.ts", "e".repeat(40)),
                 entry("src/type.ts", "6".repeat(40)),
                 entry("src/base-drift.ts", "7".repeat(40)),
+                entry("src/link", "1".repeat(40), "120000"),
+                entry("src/subdir", "2".repeat(40), "040000", "tree"),
               ],
             };
           }
@@ -157,6 +159,8 @@ describe("GitHub prior reviews", () => {
                 entry("src/current.ts", "e".repeat(40)),
                 entry("src/type.ts", "f".repeat(40), "160000", "commit"),
                 entry("src/base-drift.ts", "0".repeat(40)),
+                entry("src/link", "1".repeat(40), "120000"),
+                entry("src/subdir", "2".repeat(40), "040000", "tree"),
               ],
             };
           }
@@ -233,14 +237,14 @@ describe("GitHub prior reviews", () => {
       const currentHeadSha = "3".repeat(40);
       const baseTreeSha = "4".repeat(40);
       const headTreeSha = "5".repeat(40);
-      const runComparison = (headTree: unknown) => {
+      const runComparison = (baseTree: unknown, headTree: unknown) => {
         const client = HttpClient.make((request, url) => {
           const body = url.pathname.endsWith(`/git/commits/${REVIEWED_HEAD_SHA}`)
             ? { sha: REVIEWED_HEAD_SHA, tree: { sha: baseTreeSha } }
             : url.pathname.endsWith(`/git/commits/${currentHeadSha}`)
               ? { sha: currentHeadSha, tree: { sha: headTreeSha } }
               : url.pathname.endsWith(`/git/trees/${baseTreeSha}`)
-                ? { sha: baseTreeSha, truncated: false, tree: [] }
+                ? baseTree
                 : headTree;
           return Effect.succeed(
             HttpClientResponse.fromWeb(
@@ -276,7 +280,8 @@ describe("GitHub prior reviews", () => {
         );
       };
 
-      const truncated = yield* runComparison({
+      const emptyBaseTree = { sha: baseTreeSha, truncated: false, tree: [] };
+      const truncated = yield* runComparison(emptyBaseTree, {
         sha: headTreeSha,
         truncated: true,
         tree: [],
@@ -284,7 +289,7 @@ describe("GitHub prior reviews", () => {
       expect(truncated.truncated).toBe(true);
       expect(truncated.changedPaths).toEqual([]);
 
-      const malformed = yield* runComparison({
+      const malformed = yield* runComparison(emptyBaseTree, {
         sha: headTreeSha,
         truncated: false,
         tree: [{ path: "src/fix.ts", type: "blob", sha: "6".repeat(40) }],
@@ -292,6 +297,19 @@ describe("GitHub prior reviews", () => {
       expect(malformed._tag).toBe("PriorReviewLookupFailure");
       expect(malformed.reason).toContain("SchemaError");
       expect(malformed.reason).toContain('["tree"][0]["mode"]');
+
+      for (const entry of [
+        { path: "src/fix.ts", mode: "", type: "blob", sha: "6".repeat(40) },
+        { path: "src/fix.ts", mode: "160000", type: "blob", sha: "6".repeat(40) },
+      ]) {
+        const invalidPairing = yield* runComparison(
+          { sha: baseTreeSha, truncated: false, tree: [entry] },
+          { sha: headTreeSha, truncated: false, tree: [entry] },
+        ).pipe(Effect.flip);
+        expect(invalidPairing._tag).toBe("PriorReviewLookupFailure");
+        expect(invalidPairing.reason).toContain("SchemaError");
+        expect(invalidPairing.reason).toContain('["tree"][0]');
+      }
     }),
   );
 });

--- a/packages/pr-review/test/github.test.ts
+++ b/packages/pr-review/test/github.test.ts
@@ -109,37 +109,81 @@ describe("GitHub prior reviews", () => {
     }),
   );
 
-  it.effect("compares rewritten heads with a two-dot tree request", () =>
+  it.effect("compares rewritten heads from complete commit tree snapshots", () =>
     Effect.gen(function* () {
+      const currentHeadSha = "3".repeat(40);
+      const baseTreeSha = "4".repeat(40);
+      const headTreeSha = "5".repeat(40);
       const requested: Array<string> = [];
+      const entry = (
+        path: string,
+        sha: string,
+        mode = "100644",
+        type: "blob" | "tree" | "commit" = "blob",
+      ) => ({ path, mode, type, sha });
       const client = HttpClient.make((request, url) => {
-        requested.push(url.pathname);
+        requested.push(`${url.pathname}${url.search}`);
+        const json = (() => {
+          if (url.pathname.endsWith(`/git/commits/${REVIEWED_HEAD_SHA}`)) {
+            return { sha: REVIEWED_HEAD_SHA, tree: { sha: baseTreeSha } };
+          }
+          if (url.pathname.endsWith(`/git/commits/${currentHeadSha}`)) {
+            return { sha: currentHeadSha, tree: { sha: headTreeSha } };
+          }
+          if (url.pathname.endsWith(`/git/trees/${baseTreeSha}`)) {
+            return {
+              sha: baseTreeSha,
+              truncated: false,
+              tree: [
+                entry("src/unchanged.ts", "a".repeat(40)),
+                entry("src/changed.ts", "b".repeat(40)),
+                entry("src/mode.ts", "c".repeat(40)),
+                entry("src/removed.ts", "d".repeat(40)),
+                entry("src/previous.ts", "e".repeat(40)),
+                entry("src/type.ts", "6".repeat(40)),
+                entry("src/base-drift.ts", "7".repeat(40)),
+              ],
+            };
+          }
+          if (url.pathname.endsWith(`/git/trees/${headTreeSha}`)) {
+            return {
+              sha: headTreeSha,
+              truncated: false,
+              tree: [
+                entry("src/unchanged.ts", "a".repeat(40)),
+                entry("src/changed.ts", "8".repeat(40)),
+                entry("src/mode.ts", "c".repeat(40), "100755"),
+                entry("src/added.ts", "9".repeat(40)),
+                entry("src/current.ts", "e".repeat(40)),
+                entry("src/type.ts", "f".repeat(40), "160000", "commit"),
+                entry("src/base-drift.ts", "0".repeat(40)),
+              ],
+            };
+          }
+          throw new Error(`Unexpected request: ${url}`);
+        })();
         return Effect.succeed(
           HttpClientResponse.fromWeb(
             request,
-            new Response(
-              JSON.stringify({
-                status: "diverged",
-                base_commit: { sha: REVIEWED_HEAD_SHA },
-                merge_base_commit: { sha: "1".repeat(40) },
-                files: [
-                  {
-                    filename: "src/fix.ts",
-                    status: "modified",
-                    additions: 1,
-                    deletions: 1,
-                    patch: "@@ -1 +1 @@\n-before\n+after",
-                  },
-                ],
-              }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            ),
+            new Response(JSON.stringify(json), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
           ),
         );
       });
       const comparison = yield* Effect.gen(function* () {
         const priorReviews = yield* PriorReviews;
-        return yield* priorReviews.compareTrees(REVIEWED_HEAD_SHA, "3".repeat(40));
+        return yield* priorReviews.compareTrees(REVIEWED_HEAD_SHA, currentHeadSha, [
+          "src/unchanged.ts",
+          "src/changed.ts",
+          "src/mode.ts",
+          "src/added.ts",
+          "src/removed.ts",
+          "src/previous.ts",
+          "src/current.ts",
+          "src/type.ts",
+        ]);
       }).pipe(
         Effect.provide(
           gitHubPriorReviewsLayer.pipe(
@@ -158,12 +202,96 @@ describe("GitHub prior reviews", () => {
         ),
       );
 
-      expect(requested).toEqual([
-        `/repos/acme/widgets/compare/${REVIEWED_HEAD_SHA}..${"3".repeat(40)}`,
-      ]);
-      expect(comparison.status).toBe("ahead");
-      expect(comparison.mergeBaseSha).toBe(REVIEWED_HEAD_SHA);
-      expect(comparison.files.map((file) => file.path)).toEqual(["src/fix.ts"]);
+      expect(requested.sort()).toEqual(
+        [
+          `/repos/acme/widgets/git/commits/${REVIEWED_HEAD_SHA}`,
+          `/repos/acme/widgets/git/commits/${currentHeadSha}`,
+          `/repos/acme/widgets/git/trees/${baseTreeSha}?recursive=1`,
+          `/repos/acme/widgets/git/trees/${headTreeSha}?recursive=1`,
+        ].sort(),
+      );
+      expect(requested.some((path) => path.includes("/compare/"))).toBe(false);
+      expect(comparison).toEqual({
+        baseSha: REVIEWED_HEAD_SHA,
+        headSha: currentHeadSha,
+        changedPaths: [
+          "src/added.ts",
+          "src/changed.ts",
+          "src/current.ts",
+          "src/mode.ts",
+          "src/previous.ts",
+          "src/removed.ts",
+          "src/type.ts",
+        ],
+        truncated: false,
+      });
+    }),
+  );
+
+  it.effect("marks truncated tree snapshots incomplete and rejects malformed entries", () =>
+    Effect.gen(function* () {
+      const currentHeadSha = "3".repeat(40);
+      const baseTreeSha = "4".repeat(40);
+      const headTreeSha = "5".repeat(40);
+      const runComparison = (headTree: unknown) => {
+        const client = HttpClient.make((request, url) => {
+          const body = url.pathname.endsWith(`/git/commits/${REVIEWED_HEAD_SHA}`)
+            ? { sha: REVIEWED_HEAD_SHA, tree: { sha: baseTreeSha } }
+            : url.pathname.endsWith(`/git/commits/${currentHeadSha}`)
+              ? { sha: currentHeadSha, tree: { sha: headTreeSha } }
+              : url.pathname.endsWith(`/git/trees/${baseTreeSha}`)
+                ? { sha: baseTreeSha, truncated: false, tree: [] }
+                : headTree;
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(JSON.stringify(body), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }),
+            ),
+          );
+        });
+        return Effect.gen(function* () {
+          const priorReviews = yield* PriorReviews;
+          return yield* priorReviews.compareTrees(REVIEWED_HEAD_SHA, currentHeadSha, [
+            "src/fix.ts",
+          ]);
+        }).pipe(
+          Effect.provide(
+            gitHubPriorReviewsLayer.pipe(
+              Layer.provide(
+                Layer.merge(
+                  GitHubReviewTarget.layer({
+                    apiUrl: "https://api.github.test",
+                    repository: "acme/widgets",
+                    number: 30,
+                    token: Option.none(),
+                  }),
+                  Layer.succeed(HttpClient.HttpClient)(client),
+                ),
+              ),
+            ),
+          ),
+        );
+      };
+
+      const truncated = yield* runComparison({
+        sha: headTreeSha,
+        truncated: true,
+        tree: [],
+      });
+      expect(truncated.truncated).toBe(true);
+      expect(truncated.changedPaths).toEqual([]);
+
+      const malformed = yield* runComparison({
+        sha: headTreeSha,
+        truncated: false,
+        tree: [{ path: "src/fix.ts", type: "blob", sha: "6".repeat(40) }],
+      }).pipe(Effect.flip);
+      expect(malformed._tag).toBe("PriorReviewLookupFailure");
+      expect(malformed.reason).toContain("SchemaError");
+      expect(malformed.reason).toContain('["tree"][0]["mode"]');
     }),
   );
 });

--- a/packages/pr-review/test/review-state.test.ts
+++ b/packages/pr-review/test/review-state.test.ts
@@ -11,6 +11,7 @@ import {
   ReviewHeadComparison,
   ReviewState,
   ReviewStateAuthenticator,
+  ReviewTreeComparison,
   selectReviewRange,
   StoredAdjudication,
   StoredReviewConcern,
@@ -455,20 +456,79 @@ describe("review state", () => {
       files: [acceptedFile, correctiveFile],
       truncated: false,
     });
-    const contentComparison = ReviewHeadComparison.make({
-      status: "ahead",
+    const contentComparison = ReviewTreeComparison.make({
       baseSha: REVIEWED_HEAD_SHA,
       headSha: CURRENT_HEAD_SHA,
-      mergeBaseSha: REVIEWED_HEAD_SHA,
-      files: [correctiveFile],
+      changedPaths: [correctiveFile.path],
       truncated: false,
     });
     const selection = select({ comparison: rewritten, contentComparison });
 
     expect(selection.mode).toBe("incremental");
-    expect(selection.files.map((file) => file.path)).toEqual(["src/corrective.ts"]);
+    expect(selection.files).toEqual([correctiveFile]);
+    expect(selection.files[0]?.patch).toBe(correctiveFile.patch);
     expect(selection.reason).toContain("rewritten history");
     expect(selection.affectedPaths).toEqual(["src/corrective.ts"]);
+  });
+
+  it("hydrates renamed snapshot paths from the current PR record", () => {
+    const renamedFile = ChangedFile.make({
+      path: "src/current.ts",
+      previousPath: "src/previous.ts",
+      status: "renamed",
+      additions: 2,
+      deletions: 1,
+      patch: "@@ -1 +1,2 @@\n-old\n+new\n+line",
+    });
+    const selection = select({
+      comparison: ReviewHeadComparison.make({
+        ...comparison,
+        status: "diverged",
+        mergeBaseSha: "5".repeat(40),
+      }),
+      fullFiles: [renamedFile, correctiveFile],
+      contentComparison: ReviewTreeComparison.make({
+        baseSha: REVIEWED_HEAD_SHA,
+        headSha: CURRENT_HEAD_SHA,
+        changedPaths: ["src/previous.ts"],
+        truncated: false,
+      }),
+    });
+
+    expect(selection.mode).toBe("incremental");
+    expect(selection.files).toEqual([renamedFile]);
+    expect(selection.files[0]?.previousPath).toBe("src/previous.ts");
+    expect(selection.files[0]?.patch).toBe(renamedFile.patch);
+  });
+
+  it("falls back to the full PR for truncated or failed tree snapshots", () => {
+    const rewritten = ReviewHeadComparison.make({
+      ...comparison,
+      status: "diverged",
+      mergeBaseSha: "5".repeat(40),
+    });
+    const truncated = select({
+      comparison: rewritten,
+      contentComparison: ReviewTreeComparison.make({
+        baseSha: REVIEWED_HEAD_SHA,
+        headSha: CURRENT_HEAD_SHA,
+        changedPaths: [],
+        truncated: true,
+      }),
+    });
+    expect(truncated.mode).toBe("full");
+    expect(truncated.files).toEqual([acceptedFile, correctiveFile]);
+    expect(truncated.reason).toContain("tree snapshot comparison was truncated");
+
+    const failed = select({
+      comparison: rewritten,
+      contentComparison: undefined,
+      contentComparisonFailure: "ResponseError: status 404",
+    });
+    expect(failed.mode).toBe("full");
+    expect(failed.files).toEqual([acceptedFile, correctiveFile]);
+    expect(failed.reason).toContain("tree snapshot comparison failed");
+    expect(failed.reason).toContain("status 404");
   });
 
   it("keeps a carried unreviewed path in scope across a rename", () => {


### PR DESCRIPTION
## Summary

- Keep amended and force-pushed reviews incremental by comparing the prior and current commit tree snapshots across a bounded PR and continuity path set.
- Hydrate every selected path from the current full PR file record, preserving patches, rename metadata, additions, deletions, and mode or object-type changes.
- Fall back to the full PR with an explicit review reason when a commit or tree is unavailable, malformed, mismatched, or truncated. The committed Action bundle and package docs are updated.

## What went wrong

`PriorReviews.compareTrees` called GitHub's compare-commits REST route with `base..head`. GitHub does not support that spelling, so the request returned 404. `runReviewAction` converted the typed lookup failure to `undefined`; because the force-pushed reviewed head was no longer an ancestor, `selectReviewRange` conservatively chose the full PR.

Changing the separator to `...` would still compare from the merge base and could return essentially the whole pull request after an amend. This change instead uses GitHub's supported Git commit and recursive tree endpoints.

## Architecture

- The [GitHub adapter validates documented tree mode/type pairings](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/src/internal/github.ts#L928) before it [resolves and compares both commit trees](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/src/internal/github.ts#L1087). It treats path presence, object SHA, mode, and type as content identity, rejects duplicate or malformed entries, and marks either recursive tree's `truncated` response incomplete. GitHub documents the recursive response bound, truncation contract, modes, and pairings in [Get a tree](https://docs.github.com/en/rest/git/trees#get-a-tree).
- The Action supplies at most 300 current PR records with current and previous paths, plus the already bounded stored continuity paths. It [retains tree lookup failures for scope selection](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/src/action.ts#L650).
- The [path-only `ReviewTreeComparison` and range selector](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/src/internal/review-state.ts#L405) verify the requested head pair, reject truncation, and select only matching current PR records. No synthetic compare payload becomes model evidence.
- This branch is rebased on the merged [#157](https://github.com/danieljvdm/effect-agent/pull/157) and leaves its path-bound retry-stage behavior intact.

## Evidence

- The reported [kommunikasie job](https://github.com/reve-ai/kommunikasie/actions/runs/32770965372/job/97570966309?pr=854) produced this [56-file review](https://github.com/reve-ai/kommunikasie/pull/854#pullrequestreview-5012076457), consuming 121,452 input and 30,211 output tokens over 12 minutes for an intended small amended-head delta.
- The [GitHub adapter regression](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/test/github.test.ts#L112) proves no compare route is used and covers unchanged blobs, additions, deletions, mode changes, object-type changes, rename paths, and PR-path intersection. The [fail-closed cases](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/test/github.test.ts#L235) cover truncation, missing fields, empty modes, and impossible mode/type pairings repeated in both snapshots.
- The [range-selection regressions](https://github.com/danieljvdm/effect-agent/blob/649a7545c591c71245f57e4f0bdf3b642ff3b9e1/packages/pr-review/test/review-state.test.ts#L450) prove a diverged head selects only changed current PR records with full patches and rename metadata, while failed or truncated snapshots select the full PR.
- The refreshed [PR review run](https://github.com/danieljvdm/effect-agent/actions/runs/32779934577) exercised the incremental path against reviewed head `792c92e`, reopened only the two affected source and test files, retired the prior finding, and reported no new issues.
- Focused package validation passed: 13 test files, 191 tests passed and 1 skipped; formatting, package type check, and package build passed. The Action bundle rebuilt to 2,132,538 bytes, and a second post-commit rebuild left the worktree clean.
- Local `vp run ready` reached the repository static scan with 0 errors, then Vite+ failed to spawn `packages/sandbox#check` with `Invalid argument (os error 22)`. The independent `vp check` rerun completed with 0 errors. GitHub CI passed Static checks, Build, Tests, and `ready` at `649a754`.
