### PR TITLE
fix(scheduling): separate driver authority and recover due work safely

### DIFF
--- a/.changeset/scheduling-management-recovery.md
+++ b/.changeset/scheduling-management-recovery.md
@@ -1,0 +1,12 @@
+---
+"@effect-agent/session": minor
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-node": minor
+"@effect-agent/platform-cloudflare": minor
+---
+
+Separate scheduling management from driver authority, expose explicit public status, and fix DST delivery, failed-record starvation, and repeated resume. Allow positive host interval minimums and release operational capacity when schedules finish while retaining creation replay guarantees.
+
+BEHAVIOR CHANGE: Cloudflare consumers yield `Scheduling` from `CloudflareSchedulingClient.layer`; local drivers use `ScheduleDriver.layer`. Status omits persisted input and admission internals, and `dueBatchSize` bounds a query page within a sweep.

--- a/docs/spec/scheduling.md
+++ b/docs/spec/scheduling.md
@@ -61,7 +61,13 @@ Cron follows Effect's named-zone behavior and persists UTC intended instants. A 
 time moves forward across the spring gap. A repeated fall time selects its first occurrence, not
 both. Fixed offsets such as `+05:30` are also supported.
 
-The defaults are: 1,000 Schedules per owner, 60-second minimum recurrence, 64 KiB encoded input, 64 due records per driver pass, 8 concurrent admissions, 1-second retry base, 5-minute retry maximum, 30-second admission timeout, and 30-second recovery poll. Hosts configure finite limits through `SchedulingLimits`. The hard bounds are 100,000 Schedules per owner, a recurrence minimum of at least 60 seconds, at most 64 KiB input, at most 1,024 records per pass, and at most 64 concurrent admissions. A limit violation is typed and occurs before durable mutation. Paused, completed, and cancelled records still count toward the owner quota because they retain creation-idempotency evidence.
+The defaults are: 1,000 Schedules per owner, 60-second minimum recurrence, 64 KiB encoded input, 64 due keys per query page, 8 concurrent admissions, 1-second retry base, 5-minute retry maximum, 30-second admission timeout, and 30-second recovery poll. Hosts configure finite limits through `SchedulingLimits`. The hard bounds are 100,000 Schedules per owner, a positive interval minimum, at most 64 KiB input, at most 1,024 keys per query page, and at most 64 concurrent admissions. A limit violation is typed and occurs before durable mutation. The owner quota bounds operational capacity, not lifetime registrations. A record counts while it
+has pending delivery or a remaining cursor in active or paused state. Cancellation retains capacity
+until pending delivery resolves. Completed and cancelled records without pending work retain their
+creation fingerprint and current record for replay, but do not consume operational capacity.
+Reactivation by update or resume checks capacity atomically with the transition. Retention does
+not expire or reuse Schedule IDs; storage for replay evidence grows with registrations. Deleting
+that evidence would weaken the existing replay guarantee and is not an implicit quota policy.
 
 Building `Scheduling.layer` rejects a recovery interval whose deadline, measured from the current
 Clock, exceeds `ScheduleInstant` with `ScheduleValidationError`. Cloudflare also validates each
@@ -70,7 +76,7 @@ fails with a typed storage error instead of a defect; a failed transaction retai
 
 ## 3. Management and registration
 
-`Scheduling` provides `create`, `get`, `list`, `update`, `pause`, `resume`, and `cancel`. Every management call authorizes `ScheduleScope`. There is no global get or list.
+`Scheduling` provides `create`, `get`, `list`, `update`, `pause`, `resume`, and `cancel`. Every management call authorizes `ScheduleScope`. There is no global get or list. `Scheduling` exposes only these management operations. `ScheduleDriver` is a separate privileged host capability; it MUST NOT be provided to management callers or model Tools.
 
 List is owner-scoped keyset pagination, ordered by `ScheduleId` ascending. `after` is the last ID, and a page limit is at most 100. The service default is 50. Pages are not snapshots, but a cursor chain cannot return an item twice.
 
@@ -78,7 +84,14 @@ Create accepts owner, ID, delivery principal, Agent ID, exact definition digests
 
 Update requires `expectedRevision`. It preserves pending delivery, replaces future configuration, reactivates a paused Schedule, and recalculates next occurrence from one captured update time. A recurring rule selects strictly after that time. A one-shot accepts its supplied time and is immediately due if it is in the past. Configuration revision and the store CAS version are distinct. Management controls also fence the storage version so a concurrent completion cannot let resume restore a consumed one-shot cursor.
 
-Pause stops preparation but does not stop pending recovery. Resume skips recurring firing times missed while paused and selects strictly after resume. A never-prepared overdue one-shot retains its original intended time. Resume does not recreate a completed or conclusively refused one-shot. Update is required. Cancel is irreversible, stops future preparation, preserves pending delivery until it resolves, and does not abort an accepted Submission.
+Pause stops preparation but does not stop pending recovery. Resume on an active Schedule is a no-op after authorization and revision validation, including its cursor, skipped range, timestamps, and storage version. Resume from paused state skips recurring firing times missed while paused and selects strictly after resume. A never-prepared overdue one-shot retains its original intended time. Resume does not recreate a completed or conclusively refused one-shot. Update is required. Cancel is irreversible, stops future preparation, preserves pending delivery until it resolves, and does not abort an accepted Submission.
+
+Public `ScheduleSnapshot` is an explicit projection shared by reads, listings, and management
+responses. It exposes owner and ID, creation/update times, configuration revision, timing,
+destination, Agent ID, delivery principal, state, next time, bounded pending timing/retry status,
+and latest Receipt, refusal, and skipped range. It omits input, definition and input digests,
+creation fingerprints, CAS/storage versions, creation principal, and pending admission envelopes.
+Persistence schema changes do not implicitly extend this consumer contract.
 
 ## 4. Record and protocol
 
