### PR TITLE
fix(platform-cloudflare): observe browser controls and fence mutations

### DIFF
--- a/.changeset/observed-browser-actions.md
+++ b/.changeset/observed-browser-actions.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Expose bounded JSON page text and form-control observations, including native option selection, and wait for DOM-ready navigation with a 30-second timeout. Require unique click/fill targets, export `isBrowserRunUndispatchedActionError`, and observe bounded fetch/XHR settlement while preserving uncertainty and cleanup on interruption.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -151,6 +151,34 @@ The `./interactive-browser` export supplies `browserRunInteractiveLayer` for the
 port and `browserRunInteractiveHostLayer` for host-only Live View, handoff, redacted session
 identity, and explicit cleanup by identity. Both require `BrowserRunInteractiveBinding`; neither
 adds a registry, execution reconnect, or durable browser state.
+Navigation waits for DOM content loaded, with a 30-second provider timeout bounded further by
+the pass deadline. `readText().text` contains JSON with `pageText`, `selectorMatchCount`,
+`controls`, and `controlsTruncated`. The inventory prioritizes form controls over links, includes
+visible labels for hidden native radios and options of visible native selects, and caps the list
+at 64 entries. Each entry has an exact structural CSS selector, kind, optional label, and available
+checked, selected, disabled, required, validity, and form-validity booleans. It never reads field
+values or HTML into control diagnostics. The entire JSON text remains subject to the pass byte
+limit; an oversized observation fails with the existing returned-bytes error.
+
+Click and fill require exactly one match, including a second check on acquired element handles.
+`isBrowserRunUndispatchedActionError` recognizes missing, ambiguous, or syntactically invalid CSS
+refusals before a mutation is sent. The handle remains usable after these refusals; callers may
+correct the target, but must not automatically replay a mutation with an unknown outcome.
+Other action failures invalidate the handle. Native option observations expose labels and
+selection, never option values; they do not add a new selection action to the generic port.
+
+Actions observe only fetch/XHR requests started during the action. A 200ms quiet window after
+dispatch completion is capped at two seconds. General logs contain only action names, bounded
+target-kind categories, counts, status-class buckets, and control-state booleans. They omit URLs,
+selectors, labels, values, headers, cookies, bodies, and provider exceptions. Post-action state
+is best-effort and capped at 250ms, so losing the old document during navigation does not fail a
+successful action. Listeners close on completion, failure, and abort; handle disposal waits at
+most 250ms. Interruption fences any dispatch still waiting on a query, invalidates the handle,
+records whether dispatch occurred before teardown, and waits at most 500ms for SDK completion.
+Puppeteer cannot cancel an already dispatched mutation reliably. Its outcome remains unknown
+after interruption, even if the SDK later resolves; the owning Scope closes the remote session.
+These diagnostics add no durable journal records and do not replace the engine's ordinary-tool
+uncertainty and recovery contract.
 This is a Layer-assembly library, not an application entrypoint.
 `CloudflareDurableRuntimeOptions.toolFailureObserver` installs the same closed trusted observer
 for the Object's coordinator. It adds no journal data or Code Mode durability claim.

--- a/packages/platform-cloudflare/src/interactive-browser.ts
+++ b/packages/platform-cloudflare/src/interactive-browser.ts
@@ -58,6 +58,10 @@ const MAX_HANDOFF_TIMEOUT_MILLIS = 30 * 60_000;
 const MAX_HOST_TEXT_LENGTH = 8 * 1024;
 const CLEANUP_STEP_TIMEOUT_MILLIS = 10_000;
 const CLOSE_SESSION_TIMEOUT_MILLIS = 10_000;
