### PR TITLE
fix(durability): settle unknown submissions after authorized abort

### DIFF
--- a/.changeset/unknown-abort-recovery.md
+++ b/.changeset/unknown-abort-recovery.md
@@ -1,0 +1,9 @@
+---
+"@effect-agent/session": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Allow durably authorized aborts to settle unknown submissions and release queued followers without replaying uncertain tools. Quiesce Cloudflare maintenance for ready followers behind an unresolved external wait.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -73,11 +73,17 @@ An unknown or approval-waiting head with ready followers quiesces until an autho
 restores its maintenance alarm. Keep host decisions about whether and when to abort; there is no
 automatic inactivity deadline.
 
+A parent suspended in `WaitingForChild` does not acquire abort authority because its child is
+unknown. The host must explicitly decide to abort the parent, or apply a separately configured
+authorized policy. The fix owns child abort propagation, joining, and reservation cleanup only
+after that parent abort is durably accepted. It does not choose the parent's outcome beforehand.
+
 ## Observe a Submission outcome
 
 Persist the admission `Receipt`: its `submissionId`, `receiptId`, `conversationId`, and
-`queueSequence` identify the same obligation across retries and replacement Attempts. Existing
-public ports supply the evidence; a separate inspection RPC or recovery classifier is unnecessary.
+`queueSequence` identify the same obligation across retries and replacement Attempts. The APIs
+below supply the evidence inside a host with the real `SubmissionLedger` and `DurableAgentRuntime`
+services. They are not all remotely available through `CloudflareConversationClient`.
 
 | Need                         | Public API and evidence                                                                                                                                                                                                 |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -123,7 +129,26 @@ bound for `ConversationStore.read` (use `sequence - 1` to include the input); a 
 no Run history yet. Keep subsequent reads incremental and retain only the application's projection.
 Cloudflare already exposes `explainEncoded` for occasional remote diagnosis.
 
-For a queued follower, the ordered public `SubmissionLedger.scanNonterminal` identifies the
+An independent Worker outside the Conversation Object cannot obtain the complete operational
+snapshot through that client. The public `portCall` protocol supports ledger lookup, which returns
+the admitted input and Submission state, but has no recovery-snapshot or nonterminal-scan request.
+The routed ledger keeps `loadRecoverySnapshot` local-only and `scanNonterminal` local to its owning
+Object. Canonical paging and progress waits do not expose the authoritative suspension,
+`inputApplied` marker, or FIFO blocker. There is no public composition that obtains all of these
+remotely without an additional host boundary; repeated `explainEncoded` calls are not a bounded
+snapshot substitute.
+
+For an external Worker that needs those fields, retain an authorized, Schema-backed, read-only
+snapshot RPC inside the owning Conversation Object and its external client adapter. That RPC
+validates the Receipt against local lookup, uses the real ledger's `loadRecoverySnapshot` for
+input application, suspension, abort intent, and joined host linkage, and scans the local ordered
+nonterminal rows for an earlier FIFO blocker. It can expose the relevant child references for
+host policy. It need not copy the recovery classifier or construct dummy local services outside
+the Object. Any application-specific activity or Tool-result projection can use bounded canonical
+reads from the input marker and an incremental cursor. This remains a host adapter, not an API
+added by the abort fix.
+
+Inside the owning Object, the ordered public `SubmissionLedger.scanNonterminal` identifies the
 earlier unsettled head in its Conversation; `explain` diagnoses that head without reimplementing
 recovery. Do not infer the follower's state from the Conversation's latest Run.
 
@@ -134,8 +159,9 @@ delivery. No exactly-once external delivery is promised. Hosts must authorize pu
 and observation, and handle typed storage, protocol, and authorization errors without interpreting
 them as a terminal outcome.
 
-Delete custom inspection/classification and outcome-polling code that duplicates these contracts.
-Keep application policy for visible responses, whether an acknowledgement is sufficient,
+Replace only inspection/classification and outcome-polling logic that the APIs available at the
+caller's boundary actually cover. Keep the host snapshot RPC when an external Worker needs the
+operational evidence above. Keep application policy for visible responses, whether an acknowledgement is sufficient,
 destinations and authorization, inactivity thresholds, and delivery retries. Tool success or an
 application result tag is not a library-defined answer obligation; project that policy from
 canonical records without adding it to the runtime.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -51,6 +51,95 @@ export the rows as logs or metrics, and alert on:
 - any row with severity `overdue`, which marks accepted work without timely settlement;
 - a growing `approval` backlog.
 