@@ -94,7 +107,13 @@ The driver recovers pending work before considering the cursor. It calls `Schedu
 
 ## 5. Downtime, retry, and authorization
 
-At most one pending delivery exists per Schedule. With none pending, missed recurring firings coalesce to the latest eligible intended firing at or before captured `now`, and the cursor advances to the first future firing. Missed firings are not replayed. A one-shot retains its original intended time until preparation.
+At most one pending delivery exists per Schedule. With none pending, missed recurring firings coalesce to the latest eligible intended firing at or before captured `now`, and the cursor advances to the first future firing. Cron due selection follows the forward sequence from the stored cursor, including spring gaps
+and the first occurrence of a fall fold. Reverse named-zone traversal is not its inverse and MUST
+NOT select due instants. A UTC calendar-date query may seek to a matching local date before the
+recent transition window, then forward traversal selects the occurrence and next cursor together.
+The window includes two preceding civil days to cover IANA whole-day date-line shifts. This avoids
+walking all firings missed over long downtime. UTC and fixed-offset rules may use reverse selection
+because they have no offset transitions. Missed firings are not replayed. A one-shot retains its original intended time until preparation.
 
 `lastSkippedRange` is the half-open interval `[fromMillis, toMillis)`. Coalescing excludes the
 selected occurrence at its upper bound; resume excludes the new future cursor. It records a time
@@ -119,7 +138,24 @@ diagnostics containing input, and raw error Causes are not attached to schedulin
 
 ## 6. Ports and deployment
 
-`ScheduleStore` is the inward atomic port. Its methods own insert, owner-scoped reads and pages, revisioned changes, indexed due selection, and next-deadline lookup. `ScheduledInputAdmission` admits only an encoded envelope and returns Receipt without exposing ledger internals. Memory, SQLite, and Cloudflare adapters implement `ScheduleStore`.
+`ScheduleStore` is the inward atomic port. Its methods own insert, owner-scoped reads and pages, revisioned changes, indexed due-key selection, and next-deadline lookup. `ScheduledInputAdmission` admits only an encoded envelope and returns Receipt without exposing ledger internals. Memory, SQLite, and Cloudflare adapters implement `ScheduleStore`.
+
+Both `NodeScheduling.layer()` and `CloudflareSchedulingClient.layer` provide the same `Scheduling`
+management service. Local hosts build `ScheduleDriver.layer` separately. The driver returns internal
+records only to its privileged caller; it is not a management read path. Cloudflare transport and
+protocol failures map to `ScheduleStorageError`, preserving the common management error contract.
+
+A driver pass captures a due-query time and scans keyset pages ordered by deadline, tenant, owner,
+and Schedule ID. `dueBatchSize` bounds each query page, not the total sweep. Each record is read and
+processed independently with bounded concurrency. An expected error or defect is counted and
+logged by tag only, then the sweep continues past its original indexed key. Even a corrupt record
+cannot prevent later records from being read. Query-wide storage failure still fails the pass;
+Scope interruption stops it and preserves pending work. Failed records remain eligible for the
+next sweep. The driver uses no in-memory exclusion list that would lose progress on eviction.
+After a sweep with failures, hosts wait for the recovery poll before retrying instead of spinning
+on the unchanged earliest deadline. Node wake hints can still start a pass earlier. Cloudflare
+re-arms the recovery wake after the sweep because successful transitions may have replaced the
+wake armed at handler entry. Admission continues to use the unchanged pending envelope.
 
 The optional `NodeScheduling.layer()` calls `NodeDurableHost.submit` through its shutdown gate.
 It reuses the host's SQLite `ScheduleStore`. One Scope-owned driver uses indexed due and retry

--- a/docs/spec/security-operations.md
+++ b/docs/spec/security-operations.md
@@ -71,7 +71,9 @@ Programmatic `ToolBroker` calls are outside this authorization hook.
 
 Durable input [schedules](./scheduling.md) require an explicit `ScheduleAuthorizer` for every
 management call and occurrence preparation. Reads and listing are scoped to a tenant-qualified
-owner. Preparation authorizes completion of that one frozen delivery even if authority is later
+owner. `Scheduling` contains only management operations and explicit status projections. Driver
+operations belong to the separate privileged `ScheduleDriver`; neither that service nor
+`ScheduleStore` belongs in a management caller or model Tool environment. Preparation authorizes completion of that one frozen delivery even if authority is later
 revoked; revocation prevents future preparation, not recovery of input that may already have been
 admitted. This grant does not bypass the Tool action-time checks above. Persist only bounded policy
 and decision identifiers, never credentials or input-bearing diagnostics, as scheduling metadata.

--- a/packages/platform-cloudflare/examples/scheduling.ts
+++ b/packages/platform-cloudflare/examples/scheduling.ts
@@ -2,6 +2,7 @@ import {
   type ScheduleAuthorizer,
   type DurableSubmitAgent,
   type ScheduleCreateOptions,
+  Scheduling,
 } from "@effect-agent/session";
 import { Effect, Layer, type Schema } from "effect";
 import { WorkerEnvironment } from "effect-cf";
@@ -47,7 +48,7 @@ export const scheduleDailyReport = Effect.fn("Example.scheduleDailyReport")(func
   input: InputSchema["Type"],
   options: Omit<ScheduleCreateOptions, "timing">,
 ) {
-  const scheduling = yield* CloudflareSchedulingClient;
+  const scheduling = yield* Scheduling;
   return yield* scheduling.create(agent, input, {
     ...options,
     timing: { _tag: "Cron", expression: "0 8 * * *", timeZone: "UTC" },

--- a/packages/platform-cloudflare/src/scheduling.ts
+++ b/packages/platform-cloudflare/src/scheduling.ts
@@ -6,7 +6,6 @@ import {
   ScheduleAuthorizationError,
   type ScheduleAuthorizer,
   ScheduleCapacityError,
-  type ScheduleCreateOptions,
   ScheduleConflict,
   ScheduleDestination,
   ScheduleFailpointError,
@@ -17,16 +16,16 @@ import {
   type ScheduleScope,
   ScheduleScope as ScheduleScopeSchema,
   ScheduleSnapshot,
-  type ScheduleSnapshotPage,
   ScheduleSnapshotPage as ScheduleSnapshotPageSchema,
   ScheduleStorageError,
   ScheduleTimingRequest,
-  type ScheduleUpdateOptions,
   ScheduleValidationError,
   ScheduledInputAdmission,
   ScheduledInputRetryable,
   type ScheduledEnvelope,
   Scheduling,
+  ScheduleDriver,
+  type ScheduleManagementFailure,
   defaultSchedulingLimits,
   scheduleOwnerKey,
   ScheduleWakeNoop,
@@ -165,214 +164,166 @@ const passthroughAgent = (agentId: AgentId): DurableSubmitAgent<typeof Persisted
 
 const requestOwner = (request: ScheduleOwnerRequest): ScheduleOwner => request.scope.owner;
 
-export interface CloudflareSchedulingClientService {
-  readonly create: <InputSchema extends Schema.Top>(
-    agent: DurableSubmitAgent<InputSchema>,
-    input: InputSchema["Type"],
-    options: ScheduleCreateOptions,
-  ) => Effect.Effect<
-    typeof ScheduleSnapshot.Type,
-    ScheduleOwnerFailure | ScheduleOwnerProtocolError,
-    InputSchema["EncodingServices"]
-  >;
-  readonly update: <InputSchema extends Schema.Top>(
-    agent: DurableSubmitAgent<InputSchema>,
-    input: InputSchema["Type"],
-    options: ScheduleUpdateOptions,
-  ) => Effect.Effect<
-    typeof ScheduleSnapshot.Type,
-    ScheduleOwnerFailure | ScheduleOwnerProtocolError,
-    InputSchema["EncodingServices"]
-  >;
-  readonly get: (
-    scope: ScheduleScope,
-    scheduleId: ScheduleId,
-  ) => Effect.Effect<
-    typeof ScheduleSnapshot.Type,
-    ScheduleOwnerFailure | ScheduleOwnerProtocolError
-  >;
-  readonly list: (
-    scope: ScheduleScope,
-    options?: { readonly after?: ScheduleId; readonly limit?: number },
-  ) => Effect.Effect<ScheduleSnapshotPage, ScheduleOwnerFailure | ScheduleOwnerProtocolError>;
-  readonly pause: CloudflareScheduleControl;
-  readonly resume: CloudflareScheduleControl;
-  readonly cancel: CloudflareScheduleControl;
-}
+/** Provides the same authorized management service as NodeScheduling.layer. */
+export class CloudflareSchedulingClient {
+  static readonly layer: Layer.Layer<Scheduling, never, ScheduleOwnerNamespace> = Layer.effect(
+    Scheduling,
+    Effect.gen(function* () {
+      const { namespace } = yield* ScheduleOwnerNamespace;
 
-type CloudflareScheduleControl = (
-  scope: ScheduleScope,
-  scheduleId: ScheduleId,
-  expectedRevision: number,
-) => Effect.Effect<typeof ScheduleSnapshot.Type, ScheduleOwnerFailure | ScheduleOwnerProtocolError>;
+      const call = Effect.fn("CloudflareSchedulingClient.call")(function* (
+        owner: ScheduleOwner,
+        request: ScheduleOwnerRequest,
+      ): Effect.fn.Return<ScheduleOwnerResponse, ScheduleManagementFailure> {
+        const encoded = yield* encodeScheduleOwnerRequest(request).pipe(
+          Effect.mapError(() =>
+            ScheduleStorageError.make({ operation: "Schedule Owner protocol", reason: "corrupt" }),
+          ),
+        );
+        const raw = yield* Effect.tryPromise({
+          try: () => namespace.get(namespace.idFromName(scheduleOwnerKey(owner))).schedule(encoded),
+          catch: () =>
+            ScheduleStorageError.make({
+              operation: "call Schedule Owner",
+              reason: "unavailable",
+            }),
+        });
+        const response = yield* decodeScheduleOwnerResponse(raw).pipe(
+          Effect.mapError(() =>
+            ScheduleStorageError.make({ operation: "Schedule Owner protocol", reason: "corrupt" }),
+          ),
+        );
+        if (response._tag !== "Failed") return response;
+        return yield* response.failure._tag === "ScheduleOwnerProtocolError"
+          ? ScheduleStorageError.make({ operation: "Schedule Owner protocol", reason: "corrupt" })
+          : response.failure;
+      });
 
-export class CloudflareSchedulingClient extends Context.Service<
-  CloudflareSchedulingClient,
-  CloudflareSchedulingClientService
->()("@effect-agent/platform-cloudflare/CloudflareSchedulingClient") {
-  static readonly layer: Layer.Layer<CloudflareSchedulingClient, never, ScheduleOwnerNamespace> =
-    Layer.effect(
-      CloudflareSchedulingClient,
-      Effect.gen(function* () {
-        const { namespace } = yield* ScheduleOwnerNamespace;
+      const encodeInput = Effect.fn("CloudflareSchedulingClient.encodeInput")(function* <
+        InputSchema extends Schema.Top,
+      >(
+        agent: DurableSubmitAgent<InputSchema>,
+        input: InputSchema["Type"],
+      ): Effect.fn.Return<PersistedJson, ScheduleValidationError, InputSchema["EncodingServices"]> {
+        const encoded = yield* Schema.encodeEffect(agent.definition.input)(input).pipe(
+          Effect.mapError(() =>
+            ScheduleValidationError.make({
+              message: "Unable to encode Agent input",
+            }),
+          ),
+        );
+        return yield* Schema.decodeUnknownEffect(PersistedJson)(encoded).pipe(
+          Effect.mapError(() =>
+            ScheduleValidationError.make({
+              message: "Agent input does not satisfy the canonical persistence bounds",
+            }),
+          ),
+        );
+      });
 
-        const call = Effect.fn("CloudflareSchedulingClient.call")(function* (
-          owner: ScheduleOwner,
-          request: ScheduleOwnerRequest,
-        ): Effect.fn.Return<
-          ScheduleOwnerResponse,
-          ScheduleOwnerFailure | ScheduleOwnerProtocolError
-        > {
-          const encoded = yield* encodeScheduleOwnerRequest(request).pipe(
-            Effect.mapError(() =>
-              ScheduleOwnerProtocolError.make({
-                message: "The Schedule request could not be encoded",
-              }),
-            ),
-          );
-          const raw = yield* Effect.tryPromise({
-            try: () =>
-              namespace.get(namespace.idFromName(scheduleOwnerKey(owner))).schedule(encoded),
-            catch: () =>
-              ScheduleStorageError.make({
-                operation: "call Schedule Owner",
-                reason: "unavailable",
-              }),
+      const create: Scheduling["Service"]["create"] = (agent, input, options) =>
+        Effect.gen(function* () {
+          const payload = yield* encodeInput(agent, input);
+          const response = yield* call(options.scope.owner, {
+            _tag: "Create",
+            schemaVersion: 1,
+            agentId: agent.definition.id,
+            input: payload,
+            ...options,
           });
-          const response = yield* decodeScheduleOwnerResponse(raw).pipe(
-            Effect.mapError(() =>
-              ScheduleOwnerProtocolError.make({
-                message: "The Schedule response could not be decoded",
-              }),
-            ),
-          );
-          return response._tag === "Failed" ? yield* response.failure : response;
+          return response._tag === "Snapshot"
+            ? response.value
+            : yield* ScheduleStorageError.make({
+                operation: "Schedule Owner protocol",
+                reason: "corrupt",
+              });
         });
 
-        const encodeInput = Effect.fn("CloudflareSchedulingClient.encodeInput")(function* <
-          InputSchema extends Schema.Top,
-        >(
-          agent: DurableSubmitAgent<InputSchema>,
-          input: InputSchema["Type"],
-        ): Effect.fn.Return<
-          PersistedJson,
-          ScheduleValidationError,
-          InputSchema["EncodingServices"]
-        > {
-          const encoded = yield* Schema.encodeEffect(agent.definition.input)(input).pipe(
-            Effect.mapError(() =>
-              ScheduleValidationError.make({
-                message: "Unable to encode Agent input",
-              }),
-            ),
-          );
-          return yield* Schema.decodeUnknownEffect(PersistedJson)(encoded).pipe(
-            Effect.mapError(() =>
-              ScheduleValidationError.make({
-                message: "Agent input does not satisfy the canonical persistence bounds",
-              }),
-            ),
-          );
+      const update: Scheduling["Service"]["update"] = (agent, input, options) =>
+        Effect.gen(function* () {
+          const payload = yield* encodeInput(agent, input);
+          const response = yield* call(options.scope.owner, {
+            _tag: "Update",
+            schemaVersion: 1,
+            agentId: agent.definition.id,
+            input: payload,
+            ...options,
+          });
+          return response._tag === "Snapshot"
+            ? response.value
+            : yield* ScheduleStorageError.make({
+                operation: "Schedule Owner protocol",
+                reason: "corrupt",
+              });
         });
 
-        const create: CloudflareSchedulingClientService["create"] = (agent, input, options) =>
-          Effect.gen(function* () {
-            const payload = yield* encodeInput(agent, input);
-            const response = yield* call(options.scope.owner, {
-              _tag: "Create",
-              schemaVersion: 1,
-              agentId: agent.definition.id,
-              input: payload,
-              ...options,
-            });
-            return response._tag === "Snapshot"
-              ? response.value
-              : yield* ScheduleOwnerProtocolError.make({
-                  message: "Schedule create returned a page response",
-                });
+      const get: Scheduling["Service"]["get"] = (scope, scheduleId) =>
+        Effect.gen(function* () {
+          const response = yield* call(scope.owner, {
+            _tag: "Get",
+            schemaVersion: 1,
+            scope,
+            scheduleId,
           });
-
-        const update: CloudflareSchedulingClientService["update"] = (agent, input, options) =>
-          Effect.gen(function* () {
-            const payload = yield* encodeInput(agent, input);
-            const response = yield* call(options.scope.owner, {
-              _tag: "Update",
-              schemaVersion: 1,
-              agentId: agent.definition.id,
-              input: payload,
-              ...options,
-            });
-            return response._tag === "Snapshot"
-              ? response.value
-              : yield* ScheduleOwnerProtocolError.make({
-                  message: "Schedule update returned a page response",
-                });
-          });
-
-        const get: CloudflareSchedulingClientService["get"] = (scope, scheduleId) =>
-          Effect.gen(function* () {
-            const response = yield* call(scope.owner, {
-              _tag: "Get",
-              schemaVersion: 1,
-              scope,
-              scheduleId,
-            });
-            return response._tag === "Snapshot"
-              ? response.value
-              : yield* ScheduleOwnerProtocolError.make({
-                  message: "Schedule get returned a page response",
-                });
-          });
-
-        const list: CloudflareSchedulingClientService["list"] = (scope, options = {}) =>
-          Effect.gen(function* () {
-            const response = yield* call(scope.owner, {
-              _tag: "List",
-              schemaVersion: 1,
-              scope,
-              ...(options.after === undefined ? {} : { after: options.after }),
-              ...(options.limit === undefined ? {} : { limit: options.limit }),
-            });
-            return response._tag === "Page"
-              ? response.value
-              : yield* ScheduleOwnerProtocolError.make({
-                  message: "Schedule list returned a snapshot response",
-                });
-          });
-
-        const control = (
-          operation: "pause" | "resume" | "cancel",
-          scope: ScheduleScope,
-          scheduleId: ScheduleId,
-          expectedRevision: number,
-        ) =>
-          Effect.gen(function* () {
-            const response = yield* call(scope.owner, {
-              _tag: "Control",
-              schemaVersion: 1,
-              operation,
-              scope,
-              scheduleId,
-              expectedRevision,
-            });
-            return response._tag === "Snapshot"
-              ? response.value
-              : yield* ScheduleOwnerProtocolError.make({
-                  message: `Schedule ${operation} returned a page response`,
-                });
-          });
-
-        return CloudflareSchedulingClient.of({
-          create,
-          update,
-          get,
-          list,
-          pause: (scope, id, revision) => control("pause", scope, id, revision),
-          resume: (scope, id, revision) => control("resume", scope, id, revision),
-          cancel: (scope, id, revision) => control("cancel", scope, id, revision),
+          return response._tag === "Snapshot"
+            ? response.value
+            : yield* ScheduleStorageError.make({
+                operation: "Schedule Owner protocol",
+                reason: "corrupt",
+              });
         });
-      }),
-    );
+
+      const list: Scheduling["Service"]["list"] = (scope, options = {}) =>
+        Effect.gen(function* () {
+          const response = yield* call(scope.owner, {
+            _tag: "List",
+            schemaVersion: 1,
+            scope,
+            ...(options.after === undefined ? {} : { after: options.after }),
+            ...(options.limit === undefined ? {} : { limit: options.limit }),
+          });
+          return response._tag === "Page"
+            ? response.value
+            : yield* ScheduleStorageError.make({
+                operation: "Schedule Owner protocol",
+                reason: "corrupt",
+              });
+        });
+
+      const control = (
+        operation: "pause" | "resume" | "cancel",
+        scope: ScheduleScope,
+        scheduleId: ScheduleId,
+        expectedRevision: number,
+      ) =>
+        Effect.gen(function* () {
+          const response = yield* call(scope.owner, {
+            _tag: "Control",
+            schemaVersion: 1,
+            operation,
+            scope,
+            scheduleId,
+            expectedRevision,
+          });
+          return response._tag === "Snapshot"
+            ? response.value
+            : yield* ScheduleStorageError.make({
+                operation: "Schedule Owner protocol",
+                reason: "corrupt",
+              });
+        });
+
+      return Scheduling.of({
+        create,
+        update,
+        get,
+        list,
+        pause: (scope, id, revision) => control("pause", scope, id, revision),
+        resume: (scope, id, revision) => control("resume", scope, id, revision),
+        cancel: (scope, id, revision) => control("cancel", scope, id, revision),
+      });
+    }),
+  );
 }
 
 export class ScheduleOwnerIdentity extends Context.Service<
@@ -514,6 +465,7 @@ const admissionLayer: Layer.Layer<ScheduledInputAdmission, never, CloudflareConv
 
 type ScheduleRuntimeServices =
   | Scheduling
+  | ScheduleDriver
   | DoScheduleAlarmControl
   | ScheduleOwnerIdentity
   | DurableObjectAlarm.DurableObjectAlarm;
@@ -630,13 +582,17 @@ const scheduleAlarmHandler = (limits: SchedulingLimits) =>
             }),
           ),
         );
-        const scheduling = yield* Scheduling;
+        const scheduling = yield* ScheduleDriver;
         const alarmControl = yield* DoScheduleAlarmControl;
         const { owner } = yield* ScheduleOwnerIdentity;
         const nowMillis = yield* Clock.currentTimeMillis;
         yield* alarmControl.prearm(nowMillis + limits.recoveryPollMillis);
-        yield* scheduling.runDue(owner);
-        yield* alarmControl.reconcile;
+        const pass = yield* scheduling.runDue(owner);
+        if (pass.failed > 0) {
+          yield* alarmControl.prearm((yield* Clock.currentTimeMillis) + limits.recoveryPollMillis);
+        } else {
+          yield* alarmControl.reconcile;
+        }
       }),
     { mode: "ordered" },
   ).pipe(Effect.asVoid);
@@ -678,7 +634,7 @@ export const makeScheduleOwnerObjectClass = <E>(
       SqliteClient.layer({ storage: state.raw.storage }),
     ),
   );
-  const application = Scheduling.layer(limits).pipe(
+  const application = Layer.merge(Scheduling.layer(limits), ScheduleDriver.layer(limits)).pipe(
     Layer.provideMerge(
       scheduleStoreLayer.pipe(Layer.provide(transactionLayer), Layer.provide(sqlLayer)),
     ),

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -4,6 +4,7 @@ import {
   submissionInputRecordId,
   submissionSettlementRecordId,
   type CanonicalRecordEnvelope,
+  type Scheduling,
 } from "@effect-agent/session";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
@@ -113,9 +114,8 @@ export const scheduleStubFor = (owner: { readonly tenantId: string; readonly own
   env.SCHEDULES.get(env.SCHEDULES.idFromName(scheduleOwnerKey(owner)));
 
 /** Run one management operation through the real Worker-to-Schedule-Owner RPC client. */
-export const runScheduleClient = <A, E>(
-  effect: Effect.Effect<A, E, CloudflareSchedulingClient>,
-): Promise<A> => Effect.runPromise(effect.pipe(Effect.provide(scheduleClientLayer)));
+export const runScheduleClient = <A, E>(effect: Effect.Effect<A, E, Scheduling>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(scheduleClientLayer)));
 
 /** Fork one client Effect so tests can interrupt the real Worker-side caller deterministically. */
 export const runClientFiber = <A, E>(

--- a/packages/platform-cloudflare/test/restart/scheduling-restart-worker.ts
+++ b/packages/platform-cloudflare/test/restart/scheduling-restart-worker.ts
@@ -3,6 +3,7 @@ import {
   ScheduleFailpoint,
   ScheduleFailpointError,
   ScheduleId,
+  Scheduling,
 } from "@effect-agent/session";
 import { Effect, Layer, Schema } from "effect";
 import { WorkerEnvironment } from "effect-cf";
@@ -140,7 +141,7 @@ const handle = Effect.fn("SchedulingRestartWorker.handle")(function* (request: R
   if (url.pathname === "/create") {
     const body = yield* Effect.tryPromise(() => request.json());
     const { deadlineAtMillis } = yield* Schema.decodeUnknownEffect(CreateRequest)(body);
-    const client = yield* CloudflareSchedulingClient;
+    const client = yield* Scheduling;
     const snapshot = yield* client.create(
       { definition: plannerDefinition },
       { question: "persist across Miniflare restart", ref: conversation },
@@ -159,7 +160,7 @@ const handle = Effect.fn("SchedulingRestartWorker.handle")(function* (request: R
     return Response.json({ revision: snapshot.configurationRevision });
   }
   if (url.pathname === "/status") {
-    const client = yield* CloudflareSchedulingClient;
+    const client = yield* Scheduling;
     const snapshot = yield* client.get(scope, scheduleId);
     const env = yield* WorkerEnvironment;
     const submissionIds = yield* Effect.promise(() =>

--- a/packages/platform-cloudflare/test/scheduling.test.ts
+++ b/packages/platform-cloudflare/test/scheduling.test.ts
@@ -1,4 +1,9 @@
-import { ScheduleId, type ScheduleAuthorizer, type ScheduleOwner } from "@effect-agent/session";
+import {
+  ScheduleId,
+  type ScheduleAuthorizer,
+  type ScheduleOwner,
+  Scheduling,
+} from "@effect-agent/session";
 import { DoScheduleAlarmControl } from "@effect-agent/storage-cloudflare";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { Effect, type Layer, Schema } from "effect";
@@ -6,7 +11,6 @@ import { DurableObject, type DurableObjectState, type WorkerEnvironment } from "
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  CloudflareSchedulingClient,
   type ConversationObjectNamespace,
   type ScheduleOwnerIdentity,
   type makeScheduleOwnerObjectClass,
@@ -78,7 +82,7 @@ const storeProbe = (owner: ScheduleOwner) =>
 const snapshotFor = (data: ReturnType<typeof fixture>) =>
   runScheduleClient(
     Effect.gen(function* () {
-      const client = yield* CloudflareSchedulingClient;
+      const client = yield* Scheduling;
       return yield* client.get(data.scope, data.scheduleId);
     }),
   );
@@ -109,7 +113,7 @@ const manage = (
 ) =>
   runScheduleClient(
     Effect.gen(function* () {
-      const client = yield* CloudflareSchedulingClient;
+      const client = yield* Scheduling;
       const options = {
         scope: data.scope,
         scheduleId: data.scheduleId,
@@ -142,11 +146,7 @@ describe("Cloudflare Schedule Owner", () => {
     const policyRequired: Layer.Layer<ConversationObjectNamespace> extends Host ? false : true =
       true;
     const routingRequired: Layer.Layer<ScheduleAuthorizer> extends Host ? false : true = true;
-    const applicationDependenciesRequired: Layer.Layer<
-      Ports,
-      never,
-      CloudflareSchedulingClient
-    > extends Host
+    const applicationDependenciesRequired: Layer.Layer<Ports, never, Scheduling> extends Host
       ? false
       : true = true;
     const nativeDependenciesAccepted: Layer.Layer<
@@ -179,7 +179,7 @@ describe("Cloudflare Schedule Owner", () => {
 
     await runScheduleClient(
       Effect.gen(function* () {
-        const client = yield* CloudflareSchedulingClient;
+        const client = yield* Scheduling;
         return yield* client.cancel(data.scope, data.scheduleId, created.configurationRevision);
       }),
     );
@@ -187,6 +187,31 @@ describe("Cloudflare Schedule Owner", () => {
     expect(
       await runInDurableObject(stub, (_instance, state) => state.storage.getAlarm()),
     ).toBeNull();
+  });
+
+  it("delivers healthy work beside a corrupt record and retains a future recovery alarm", async () => {
+    const broken = fixture("corrupt-a");
+    const healthy = { ...fixture("healthy-b"), owner: broken.owner, scope: broken.scope };
+    await manage(broken, Date.now() + 60_000, "corrupt this record");
+    await manage(healthy, Date.now() + 60_000, "deliver this record");
+    await runInDurableObject(scheduleStubFor(broken.owner), (_instance, state) => {
+      state.storage.sql.exec(
+        "UPDATE effect_agent_schedules SET deadline_at_millis = 0, record_json = json_set(record_json, '$.nextAtMillis', 0)",
+      );
+      state.storage.sql.exec(
+        "UPDATE effect_agent_schedules SET record_json = ? WHERE schedule_id = ?",
+        "{invalid-json",
+        broken.scheduleId,
+      );
+      state.storage.sql.exec("UPDATE effect_cf_scheduled_alarms SET run_at = 0");
+    });
+    const result = await runAlarmDirectExit(broken.owner);
+    expect(result._tag).toBe("Success");
+    expect((await snapshotFor(healthy)).lastReceipt).not.toBeNull();
+    expect(await laneRows(healthy.conversation)).toHaveLength(1);
+    const alarms = await alarmRows(broken.owner);
+    expect(alarms).toHaveLength(1);
+    expect(alarms[0]?.run_at).toBeGreaterThan(Date.now());
   });
 
   it("rolls back the schedule row and logical/native alarm when alarm mutation fails", async () => {
@@ -319,7 +344,7 @@ describe("Cloudflare Schedule Owner", () => {
 
       const controlled = await runScheduleClient(
         Effect.gen(function* () {
-          const client = yield* CloudflareSchedulingClient;
+          const client = yield* Scheduling;
           return yield* client[operation](
             data.scope,
             data.scheduleId,

--- a/packages/platform-cloudflare/test/scheduling.test.ts
+++ b/packages/platform-cloudflare/test/scheduling.test.ts
@@ -205,13 +205,14 @@ describe("Cloudflare Schedule Owner", () => {
       );
       state.storage.sql.exec("UPDATE effect_cf_scheduled_alarms SET run_at = 0");
     });
+    const passStartedAt = Date.now();
     const result = await runAlarmDirectExit(broken.owner);
     expect(result._tag).toBe("Success");
     expect((await snapshotFor(healthy)).lastReceipt).not.toBeNull();
     expect(await laneRows(healthy.conversation)).toHaveLength(1);
     const alarms = await alarmRows(broken.owner);
     expect(alarms).toHaveLength(1);
-    expect(alarms[0]?.run_at).toBeGreaterThan(Date.now());
+    expect(alarms[0]?.run_at).toBeGreaterThan(passStartedAt);
   });
 
   it("rolls back the schedule row and logical/native alarm when alarm mutation fails", async () => {

--- a/packages/platform-node/src/scheduling.ts
+++ b/packages/platform-node/src/scheduling.ts
@@ -11,6 +11,7 @@ import {
   ScheduledInputRetryable,
   ScheduleWake,
   Scheduling,
+  ScheduleDriver,
   defaultSchedulingLimits,
   PersistedJson,
 } from "@effect-agent/session";
@@ -98,18 +99,19 @@ const reportPassFailure = (cause: Cause.Cause<ScheduleProcessFailure>): Effect.E
 
 const nodeSchedulingDriverLayer = (
   limits: SchedulingLimits,
-): Layer.Layer<never, never, Scheduling | ScheduleStore | ScheduleWake> =>
+): Layer.Layer<never, never, ScheduleDriver | ScheduleStore | ScheduleWake> =>
   Layer.effectDiscard(
     Effect.gen(function* () {
-      const scheduling = yield* Scheduling;
+      const scheduling = yield* ScheduleDriver;
       const store = yield* ScheduleStore;
       const wake = yield* ScheduleWake;
 
       const run = Effect.gen(function* () {
         while (true) {
-          const passSucceeded = yield* scheduling
-            .runDue()
-            .pipe(Effect.as(true), Effect.catchCause(reportPassFailure));
+          const passSucceeded = yield* scheduling.runDue().pipe(
+            Effect.map((pass) => pass.failed === 0),
+            Effect.catchCause(reportPassFailure),
+          );
           const deadlineResult = passSucceeded
             ? yield* store.nextDeadline().pipe(Effect.result)
             : Result.fail(
@@ -150,7 +152,8 @@ export class NodeScheduling {
   > {
     const limits = options.limits ?? defaultSchedulingLimits;
     const schedulingWithDriver = nodeSchedulingDriverLayer(limits).pipe(
-      Layer.provideMerge(Scheduling.layer(limits)),
+      Layer.provide(ScheduleDriver.layer(limits)),
+      Layer.merge(Scheduling.layer(limits)),
     );
     return schedulingWithDriver.pipe(
       Layer.provide(

--- a/packages/platform-node/test/scheduling.test.ts
+++ b/packages/platform-node/test/scheduling.test.ts
@@ -149,7 +149,10 @@ it.effect("recovers one pending admission after a lost reply and host reopen", (
         );
         expect(pending.lastReceipt).toBeNull();
         expect(pending.pending?.retry.lastFailure).toBe("ambiguous");
-        const envelope = pending.pending?.envelope;
+        const envelope = (yield* Context.get(firstContext, ScheduleStore).get({
+          owner: scheduleScope.owner,
+          scheduleId,
+        }))?.pending?.envelope;
         expect(envelope).toBeDefined();
 
         yield* Scope.close(firstScope, Exit.void);

--- a/packages/session/src/schedule-conformance.ts
+++ b/packages/session/src/schedule-conformance.ts
@@ -262,6 +262,132 @@ const ownerCapacity = conformanceCase(
     }),
 );
 
+const retainedEvidence = conformanceCase(
+  "releases terminal capacity without deleting replay evidence and fences reactivation",
+  (ensure) =>
+    Effect.gen(function* () {
+      const store = yield* ScheduleStore;
+      const original = pendingRecord("capacity-retained");
+      yield* store.insert(original, 1);
+      const paused = yield* store.change(original, {
+        _tag: "Control",
+        expectedRevision: 1,
+        expectedVersion: original.version,
+        action: "pause",
+        nextAtMillis: null,
+        nowMillis: 120,
+        skippedRange: null,
+      });
+      const cancelled = yield* store.change(original, {
+        _tag: "Control",
+        expectedRevision: 1,
+        expectedVersion: paused.version,
+        action: "cancel",
+        nextAtMillis: null,
+        nowMillis: 130,
+        skippedRange: null,
+      });
+      const blocked = yield* store.insert(record("capacity-next"), 1).pipe(Effect.result);
+      yield* ensure(
+        Result.isFailure(blocked) && blocked.failure._tag === "ScheduleCapacityError",
+        "cancellation released unresolved pending capacity",
+      );
+      const completed = yield* store.change(original, {
+        _tag: "Complete",
+        occurrenceId: original.pending?.envelope.occurrenceId ?? digest,
+        receipt,
+        nowMillis: 140,
+      });
+      yield* ensure(
+        completed.pending === null && cancelled.pending !== null,
+        "completion did not clear pending work",
+      );
+      yield* store.insert(record("capacity-next"), 1);
+      const replay = yield* store.insert(original, 1);
+      yield* ensure(
+        replay.version === completed.version && replay.state === "cancelled",
+        "terminal replay lost its creation evidence",
+      );
+
+      const second = record("capacity-next");
+      const pausedSecond = yield* store.change(second, {
+        _tag: "Control",
+        expectedRevision: 1,
+        expectedVersion: second.version,
+        action: "pause",
+        nextAtMillis: second.nextAtMillis,
+        nowMillis: 150,
+        skippedRange: null,
+      });
+      const pausedCapacity = yield* store.insert(record("capacity-third"), 1).pipe(Effect.result);
+      yield* ensure(
+        Result.isFailure(pausedCapacity) && pausedCapacity.failure._tag === "ScheduleCapacityError",
+        "paused future work did not reserve capacity",
+      );
+      yield* store.change(second, {
+        _tag: "Control",
+        expectedRevision: 1,
+        expectedVersion: pausedSecond.version,
+        action: "cancel",
+        nextAtMillis: null,
+        nowMillis: 160,
+        skippedRange: null,
+      });
+      const admitted = pendingRecord("capacity-completed");
+      yield* store.insert(admitted, 1);
+      const settled = yield* store.change(admitted, {
+        _tag: "Complete",
+        occurrenceId: admitted.pending?.envelope.occurrenceId ?? digest,
+        receipt,
+        nowMillis: 170,
+      });
+      yield* store.insert(record("capacity-third"), 1);
+      const reactivated = yield* store
+        .change(
+          admitted,
+          {
+            _tag: "Update",
+            expectedRevision: 1,
+            configuration: admitted.configuration,
+            nextAtMillis: 200,
+            nowMillis: 180,
+          },
+          1,
+        )
+        .pipe(Effect.result);
+      yield* ensure(
+        Result.isFailure(reactivated) && reactivated.failure._tag === "ScheduleCapacityError",
+        "reactivation exceeded operational capacity",
+      );
+      yield* ensure(
+        (yield* store.get(admitted))?.version === settled.version,
+        "capacity failure mutated the completed record",
+      );
+    }),
+);
+
+const duePagination = conformanceCase(
+  "advances due pagination beyond unchanged rows with equal deadlines",
+  (ensure) =>
+    Effect.gen(function* () {
+      const store = yield* ScheduleStore;
+      for (const name of ["due-a", "due-b", "due-c"]) yield* store.insert(record(name), 10);
+      const first = yield* store.due(100, 1);
+      const second = yield* store.due(100, 1, undefined, first[0]);
+      const third = yield* store.due(100, 1, undefined, second[0]);
+      yield* ensure(
+        first[0]?.scheduleId === id("due-a") &&
+          second[0]?.scheduleId === id("due-b") &&
+          third[0]?.scheduleId === id("due-c"),
+        "due pages repeated or skipped a key",
+      );
+      yield* ensure(
+        (yield* store.due(100, 1, undefined, third[0])).length === 0,
+        "due cursor did not terminate",
+      );
+    }),
+);
+
 const transitionFencing = conformanceCase(
   "fences stale preparation and control while preserving frozen pending work",
   (ensure) =>
@@ -375,5 +501,7 @@ export const scheduleStoreConformanceCases: ReadonlyArray<ScheduleStoreConforman
   staleCompletion,
   isolationAndCloning,
   ownerCapacity,
+  retainedEvidence,
+  duePagination,
   transitionFencing,
 ];

--- a/packages/session/src/schedule-time.ts
+++ b/packages/session/src/schedule-time.ts
@@ -133,7 +133,16 @@ export const scheduleNextAfter = (
       const cron = parsedStoredCron(timing);
       if (Result.isFailure(cron)) return Result.fail(cron.failure);
       return Result.try({
-        try: () => Cron.next(cron.success, afterMillis).getTime(),
+        try: () => {
+          let next = Cron.next(cron.success, afterMillis).getTime();
+          // Inside a fall fold Effect may select the first, already elapsed local instant.
+          while (next <= afterMillis) {
+            const following = Cron.next(cron.success, next).getTime();
+            if (following <= next) throw new Error("Cron did not advance");
+            next = following;
+          }
+          return next;
+        },
         catch: () => ScheduleValidationError.make({ message: "Cron has no supported next firing" }),
       }).pipe(Result.flatMap((next) => checkedInstant(next, "Next cron occurrence")));
     }
@@ -153,7 +162,7 @@ export interface DueScheduleOccurrence {
   readonly skippedRange: ScheduleSkippedRange | null;
 }
 
-/** Coalesces due recurring occurrences without walking every missed firing. */
+/** Coalesces recurring occurrences using the same forward sequence as registration. */
 export const scheduleDueOccurrence = (
   timing: ScheduleTiming,
   cursorMillis: number,
@@ -175,17 +184,64 @@ export const scheduleDueOccurrence = (
   } else {
     const cron = parsedStoredCron(timing);
     if (Result.isFailure(cron)) return Result.fail(cron.failure);
-    const exclusiveBoundary = checkedInstant(
-      Math.floor(nowMillis / 1_000) * 1_000 + 1_000,
-      "Cron due boundary",
-    );
-    if (Result.isFailure(exclusiveBoundary)) return Result.fail(exclusiveBoundary.failure);
-    const latest = Result.try({
-      try: () => Cron.prev(cron.success, exclusiveBoundary.success).getTime(),
+    const due = Result.try({
+      try: () => {
+        let intended = cursorMillis;
+        // Reverse traversal is safe only without offset transitions. Named-zone reverse
+        // traversal has different gap/fold semantics from the forward occurrence sequence.
+        const zone = Option.getOrUndefined(cron.success.tz);
+        if (zone !== undefined && (DateTime.isTimeZoneOffset(zone) || zone.id === "UTC")) {
+          intended = Math.max(cursorMillis, Cron.prev(cron.success, nowMillis + 1_000).getTime());
+        } else {
+          // Seek by calendar date in UTC, where reverse traversal has no DST ambiguity.
+          // Include two prior civil days to cover even IANA date-line shifts. There are no
+          // matching dates between this seed day and that boundary, so forward traversal
+          // visits only the seed day and the recent days, regardless of downtime length.
+          const calendar = Cron.make({
+            ...cron.success,
+            seconds: [0],
+            minutes: [0],
+            hours: [0],
+            tz: DateTime.zoneMakeNamedUnsafe("UTC"),
+          });
+          const localDay = DateTime.makeUnsafe(
+            DateTime.toDate(DateTime.makeZonedUnsafe(nowMillis, { timeZone: zone })),
+          ).pipe(DateTime.startOf("day"), DateTime.subtract({ days: 2 }));
+          const seedDay = Cron.prev(calendar, DateTime.toEpochMillis(localDay) + 1_000);
+          const seed =
+            DateTime.makeZonedUnsafe(seedDay, {
+              timeZone: zone,
+              adjustForTimeZone: true,
+            }).pipe(DateTime.toEpochMillis) - 1_000;
+          if (seed > cursorMillis) {
+            const first = Cron.next(cron.success, seed).getTime();
+            if (first <= nowMillis) intended = Math.max(intended, first);
+          }
+        }
+        let next = Cron.next(cron.success, intended).getTime();
+        while (next <= nowMillis) {
+          if (next <= intended) throw new Error("Cron did not advance");
+          intended = next;
+          next = Cron.next(cron.success, intended).getTime();
+        }
+        return { intended, next };
+      },
       catch: () => ScheduleValidationError.make({ message: "Cron has no supported due firing" }),
     });
-    if (Result.isFailure(latest)) return Result.fail(latest.failure);
-    intendedAtMillis = Math.max(cursorMillis, latest.success);
+    if (Result.isFailure(due)) return Result.fail(due.failure);
+    const next = checkedInstant(due.success.next, "Next cron occurrence");
+    if (Result.isFailure(next)) return Result.fail(next.failure);
+    return Result.succeed({
+      intendedAtMillis: due.success.intended,
+      nextAtMillis: next.success,
+      skippedRange:
+        due.success.intended === cursorMillis
+          ? null
+          : {
+              fromMillis: cursorMillis,
+              toMillis: due.success.intended,
+            },
+    });
   }
 
   const next = scheduleNextAfter(timing, nowMillis);

--- a/packages/session/src/schedule-transition.ts
+++ b/packages/session/src/schedule-transition.ts
@@ -46,6 +46,10 @@ export const scheduleDeadline = (record: ScheduleRecord): number | null => {
   return record.state === "active" ? record.nextAtMillis : null;
 };
 
+/** Paused work reserves capacity; terminal replay evidence does not. */
+export const scheduleUsesCapacity = (record: ScheduleRecord): boolean =>
+  record.pending !== null || (record.state !== "cancelled" && record.nextAtMillis !== null);
+
 const conflict = (record: ScheduleRecord, reason: "revision" | "cancelled") =>
   Result.fail(ScheduleConflict.make({ reason, key: scheduleKeyOf(record) }));
 
@@ -85,6 +89,7 @@ export const applyScheduleChange = (
         return conflict(record, "revision");
       }
       if (record.version !== change.expectedVersion) return conflict(record, "revision");
+      if (change.action === "resume" && record.state === "active") return Result.succeed(record);
       if (change.action === "pause") {
         return changed(record, {
           state: "paused",

--- a/packages/session/src/schedule.ts
+++ b/packages/session/src/schedule.ts
@@ -157,7 +157,37 @@ export const ScheduleRecord = Schema.Struct({
 export type ScheduleRecord = typeof ScheduleRecord.Type;
 
 export const ScheduleSnapshot = Schema.Struct({
-  ...ScheduleRecord.fields,
+  owner: ScheduleOwner,
+  scheduleId: ScheduleId,
+  createdAtMillis: ScheduleInstant,
+  updatedAtMillis: ScheduleInstant,
+  configurationRevision: Positive,
+  configuration: Schema.Struct({
+    timing: ScheduleTiming,
+    destination: ScheduleDestination,
+    deliveryPrincipal: Principal,
+    agentId: AgentId,
+  }),
+  state: Schema.Literals(["active", "paused", "cancelled"]),
+  nextAtMillis: Schema.NullOr(ScheduleInstant),
+  pending: Schema.NullOr(
+    Schema.Struct({
+      intendedAtMillis: ScheduleInstant,
+      preparedAtMillis: ScheduleInstant,
+      occurrenceId: Digest,
+      retry: ScheduleRetry,
+    }),
+  ),
+  lastReceipt: Schema.NullOr(
+    Schema.Struct({
+      atMillis: ScheduleInstant,
+      intendedAtMillis: ScheduleInstant,
+      occurrenceId: Digest,
+      receipt: Receipt,
+    }),
+  ),
+  lastRefusal: Schema.NullOr(ScheduleRefusal),
+  lastSkippedRange: Schema.NullOr(ScheduleSkippedRange),
   observedAtMillis: ScheduleInstant,
   pendingAgeMillis: Schema.NullOr(Schema.Natural),
   latenessMillis: Schema.Natural,
@@ -255,7 +285,7 @@ export class ScheduleAuthorizer extends Context.Service<
 
 export const SchedulingLimits = Schema.Struct({
   maxSchedulesPerOwner: Positive.check(Schema.isLessThanOrEqualTo(100_000)),
-  minIntervalMillis: Positive.check(Schema.isGreaterThanOrEqualTo(60_000)),
+  minIntervalMillis: Positive,
   maxInputBytes: Positive.check(Schema.isLessThanOrEqualTo(65_536)),
   dueBatchSize: Positive.check(Schema.isLessThanOrEqualTo(1_024)),
   admissionConcurrency: Positive.check(Schema.isLessThanOrEqualTo(64)),
@@ -288,6 +318,14 @@ export const SchedulePage = Schema.Struct({
   next: Schema.NullOr(ScheduleId),
 });
 export type SchedulePage = typeof SchedulePage.Type;
+
+/** Driver pagination uses the index only; a corrupt record cannot poison an entire page. */
+export const ScheduleDueCursor = Schema.Struct({
+  owner: ScheduleOwner,
+  scheduleId: ScheduleId,
+  deadlineAtMillis: ScheduleInstant,
+});
+export type ScheduleDueCursor = typeof ScheduleDueCursor.Type;
 
 /** Local transaction commands. Admission is deliberately absent from this union. */
 export const ScheduleChange = Schema.Union([
@@ -365,13 +403,15 @@ export class ScheduleStore extends Context.Service<
     readonly change: (
       key: ScheduleKey,
       change: ScheduleChange,
+      ownerLimit?: number,
     ) => Effect.Effect<ScheduleRecord, ScheduleStoreFailure>;
     /** Internal driver query, not a public management listing. Pending deadlines take precedence. */
     readonly due: (
       nowMillis: number,
       limit: number,
       owner?: ScheduleOwner,
-    ) => Effect.Effect<ReadonlyArray<ScheduleRecord>, ScheduleStorageError>;
+      after?: ScheduleDueCursor,
+    ) => Effect.Effect<ReadonlyArray<ScheduleDueCursor>, ScheduleStorageError>;
     readonly nextDeadline: (
       owner?: ScheduleOwner,
     ) => Effect.Effect<number | null, ScheduleStorageError>;

--- a/packages/session/src/scheduling.ts
+++ b/packages/session/src/scheduling.ts
@@ -1,11 +1,13 @@
 import { type AgentId, ConversationId } from "@effect-agent/core";
 import {
+  Cause,
   Context,
   Crypto,
   DateTime,
   Effect,
   Encoding,
   Layer,
+  Option,
   Result,
   Schema,
   Semaphore,
@@ -32,6 +34,7 @@ import {
   type ScheduleDestination,
   ScheduleFailpoint,
   type ScheduleId,
+  type ScheduleDueCursor,
   ScheduleInstant,
   type ScheduleKey,
   SchedulingLimits,
@@ -94,7 +97,31 @@ const notFound = (key: ScheduleKey) => ScheduleNotFound.make({ key });
 const asSnapshot = (record: ScheduleRecord, observedAtMillis: number): ScheduleSnapshot => {
   const intendedAtMillis = record.pending?.envelope.intendedAtMillis ?? record.nextAtMillis;
   return {
-    ...record,
+    owner: record.owner,
+    scheduleId: record.scheduleId,
+    createdAtMillis: record.createdAtMillis,
+    updatedAtMillis: record.updatedAtMillis,
+    configurationRevision: record.configurationRevision,
+    configuration: {
+      timing: record.configuration.timing,
+      destination: record.configuration.destination,
+      deliveryPrincipal: record.configuration.deliveryPrincipal,
+      agentId: record.configuration.agentId,
+    },
+    state: record.state,
+    nextAtMillis: record.nextAtMillis,
+    pending:
+      record.pending === null
+        ? null
+        : {
+            intendedAtMillis: record.pending.envelope.intendedAtMillis,
+            preparedAtMillis: record.pending.envelope.preparedAtMillis,
+            occurrenceId: record.pending.envelope.occurrenceId,
+            retry: record.pending.retry,
+          },
+    lastReceipt: record.lastReceipt,
+    lastRefusal: record.lastRefusal,
+    lastSkippedRange: record.lastSkippedRange,
     observedAtMillis,
     pendingAgeMillis:
       record.pending === null
@@ -160,7 +187,7 @@ const resolveInput = Effect.fn("Scheduling.resolveInput")(function* <
   return { payload, digest };
 });
 
-const make = (limits: SchedulingLimits) =>
+const makeManagement = (limits: SchedulingLimits) =>
   Effect.gen(function* () {
     const nowMillis = yield* currentMillis;
     yield* Schema.decodeUnknownEffect(ScheduleInstant)(nowMillis + limits.recoveryPollMillis).pipe(
@@ -172,11 +199,8 @@ const make = (limits: SchedulingLimits) =>
     );
     const store = yield* ScheduleStore;
     const authorizer = yield* ScheduleAuthorizer;
-    const admission = yield* ScheduledInputAdmission;
     const wake = yield* ScheduleWake;
-    const failpoint = yield* ScheduleFailpoint;
     const crypto = yield* Crypto.Crypto;
-    const admissionSemaphore = yield* Semaphore.make(limits.admissionConcurrency);
 
     const withCrypto = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto>) =>
       Effect.provideService(effect, Crypto.Crypto, crypto);
@@ -372,13 +396,17 @@ const make = (limits: SchedulingLimits) =>
         scheduleId: options.scheduleId,
         configuration: nextConfiguration,
       });
-      const changed = yield* store.change(key, {
-        _tag: "Update",
-        expectedRevision: options.expectedRevision,
-        configuration: nextConfiguration,
-        nextAtMillis,
-        nowMillis,
-      });
+      const changed = yield* store.change(
+        key,
+        {
+          _tag: "Update",
+          expectedRevision: options.expectedRevision,
+          configuration: nextConfiguration,
+          nextAtMillis,
+          nowMillis,
+        },
+        limits.maxSchedulesPerOwner,
+      );
       yield* wake.notify;
       return asSnapshot(changed, nowMillis);
     });
@@ -430,6 +458,7 @@ const make = (limits: SchedulingLimits) =>
             if (record.configurationRevision !== expectedRevision) {
               return yield* ScheduleConflict.make({ reason: "revision", key });
             }
+            if (operation === "resume" && record.state === "active") return record;
             const nowMillis = yield* currentMillis;
             const nextAtMillis =
               operation === "resume"
@@ -452,15 +481,19 @@ const make = (limits: SchedulingLimits) =>
                 ? { fromMillis: record.nextAtMillis, toMillis: nextAtMillis }
                 : null;
             return yield* store
-              .change(key, {
-                _tag: "Control",
-                expectedRevision,
-                expectedVersion: record.version,
-                action: operation,
-                nextAtMillis,
-                nowMillis,
-                skippedRange,
-              })
+              .change(
+                key,
+                {
+                  _tag: "Control",
+                  expectedRevision,
+                  expectedVersion: record.version,
+                  action: operation,
+                  nextAtMillis,
+                  nowMillis,
+                  skippedRange,
+                },
+                limits.maxSchedulesPerOwner,
+              )
               .pipe(
                 Effect.catchTag("ScheduleConflict", (error) =>
                   error.reason === "revision" ? attempt() : Effect.fail(error),
@@ -472,6 +505,28 @@ const make = (limits: SchedulingLimits) =>
       yield* wake.notify;
       return asSnapshot(changed, yield* currentMillis);
     });
+
+    return Scheduling.of({
+      create,
+      update,
+      get,
+      list,
+      pause: (scope, id, revision) => control("pause", scope, id, revision),
+      resume: (scope, id, revision) => control("resume", scope, id, revision),
+      cancel: (scope, id, revision) => control("cancel", scope, id, revision),
+    });
+  });
+
+const makeDriver = (limits: SchedulingLimits) =>
+  Effect.gen(function* () {
+    const store = yield* ScheduleStore;
+    const authorizer = yield* ScheduleAuthorizer;
+    const admission = yield* ScheduledInputAdmission;
+    const failpoint = yield* ScheduleFailpoint;
+    const crypto = yield* Crypto.Crypto;
+    const admissionSemaphore = yield* Semaphore.make(limits.admissionConcurrency);
+    const withCrypto = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto>) =>
+      Effect.provideService(effect, Crypto.Crypto, crypto);
 
     const retry = Effect.fn("Scheduling.retry")(function* (
       key: ScheduleKey,
@@ -737,51 +792,69 @@ const make = (limits: SchedulingLimits) =>
             ),
         ),
       );
-      return asSnapshot(processed, yield* currentMillis);
+      return processed;
     });
 
-    const runDue = Effect.fn("Scheduling.runDue")(function* (owner?: ScheduleOwner) {
+    const runDue = Effect.fn("ScheduleDriver.runDue")(function* (owner?: ScheduleOwner) {
       const nowMillis = yield* currentMillis;
-      const due = yield* store.due(nowMillis, limits.dueBatchSize, owner);
-      const processed = yield* Effect.forEach(
-        due,
-        (record) => {
-          const key = { owner: record.owner, scheduleId: record.scheduleId };
-          return processRecord(key, record, nowMillis).pipe(
-            Effect.catchTag("ScheduleConflict", () =>
-              store
-                .get(key)
-                .pipe(
-                  Effect.flatMap((current) =>
-                    current === null
-                      ? Effect.fail(notFound(key))
-                      : processRecord(key, current, nowMillis),
-                  ),
-                ),
+      let after: ScheduleDueCursor | undefined;
+      let processed = 0;
+      let failed = 0;
+      while (true) {
+        const due = yield* store.due(nowMillis, limits.dueBatchSize, owner, after);
+        if (due.length === 0) break;
+        yield* Effect.forEach(
+          due,
+          (key) =>
+            process(key).pipe(
+              Effect.matchCauseEffect({
+                onSuccess: () =>
+                  Effect.sync(() => {
+                    processed += 1;
+                  }),
+                onFailure: (cause) =>
+                  Cause.hasInterrupts(cause)
+                    ? Effect.interrupt
+                    : Effect.gen(function* () {
+                        failed += 1;
+                        yield* Effect.logWarning("Schedule processing failed").pipe(
+                          Effect.annotateLogs({
+                            failureTag: Option.match(Cause.findErrorOption(cause), {
+                              onNone: () => "Defect",
+                              onSome: (error) => error._tag,
+                            }),
+                          }),
+                        );
+                      }),
+              }),
             ),
-          );
-        },
-        { concurrency: "unbounded" },
-      );
-      const observedAtMillis = yield* currentMillis;
-      return processed.map((record) => asSnapshot(record, observedAtMillis));
+          { concurrency: limits.admissionConcurrency },
+        );
+        after = due.at(-1);
+        if (due.length < limits.dueBatchSize) break;
+      }
+      return { processed, failed };
     });
 
-    return Scheduling.of({
-      create,
-      update,
-      get,
-      list,
-      pause: (scope, id, revision) => control("pause", scope, id, revision),
-      resume: (scope, id, revision) => control("resume", scope, id, revision),
-      cancel: (scope, id, revision) => control("cancel", scope, id, revision),
-      process,
-      runDue,
-    });
+    return ScheduleDriver.of({ process, runDue });
   });
 
 const corrupt = (operation: string): ScheduleStorageError =>
   ScheduleStorageError.make({ operation, reason: "corrupt" });
+
+const validateLimits = (limits: SchedulingLimits) =>
+  Schema.decodeUnknownEffect(SchedulingLimits)(limits).pipe(
+    Effect.mapError((error) =>
+      ScheduleValidationError.make({ message: `Invalid Scheduling limits: ${error.message}` }),
+    ),
+    Effect.filterOrFail(
+      (validated) => validated.retryBaseMillis <= validated.retryMaxMillis,
+      () =>
+        ScheduleValidationError.make({
+          message: "Scheduling retryBaseMillis must not exceed retryMaxMillis",
+        }),
+    ),
+  );
 
 export class Scheduling extends Context.Service<
   Scheduling,
@@ -807,17 +880,11 @@ export class Scheduling extends Context.Service<
     readonly get: (
       scope: ScheduleScope,
       scheduleId: ScheduleId,
-    ) => Effect.Effect<
-      ScheduleSnapshot,
-      ScheduleAuthorizationError | ScheduleStorageError | ScheduleNotFound
-    >;
+    ) => Effect.Effect<ScheduleSnapshot, ScheduleManagementFailure>;
     readonly list: (
       scope: ScheduleScope,
       options?: ScheduleListOptions,
-    ) => Effect.Effect<
-      ScheduleSnapshotPage,
-      ScheduleAuthorizationError | ScheduleStorageError | ScheduleValidationError
-    >;
+    ) => Effect.Effect<ScheduleSnapshotPage, ScheduleManagementFailure>;
     readonly pause: (
       scope: ScheduleScope,
       scheduleId: ScheduleId,
@@ -833,10 +900,6 @@ export class Scheduling extends Context.Service<
       scheduleId: ScheduleId,
       expectedRevision: number,
     ) => Effect.Effect<ScheduleSnapshot, ScheduleManagementFailure>;
-    readonly process: (key: ScheduleKey) => Effect.Effect<ScheduleSnapshot, ScheduleProcessFailure>;
-    readonly runDue: (
-      owner?: ScheduleOwner,
-    ) => Effect.Effect<ReadonlyArray<ScheduleSnapshot>, ScheduleProcessFailure>;
   }
 >()("@effect-agent/session/Scheduling") {
   static layer(
@@ -844,24 +907,9 @@ export class Scheduling extends Context.Service<
   ): Layer.Layer<
     Scheduling,
     ScheduleValidationError,
-    ScheduleStore | ScheduleAuthorizer | ScheduledInputAdmission | ScheduleWake | Crypto.Crypto
+    ScheduleStore | ScheduleAuthorizer | ScheduleWake | Crypto.Crypto
   > {
-    return Layer.effect(
-      Scheduling,
-      Schema.decodeUnknownEffect(SchedulingLimits)(limits).pipe(
-        Effect.mapError((error) =>
-          ScheduleValidationError.make({ message: `Invalid Scheduling limits: ${error.message}` }),
-        ),
-        Effect.filterOrFail(
-          (validated) => validated.retryBaseMillis <= validated.retryMaxMillis,
-          () =>
-            ScheduleValidationError.make({
-              message: "Scheduling retryBaseMillis must not exceed retryMaxMillis",
-            }),
-        ),
-        Effect.flatMap(make),
-      ),
-    );
+    return Layer.effect(Scheduling, validateLimits(limits).pipe(Effect.flatMap(makeManagement)));
   }
 }
 
@@ -869,3 +917,27 @@ export const ScheduleWakeNoop: Layer.Layer<ScheduleWake> = Layer.succeed(Schedul
   notify: Effect.void,
   await: Effect.never,
 });
+
+/** Privileged host capability. Never provide this service to management callers or model tools. */
+export class ScheduleDriver extends Context.Service<
+  ScheduleDriver,
+  {
+    readonly process: (key: ScheduleKey) => Effect.Effect<ScheduleRecord, ScheduleProcessFailure>;
+    readonly runDue: (
+      owner?: ScheduleOwner,
+    ) => Effect.Effect<
+      { readonly processed: number; readonly failed: number },
+      ScheduleStorageError
+    >;
+  }
+>()("@effect-agent/session/ScheduleDriver") {
+  static layer(
+    limits: SchedulingLimits = defaultSchedulingLimits,
+  ): Layer.Layer<
+    ScheduleDriver,
+    ScheduleValidationError,
+    ScheduleStore | ScheduleAuthorizer | ScheduledInputAdmission | Crypto.Crypto
+  > {
+    return Layer.effect(ScheduleDriver, validateLimits(limits).pipe(Effect.flatMap(makeDriver)));
+  }
+}

--- a/packages/session/test/schedule-schema.test.ts
+++ b/packages/session/test/schedule-schema.test.ts
@@ -104,6 +104,39 @@ const record = ScheduleRecord.make({
   lastSkippedRange: { fromMillis: 10, toMillis: 50 },
 });
 
+const snapshot = ScheduleSnapshot.make({
+  owner,
+  scheduleId,
+  createdAtMillis: 1,
+  updatedAtMillis: 110,
+  configurationRevision: 1,
+  configuration: {
+    timing: { _tag: "Interval", everyMillis: 60_000, anchorMillis: 100 },
+    destination: { _tag: "ExistingConversation", conversationId },
+    deliveryPrincipal: principal,
+    agentId,
+  },
+  state: "active",
+  nextAtMillis: 60_100,
+  pending: {
+    intendedAtMillis: 100,
+    preparedAtMillis: 110,
+    occurrenceId,
+    retry: {
+      attempts: 1,
+      nextAttemptAtMillis: 1_110,
+      lastAttemptAtMillis: 110,
+      lastFailure: "transport",
+    },
+  },
+  lastReceipt: record.lastReceipt,
+  lastRefusal: record.lastRefusal,
+  lastSkippedRange: record.lastSkippedRange,
+  observedAtMillis: 1_200,
+  pendingAgeMillis: 1_090,
+  latenessMillis: 1_100,
+});
+
 const roundTrip = <A, I>(schema: Schema.Codec<A, I, never, never>, value: A): void => {
   const encoded = Schema.encodeSync(schema)(value);
   expect(Schema.decodeSync(schema)(encoded)).toEqual(value);
@@ -122,25 +155,10 @@ describe("Schedule persisted schemas", () => {
     roundTrip(ScheduleDestination, { _tag: "FreshConversation" });
     roundTrip(ScheduledEnvelope, envelope);
     roundTrip(ScheduleRecord, record);
-    roundTrip(ScheduleSnapshot, {
-      ...record,
-      observedAtMillis: 1_200,
-      pendingAgeMillis: 1_090,
-      latenessMillis: 1_100,
-    });
+    roundTrip(ScheduleSnapshot, snapshot);
     roundTrip(SchedulePageRequest, { owner, after: scheduleId, limit: 25 });
     roundTrip(SchedulePage, { items: [record], next: scheduleId });
-    roundTrip(ScheduleSnapshotPage, {
-      items: [
-        {
-          ...record,
-          observedAtMillis: 1_200,
-          pendingAgeMillis: 1_090,
-          latenessMillis: 1_100,
-        },
-      ],
-      next: null,
-    });
+    roundTrip(ScheduleSnapshotPage, { items: [snapshot], next: null });
     roundTrip(SchedulingLimits, defaultSchedulingLimits);
 
     const changes: ReadonlyArray<typeof ScheduleChange.Type> = [

--- a/packages/session/test/schedule-time.test.ts
+++ b/packages/session/test/schedule-time.test.ts
@@ -124,6 +124,13 @@ describe("Schedule timing", () => {
     expect(success(scheduleNextAfter(timing, Date.parse("2026-03-07T07:31:00.000Z")))).toBe(
       Date.parse("2026-03-08T07:30:00.000Z"),
     );
+    for (const cursor of ["2026-03-07T07:30:00Z", "2026-03-08T07:30:00Z"]) {
+      for (const now of ["2026-03-08T07:30:00Z", "2026-03-08T08:00:00Z"]) {
+        const due = success(scheduleDueOccurrence(timing, Date.parse(cursor), Date.parse(now)));
+        expect(due?.intendedAtMillis).toBe(Date.parse("2026-03-08T07:30:00Z"));
+        expect(due?.nextAtMillis).toBe(Date.parse("2026-03-09T06:30:00Z"));
+      }
+    }
 
     const repeated = {
       _tag: "Cron" as const,
@@ -136,6 +143,18 @@ describe("Schedule timing", () => {
     expect(success(scheduleNextAfter(repeated, first))).toBe(
       Date.parse("2026-11-02T06:30:00.000Z"),
     );
+    expect(success(scheduleNextAfter(repeated, Date.parse("2026-11-01T06:15:00Z")))).toBe(
+      Date.parse("2026-11-02T06:30:00Z"),
+    );
+    const folded = success(
+      scheduleDueOccurrence(
+        repeated,
+        Date.parse("2026-10-31T05:30:00Z"),
+        Date.parse("2026-11-01T06:15:00Z"),
+      ),
+    );
+    expect(folded?.intendedAtMillis).toBe(Date.parse("2026-11-01T05:30:00Z"));
+    expect(folded?.nextAtMillis).toBe(Date.parse("2026-11-02T06:30:00Z"));
     expect(
       success(
         scheduleDueOccurrence(
@@ -149,5 +168,52 @@ describe("Schedule timing", () => {
       nextAtMillis: Date.parse("2026-11-02T06:30:00.000Z"),
       skippedRange: null,
     });
+  });
+
+  it("coalesces long named-zone downtime across sparse dates and whole-day gaps", () => {
+    for (const [expression, timeZone, cursor, now, intended, next] of [
+      [
+        "* * * * *",
+        "America/New_York",
+        "2000-01-01T05:00Z",
+        "2026-03-08T07:15Z",
+        "2026-03-08T07:15Z",
+        "2026-03-08T07:16Z",
+      ],
+      [
+        "30 2 * * *",
+        "America/New_York",
+        "2000-01-01T07:30Z",
+        "2026-03-08T07:45Z",
+        "2026-03-08T07:30Z",
+        "2026-03-09T06:30Z",
+      ],
+      [
+        "0 0 29 2 *",
+        "America/New_York",
+        "2000-02-29T05:00Z",
+        "2026-03-08T07:45Z",
+        "2024-02-29T05:00Z",
+        "2028-02-29T05:00Z",
+      ],
+      [
+        "0 12 * * *",
+        "Pacific/Apia",
+        "2011-12-28T22:00Z",
+        "2011-12-31T00:00Z",
+        "2011-12-30T22:00Z",
+        "2011-12-31T22:00Z",
+      ],
+    ] as const) {
+      const due = success(
+        scheduleDueOccurrence(
+          { _tag: "Cron", expression, timeZone },
+          Date.parse(cursor),
+          Date.parse(now),
+        ),
+      );
+      expect(due?.intendedAtMillis).toBe(Date.parse(intended));
+      expect(due?.nextAtMillis).toBe(Date.parse(next));
+    }
   });
 });

--- a/packages/session/test/scheduling-types.test.ts
+++ b/packages/session/test/scheduling-types.test.ts
@@ -5,16 +5,15 @@ import type { Crypto, Effect, Layer, Schema } from "effect";
 import {
   type DurableSubmitAgent,
   type ScheduleCreateOptions,
-  type ScheduleAuthorizationError,
   type ScheduleAuthorizer,
   type ScheduleListOptions,
   type ScheduleManagementFailure,
-  type ScheduleNotFound,
   type ScheduleProcessFailure,
   type ScheduleScope,
   type ScheduleId,
   type ScheduledInputAdmission,
   Scheduling,
+  ScheduleDriver,
   type ScheduleStorageError,
   type ScheduleStore,
   type ScheduleValidationError,
@@ -46,7 +45,10 @@ declare const scope: ScheduleScope;
 declare const scheduleId: ScheduleId;
 declare const listOptions: ScheduleListOptions;
 
-const proveServiceOperations = (service: Scheduling["Service"]) => {
+const proveServiceOperations = (
+  service: Scheduling["Service"],
+  driver: ScheduleDriver["Service"],
+) => {
   const created = service.create(agent, { value: "value" }, createOptions);
   const updated = service.update(
     agent,
@@ -59,8 +61,8 @@ const proveServiceOperations = (service: Scheduling["Service"]) => {
   const got = service.get(scope, scheduleId);
   const listed = service.list(scope, listOptions);
   const paused = service.pause(scope, scheduleId, 1);
-  const processed = service.process({ owner: scope.owner, scheduleId });
-  const due = service.runDue(scope.owner);
+  const processed = driver.process({ owner: scope.owner, scheduleId });
+  const due = driver.runDue(scope.owner);
 
   type CreateRequirementsProof = Assert<
     Equal<Effect.Services<typeof created>, InputEncodingContext>
@@ -70,21 +72,11 @@ const proveServiceOperations = (service: Scheduling["Service"]) => {
     Equal<Effect.Services<typeof updated>, InputEncodingContext>
   >;
   type UpdateFailureProof = Assert<Equal<Effect.Error<typeof updated>, ScheduleManagementFailure>>;
-  type GetFailureProof = Assert<
-    Equal<
-      Effect.Error<typeof got>,
-      ScheduleAuthorizationError | ScheduleStorageError | ScheduleNotFound
-    >
-  >;
-  type ListFailureProof = Assert<
-    Equal<
-      Effect.Error<typeof listed>,
-      ScheduleAuthorizationError | ScheduleStorageError | ScheduleValidationError
-    >
-  >;
+  type GetFailureProof = Assert<Equal<Effect.Error<typeof got>, ScheduleManagementFailure>>;
+  type ListFailureProof = Assert<Equal<Effect.Error<typeof listed>, ScheduleManagementFailure>>;
   type ControlFailureProof = Assert<Equal<Effect.Error<typeof paused>, ScheduleManagementFailure>>;
   type ProcessFailureProof = Assert<Equal<Effect.Error<typeof processed>, ScheduleProcessFailure>>;
-  type RunDueFailureProof = Assert<Equal<Effect.Error<typeof due>, ScheduleProcessFailure>>;
+  type RunDueFailureProof = Assert<Equal<Effect.Error<typeof due>, ScheduleStorageError>>;
 
   const proofs: readonly [
     CreateRequirementsProof,
@@ -108,7 +100,21 @@ type SchedulingLayerFailureProof = Assert<
 type SchedulingLayerRequirementsProof = Assert<
   Equal<
     Layer.Services<typeof schedulingLayer>,
-    ScheduleStore | ScheduleAuthorizer | ScheduledInputAdmission | ScheduleWake | Crypto.Crypto
+    ScheduleStore | ScheduleAuthorizer | ScheduleWake | Crypto.Crypto
+  >
+>;
+
+const driverLayer = ScheduleDriver.layer();
+type DriverRequirementsProof = Assert<
+  Equal<
+    Layer.Services<typeof driverLayer>,
+    ScheduleStore | ScheduleAuthorizer | ScheduledInputAdmission | Crypto.Crypto
+  >
+>;
+type ManagementKeysProof = Assert<
+  Equal<
+    keyof Scheduling["Service"],
+    "create" | "update" | "get" | "list" | "pause" | "resume" | "cancel"
   >
 >;
 
@@ -119,6 +125,9 @@ describe("Scheduling public types", () => {
     const failureProof: SchedulingLayerFailureProof = true;
     const requirementsProof: SchedulingLayerRequirementsProof = true;
 
+    const driverProof: DriverRequirementsProof = true;
+    const managementProof: ManagementKeysProof = true;
+    expect([driverProof, managementProof]).toEqual([true, true]);
     expect(serviceProof).toBe(proveServiceOperations);
     expect([successProof, failureProof, requirementsProof]).toEqual([true, true, true]);
   });

--- a/packages/storage-cloudflare/src/do-schedule-store.ts
+++ b/packages/storage-cloudflare/src/do-schedule-store.ts
@@ -1,6 +1,9 @@
 import {
   applyScheduleChange,
   ScheduleCapacityError,
+  ScheduleDueCursor,
+  defaultSchedulingLimits,
+  scheduleUsesCapacity,
   ScheduleChange,
   ScheduleConflict,
   scheduleDeadline,
@@ -35,6 +38,13 @@ class ScheduleRow extends Schema.Class<ScheduleRow>("@effect-agent/storage-cloud
     record_json: StoredScheduleJson,
   },
 ) {}
+
+const ScheduleDueRow = Schema.Struct({
+  tenant_id: ScheduleOwner.fields.tenantId,
+  owner_id: ScheduleOwner.fields.ownerId,
+  schedule_id: ScheduleId,
+  deadline_at_millis: ScheduleInstant,
+});
 
 class ScheduleCountRow extends Schema.Class<ScheduleCountRow>(
   "@effect-agent/storage-cloudflare/ScheduleCountRow",
@@ -313,6 +323,8 @@ const makeServices = Effect.gen(function* () {
             FROM effect_agent_schedules
             WHERE tenant_id = ${canonical.owner.tenantId}
               AND owner_id = ${canonical.owner.ownerId}
+              AND (json_extract(record_json, '$.pending') IS NOT NULL OR
+                (json_extract(record_json, '$.state') != 'cancelled' AND json_extract(record_json, '$.nextAtMillis') IS NOT NULL))
           `.pipe(Effect.mapError(() => unavailable(operation)));
           const counts = yield* decodeRows(Schema.Array(ScheduleCountRow), rawCounts, operation);
           if (counts.length !== 1) return yield* corrupt(operation);
