### PR TITLE
feat(platform-cloudflare): expose host browser viewport controls

### DIFF
--- a/.changeset/host-browser-viewport.md
+++ b/.changeset/host-browser-viewport.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/platform-cloudflare": minor
+---
+
+Expose a validated launch viewport and host-only session resizing without spending the agent action budget.
+
+BEHAVIOR CHANGE: Handle `InteractiveBrowserPolicyDeniedError` when building `BrowserRunInteractiveBinding.layer` with invalid viewport configuration.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -148,9 +148,30 @@ Effect `HttpClient` requirement. The Node-safe `./browser-rest-crawl` export ada
 Cloudflare's REST crawl endpoint with explicit redacted credentials, bounded polling and lazy
 pagination, and scoped remote-job cleanup. Neither REST subpath imports Worker runtime modules.
 The `./interactive-browser` export supplies `browserRunInteractiveLayer` for the generic browser
-port and `browserRunInteractiveHostLayer` for host-only Live View, handoff, redacted session
+port and `browserRunInteractiveHostLayer` for host-only viewport resizing, Live View, handoff, redacted session
 identity, and explicit cleanup by identity. Both require `BrowserRunInteractiveBinding`; neither
 adds a registry, execution reconnect, or durable browser state.
+
+`BrowserRunInteractiveBinding.layer({ browser, viewport: { width: 1440, height: 900 } })`
+sets Puppeteer's launch `defaultViewport`. Omitting `viewport` preserves Puppeteer's default.
+The exported `BrowserRunViewport` Schema accepts integer CSS dimensions in `1..2048`, optional
+finite `deviceScaleFactor` in `1..2`, defaulting to `1`, and requires
+`max(width, height) * deviceScaleFactor <= 2048`. Hosts can impose narrower UI limits.
+Invalid configuration fails Layer construction with `InteractiveBrowserPolicyDeniedError`
+before launching a browser.
+
+`session.resizeViewport({ width: 1024, height: 768, deviceScaleFactor: 2 })` changes host
+presentation state through `page.setViewport`. It spends no agent action and remains available
+after the action budget is exhausted. It shares the session's fail-fast operation lock,
+page-policy preflight, elapsed deadline, and cleanup. Invalid requests are policy failures;
+provider failures are protocol errors, remote closure is an expired-session error, and timeout
+or interruption makes the session unusable without retrying the resize. Width, height, and
+density are the only supported fields. Mobile, touch, and orientation emulation switches are
+rejected, so resizing does not trigger an emulation-mode reload. Page scripts can still react to
+resize events, subject to the existing network policy. The adapter adds no viewport telemetry
+payload or persistence. The consumer must authorize resizing, including viewer ownership and
+handoff fencing.
+
 This is a Layer-assembly library, not an application entrypoint.
 `CloudflareDurableRuntimeOptions.toolFailureObserver` installs the same closed trusted observer
 for the Object's coordinator. It adds no journal data or Code Mode durability claim.

--- a/packages/platform-cloudflare/src/interactive-browser.ts
+++ b/packages/platform-cloudflare/src/interactive-browser.ts
@@ -132,6 +132,38 @@ const HandoffStateObservation = Schema.Union([
   }),
 ]);
 