+const ACTION_NETWORK_QUIET_MILLIS = 200;
+const ACTION_NETWORK_SETTLE_MILLIS = 2_000;
+const ACTION_POST_STATE_MILLIS = 250;
+const MAX_OBSERVED_CONTROLS = 64;
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
 const BoundedHostText = Schema.String.check(
   Schema.isMinLength(1),
@@ -69,6 +73,55 @@ const TextObservation = Schema.Union([
   Schema.Struct({ _tag: Schema.Literal("MissingElement") }),
   Schema.Struct({ _tag: Schema.Literal("OverLimit"), observed: Schema.Natural }),
 ]);
+const ActionTargetState = Schema.Struct({
+  matchCount: Schema.Natural,
+  invalidSelector: Schema.optionalKey(Schema.Boolean),
+  kind: Schema.optionalKey(
+    Schema.Literals(["button", "checkbox", "radio", "select", "text", "link", "other"]),
+  ),
+  checked: Schema.optionalKey(Schema.Boolean),
+  selected: Schema.optionalKey(Schema.Boolean),
+  disabled: Schema.optionalKey(Schema.Boolean),
+  required: Schema.optionalKey(Schema.Boolean),
+  valid: Schema.optionalKey(Schema.Boolean),
+  formValid: Schema.optionalKey(Schema.Boolean),
+});
+const ActionNetworkState = Schema.Struct({
+  total: Schema.Natural,
+  status2xx: Schema.Natural,
+  status3xx: Schema.Natural,
+  status4xx: Schema.Natural,
+  status5xx: Schema.Natural,
+  failed: Schema.Natural,
+  pending: Schema.Natural,
+  settleTimedOut: Schema.Boolean,
+});
+const ActionObservation = Schema.Struct({
+  before: ActionTargetState,
+  after: Schema.optionalKey(ActionTargetState),
+  afterUnavailable: Schema.Boolean,
+  network: ActionNetworkState,
+});
+const PageObservation = Schema.fromJsonString(
+  Schema.Struct({
+    pageText: BoundedRemoteText,
+    selectorMatchCount: Schema.Natural,
+    controlsTruncated: Schema.Boolean,
+    controls: Schema.Array(
+      Schema.Struct({
+        selector: BoundedRemoteText,
+        kind: BoundedRemoteText,
+        label: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(200))),
+        checked: Schema.optionalKey(Schema.Boolean),
+        selected: Schema.optionalKey(Schema.Boolean),
+        disabled: Schema.optionalKey(Schema.Boolean),
+        required: Schema.optionalKey(Schema.Boolean),
+        valid: Schema.optionalKey(Schema.Boolean),
+        formValid: Schema.optionalKey(Schema.Boolean),
+      }),
+    ).check(Schema.isMaxLength(MAX_OBSERVED_CONTROLS)),
+  }),
+);
 const PngBytes = Schema.Uint8Array.check(
   Schema.isMaxLength(MAX_SCREENSHOT_BYTES),
   Schema.makeFilter(
@@ -209,8 +262,17 @@ export interface BrowserRunInteractivePage {
   readonly goto: (url: string) => Promise<void>;
   readonly url: () => unknown;
   readonly readText: (selector: string | undefined, maximumBytes: number) => Promise<unknown>;
-  readonly fill: (selector: string, value: string) => Promise<void>;
-  readonly click: (selector: string) => Promise<void>;
+  readonly fill: (
+    selector: string,
+    value: string,
+    signal: AbortSignal,
+    onDispatch: () => void,
+  ) => Promise<unknown>;
+  readonly click: (
+    selector: string,
+    signal: AbortSignal,
+    onDispatch: () => void,
+  ) => Promise<unknown>;
   readonly screenshot: (fullPage: boolean) => Promise<unknown>;
   readonly scroll: (deltaX: number, deltaY: number) => Promise<void>;
   readonly createCdpSession: () => Promise<BrowserRunInteractiveCdpSession>;
@@ -294,6 +356,288 @@ const makeProductionCdpSession = (session: CDPSession): BrowserRunInteractiveCdp
   detach: () => session.detach(),
 });
 
+class BrowserRunActionUndispatched extends Error {
+  readonly matchCount: number;
+
+  constructor(matchCount: number) {
+    super("The browser action selector did not resolve to exactly one element");
+    this.matchCount = matchCount;
+  }
+}
+
+const readActionTarget = (page: Page, selector: string): Promise<unknown> =>
+  page.evaluate((requestedSelector) => {
+    const pageDocument = Reflect.get(globalThis, "document");
+    let matches;
+    try {
+      matches = Reflect.apply(Reflect.get(pageDocument, "querySelectorAll"), pageDocument, [
+        requestedSelector,
+      ]);
+    } catch (cause) {
+      if (cause instanceof Error && cause.name === "SyntaxError") {
+        return { matchCount: 0, invalidSelector: true };
+      }
+      throw cause;
+    }
+    if (typeof matches !== "object" || matches === null) throw new Error("Invalid query result");
+    const matchCount = Math.min(10_000, Reflect.get(matches, "length"));
+    const element = Reflect.get(matches, 0);
+    if (element === undefined) return { matchCount };
+
+    const associated = Reflect.get(element, "control") ?? element;
+    const tagName = String(Reflect.get(associated, "tagName") ?? "").toLowerCase();
+    const inputType = String(Reflect.get(associated, "type") ?? "").toLowerCase();
+    const role = String(
+      Reflect.apply(Reflect.get(element, "getAttribute"), element, ["role"]) ?? "",
+    ).toLowerCase();
+    const kind =
+      tagName === "button" || role === "button"
+        ? "button"
+        : inputType === "checkbox" || role === "checkbox" || role === "switch"
+          ? "checkbox"
+          : inputType === "radio" || role === "radio"
+            ? "radio"
+            : tagName === "select"
+              ? "select"
+              : tagName === "input" || tagName === "textarea"
+                ? "text"
+                : tagName === "a"
+                  ? "link"
+                  : "other";
+    const checked = Reflect.get(associated, "checked");
+    const selected =
+      tagName === "select"
+        ? Reflect.get(associated, "selectedIndex") >= 0
+        : Reflect.get(associated, "selected");
+    const disabled = Reflect.get(associated, "disabled");
+    const required = Reflect.get(associated, "required");
+    const validity = Reflect.get(associated, "validity");
+    const form = Reflect.get(associated, "form");
+    const formMatches =
+      form === null || form === undefined ? undefined : Reflect.get(form, "matches");
+    const ariaChecked = Reflect.apply(Reflect.get(element, "getAttribute"), element, [
+      "aria-checked",
+    ]);
+    const ariaDisabled = Reflect.apply(Reflect.get(element, "getAttribute"), element, [
+      "aria-disabled",
+    ]);
+    const ariaSelected = Reflect.apply(Reflect.get(element, "getAttribute"), element, [
+      "aria-selected",
+    ]);
+
+    return {
+      matchCount,
+      kind,
+      ...(typeof checked === "boolean"
+        ? { checked }
+        : ariaChecked === "true" || ariaChecked === "false"
+          ? { checked: ariaChecked === "true" }
+          : {}),
+      ...(typeof selected === "boolean"
+        ? { selected }
+        : ariaSelected === "true" || ariaSelected === "false"
+          ? { selected: ariaSelected === "true" }
+          : {}),
+      disabled: typeof disabled === "boolean" ? disabled : ariaDisabled === "true",
+      ...(typeof required === "boolean" ? { required } : {}),
+      ...(validity !== undefined && typeof Reflect.get(validity, "valid") === "boolean"
+        ? { valid: Reflect.get(validity, "valid") }
+        : {}),
+      ...(typeof formMatches === "function"
+        ? { formValid: Reflect.apply(formMatches, form, [":valid"]) }
+        : {}),
+    };
+  }, selector);
+
+// SDK promises cannot be cancelled. Clear our timer and observe late rejections;
+// the owning browser Scope is responsible for terminating the remote session.
+const boundedBestEffort = async <A>(
+  promise: Promise<A>,
+  millis: number,
+): Promise<A | undefined> => {
+  let timer: ReturnType<typeof setTimeout> | number | undefined;
+  try {
+    return await Promise.race([
+      promise.catch(() => undefined),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(resolve, millis);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const readActionTargetAfter = (page: Page, selector: string) =>
+  boundedBestEffort(
+    readActionTarget(page, selector).then(Schema.decodeUnknownSync(ActionTargetState)),
+    ACTION_POST_STATE_MILLIS,
+  );
+
+const makeActionRequestTracker = (page: Page, signal: AbortSignal) => {
+  const pending = new Set<HTTPRequest>();
+  let total = 0;
+  let status2xx = 0;
+  let status3xx = 0;
+  let status4xx = 0;
+  let status5xx = 0;
+  let failed = 0;
+  let lastChange = performance.now();
+  let closed = false;
+  let wake: (() => void) | undefined;
+  let timer: ReturnType<typeof setTimeout> | number | undefined;
+
+  const relevant = (request: HTTPRequest) => {
+    const resourceType = request.resourceType();
+    return resourceType === "fetch" || resourceType === "xhr";
+  };
+  const onRequest = (request: HTTPRequest) => {
+    if (!relevant(request)) return;
+    pending.add(request);
+    total++;
+    lastChange = performance.now();
+  };
+  const onFinished = (request: HTTPRequest) => {
+    if (!pending.delete(request)) return;
+    let status: number | undefined;
+    try {
+      status = request.response()?.status();
+    } catch {
+      // Provider response details remain intentionally unavailable to diagnostics.
+    }
+    if (status !== undefined) {
+      if (status >= 200 && status < 300) status2xx++;
+      else if (status >= 300 && status < 400) status3xx++;
+      else if (status >= 400 && status < 500) status4xx++;
+      else if (status >= 500 && status < 600) status5xx++;
+    }
+    lastChange = performance.now();
+  };
+  const onFailed = (request: HTTPRequest) => {
+    if (!pending.delete(request)) return;
+    failed++;
+    lastChange = performance.now();
+  };
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    page.off("request", onRequest);
+    page.off("requestfinished", onFinished);
+    page.off("requestfailed", onFailed);
+    signal.removeEventListener("abort", close);
+    clearTimeout(timer);
+    wake?.();
+  };
+
+  try {
+    page.on("request", onRequest);
+    page.on("requestfinished", onFinished);
+    page.on("requestfailed", onFailed);
+    signal.addEventListener("abort", close, { once: true });
+    if (signal.aborted) close();
+  } catch (cause) {
+    close();
+    throw cause;
+  }
+
+  const wait = async () => {
+    const startedAt = performance.now();
+    let settleTimedOut = false;
+    while (!closed) {
+      const now = performance.now();
+      if (pending.size === 0 && now - lastChange >= ACTION_NETWORK_QUIET_MILLIS) break;
+      if (now - startedAt >= ACTION_NETWORK_SETTLE_MILLIS) {
+        settleTimedOut = true;
+        break;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+        timer = setTimeout(() => resolve(), 50);
+      });
+      wake = undefined;
+    }
+    return {
+      total,
+      status2xx,
+      status3xx,
+      status4xx,
+      status5xx,
+      failed,
+      pending: pending.size,
+      settleTimedOut,
+    };
+  };
+
+  return {
+    wait,
+    close,
+    markActionSettled: () => {
+      lastChange = performance.now();
+    },
+  };
+};
+
+const disposeActionHandles = async (handles: ReadonlyArray<{ dispose: () => Promise<void> }>) => {
+  await boundedBestEffort(
+    Promise.allSettled(handles.map(async (handle) => handle.dispose())),
+    ACTION_POST_STATE_MILLIS,
+  );
+};
+
+const runObservedPageAction = async (
+  page: Page,
+  selector: string,
+  signal: AbortSignal,
+  onDispatch: () => void,
+  action: (element: NonNullable<Awaited<ReturnType<Page["$"]>>>) => Promise<void>,
+): Promise<unknown> => {
+  if (signal.aborted) throw new BrowserRunActionUndispatched(0);
+  const before = Schema.decodeUnknownSync(ActionTargetState)(
+    await readActionTarget(page, selector),
+  );
+  if (before.matchCount !== 1 || before.invalidSelector === true) {
+    throw new BrowserRunActionUndispatched(before.matchCount);
+  }
+  const matches = await page.$$(selector);
+  if (matches.length !== 1 || matches[0] === undefined) {
+    await disposeActionHandles(matches);
+    throw new BrowserRunActionUndispatched(Math.min(10_000, matches.length));
+  }
+  if (signal.aborted) {
+    await disposeActionHandles(matches);
+    throw new BrowserRunActionUndispatched(1);
+  }
+
+  let tracker: ReturnType<typeof makeActionRequestTracker> | undefined;
+  let disposing: Promise<void> | undefined;
+  const dispose = () => (disposing ??= disposeActionHandles(matches));
+  const onAbort = () => {
+    void dispose();
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    tracker = makeActionRequestTracker(page, signal);
+    // No await between the final cancellation fence and SDK dispatch. Once
+    // dispatched, interruption is uncertain, even if the SDK later resolves.
+    if (signal.aborted) throw new BrowserRunActionUndispatched(1);
+    onDispatch();
+    await action(matches[0]);
+    tracker.markActionSettled();
+    const network = await tracker.wait();
+    const after = signal.aborted ? undefined : await readActionTargetAfter(page, selector);
+    return {
+      before,
+      ...(after === undefined ? {} : { after }),
+      afterUnavailable: after === undefined,
+      network,
+    };
+  } finally {
+    tracker?.close();
+    signal.removeEventListener("abort", onAbort);
+    await dispose();
+  }
+};
+
 const makeProductionPage = (page: Page): BrowserRunInteractivePage => {
   const listeners = new Map<BrowserRunInteractiveRequestListener, (request: HTTPRequest) => void>();
   return {
@@ -313,38 +657,234 @@ const makeProductionPage = (page: Page): BrowserRunInteractivePage => {
       }
     },
     goto: async (url) => {
-      await page.goto(url, { waitUntil: "networkidle0", timeout: 0 });
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 });
     },
     url: () => page.url(),
-    readText: (selector, maximumBytes) =>
-      page.evaluate(
-        (requestedSelector, maximum) => {
-          const pageDocument = Reflect.get(globalThis, "document");
-          const element =
-            requestedSelector === undefined
-              ? Reflect.get(pageDocument, "body")
-              : Reflect.apply(Reflect.get(pageDocument, "querySelector"), pageDocument, [
-                  requestedSelector,
-                ]);
-          if (element === null) return { _tag: "MissingElement" };
-          const innerText = Reflect.get(element, "innerText");
-          const textContent = Reflect.get(element, "textContent");
-          const text =
-            typeof innerText === "string"
-              ? innerText
-              : typeof textContent === "string"
-                ? textContent
-                : "";
-          const observed = new TextEncoder().encode(text).byteLength;
-          return observed > maximum ? { _tag: "OverLimit", observed } : { _tag: "Text", text };
-        },
-        selector,
-        maximumBytes,
-      ),
-    fill: async (selector, value) => {
-      await page.$eval(
-        selector,
-        (element, nextValue) => {
+    readText: async (selector, maximumBytes) => {
+      const observation = Schema.decodeUnknownSync(TextObservation)(
+        await page.evaluate(
+          (requestedSelector, maximum, maximumControls) => {
+            const pageDocument = Reflect.get(globalThis, "document");
+            const matches =
+              requestedSelector === undefined
+                ? undefined
+                : Reflect.apply(Reflect.get(pageDocument, "querySelectorAll"), pageDocument, [
+                    requestedSelector,
+                  ]);
+            const selectorMatchCount =
+              matches === undefined || matches === null
+                ? 1
+                : Math.min(10_000, Reflect.get(matches, "length"));
+            const element =
+              matches === undefined || matches === null
+                ? Reflect.get(pageDocument, "body")
+                : Reflect.get(matches, 0);
+            if (element === null) return { _tag: "MissingElement" };
+            if (element === undefined) return { _tag: "MissingElement" };
+            const innerText = Reflect.get(element, "innerText");
+            const textContent = Reflect.get(element, "textContent");
+            const pageText =
+              typeof innerText === "string"
+                ? innerText
+                : typeof textContent === "string"
+                  ? textContent
+                  : "";
+            const primaryControlSelector =
+              'input,select,textarea,label,button,[role="checkbox"],[role="radio"],[role="option"],[role="switch"],[role="tab"],[role="button"]';
+            const optionSelector = "select option";
+            const secondaryControlSelector = "a[href]";
+            const controlSelector = `${primaryControlSelector},${optionSelector},${secondaryControlSelector}`;
+            const selectorFor = (candidate: object) => {
+              const parts: Array<string> = [];
+              let current: object | null = candidate;
+              while (current !== null && current !== undefined) {
+                const tagName = String(Reflect.get(current, "tagName") ?? "").toLowerCase();
+                if (tagName === "") break;
+                const parent: object | null = Reflect.get(current, "parentElement");
+                if (parent === null) {
+                  parts.push(tagName);
+                  break;
+                }
+                let sibling = Reflect.get(current, "previousElementSibling");
+                let index = 1;
+                while (sibling !== null && sibling !== undefined) {
+                  if (String(Reflect.get(sibling, "tagName") ?? "").toLowerCase() === tagName)
+                    index++;
+                  sibling = Reflect.get(sibling, "previousElementSibling");
+                }
+                parts.push(`${tagName}:nth-of-type(${index})`);
+                current = parent;
+              }
+              return parts.reverse().join(" > ");
+            };
+            const visible = (candidate: object) => {
+              const hidden = Reflect.get(candidate, "hidden");
+              const ariaHidden = Reflect.apply(Reflect.get(candidate, "getAttribute"), candidate, [
+                "aria-hidden",
+              ]);
+              const rects = Reflect.apply(Reflect.get(candidate, "getClientRects"), candidate, []);
+              return (
+                hidden !== true &&
+                ariaHidden !== "true" &&
+                typeof rects === "object" &&
+                rects !== null &&
+                Reflect.get(rects, "length") > 0
+              );
+            };
+            const candidates: Array<object> = [];
+            let controlsTruncated = false;
+            const consider = (candidate: object) => {
+              const tagName = String(Reflect.get(candidate, "tagName") ?? "").toLowerCase();
+              // Collapsed native options have no client rects. Their owning
+              // select determines visibility; observe text/selection, never value.
+              const visibilityTarget =
+                tagName === "option"
+                  ? Reflect.apply(Reflect.get(candidate, "closest"), candidate, ["select"])
+                  : candidate;
+              const actionable = tagName !== "label" || Reflect.get(candidate, "control") !== null;
+              if (
+                !actionable ||
+                typeof visibilityTarget !== "object" ||
+                visibilityTarget === null ||
+                !visible(visibilityTarget)
+              )
+                return;
+              candidates.push(candidate);
+              if (candidates.length > maximumControls) controlsTruncated = true;
+            };
+            const elementMatches = Reflect.get(element, "matches");
+            if (
+              typeof elementMatches === "function" &&
+              Reflect.apply(elementMatches, element, [controlSelector])
+            ) {
+              consider(element);
+            }
+            const considerSelector = (candidateSelector: string) => {
+              const descendants = Reflect.apply(Reflect.get(element, "querySelectorAll"), element, [
+                candidateSelector,
+              ]);
+              if (typeof descendants !== "object" || descendants === null) return;
+              const descendantCount = Reflect.get(descendants, "length");
+              for (let index = 0; index < descendantCount && !controlsTruncated; index++) {
+                consider(Reflect.get(descendants, index));
+              }
+            };
+            considerSelector(primaryControlSelector);
+            if (!controlsTruncated) considerSelector(optionSelector);
+            if (!controlsTruncated) considerSelector(secondaryControlSelector);
+            const controls = candidates.slice(0, maximumControls).map((candidate) => {
+              const associated = Reflect.get(candidate, "control") ?? candidate;
+              const tagName = String(Reflect.get(candidate, "tagName") ?? "").toLowerCase();
+              const inputType = String(Reflect.get(associated, "type") ?? "").toLowerCase();
+              const role = String(
+                Reflect.apply(Reflect.get(candidate, "getAttribute"), candidate, ["role"]) ?? "",
+              ).toLowerCase();
+              const ariaLabel = Reflect.apply(Reflect.get(candidate, "getAttribute"), candidate, [
+                "aria-label",
+              ]);
+              const candidateText =
+                tagName === "textarea" || tagName === "input" || tagName === "select"
+                  ? undefined
+                  : Reflect.get(candidate, tagName === "option" ? "label" : "innerText");
+              const associatedLabels = Reflect.get(associated, "labels");
+              const associatedLabel =
+                associatedLabels !== undefined &&
+                associatedLabels !== null &&
+                Reflect.get(associatedLabels, "length") > 0
+                  ? Reflect.get(Reflect.get(associatedLabels, 0), "innerText")
+                  : undefined;
+              const label = String(
+                typeof ariaLabel === "string" && ariaLabel !== ""
+                  ? ariaLabel
+                  : typeof candidateText === "string" && candidateText !== ""
+                    ? candidateText
+                    : (associatedLabel ?? ""),
+              )
+                .replace(/\s+/g, " ")
+                .trim()
+                .slice(0, 200);
+              const checked = Reflect.get(associated, "checked");
+              const selected =
+                tagName === "select"
+                  ? Reflect.get(associated, "selectedIndex") >= 0
+                  : Reflect.get(associated, "selected");
+              const disabled = Reflect.get(associated, "disabled");
+              const required = Reflect.get(associated, "required");
+              const validity = Reflect.get(associated, "validity");
+              const form = Reflect.get(associated, "form");
+              const formMatches =
+                form === null || form === undefined ? undefined : Reflect.get(form, "matches");
+              const ariaChecked = Reflect.apply(Reflect.get(candidate, "getAttribute"), candidate, [
+                "aria-checked",
+              ]);
+              const ariaSelected = Reflect.apply(
+                Reflect.get(candidate, "getAttribute"),
+                candidate,
+                ["aria-selected"],
+              );
+              const ariaDisabled = Reflect.apply(
+                Reflect.get(candidate, "getAttribute"),
+                candidate,
+                ["aria-disabled"],
+              );
+
+              return {
+                selector: selectorFor(candidate),
+                kind:
+                  tagName === "label"
+                    ? `label:${inputType || "control"}`
+                    : tagName === "input"
+                      ? `input:${inputType || "text"}`
+                      : role !== ""
+                        ? `role:${role}`
+                        : tagName,
+                ...(label === "" ? {} : { label }),
+                ...(typeof checked === "boolean"
+                  ? { checked }
+                  : ariaChecked === "true" || ariaChecked === "false"
+                    ? { checked: ariaChecked === "true" }
+                    : {}),
+                ...(typeof selected === "boolean"
+                  ? { selected }
+                  : ariaSelected === "true" || ariaSelected === "false"
+                    ? { selected: ariaSelected === "true" }
+                    : {}),
+                ...(typeof disabled === "boolean"
+                  ? { disabled }
+                  : ariaDisabled === "true" || ariaDisabled === "false"
+                    ? { disabled: ariaDisabled === "true" }
+                    : {}),
+                ...(typeof required === "boolean" ? { required } : {}),
+                ...(validity !== undefined && typeof Reflect.get(validity, "valid") === "boolean"
+                  ? { valid: Reflect.get(validity, "valid") }
+                  : {}),
+                ...(typeof formMatches === "function"
+                  ? { formValid: Reflect.apply(formMatches, form, [":valid"]) }
+                  : {}),
+              };
+            });
+            // JSON is the bounded wire representation of this existing text result.
+            // eslint-disable-next-line no-restricted-properties
+            const text = JSON.stringify({
+              pageText,
+              selectorMatchCount,
+              controls,
+              controlsTruncated,
+            });
+            const observed = new TextEncoder().encode(text).byteLength;
+            return observed > maximum ? { _tag: "OverLimit", observed } : { _tag: "Text", text };
+          },
+          selector,
+          maximumBytes,
+          MAX_OBSERVED_CONTROLS,
+        ),
+      );
+      if (observation._tag === "Text") Schema.decodeUnknownSync(PageObservation)(observation.text);
+      return observation;
+    },
+    fill: (selector, value, signal, onDispatch) =>
+      runObservedPageAction(page, selector, signal, onDispatch, (element) =>
+        element.evaluate((element, nextValue) => {
           // Bypass instance setters so React can detect the change when events fire.
           let prototype = Reflect.getPrototypeOf(element);
           let setValue: ((value: string) => void) | undefined;
@@ -367,11 +907,10 @@ const makeProductionPage = (page: Page): BrowserRunInteractivePage => {
             Reflect.apply(dispatchEvent, element, [new Event("input", { bubbles: true })]);
             Reflect.apply(dispatchEvent, element, [new Event("change", { bubbles: true })]);
           }
-        },
-        value,
-      );
-    },
-    click: (selector) => page.click(selector),
+        }, value),
+      ),
+    click: (selector, signal, onDispatch) =>
+      runObservedPageAction(page, selector, signal, onDispatch, (element) => element.click()),
     // Puppeteer materializes the complete image before returning. The adapter
     // validates the 8 MiB Schema ceiling and pass limit immediately afterward.
     screenshot: (fullPage) => page.screenshot({ type: "png", fullPage }),
@@ -420,6 +959,20 @@ const actionError = (operation: BrowserOperation, cause?: unknown): InteractiveB
     message: `The interactive browser ${operation} operation failed`,
     ...(cause === undefined ? {} : { cause }),
   });