@@ -377,66 +389,97 @@ const makeServices = Effect.gen(function* () {
     return { items, next: hasNext ? (items.at(-1)?.scheduleId ?? null) : null };
   });
 
-  const change: ScheduleStore["Service"]["change"] = Effect.fn("DoScheduleStore.change")(
-    function* (key, change) {
-      const operation = "change schedule";
-      const canonicalKey = yield* decodeBoundary(ScheduleKey, key, operation);
-      const canonicalChange = yield* decodeBoundary(ScheduleChange, change, operation);
-      const result = yield* transactions.run((replace) =>
-        Effect.gen(function* () {
-          const current = yield* readOne(canonicalKey, operation);
-          if (current === null) return yield* ScheduleNotFound.make({ key: canonicalKey });
-          const transition = applyScheduleChange(current, canonicalChange);
-          if (Result.isFailure(transition)) return yield* transition.failure;
-          const next = transition.success;
-          if (next === current) return { record: current, changed: false } as const;
-          const recordJson = yield* encodeRecord(next);
-          yield* scheduleFailpoint.hit(`schedule:${canonicalChange._tag.toLowerCase()}:before`);
-          yield* sql`
+  const change: ScheduleStore["Service"]["change"] = Effect.fn("DoScheduleStore.change")(function* (
+    key,
+    change,
+    ownerLimit = defaultSchedulingLimits.maxSchedulesPerOwner,
+  ) {
+    const operation = "change schedule";
+    const canonicalKey = yield* decodeBoundary(ScheduleKey, key, operation);
+    const canonicalChange = yield* decodeBoundary(ScheduleChange, change, operation);
+    const result = yield* transactions.run((replace) =>
+      Effect.gen(function* () {
+        const current = yield* readOne(canonicalKey, operation);
+        if (current === null) return yield* ScheduleNotFound.make({ key: canonicalKey });
+        const transition = applyScheduleChange(current, canonicalChange);
+        if (Result.isFailure(transition)) return yield* transition.failure;
+        const next = transition.success;
+        if (!scheduleUsesCapacity(current) && scheduleUsesCapacity(next)) {
+          const rawCounts = yield* sql<Record<string, unknown>>`
+              SELECT COUNT(*) AS schedule_count FROM effect_agent_schedules
+              WHERE tenant_id = ${key.owner.tenantId} AND owner_id = ${key.owner.ownerId}
+                AND (json_extract(record_json, '$.pending') IS NOT NULL OR
+                  (json_extract(record_json, '$.state') != 'cancelled' AND json_extract(record_json, '$.nextAtMillis') IS NOT NULL))
+            `.pipe(Effect.mapError(() => unavailable(operation)));
+          const counts = yield* decodeRows(Schema.Array(ScheduleCountRow), rawCounts, operation);
+          if (counts.length !== 1) return yield* corrupt(operation);
+          if (counts[0].schedule_count >= ownerLimit)
+            return yield* ScheduleCapacityError.make({ limit: ownerLimit });
+        }
+        if (next === current) return { record: current, changed: false } as const;
+        const recordJson = yield* encodeRecord(next);
+        yield* scheduleFailpoint.hit(`schedule:${canonicalChange._tag.toLowerCase()}:before`);
+        yield* sql`
             UPDATE effect_agent_schedules
             SET deadline_at_millis = ${scheduleDeadline(next)}, record_json = ${recordJson}
             WHERE tenant_id = ${canonicalKey.owner.tenantId}
               AND owner_id = ${canonicalKey.owner.ownerId}
               AND schedule_id = ${canonicalKey.scheduleId}
           `.pipe(Effect.mapError(() => unavailable(operation)));
-          const deadline = yield* readNextDeadline(undefined, operation);
-          yield* replaceAlarm(replace, deadline, operation);
-          return { record: next, changed: true } as const;
-        }),
-      );
-      if (result.changed) {
-        yield* scheduleFailpoint.hit(`schedule:${canonicalChange._tag.toLowerCase()}:after`);
-      }
-      return result.record;
-    },
-  );
+        const deadline = yield* readNextDeadline(undefined, operation);
+        yield* replaceAlarm(replace, deadline, operation);
+        return { record: next, changed: true } as const;
+      }),
+    );
+    if (result.changed) {
+      yield* scheduleFailpoint.hit(`schedule:${canonicalChange._tag.toLowerCase()}:after`);
+    }
+    return result.record;
+  });
 
   const due: ScheduleStore["Service"]["due"] = Effect.fn("DoScheduleStore.due")(function* (
     nowMillis,
     limit,
     owner?: ScheduleOwner,
+    after?: ScheduleDueCursor,
   ) {
     const operation = "query due schedules";
+    const cursor =
+      after === undefined
+        ? undefined
+        : yield* Schema.decodeUnknownEffect(ScheduleDueCursor)(after).pipe(
+            Effect.mapError(() => corrupt(operation)),
+          );
+    const continuation =
+      cursor === undefined
+        ? sql`1 = 1`
+        : sql`
+      (deadline_at_millis, tenant_id, owner_id, schedule_id) >
+      (${cursor.deadlineAtMillis}, ${cursor.owner.tenantId}, ${cursor.owner.ownerId}, ${cursor.scheduleId})`;
     const rows =
       owner === undefined
         ? yield* sql<Record<string, unknown>>`
-            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis, record_json
+            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis
             FROM effect_agent_schedules
-            WHERE deadline_at_millis <= ${nowMillis}
+            WHERE deadline_at_millis <= ${nowMillis} AND ${continuation}
             ORDER BY deadline_at_millis, tenant_id, owner_id, schedule_id
             LIMIT ${limit}
           `.pipe(Effect.mapError(() => unavailable(operation)))
         : yield* sql<Record<string, unknown>>`
-            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis, record_json
+            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis
             FROM effect_agent_schedules
             WHERE tenant_id = ${owner.tenantId}
               AND owner_id = ${owner.ownerId}
-              AND deadline_at_millis <= ${nowMillis}
+              AND deadline_at_millis <= ${nowMillis} AND ${continuation}
             ORDER BY deadline_at_millis, schedule_id
             LIMIT ${limit}
           `.pipe(Effect.mapError(() => unavailable(operation)));
-    const decoded = yield* decodeRows(Schema.Array(ScheduleRow), rows, operation);
-    return yield* Effect.forEach(decoded, decodeRecord);
+    const decoded = yield* decodeRows(Schema.Array(ScheduleDueRow), rows, operation);
+    return decoded.map((row) => ({
+      owner: { tenantId: row.tenant_id, ownerId: row.owner_id },
+      scheduleId: row.schedule_id,
+      deadlineAtMillis: row.deadline_at_millis,
+    }));
   });
 
   const nextDeadline: ScheduleStore["Service"]["nextDeadline"] = Effect.fn(

--- a/packages/storage-memory/src/memory-schedule-store.ts
+++ b/packages/storage-memory/src/memory-schedule-store.ts
@@ -1,5 +1,8 @@
 import {
   ScheduleCapacityError,
+  ScheduleDueCursor,
+  defaultSchedulingLimits,
+  scheduleUsesCapacity,
   ScheduleChange,
   ScheduleConflict,
   ScheduleFailpoint,
@@ -99,7 +102,11 @@ const makeScheduleStore = Effect.gen(function* () {
                 if (Result.isFailure(decoded)) {
                   return [Result.fail(decoded.failure), current];
                 }
-                if (sameOwner(decoded.success, record.owner)) ownerCount += 1;
+                if (
+                  sameOwner(decoded.success, record.owner) &&
+                  scheduleUsesCapacity(decoded.success)
+                )
+                  ownerCount += 1;
               }
               if (ownerCount >= ownerLimit) {
                 return [Result.fail(ScheduleCapacityError.make({ limit: ownerLimit })), current];
@@ -150,7 +157,7 @@ const makeScheduleStore = Effect.gen(function* () {
   );
 
   const change: ScheduleStore["Service"]["change"] = Effect.fn("MemoryScheduleStore.change")(
-    (key, command) =>
+    (key, command, ownerLimit = defaultSchedulingLimits.maxSchedulesPerOwner) =>
       Effect.gen(function* () {
         const decodedKey = yield* decodeInput("change", ScheduleKey, key);
         const decodedCommand = yield* decodeInput("change", ScheduleChange, command);
@@ -163,7 +170,7 @@ const makeScheduleStore = Effect.gen(function* () {
             ): readonly [
               Result.Result<
                 ScheduleRecord,
-                ScheduleConflict | ScheduleStorageError | ScheduleNotFound
+                ScheduleConflict | ScheduleStorageError | ScheduleNotFound | ScheduleCapacityError
               >,
               MemoryScheduleState,
             ] => {
@@ -185,6 +192,23 @@ const makeScheduleStore = Effect.gen(function* () {
               }
               if (applied.success === decoded.success) {
                 return [Result.succeed(decoded.success), current];
+              }
+              if (!scheduleUsesCapacity(decoded.success) && scheduleUsesCapacity(applied.success)) {
+                let count = 0;
+                for (const text of current.records.values()) {
+                  const candidate = Schema.decodeUnknownResult(
+                    Schema.fromJsonString(ScheduleRecord),
+                  )(text);
+                  if (Result.isFailure(candidate))
+                    return [Result.fail(storageError("change", "corrupt")), current];
+                  if (
+                    sameOwner(candidate.success, decodedKey.owner) &&
+                    scheduleUsesCapacity(candidate.success)
+                  )
+                    count += 1;
+                }
+                if (count >= ownerLimit)
+                  return [Result.fail(ScheduleCapacityError.make({ limit: ownerLimit })), current];
               }
               const encoded = Result.try({
                 try: () =>
@@ -208,23 +232,28 @@ const makeScheduleStore = Effect.gen(function* () {
   );
 
   const due: ScheduleStore["Service"]["due"] = Effect.fn("MemoryScheduleStore.due")(
-    function* (nowMillis, limit, owner) {
+    function* (nowMillis, limit, owner, after) {
       const decodedOwner =
         owner === undefined ? undefined : yield* decodeInput("due", ScheduleOwner, owner);
-      const records: Array<ScheduleRecord> = [];
+      const cursor =
+        after === undefined ? undefined : yield* decodeInput("due", ScheduleDueCursor, after);
+      const records: Array<ScheduleDueCursor> = [];
       for (const text of (yield* Ref.get(state)).records.values()) {
         const record = yield* decodeRecord("due", text);
         const deadline = scheduleDeadline(record);
         if (
           deadline !== null &&
           deadline <= nowMillis &&
-          (decodedOwner === undefined || sameOwner(record, decodedOwner))
+          (decodedOwner === undefined || sameOwner(record, decodedOwner)) &&
+          (cursor === undefined ||
+            deadline > cursor.deadlineAtMillis ||
+            (deadline === cursor.deadlineAtMillis && compareScheduleKeys(record, cursor) > 0))
         ) {
-          records.push(record);
+          records.push({ ...scheduleKeyOf(record), deadlineAtMillis: deadline });
         }
       }
       records.sort((left, right) => {
-        const byDeadline = (scheduleDeadline(left) ?? 0) - (scheduleDeadline(right) ?? 0);
+        const byDeadline = left.deadlineAtMillis - right.deadlineAtMillis;
         return byDeadline !== 0 ? byDeadline : compareScheduleKeys(left, right);
       });
       return records.slice(0, limit);

--- a/packages/storage-memory/test/scheduling-regressions.test.ts
+++ b/packages/storage-memory/test/scheduling-regressions.test.ts
@@ -15,7 +15,8 @@ import {
   ScheduledInputRefused,
   ScheduledInputRetryable,
   Scheduling,
-  type SchedulingLimits,
+  ScheduleDriver,
+  SchedulingLimits,
   ScheduleStore,
   ScheduleStorageError,
   type ScheduleTimingRequest,
@@ -70,7 +71,7 @@ const layer = (
   limits: SchedulingLimits = defaultSchedulingLimits,
   store: Layer.Layer<ScheduleStore> = MemoryScheduleStoreLive,
 ) =>
-  Scheduling.layer(limits).pipe(
+  Layer.merge(Scheduling.layer(limits), ScheduleDriver.layer(limits)).pipe(
     Layer.provideMerge(store),
     Layer.provide(
       Layer.mergeAll(
@@ -83,6 +84,169 @@ const layer = (
   );
 
 describe("Scheduling public recovery contract", () => {
+  it.effect("management cannot acquire driver authority or reveal persistence fields", () => {
+    let revoked = false;
+    return Effect.gen(function* () {
+      const scheduler = yield* Scheduling;
+      const request = options("private-input");
+      const created = yield* scheduler.create(agent, { text: "private-sentinel" }, request);
+      yield* (yield* ScheduleDriver).process(keyOf(request));
+      const snapshot = yield* scheduler.get(scope, request.scheduleId);
+      const page = yield* scheduler.list(scope);
+      for (const value of [created, snapshot, ...page.items]) {
+        expect(value).not.toHaveProperty("creationFingerprint");
+        expect(value).not.toHaveProperty("version");
+        expect(value).not.toHaveProperty("schemaVersion");
+        expect(value.configuration).not.toHaveProperty("input");
+        expect(value.configuration).not.toHaveProperty("inputDigest");
+        if (value.pending !== null) expect(value.pending).not.toHaveProperty("envelope");
+        expect(JSON.stringify(value)).not.toContain("private-sentinel");
+      }
+      expect(scheduler).not.toHaveProperty("process");
+      expect(scheduler).not.toHaveProperty("runDue");
+      revoked = true;
+      expect((yield* scheduler.get(scope, request.scheduleId).pipe(Effect.flip))._tag).toBe(
+        "ScheduleAuthorizationError",
+      );
+      expect((yield* scheduler.list(scope).pipe(Effect.flip))._tag).toBe(
+        "ScheduleAuthorizationError",
+      );
+    }).pipe(
+      Effect.provide(
+        layer(() => Effect.fail(ScheduledInputRetryable.make({ reason: "ambiguous" })), {
+          ...allow,
+          manage: () =>
+            revoked
+              ? Effect.fail(ScheduleAuthorizationError.make({ code: "revoked" }))
+              : Effect.void,
+        }),
+      ),
+    );
+  });
+
+  it.effect("repeated resume preserves an active due occurrence and its storage version", () =>
+    Effect.gen(function* () {
+      const scheduler = yield* Scheduling;
+      const store = yield* ScheduleStore;
+      const request = options("resume-replay", { _tag: "Interval", everyMillis: 60_000 });
+      yield* scheduler.create(agent, { text: "tick" }, request);
+      yield* scheduler.pause(scope, request.scheduleId, 1);
+      yield* scheduler.resume(scope, request.scheduleId, 1);
+      const before = yield* store.get(keyOf(request));
+      yield* TestClock.adjust(60_000);
+      const resumed = yield* scheduler.resume(scope, request.scheduleId, 1);
+      expect(resumed.nextAtMillis).toBe(60_000);
+      expect(yield* store.get(keyOf(request))).toEqual(before);
+      const delivered = yield* (yield* ScheduleDriver).process(keyOf(request));
+      expect(delivered.lastReceipt?.intendedAtMillis).toBe(60_000);
+      expect((yield* scheduler.resume(scope, request.scheduleId, 2).pipe(Effect.flip))._tag).toBe(
+        "ScheduleConflict",
+      );
+    }).pipe(Effect.provide(layer())),
+  );
+
+  it.effect("supports a lower positive host interval minimum without changing the default", () =>
+    Effect.gen(function* () {
+      const scheduler = yield* Scheduling;
+      const request = options("fast-interval", { _tag: "Interval", everyMillis: 100 });
+      yield* scheduler.create(agent, { text: "tick" }, request);
+      yield* TestClock.adjust(100);
+      expect(
+        (yield* (yield* ScheduleDriver).process(keyOf(request))).lastReceipt?.intendedAtMillis,
+      ).toBe(100);
+      expect(defaultSchedulingLimits.minIntervalMillis).toBe(60_000);
+      expect(
+        Schema.is(SchedulingLimits)({ ...defaultSchedulingLimits, minIntervalMillis: 0 }),
+      ).toBe(false);
+    }).pipe(
+      Effect.provide(
+        layer(undefined, allow, { ...defaultSchedulingLimits, minIntervalMillis: 100 }),
+      ),
+    ),
+  );
+
+  for (const failure of ["storage", "defect", "decode"] as const) {
+    it.effect(`a ${failure} failure cannot starve later schedules with a one-record page`, () => {
+      let broken = true;
+      const wrapped = Layer.effect(
+        ScheduleStore,
+        Effect.gen(function* () {
+          const store = yield* ScheduleStore;
+          return ScheduleStore.of({
+            ...store,
+            get: (key) =>
+              failure === "decode" && broken && key.scheduleId === "a-failing"
+                ? Effect.fail(ScheduleStorageError.make({ operation: "decode", reason: "corrupt" }))
+                : store.get(key),
+          });
+        }),
+      ).pipe(Layer.provide(MemoryScheduleStoreLive));
+      return Effect.gen(function* () {
+        const scheduler = yield* Scheduling;
+        const driver = yield* ScheduleDriver;
+        broken = false;
+        yield* scheduler.create(agent, { text: "first" }, options("a-failing"));
+        yield* scheduler.create(agent, { text: "second" }, options("b-healthy"));
+        broken = true;
+        expect(yield* driver.runDue()).toEqual({ processed: 1, failed: 1 });
+        expect(
+          (yield* scheduler.get(scope, options("b-healthy").scheduleId)).lastReceipt,
+        ).not.toBeNull();
+        expect(yield* driver.runDue()).toEqual({ processed: 0, failed: 1 });
+        broken = false;
+        expect(yield* driver.runDue()).toEqual({ processed: 1, failed: 0 });
+      }).pipe(
+        Effect.provide(
+          layer(
+            (envelope) =>
+              broken && envelope.scheduleId === "a-failing" && failure !== "decode"
+                ? failure === "defect"
+                  ? Effect.die("injected")
+                  : Effect.fail(
+                      ScheduleStorageError.make({ operation: "admit", reason: "corrupt" }),
+                    )
+                : Effect.succeed(receiptFor(envelope)),
+            allow,
+            { ...defaultSchedulingLimits, dueBatchSize: 1 },
+            wrapped,
+          ),
+        ),
+      );
+    });
+  }
+
+  it.effect("delivers the spring-gap occurrence through ordinary admission", () => {
+    const submitted: Array<number> = [];
+    return Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse("2026-03-07T12:00:00Z"));
+      const scheduler = yield* Scheduling;
+      const request = options("spring-forward", {
+        _tag: "Cron",
+        expression: "30 2 * * *",
+        timeZone: "America/New_York",
+      });
+      const created = yield* scheduler.create(agent, { text: "spring" }, request);
+      expect(created.nextAtMillis).toBe(Date.parse("2026-03-08T07:30:00Z"));
+      yield* TestClock.setTime(Date.parse("2026-03-08T07:30:00Z"));
+      yield* (yield* ScheduleDriver).runDue();
+      yield* TestClock.setTime(Date.parse("2026-03-09T06:30:00Z"));
+      yield* (yield* ScheduleDriver).runDue();
+      expect(submitted).toEqual([
+        Date.parse("2026-03-08T07:30:00Z"),
+        Date.parse("2026-03-09T06:30:00Z"),
+      ]);
+    }).pipe(
+      Effect.provide(
+        layer((envelope) =>
+          Effect.sync(() => {
+            submitted.push(envelope.intendedAtMillis);
+            return receiptFor(envelope);
+          }),
+        ),
+      ),
+    );
+  });
+
   it.effect(
     "rejects an unrepresentable recovery deadline through the typed initialization channel",
     () =>
@@ -118,7 +282,7 @@ describe("Scheduling public recovery contract", () => {
       const scheduler = yield* Scheduling;
       const request = options("authorization-outage");
       yield* scheduler.create(agent, { text: "work" }, request);
-      const failure = yield* scheduler.process(keyOf(request)).pipe(Effect.flip);
+      const failure = yield* (yield* ScheduleDriver).process(keyOf(request)).pipe(Effect.flip);
       expect(failure).toMatchObject({ _tag: "ScheduleStorageError", reason: "unavailable" });
       const unchanged = yield* scheduler.get(scope, request.scheduleId);
       expect(unchanged.state).toBe("active");
@@ -126,7 +290,7 @@ describe("Scheduling public recovery contract", () => {
       expect(unchanged.nextAtMillis).toBe(0);
       expect(unchanged.lastRefusal).toBeNull();
       unavailable = false;
-      const delivered = yield* scheduler.process(keyOf(request));
+      const delivered = yield* (yield* ScheduleDriver).process(keyOf(request));
       expect(delivered.lastReceipt?.intendedAtMillis).toBe(0);
     }).pipe(Effect.provide(layer(undefined, authorizer)));
   });
@@ -143,22 +307,22 @@ describe("Scheduling public recovery contract", () => {
         timeZone: "UTC",
       });
       yield* TestClock.adjust(180_000);
-      const first = yield* scheduler.process(keyOf(request));
+      const first = yield* (yield* ScheduleDriver).process(keyOf(request));
       expect(first.lastReceipt?.intendedAtMillis).toBe(180_000);
       expect(first.nextAtMillis).toBe(240_000);
       expect(first.lastSkippedRange).toEqual({ fromMillis: 60_000, toMillis: 180_000 });
       yield* scheduler.pause(scope, request.scheduleId, 1);
       yield* TestClock.adjust(150_000);
-      expect(yield* scheduler.runDue()).toEqual([]);
+      expect(yield* (yield* ScheduleDriver).runDue()).toEqual({ processed: 0, failed: 0 });
       const resumed = yield* scheduler.resume(scope, request.scheduleId, 1);
       expect(resumed.nextAtMillis).toBe(360_000);
       expect(resumed.lastSkippedRange).toEqual({ fromMillis: 240_000, toMillis: 360_000 });
       yield* TestClock.adjust(30_000);
-      yield* scheduler.process(keyOf(request));
+      yield* (yield* ScheduleDriver).process(keyOf(request));
       yield* TestClock.setTime(300_000);
-      expect(yield* scheduler.runDue()).toEqual([]);
+      expect(yield* (yield* ScheduleDriver).runDue()).toEqual({ processed: 0, failed: 0 });
       yield* TestClock.setTime(420_000);
-      yield* scheduler.process(keyOf(request));
+      yield* (yield* ScheduleDriver).process(keyOf(request));
       expect(intended).toEqual([180_000, 360_000, 420_000]);
     }).pipe(
       Effect.provide(
@@ -180,11 +344,9 @@ describe("Scheduling public recovery contract", () => {
       yield* scheduler.create(agent, input, request);
       input.text = "mutated";
       const first = yield* scheduler.get(scope, request.scheduleId);
-      expect(first.configuration.input).toEqual({ text: "original" });
-      Reflect.set(first.configuration, "input", { text: "changed snapshot" });
-      expect((yield* scheduler.get(scope, request.scheduleId)).configuration.input).toEqual({
-        text: "original",
-      });
+      expect(first.configuration).not.toHaveProperty("input");
+      const store = yield* ScheduleStore;
+      expect((yield* store.get(keyOf(request)))?.configuration.input).toEqual({ text: "original" });
       const capacity = yield* scheduler
         .create(agent, { text: "new" }, options("excess"))
         .pipe(Effect.flip);
@@ -192,9 +354,8 @@ describe("Scheduling public recovery contract", () => {
       const otherScope = { ...scope, owner: { ...scope.owner, ownerId: "other" } };
       yield* scheduler.create(agent, { text: "other" }, { ...request, scope: otherScope });
       const page = yield* scheduler.list(scope);
-      expect(page.items.map((record) => record.configuration.input)).toEqual([
-        { text: "original" },
-      ]);
+      expect(page.items.map((record) => record.scheduleId)).toEqual([request.scheduleId]);
+      expect(JSON.stringify(page)).not.toContain("original");
       expect(page.next).toBeNull();
       const oversized = yield* scheduler
         .create(
@@ -238,7 +399,6 @@ describe("Scheduling public recovery contract", () => {
         expect(replay.nextAtMillis).toBe(32_000);
         expect(replay.createdAtMillis).toBe(0);
         expect(replay.configurationRevision).toBe(2);
-        expect(replay.creationFingerprint).toBe(created.creationFingerprint);
         const conflict = yield* scheduler
           .create(agent, { text: "different" }, request)
           .pipe(Effect.flip);
@@ -273,7 +433,7 @@ describe("Scheduling public recovery contract", () => {
         const scheduler = yield* Scheduling;
         const request = options("lost-reply");
         yield* scheduler.create(agent, { text: "frozen" }, request);
-        const pending = yield* scheduler.process(keyOf(request));
+        const pending = yield* (yield* ScheduleDriver).process(keyOf(request));
         expect(pending.pending?.retry.lastFailure).toBe("ambiguous");
         expect(pending.pending?.retry.nextAttemptAtMillis).toBe(1_000);
         const envelope = pending.pending?.envelope;
@@ -290,13 +450,19 @@ describe("Scheduling public recovery contract", () => {
             timing: { _tag: "At", atMillis: 50_000 },
           },
         );
-        expect(updated.pending?.envelope).toEqual(envelope);
+        expect(updated.pending?.occurrenceId).toBe(envelope?.occurrenceId);
+        expect((yield* (yield* ScheduleStore).get(keyOf(request)))?.pending?.envelope).toEqual(
+          envelope,
+        );
         yield* scheduler.pause(scope, request.scheduleId, 2);
         const cancelled = yield* scheduler.cancel(scope, request.scheduleId, 2);
-        expect(cancelled.pending?.envelope).toEqual(envelope);
+        expect(cancelled.pending?.occurrenceId).toBe(envelope?.occurrenceId);
+        expect((yield* (yield* ScheduleStore).get(keyOf(request)))?.pending?.envelope).toEqual(
+          envelope,
+        );
         revoked = true;
         yield* TestClock.adjust(1_000);
-        const recovered = yield* scheduler.process(keyOf(request));
+        const recovered = yield* (yield* ScheduleDriver).process(keyOf(request));
         expect(recovered.state).toBe("cancelled");
         expect(recovered.pending).toBeNull();
         expect(recovered.nextAtMillis).toBeNull();
@@ -323,12 +489,14 @@ describe("Scheduling public recovery contract", () => {
       yield* Effect.forEach(requests, (request) =>
         scheduler.create(agent, { text: "work" }, request),
       );
-      yield* Effect.all([scheduler.runDue(), scheduler.runDue()], { concurrency: "unbounded" });
+      yield* Effect.all([(yield* ScheduleDriver).runDue(), (yield* ScheduleDriver).runDue()], {
+        concurrency: "unbounded",
+      });
       const snapshots = yield* scheduler.list(scope);
       expect(snapshots.items.map((record) => record.pending)).toEqual([null, null]);
       expect(snapshots.items.every((record) => record.lastReceipt !== null)).toBe(true);
       expect(admitted.size).toBe(2);
-      expect(yield* scheduler.runDue()).toEqual([]);
+      expect(yield* (yield* ScheduleDriver).runDue()).toEqual({ processed: 0, failed: 0 });
     }).pipe(Effect.provide(layer(submit)));
   });
 
@@ -344,10 +512,13 @@ describe("Scheduling public recovery contract", () => {
       const scheduler = yield* Scheduling;
       const request = options("wrong-receipt");
       yield* scheduler.create(agent, { text: "work" }, request);
-      const failure = yield* scheduler.process(keyOf(request)).pipe(Effect.flip);
+      const failure = yield* (yield* ScheduleDriver).process(keyOf(request)).pipe(Effect.flip);
       expect(failure).toMatchObject({ _tag: "ScheduleStorageError", reason: "corrupt" });
       const current = yield* scheduler.get(scope, request.scheduleId);
-      expect(current.pending?.envelope.input).toEqual({ text: "work" });
+      expect(current.pending).not.toBeNull();
+      expect((yield* (yield* ScheduleStore).get(keyOf(request)))?.pending?.envelope.input).toEqual({
+        text: "work",
+      });
       expect(current.lastReceipt).toBeNull();
     }).pipe(Effect.provide(layer(submit)));
   });
@@ -377,7 +548,7 @@ describe("Scheduling public recovery contract", () => {
         const scheduler = yield* Scheduling;
         const request = options("completion-storage-backoff");
         yield* scheduler.create(agent, { text: "work" }, request);
-        const pending = yield* scheduler.process(keyOf(request));
+        const pending = yield* (yield* ScheduleDriver).process(keyOf(request));
         expect(pending.pending?.retry).toMatchObject({
           attempts: 1,
           nextAttemptAtMillis: 1_000,
@@ -385,7 +556,7 @@ describe("Scheduling public recovery contract", () => {
         });
         expect(pending.lastReceipt).toBeNull();
         yield* TestClock.adjust(1_000);
-        const completed = yield* scheduler.process(keyOf(request));
+        const completed = yield* (yield* ScheduleDriver).process(keyOf(request));
         expect(completed.pending).toBeNull();
         expect(completed.lastReceipt).not.toBeNull();
       }).pipe(Effect.provide(layer(undefined, allow, defaultSchedulingLimits, wrappedStore)));
@@ -434,7 +605,7 @@ describe("Scheduling public recovery contract", () => {
         const request = options("corrupt-current-input");
         yield* scheduler.create(agent, { text: "original" }, request);
         corruptReads = true;
-        const failure = yield* scheduler.process(keyOf(request)).pipe(Effect.flip);
+        const failure = yield* (yield* ScheduleDriver).process(keyOf(request)).pipe(Effect.flip);
         expect(failure).toMatchObject({ _tag: "ScheduleStorageError", reason: "corrupt" });
         expect(yield* Ref.get(preparations)).toBe(0);
         expect(yield* Ref.get(submissions)).toBe(0);
@@ -531,9 +702,9 @@ describe("Scheduling public recovery contract", () => {
         const b = options("bounded-b");
         yield* scheduler.create(agent, { text: "a" }, a);
         yield* scheduler.create(agent, { text: "b" }, b);
-        const first = yield* scheduler.process(keyOf(a)).pipe(Effect.forkScoped);
+        const first = yield* (yield* ScheduleDriver).process(keyOf(a)).pipe(Effect.forkScoped);
         yield* Deferred.await(firstEntered);
-        const second = yield* scheduler.process(keyOf(b)).pipe(Effect.forkScoped);
+        const second = yield* (yield* ScheduleDriver).process(keyOf(b)).pipe(Effect.forkScoped);
         yield* Effect.yieldNow;
         expect(yield* Ref.get(active)).toBe(1);
         yield* Deferred.succeed(releaseFirst, undefined);
@@ -562,7 +733,7 @@ describe("Scheduling public recovery contract", () => {
       const scheduler = yield* Scheduling;
       const request = options("one-shot-refusal");
       yield* scheduler.create(agent, { text: "work" }, request);
-      const denied = yield* scheduler.process(keyOf(request));
+      const denied = yield* (yield* ScheduleDriver).process(keyOf(request));
       expect(denied.state).toBe("paused");
       expect(denied.pending).toBeNull();
       expect(denied.nextAtMillis).toBe(0);
@@ -570,13 +741,13 @@ describe("Scheduling public recovery contract", () => {
       yield* TestClock.adjust(5_000);
       const resumed = yield* scheduler.resume(scope, request.scheduleId, 1);
       expect(resumed.nextAtMillis).toBe(0);
-      const refused = yield* scheduler.process(keyOf(request));
+      const refused = yield* (yield* ScheduleDriver).process(keyOf(request));
       expect(refused.lastRefusal?.phase).toBe("admission");
       expect(refused.pending).toBeNull();
       expect(refused.state).toBe("paused");
       const secondResume = yield* scheduler.resume(scope, request.scheduleId, 1);
       expect(secondResume.nextAtMillis).toBeNull();
-      expect(yield* scheduler.runDue()).toEqual([]);
+      expect(yield* (yield* ScheduleDriver).runDue()).toEqual({ processed: 0, failed: 0 });
       const updated = yield* scheduler.update(
         agent,
         { text: "changed" },
@@ -615,7 +786,9 @@ describe("Scheduling public recovery contract", () => {
         const scheduler = yield* Scheduling;
         const request = options("failure-paths");
         yield* scheduler.create(agent, { text: "work" }, request);
-        const timed = yield* scheduler.process(keyOf(request)).pipe(Effect.forkScoped);
+        const timed = yield* (yield* ScheduleDriver)
+          .process(keyOf(request))
+          .pipe(Effect.forkScoped);
         yield* Deferred.await(entered);
         yield* TestClock.adjust(100);
         const pending = yield* Fiber.join(timed);
@@ -623,20 +796,22 @@ describe("Scheduling public recovery contract", () => {
         const envelope = pending.pending?.envelope;
         yield* TestClock.adjust(1_000);
         behavior = "interruption";
-        const interrupted = yield* scheduler.process(keyOf(request)).pipe(Effect.forkScoped);
+        const interrupted = yield* (yield* ScheduleDriver)
+          .process(keyOf(request))
+          .pipe(Effect.forkScoped);
         yield* Effect.yieldNow;
         yield* Fiber.interrupt(interrupted);
-        expect((yield* scheduler.get(scope, request.scheduleId)).pending?.envelope).toEqual(
+        expect((yield* (yield* ScheduleStore).get(keyOf(request)))?.pending?.envelope).toEqual(
           envelope,
         );
         behavior = "defect";
-        const defect = yield* scheduler.process(keyOf(request)).pipe(Effect.exit);
+        const defect = yield* (yield* ScheduleDriver).process(keyOf(request)).pipe(Effect.exit);
         expect(defect._tag).toBe("Failure");
-        expect((yield* scheduler.get(scope, request.scheduleId)).pending?.envelope).toEqual(
+        expect((yield* (yield* ScheduleStore).get(keyOf(request)))?.pending?.envelope).toEqual(
           envelope,
         );
         behavior = "success";
-        const completed = yield* scheduler.process(keyOf(request));
+        const completed = yield* (yield* ScheduleDriver).process(keyOf(request));
         expect(completed.pending).toBeNull();
         expect(completed.lastReceipt?.occurrenceId).toBe(envelope?.occurrenceId);
       }).pipe(

--- a/packages/storage-sqlite/src/sqlite-schedule-store.ts
+++ b/packages/storage-sqlite/src/sqlite-schedule-store.ts
@@ -1,5 +1,8 @@
 import {
   ScheduleCapacityError,
+  ScheduleDueCursor,
+  defaultSchedulingLimits,
+  scheduleUsesCapacity,
   ScheduleChange,
   ScheduleConflict,
   ScheduleFailpoint,
@@ -36,6 +39,13 @@ class ScheduleRow extends Schema.Class<ScheduleRow>("@effect-agent/storage-sqlit
   deadline_at_millis: StoredDeadline,
   record_json: StoredScheduleJson,
 }) {}
+
+const ScheduleDueRow = Schema.Struct({
+  tenant_id: ScheduleOwner.fields.tenantId,
+  owner_id: ScheduleOwner.fields.ownerId,
+  schedule_id: ScheduleId,
+  deadline_at_millis: ScheduleInstant,
+});
 
 class ScheduleCountRow extends Schema.Class<ScheduleCountRow>(
   "@effect-agent/storage-sqlite/ScheduleCountRow",
@@ -153,6 +163,8 @@ const makeScheduleStore = Effect.gen(function* () {
             FROM effect_agent_schedules
             WHERE tenant_id = ${canonical.owner.tenantId}
               AND owner_id = ${canonical.owner.ownerId}
+              AND (json_extract(record_json, '$.pending') IS NOT NULL OR
+                (json_extract(record_json, '$.state') != 'cancelled' AND json_extract(record_json, '$.nextAtMillis') IS NOT NULL))
           `.pipe(Effect.mapError(() => unavailable(operation)));
             const counts = yield* decodeRows(Schema.Array(ScheduleCountRow), rawCounts, operation);
             if (counts.length !== 1) return yield* corrupt(operation);
@@ -219,7 +231,7 @@ const makeScheduleStore = Effect.gen(function* () {
   });
 
   const change: ScheduleStore["Service"]["change"] = Effect.fn("SqliteScheduleStore.change")(
-    function* (key, change) {
+    function* (key, change, ownerLimit = defaultSchedulingLimits.maxSchedulesPerOwner) {
       const operation = "change schedule";
       const decodedKey = yield* decodeInput(operation, ScheduleKey, key);
       const decodedChange = yield* decodeInput(operation, ScheduleChange, change);
@@ -231,6 +243,22 @@ const makeScheduleStore = Effect.gen(function* () {
             const transition = applyScheduleChange(current, decodedChange);
             if (Result.isFailure(transition)) return yield* transition.failure;
             const next = transition.success;
+            if (!scheduleUsesCapacity(current) && scheduleUsesCapacity(next)) {
+              const rawCounts = yield* sql<Record<string, unknown>>`
+              SELECT COUNT(*) AS schedule_count FROM effect_agent_schedules
+              WHERE tenant_id = ${key.owner.tenantId} AND owner_id = ${key.owner.ownerId}
+                AND (json_extract(record_json, '$.pending') IS NOT NULL OR
+                  (json_extract(record_json, '$.state') != 'cancelled' AND json_extract(record_json, '$.nextAtMillis') IS NOT NULL))
+            `.pipe(Effect.mapError(() => unavailable(operation)));
+              const counts = yield* decodeRows(
+                Schema.Array(ScheduleCountRow),
+                rawCounts,
+                operation,
+              );
+              if (counts.length !== 1) return yield* corrupt(operation);
+              if (counts[0].schedule_count >= ownerLimit)
+                return yield* ScheduleCapacityError.make({ limit: ownerLimit });
+            }
             if (next === current) return { record: current, changed: false } as const;
             const recordJson = yield* encodeRecord(next);
             yield* scheduleFailpoint.hit(`schedule:${decodedChange._tag.toLowerCase()}:before`);
@@ -256,30 +284,47 @@ const makeScheduleStore = Effect.gen(function* () {
     nowMillis,
     limit,
     owner?: ScheduleOwner,
+    after?: ScheduleDueCursor,
   ) {
     const operation = "query due schedules";
     const decodedOwner =
       owner === undefined ? undefined : yield* decodeInput(operation, ScheduleOwner, owner);
+    const cursor =
+      after === undefined
+        ? undefined
+        : yield* Schema.decodeUnknownEffect(ScheduleDueCursor)(after).pipe(
+            Effect.mapError(() => corrupt(operation)),
+          );
+    const continuation =
+      cursor === undefined
+        ? sql`1 = 1`
+        : sql`
+      (deadline_at_millis, tenant_id, owner_id, schedule_id) >
+      (${cursor.deadlineAtMillis}, ${cursor.owner.tenantId}, ${cursor.owner.ownerId}, ${cursor.scheduleId})`;
     const rows =
       decodedOwner === undefined
         ? yield* sql<Record<string, unknown>>`
-            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis, record_json
+            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis
             FROM effect_agent_schedules
-            WHERE deadline_at_millis <= ${nowMillis}
+            WHERE deadline_at_millis <= ${nowMillis} AND ${continuation}
             ORDER BY deadline_at_millis, tenant_id, owner_id, schedule_id
             LIMIT ${limit}
           `.pipe(Effect.mapError(() => unavailable(operation)))
         : yield* sql<Record<string, unknown>>`
-            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis, record_json
+            SELECT tenant_id, owner_id, schedule_id, deadline_at_millis
             FROM effect_agent_schedules
             WHERE tenant_id = ${decodedOwner.tenantId}
               AND owner_id = ${decodedOwner.ownerId}
-              AND deadline_at_millis <= ${nowMillis}
+              AND deadline_at_millis <= ${nowMillis} AND ${continuation}
             ORDER BY deadline_at_millis, schedule_id
             LIMIT ${limit}
           `.pipe(Effect.mapError(() => unavailable(operation)));
-    const decoded = yield* decodeRows(Schema.Array(ScheduleRow), rows, operation);
-    return yield* Effect.forEach(decoded, decodeRecord);
+    const decoded = yield* decodeRows(Schema.Array(ScheduleDueRow), rows, operation);
+    return decoded.map((row) => ({
+      owner: { tenantId: row.tenant_id, ownerId: row.owner_id },
+      scheduleId: row.schedule_id,
+      deadlineAtMillis: row.deadline_at_millis,
+    }));
   });
 
   const nextDeadline: ScheduleStore["Service"]["nextDeadline"] = Effect.fn(


### PR DESCRIPTION
## Summary

Follow up on #212 to fix authorization bypasses, missed DST deliveries, schedule starvation, and resume retries that skip due work. Also separate operational capacity from retained replay evidence, allow hosts to choose a positive interval minimum below the one-minute default, and make public status independent of the persistence record.

## What went wrong

- `Scheduling.process` and `runDue` shared the management service but bypassed management authorization and returned full records. A caller denied by `get` could still retrieve input through `process`. Management now exposes only authorized operations; driver authority requires a separate service.
- Due cron calculation used `Cron.prev`, whose named-zone behavior is not the inverse of registration's forward calculation. New York's nonexistent 02:30 on March 8, 2026 was registered successfully but rejected during processing. Due selection now follows the forward sequence and derives its next cursor from the selected occurrence. Calendar-date seeking avoids enumerating every firing missed during long downtime.
- A single error failed a bounded batch and left the failing record at the front of the next query. The driver now pages through indexed keys and isolates record reads and processing failures, so even corrupt stored JSON cannot block healthy work. Failed sweeps retain recovery wakes and back off instead of spinning.
- `resume` recalculated the cursor even when the schedule was already active. It now leaves active state unchanged after authorization and revision validation, including the due cursor and storage version.

## Architecture and consumer changes

- [Management and driver services](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/session/src/scheduling.ts#L859) are separate capabilities. Both platform Layers provide `Scheduling`; Cloudflare callers now yield it instead of `CloudflareSchedulingClient`. Privileged local drivers use `ScheduleDriver.layer`.
- [Public status](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/session/src/schedule.ts#L159) explicitly projects timing, state, retry status, and recent outcomes. It omits input, fingerprints, storage versions, and pending admission envelopes.
- [Due sweeps](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/session/src/scheduling.ts#L798) use bounded query pages and admission concurrency. `dueBatchSize` now limits a page, not the total sweep.
- Capacity counts pending delivery or a remaining active/paused cursor. Completed and cancelled schedules without pending delivery retain creation replay evidence without consuming capacity. Reactivation checks capacity in the same transaction. Retained records still consume storage; this change does not expire idempotency evidence or reuse IDs.
- The immutable pending envelope, ordinary Submission admission, explicit occurrence authorization, and shared transition reducer remain intact. SQLite and Cloudflare keep their separate adapters; no job framework or persistence migration is introduced.

The [scheduling specification](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/docs/spec/scheduling.md) and changeset document these contract changes.

## Evidence

Regression cases verified locally:

| Case | Observed result |
| --- | --- |
| New York `30 2 * * *` on March 8, 2026 | Admits the shifted occurrence at `07:30Z`, then March 9 at `06:30Z`. |
| Repeat resume when the 60,000ms interval is due | Preserves the 60,000ms cursor and storage version, then admits that occurrence. |
| One-record pages with storage, defect, or decode failure | First sweep reports one processed and one failed; healthy work completes and the failed schedule remains recoverable. |
| Corrupt JSON in a Cloudflare Schedule Owner | Healthy neighboring work completes and a future recovery alarm remains armed. |
| Owner capacity of one | Cancellation retains unresolved pending capacity; completion releases it without losing replay evidence. Reactivation at capacity fails without mutation. |

See the [management and recovery regressions](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/storage-memory/test/scheduling-regressions.test.ts#L127), [Cloudflare corruption regression](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/platform-cloudflare/test/scheduling.test.ts#L192), and [capacity contract shared by all three stores](https://github.com/danieljvdm/effect-agent/blob/3c51064aef63220a1bb824758870ba93c2cdbd24/packages/session/src/schedule-conformance.ts#L265).
