### PR TITLE
fix(engine): normalize overlapping cache writes

### DIFF
--- a/.changeset/normalize-overlapping-cache-writes.md
+++ b/.changeset/normalize-overlapping-cache-writes.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/engine": patch
+---
+
+Normalize provider cache-write usage when the provider also includes those tokens in uncached
+input. Preserve additive canonical usage totals without rejecting valid model responses.

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -36250,8 +36250,11 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
   const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
   const reportedText = providerUsage.outputTokens.text ?? 0;
   const reasoning = providerUsage.outputTokens.reasoning ?? 0;
-  const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
   const reportedInputTotal = providerUsage.inputTokens.total;
+  const reportedInputWithoutWrite = yield* decodeProviderUsageTotal(reportedUncached + cacheRead);
+  const cacheWriteOverlapsUncached = reportedInputTotal !== undefined && providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheWrite !== undefined && cacheWrite <= reportedUncached && reportedInputWithoutWrite <= reportedInputTotal && cacheWrite > reportedInputTotal - reportedInputWithoutWrite;
+  const disjointReportedUncached = reportedUncached - (cacheWriteOverlapsUncached ? cacheWrite : 0);
+  const reportedInputComponents = yield* decodeProviderUsageTotal(disjointReportedUncached + cacheRead + cacheWrite);
   const allInputComponentsReported = providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite !== undefined;
   if (reportedInputTotal !== undefined && (reportedInputTotal < reportedInputComponents || allInputComponentsReported && reportedInputTotal !== reportedInputComponents)) {
     return yield* invalidProviderUsage();
@@ -36266,7 +36269,7 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options) => e
   const outputTokens = reportedOutputTotal ?? reportedOutputComponents;
   const inputRemainder = inputTokens - reportedInputComponents;
   const outputRemainder = outputTokens - reportedOutputComponents;
-  const uncached = reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+  const uncached = disjointReportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
   const normalizedCacheRead = cacheRead + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead === undefined ? inputRemainder : 0);
   const normalizedCacheWrite = cacheWrite + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite === undefined ? inputRemainder : 0);
   const text = reportedText + (providerUsage.outputTokens.text === undefined ? outputRemainder : 0);

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -657,7 +657,10 @@ the engine contributes approval policy, scheduling, budgets, encoding, and telem
   the same integer bound, with last-call token counts no greater than cumulative totals; invalid
   seeds fail before Run input hooks or external execution. A reported provider total must not be
   smaller than its explicit components and must equal them when every component is present;
-  only genuinely omitted components may receive an inferred remainder.
+  only genuinely omitted components may receive an inferred remainder. When a provider reports
+  cache-write tokens both separately and inside uncached input, the engine separates that overlap
+  before validating and persisting the canonical additive components while preserving the raw
+  provider usage for cost estimation.
 - **RUN-024:** With policy `runStatus: "appended"`, every outgoing model request carries a
   derived run-status message showing Turns, Tool Calls, tokens, and elapsed time; the
   message is never persisted as canonical history.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2375,10 +2375,23 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
     // Gross token accounting never discounts cache activity. An omitted
     // aggregate is derived from present components; an omitted component may
     // receive the aggregate remainder. Explicitly contradictory fields fail.
-    const reportedInputComponents = yield* decodeProviderUsageTotal(
-      reportedUncached + cacheRead + cacheWrite,
-    );
+    // Some providers include cache writes in `uncached` while also reporting
+    // them separately. Separate that overlap before constructing the canonical,
+    // additive input components, but retain the raw provider usage for pricing.
     const reportedInputTotal = providerUsage.inputTokens.total;
+    const reportedInputWithoutWrite = yield* decodeProviderUsageTotal(reportedUncached + cacheRead);
+    const cacheWriteOverlapsUncached =
+      reportedInputTotal !== undefined &&
+      providerUsage.inputTokens.uncached !== undefined &&
+      providerUsage.inputTokens.cacheWrite !== undefined &&
+      cacheWrite <= reportedUncached &&
+      reportedInputWithoutWrite <= reportedInputTotal &&
+      cacheWrite > reportedInputTotal - reportedInputWithoutWrite;
+    const disjointReportedUncached =
+      reportedUncached - (cacheWriteOverlapsUncached ? cacheWrite : 0);
+    const reportedInputComponents = yield* decodeProviderUsageTotal(
+      disjointReportedUncached + cacheRead + cacheWrite,
+    );
     const allInputComponentsReported =
       providerUsage.inputTokens.uncached !== undefined &&
       providerUsage.inputTokens.cacheRead !== undefined &&
@@ -2411,7 +2424,8 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
     const inputRemainder = inputTokens - reportedInputComponents;
     const outputRemainder = outputTokens - reportedOutputComponents;
     const uncached =
-      reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+      disjointReportedUncached +
+      (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
     const normalizedCacheRead =
       cacheRead +
       (providerUsage.inputTokens.uncached !== undefined &&

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -354,6 +354,52 @@ layer(identifiers)("context economics — bounding, tracking, status, exhaustion
       }),
   );
 