+
+const undispatchedActionError = (operation: BrowserOperation): InteractiveBrowserActionError =>
+  InteractiveBrowserActionError.make({
+    implementation: browserRunInteractiveImplementation,
+    operation,
+    message: `The interactive browser ${operation} operation was not dispatched`,
+  });
+
+/** Recognizes a local pre-dispatch refusal without exposing selector or page content. */
+export const isBrowserRunUndispatchedActionError = (error: unknown): boolean =>
+  Schema.is(InteractiveBrowserActionError)(error) &&
+  error.implementation.identity === browserRunInteractiveImplementation.identity &&
+  (error.operation === "click" || error.operation === "fill") &&
+  error.message === `The interactive browser ${error.operation} operation was not dispatched`;
 
 const policyError = (message: string): InteractiveBrowserPolicyDeniedError =>
   InteractiveBrowserPolicyDeniedError.make({
@@ -593,6 +1146,14 @@ interface HandleRuntime {
   ) => Effect.Effect<A, BrowserFailure>;
 }
 
+class BrowserRunRemoteFailure {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    this.cause = cause;
+  }
+}
+
 const awaitPendingRequests = (state: HandleState): Effect.Effect<void> =>
   Effect.suspend(() => {
     const pending = [...state.pendingRequests];
@@ -685,17 +1246,136 @@ const makeHandle = Effect.fn("BrowserRunInteractive.makeHandle")(function* (
   const permits = yield* Semaphore.make(1);
   const actions = yield* Ref.make(0);
 
-  const remote = <A>(operation: BrowserOperation, evaluate: () => Promise<A>) =>
+  const remote = <A>(operation: BrowserOperation, evaluate: (signal: AbortSignal) => Promise<A>) =>
     Effect.tryPromise({
       try: evaluate,
-      catch: (cause) => {
-        if (state.disconnected.value || isRemoteClosure(cause)) {
-          state.disconnected.value = true;
-          return expiredError();
-        }
-        return actionError(operation, cause);
-      },
+      catch: (cause) => new BrowserRunRemoteFailure(cause),
+    }).pipe(
+      Effect.catch(
+        (
+          failure,
+        ): Effect.Effect<never, InteractiveBrowserActionError | InteractiveBrowserExpiredError> => {
+          const cause = failure.cause;
+          if (cause instanceof BrowserRunActionUndispatched) {
+            return Effect.logInfo("Browser interactive action was not dispatched").pipe(
+              Effect.annotateLogs({
+                "browser.action": operation,
+                "browser.selector_match_count": cause.matchCount,
+              }),
+              Effect.andThen(Effect.fail(undispatchedActionError(operation))),
+            );
+          }
+          if (state.disconnected.value || isRemoteClosure(cause)) {
+            state.disconnected.value = true;
+            return Effect.fail(expiredError());
+          }
+          return Effect.fail(actionError(operation, cause));
+        },
+      ),
+    );
+
+  const observedAction = (
+    operation: "fill" | "click",
+    evaluate: (signal: AbortSignal, onDispatch: () => void) => Promise<unknown>,
+  ) =>
+    Effect.suspend(() => {
+      let dispatched = false;
+      let pending: Promise<unknown> | undefined;
+      return remote(operation, (signal) => {
+        pending = evaluate(signal, () => {
+          dispatched = true;
+        });
+        return pending;
+      }).pipe(
+        Effect.onInterrupt(() =>
+          Effect.gen(function* () {
+            state.uncertain.value = true;
+            // Retain evidence before Scope teardown, without claiming SDK
+            // cancellation or success. A late completion never makes this replayable.
+            yield* Effect.logWarning("Browser interactive action interrupted").pipe(
+              Effect.annotateLogs({
+                "browser.action": operation,
+                "browser.action_dispatched": dispatched,
+                "browser.action_outcome_unknown": dispatched,
+              }),
+            );
+            const completion = pending;
+            if (completion !== undefined) {
+              yield* Effect.promise(() => boundedBestEffort(completion, 500));
+            }
+          }),
+        ),
+      );
     });
+
+  const decodeActionObservation = Effect.fn("BrowserRunInteractive.decodeActionObservation")(
+    function* (raw: unknown) {
+      return yield* Schema.decodeUnknownEffect(ActionObservation)(raw).pipe(
+        Effect.mapError((cause) =>
+          protocolError("The browser returned a malformed action observation", cause),
+        ),
+      );
+    },
+  );
+
+  const logActionObservation = (
+    operation: "fill" | "click",
+    observation: typeof ActionObservation.Type,
+  ) =>
+    Effect.logInfo("Browser interactive action observed").pipe(
+      Effect.annotateLogs({
+        "browser.action": operation,
+        "browser.selector_match_count": observation.before.matchCount,
+        ...(observation.before.kind === undefined
+          ? {}
+          : { "browser.target_kind": observation.before.kind }),
+        ...(observation.before.checked === undefined
+          ? {}
+          : { "browser.target_checked_before": observation.before.checked }),
+        ...(observation.after?.checked === undefined
+          ? {}
+          : { "browser.target_checked_after": observation.after.checked }),
+        ...(observation.before.selected === undefined
+          ? {}
+          : { "browser.target_selected_before": observation.before.selected }),
+        ...(observation.after?.selected === undefined
+          ? {}
+          : { "browser.target_selected_after": observation.after.selected }),
+        ...(observation.before.disabled === undefined
+          ? {}
+          : { "browser.target_disabled_before": observation.before.disabled }),
+        ...(observation.after?.disabled === undefined
+          ? {}
+          : { "browser.target_disabled_after": observation.after.disabled }),
+        ...(observation.before.required === undefined
+          ? {}
+          : { "browser.target_required_before": observation.before.required }),
+        ...(observation.after?.required === undefined
+          ? {}
+          : { "browser.target_required_after": observation.after.required }),
+        ...(observation.before.valid === undefined
+          ? {}
+          : { "browser.target_valid_before": observation.before.valid }),
+        ...(observation.after?.valid === undefined
+          ? {}
+          : { "browser.target_valid_after": observation.after.valid }),
+        ...(observation.before.formValid === undefined
+          ? {}
+          : { "browser.form_valid_before": observation.before.formValid }),
+        ...(observation.after?.formValid === undefined
+          ? {}
+          : { "browser.form_valid_after": observation.after.formValid }),
+        "browser.target_after_unavailable": observation.afterUnavailable,
+        "browser.fetch_xhr_total": observation.network.total,
+        "browser.fetch_xhr_2xx": observation.network.status2xx,
+        "browser.fetch_xhr_3xx": observation.network.status3xx,
+        "browser.fetch_xhr_4xx": observation.network.status4xx,
+        "browser.fetch_xhr_5xx": observation.network.status5xx,
+        "browser.fetch_xhr_failed": observation.network.failed,
+        "browser.fetch_xhr_pending": observation.network.pending,
+        "browser.network_settle_timed_out": observation.network.settleTimedOut,
+      }),
+    );
 
   const run = <A>(
     effect: Effect.Effect<A, BrowserFailure>,
@@ -750,6 +1430,12 @@ const makeHandle = Effect.fn("BrowserRunInteractive.makeHandle")(function* (
                 return Effect.fail(error);
               }
               const failure = stateFailure(state);
+              if (
+                Schema.is(InteractiveBrowserActionError)(error) &&
+                !isBrowserRunUndispatchedActionError(error)
+              ) {
+                state.uncertain.value = true;
+              }
               return Effect.fail(failure ?? error);
             }),
           );
@@ -825,15 +1511,23 @@ const makeHandle = Effect.fn("BrowserRunInteractive.makeHandle")(function* (
       ),
     fill: (request) =>
       run(
-        remote("fill", () => page.fill(request.selector, request.value)).pipe(
-          Effect.andThen(decodeActionResult(page, policy)),
-        ),
+        Effect.gen(function* () {
+          const observation = yield* observedAction("fill", (signal, onDispatch) =>
+            page.fill(request.selector, request.value, signal, onDispatch),
+          ).pipe(Effect.flatMap(decodeActionObservation));
+          yield* logActionObservation("fill", observation);
+          return yield* decodeActionResult(page, policy);
+        }),
       ),
     click: (request) =>
       run(
-        remote("click", () => page.click(request.selector)).pipe(
-          Effect.andThen(decodeActionResult(page, policy)),
-        ),
+        Effect.gen(function* () {
+          const observation = yield* observedAction("click", (signal, onDispatch) =>
+            page.click(request.selector, signal, onDispatch),
+          ).pipe(Effect.flatMap(decodeActionObservation));
+          yield* logActionObservation("click", observation);
+          return yield* decodeActionResult(page, policy);
+        }),
       ),
     screenshot: (request) =>
       Schema.decodeUnknownEffect(BrowserScreenshotRequest)(request).pipe(

--- a/packages/platform-cloudflare/test/interactive-browser-actions.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-actions.test.ts
@@ -1,0 +1,387 @@
+import {
+  BrowserClickRequest,
+  BrowserFillRequest,
+  InteractiveBrowser,
+  InteractiveBrowserPolicy,
+} from "@effect-agent/sandbox";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Fiber, Layer, Logger } from "effect";
+import { afterEach, beforeEach, vi } from "vite-plus/test";
+
+import {
+  BrowserRunInteractiveBinding,
+  browserRunInteractiveLayer,
+  isBrowserRunUndispatchedActionError,
+} from "../src/interactive-browser.ts";
+
+const sdk = vi.hoisted(() => ({ launch: vi.fn<() => Promise<object>>() }));
+vi.mock("@cloudflare/puppeteer", () => ({ default: sdk }));
+
+// Node's virtual timers cover the SDK boundary's quiet/deadline windows without
+// sleeps. Public handles still run in Effect; only the remote SDK is replaced.
+beforeEach(() => vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] }));
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+interface Request {
+  resourceType: () => string;
+  response: () => { status: () => number } | null;
+}
+const request = (type = "fetch", status = 200): Request => ({
+  resourceType: () => type,
+  response: () => ({ status: () => status }),
+});
+const emptyState = { matchCount: 1, kind: "button", formValid: false };
+const gate = <A>() => {
+  let resolve: (value: A) => void = () => {
+    throw new Error("Uninitialized gate");
+  };
+  const promise = new Promise<A>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+};
+
+const fixture = (
+  options: {
+    readonly state?: (
+      evaluate: (selector: string) => unknown,
+      selector: string,
+    ) => Promise<unknown>;
+    readonly matches?: number;
+    readonly action?: () => Promise<void>;
+    readonly dispose?: () => Promise<void>;
+  } = {},
+) => {
+  const events: Array<string> = [];
+  const logs: Array<ReturnType<typeof Logger.formatStructured.log>> = [];
+  const listeners = new Map<string, Set<(request: Request) => void>>();
+  const started = gate<void>();
+  const action = async () => {
+    events.push("dispatch");
+    started.resolve();
+    await options.action?.();
+  };
+  const page = {
+    evaluate: options.state ?? (async () => emptyState),
+    $$: async () =>
+      Array.from({ length: options.matches ?? 1 }, () => ({
+        click: action,
+        evaluate: action,
+        dispose: async () => {
+          events.push("dispose");
+          await options.dispose?.();
+        },
+      })),
+    url: () => "https://example.com/private",
+    close: async () => {
+      events.push("close");
+    },
+    setBypassServiceWorker: async () => {},
+    setRequestInterception: async () => {},
+    on: (event: string, listener: (request: Request) => void) => {
+      const existing = listeners.get(event) ?? new Set();
+      existing.add(listener);
+      listeners.set(event, existing);
+    },
+    off: (event: string, listener: (request: Request) => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  sdk.launch.mockResolvedValue({
+    createBrowserContext: async () => ({ newPage: async () => page, close: async () => {} }),
+    sessionId: () => "actions-test",
+    isConnected: () => true,
+    on: () => {},
+    off: () => {},
+    close: async () => {},
+  });
+  const unused = async (): Promise<Response> => {
+    throw new Error("No live Browser Run calls");
+  };
+  const layer = browserRunInteractiveLayer().pipe(
+    Layer.provide(
+      BrowserRunInteractiveBinding.layer({ browser: { fetch: unused, quickAction: unused } }),
+    ),
+  );
+  return {
+    layer: Layer.merge(
+      layer,
+      Logger.layer([
+        Logger.map(Logger.formatStructured, (entry) => {
+          logs.push(entry);
+          events.push("log");
+        }),
+      ]),
+    ),
+    started: started.promise,
+    events,
+    logs,
+    emit: (event: string, value: Request) => {
+      // The separately installed policy request listener is not a network observer.
+      const callbacks = [...(listeners.get(event) ?? [])];
+      for (const callback of event === "request" ? callbacks.slice(1) : callbacks) callback(value);
+    },
+    observerCount: () =>
+      [...listeners].reduce(
+        (total, [name, values]) =>
+          total + values.size - (name === "request" && values.size > 0 ? 1 : 0),
+        0,
+      ),
+  };
+};
+
+const open = Effect.gen(function* () {
+  return yield* (yield* InteractiveBrowser).open(
+    InteractiveBrowserPolicy.make({
+      network: { _tag: "Unrestricted" },
+      maxActions: 10,
+      maxElapsedMillis: 10_000,
+      maxReturnedBytes: 256 * 1024,
+    }),
+  );
+});
+const click = BrowserClickRequest.make({ selector: "#private-selector" });
+const advance = (millis: number) => Effect.promise(() => vi.advanceTimersByTimeAsync(millis));
+
+describe("Browser Run observed mutations", () => {
+  it.effect(
+    "classifies a DOM syntax error as definitely undispatched without retaining the selector",
+    () => {
+      vi.stubGlobal("document", {
+        querySelectorAll: () => {
+          throw new DOMException("private invalid selector", "SyntaxError");
+        },
+      });
+      const f = fixture({ state: async (evaluate, selector) => evaluate(selector) });
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const error = yield* handle
+          .click(BrowserClickRequest.make({ selector: "[" }))
+          .pipe(Effect.flip);
+        expect(isBrowserRunUndispatchedActionError(error)).toBe(true);
+        expect(error).not.toHaveProperty("cause");
+        expect(f.events).not.toContain("dispatch");
+        expect(f.logs[0]?.annotations["browser.selector_match_count"]).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+
+  it.effect("fences dispatch when a preflight query completes after interruption", () => {
+    const query = gate<unknown>();
+    const entered = gate<void>();
+    const f = fixture({
+      state: () => {
+        entered.resolve();
+        return query.promise;
+      },
+    });
+    return Effect.gen(function* () {
+      const handle = yield* open;
+      const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+      yield* Effect.promise(() => entered.promise);
+      const interrupt = yield* Fiber.interrupt(fiber).pipe(Effect.forkChild);
+      yield* advance(500);
+      yield* Fiber.join(interrupt);
+      query.resolve(emptyState);
+      yield* advance(0);
+      expect(f.events).not.toContain("dispatch");
+      expect(f.events.filter((e) => e === "dispose")).toHaveLength(1);
+      expect(f.logs[0]?.annotations).toMatchObject({
+        "browser.action_dispatched": false,
+        "browser.action_outcome_unknown": false,
+      });
+      expect(f.observerCount()).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  });
+
+  it.effect.each([0, 2])(
+    "refuses %i matches without dispatch or invalidating the session",
+    (count) => {
+      let matches = count;
+      const f = fixture({ state: async () => ({ matchCount: matches }) });
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const error = yield* handle.click(click).pipe(Effect.flip);
+        expect(isBrowserRunUndispatchedActionError(error)).toBe(true);
+        expect(f.events).not.toContain("dispatch");
+        expect(f.logs[0]?.annotations["browser.selector_match_count"]).toBe(count);
+        matches = 1;
+        const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+        yield* Effect.promise(() => f.started);
+        yield* advance(200);
+        yield* Fiber.join(fiber);
+        expect(f.events.filter((e) => e === "dispatch")).toHaveLength(1);
+        expect(f.observerCount()).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+
+  it.effect("rechecks uniqueness on the acquired handles and disposes an ambiguous batch", () => {
+    const f = fixture({ matches: 2 });
+    return Effect.gen(function* () {
+      const handle = yield* open;
+      expect(
+        isBrowserRunUndispatchedActionError(
+          yield* handle
+            .fill(BrowserFillRequest.make({ selector: "input", value: "private-value" }))
+            .pipe(Effect.flip),
+        ),
+      ).toBe(true);
+      expect(f.events.filter((e) => e === "dispose")).toHaveLength(2);
+      expect(f.events).not.toContain("dispatch");
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  });
+
+  it.effect(
+    "observes delayed fetch/XHR and ignores unrelated requests without leaking request data",
+    () => {
+      const f = fixture();
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+        yield* Effect.promise(() => f.started);
+        yield* advance(100);
+        f.emit("request", request("image"));
+        const requests = [
+          request("fetch", 204),
+          request("xhr", 302),
+          request("fetch", 404),
+          request("xhr", 503),
+        ];
+        for (const req of requests) f.emit("request", req);
+        const failed = request();
+        f.emit("request", failed);
+        f.emit("requestfailed", failed);
+        yield* advance(300);
+        expect(f.logs).toHaveLength(0);
+        for (const req of requests) f.emit("requestfinished", req);
+        yield* advance(200);
+        yield* Fiber.join(fiber);
+        expect(f.logs[0]?.annotations).toMatchObject({
+          "browser.fetch_xhr_total": 5,
+          "browser.fetch_xhr_2xx": 1,
+          "browser.fetch_xhr_3xx": 1,
+          "browser.fetch_xhr_4xx": 1,
+          "browser.fetch_xhr_5xx": 1,
+          "browser.fetch_xhr_failed": 1,
+          "browser.fetch_xhr_pending": 0,
+          "browser.network_settle_timed_out": false,
+        });
+        expect(f.logs[0]?.cause).toBeUndefined();
+        expect(
+          Object.values(f.logs[0]?.annotations ?? {}).every(
+            (v) =>
+              typeof v === "boolean" || typeof v === "number" || v === "click" || v === "button",
+          ),
+        ).toBe(true);
+        expect(f.observerCount()).toBe(0);
+        expect(vi.getTimerCount()).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+
+  it.effect(
+    "caps pending network settlement at two seconds and post-navigation state at 250ms",
+    () => {
+      let reads = 0;
+      const f = fixture({
+        state: async () => (++reads === 1 ? emptyState : new Promise(() => {})),
+      });
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+        yield* Effect.promise(() => f.started);
+        f.emit("request", request());
+        yield* advance(2_250);
+        yield* Fiber.join(fiber);
+        expect(f.logs[0]?.annotations).toMatchObject({
+          "browser.fetch_xhr_pending": 1,
+          "browser.network_settle_timed_out": true,
+          "browser.target_after_unavailable": true,
+        });
+        expect(f.observerCount()).toBe(0);
+        expect(vi.getTimerCount()).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+
+  it.effect("does not turn a destroyed post-action document into an action failure", () => {
+    let reads = 0;
+    const f = fixture({
+      state: async () => {
+        if (++reads > 1) throw new Error("private provider exception");
+        return emptyState;
+      },
+    });
+    return Effect.gen(function* () {
+      const handle = yield* open;
+      const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+      yield* Effect.promise(() => f.started);
+      yield* advance(200);
+      yield* Fiber.join(fiber);
+      expect(f.logs[0]?.annotations["browser.target_after_unavailable"]).toBe(true);
+      expect(f.logs[0]?.cause).toBeUndefined();
+      expect(f.observerCount()).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  });
+
+  it.effect(
+    "cleans up a failed mutation and refuses subsequent mutations on the uncertain handle",
+    () => {
+      const f = fixture({
+        action: async () => {
+          throw new Error("private provider exception");
+        },
+        dispose: () => new Promise(() => {}),
+      });
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const fiber = yield* handle.click(click).pipe(Effect.flip, Effect.forkChild);
+        yield* Effect.promise(() => f.started);
+        yield* advance(250);
+        expect(isBrowserRunUndispatchedActionError(yield* Fiber.join(fiber))).toBe(false);
+        expect(yield* handle.click(click).pipe(Effect.flip)).toMatchObject({
+          _tag: "InteractiveBrowserExpiredError",
+        });
+        expect(f.events.filter((e) => e === "dispatch")).toHaveLength(1);
+        expect(f.observerCount()).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+
+  it.effect(
+    "records uncertainty before teardown on abort, bounds cleanup, and never replays a late mutation",
+    () => {
+      const action = gate<void>();
+      const f = fixture({ action: () => action.promise });
+      return Effect.gen(function* () {
+        const handle = yield* open;
+        const fiber = yield* handle.click(click).pipe(Effect.forkChild);
+        yield* Effect.promise(() => f.started);
+        const interrupt = yield* Fiber.interrupt(fiber).pipe(Effect.forkChild);
+        yield* advance(500);
+        yield* Fiber.join(interrupt);
+        expect(f.observerCount()).toBe(0);
+        expect(f.logs[0]?.annotations).toMatchObject({
+          "browser.action_dispatched": true,
+          "browser.action_outcome_unknown": true,
+        });
+        expect(f.events).not.toContain("close");
+        expect(yield* handle.click(click).pipe(Effect.flip)).toMatchObject({
+          _tag: "InteractiveBrowserExpiredError",
+        });
+        yield* handle.close;
+        expect(f.events.indexOf("log")).toBeLessThan(f.events.indexOf("close"));
+        action.resolve();
+        yield* advance(0);
+        expect(f.events.filter((e) => e === "dispatch")).toHaveLength(1);
+        expect(f.events.filter((e) => e === "dispose")).toHaveLength(1);
+        expect(f.logs).toHaveLength(1);
+        expect(vi.getTimerCount()).toBe(0);
+      }).pipe(Effect.scoped, Effect.provide(f.layer));
+    },
+  );
+});

--- a/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
@@ -16,17 +16,20 @@ const sdk = vi.hoisted(() => ({ launch: vi.fn<() => Promise<object>>() }));
 
 vi.mock("@cloudflare/puppeteer", () => ({ default: sdk }));
 
-// Only the SDK transport is replaced: fill runs the production $eval callback.
+// Only the SDK transport is replaced: fill runs the production element callback.
 const nativeLayer = (element: object) => {
   const page = {
-    $eval: async (
-      selector: string,
-      evaluate: (field: object, value: string) => void,
-      value: string,
-    ) => {
-      if (selector !== "#field") throw new Error("No element matches the selector");
-      evaluate(element, value);
-    },
+    evaluate: async () => ({ matchCount: 1 }),
+    $$: async (selector: string) =>
+      selector === "#field"
+        ? [
+            {
+              evaluate: async (evaluate: (field: object, value: string) => void, value: string) =>
+                evaluate(element, value),
+              dispose: async () => {},
+            },
+          ]
+        : [],
     url: () => "https://example.com/form",
     close: async () => {},
     setBypassServiceWorker: async () => {},

--- a/packages/platform-cloudflare/test/interactive-browser-native.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-native.test.ts
@@ -1,0 +1,229 @@
+import { createServer } from "node:http";
+
+import nativePuppeteer from "@cloudflare/puppeteer/internal/puppeteer-core.js";
+import {
+  BrowserClickRequest,
+  BrowserFillRequest,
+  BrowserNavigateRequest,
+  BrowserReadTextRequest,
+  InteractiveBrowser,
+  InteractiveBrowserPolicy,
+} from "@effect-agent/sandbox";
+import { expect, it } from "@effect/vitest";
+import { Config, Effect, Layer, Logger, Option, Schema } from "effect";
+import { vi } from "vite-plus/test";
+
+import {
+  BrowserRunInteractiveBinding,
+  browserRunInteractiveLayer,
+  isBrowserRunUndispatchedActionError,
+} from "../src/interactive-browser.ts";
+
+const sdk = vi.hoisted(() => ({ launch: vi.fn<() => Promise<object>>() }));
+vi.mock("@cloudflare/puppeteer", () => ({ default: sdk }));
+
+class NativeProbeError extends Schema.TaggedError<NativeProbeError>()("NativeProbeError", {
+  cause: Schema.Defect(),
+}) {}
+const sdkCall = <A>(run: () => Promise<A>) =>
+  Effect.tryPromise({ try: run, catch: (cause) => new NativeProbeError({ cause }) });
+const Observation = Schema.fromJsonString(
+  Schema.Struct({
+    pageText: Schema.String,
+    controlsTruncated: Schema.Boolean,
+    controls: Schema.Array(
+      Schema.Struct({
+        selector: Schema.String,
+        kind: Schema.String,
+        label: Schema.optionalKey(Schema.String),
+        checked: Schema.optionalKey(Schema.Boolean),
+        selected: Schema.optionalKey(Schema.Boolean),
+        required: Schema.optionalKey(Schema.Boolean),
+        valid: Schema.optionalKey(Schema.Boolean),
+        formValid: Schema.optionalKey(Schema.Boolean),
+      }),
+    ),
+  }),
+);
+
+// Opt-in local transport proof. No Cloudflare credentials or deployment. The
+// Puppeteer version and every adapter callback are the production ones.
+it.live(
+  "observes native product controls and delayed cart requests in real Chromium",
+  (context) =>
+    Effect.gen(function* () {
+      const executable = yield* Config.option(Config.string("BROWSER_TEST_EXECUTABLE"));
+      if (Option.isNone(executable)) return context.skip();
+      let cartRequests = 0;
+      const html = `<!doctype html><html><body>
+    <nav>${Array.from({ length: 80 }, (_, i) => `<a href="#nav${i}">Navigation ${i}</a>`).join("")}</nav>
+    <form id="cart">
+      <input id="small" type="radio" name="size" value="private-small-value" required style="display:none"><label for="small">12oz</label>
+      <input id="large" type="radio" name="size" value="private-large-value" required style="display:none"><label for="large">2lb</label>
+      <select id="roast" required><option value="">Choose roast</option><option value="private-roast-value">Light</option><option value="private-dark-value">Dark</option></select>
+      <input type="password" value="private-credential"><textarea>private-textarea-default</textarea>
+      <button>Add to Cart</button>
+    </form>
+    <script>document.querySelector('#cart').addEventListener('submit', e => { e.preventDefault(); setTimeout(() => fetch('/cart', {method:'POST',body:'private-body'}), 100); });</script>
+  </body></html>`;
+
+      // Node HTTP is isolated to this scoped test fixture, with all connection and
+      // timer ownership here. Production browser code stays platform-independent.
+      const timers = new Set<ReturnType<typeof setTimeout>>();
+      const server = yield* Effect.acquireRelease(
+        sdkCall(
+          () =>
+            new Promise<ReturnType<typeof createServer>>((resolve, reject) => {
+              const server = createServer((request, response) => {
+                if (request.url === "/cart") {
+                  cartRequests++;
+                  const timer = setTimeout(() => {
+                    timers.delete(timer);
+                    response.writeHead(200, { "content-type": "application/json" }).end("{}");
+                  }, 150);
+                  timers.add(timer);
+                } else {
+                  response.setHeader("content-type", "text/html");
+                  response.end(html);
+                }
+              });
+              server.once("error", reject);
+              server.listen(0, "127.0.0.1", () => resolve(server));
+            }),
+        ),
+        (server) =>
+          Effect.promise(
+            () =>
+              new Promise<void>((resolve) => {
+                for (const timer of timers) clearTimeout(timer);
+                server.closeAllConnections();
+                server.close(() => resolve());
+              }),
+          ),
+      );
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        return yield* Effect.die("Missing local server address");
+      const url = `http://127.0.0.1:${address.port}`;
+      const browser = yield* Effect.acquireRelease(
+        sdkCall(() => nativePuppeteer.launch({ executablePath: executable.value, headless: true })),
+        (browser) => Effect.promise(() => browser.close()),
+      );
+      const page = yield* sdkCall(() => browser.newPage());
+      const requestListenerBaseline = page.listenerCount("request");
+      sdk.launch.mockResolvedValue({
+        createBrowserContext: async () => ({ newPage: async () => page, close: async () => {} }),
+        sessionId: () => "native-probe",
+        isConnected: () => browser.isConnected(),
+        on: () => {},
+        off: () => {},
+        close: async () => {},
+      });
+      const unused = async (): Promise<Response> => {
+        throw new Error("No Cloudflare requests");
+      };
+      const logs: Array<ReturnType<typeof Logger.formatStructured.log>> = [];
+      const layer = browserRunInteractiveLayer().pipe(
+        Layer.provide(
+          BrowserRunInteractiveBinding.layer({ browser: { fetch: unused, quickAction: unused } }),
+        ),
+      );
+      yield* Effect.gen(function* () {
+        const handle = yield* (yield* InteractiveBrowser).open(
+          InteractiveBrowserPolicy.make({
+            network: { _tag: "Unrestricted" },
+            maxActions: 30,
+            maxElapsedMillis: 30_000,
+            maxReturnedBytes: 256 * 1024,
+          }),
+        );
+        yield* handle.navigate(BrowserNavigateRequest.make({ url }));
+        const read = handle.readText(BrowserReadTextRequest.make({}));
+        const initial = yield* read;
+        const observed = yield* Schema.decodeUnknownEffect(Observation)(initial.text);
+        expect(observed.controlsTruncated).toBe(true);
+        expect(observed.controls).toHaveLength(64);
+        const size = observed.controls.find((c) => c.label === "12oz");
+        const cart = observed.controls.find((c) => c.label === "Add to Cart");
+        expect(size).toMatchObject({
+          kind: "label:radio",
+          checked: false,
+          required: true,
+          valid: false,
+          formValid: false,
+        });
+        expect(cart).toBeDefined();
+        expect(observed.controls.filter((c) => c.kind === "option")).toMatchObject([
+          { label: "Choose roast", selected: true },
+          { label: "Light", selected: false },
+          { label: "Dark", selected: false },
+        ]);
+        for (const control of observed.controls) {
+          expect(
+            yield* sdkCall(() => page.$$eval(control.selector, (elements) => elements.length)),
+          ).toBe(1);
+          expect(control.selector).not.toContain("private-");
+        }
+        expect(initial.text).not.toContain("private-small-value");
+        expect(initial.text).not.toContain("private-roast-value");
+        expect(initial.text).not.toContain("private-credential");
+        expect(observed.controls.every((control) => !control.label?.includes("private-"))).toBe(
+          true,
+        );
+        expect(
+          isBrowserRunUndispatchedActionError(
+            yield* handle.click(BrowserClickRequest.make({ selector: "[" })).pipe(Effect.flip),
+          ),
+        ).toBe(true);
+        expect(
+          isBrowserRunUndispatchedActionError(
+            yield* handle.click(BrowserClickRequest.make({ selector: "label" })).pipe(Effect.flip),
+          ),
+        ).toBe(true);
+        if (size === undefined || cart === undefined)
+          return yield* Effect.die("Missing product controls");
+        yield* handle.click(BrowserClickRequest.make({ selector: cart.selector }));
+        expect(cartRequests).toBe(0);
+        yield* handle.click(BrowserClickRequest.make({ selector: size.selector }));
+        yield* handle.fill(
+          BrowserFillRequest.make({ selector: "#roast", value: "private-roast-value" }),
+        );
+        const selected = yield* Schema.decodeUnknownEffect(Observation)((yield* read).text);
+        expect(selected.controls.find((c) => c.label === "12oz")).toMatchObject({
+          checked: true,
+          formValid: true,
+        });
+        expect(
+          selected.controls.find((c) => c.kind === "option" && c.label === "Light"),
+        ).toMatchObject({ selected: true });
+        yield* handle.click(BrowserClickRequest.make({ selector: cart.selector }));
+        expect(cartRequests).toBe(1);
+        expect(logs.at(-1)?.annotations).toMatchObject({
+          "browser.fetch_xhr_total": 1,
+          "browser.fetch_xhr_failed": 0,
+          "browser.fetch_xhr_2xx": 1,
+          "browser.fetch_xhr_pending": 0,
+          "browser.network_settle_timed_out": false,
+        });
+        expect(page.listenerCount("requestfinished")).toBe(0);
+        expect(page.listenerCount("requestfailed")).toBe(0);
+        expect(page.listenerCount("request")).toBe(requestListenerBaseline + 1);
+        yield* handle.close;
+        expect(page.listenerCount("request")).toBe(0);
+        expect(logs.every((entry) => entry.cause === undefined)).toBe(true);
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(
+          Layer.merge(
+            layer,
+            Logger.layer([
+              Logger.map(Logger.formatStructured, (entry) => {
+                logs.push(entry);
+              }),
+            ]),
+          ),
+        ),
+      );
+    }).pipe(Effect.scoped),
+  30_000,
+);

--- a/packages/platform-cloudflare/test/interactive-browser.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser.test.ts
@@ -151,6 +151,21 @@ const makeGate = <A>(): Gate<A> => {
 };
 
 const makeFixture = (options: FixtureOptions = {}): Fixture => {
+  const observation = {
+    before: { matchCount: 1 },
+    after: { matchCount: 1 },
+    afterUnavailable: false,
+    network: {
+      total: 0,
+      status2xx: 0,
+      status3xx: 0,
+      status4xx: 0,
+      status5xx: 0,
+      failed: 0,
+      pending: 0,
+      settleTimedOut: false,
+    },
+  };
   const calls: Array<string> = [];
   const keepAliveMillis: Array<number> = [];
   let currentUrl: unknown = options.initialUrl ?? "https://example.com/";
@@ -238,13 +253,17 @@ const makeFixture = (options: FixtureOptions = {}): Fixture => {
         ? { _tag: "Text", text: "Example Domain" }
         : await options.readText(selector, maximumBytes);
     },
-    fill: async (selector, value) => {
+    fill: async (selector, value, _signal, onDispatch) => {
       calls.push(`page.fill:${selector}:${value}`);
+      onDispatch();
       await options.fill?.(selector, value);
+      return observation;
     },
-    click: async (selector) => {
+    click: async (selector, _signal, onDispatch) => {
       calls.push(`page.click:${selector}`);
+      onDispatch();
       await options.click?.(selector);
+      return observation;
     },
     screenshot: async (fullPage) => {
       calls.push(`page.screenshot:${String(fullPage)}`);

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -7,6 +7,7 @@ const run: NonNullable<UserConfig["run"]> = {
   tasks: {
     test: {
       command: "vitest run",
+      env: ["BROWSER_TEST_EXECUTABLE"],
       input: [
         { auto: true },
         { pattern: "bun.lock", base: "workspace" },
@@ -85,7 +86,22 @@ export default defineConfig({
         test: {
           name: "workerd",
           include: ["test/**/*.test.ts"],
-          exclude: ["test/restart/**", "test/code-mode/**", "test/travel-planner-dc.test.ts"],
+          exclude: [
+            "test/restart/**",
+            "test/code-mode/**",
+            "test/interactive-browser-actions.test.ts",
+            "test/interactive-browser-native.test.ts",
+            "test/travel-planner-dc.test.ts",
+          ],
+        },
+      },
+      {
+        test: {
+          name: "browser-actions",
+          include: [
+            "test/interactive-browser-actions.test.ts",
+            "test/interactive-browser-native.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary

Upstream the generic browser fixes from [Kommunikasie #1043](https://github.com/reve-ai/kommunikasie/pull/1043), reviewed against consumer commit `2159af1fdec0583b8f707a7a84c0304a6bb189b6` and its parent. This replaces the need for its platform-cloudflare patch once a compatible release is actually published. The consumer worktree is untouched.

- [Page observations](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/packages/platform-cloudflare/src/interactive-browser.ts#L641) return bounded JSON through the existing text result. The 64-control inventory prioritizes forms over links, includes labels for hidden radios and native option labels/selection, and gives structural CSS selectors without reading field values. Navigation uses DOM content loaded with a 30-second provider timeout.
- [Mutation dispatch](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/packages/platform-cloudflare/src/interactive-browser.ts#L587) requires one match before acquiring and using an element handle. Missing, ambiguous, and syntactically invalid CSS targets are recognized by the exported `isBrowserRunUndispatchedActionError` helper. No mutation is automatically retried.
- Fetch/XHR settlement uses a 200ms quiet window and two-second cap. Logs contain only bounded target categories, booleans, counts, and status-class buckets. Listeners and handles are cleaned up on completion, failure, and interruption. Post-action state is best-effort with a 250ms cap.

## What went wrong

Plain page text hid required controls and the state of hidden native radios. First-match click/fill could mutate the wrong element, and returning immediately after dispatch hid delayed cart requests. Global network-idle navigation could wait indefinitely on busy pages. The consumer compensated by patching source, JavaScript, and declarations in an older package.

The consumer patch also had two gaps addressed here. Native select options were absent, so observing `selected` on a select did not identify the selected option. An abort removed listeners but could leave an uncancellable SDK action running without recording its dispatch state.

The [interruption boundary](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/packages/platform-cloudflare/src/interactive-browser.ts#L1277) now fences late preflight completion, invalidates the handle, records whether dispatch occurred before teardown, and waits at most 500ms for SDK completion. An already dispatched mutation remains uncertain even if it later completes. This does not claim remote cancellation or exactly-once execution. The existing engine owns durable ordinary-tool uncertainty; these diagnostics add no journal records.

Public tool request/result Schemas stay unchanged. New observations are Schema-validated inside this adapter. The SDK testing interface gains an abort signal, dispatch notification, and observation result for click/fill. Persona policy, screenshot resolution, crawler recovery, dev tokens, and advisor ledgers remain consumer-owned.

## Consumer patch audit

| Consumer hunk | Upstream disposition |
| --- | --- |
| `src/alarm.ts` and `dist/index.mjs`: accepted-abort maintenance and dormant FIFO followers | Already merged in [#214](https://github.com/danieljvdm/effect-agent/pull/214). Verified in both source and JavaScript of the published platform-cloudflare `0.1.0-beta.36` tarball. No reimplementation here. |
| DOM-ready navigation with 30-second timeout | Present before the consumer reference commit, still absent from published beta.36 and current main. Included here. |
| Text/control inventory, unique target checks, fetch/XHR observations, undispatched helper | Added by the consumer reference commit. Ported as source changes onto current main, with invalid CSS, native options, and interruption fixes. |
| `dist/interactive-browser.mjs` and `dist/interactive-browser.d.mts` | Generated by the upstream build. No hand-edited distribution files. The built declaration exports the helper. |

The separate consumer storage-cloudflare patch only adds abort-intent-aware claiming of unknown heads. I also verified that exact behavior in the published storage-cloudflare beta.36 source and JavaScript. It is already superseded; it does not need another patch during the eventual coordinated upgrade.

## Evidence

- [Deterministic production-adapter regressions](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/packages/platform-cloudflare/test/interactive-browser-actions.test.ts): 10 passed, including abort during preflight, abort after dispatch with late completion, ambiguous acquired handles, invalid CSS, delayed requests, hard settlement limits, destroyed documents, bounded disposal, and log privacy.
- [Real Chromium proof](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/packages/platform-cloudflare/test/interactive-browser-native.test.ts): 1 passed without cache on this commit. It uses the pinned Cloudflare Puppeteer implementation with local Chromium and a disposable localhost form. All 64 emitted selectors match exactly one element despite 80 navigation links. Hidden-radio labels and native option selection are present; invalid form submission sends zero cart requests; a valid submission sends one delayed request and reports `2xx=1`, `pending=0`, `timedOut=false`. Observers are removed after actions and session close. No hosted browser, purchase, credentials, or deployment is involved.

Run the opt-in proof with `BROWSER_TEST_EXECUTABLE=/path/to/chromium vp run --no-cache @effect-agent/platform-cloudflare#test test/interactive-browser-native.test.ts`. The ordinary suite skips this test when no executable is configured. Existing browser tests also pass. The full local `vp run ready` gate passed after a fresh frozen installation repaired an incomplete local dependency tree; no dependency versions were changed for this PR.

## Release and consumer handoff

This PR does not authorize merging, npm publication, tags, or deployment. Dan must approve merging this implementation and then the regenerated [Version Packages PR #216](https://github.com/danieljvdm/effect-agent/pull/216) after it includes this changeset. Its merge triggers the trusted-publishing workflow, which builds and publishes to npm's `beta` tag and then creates package tags. Do not merge the current release PR expecting it to contain this unmerged change.

The [fixed release group](https://github.com/danieljvdm/effect-agent/blob/8d9c875e44ef9cfbba1f7eeb90caef606eb73779/.changeset/config.json) contains fourteen packages: `@effect-agent/{capabilities,core,engine,platform-cloudflare,platform-node,pr-review,sandbox,sandbox-local,session,storage-cloudflare,storage-memory,storage-sqlite,testing}` and `effect-agent`. One shared published version is the upgrade coordinate. The current npm beta is `0.1.0-beta.36`, which does **not** contain this browser fix. No future version is assumed here.

The originating consumer agent should:

1. Wait for successful publication of a release containing this commit, verify npm artifacts and the helper export, and confirm that the full fixed package set was published. A merged code PR or generated version PR alone is insufficient.
2. Align the direct framework versions in root `package.json`, `apps/api/package.json`, and `packages/browser/package.json` to that actual published version. Current upstream requires `effect-cf ^0.37.0`; update the consumer's `0.34.0` catalog/override consistently. `effect-cf 0.37.0` is published. Effect remains `4.0.0-rc.111` at this PR's base; verify the eventual release's exact requirements.
3. Remove `patches/@effect-agent%2Fplatform-cloudflare@0.1.0-beta.35.patch` and its `patchedDependencies` entry. The unchanged storage-cloudflare beta.35 patch and entry can also be removed because its entire fix is already in beta.36 and retained upstream. Do not substitute file/git overrides or another platform patch.
4. Regenerate the lockfile with `vp install`, verify a frozen install, and rerun consumer checks and the browser/advisor proof. Keep the consumer-specific fixes in #1043. Consumer integration is not complete until these steps run against the published release.
