### PR TITLE
chore(docs): use effect-agent.com custom domain

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,5 @@
 # Deploys the VitePress docs site to a Cloudflare Worker with Alchemy
-# (alchemy.run.ts, stage `prod`, https://effect-agent.danvdm.com). Alchemy
+# (alchemy.run.ts, stage `prod`, https://effect-agent.com). Alchemy
 # runs `bun run docs:build` itself, content-hashes the output, and skips the
 # deploy when nothing changed; state lives in the account-wide Cloudflare
 # state store, whose credentials the CI run resolves from the account's

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -31,7 +31,7 @@ const stack = Effect.gen(function* () {
     name: "effect-agent-docs",
     command: "bun run docs:build",
     outdir: "docs/.vitepress/dist",
-    domain: "effect-agent.danvdm.com",
+    domain: "effect-agent.com",
     workersDev: false,
     dev: { command: "bun run docs:dev" },
     // VitePress emits 404.html; its cleanUrls links match the default


### PR DESCRIPTION
Change the docs custom domain from `effect-agent.danvdm.com` to `effect-agent.com` in the [Alchemy stack](https://github.com/danieljvdm/effect-agent/blob/664b30e/alchemy.run.ts#L30), and update the deployment workflow's URL comment. The existing Worker and shared production state remain in place.

Applied the production Alchemy deployment. `https://effect-agent.com/` returns HTTP 200 with a valid TLS certificate and the title `Effect Agent`.

Merge this change before the next docs deployment from `main`, which would otherwise restore the old hostname. This replaces the old hostname; it does not add a redirect.
