### PR TITLE
fix(browser): notify controlled React fields when filling

### DIFF
--- a/.changeset/react-controlled-browser-fill.md
+++ b/.changeset/react-controlled-browser-fill.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Update controlled React form state when filling interactive browser fields.

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -466,6 +466,12 @@ subrequest use the immutable exact-host policy. Capacity refusal and remote expi
 uncertain actions are never retried or replayed. This capability has no durable session, registry,
 execution reconnect, or model Tool.
 
+`fill` replaces the value of input, textarea, and select controls. It focuses the element,
+invokes a callable `value` setter from the element's prototype chain, then dispatches bubbling
+`input` and `change` events. Bypassing instance setters lets controlled React fields detect the
+change through `onChange` and update component state. A missing selector match or an element
+without a callable prototype setter fails with `InteractiveBrowserActionError` for `fill`.
+
 Arbitrary CDP execution is intentionally absent. The pinned browser client cannot enforce an immutable
 session egress boundary, and Cloudflare's newer hostname-only guardrail cannot express the exact
 HTTPS-origin policy required by the portable contract. Request interception is not sufficient

--- a/packages/platform-cloudflare/src/interactive-browser.ts
+++ b/packages/platform-cloudflare/src/interactive-browser.ts
@@ -342,12 +342,23 @@ const makeProductionPage = (page: Page): BrowserRunInteractivePage => {
       await page.$eval(
         selector,
         (element, nextValue) => {
-          if (!("value" in element)) {
+          // Bypass instance setters so React can detect the change when events fire.
+          let prototype = Reflect.getPrototypeOf(element);
+          let setValue: ((value: string) => void) | undefined;
+          while (prototype !== null) {
+            const setter = Reflect.getOwnPropertyDescriptor(prototype, "value")?.set;
+            if (typeof setter === "function") {
+              setValue = setter;
+              break;
+            }
+            prototype = Reflect.getPrototypeOf(prototype);
+          }
+          if (setValue === undefined) {
             throw new Error("The selector did not resolve to a fillable field");
           }
           const focus = Reflect.get(element, "focus");
           if (typeof focus === "function") Reflect.apply(focus, element, []);
-          Reflect.set(element, "value", nextValue);
+          Reflect.apply(setValue, element, [nextValue]);
           const dispatchEvent = Reflect.get(element, "dispatchEvent");
           if (typeof dispatchEvent === "function") {
             Reflect.apply(dispatchEvent, element, [new Event("input", { bubbles: true })]);

--- a/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
@@ -1,0 +1,191 @@
+import {
+  BrowserFillRequest,
+  InteractiveBrowser,
+  InteractiveBrowserPolicy,
+} from "@effect-agent/sandbox";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { vi } from "vite-plus/test";
+
+import {
+  BrowserRunInteractiveBinding,
+  browserRunInteractiveLayer,
+} from "../src/interactive-browser.ts";
+
+const sdk = vi.hoisted(() => ({ launch: vi.fn<() => Promise<object>>() }));
+
+vi.mock("@cloudflare/puppeteer", () => ({ default: sdk }));
+
+// Only the SDK transport is replaced: fill runs the production $eval callback.
+const nativeLayer = (element: object) => {
+  const page = {
+    $eval: async (
+      selector: string,
+      evaluate: (field: object, value: string) => void,
+      value: string,
+    ) => {
+      if (selector !== "#field") throw new Error("No element matches the selector");
+      evaluate(element, value);
+    },
+    url: () => "https://example.com/form",
+    close: async () => {},
+    setBypassServiceWorker: async () => {},
+    setRequestInterception: async () => {},
+    on: () => {},
+    off: () => {},
+  };
+
+  sdk.launch.mockResolvedValue({
+    createBrowserContext: async () => ({
+      newPage: async () => page,
+      close: async () => {},
+    }),
+    sessionId: () => "fill-regression",
+    isConnected: () => true,
+    on: () => {},
+    off: () => {},
+    close: async () => {},
+  });
+
+  const unusedRpc = async (): Promise<Response> => {
+    throw new Error("The SDK transport must not call Browser Run");
+  };
+
+  return browserRunInteractiveLayer().pipe(
+    Layer.provide(
+      BrowserRunInteractiveBinding.layer({
+        browser: { fetch: unusedRpc, quickAction: unusedRpc },
+      }),
+    ),
+  );
+};
+
+const open = Effect.gen(function* () {
+  const browser = yield* InteractiveBrowser;
+
+  return yield* browser.open(
+    InteractiveBrowserPolicy.make({
+      allowedHosts: ["example.com"],
+      maxActions: 8,
+      maxElapsedMillis: 5_000,
+      maxReturnedBytes: 1_024,
+    }),
+  );
+});
+
+class Field extends EventTarget {
+  #value = "initial";
+  focused = false;
+
+  get value() {
+    return this.#value;
+  }
+
+  set value(value: string) {
+    this.#value = value;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+}
+
+class InheritedField extends Field {}
+
+describe("Browser Run native field filling", () => {
+  it.effect.each([Field, InheritedField])(
+    "notifies controlled fields when replacing and clearing their value (%#)",
+    (FieldType) =>
+      Effect.gen(function* () {
+        const field = new FieldType();
+        let trackedValue = field.value;
+        let state = field.value;
+        let changes = 0;
+
+        // React's own setter tracks assignments before input-event change detection.
+        Object.defineProperty(field, "value", {
+          get: () => Reflect.get(Field.prototype, "value", field),
+          set: (value: string) => {
+            trackedValue = value;
+            Reflect.set(Field.prototype, "value", value, field);
+          },
+        });
+        field.addEventListener("input", () => {
+          if (field.value !== trackedValue) {
+            trackedValue = field.value;
+            state = field.value;
+            changes += 1;
+          }
+        });
+
+        yield* Effect.gen(function* () {
+          const handle = yield* open;
+
+          for (const value of ["agent-first", "replacement", ""]) {
+            yield* handle.fill(BrowserFillRequest.make({ selector: "#field", value }));
+            expect(state).toBe(value);
+            expect(field.value).toBe(value);
+          }
+        }).pipe(Effect.scoped, Effect.provide(nativeLayer(field)));
+
+        expect(changes).toBe(3);
+      }),
+  );
+
+  it.effect("focuses ordinary fields and emits bubbling input then change with the new value", () =>
+    Effect.gen(function* () {
+      const field = new Field();
+      const events: Array<{
+        type: string;
+        bubbles: boolean;
+        value: string;
+        focused: boolean;
+      }> = [];
+
+      for (const type of ["input", "change"]) {
+        field.addEventListener(type, (event) => {
+          events.push({
+            type: event.type,
+            bubbles: event.bubbles,
+            value: field.value,
+            focused: field.focused,
+          });
+        });
+      }
+
+      yield* Effect.gen(function* () {
+        const handle = yield* open;
+
+        yield* handle.fill(BrowserFillRequest.make({ selector: "#field", value: "agent-first" }));
+      }).pipe(Effect.scoped, Effect.provide(nativeLayer(field)));
+
+      expect(events).toEqual([
+        { type: "input", bubbles: true, value: "agent-first", focused: true },
+        { type: "change", bubbles: true, value: "agent-first", focused: true },
+      ]);
+    }),
+  );
+
+  it.effect.each([
+    {},
+    { value: "own data property" },
+    new (class {
+      get value() {
+        return "read only";
+      }
+    })(),
+  ])("rejects nonfillable elements with a typed fill failure (%#)", (element) =>
+    Effect.gen(function* () {
+      const handle = yield* open;
+      const error = yield* handle
+        .fill(BrowserFillRequest.make({ selector: "#field", value: "agent-first" }))
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "InteractiveBrowserActionError",
+        operation: "fill",
+        cause: new Error("The selector did not resolve to a fillable field"),
+      });
+    }).pipe(Effect.scoped, Effect.provide(nativeLayer(element))),
+  );
+});


### PR DESCRIPTION
Fixes #195.

Controlled React fields now update application state when interactive browser `fill` runs. The [native adapter](https://github.com/danieljvdm/effect-agent/blob/b291a30a682fb98071606356f287ebb38d7ff94d/packages/platform-cloudflare/src/interactive-browser.ts#L341) calls a callable `value` setter from the element's prototype chain, then emits the existing bubbling `input` and `change` events. Input, textarea, and select remain supported. Elements without a prototype setter fail with the existing typed fill error.

Includes the required `@effect-agent/platform-cloudflare` patch changeset and a specification update. No new dependency or public API.

## What went wrong

`Reflect.set(element, "value", nextValue)` called React's own setter, which advanced its value tracker before event handling. React then saw no change, skipped `onChange`, and left component state stale. A later render could restore the old value. Calling the prototype setter bypasses that instance tracker so the normal events update state; applications can keep using `onChange`.

## Evidence

The [six native fill regression cases](https://github.com/danieljvdm/effect-agent/blob/b291a30a682fb98071606356f287ebb38d7ff94d/packages/platform-cloudflare/test/interactive-browser-fill.test.ts) execute the production fill callback through `BrowserRunInteractiveBinding.layer`. They cover tracked fields, an inherited setter, replacement and clearing, focus/event order, and typed rejection of nonfillable elements. The tracked-field cases failed against the original implementation with `expected 'initial' to be 'agent-first'`; all six pass with the fix, alongside the 27 existing interactive-browser tests.

A disposable React **19.2.8** form in Chromium **151.0.7922.174** used controlled `value`/`onChange` fields and the production binding/handle for Fill → Click Save → Read, followed by a separate render:

| Control | Original adapter, saved result | Fixed adapter, saved result |
| --- | --- | --- |
| Input | `Saved:` | `Saved: agent-first` |
| Textarea | `Saved:` | `Saved: agent-first` |
| Select | `Saved: agent-first` | `Saved: agent-first` |

All three controls also passed replacement, clearing, and value retention after another render, nine fixed cases in total. The original input and textarea reverted to empty values.

This is real React/DOM evidence with a local SDK transport executing the production page callbacks. It is not a hosted Cloudflare transport or Kommunikasie acceptance run.

