### PR TITLE
ci: skip automatic review of generated release changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ on:
     branches: [main]
   # Changesets release PRs contain only these generated paths. They receive a
   # `ready` check from the trusted main-branch Release workflow after exact
-  # regeneration. GITHUB_TOKEN updates cannot trigger this workflow, so the
-  # verifier itself rejects any unexpected path. A later human update with an
-  # unexpected path stops matching this filter and runs ordinary CI.
+  # regeneration. Filtering before run creation avoids GITHUB_TOKEN's workflow
+  # approval prompt. The verifier itself rejects any unexpected path; an update
+  # with an unexpected path stops matching this filter and triggers ordinary CI.
   pull_request:
     paths-ignore:
       - ".changeset/**"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,6 +3,13 @@ name: PR Review
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
+    # Match CI's generated-release filter before GitHub creates a run that
+    # needs approval. The Release workflow owns the release PR's ready check.
+    paths-ignore:
+      - ".changeset/**"
+      - "bun.lock"
+      - "packages/*/CHANGELOG.md"
+      - "packages/*/package.json"
   issue_comment:
     types: [created]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,9 @@ jobs:
       - name: Install trusted verifier dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Pull requests created or updated with GITHUB_TOKEN cannot trigger their
-      # own pull_request workflows. Verify the generated head from this trusted
-      # main-branch run and post the required check directly.
+      # Generated paths are filtered out of pull_request workflows, which would
+      # otherwise require approval for GITHUB_TOKEN updates. Verify from this
+      # trusted main-branch run and post the required check directly.
       - name: Resolve the generated release head
         id: release-pr
         env:

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -200,10 +200,12 @@ by Changesets, validates its repository, branch, base, and commit identities,
 runs `changeset version` and lockfile generation in a temporary worktree, and
 requires the resulting complete Git tree to match the proposed head
 byte-for-byte. It posts the required `ready` check directly to that immutable
-head only after successful verification. GitHub suppresses `pull_request`
-workflow runs caused by `GITHUB_TOKEN`, so an unexpected path in an automated
-Changesets update is rejected by that exact-tree verification and receives a
-failing `ready`; path routing is not its security boundary. A later human
+head only after successful verification. GitHub requires approval for matching
+`pull_request` workflows triggered by `GITHUB_TOKEN` on opened, synchronize, or
+reopened events. The path filters prevent those runs and their approval prompt
+for generated-only changes. Explicit `@effect-agent review` comments still work.
+An unexpected path in an automated Changesets update is rejected by exact-tree
+verification and receives a failing `ready`; path routing is not its security boundary. A later human
 mutation with an unexpected path invokes the ordinary PR workflows, while a
 generated-only mutation has a new head without a verified check and remains
 unmergeable. The exact-tree verifier runs in a fresh read-only job checked out from the triggering
@@ -355,8 +357,8 @@ separate runners. Its remaining-workspace job includes every other package, incl
 packages. Each runner executes one package test task at a time, because every task already
 starts its own Vitest worker pool. File isolation, test counts, and timeouts remain unchanged.
 The exact internal Changesets release PR is the only exception: CI and PR Review path-filter the exact set of files
-Changesets may generate. GitHub suppresses `pull_request` workflows caused by `GITHUB_TOKEN`, so
-the trusted Release run validates the PR lineage, regenerates the complete tree from its checked-out
+Changesets may generate, avoiding approval-required workflow runs on `GITHUB_TOKEN` updates.
+The trusted Release run validates the PR lineage, regenerates the complete tree from its checked-out
 `main` commit, and creates the required `ready` check on the verified head through the Checks API.
 The check is success only after an exact-tree comparison in a fresh read-only job; unexpected files,
 setup failures, or any other incomplete verification post failure to the current PR head. An invalid

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -887,6 +887,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(reviewWorkflow.on).toEqual({
         pull_request: {
           types: ["opened", "reopened", "ready_for_review", "synchronize"],
+          "paths-ignore": generatedPaths,
         },
         issue_comment: { types: ["created"] },
       });


### PR DESCRIPTION
## Summary

Restore the [PR Review trigger filter](https://github.com/danieljvdm/effect-agent/blob/1aabb9e/.github/workflows/pr-review.yml#L3) so changes limited to Changesets metadata, the lockfile, package manifests, and changelogs do not start automatic review or request workflow approval. Explicit `@effect-agent review` comments still work.

Keep the existing release-tree verification and required `ready` check. Update the [workflow contract test](https://github.com/danieljvdm/effect-agent/blob/1aabb9e/packages/testing/test/toolchain.test.ts#L851) and correct the outdated workflow comments and toolchain documentation.

## What went wrong

PR #161 removed the generated-file filter while rebuilding the reviewer. CI still filtered these files, but PR Review matched each Changesets update. GitHub puts matching workflows triggered by `GITHUB_TOKEN` PR updates into an approval-required state, producing the banner seen on #216 and an unnecessary review after approval.

Filtering at the workflow trigger prevents run creation. Changing the bot token or relaxing branch protection would add authority without addressing the unnecessary review. The trusted Release workflow continues to verify that the complete proposed tree matches Changesets output and reports `ready` independently.
