### PR TITLE
fix(release): restore changeset frontmatter

### DIFF
--- a/.changeset/scoped-interactive-browser.md
+++ b/.changeset/scoped-interactive-browser.md
@@ -1,3 +1,4 @@
+---
 "@effect-agent/sandbox": patch
 "@effect-agent/platform-cloudflare": patch
 ---


### PR DESCRIPTION
## Summary

- Restore the [opening Changesets frontmatter delimiter](https://github.com/danieljvdm/effect-agent/blob/a96620490cdceafacec97e4b666930f8f71cc09e/.changeset/scoped-interactive-browser.md#L1-L4) for the interactive browser release note.
- Unblock the release workflow so it can regenerate PR #168 from current `main`.

## What went wrong

The changeset began with package entries instead of `---`. Changesets stopped parsing before it could update the generated release branch. PR #168 therefore remained based on the commit before #172 and reported an adjacent-line conflict in `packages/platform-cloudflare/package.json`.

## Evidence

- `vp run changeset -- status` parses every pending changeset and reports the expected patch bumps.