+  it.effect("RUN-023: separates cache writes already included in provider uncached input", () =>
+    Effect.gen(function* () {
+      const deltas = yield* Ref.make<ReadonlyArray<RunUsageDelta>>([]);
+      const definition = Agent.define("overlapping-cache-write", {
+        input: Schema.Struct({ question: Schema.String }),
+        output: answerOutput,
+        instructions: "Answer.",
+        toolkit: Toolkit.empty,
+        policy: AgentPolicy.make({
+          maxTurns: 2,
+          maxToolCalls: 1,
+          maxDuration: "30 seconds",
+          toolConcurrency: 1,
+        }),
+      });
+      const rawUsage: FinishUsage = {
+        inputTokens: { total: 100, uncached: 90, cacheRead: 10, cacheWrite: 40 },
+        outputTokens: { total: 5, text: 5, reasoning: 0 },
+      };
+      const { model } = scriptedModel([finalParts('{"answer":"done"}', rawUsage)]);
+
+      yield* AgentRuntime.run(
+        Agent.withModel(definition, model),
+        { question: "q" },
+        {
+          budget: {
+            guard: (effect) => effect,
+            consume: (delta) => Ref.update(deltas, (all) => [...all, delta]),
+          },
+        },
+      );
+
+      const observed = (yield* Ref.get(deltas))[0];
+      if (observed === undefined) throw new Error("expected one usage delta");
+      expect(observed.inputTokens).toBe(100);
+      expect(observed.usage).toEqual(rawUsage);
+      if (observed.modelUsage === undefined) throw new Error("expected canonical model usage");
+      expect(observed.modelUsage.inputTokens).toEqual({
+        total: 100,
+        uncached: 50,
+        cacheRead: 10,
+        cacheWrite: 40,
+      });
+    }),
+  );
+
   it.effect("RUN-023: rejects malformed provider token usage instead of counting it as zero", () =>
     Effect.gen(function* () {
       const estimatorCalls = yield* Ref.make(0);

--- a/work-order-action/dist/index.mjs
+++ b/work-order-action/dist/index.mjs
@@ -38101,8 +38101,11 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
   const cacheWrite = providerUsage.inputTokens.cacheWrite ?? 0;
   const reportedText = providerUsage.outputTokens.text ?? 0;
   const reasoning = providerUsage.outputTokens.reasoning ?? 0;
-  const reportedInputComponents = yield* decodeProviderUsageTotal(reportedUncached + cacheRead + cacheWrite);
   const reportedInputTotal = providerUsage.inputTokens.total;
+  const reportedInputWithoutWrite = yield* decodeProviderUsageTotal(reportedUncached + cacheRead);
+  const cacheWriteOverlapsUncached = reportedInputTotal !== undefined && providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheWrite !== undefined && cacheWrite <= reportedUncached && reportedInputWithoutWrite <= reportedInputTotal && cacheWrite > reportedInputTotal - reportedInputWithoutWrite;
+  const disjointReportedUncached = reportedUncached - (cacheWriteOverlapsUncached ? cacheWrite : 0);
+  const reportedInputComponents = yield* decodeProviderUsageTotal(disjointReportedUncached + cacheRead + cacheWrite);
   const allInputComponentsReported = providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite !== undefined;
   if (reportedInputTotal !== undefined && (reportedInputTotal < reportedInputComponents || allInputComponentsReported && reportedInputTotal !== reportedInputComponents)) {
     return yield* invalidProviderUsage();
@@ -38117,7 +38120,7 @@ var consumeUsage = (agent2, context3, usage2, toolCallCount, turn, options3) => 
   const outputTokens = reportedOutputTotal ?? reportedOutputComponents;
   const inputRemainder = inputTokens - reportedInputComponents;
   const outputRemainder = outputTokens - reportedOutputComponents;
-  const uncached = reportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
+  const uncached = disjointReportedUncached + (providerUsage.inputTokens.uncached === undefined ? inputRemainder : 0);
   const normalizedCacheRead = cacheRead + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead === undefined ? inputRemainder : 0);
   const normalizedCacheWrite = cacheWrite + (providerUsage.inputTokens.uncached !== undefined && providerUsage.inputTokens.cacheRead !== undefined && providerUsage.inputTokens.cacheWrite === undefined ? inputRemainder : 0);
   const text2 = reportedText + (providerUsage.outputTokens.text === undefined ? outputRemainder : 0);


### PR DESCRIPTION
## Summary

- Normalize provider cache-write counts that are also included in uncached input into disjoint canonical components.
- Preserve the raw provider usage object for pricing and budget hooks.
- Document the overlap rule, add a patch changeset, and rebuild the committed Action bundles.

## Why

Effect AI's OpenAI adapter reports uncached input as total input minus cache reads, while also exposing cache writes separately. A valid response such as total 100, uncached 90, cache-read 10, cache-write 40 therefore crossed Effect Agent's new additive-total check and failed with ModelProtocolError.

This was reproduced in the downstream [Kommunikasie beta.27 update](https://github.com/reve-ai/kommunikasie/pull/878), where static checks and tests passed but the [deployed Workspace Assistant smoke test](https://github.com/reve-ai/kommunikasie/actions/runs/32784455438/job/97615405866) returned 503.

## Review guide

- [Normalization seam](https://github.com/danieljvdm/effect-agent/blob/95a130eb79a50b7b158e0a02d980b8a74c4e4165/packages/engine/src/index.ts#L2375-L2401)
- [Production-shaped regression test](https://github.com/danieljvdm/effect-agent/blob/95a130eb79a50b7b158e0a02d980b8a74c4e4165/packages/engine/test/context-economics.test.ts#L357-L402)
- [RUN-023 contract](https://github.com/danieljvdm/effect-agent/blob/95a130eb79a50b7b158e0a02d980b8a74c4e4165/docs/spec/runtime.md#L651-L665)

Already-disjoint reports are unchanged. Contradictory and unsafe usage still fails before cost estimation or budget consumption.

## Validation

- `vp check`
- `vp test run packages/engine/test/context-economics.test.ts` — 39 passed
- `vp run test` — all package and example suites passed
- `vp run build`
- `vp fmt --check`