+/**
+ * Host presentation state in CSS pixels. Dimensions are integers in 1..2048,
+ * density is finite in 1..2 (default 1), and neither scaled dimension may exceed
+ * 2048 pixels. Mobile, touch, and orientation emulation are not supported.
+ */
+export class BrowserRunViewport extends Schema.Class<BrowserRunViewport>("BrowserRunViewport")(
+  Schema.Struct({
+    width: PositiveInt.check(Schema.isLessThanOrEqualTo(2_048)),
+    height: PositiveInt.check(Schema.isLessThanOrEqualTo(2_048)),
+    deviceScaleFactor: Schema.optionalKey(
+      Schema.Finite.check(Schema.isBetween({ minimum: 1, maximum: 2 })),
+    ),
+  }).check(
+    Schema.makeFilter(
+      (viewport) =>
+        Math.max(viewport.width, viewport.height) * (viewport.deviceScaleFactor ?? 1) <= 2_048,
+      { title: "a viewport with scaled dimensions no larger than 2048 pixels" },
+    ),
+  ),
+) {}
+
+const decodeViewport = (input: BrowserRunViewport) =>
+  Schema.decodeUnknownEffect(BrowserRunViewport)(input, { onExcessProperty: "error" }).pipe(
+    Effect.mapError(() => policyError("The browser viewport is malformed")),
+    // Copy only presentation fields, including for Schema class instances.
+    Effect.map((viewport) => ({
+      width: viewport.width,
+      height: viewport.height,
+      deviceScaleFactor: viewport.deviceScaleFactor ?? 1,
+    })),
+  );
+
 /** Host-only request for a redacted Cloudflare Live View URL. */
 export class BrowserRunLiveViewRequest extends Schema.Class<BrowserRunLiveViewRequest>(
   "BrowserRunLiveViewRequest",
@@ -213,6 +245,7 @@ export interface BrowserRunInteractivePage {
   readonly click: (selector: string) => Promise<void>;
   readonly screenshot: (fullPage: boolean) => Promise<unknown>;
   readonly scroll: (deltaX: number, deltaY: number) => Promise<void>;
+  readonly setViewport: (viewport: BrowserRunViewport) => Promise<void>;
   readonly createCdpSession: () => Promise<BrowserRunInteractiveCdpSession>;
 }
 
@@ -240,23 +273,40 @@ export class BrowserRunInteractiveBinding extends Context.Service<
 >()("@effect-agent/platform-cloudflare/BrowserRunInteractiveBinding") {
   static layer(options: {
     readonly browser: BrowserRun;
-  }): Layer.Layer<BrowserRunInteractiveBinding> {
-    return Layer.succeed(BrowserRunInteractiveBinding)({
-      launch: async (keepAliveMillis) =>
-        makeProductionBrowser(
-          await puppeteer.launch(options.browser, {
-            keep_alive: keepAliveMillis,
-          }),
-        ),
-      connect: async (sessionId) =>
-        makeProductionBrowser(await puppeteer.connect(options.browser, sessionId)),
-    });
+    readonly viewport?: BrowserRunViewport;
+  }): Layer.Layer<BrowserRunInteractiveBinding, InteractiveBrowserPolicyDeniedError> {
+    return Layer.effect(BrowserRunInteractiveBinding)(
+      Effect.gen(function* () {
+        const viewport =
+          options.viewport === undefined ? undefined : yield* decodeViewport(options.viewport);
+        return {
+          launch: async (keepAliveMillis: number) =>
+            makeProductionBrowser(
+              await puppeteer.launch(options.browser, {
+                keep_alive: keepAliveMillis,
+                ...(viewport === undefined ? {} : { defaultViewport: { ...viewport } }),
+              }),
+            ),
+          connect: async (sessionId: string) =>
+            makeProductionBrowser(await puppeteer.connect(options.browser, sessionId)),
+        };
+      }),
+    );
   }
 }
 
 export interface BrowserRunInteractiveSession {
   readonly handle: BrowserHandle;
   readonly sessionId: Redacted.Redacted<string>;
+  /**
+   * Resize without charging an agent action or changing emulation modes. Shares
+   * the handle's fail-fast lock, page-policy preflight, and elapsed deadline.
+   * A timeout or interruption leaves the session unusable; no resize is retried.
+   * The host must authorize callers. No viewer ownership or durable state is added.
+   */
+  readonly resizeViewport: (
+    viewport: BrowserRunViewport,
+  ) => Effect.Effect<void, InteractiveBrowserError>;
   readonly getLiveView: (
     request: BrowserRunLiveViewRequest,
   ) => Effect.Effect<BrowserRunLiveViewResult, InteractiveBrowserError>;
@@ -385,6 +435,7 @@ const makeProductionPage = (page: Page): BrowserRunInteractivePage => {
         deltaY,
       ),
     createCdpSession: async () => makeProductionCdpSession(await page.createCDPSession()),
+    setViewport: (viewport) => page.setViewport(viewport),
   };
 };
 