+## Abort unknown work
+
+Call `DurableAgentRuntime.abort(AbortCommand.make({ submissionId, author, reason }))` after the
+host authorizes stopping that Submission. On Cloudflare, use
+`CloudflareConversationClient.abort(receipt.conversationId, command)`. Abort authority remains
+service possession plus the host's authenticated boundary; it does not grant callers broader
+Tool-resolution authority.
+
+Normal recovery/maintenance now claims an unknown head with that durable intent, cleans up and
+joins attached children, and records the aborted settlement. It releases queued followers without
+replaying uncertain ordinary Tools. The original abort audit and unknown evidence remain; abort
+does not claim that an external action was rolled back. Repeated commands preserve the first
+intent. A `SettlementConflict` reports an outcome that already won, including an aborted outcome
+whose acknowledgement was lost.
+
+Remove consumer loops that follow abort with `ResolutionAbortSubmission` for every unresolved
+call, manually clean up children after an accepted parent abort, edit ledger state, or repeatedly
+wake a blocked lane.
+An unknown or approval-waiting head with ready followers quiesces until an authorized mutation
+restores its maintenance alarm. Keep host decisions about whether and when to abort; there is no
+automatic inactivity deadline.
+
+## Observe a Submission outcome
+
+Persist the admission `Receipt`: its `submissionId`, `receiptId`, `conversationId`, and
+`queueSequence` identify the same obligation across retries and replacement Attempts. Existing
+public ports supply the evidence; a separate inspection RPC or recovery classifier is unnecessary.
+
+| Need                         | Public API and evidence                                                                                                                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admitted or queued           | `SubmissionLedger.lookup(SubmissionLookupById.make({ submissionId }))`: `admitted` or `ready`; the Receipt proves admission.                                                                                            |
+| Execution stage              | The same lookup returns `running` or `input-applied`. This is durable operational state, not proof that a worker is alive.                                                                                              |
+| Intentional wait             | `loadRecoverySnapshot(RecoverySnapshotRequest.make({ submissionId }))` exposes `suspension` and joined host linkage. `explain(submissionId)` supplies the existing classifier decision.                                 |
+| Unknown outcome              | Lookup returns `unknown`; `explain` adds open calls, uncertainty audits, accepted resolutions, and abort intent.                                                                                                        |
+| Completed, failed, aborted   | `awaitSettlement(receipt)` returns the durable terminal identity/outcome and bounded failure diagnostic. Interrupting the wait detaches the caller; it does not abort the Submission.                                   |
+| Terminal stop/budget details | The canonical `SubmissionSettled` record carries `finishReason`, `exhausted`, and `policyLimit` where applicable. These fields are **not** currently on the returned `Settlement`; read the record through observation. |
+
+For live progress use `DurableAgentRuntime.observe(receipt, { after })`. It is a Conversation
+Stream, so filter by `submissionId` or `runIdForSubmission(submissionId)` as appropriate. Joined
+input shares its host's Run; use the snapshot's `hostSubmissionId` for Run evidence, and the
+original Submission ID for its own terminal record. For example, this Stream yields the exact
+terminal envelope, including budget metadata and its resumable cursor:
+
+```ts
+import { DurableAgentRuntime, type ObservationOffset, type Receipt } from "@effect-agent/session";
+import { Effect, Stream } from "effect";
+
+const observeOutcome = (receipt: Receipt, after?: ObservationOffset) =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      return runtime.observe(receipt, { after }).pipe(
+        Stream.filter(
+          ({ record }) =>
+            record.payload._tag === "SubmissionSettled" &&
+            record.payload.submissionId === receipt.submissionId,
+        ),
+        Stream.take(1),
+      );
+    }),
+  );
+```
+
+On Cloudflare, consume bounded `CloudflareConversationClient.readPage` pages and retain the last
+`sequence`; after an empty page, `awaitProgress(conversationId, sequence)` waits for a hint or
+already committed progress before another read. Do not call `readAll` or `explain` in a polling
+loop: `explain` is a diagnostic read of conversation history. For a first run-scoped read inside
+an authorized host, the public recovery snapshot's `inputApplied.sequence` provides a lower
+bound for `ConversationStore.read` (use `sequence - 1` to include the input); a ready follower has
+no Run history yet. Keep subsequent reads incremental and retain only the application's projection.
+Cloudflare already exposes `explainEncoded` for occasional remote diagnosis.
+
+For a queued follower, the ordered public `SubmissionLedger.scanNonterminal` identifies the
+earlier unsettled head in its Conversation; `explain` diagnoses that head without reimplementing
+recovery. Do not infer the follower's state from the Conversation's latest Run.
+
+Canonical records replay from the saved cursor. Consumers own cursor persistence and idempotent
+projection or delivery; checkpointing after a side effect can redeliver it after a crash. Neither
+the Stream, a notification, a callback, nor a process-local finalizer guarantees durable external
+delivery. No exactly-once external delivery is promised. Hosts must authorize public ledger reads
+and observation, and handle typed storage, protocol, and authorization errors without interpreting
+them as a terminal outcome.
+
+Delete custom inspection/classification and outcome-polling code that duplicates these contracts.
+Keep application policy for visible responses, whether an acknowledgement is sufficient,
+destinations and authorization, inactivity thresholds, and delivery retries. Tool success or an
+application result tag is not a library-defined answer obligation; project that policy from
+canonical records without adding it to the runtime.
+
 ## Backup and restore on DN
 
 Any file-consistent snapshot works as a backup: copy the `.sqlite`, `-wal`, and `-shm` files

--- a/docs/spec/deployment.md
+++ b/docs/spec/deployment.md
@@ -327,6 +327,10 @@ stores a versioned `dirty`/`processed` generation beside its single alarm slot:
   outcome, joined child, or child awaiting parent establishment), the observed generation is
   acknowledged and the alarm clears. Its resolving mutation re-establishes both generation and
   alarm before changing the wait;
+- ready FIFO followers behind a stable external wait do not make the lane actionable. Admission
+  repair, an accepted abort, and pending terminalization still require maintenance, including an
+  abort whose ownership claim was deferred. Neither elapsed time nor queued followers authorize
+  resolving or aborting an unknown outcome;
 - autonomous retry, indeterminate admission/establishment, lease recovery, and other locally
   actionable states leave the generation unprocessed and rearm with bounded backoff;
 - a forced alarm with `processed >= dirty` reads only the maintenance record, clears the alarm,

--- a/docs/spec/durability.md
+++ b/docs/spec/durability.md
@@ -396,6 +396,20 @@ Abort is a durable command with identity, author, reason, and target.
 - Repeating the same abort command is idempotent.
 - A completed or failed submission cannot later become aborted.
 
+An `unknown` FIFO head with a durably accepted abort intent MUST be claimable under the normal
+ownership lease and producer fence. The claim authorizes the existing abort recovery path,
+including request-abort-and-join for attached children; it does not authorize ordinary Tool replay.
+The ledger retains the unknown mark and canonical `ToolCallUnknown` evidence. Neither callers nor
+recovery need to manufacture a `ResolutionAbortSubmission` for each open call. Without an abort
+intent or covering authorized resolutions, the head remains blocked.
+
+Claimability reads the intent in the existing atomic claim operation, rather than changing unknown
+state in `requestAbort`. This also covers an abort accepted before a racing unknown mark and an
+acknowledgement lost after either write. Existing claim, abort-intent, reservation, canonical-append,
+and finalization failpoints bound the protocol; no additional durable mutation is introduced.
+The original abort author, reason, and timestamp survive retries. A previously reserved or
+canonical terminal outcome still wins over a later abort.
+
 ## 14. Recovery algorithm
 
 A recovery worker:

--- a/docs/spec/persistence.md
+++ b/docs/spec/persistence.md
@@ -115,6 +115,11 @@ operations and also exposes strongly consistent `lookup`, graceful `releaseOwner
 the idempotent `markInputApplied` canonical-input marker, idempotent `requestAbort`, the ordered
 `scanNonterminal` stream, and a `capabilities` durability declaration.
 
+An unknown head is claimable only when its durable abort intent exists, checked atomically with
+the ordinary ownership claim. This exception preserves FIFO, lease checks, producer fencing, and
+uncertainty evidence; it enables cleanup and aborted settlement, never uncertain Tool replay.
+Memory, SQLite, and Durable Object SQLite adapters share this contract.
+
 Each method has an explicit atomic and idempotent contract. Admission and settlement intentionally
 span the two stores through recoverable states:
 

--- a/packages/platform-cloudflare/src/alarm.ts
+++ b/packages/platform-cloudflare/src/alarm.ts
@@ -240,11 +240,15 @@ const stableExternalWait = (
   snapshot: SubmissionSnapshot,
   reports: ReadonlyMap<string, RecoveryReport>,
 ): boolean => {
+  const decision = reports.get(snapshot.submissionId)?.decision._tag;
+  // An accepted abort still owes cleanup/settlement even if its claim was deferred this pass.
+  if (decision === "SettleAborted") return false;
   switch (snapshot.state) {
     case "suspended":
-    case "unknown":
     case "joined":
       return true;
+    case "unknown":
+      return decision === "AwaitUnknownResolution" || decision === "MarkUnknown";
     case "admitted":
       return reports.get(snapshot.submissionId)?.decision._tag === "AwaitParentEstablishment";
     case "input-applied":
@@ -478,7 +482,20 @@ export class ConversationMaintenance extends Context.Service<
         // Observe residual state before acknowledging this exact pass-start generation.
         const remaining = yield* Stream.runCollect(ledger.scanNonterminal);
         const reports = new Map(recovered.map((report) => [report.submissionId, report]));
-        const autonomous = remaining.some((snapshot) => !stableExternalWait(snapshot, reports));
+        const head = remaining[0];
+        const headWaiting = head !== undefined && stableExternalWait(head, reports);
+        const autonomous = remaining.some((snapshot, index) => {
+          // FIFO followers cannot execute through a stable external wait. Only plain queued
+          // input is dormant here; admission repairs and accepted aborts still need a pass.
+          if (
+            index > 0 &&
+            headWaiting &&
+            snapshot.state === "ready" &&
+            reports.get(snapshot.submissionId)?.decision._tag === "ApplyInput"
+          )
+            return false;
+          return !stableExternalWait(snapshot, reports);
+        });
         const progressed =
           settlements.length > 0 || recovered.some((report) => report.disposition === "repaired");
         const delay = autonomous ? yield* rearmDelay(progressed) : 0;

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -1,4 +1,5 @@
 import {
+  AbortCommand,
   ApprovalDecisionCommand,
   ResolutionNeverHappened,
   UnknownResolutionCommand,
@@ -12,6 +13,7 @@ import {
   BOOK_TOOL_CALL_ID,
   approvalDefinition,
   armRuntimeEviction,
+  armStorageEviction,
   armedEvictionsRemaining,
   armedRuntimeFailures,
   bookDefinition,
@@ -19,6 +21,8 @@ import {
   armMaintenancePause,
   awaitMaintenancePause,
   plannerDefinition,
+  lostBookReplies,
+  supplierCountsFor,
   releaseMaintenancePause,
   submitOptions,
 } from "./fixtures.ts";
@@ -30,6 +34,7 @@ import {
   laneRows,
   readCanonical,
   runClient,
+  runClientExit,
   scheduledAlarm,
   stubFor,
 } from "./harness.ts";
@@ -48,6 +53,7 @@ const lane = (label: string): string => `cf-alarm-${label}-${laneCounter++}`;
 const submitTo = (
   definition: typeof plannerDefinition | typeof approvalDefinition | typeof bookDefinition,
   conversation: string,
+  key = `${conversation}-key`,
 ) =>
   runClient(
     Effect.gen(function* () {
@@ -55,7 +61,7 @@ const submitTo = (
       return yield* client.submit(
         { definition },
         { question: "alarm semantics", ref: conversation },
-        submitOptions(conversation, `${conversation}-key`),
+        submitOptions(conversation, key),
       );
     }),
   );
@@ -89,6 +95,7 @@ describe("DC alarm semantics", () => {
     const conversation = lane("issue-93-quiescent-approval");
     const receipt = await submitTo(approvalDefinition, conversation);
     await drainAlarmsUntil(conversation, anyInState(conversation, "suspended"));
+    await submitTo(plannerDefinition, conversation, `${conversation}-follower`);
     await drainAlarmsUntil(conversation, async () => (await scheduledAlarm(conversation)) === null);
 
     const suspendedFingerprint = await canonicalFingerprint(conversation);
@@ -264,6 +271,7 @@ describe("DC alarm semantics", () => {
     armRuntimeEviction(conversation, "tools:after-prepared-append");
     const receipt = await submitTo(bookDefinition, conversation);
     await drainAlarmsUntil(conversation, anyInState(conversation, "unknown"));
+    await submitTo(plannerDefinition, conversation, `${conversation}-follower`);
     await drainAlarmsUntil(conversation, async () => (await scheduledAlarm(conversation)) === null);
     const blockedFingerprint = await canonicalFingerprint(conversation);
     await runDurableObjectAlarm(stubFor(conversation)).catch(() => undefined);
@@ -293,6 +301,75 @@ describe("DC alarm semantics", () => {
     await drainAlarmsUntil(conversation, allSettled(conversation));
     await assertConvergence(conversation);
   }, 30_000);
+
+  it.each([
+    undefined,
+    "abort:after-intent",
+    "terminalize:after-reserve",
+    "terminalize:after-canonical-append",
+  ] as const)(
+    "authorized abort releases an unknown head after lost external reply (eviction=%s)",
+    async (eviction) => {
+      const conversation = lane(`unknown-abort-${eviction ?? "none"}`);
+      lostBookReplies.add(conversation);
+      // Real eviction after recovery has persisted uncertainty. No fake clock races automatic
+      // alarms: both the reply loss and eviction are armed before admission.
+      armStorageEviction(conversation, "ledger:mark-unknown:after");
+      const receipt = await submitTo(bookDefinition, conversation);
+      await drainAlarmsUntil(conversation, anyInState(conversation, "unknown"));
+      const follower = await submitTo(plannerDefinition, conversation, `${conversation}-follower`);
+      expect(supplierCountsFor(conversation)).toEqual({ book: 1 });
+      const unknownBefore = (await readCanonical(conversation)).filter(
+        ({ record }) => record.payload._tag === "ToolCallUnknown",
+      );
+      expect(unknownBefore).toHaveLength(1);
+      if (eviction !== undefined) armRuntimeEviction(conversation, eviction);
+      const command = AbortCommand.make({
+        submissionId: receipt.submissionId,
+        author: "authorized-operator",
+        reason: "stop this submission; the external outcome is still uncertain",
+      });
+      const accepted = await runClientExit(
+        Effect.gen(function* () {
+          const client = yield* CloudflareConversationClient;
+          return yield* client.abort(decodeConversationId(conversation), command);
+        }),
+      );
+      expect(accepted.ok).toBe(eviction !== "abort:after-intent");
+      await drainAlarmsUntil(conversation, allSettled(conversation));
+      await assertConvergence(conversation, {
+        supplier: { ref: conversation, counts: { book: 1 } },
+      });
+      expect(armedEvictionsRemaining(conversation)).toBe(0);
+      const records = await readCanonical(conversation);
+      expect(records.filter(({ record }) => record.payload._tag === "ToolCallUnknown")).toEqual(
+        unknownBefore,
+      );
+      expect(records.filter(({ record }) => record.payload._tag === "ToolCallResolved")).toEqual(
+        [],
+      );
+      expect(records.filter(({ record }) => record.payload._tag === "ToolCallSettled")).toEqual([]);
+      expect(
+        records
+          .filter(({ record }) => record.payload._tag === "AbortRequested")
+          .map(({ record }) => record.payload),
+      ).toEqual([
+        expect.objectContaining({
+          author: command.author,
+          reason: command.reason,
+          submissionId: receipt.submissionId,
+        }),
+      ]);
+      const outcomes = await runClient(
+        Effect.gen(function* () {
+          const client = yield* CloudflareConversationClient;
+          return [yield* client.awaitSettlement(receipt), yield* client.awaitSettlement(follower)];
+        }),
+      );
+      expect(outcomes.map(({ outcome }) => outcome)).toEqual(["aborted", "completed"]);
+    },
+    30_000,
+  );
 
   it("a typed failure inside the pass rejects the delivery and redelivery converges the lane", async () => {
     const conversation = lane("throw-retry");

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -545,12 +545,15 @@ const BookTool = Tool.make("book", {
   parameters: Schema.Struct({ ref: Schema.String }),
   success: Schema.Struct({ confirmation: Schema.String }),
 });
-const bookTools = Toolkit.make(BookTool);
+export const bookTools = Toolkit.make(BookTool);
+/** Lose the RPC reply after the external action, without claiming a safe-to-retry failure. */
+export const lostBookReplies = new Set<string>();
 export const bookToolLayer = bookTools.toLayer({
   book: ({ ref }) =>
-    Effect.sync(() => {
+    Effect.gen(function* () {
       const confirmation = `confirmed-${ref}`;
       recordSupplierCall("book", ref, confirmation);
+      if (lostBookReplies.delete(ref)) return yield* Effect.die("external reply lost");
       return { confirmation };
     }),
 });

--- a/packages/platform-cloudflare/test/subagent-fixtures.ts
+++ b/packages/platform-cloudflare/test/subagent-fixtures.ts
@@ -14,7 +14,13 @@ import {
 import { Duration, Effect, Layer, Schema, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
-import { TEST_DIGESTS, recordSupplierCall, supplierCountsFor } from "./fixtures.ts";
+import {
+  TEST_DIGESTS,
+  bookTools,
+  bookToolLayer,
+  recordSupplierCall,
+  supplierCountsFor,
+} from "./fixtures.ts";
 
 /**
  * WP4 cross-Object subagent fixtures (plan §4 WP4): the crash-shape coordinator → researcher
@@ -70,6 +76,8 @@ export const transportFaultReason = (name: string | undefined): string | undefin
 // ---------------------------------------------------------------------------
 
 const gatedChildRefs = new Set<string>();
+/** Exercise ordinary Tool uncertainty inside the existing attached child fixture. */
+export const uncertainChildRefs = new Set<string>();
 
 /** Make the researcher model for `ref` HANG mid-stream until released. */
 export const gateChildModel = (ref: string): void => {
@@ -225,11 +233,17 @@ const siblingCoordinatorModel = promptAwareModel("cf-s2-sibling-coordinator", (p
 const researcherModel = promptAwareModel("cf-s2-researcher", (promptJson) => {
   const ref = childRefFromPrompt(promptJson);
   recordSupplierCall(CHILD_MODEL_OP, ref, "invoked");
+  const response = Stream.fromIterable(
+    uncertainChildRefs.has(ref)
+      ? [
+          toolCallPart("book-1", "book", { ref }),
+          { type: "finish", reason: "tool-calls", usage } satisfies Response.StreamPartEncoded,
+        ]
+      : finalParts(CHILD_ANSWER),
+  );
   return gatedChildRefs.has(ref)
-    ? Stream.fromEffectDrain(awaitChildRelease(ref)).pipe(
-        Stream.concat(Stream.fromIterable(finalParts(CHILD_ANSWER))),
-      )
-    : Stream.fromIterable(finalParts(CHILD_ANSWER));
+    ? Stream.fromEffectDrain(awaitChildRelease(ref)).pipe(Stream.concat(response))
+    : response;
 });
 
 // ---------------------------------------------------------------------------
@@ -245,7 +259,7 @@ export const researcherDefinition = Agent.define("cf-s2-researcher", {
   input: ResearcherInput,
   output: ResearcherOutput,
   instructions: ({ question }) => `Answer ${question} as JSON.`,
-  toolkit: Toolkit.empty,
+  toolkit: bookTools,
   policy: AgentPolicy.make({
     maxTurns: 2,
     maxToolCalls: 1,
@@ -331,7 +345,7 @@ export const makeSubagentTestBindings: Effect.Effect<ReadonlyArray<ResolvedBindi
     const delegationLayer = SubagentRuntime.layer(researchDelegation, childBinding, {
       mapChildFailure,
       durable: { targetDigests: SUBAGENT_CHILD_DIGEST_STRINGS },
-    }).pipe(Layer.provide(delegationSupport));
+    }).pipe(Layer.provide([delegationSupport, bookToolLayer]));
     const siblingLookupLayer = Toolkit.make(SiblingLookup).toLayer({
       lookup: ({ key }) =>
         Effect.sync(() => {
@@ -352,7 +366,7 @@ export const makeSubagentTestBindings: Effect.Effect<ReadonlyArray<ResolvedBindi
     const researcher: ResolvedBinding = yield* DurableWorkerBinding.make(
       childBinding,
       SUBAGENT_CHILD_DIGESTS,
-    );
+    ).pipe(Effect.provide(bookToolLayer));
     return [coordinator, sibling, researcher];
   },
 );

--- a/packages/platform-cloudflare/test/subagents-cross-do.test.ts
+++ b/packages/platform-cloudflare/test/subagents-cross-do.test.ts
@@ -23,6 +23,8 @@ import {
   armStorageEviction,
   armedEvictionsRemaining,
   decodeConversationId,
+  lostBookReplies,
+  supplierCountsFor,
   submitOptions,
 } from "./fixtures.ts";
 import {
@@ -43,6 +45,7 @@ import {
   releaseChildModel,
   siblingCoordinatorDefinition,
   siblingLookupInvocations,
+  uncertainChildRefs,
 } from "./subagent-fixtures.ts";
 import {
   SUBAGENTS,
@@ -443,55 +446,76 @@ describe("DC cross-Object subagent matrix (parent and child in different Durable
   // Abort propagation parent→child across Objects (request-abort-and-join).
   // -------------------------------------------------------------------------
 
-  it("aborting the waiting parent propagates ONE durable abort to the child's Object and settles only after the join", async () => {
-    const ref = lane("abort-propagation");
-    const key = `${ref}-key`;
-    gateChildModel(ref);
-    const receipt = await submitCoordinator("coordinator", ref, key);
-    const child = childConversationOf(receipt, ref);
-    await drainDelegationUntil([ref], anyInState(ref, "suspended", SUBAGENTS));
-    await waitFor(() => {
-      kickWithoutAwaiting(child);
-      return childModelInvocations(ref) === 1;
-    }, "the hanging researcher invocation");
+  it.each(["active", "unknown"])(
+    "aborting the waiting parent joins its %s child before settlement",
+    async (childState) => {
+      const ref = lane(`abort-propagation-${childState}`);
+      const key = `${ref}-key`;
+      gateChildModel(ref);
+      if (childState === "unknown") {
+        uncertainChildRefs.add(ref);
+        lostBookReplies.add(ref);
+      }
+      const receipt = await submitCoordinator("coordinator", ref, key);
+      const child = childConversationOf(receipt, ref);
+      await drainDelegationUntil([ref], anyInState(ref, "suspended", SUBAGENTS));
+      await waitFor(() => {
+        kickWithoutAwaiting(child);
+        return childModelInvocations(ref) === 1;
+      }, "the hanging researcher invocation");
 
-    await abortParent(ref, receipt);
-    // The parent's alarm passes propagate the abort across the Object boundary; the child's
-    // active Attempt observes its durable intent, interrupts the hanging stream, settles
-    // aborted, and the join wakes the parent (spec §13.1).
-    await drainDelegationUntil([ref, child], allLanesSettled(ref, child));
+      if (childState === "unknown") {
+        armStorageEviction(child, "ledger:mark-unknown:after");
+        releaseChildModel(ref);
+        await drainDelegationUntil([child], anyInState(child, "unknown", SUBAGENTS));
+        expect(supplierCountsFor(ref).book).toBe(1);
+      }
 
-    // Exactly one canonical child abort command, authored by the propagation (DUR-012).
-    const childRecords = await readCanonical(child, SUBAGENTS);
-    const abortRecords = payloadsOf(childRecords, "AbortRequested");
-    expect(abortRecords).toHaveLength(1);
-    const abortPayload = abortRecords[0]?.record.payload;
-    if (abortPayload?._tag === "AbortRequested") {
-      expect(abortPayload.author).toBe("subagent-parent-abort");
-    }
-    const childSettled = payloadsOf(childRecords, "SubmissionSettled")[0]?.record.payload;
-    if (childSettled?._tag === "SubmissionSettled") {
-      expect(childSettled.outcome).toBe("aborted");
-    }
+      await abortParent(ref, receipt);
+      // The parent's alarm passes propagate the abort across the Object boundary; the child's
+      // active Attempt observes its durable intent, interrupts the hanging stream, settles
+      // aborted, and the join wakes the parent (spec §13.1).
+      await drainDelegationUntil([ref, child], allLanesSettled(ref, child));
 
-    // The join committed with the child's ACTUAL outcome, strictly BEFORE the parent's
-    // aborted settlement ("the parent settles only after the joins").
-    const parentRecords = await readCanonical(ref, SUBAGENTS);
-    const joined = payloadsOf(parentRecords, "SubagentJoined");
-    expect(joined).toHaveLength(1);
-    const joinedPayload = joined[0]?.record.payload;
-    if (joinedPayload?._tag !== "SubagentJoined") throw new Error("Expected SubagentJoined");
-    expect(joinedPayload.childOutcome).toBe("aborted");
-    const settledEnvelope = payloadsOf(parentRecords, "SubmissionSettled")[0];
-    expect(settledEnvelope).toBeDefined();
-    if (settledEnvelope !== undefined && joined[0] !== undefined) {
-      expect(Number(joined[0].sequence)).toBeLessThan(Number(settledEnvelope.sequence));
-    }
-    expect(await parentOutcomeOf(ref)).toBe("aborted");
-    expect(await reservationStatuses(ref)).toEqual(["released"]);
-    // The interrupted researcher was invoked exactly once and never re-executed to abort it.
-    expect(childModelInvocations(ref)).toBe(1);
-  }, 40_000);
+      // Exactly one canonical child abort command, authored by the propagation (DUR-012).
+      const childRecords = await readCanonical(child, SUBAGENTS);
+      const abortRecords = payloadsOf(childRecords, "AbortRequested");
+      expect(abortRecords).toHaveLength(1);
+      const abortPayload = abortRecords[0]?.record.payload;
+      if (abortPayload?._tag === "AbortRequested") {
+        expect(abortPayload.author).toBe("subagent-parent-abort");
+      }
+      const childSettled = payloadsOf(childRecords, "SubmissionSettled")[0]?.record.payload;
+      if (childSettled?._tag === "SubmissionSettled") {
+        expect(childSettled.outcome).toBe("aborted");
+      }
+
+      // The join committed with the child's ACTUAL outcome, strictly BEFORE the parent's
+      // aborted settlement ("the parent settles only after the joins").
+      const parentRecords = await readCanonical(ref, SUBAGENTS);
+      const joined = payloadsOf(parentRecords, "SubagentJoined");
+      expect(joined).toHaveLength(1);
+      const joinedPayload = joined[0]?.record.payload;
+      if (joinedPayload?._tag !== "SubagentJoined") throw new Error("Expected SubagentJoined");
+      expect(joinedPayload.childOutcome).toBe("aborted");
+      const settledEnvelope = payloadsOf(parentRecords, "SubmissionSettled")[0];
+      expect(settledEnvelope).toBeDefined();
+      if (settledEnvelope !== undefined && joined[0] !== undefined) {
+        expect(Number(joined[0].sequence)).toBeLessThan(Number(settledEnvelope.sequence));
+      }
+      expect(await parentOutcomeOf(ref)).toBe("aborted");
+      expect(await reservationStatuses(ref)).toEqual(["released"]);
+      // The interrupted researcher was invoked exactly once and never re-executed to abort it.
+      expect(childModelInvocations(ref)).toBe(1);
+      if (childState === "unknown") {
+        expect(supplierCountsFor(ref).book).toBe(1);
+        expect(payloadsOf(childRecords, "ToolCallUnknown")).toHaveLength(1);
+        expect(payloadsOf(childRecords, "ToolCallSettled")).toHaveLength(0);
+        expect(armedEvictionsRemaining(child)).toBe(0);
+      }
+    },
+    40_000,
+  );
 
   it("eviction at subagent:after-child-abort-intent: the replayed propagation is a no-op, never a second cross-Object command", async () => {
     const ref = lane("subagent:after-child-abort-intent");

--- a/packages/session/src/ledger-conformance.ts
+++ b/packages/session/src/ledger-conformance.ts
@@ -1966,6 +1966,115 @@ const approvalDecisionIdempotency = conformanceCase(
     }),
 );
 
+const unknownAbortClaim = conformanceCase(
+  "a durable abort makes an unknown head claimable without resolving or replaying its calls",
+  ({ ensure, expectFailure, expectSome }) =>
+    Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+      for (const abortFirst of [false, true]) {
+        const conversationId = decodeConversationId(
+          `ledger-conformance-unknown-abort-${abortFirst}`,
+        );
+        const head = yield* admitReady(conversationId, "head", { work: "uncertain" });
+        const original = yield* expectSome(
+          "original claim",
+          yield* claimLane(conversationId, PRODUCER_A),
+        );
+        const follower = yield* admitReady(conversationId, "follower", { work: "later" });
+        const command = AbortCommand.make({
+          submissionId: head.submissionId,
+          author: "first-operator",
+          reason: "stop without asserting external rollback",
+        });
+        if (abortFirst) yield* ledger.requestAbort(command);
+        yield* ledger.markUnknown(
+          MarkUnknownRequest.make({
+            submissionId: head.submissionId,
+            toolCallIds: [decodeToolCallId("uncertain-one"), decodeToolCallId("uncertain-two")],
+            reason: "external replies were lost",
+          }),
+        );
+        if (abortFirst) {
+          yield* ensure(
+            Option.isNone(yield* claimLane(conversationId, PRODUCER_B)),
+            "Abort must not bypass a still-live ownership lease",
+          );
+        }
+        yield* advancePastLease(original.leaseExpiresAt);
+        if (!abortFirst) {
+          yield* ensure(
+            Option.isNone(yield* claimLane(conversationId, PRODUCER_B)),
+            "Unknown work and its follower must wait without an authorized abort",
+          );
+        }
+        const intent = yield* ledger.requestAbort(command);
+        const duplicate = yield* ledger.requestAbort(
+          AbortCommand.make({
+            ...command,
+            author: "later-operator",
+            reason: "lost acknowledgement retry",
+          }),
+        );
+        yield* ensure(
+          duplicate.author === intent.author &&
+            duplicate.reason === intent.reason &&
+            sameInstant(duplicate.requestedAt, intent.requestedAt),
+          "The first abort audit must win",
+        );
+        const reclaimed = yield* expectSome(
+          "unknown head with durable abort",
+          yield* claimLane(conversationId, PRODUCER_B),
+        );
+        yield* ensure(
+          reclaimed.submissionId === head.submissionId &&
+            reclaimed.producerEpoch > original.producerEpoch,
+          "Abort must claim the head with a fresh fence, never skip to its follower",
+        );
+        const snapshot = yield* recoverySnapshot(head.submissionId);
+        yield* ensure(
+          snapshot.submission.state === "unknown" && snapshot.unknownResolutions.length === 0,
+          "Claiming for abort must not erase uncertainty or manufacture tool resolutions",
+        );
+        const stale = yield* expectFailure(
+          "stale owner",
+          ledger.reserveSettlement(
+            yield* settlementReservation({
+              ...head,
+              ownershipToken: original.ownershipToken,
+              outcome: "completed",
+            }),
+          ),
+        );
+        yield* ensure(isOwnershipLost(stale), "The original owner must remain fenced");
+        const reservation = yield* settlementReservation({
+          ...head,
+          ownershipToken: reclaimed.ownershipToken,
+          outcome: "aborted",
+        });
+        yield* ledger.reserveSettlement(reservation);
+        yield* ledger.requestAbort(command);
+        const settled = yield* ledger.finalizeSettlement(SettlementFinalization.make(reservation));
+        yield* ensure(
+          settled.outcome === "aborted",
+          "The abort reservation must survive a duplicate command",
+        );
+        const late = yield* expectFailure("abort after settlement", ledger.requestAbort(command));
+        yield* ensure(
+          isSettlementConflict(late) && late.existingOutcome === "aborted",
+          "A terminal outcome must not change",
+        );
+        const next = yield* expectSome(
+          "follower claim",
+          yield* claimLane(conversationId, PRODUCER_B),
+        );
+        yield* ensure(
+          next.submissionId === follower.submissionId,
+          "Settlement must release the follower",
+        );
+      }
+    }),
+);
+
 const unknownResolutionLifecycle = conformanceCase(
   "unknown resolutions reopen the lane only when no open call remains",
   ({ ensure, expectFailure, expectSome }) =>
@@ -3426,6 +3535,7 @@ export const submissionLedgerConformanceCases: ReadonlyArray<SubmissionLedgerCon
   claimNeverGrantsBlockedHead,
   approvalDecisionIdempotency,
   unknownResolutionLifecycle,
+  unknownAbortClaim,
   suspendResumesImmediatelyWhenDecided,
   joinedSettlementLinkageAuthority,
   childReservationIdempotency,

--- a/packages/session/src/ledger.ts
+++ b/packages/session/src/ledger.ts
@@ -70,10 +70,11 @@ export type QueueSequence = typeof QueueSequence.Type;
  * - `suspended` — durably waiting for explicit approval decisions; the ownership period has
  *   ended and the lane consumes no worker permit while the obligation stays owed.
  * - `unknown` — at least one ordinary Tool Call has a durable Unknown Outcome; the lane is
- *   blocked until an authorized resolution covers every open call (DUR-017).
+ *   blocked until an authorized resolution covers every open call or a durable abort intent
+ *   authorizes cleanup and aborted settlement without Tool replay (DUR-012/DUR-017).
  *
- * `claim` never grants a `joining`, `joined`, `suspended`, or `unknown` head: the lane is
- * host-owned or blocked, never worker-claimable.
+ * `claim` never grants a `joining`, `joined`, or `suspended` head. An `unknown` head is
+ * claimable only with a durable abort intent, under the ordinary lease and fencing rules.
  */
 export const SubmissionState = Schema.Literals([
   "admitted",

--- a/packages/storage-cloudflare/src/do-ledger.ts
+++ b/packages/storage-cloudflare/src/do-ledger.ts
@@ -1210,14 +1210,15 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
           if (heads.length === 0) return Option.none<Claim>();
           const head = heads[0];
 
-          // A joining/joined head is host-owned and a suspended/unknown head is durably
-          // blocked (DUR-017); the lane produces no claim and later ready work is never
-          // skipped past the blocked head (DUR-004).
+          // Unknown work is claimable only for a durably requested abort: the coordinator
+          // cleans up children and settles without replaying ordinary Tools. Read the intent
+          // in this claim transaction; retain uncertainty evidence and all ownership fencing.
           if (
             head.state === "joining" ||
             head.state === "joined" ||
             head.state === "suspended" ||
-            head.state === "unknown"
+            (head.state === "unknown" &&
+              Option.isNone(yield* readAbortIntent(operation, head.submission_id)))
           ) {
             return Option.none<Claim>();
           }

--- a/packages/storage-cloudflare/test/certification.test.ts
+++ b/packages/storage-cloudflare/test/certification.test.ts
@@ -86,14 +86,12 @@ const CERTIFICATION_TIMEOUT = 240_000;
 
 describe("TEST-004 STORE-010 STORE-013 adapter certification — storage-cloudflare (DC, in-workerd)", () => {
   it(
-    "TIER1: all 32 SubmissionLedger and 8 ConversationStore contract cases pass",
+    "TIER1: all SubmissionLedger and ConversationStore contract cases pass",
     async () => {
       const report = await certified();
       const ledgerCases = report.tier1.filter((result) => result.suite === "submission-ledger");
       const storeCases = report.tier1.filter((result) => result.suite === "conversation-store");
-      expect(ledgerCases).toHaveLength(32);
       expect(ledgerCases).toHaveLength(submissionLedgerConformanceCases.length);
-      expect(storeCases).toHaveLength(8);
       expect(storeCases).toHaveLength(conversationStoreConformanceCases.length);
       expect(report.tier1.filter((result) => result.status !== "passed")).toEqual([]);
     },

--- a/packages/storage-memory/src/memory-ledger.ts
+++ b/packages/storage-memory/src/memory-ledger.ts
@@ -175,13 +175,13 @@ interface StoredSubmission {
 
 /**
  * States in which `claim` never grants the head: the lane is host-owned (`joining`/`joined`)
- * or durably blocked (`suspended`/`unknown`) rather than worker-claimable.
+ * or durably suspended rather than worker-claimable. Unknown heads are checked against abort
+ * intent separately: abort authorizes cleanup and settlement, never ordinary Tool replay.
  */
 const BLOCKED_HEAD_STATES: ReadonlySet<SubmissionState> = new Set([
   "joining",
   "joined",
   "suspended",
-  "unknown",
 ]);
 
 interface LaneState {
@@ -597,9 +597,11 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
             (current): readonly [Decision<Option.Option<Claim>, LedgerError>, LedgerState] => {
               const head = findHead(current, request.conversationId);
               if (head === undefined) return [success(Option.none()), current];
-              // A joining/joined head is host-owned and a suspended/unknown head is durably
-              // blocked; the lane produces no claim and later ready work is never skipped.
-              if (BLOCKED_HEAD_STATES.has(head.row.state)) return [success(Option.none()), current];
+              if (
+                BLOCKED_HEAD_STATES.has(head.row.state) ||
+                (head.row.state === "unknown" && head.abortIntent === undefined)
+              )
+                return [success(Option.none()), current];
               if (
                 head.ownership !== undefined &&
                 head.ownership.leaseExpiresAtMillis > nowMillis &&

--- a/packages/storage-sqlite/src/sqlite-ledger.ts
+++ b/packages/storage-sqlite/src/sqlite-ledger.ts
@@ -1146,14 +1146,15 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
           if (heads.length === 0) return Option.none<Claim>();
           const head = heads[0];
 
-          // A joining/joined head is host-owned and a suspended/unknown head is durably
-          // blocked (DUR-017); the lane produces no claim and later ready work is never
-          // skipped past the blocked head (DUR-004).
+          // Unknown work is claimable only for a durably requested abort: the coordinator
+          // cleans up children and settles without replaying ordinary Tools. Read the intent
+          // in this claim transaction; retain uncertainty evidence and all ownership fencing.
           if (
             head.state === "joining" ||
             head.state === "joined" ||
             head.state === "suspended" ||
-            head.state === "unknown"
+            (head.state === "unknown" &&
+              Option.isNone(yield* readAbortIntent(operation, head.submission_id)))
           ) {
             return Option.none<Claim>();
           }

--- a/packages/testing/test/certification-memory.test.ts
+++ b/packages/testing/test/certification-memory.test.ts
@@ -51,15 +51,13 @@ const certified = Effect.gen(function* () {
 
 describe("TEST-004 STORE-010 adapter certification — storage-memory reference (Tier 3 N/A)", () => {
   it.effect(
-    "TIER1: all 32 SubmissionLedger and 8 ConversationStore contract cases pass",
+    "TIER1: all SubmissionLedger and ConversationStore contract cases pass",
     () =>
       Effect.gen(function* () {
         const report = yield* certified;
         const ledgerCases = report.tier1.filter((result) => result.suite === "submission-ledger");
         const storeCases = report.tier1.filter((result) => result.suite === "conversation-store");
-        expect(ledgerCases).toHaveLength(32);
         expect(ledgerCases).toHaveLength(submissionLedgerConformanceCases.length);
-        expect(storeCases).toHaveLength(8);
         expect(storeCases).toHaveLength(conversationStoreConformanceCases.length);
         expect(report.tier1.filter((result) => result.status !== "passed")).toEqual([]);
       }),

--- a/packages/testing/test/certification-sqlite.test.ts
+++ b/packages/testing/test/certification-sqlite.test.ts
@@ -83,15 +83,13 @@ const certified = Effect.gen(function* () {
 
 describe("TEST-004 STORE-010 adapter certification — storage-sqlite (DN)", () => {
   it.effect(
-    "TIER1: all 32 SubmissionLedger and 8 ConversationStore contract cases pass",
+    "TIER1: all SubmissionLedger and ConversationStore contract cases pass",
     () =>
       Effect.gen(function* () {
         const report = yield* certified;
         const ledgerCases = report.tier1.filter((result) => result.suite === "submission-ledger");
         const storeCases = report.tier1.filter((result) => result.suite === "conversation-store");
-        expect(ledgerCases).toHaveLength(32);
         expect(ledgerCases).toHaveLength(submissionLedgerConformanceCases.length);
-        expect(storeCases).toHaveLength(8);
         expect(storeCases).toHaveLength(conversationStoreConformanceCases.length);
         expect(report.tier1.filter((result) => result.status !== "passed")).toEqual([]);
       }),


### PR DESCRIPTION
## Summary

An authorized abort now releases an unknown Submission through normal recovery, including attached-child cleanup, without replaying uncertain Tools or requiring callers to resolve each Tool obligation. Cloudflare maintenance also stops rearming for ready followers behind an unresolved external wait.

The correction stays in the existing [ledger claim contract](https://github.com/danieljvdm/effect-agent/blob/fd862a2a03b97edef82824cf76f9e29a24cd9df1/packages/session/src/ledger.ts#L70), its memory/SQLite/Durable Object adapters, and the [maintenance work predicate](https://github.com/danieljvdm/effect-agent/blob/fd862a2a03b97edef82824cf76f9e29a24cd9df1/packages/platform-cloudflare/src/alarm.ts#L239). No new API, storage mutation, queue, watchdog, or automatic-abort policy is added. Includes a patch changeset.

## What went wrong

Reproduced on current main `c2af4df`, not just inferred from the consumer incident. Recovery already classified an unknown Submission with an accepted abort as `SettleAborted`, but every ledger adapter unconditionally rejected claims on an unknown head. Recovery could never execute that decision, so the FIFO follower remained ready forever. Independently, the maintenance predicate treated that ready follower as autonomous work and kept scheduling alarms.

The adapters now read the existing abort intent atomically when claiming an unknown head. The normal lease and producer fence still apply, and the coordinator's existing abort path owns cleanup and terminalization. Unknown evidence is retained; no Tool resolution is fabricated. An abort accepted before a racing unknown mark works too. Duplicate commands retain the first author/reason/time, and a reserved or canonical terminal outcome still wins.

Maintenance ignores plain ready followers behind a stable wait, while preserving retries for admission repairs, accepted aborts, and terminalization. Resolving mutations retain the existing durable generation/pre-arm protocol. Approval and unknown waits without authorization remain waits.

## Evidence

- Before the correction, the new shared ledger case failed with `Expected a value but found none: unknown head with durable abort`. All four workerd abort cases ended with the original row `unknown` and its follower `ready`; the follower quiescence assertion also failed.
- Afterward, the [real workerd regression](https://github.com/danieljvdm/effect-agent/blob/fd862a2a03b97edef82824cf76f9e29a24cd9df1/packages/platform-cloudflare/test/alarm.test.ts#L304) loses a reply after recording an external action, evicts after unknown marking, publicly aborts, and converges by maintenance alone. It verifies one external action, one aborted settlement, follower completion, unchanged uncertainty evidence, and no fabricated Tool settlement/resolution. Variants evict after abort acceptance, settlement reservation, and canonical settlement append.
- The [shared contract](https://github.com/danieljvdm/effect-agent/blob/fd862a2a03b97edef82824cf76f9e29a24cd9df1/packages/session/src/ledger-conformance.ts#L1969) passes on memory, Node SQLite, and Durable Object SQLite. It covers abort/unknown ordering, multiple unresolved calls, duplicate aborts, live-lease exclusion, stale-owner fencing, and terminal conflict. Certification still checks every exported case; redundant fixed case counts were removed.
- The existing cross-Object child fixture now also proves an unknown child settles after parent abort, retains its unknown audit and single external action, joins before parent settlement, and releases its budget reservation. The full existing crash, approval, adapter, and child suites pass.

## Consumer migration

See the [corrected operations guide](https://github.com/danieljvdm/effect-agent/blob/5fea311/docs/guide/operations.md#observe-a-submission-outcome).

Delete abort-then-`resolveUnknown(ResolutionAbortSubmission)` loops and manual child cleanup after an accepted parent abort. A parent in `WaitingForChild` with an unknown child still needs a host decision to abort the parent. This fix owns cleanup only after that decision is durably accepted.

The owner-side ledger ports are not all available to an external Worker. `CloudflareConversationClient` supplies `readPage`/`awaitProgress`/`awaitSettlement`; public `portCall` supports ledger lookup but not recovery snapshots or nonterminal scans. No current public composition supplies authoritative suspension, input-applied offset, and FIFO blocker to an independent Queue consumer without an additional host boundary. `explainEncoded` is a history-reading diagnostic, not a bounded polling substitute.

Keep the authorized, Schema-backed, read-only snapshot RPC inside the owning Conversation Object and its external client adapter, such as the consumer's `AgentRunInspector.inspectRun` and `AgentRunRecovery.inspect`. It uses the real local ledger to validate the Receipt, read recovery state and joined host linkage, and find the earlier nonterminal head. Retain any bounded activity/Tool-result projection needed by host policy. The earlier guide claim that a separate inspection RPC was unnecessary was too broad and has been corrected; this PR adds no snapshot API.

Budget stop details are on canonical `SubmissionSettled`, not the current returned `Settlement`. Consume them incrementally with a saved cursor instead of repeated full-conversation inspection. Hosts retain visible-response policy, destination authorization, inactivity thresholds, and idempotent delivery/cursor persistence; observation is replayable evidence, not an exactly-once external delivery guarantee.