@@ -590,6 +641,7 @@ interface HandleRuntime {
   readonly run: <A>(
     effect: Effect.Effect<A, BrowserFailure>,
     preflight?: Effect.Effect<void, BrowserFailure>,
+    consumeAction?: boolean,
   ) => Effect.Effect<A, BrowserFailure>;
 }
 
@@ -700,6 +752,7 @@ const makeHandle = Effect.fn("BrowserRunInteractive.makeHandle")(function* (
   const run = <A>(
     effect: Effect.Effect<A, BrowserFailure>,
     preflight: Effect.Effect<void, BrowserFailure> = Effect.void,
+    consumeAction = true,
   ) =>
     permits
       .withPermitsIfAvailable(1)(
@@ -708,19 +761,21 @@ const makeHandle = Effect.fn("BrowserRunInteractive.makeHandle")(function* (
           if (unavailable !== undefined) return yield* unavailable;
           yield* preflight;
 
-          const admitted = yield* Ref.modify(actions, (count) =>
-            count >= policy.maxActions
-              ? [{ allowed: false, observed: count + 1 }, count]
-              : [{ allowed: true, observed: count + 1 }, count + 1],
-          );
-          if (!admitted.allowed) {
-            return yield* InteractiveBrowserLimitError.make({
-              implementation: browserRunInteractiveImplementation,
-              limit: "actions",
-              maximum: policy.maxActions,
-              observed: admitted.observed,
-              message: "The browser action limit was reached",
-            });
+          if (consumeAction) {
+            const admitted = yield* Ref.modify(actions, (count) =>
+              count >= policy.maxActions
+                ? [{ allowed: false, observed: count + 1 }, count]
+                : [{ allowed: true, observed: count + 1 }, count + 1],
+            );
+            if (!admitted.allowed) {
+              return yield* InteractiveBrowserLimitError.make({
+                implementation: browserRunInteractiveImplementation,
+                limit: "actions",
+                maximum: policy.maxActions,
+                observed: admitted.observed,
+                message: "The browser action limit was reached",
+              });
+            }
           }
 
           const completed = effect.pipe(
@@ -1204,6 +1259,25 @@ const makeHostService = (
     return {
       handle: runtime.handle,
       sessionId: Redacted.make(sessionIdValue),
+      resizeViewport: (viewport) =>
+        decodeViewport(viewport).pipe(
+          Effect.flatMap((decoded) =>
+            runtime.run(
+              Effect.tryPromise({
+                try: () => page.setViewport(decoded),
+                catch: (cause) => {
+                  if (state.disconnected.value || isRemoteClosure(cause)) {
+                    state.disconnected.value = true;
+                    return expiredError();
+                  }
+                  return protocolError("Resizing the browser viewport failed", cause);
+                },
+              }),
+              currentPagePreflight,
+              false,
+            ),
+          ),
+        ),
       getLiveView: (request) =>
         Schema.decodeUnknownEffect(BrowserRunLiveViewRequest)(request).pipe(
           Effect.mapError(() => policyError("The Live View request is malformed")),

--- a/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
@@ -1,0 +1,167 @@
+import { InteractiveBrowserPolicy } from "@effect-agent/sandbox";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Schema } from "effect";
+import { vi } from "vite-plus/test";
+
+import {
+  BrowserRunInteractiveBinding,
+  BrowserRunInteractiveHost,
+  BrowserRunViewport,
+  browserRunInteractiveHostLayer,
+} from "../src/interactive-browser.ts";
+
+const sdk = vi.hoisted(() => ({ launch: vi.fn<(...args: Array<unknown>) => Promise<object>>() }));
+vi.mock("@cloudflare/puppeteer", () => ({ default: sdk }));
+
+const unusedRpc = async (): Promise<Response> => {
+  throw new Error("The mocked SDK must not call Browser Run");
+};
+const browser = { fetch: unusedRpc, quickAction: unusedRpc };
+
+const open = Effect.gen(function* () {
+  const host = yield* BrowserRunInteractiveHost;
+  return yield* host.open(
+    InteractiveBrowserPolicy.make({
+      network: { _tag: "ExactHosts", allowedHosts: ["example.com"] },
+      maxActions: 1,
+      maxElapsedMillis: 5_000,
+      maxReturnedBytes: 1_024,
+    }),
+  );
+});
+
+describe("Browser Run viewport boundary", () => {
+  it.effect.each([
+    { width: 1, height: 1 },
+    { width: 2_048, height: 2_048 },
+    { width: 1_440, height: 900, deviceScaleFactor: 1 },
+    { width: 1_024, height: 1_024, deviceScaleFactor: 2 },
+    { width: 1_280, height: 720, deviceScaleFactor: 1.5 },
+  ])("round-trips bounded presentation state (%#)", (input) =>
+    Effect.gen(function* () {
+      const viewport = yield* Schema.decodeUnknownEffect(BrowserRunViewport)(input);
+      const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(BrowserRunViewport))(
+        viewport,
+      );
+      expect(
+        yield* Schema.decodeUnknownEffect(Schema.fromJsonString(BrowserRunViewport))(encoded),
+      ).toEqual(viewport);
+      expect(JSON.parse(encoded)).toEqual(input);
+    }),
+  );
+
+  it.effect.each([
+    { width: 0, height: 600 },
+    { width: -1, height: 600 },
+    { width: 800.5, height: 600 },
+    { width: 800, height: 0 },
+    { width: 800, height: 600.5 },
+    { width: NaN, height: 600 },
+    { width: 800, height: Infinity },
+    { width: 2_049, height: 600 },
+    { width: 800, height: 2_049 },
+    { width: 800, height: 600, deviceScaleFactor: NaN },
+    { width: 800, height: 600, deviceScaleFactor: Infinity },
+    { width: 800, height: 600, deviceScaleFactor: 0.5 },
+    { width: 800, height: 600, deviceScaleFactor: 2.1 },
+    { width: 1_025, height: 600, deviceScaleFactor: 2 },
+    { width: 800, height: 1_025, deviceScaleFactor: 2 },
+    { width: 800, height: 600, isMobile: true },
+    { width: 800, height: 600, hasTouch: true },
+    { width: 800, height: 600, isLandscape: true },
+  ])("rejects unsafe launch and resize requests without calling Puppeteer (%#)", (viewport) =>
+    Effect.gen(function* () {
+      sdk.launch.mockClear();
+      const error = yield* BrowserRunInteractiveBinding.pipe(
+        Effect.provide(BrowserRunInteractiveBinding.layer({ browser, viewport })),
+        Effect.flip,
+      );
+      expect(error).toMatchObject({ _tag: "InteractiveBrowserPolicyDeniedError" });
+      expect(sdk.launch).not.toHaveBeenCalled();
+
+      const setViewport = vi.fn<(...args: Array<unknown>) => Promise<void>>(async () => {});
+      mockBrowser(setViewport);
+      yield* Effect.gen(function* () {
+        const session = yield* open;
+        expect(yield* session.resizeViewport(viewport).pipe(Effect.flip)).toMatchObject({
+          _tag: "InteractiveBrowserPolicyDeniedError",
+        });
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(
+          browserRunInteractiveHostLayer().pipe(
+            Layer.provide(BrowserRunInteractiveBinding.layer({ browser })),
+          ),
+        ),
+      );
+      expect(setViewport).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect.each([
+    undefined,
+    { width: 1_440, height: 900 },
+    { width: 1_024, height: 768, deviceScaleFactor: 2 },
+  ])(
+    "forwards launch and resize presentation fields without emulation or navigation (%#)",
+    (viewport) =>
+      Effect.gen(function* () {
+        sdk.launch.mockClear();
+        const setViewport = vi.fn<(...args: Array<unknown>) => Promise<void>>(async () => {});
+        mockBrowser(setViewport);
+        yield* Effect.gen(function* () {
+          const session = yield* open;
+          yield* session.resizeViewport({ width: 960, height: 720, deviceScaleFactor: 2 });
+          yield* session.resizeViewport({ width: 1_440, height: 900 });
+        }).pipe(
+          Effect.scoped,
+          Effect.provide(
+            browserRunInteractiveHostLayer().pipe(
+              Layer.provide(
+                BrowserRunInteractiveBinding.layer({
+                  browser,
+                  ...(viewport === undefined ? {} : { viewport }),
+                }),
+              ),
+            ),
+          ),
+        );
+        expect(sdk.launch).toHaveBeenCalledExactlyOnceWith(browser, {
+          keep_alive: 10_000,
+          ...(viewport === undefined
+            ? {}
+            : {
+                defaultViewport: {
+                  ...viewport,
+                  deviceScaleFactor: viewport.deviceScaleFactor ?? 1,
+                },
+              }),
+        });
+        expect(setViewport.mock.calls).toEqual([
+          [{ width: 960, height: 720, deviceScaleFactor: 2 }],
+          [{ width: 1_440, height: 900, deviceScaleFactor: 1 }],
+        ]);
+      }),
+  );
+});
+
+// Transport substitute deliberately exposes no goto/reload or emulation methods.
+const mockBrowser = (setViewport: (viewport: unknown) => Promise<void>) => {
+  const page = {
+    setViewport,
+    url: () => "https://example.com/",
+    close: async () => {},
+    setBypassServiceWorker: async () => {},
+    setRequestInterception: async () => {},
+    on: () => {},
+    off: () => {},
+  };
+  sdk.launch.mockResolvedValue({
+    createBrowserContext: async () => ({ newPage: async () => page, close: async () => {} }),
+    sessionId: () => "viewport-regression",
+    isConnected: () => true,
+    on: () => {},
+    off: () => {},
+    close: async () => {},
+  });
+};

--- a/packages/platform-cloudflare/test/interactive-browser.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser.test.ts
@@ -20,6 +20,7 @@ import {
   BrowserRunInteractiveHost,
   BrowserRunLiveViewRequest,
   BrowserRunHandoffRequest,
+  BrowserRunViewport,
   browserRunInteractiveHostLayer,
   browserRunInteractiveLayer,
   type BrowserRunCloudflareCommand,
@@ -29,6 +30,7 @@ import {
   type BrowserRunInteractivePage,
   type BrowserRunInteractiveRequest,
   type BrowserRunInteractiveRequestListener,
+  type BrowserRunInteractiveSession,
 } from "../src/interactive-browser.ts";
 
 type Equal<Left, Right> =
@@ -40,6 +42,10 @@ type LayerRequirements<Value> =
 type InteractiveLayerRequiresBinding = Equal<
   LayerRequirements<ReturnType<typeof browserRunInteractiveLayer>>,
   BrowserRunInteractiveBinding
+>;
+type ResizeEffect = Equal<
+  ReturnType<BrowserRunInteractiveSession["resizeViewport"]>,
+  Effect.Effect<void, InteractiveBrowserError>
 >;
 type ScopedOpenRequirement = Equal<
   ReturnType<InteractiveBrowser["Service"]["open"]> extends Effect.Effect<
@@ -102,6 +108,7 @@ interface FixtureOptions {
   readonly click?: (selector: string) => Promise<void>;
   readonly screenshot?: (fullPage: boolean) => Promise<unknown>;
   readonly scroll?: (deltaX: number, deltaY: number) => Promise<void>;
+  readonly setViewport?: (viewport: BrowserRunViewport) => Promise<void>;
   readonly cdpSend?: (
     command: BrowserRunCloudflareCommand,
     parameters: unknown,
@@ -278,6 +285,10 @@ const makeFixture = (options: FixtureOptions = {}): Fixture => {
       };
       return options.createCdp === undefined ? session : options.createCdp(session);
     },
+    setViewport: async (viewport) => {
+      calls.push("page.setViewport");
+      await options.setViewport?.(viewport);
+    },
   };
 
   const context: BrowserRunInteractiveContext = {
@@ -410,10 +421,236 @@ const expectResourcesClosedOnce = (fixture: Fixture): void => {
 const awaitPromise = <A>(promise: Promise<A>): Effect.Effect<A> => Effect.promise(() => promise);
 
 describe("Browser Run interactive browser adapter", () => {
+  it.effect(
+    "resizes before and after action exhaustion without spending or restoring actions",
+    () =>
+      Effect.gen(function* () {
+        const viewports: Array<BrowserRunViewport> = [];
+        const fixture = makeFixture({
+          setViewport: async (viewport) => {
+            viewports.push(viewport);
+          },
+        });
+        yield* withHost(fixture, (host) =>
+          Effect.gen(function* () {
+            const session = yield* host.open(policy({ maxActions: 1 }));
+            yield* session.resizeViewport({ width: 1_440, height: 900 });
+            yield* session.handle.navigate(navigate());
+            yield* session.resizeViewport({ width: 1_024, height: 768, deviceScaleFactor: 2 });
+            expect(yield* session.handle.readText(readText()).pipe(Effect.flip)).toMatchObject({
+              _tag: "InteractiveBrowserLimitError",
+              limit: "actions",
+              observed: 2,
+            });
+          }),
+        );
+        expect(viewports).toEqual([
+          { width: 1_440, height: 900, deviceScaleFactor: 1 },
+          { width: 1_024, height: 768, deviceScaleFactor: 2 },
+        ]);
+        expectResourcesClosedOnce(fixture);
+      }),
+  );
+
+  it.effect("validates mutated viewport values before provider dispatch or budget admission", () =>
+    Effect.gen(function* () {
+      const fixture = makeFixture();
+      yield* withHost(fixture, (host) =>
+        Effect.gen(function* () {
+          const session = yield* host.open(policy({ maxActions: 1 }));
+          const viewport = BrowserRunViewport.make({ width: 1_440, height: 900 });
+          Reflect.set(viewport, "deviceScaleFactor", 2);
+          expect(yield* session.resizeViewport(viewport).pipe(Effect.flip)).toMatchObject({
+            _tag: "InteractiveBrowserPolicyDeniedError",
+          });
+          yield* session.handle.navigate(navigate());
+        }),
+      );
+      expect(fixture.calls).not.toContain("page.setViewport");
+      expectResourcesClosedOnce(fixture);
+    }),
+  );
+
+  it.effect.each([
+    "off-policy",
+    "malformed-url",
+    "closed",
+    "disconnected",
+    "elapsed",
+    "scope-closed",
+  ])("rejects resize on an unavailable page (%s)", (reason) =>
+    Effect.gen(function* () {
+      const fixture = makeFixture();
+      yield* withHost(fixture, (host) =>
+        Effect.gen(function* () {
+          const session = yield* reason === "scope-closed"
+            ? Effect.scoped(host.open(policy()))
+            : host.open(policy());
+          if (reason === "closed") yield* session.close;
+          if (reason === "disconnected") fixture.controls.disconnect();
+          if (reason === "off-policy") fixture.controls.setUrl("https://elsewhere.example/");
+          if (reason === "malformed-url") fixture.controls.setUrl(123);
+          if (reason === "elapsed") yield* TestClock.adjust(Duration.millis(5_000));
+          expect(
+            yield* session.resizeViewport({ width: 800, height: 600 }).pipe(Effect.flip),
+          ).toMatchObject({
+            _tag:
+              reason === "off-policy"
+                ? "InteractiveBrowserPolicyDeniedError"
+                : reason === "malformed-url"
+                  ? "InteractiveBrowserProtocolError"
+                  : reason === "elapsed"
+                    ? "InteractiveBrowserLimitError"
+                    : "InteractiveBrowserExpiredError",
+          });
+        }),
+      );
+      expect(fixture.calls).not.toContain("page.setViewport");
+      expectResourcesClosedOnce(fixture);
+    }),
+  );
+
+  it.effect.each(["resize", "navigate", "handoff"])(
+    "shares the fail-fast lock with %s and releases it on success",
+    (operation) =>
+      Effect.gen(function* () {
+        const gate = makeGate<void>();
+        const wait = () => {
+          gate.markStarted();
+          return gate.promise;
+        };
+        const fixture = makeFixture({
+          setViewport: operation === "resize" ? wait : undefined,
+          goto: operation === "navigate" ? wait : undefined,
+          cdpSend:
+            operation === "handoff"
+              ? async () => {
+                  await wait();
+                  return { active: false };
+                }
+              : undefined,
+        });
+        yield* withHost(fixture, (host) =>
+          Effect.gen(function* () {
+            const session = yield* host.open(policy());
+            const resize = session.resizeViewport({ width: 800, height: 600 });
+            const pending = yield* (
+              operation === "resize"
+                ? resize
+                : operation === "navigate"
+                  ? session.handle.navigate(navigate()).pipe(Effect.asVoid)
+                  : session.getHandoffState.pipe(Effect.asVoid)
+            ).pipe(Effect.forkChild);
+            yield* awaitPromise(gate.started);
+            expect(yield* resize.pipe(Effect.flip)).toMatchObject({
+              _tag: "InteractiveBrowserBusyError",
+            });
+            expect(yield* session.handle.readText(readText()).pipe(Effect.flip)).toMatchObject({
+              _tag: "InteractiveBrowserBusyError",
+            });
+            gate.resolve(undefined);
+            yield* Fiber.join(pending);
+            yield* resize;
+            yield* session.handle.readText(readText());
+          }),
+        );
+        expectResourcesClosedOnce(fixture);
+      }),
+  );
+
+  it.effect.each(["reject", "throw", "remote-closure"])(
+    "returns typed provider failures for resize (%s)",
+    (failure) =>
+      Effect.gen(function* () {
+        const cause = new Error(
+          failure === "remote-closure" ? "Target closed" : "private-provider-error",
+        );
+        const fixture = makeFixture({
+          setViewport: () => {
+            if (failure === "throw") throw cause;
+            return Promise.reject(cause);
+          },
+        });
+        yield* withHost(fixture, (host) =>
+          Effect.gen(function* () {
+            const session = yield* host.open(policy({ maxActions: 1 }));
+            const error = yield* session
+              .resizeViewport({ width: 800, height: 600 })
+              .pipe(Effect.flip);
+            expect(error).toMatchObject({
+              _tag:
+                failure === "remote-closure"
+                  ? "InteractiveBrowserExpiredError"
+                  : "InteractiveBrowserProtocolError",
+            });
+            if (failure === "remote-closure") {
+              expect(yield* session.handle.navigate(navigate()).pipe(Effect.flip)).toMatchObject({
+                _tag: "InteractiveBrowserExpiredError",
+              });
+            } else {
+              expect(error).toHaveProperty("cause", cause);
+              expect(error.message).not.toContain("private-provider-error");
+              yield* session.handle.navigate(navigate());
+            }
+          }),
+        );
+        expectResourcesClosedOnce(fixture);
+      }),
+  );
+
+  it.effect.each(["timeout", "interruption", "close"])(
+    "expires an in-flight resize after %s without replay",
+    (ending) =>
+      Effect.gen(function* () {
+        const gate = makeGate<void>();
+        const fixture = makeFixture({
+          setViewport: () => {
+            gate.markStarted();
+            return gate.promise;
+          },
+        });
+        yield* withHost(fixture, (host) =>
+          Effect.gen(function* () {
+            const session = yield* host.open(policy({ maxElapsedMillis: 100 }));
+            const resize = session.resizeViewport({ width: 800, height: 600 });
+            const pending = yield* resize.pipe(Effect.forkChild);
+            yield* awaitPromise(gate.started);
+            if (ending === "timeout") {
+              yield* TestClock.adjust(Duration.millis(100));
+              expect(yield* Fiber.join(pending).pipe(Effect.flip)).toMatchObject({
+                _tag: "InteractiveBrowserLimitError",
+                limit: "elapsed",
+              });
+            } else if (ending === "interruption") {
+              yield* Fiber.interrupt(pending);
+              expect(Exit.hasInterrupts(yield* Fiber.await(pending))).toBe(true);
+            } else {
+              yield* session.close;
+            }
+            gate.resolve(undefined);
+            if (ending === "close") {
+              expect(yield* Fiber.join(pending).pipe(Effect.flip)).toMatchObject({
+                _tag: "InteractiveBrowserExpiredError",
+              });
+            }
+            expect(yield* resize.pipe(Effect.flip)).toMatchObject({
+              _tag: "InteractiveBrowserExpiredError",
+            });
+            expect(yield* session.handle.readText(readText()).pipe(Effect.flip)).toMatchObject({
+              _tag: "InteractiveBrowserExpiredError",
+            });
+          }),
+        );
+        expect(fixture.calls.filter((call) => call === "page.setViewport")).toHaveLength(1);
+        expectResourcesClosedOnce(fixture);
+      }),
+  );
+
   it("keeps native binding authority visible in the Layer requirement", () => {
     const proof: InteractiveLayerRequiresBinding = true;
     const scoped: ScopedOpenRequirement = true;
-    expect(proof && scoped).toBe(true);
+    const resize: ResizeEffect = true;
+    expect(proof && scoped && resize).toBe(true);
   });
 
   it.effect("runs the bounded exact-host flow and closes page, context, then browser", () =>


### PR DESCRIPTION
## Summary

Expose launch viewport configuration and `BrowserRunInteractiveSession.resizeViewport` so [Kommunikasie #1041](https://github.com/reve-ai/kommunikasie/pull/1041) can stop patching this dependency for viewport support.

- [Validate presentation state](https://github.com/danieljvdm/effect-agent/blob/2d9d69b06bde7d8b52e6740321fb918f4f468ebb/packages/platform-cloudflare/src/interactive-browser.ts#L140) through exported `BrowserRunViewport`: integer CSS dimensions `1..2048`, finite density `1..2`, default `1`, and scaled dimensions at most `2048`. Invalid launch configuration is a typed Layer failure. Omitted launch configuration preserves Puppeteer's default.
- [Resize through the existing session runtime](https://github.com/danieljvdm/effect-agent/blob/2d9d69b06bde7d8b52e6740321fb918f4f468ebb/packages/platform-cloudflare/src/interactive-browser.ts#L1262), retaining its lock, page-policy preflight, deadline, and cleanup while bypassing action accounting. Only width, height, and density reach Puppeteer; emulation switches are rejected.
- Keep viewer ownership and TakeOver fencing in the consumer. No consumer files, alarm fixes, navigation fixes, persistence, or dependency versions change. Builds generate public declarations normally; no generated files are patched.

## Evidence

The two focused workerd browser suites pass: **76 tests**. [Budget and lifecycle regressions](https://github.com/danieljvdm/effect-agent/blob/2d9d69b06bde7d8b52e6740321fb918f4f468ebb/packages/platform-cloudflare/test/interactive-browser.test.ts#L424) cover resize after action exhaustion, serialization with other operations, closed/expired sessions, provider rejection and synchronous throws, timeout, interruption, and finalizers. [SDK-boundary tests](https://github.com/danieljvdm/effect-agent/blob/2d9d69b06bde7d8b52e6740321fb918f4f468ebb/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts#L34) cover JSON round trips, invalid inputs, and the exact launch/setViewport arguments. The SDK transport is mocked; this is not a live hosted-browser visual test.

## Consumer release gate

npm currently publishes `@effect-agent/platform-cloudflare@0.1.0-beta.36`, which lacks these APIs. [Version PR #216](https://github.com/danieljvdm/effect-agent/pull/216) currently proposes `0.1.0-beta.37` but does not yet include this change. Do not pin that version on this basis.

After Dan approves merging this PR, let Changesets regenerate the version PR to include `host-browser-viewport`. Dan must separately approve that release. Wait for successful npm publication, then install the actual published version containing these APIs, keeping installed `@effect-agent/*` packages on the shared release version and satisfying `effect-cf ^0.37.0`. No guessed version, Git dependency, or consumer viewport patch is needed. This PR does not authorize merge or publication.
