### PR TITLE
fix(browser): confirm remote session termination before cleanup succeeds

### DIFF
--- a/.changeset/confirm-browser-terminal-cleanup.md
+++ b/.changeset/confirm-browser-terminal-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Confirm exact Browser Run session termination before reporting cleanup success, including already-absent sessions. Provide `BrowserRunSessionLifecycle.layer({ accountId, apiToken })` with an account-scoped Browser Rendering Write token when constructing the interactive binding.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -183,6 +183,13 @@ uncertainty and recovery contract.
 
 `BrowserRunInteractiveBinding.layer({ browser, viewport: { width: 1440, height: 900 } })`
 sets Puppeteer's launch `defaultViewport`. Omitting `viewport` preserves Puppeteer's default.
+The binding requires `BrowserRunSessionLifecycle.layer({ accountId, apiToken })`, backed by an
+`HttpClient` and an account-scoped Browser Rendering Write token. Both `session.close` and
+`host.closeSession` confirm whole-browser termination or exact-session absence. Cleanup sends at
+most one DELETE and two metadata reads within ten seconds. A `closing` response remains pending;
+authentication, malformed responses, and transport failures never count as absence. Local
+teardown errors cannot veto confirmed termination. `BrowserRunCleanupError` carries a sanitized
+reason in the close error's cause; park authorization/configuration failures until corrected.
 The exported `BrowserRunViewport` Schema accepts integer CSS dimensions in `1..2048`, optional
 finite `deviceScaleFactor` in `1..2`, defaulting to `1`, and requires
 `max(width, height) * deviceScaleFactor <= 2048`. Hosts can impose narrower UI limits.

--- a/examples/browser-run-worker-proof/README.md
+++ b/examples/browser-run-worker-proof/README.md
@@ -25,17 +25,22 @@ metadata. It uses no language model or Workers AI extraction. The scroll check p
 was accepted on the current page; the short Example Domain page may not have vertical overflow.
 
 The live workflow generates a fresh Worker name, rejects an existing name, deploys through the
-example's direct Wrangler dependency, waits 15 seconds for route propagation, invokes the Worker
+example's direct Wrangler dependency, provisions its narrow Browser Rendering token, waits 15 seconds for route propagation, invokes the Worker
 once, and deletes the deployment when its Scope closes. The propagation wait and invocation share
 a 150-second timeout. It never retries an unresolved invocation. The deletion
 finalizer is registered only after Wrangler confirms deployment, and a deletion failure fails the
 task instead of being logged and ignored.
+The deployment credential stays in the local workflow. Only the account ID and the narrow browser
+token enter the temporary Worker; deleting the Worker also removes that secret. Remote browser
+cleanup must confirm exact-session termination before the proof succeeds.
 
 Set these values before opting in:
 
 - `CLOUDFLARE_ACCOUNT_ID`: the 32-character account ID;
 - `CLOUDFLARE_API_TOKEN`: a token that can read and edit Workers Scripts, held as an Effect
   `Redacted` value;
+- `BROWSER_RENDERING_API_TOKEN`: an account-scoped Browser Rendering Write token, uploaded only
+  to the temporary Worker after its deletion finalizer is registered;
 - `CLOUDFLARE_WORKERS_SUBDOMAIN`: the account's workers.dev subdomain without `.workers.dev`.
 
 Run the proof from the repository root:

--- a/examples/browser-run-worker-proof/src/contract.ts
+++ b/examples/browser-run-worker-proof/src/contract.ts
@@ -3,6 +3,40 @@ import { Schema } from "effect";
 export const PROOF_SOURCE_URL = "https://example.com/";
 export const PROOF_FACT = "Example Domain";
 
+export const BrowserRunProofStage = Schema.Literals([
+  "capture",
+  "scrape",
+  "screenshot",
+  "open",
+  "navigate",
+  "read",
+  "scroll",
+  "interactive-screenshot",
+  "live-view",
+  "handoff",
+  "handoff-state",
+  "close",
+  "closed-handle",
+]);
+export class BrowserRunWorkerProofFailure extends Schema.Class<BrowserRunWorkerProofFailure>(
+  "BrowserRunWorkerProofFailure",
+)({
+  error: Schema.Literal("The Browser Run binding proof failed"),
+  stage: BrowserRunProofStage,
+  cleanupReason: Schema.optionalKey(
+    Schema.Literals([
+      "configuration",
+      "authorization",
+      "rate-limited",
+      "provider",
+      "malformed",
+      "timeout",
+      "pending",
+    ]),
+  ),
+  cleanupStatus: Schema.optionalKey(Schema.Int),
+}) {}
+
 const ScreenshotProof = Schema.Struct({
   mediaType: Schema.Literal("image/png"),
   pngSignatureValid: Schema.Literal(true),

--- a/examples/browser-run-worker-proof/src/worker.ts
+++ b/examples/browser-run-worker-proof/src/worker.ts
@@ -8,6 +8,7 @@ import {
   BrowserRunHandoffRequest,
   BrowserRunInteractiveBinding,
   BrowserRunInteractiveHost,
+  BrowserRunSessionLifecycle,
   BrowserRunLiveViewRequest,
   browserRunInteractiveHostLayer,
 } from "@effect-agent/platform-cloudflare/interactive-browser";
@@ -22,9 +23,20 @@ import {
   PageScreenshotRequest,
   PageUrlTarget,
 } from "@effect-agent/sandbox";
-import { Duration, Effect, Layer, Option, Redacted, Schema, Stream } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Redacted,
+  Schema,
+  Stream,
+} from "effect";
 import { Worker, WorkerEnvironment } from "effect-cf";
 import { Toolkit } from "effect/unstable/ai";
+import { FetchHttpClient } from "effect/unstable/http";
 
 import {
   BrowserRunInteractiveProof,
@@ -82,13 +94,23 @@ class WorkerCaptureProofError extends Schema.TaggedError<WorkerCaptureProofError
 ) {}
 
 const proofLayer = Layer.unwrap(
-  Effect.map(WorkerEnvironment, (env) => {
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvironment;
+    const lifecycleConfig = yield* Config.all({
+      accountId: Config.string("CLOUDFLARE_ACCOUNT_ID"),
+      apiToken: Config.redacted("BROWSER_RENDERING_API_TOKEN"),
+    }).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(env)));
     const quickActionLayer = Layer.mergeAll(
       browserQuickActionCaptureLayer(),
       browserQuickActionScreenshotLayer(),
     ).pipe(Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })));
     const interactiveLayer = browserRunInteractiveHostLayer().pipe(
       Layer.provide(BrowserRunInteractiveBinding.layer({ browser: env.BROWSER })),
+      Layer.provide(
+        BrowserRunSessionLifecycle.layer(lifecycleConfig).pipe(
+          Layer.provide(FetchHttpClient.layer),
+        ),
+      ),
     );
     const browserRunLayer = Layer.merge(quickActionLayer, interactiveLayer);
     return Layer.merge(proofCapture.handlers, proofScrape.handlers).pipe(

--- a/examples/browser-run-worker-proof/src/worker.ts
+++ b/examples/browser-run-worker-proof/src/worker.ts
@@ -6,6 +6,7 @@ import {
 } from "@effect-agent/platform-cloudflare/browser-quick-action";
 import {
   BrowserRunHandoffRequest,
+  BrowserRunCleanupError,
   BrowserRunInteractiveBinding,
   BrowserRunInteractiveHost,
   BrowserRunSessionLifecycle,
@@ -18,6 +19,7 @@ import {
   BrowserScreenshotRequest,
   BrowserScrollRequest,
   InteractiveBrowserPolicy,
+  InteractiveBrowserActionError,
   PageScreenshot,
   PageScreenshotLimits,
   PageScreenshotRequest,
@@ -38,8 +40,10 @@ import { Worker, WorkerEnvironment } from "effect-cf";
 import { Toolkit } from "effect/unstable/ai";
 import { FetchHttpClient } from "effect/unstable/http";
 
+import type { BrowserRunProofStage } from "./contract.ts";
 import {
   BrowserRunInteractiveProof,
+  BrowserRunWorkerProofFailure,
   BrowserRunWorkerProofResult,
   PROOF_FACT,
   PROOF_SOURCE_URL,
@@ -120,148 +124,180 @@ const proofLayer = Layer.unwrap(
 );
 
 const runProof = Effect.gen(function* () {
-  const toolkit = yield* Toolkit.make(proofCapture.tool);
-  const results = yield* toolkit.handle("capture_example_domain", {
-    url: PROOF_SOURCE_URL,
-    action: "markdown",
-  });
-  const last = yield* Stream.runLast(results);
-  if (Option.isNone(last) || last.value.preliminary) {
-    return yield* WorkerCaptureProofError.make({
-      message: "The WebCapture handler did not return a final result",
-    });
-  }
-  const result = last.value.result;
-  if (!Schema.is(WebCaptureSuccess)(result) || !result.markdown?.includes(PROOF_FACT)) {
-    return yield* WorkerCaptureProofError.make({
-      message: "The Markdown capture did not contain the expected stable fact",
-    });
-  }
-  yield* Effect.sleep(QUICK_ACTION_PACING_DELAY);
-  const scrapeToolkit = yield* Toolkit.make(proofScrape.tool);
-  const scrapeResults = yield* scrapeToolkit.handle("scrape_example_domain", {
-    url: PROOF_SOURCE_URL,
-    selectors: PROOF_SCRAPE_SELECTORS,
-  });
-  const scrapeLast = yield* Stream.runLast(scrapeResults);
-  if (Option.isNone(scrapeLast) || scrapeLast.value.preliminary) {
-    return yield* WorkerCaptureProofError.make({
-      message: "The selector scrape handler did not return a final result",
-    });
-  }
-  const scrapeResult = scrapeLast.value.result;
-  const heading = Schema.is(WebCaptureScrapeSuccess)(scrapeResult)
-    ? scrapeResult.groups.find((group) => group.selector === "h1")
-    : undefined;
-  if (
-    heading === undefined ||
-    !heading.results.some((element) => element.text.includes(PROOF_FACT))
-  ) {
-    return yield* WorkerCaptureProofError.make({
-      message: "The selector scrape did not contain the expected stable heading",
-    });
-  }
-  yield* Effect.sleep(QUICK_ACTION_PACING_DELAY);
-  const screenshots = yield* PageScreenshot;
-  const screenshot = yield* screenshots.capture(screenshotRequest);
-  if (screenshot.mediaType !== "image/png" || !hasPngSignature(screenshot.bytes)) {
-    return yield* WorkerCaptureProofError.make({
-      message: "The screenshot was not a PNG with the expected signature",
-    });
-  }
-  const interactive = yield* Effect.scoped(
-    Effect.gen(function* () {
-      const browsers = yield* BrowserRunInteractiveHost;
-      const session = yield* browsers.open(interactivePolicy);
-      const handle = session.handle;
-      const navigation = yield* handle.navigate(interactiveNavigateRequest);
-      if (navigation.url !== PROOF_SOURCE_URL) {
-        return yield* WorkerCaptureProofError.make({
-          message: "The interactive browser did not finish at the expected URL",
-        });
-      }
-      const page = yield* handle.readText(interactiveReadTextRequest);
-      if (
-        !page.text.includes(PROOF_FACT) ||
-        new TextEncoder().encode(page.text).byteLength > INTERACTIVE_MAX_TEXT_BYTES
-      ) {
-        return yield* WorkerCaptureProofError.make({
-          message: "The interactive browser text did not contain the expected stable fact",
-        });
-      }
-      const scrolled = yield* handle.scroll(BrowserScrollRequest.make({ deltaX: 0, deltaY: 128 }));
-      if (scrolled.url !== PROOF_SOURCE_URL) {
-        return yield* WorkerCaptureProofError.make({
-          message: "The interactive scroll changed the expected page URL",
-        });
-      }
-      const image = yield* handle.screenshot(BrowserScreenshotRequest.make({ fullPage: false }));
-      if (image.mediaType !== "image/png" || !hasPngSignature(image.bytes)) {
-        return yield* WorkerCaptureProofError.make({
-          message: "The interactive screenshot was not a PNG with the expected signature",
-        });
-      }
-      const liveView = yield* session.getLiveView(
-        BrowserRunLiveViewRequest.make({ mode: "tab", expiresInMs: 60_000 }),
-      );
-      const handoff = yield* session.handoff(
-        BrowserRunHandoffRequest.make({
-          instructions: "Temporary browser proof. The host will close this session immediately.",
-          timeout: 5_000,
-        }),
-      );
-      const handoffState = yield* session.getHandoffState;
-      if (
-        !handoffState.active ||
-        handoffState.handoffId === undefined ||
-        Redacted.value(handoffState.handoffId) !== Redacted.value(handoff.handoffId) ||
-        !Redacted.isRedacted(session.sessionId) ||
-        !Redacted.isRedacted(liveView.devtoolsFrontendUrl)
-      ) {
-        return yield* WorkerCaptureProofError.make({
-          message: "The interactive host controls did not return the expected private state",
-        });
-      }
-      yield* session.close;
-      const afterClose = yield* handle.readText(interactiveReadTextRequest).pipe(Effect.flip);
-      if (afterClose._tag !== "InteractiveBrowserExpiredError") {
-        return yield* WorkerCaptureProofError.make({
-          message: "The explicitly closed browser handle did not reject further actions",
-        });
-      }
-      return BrowserRunInteractiveProof.make({
-        finalUrl: PROOF_SOURCE_URL,
-        readFact: PROOF_FACT,
-        screenshot: { mediaType: "image/png", pngSignatureValid: true },
-        scrolled: true,
-        liveViewCreated: true,
-        handoffActive: true,
-        closed: true,
-      });
-    }),
-  );
-  return Response.json(
-    BrowserRunWorkerProofResult.make({
-      sourceUrl: PROOF_SOURCE_URL,
+  let stage: typeof BrowserRunProofStage.Type = "capture";
+  return yield* Effect.gen(function* () {
+    const toolkit = yield* Toolkit.make(proofCapture.tool);
+    const results = yield* toolkit.handle("capture_example_domain", {
+      url: PROOF_SOURCE_URL,
       action: "markdown",
-      fact: PROOF_FACT,
-      scrape: {
-        selectors: PROOF_SCRAPE_SELECTORS,
-        headingFact: PROOF_FACT,
-      },
-      screenshot: {
-        mediaType: "image/png",
-        pngSignatureValid: true,
-      },
-      interactive,
-    }),
-  );
-}).pipe(
-  Effect.catch(() =>
-    Effect.succeed(
-      Response.json({ error: "The Browser Run binding proof failed" }, { status: 502 }),
+    });
+    const last = yield* Stream.runLast(results);
+    if (Option.isNone(last) || last.value.preliminary) {
+      return yield* WorkerCaptureProofError.make({
+        message: "The WebCapture handler did not return a final result",
+      });
+    }
+    const result = last.value.result;
+    if (!Schema.is(WebCaptureSuccess)(result) || !result.markdown?.includes(PROOF_FACT)) {
+      return yield* WorkerCaptureProofError.make({
+        message: "The Markdown capture did not contain the expected stable fact",
+      });
+    }
+    yield* Effect.sleep(QUICK_ACTION_PACING_DELAY);
+    stage = "scrape";
+    const scrapeToolkit = yield* Toolkit.make(proofScrape.tool);
+    const scrapeResults = yield* scrapeToolkit.handle("scrape_example_domain", {
+      url: PROOF_SOURCE_URL,
+      selectors: PROOF_SCRAPE_SELECTORS,
+    });
+    const scrapeLast = yield* Stream.runLast(scrapeResults);
+    if (Option.isNone(scrapeLast) || scrapeLast.value.preliminary) {
+      return yield* WorkerCaptureProofError.make({
+        message: "The selector scrape handler did not return a final result",
+      });
+    }
+    const scrapeResult = scrapeLast.value.result;
+    const heading = Schema.is(WebCaptureScrapeSuccess)(scrapeResult)
+      ? scrapeResult.groups.find((group) => group.selector === "h1")
+      : undefined;
+    if (
+      heading === undefined ||
+      !heading.results.some((element) => element.text.includes(PROOF_FACT))
+    ) {
+      return yield* WorkerCaptureProofError.make({
+        message: "The selector scrape did not contain the expected stable heading",
+      });
+    }
+    yield* Effect.sleep(QUICK_ACTION_PACING_DELAY);
+    const screenshots = yield* PageScreenshot;
+    stage = "screenshot";
+    const screenshot = yield* screenshots.capture(screenshotRequest);
+    if (screenshot.mediaType !== "image/png" || !hasPngSignature(screenshot.bytes)) {
+      return yield* WorkerCaptureProofError.make({
+        message: "The screenshot was not a PNG with the expected signature",
+      });
+    }
+    const interactive = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const browsers = yield* BrowserRunInteractiveHost;
+        stage = "open";
+        const session = yield* browsers.open(interactivePolicy);
+        const handle = session.handle;
+        stage = "navigate";
+        const navigation = yield* handle.navigate(interactiveNavigateRequest);
+        if (navigation.url !== PROOF_SOURCE_URL) {
+          return yield* WorkerCaptureProofError.make({
+            message: "The interactive browser did not finish at the expected URL",
+          });
+        }
+        stage = "read";
+        const page = yield* handle.readText(interactiveReadTextRequest);
+        if (
+          !page.text.includes(PROOF_FACT) ||
+          new TextEncoder().encode(page.text).byteLength > INTERACTIVE_MAX_TEXT_BYTES
+        ) {
+          return yield* WorkerCaptureProofError.make({
+            message: "The interactive browser text did not contain the expected stable fact",
+          });
+        }
+        stage = "scroll";
+        const scrolled = yield* handle.scroll(
+          BrowserScrollRequest.make({ deltaX: 0, deltaY: 128 }),
+        );
+        if (scrolled.url !== PROOF_SOURCE_URL) {
+          return yield* WorkerCaptureProofError.make({
+            message: "The interactive scroll changed the expected page URL",
+          });
+        }
+        stage = "interactive-screenshot";
+        const image = yield* handle.screenshot(BrowserScreenshotRequest.make({ fullPage: false }));
+        if (image.mediaType !== "image/png" || !hasPngSignature(image.bytes)) {
+          return yield* WorkerCaptureProofError.make({
+            message: "The interactive screenshot was not a PNG with the expected signature",
+          });
+        }
+        stage = "live-view";
+        const liveView = yield* session.getLiveView(
+          BrowserRunLiveViewRequest.make({ mode: "tab", expiresInMs: 60_000 }),
+        );
+        stage = "handoff";
+        const handoff = yield* session.handoff(
+          BrowserRunHandoffRequest.make({
+            instructions: "Temporary browser proof. The host will close this session immediately.",
+            timeout: 5_000,
+          }),
+        );
+        stage = "handoff-state";
+        const handoffState = yield* session.getHandoffState;
+        if (
+          !handoffState.active ||
+          handoffState.handoffId === undefined ||
+          Redacted.value(handoffState.handoffId) !== Redacted.value(handoff.handoffId) ||
+          !Redacted.isRedacted(session.sessionId) ||
+          !Redacted.isRedacted(liveView.devtoolsFrontendUrl)
+        ) {
+          return yield* WorkerCaptureProofError.make({
+            message: "The interactive host controls did not return the expected private state",
+          });
+        }
+        stage = "close";
+        yield* session.close;
+        stage = "closed-handle";
+        const afterClose = yield* handle.readText(interactiveReadTextRequest).pipe(Effect.flip);
+        if (afterClose._tag !== "InteractiveBrowserExpiredError") {
+          return yield* WorkerCaptureProofError.make({
+            message: "The explicitly closed browser handle did not reject further actions",
+          });
+        }
+        return BrowserRunInteractiveProof.make({
+          finalUrl: PROOF_SOURCE_URL,
+          readFact: PROOF_FACT,
+          screenshot: { mediaType: "image/png", pngSignatureValid: true },
+          scrolled: true,
+          liveViewCreated: true,
+          handoffActive: true,
+          closed: true,
+        });
+      }),
+    );
+    return Response.json(
+      BrowserRunWorkerProofResult.make({
+        sourceUrl: PROOF_SOURCE_URL,
+        action: "markdown",
+        fact: PROOF_FACT,
+        scrape: {
+          selectors: PROOF_SCRAPE_SELECTORS,
+          headingFact: PROOF_FACT,
+        },
+        screenshot: {
+          mediaType: "image/png",
+          pngSignatureValid: true,
+        },
+        interactive,
+      }),
+    );
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.succeed(
+        Response.json(
+          BrowserRunWorkerProofFailure.make({
+            error: "The Browser Run binding proof failed",
+            stage,
+            ...(Schema.is(InteractiveBrowserActionError)(error) &&
+            Schema.is(BrowserRunCleanupError)(error.cause)
+              ? {
+                  cleanupReason: error.cause.reason,
+                  ...(error.cause.status === undefined
+                    ? {}
+                    : { cleanupStatus: error.cause.status }),
+                }
+              : {}),
+          }),
+          { status: 502 },
+        ),
+      ),
     ),
-  ),
-);
+  );
+});
 
 export default Worker.make(proofLayer, runProof);

--- a/examples/browser-run-worker-proof/src/workflow.ts
+++ b/examples/browser-run-worker-proof/src/workflow.ts
@@ -15,10 +15,11 @@ import {
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
-import { BrowserRunWorkerProofResult } from "./contract.ts";
+import { BrowserRunWorkerProofFailure, BrowserRunWorkerProofResult } from "./contract.ts";
 
 const CLOUDFLARE_ACCOUNT_ID = "CLOUDFLARE_ACCOUNT_ID";
 const CLOUDFLARE_API_TOKEN = "CLOUDFLARE_API_TOKEN";
+const BROWSER_RENDERING_API_TOKEN = "BROWSER_RENDERING_API_TOKEN";
 const CLOUDFLARE_WORKERS_SUBDOMAIN = "CLOUDFLARE_WORKERS_SUBDOMAIN";
 const MAX_PROCESS_OUTPUT_BYTES = 64 * 1_024;
 const PROCESS_TIMEOUT = Duration.seconds(120);
@@ -66,6 +67,7 @@ export interface WorkerDeploymentOperations {
 const proofConfig = Config.all({
   accountId: Config.schema(AccountId, CLOUDFLARE_ACCOUNT_ID),
   apiToken: Config.redacted(CLOUDFLARE_API_TOKEN),
+  browserToken: Config.redacted(BROWSER_RENDERING_API_TOKEN),
   workersSubdomain: Config.schema(WorkersSubdomain, CLOUDFLARE_WORKERS_SUBDOMAIN),
   executableSearchPath: Config.nonEmptyString("PATH"),
   userHome: Config.nonEmptyString("HOME"),
@@ -76,7 +78,7 @@ const loadProofConfig = proofConfig.pipe(
     WorkerProofError.make({
       reason: "configuration",
       operation: "load Cloudflare proof configuration",
-      message: `Set ${CLOUDFLARE_ACCOUNT_ID}, ${CLOUDFLARE_API_TOKEN}, and ${CLOUDFLARE_WORKERS_SUBDOMAIN} before running the live proof`,
+      message: `Set ${CLOUDFLARE_ACCOUNT_ID}, ${CLOUDFLARE_API_TOKEN}, ${BROWSER_RENDERING_API_TOKEN}, and ${CLOUDFLARE_WORKERS_SUBDOMAIN} before running the live proof`,
       cause,
     }),
   ),
@@ -225,13 +227,49 @@ export const makeLiveOperations = Effect.fn("BrowserRunWorkerProof.makeLiveOpera
       runProcess({
         spawner,
         executable: wranglerExecutable,
-        args: ["deploy", "--name", name, "--config", wranglerConfig],
+        args: [
+          "deploy",
+          "--name",
+          name,
+          "--config",
+          wranglerConfig,
+          "--var",
+          `CLOUDFLARE_ACCOUNT_ID:${config.accountId}`,
+        ],
         cwd: repositoryRoot,
         env: subprocessEnv,
         operation: "deployment",
       });
 
     const invoke = Effect.fn("BrowserRunWorkerProof.invoke")(function* (name: string) {
+      // The deployment finalizer is registered before provisioning its secret.
+      // This request's body contains a token; never include it or its cause in diagnostics.
+      const secretResponse = yield* execute(
+        HttpClientRequest.put(`${scriptUrl(name)}/secrets`).pipe(
+          HttpClientRequest.bodyJsonUnsafe({
+            name: BROWSER_RENDERING_API_TOKEN,
+            text: Redacted.value(config.browserToken),
+            type: "secret_text",
+          }),
+        ),
+        () =>
+          workerProofError(
+            "deployment",
+            "provision browser token",
+            "Cloudflare could not provision the temporary Worker's browser token",
+          ),
+      ).pipe(
+        Effect.withTracerEnabled(false),
+        Effect.provideService(FetchHttpClient.RequestInit, { redirect: "error" }),
+      );
+      if (secretResponse.status < 200 || secretResponse.status >= 300) {
+        return yield* workerProofError(
+          "deployment",
+          "provision browser token",
+          "Cloudflare rejected the temporary Worker's browser token",
+          { status: secretResponse.status },
+        );
+      }
       yield* Effect.sleep(DEPLOYMENT_PROPAGATION_DELAY);
       const response = yield* client
         .execute(HttpClientRequest.get(invocationUrl(name)))
@@ -246,10 +284,16 @@ export const makeLiveOperations = Effect.fn("BrowserRunWorkerProof.makeLiveOpera
           ),
         );
       if (response.status < 200 || response.status >= 300) {
+        const failure = yield* response.json.pipe(
+          Effect.flatMap(Schema.decodeUnknownEffect(BrowserRunWorkerProofFailure)),
+          Effect.option,
+        );
         return yield* workerProofError(
           "invocation",
           "invoke temporary Worker",
-          `The temporary Worker returned HTTP ${String(response.status)}`,
+          Option.isSome(failure)
+            ? `The temporary Worker proof failed at ${failure.value.stage}${failure.value.cleanupReason === undefined ? "" : ` (${failure.value.cleanupReason}, HTTP ${failure.value.cleanupStatus ?? "none"})`}`
+            : `The temporary Worker returned HTTP ${String(response.status)}`,
           { status: response.status },
         );
       }
@@ -307,9 +351,10 @@ export const temporaryWorker = Effect.fn("BrowserRunWorkerProof.temporaryWorker"
       return name;
     }),
     (deployedName) =>
-      operations
-        .delete(deployedName)
-        .pipe(Effect.catch((error) => Ref.set(deletionFailure, Option.some(error)))),
+      operations.delete(deployedName).pipe(
+        Effect.tap(() => Effect.logInfo(`Temporary Worker ${deployedName} was deleted`)),
+        Effect.catch((error) => Ref.set(deletionFailure, Option.some(error))),
+      ),
   );
 });
 

--- a/packages/platform-cloudflare/src/browser-session-lifecycle.ts
+++ b/packages/platform-cloudflare/src/browser-session-lifecycle.ts
@@ -13,6 +13,7 @@ export class BrowserRunCleanupError extends Schema.TaggedError<BrowserRunCleanup
       "timeout",
       "pending",
     ]),
+    status: Schema.optionalKey(Schema.Int),
   },
 ) {}
 
@@ -60,15 +61,25 @@ export class BrowserRunSessionLifecycle extends Context.Service<
               ).pipe(HttpClientRequest.bearerToken(options.apiToken)),
             )
             .pipe(
-              Effect.provideService(FetchHttpClient.RequestInit, { redirect: "error" }),
+              // workerd supports manual/follow, not error. Reject every redirect below.
+              Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" }),
               Effect.mapError(() => new BrowserRunCleanupError({ reason: "provider" })),
             );
           if (response.status === 401 || response.status === 403)
-            return yield* new BrowserRunCleanupError({ reason: "authorization" });
+            return yield* new BrowserRunCleanupError({
+              reason: "authorization",
+              status: response.status,
+            });
           if (response.status === 429)
-            return yield* new BrowserRunCleanupError({ reason: "rate-limited" });
+            return yield* new BrowserRunCleanupError({
+              reason: "rate-limited",
+              status: response.status,
+            });
           if (response.status !== 200 && response.status !== 404)
-            return yield* new BrowserRunCleanupError({ reason: "provider" });
+            return yield* new BrowserRunCleanupError({
+              reason: "provider",
+              status: response.status,
+            });
           if (response.headers["content-type"]?.split(";", 1)[0]?.trim() !== "application/json")
             return yield* new BrowserRunCleanupError({ reason: "malformed" });
           const bytes = yield* Stream.runFoldEffect(

--- a/packages/platform-cloudflare/src/browser-session-lifecycle.ts
+++ b/packages/platform-cloudflare/src/browser-session-lifecycle.ts
@@ -1,0 +1,131 @@
+import { Context, Effect, Layer, Option, Redacted, Schema, Stream } from "effect";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+
+export class BrowserRunCleanupError extends Schema.TaggedError<BrowserRunCleanupError>()(
+  "BrowserRunCleanupError",
+  {
+    reason: Schema.Literals([
+      "configuration",
+      "authorization",
+      "rate-limited",
+      "provider",
+      "malformed",
+      "timeout",
+      "pending",
+    ]),
+  },
+) {}
+
+export interface BrowserRunLifecycleOptions {
+  readonly accountId: string;
+  readonly apiToken: Redacted.Redacted<string>;
+}
+
+const Identity = Schema.String.check(Schema.isUUID());
+const Account = Schema.String.check(Schema.isPattern(/^[a-f0-9]{32}$/));
+const Closed = Schema.Struct({ status: Schema.Literals(["closing", "closed"]) });
+const Metadata = Schema.Struct({ sessionId: Identity, endTime: Schema.optionalKey(Schema.Finite) });
+// This exact provider response is accepted only on a fixed-origin, authenticated,
+// exact-session request. An arbitrary 404 or a listing omission is never absence.
+const Absent = Schema.Struct({ error: Schema.Literal("Session not found") });
+
+export class BrowserRunSessionLifecycle extends Context.Service<
+  BrowserRunSessionLifecycle,
+  {
+    readonly close: (
+      sessionId: Redacted.Redacted<string>,
+    ) => Effect.Effect<void, BrowserRunCleanupError>;
+  }
+>()("@effect-agent/platform-cloudflare/BrowserRunSessionLifecycle") {
+  static layer(options: BrowserRunLifecycleOptions) {
+    return Layer.effect(
+      this,
+      Effect.gen(function* () {
+        if (
+          !Schema.is(Account)(options.accountId) ||
+          Redacted.value(options.apiToken).length === 0
+        ) {
+          return yield* new BrowserRunCleanupError({ reason: "configuration" });
+        }
+        const client = yield* HttpClient.HttpClient;
+        const request = Effect.fn("BrowserRunSessionLifecycle.request")(function* (
+          method: "GET" | "DELETE",
+          sessionId: string,
+        ) {
+          const path = method === "DELETE" ? "browser" : "session";
+          const response = yield* client
+            .execute(
+              HttpClientRequest.make(method)(
+                `https://api.cloudflare.com/client/v4/accounts/${options.accountId}/browser-rendering/devtools/${path}/${sessionId}`,
+              ).pipe(HttpClientRequest.bearerToken(options.apiToken)),
+            )
+            .pipe(
+              Effect.provideService(FetchHttpClient.RequestInit, { redirect: "error" }),
+              Effect.mapError(() => new BrowserRunCleanupError({ reason: "provider" })),
+            );
+          if (response.status === 401 || response.status === 403)
+            return yield* new BrowserRunCleanupError({ reason: "authorization" });
+          if (response.status === 429)
+            return yield* new BrowserRunCleanupError({ reason: "rate-limited" });
+          if (response.status !== 200 && response.status !== 404)
+            return yield* new BrowserRunCleanupError({ reason: "provider" });
+          if (response.headers["content-type"]?.split(";", 1)[0]?.trim() !== "application/json")
+            return yield* new BrowserRunCleanupError({ reason: "malformed" });
+          const bytes = yield* Stream.runFoldEffect(
+            response.stream,
+            () => new Uint8Array(),
+            (body, chunk) => {
+              if (body.byteLength + chunk.byteLength > 16_384)
+                return Effect.fail(new BrowserRunCleanupError({ reason: "malformed" }));
+              const combined = new Uint8Array(body.byteLength + chunk.byteLength);
+              combined.set(body);
+              combined.set(chunk, body.byteLength);
+              return Effect.succeed(combined);
+            },
+          ).pipe(Effect.mapError(() => new BrowserRunCleanupError({ reason: "malformed" })));
+          const body = yield* Effect.try({
+            try: () => new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(bytes),
+            catch: () => new BrowserRunCleanupError({ reason: "malformed" }),
+          });
+          if (response.status === 404) {
+            const absent = Schema.decodeUnknownOption(Schema.fromJsonString(Absent))(body, {
+              onExcessProperty: "error",
+            });
+            if (Option.isSome(absent)) return true;
+            return yield* new BrowserRunCleanupError({ reason: "malformed" });
+          }
+          if (method === "DELETE") {
+            const result = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Closed))(
+              body,
+            ).pipe(Effect.mapError(() => new BrowserRunCleanupError({ reason: "malformed" })));
+            return result.status === "closed";
+          }
+          const result = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Metadata))(
+            body,
+          ).pipe(Effect.mapError(() => new BrowserRunCleanupError({ reason: "malformed" })));
+          if (result.sessionId !== sessionId)
+            return yield* new BrowserRunCleanupError({ reason: "malformed" });
+          return result.endTime !== undefined && result.endTime > 0;
+        });
+        const close = Effect.fn("BrowserRunSessionLifecycle.close")(
+          function* (sessionId: Redacted.Redacted<string>) {
+            const id = yield* Schema.decodeUnknownEffect(Identity)(Redacted.value(sessionId)).pipe(
+              Effect.mapError(() => new BrowserRunCleanupError({ reason: "configuration" })),
+            );
+            if (yield* request("DELETE", id)) return;
+            for (let read = 0; read < 2; read++) {
+              if (yield* request("GET", id)) return;
+            }
+            return yield* new BrowserRunCleanupError({ reason: "pending" });
+          },
+          Effect.timeoutOrElse({
+            duration: "10 seconds",
+            orElse: () => Effect.fail(new BrowserRunCleanupError({ reason: "timeout" })),
+          }),
+          Effect.withTracerEnabled(false),
+        );
+        return { close };
+      }),
+    );
+  }
+}

--- a/packages/platform-cloudflare/src/interactive-browser.ts
+++ b/packages/platform-cloudflare/src/interactive-browser.ts
@@ -32,6 +32,7 @@ import {
 } from "@effect-agent/sandbox";
 import {
   Context,
+  Clock,
   Duration,
   Effect,
   Layer,
@@ -42,6 +43,9 @@ import {
   Semaphore,
   type Scope,
 } from "effect";
+
+import { BrowserRunSessionLifecycle } from "./browser-session-lifecycle.ts";
+export { BrowserRunCleanupError, BrowserRunSessionLifecycle } from "./browser-session-lifecycle.ts";
 
 export const browserRunInteractiveImplementation = SandboxImplementation.make({
   isolation: "isolated",
@@ -57,7 +61,6 @@ const MAX_LIVE_VIEW_EXPIRY_MILLIS = 60 * 60_000;
 const MAX_HANDOFF_TIMEOUT_MILLIS = 30 * 60_000;
 const MAX_HOST_TEXT_LENGTH = 8 * 1024;
 const CLEANUP_STEP_TIMEOUT_MILLIS = 10_000;
-const CLOSE_SESSION_TIMEOUT_MILLIS = 10_000;
 const ACTION_NETWORK_QUIET_MILLIS = 200;
 const ACTION_NETWORK_SETTLE_MILLIS = 2_000;
 const ACTION_POST_STATE_MILLIS = 250;
@@ -330,15 +333,23 @@ export class BrowserRunInteractiveBinding extends Context.Service<
   BrowserRunInteractiveBinding,
   {
     readonly launch: (keepAliveMillis: number) => Promise<BrowserRunInteractiveBrowser>;
-    readonly connect: (sessionId: string) => Promise<BrowserRunInteractiveBrowser>;
+    /** Success proves whole-browser termination or exact-session absence. */
+    readonly closeSession: (
+      sessionId: Redacted.Redacted<string>,
+    ) => Effect.Effect<void, InteractiveBrowserError>;
   }
 >()("@effect-agent/platform-cloudflare/BrowserRunInteractiveBinding") {
   static layer(options: {
     readonly browser: BrowserRun;
     readonly viewport?: BrowserRunViewport;
-  }): Layer.Layer<BrowserRunInteractiveBinding, InteractiveBrowserPolicyDeniedError> {
+  }): Layer.Layer<
+    BrowserRunInteractiveBinding,
+    InteractiveBrowserPolicyDeniedError,
+    BrowserRunSessionLifecycle
+  > {
     return Layer.effect(BrowserRunInteractiveBinding)(
       Effect.gen(function* () {
+        const lifecycle = yield* BrowserRunSessionLifecycle;
         const viewport =
           options.viewport === undefined ? undefined : yield* decodeViewport(options.viewport);
         return {
@@ -349,8 +360,10 @@ export class BrowserRunInteractiveBinding extends Context.Service<
                 ...(viewport === undefined ? {} : { defaultViewport: { ...viewport } }),
               }),
             ),
-          connect: async (sessionId: string) =>
-            makeProductionBrowser(await puppeteer.connect(options.browser, sessionId)),
+          closeSession: (sessionId: Redacted.Redacted<string>) =>
+            lifecycle
+              .close(sessionId)
+              .pipe(Effect.mapError((cause) => actionError("close", cause))),
         };
       }),
     );
@@ -383,6 +396,7 @@ export interface BrowserRunInteractiveSession {
 export class BrowserRunInteractiveHost extends Context.Service<
   BrowserRunInteractiveHost,
   {
+    readonly cleanupSemantics?: "confirmed-terminal";
     readonly open: (
       policy: InteractiveBrowserPolicy,
     ) => Effect.Effect<BrowserRunInteractiveSession, InteractiveBrowserError, Scope.Scope>;
@@ -1719,6 +1733,55 @@ const cdpCommand = <A>(
 const makeHostService = (
   binding: BrowserRunInteractiveBinding["Service"],
 ): BrowserRunInteractiveHost["Service"] => {
+  const closeSession = binding.closeSession;
+  const terminate = Effect.fn("BrowserRunInteractiveHost.terminate")(function* (
+    sessionId: Redacted.Redacted<string>,
+    entries: ReadonlyArray<CloseEntry>,
+  ) {
+    const deadline = (yield* Clock.currentTimeMillis) + 10_000;
+    yield* closeSession(sessionId).pipe(
+      Effect.interruptible,
+      Effect.timeoutOrElse({
+        duration: "10 seconds",
+        orElse: () => Effect.fail(actionError("close")),
+      }),
+    );
+    const remaining = deadline - (yield* Clock.currentTimeMillis);
+    if (remaining <= 0)
+      return yield* Effect.logWarning(
+        "Local browser teardown skipped after confirmed termination deadline",
+      );
+    // Remote termination is authoritative. Local cleanup must not veto it or extend the deadline.
+    yield* runTeardown(entries).pipe(
+      Effect.flatMap((failures) =>
+        Effect.forEach(failures, (failure) => Effect.logWarning(failure.warning), {
+          discard: true,
+        }),
+      ),
+      Effect.interruptible,
+      Effect.timeout(`${remaining} millis`),
+      Effect.catchCause(() =>
+        Effect.logWarning("Local browser teardown incomplete after confirmed termination"),
+      ),
+    );
+  });
+  const closeAcquired = Effect.fn("BrowserRunInteractiveHost.closeAcquired")(function* (
+    browser: BrowserRunInteractiveBrowser,
+  ) {
+    const sessionId = yield* Effect.try({
+      try: browser.sessionId,
+      catch: () => actionError("close"),
+    }).pipe(
+      Effect.flatMap(Schema.decodeUnknownEffect(BrowserRunSessionId)),
+      Effect.mapError(() => actionError("close")),
+      Effect.onError(() =>
+        closeWithWarning(browser.close, "Closing an unidentified browser failed"),
+      ),
+    );
+    yield* terminate(Redacted.make(sessionId), [
+      closeEntry(browser.close, "Closing the local browser connection failed"),
+    ]);
+  });
   const open = Effect.fn("BrowserRunInteractiveHost.open")(function* (
     policy: InteractiveBrowserPolicy,
   ): Effect.fn.Return<BrowserRunInteractiveSession, InteractiveBrowserError, Scope.Scope> {
@@ -1733,7 +1796,6 @@ const makeHostService = (
     };
     const lifecycle = {
       managedTeardownInstalled: false,
-      explicitCloseInvoked: false,
     };
     const closers: Array<CloseEntry> = [];
     const releaseBeforeManaged = (entry: CloseEntry): Effect.Effect<void> =>
@@ -1750,7 +1812,7 @@ const makeHostService = (
             closeLateAcquisition(
               signal,
               () => binding.launch(keepAliveMillis(fixedPolicy)),
-              (acquired) => acquired.close(),
+              (acquired) => Effect.runPromise(closeAcquired(acquired)),
             ),
           catch: (cause) =>
             isCapacityRefusal(cause)
@@ -1765,9 +1827,11 @@ const makeHostService = (
       ),
       (acquired) => {
         state.disconnected.value = true;
-        return releaseBeforeManaged(
-          closeEntry(acquired.close, "Closing the interactive browser failed"),
-        );
+        return lifecycle.managedTeardownInstalled
+          ? Effect.void
+          : closeAcquired(acquired).pipe(
+              Effect.catch(() => Effect.logWarning("Whole-browser cleanup remains unconfirmed")),
+            );
       },
       { interruptible: true },
     );
@@ -1901,7 +1965,7 @@ const makeHostService = (
 
     const teardown = yield* Effect.uninterruptible(
       Effect.gen(function* () {
-        const cached = yield* Effect.cached(runTeardown(closers));
+        const cached = yield* Effect.cached(terminate(Redacted.make(sessionIdValue), closers));
         lifecycle.managedTeardownInstalled = true;
         yield* Effect.addFinalizer(() =>
           Effect.uninterruptible(
@@ -1910,13 +1974,7 @@ const makeHostService = (
               state.disconnected.value = true;
             }).pipe(
               Effect.andThen(cached),
-              Effect.flatMap((failures) =>
-                lifecycle.explicitCloseInvoked
-                  ? Effect.void
-                  : Effect.forEach(failures, (failure) => Effect.logWarning(failure.warning)).pipe(
-                      Effect.asVoid,
-                    ),
-              ),
+              Effect.catch(() => Effect.logWarning("Whole-browser cleanup remains unconfirmed")),
             ),
           ),
         );
@@ -1926,15 +1984,9 @@ const makeHostService = (
 
     const close: Effect.Effect<void, InteractiveBrowserError> = Effect.uninterruptible(
       Effect.sync(() => {
-        lifecycle.explicitCloseInvoked = true;
         state.closed.value = true;
         state.disconnected.value = true;
-      }).pipe(
-        Effect.andThen(teardown),
-        Effect.flatMap((failures) =>
-          failures[0] === undefined ? Effect.void : Effect.fail(failures[0].error),
-        ),
-      ),
+      }).pipe(Effect.andThen(teardown)),
     );
 
     const runtime = yield* makeHandle(page, fixedPolicy, startedAt, state, close);
@@ -2057,52 +2109,11 @@ const makeHostService = (
     };
   });
 
-  const closeSession = Effect.fn("BrowserRunInteractiveHost.closeSession")(function* (
-    sessionId: Redacted.Redacted<string>,
-  ) {
-    const decoded = yield* Schema.decodeUnknownEffect(Schema.Redacted(BrowserRunSessionId))(
-      sessionId,
-    ).pipe(
-      Effect.mapError(() => policyError("The Browser Run cleanup session identity is malformed")),
-    );
-    return yield* Effect.scoped(
-      Effect.gen(function* () {
-        const closeAttempted = { value: false };
-        const browser = yield* Effect.acquireRelease(
-          Effect.tryPromise({
-            try: (signal) =>
-              closeLateAcquisition(
-                signal,
-                () => binding.connect(Redacted.value(decoded)),
-                (acquired) => acquired.close(),
-              ),
-            catch: (cause) => actionError("close", cause),
-          }),
-          (acquired) =>
-            closeAttempted.value
-              ? Effect.void
-              : closeWithWarning(acquired.close, "Closing the leaked Browser Run session failed"),
-          { interruptible: true },
-        );
-        return yield* Effect.tryPromise({
-          try: () => {
-            // Mark and start are synchronous so interruption cannot suppress the
-            // Scope fallback before the one remote close attempt begins.
-            closeAttempted.value = true;
-            return browser.close();
-          },
-          catch: (cause) => actionError("close", cause),
-        });
-      }),
-    ).pipe(
-      Effect.timeoutOrElse({
-        duration: Duration.millis(CLOSE_SESSION_TIMEOUT_MILLIS),
-        orElse: () => Effect.fail(actionError("close")),
-      }),
-    );
+  return BrowserRunInteractiveHost.of({
+    open,
+    closeSession,
+    cleanupSemantics: "confirmed-terminal",
   });
-
-  return BrowserRunInteractiveHost.of({ open, closeSession });
 };
 
 /** Cloudflare host controls and private session identity for one scoped Browser Run pass. */

--- a/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
+++ b/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
@@ -1,11 +1,30 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Redacted } from "effect";
-import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 
 const sessionId = "c8b9c4b1-d1bf-4663-b4d8-a0b009cc8b99";
 const accountId = "1234567890abcdef1234567890abcdef";
+
+it.effect("uses a credential-preserving redirect policy supported by the Worker runtime", () =>
+  Effect.gen(function* () {
+    yield* (yield* BrowserRunSessionLifecycle).close(Redacted.make(sessionId));
+  }).pipe(
+    Effect.provide(
+      BrowserRunSessionLifecycle.layer({ accountId, apiToken: Redacted.make("fixture-token") }),
+    ),
+    Effect.provide(FetchHttpClient.layer),
+    Effect.provideService(FetchHttpClient.Fetch, async (input, init) => {
+      // The real workerd Request constructor rejects unsupported fetch options.
+      const request = new Request(input, init);
+      expect(request.redirect).toBe("manual");
+      return new Response('{"status":"closed"}', {
+        headers: { "content-type": "application/json" },
+      });
+    }),
+  ),
+);
 
 it.effect(
   "confirms exact-session termination without treating pending or untrusted responses as absence",

--- a/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
+++ b/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Redacted } from "effect";
+import { Effect, Layer, Redacted } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
@@ -12,9 +12,11 @@ it.effect("uses a credential-preserving redirect policy supported by the Worker 
     yield* (yield* BrowserRunSessionLifecycle).close(Redacted.make(sessionId));
   }).pipe(
     Effect.provide(
-      BrowserRunSessionLifecycle.layer({ accountId, apiToken: Redacted.make("fixture-token") }),
+      BrowserRunSessionLifecycle.layer({
+        accountId,
+        apiToken: Redacted.make("fixture-token"),
+      }).pipe(Layer.provide(FetchHttpClient.layer)),
     ),
-    Effect.provide(FetchHttpClient.layer),
     Effect.provideService(FetchHttpClient.Fetch, async (input, init) => {
       // The real workerd Request constructor rejects unsupported fetch options.
       const request = new Request(input, init);

--- a/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
+++ b/packages/platform-cloudflare/test/browser-session-lifecycle.test.ts
@@ -1,0 +1,94 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Redacted } from "effect";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
+
+const sessionId = "c8b9c4b1-d1bf-4663-b4d8-a0b009cc8b99";
+const accountId = "1234567890abcdef1234567890abcdef";
+
+it.effect(
+  "confirms exact-session termination without treating pending or untrusted responses as absence",
+  () =>
+    Effect.gen(function* () {
+      for (const scenario of [
+        { responses: [[200, '{"status":"closed"}']], terminal: true, requests: 1 },
+        { responses: [[404, '{"error":"Session not found"}']], terminal: true, requests: 1 },
+        {
+          responses: [
+            [200, '{"status":"closing"}'],
+            [200, `{"sessionId":"${sessionId}"}`],
+            [404, '{"error":"Session not found"}'],
+          ],
+          terminal: true,
+          requests: 3,
+        },
+        {
+          responses: [
+            [200, '{"status":"closing"}'],
+            [200, `{"sessionId":"${sessionId}","endTime":1}`],
+          ],
+          terminal: true,
+          requests: 2,
+        },
+        {
+          responses: [
+            [200, '{"status":"closing"}'],
+            [200, `{"sessionId":"${sessionId}"}`],
+            [200, `{"sessionId":"${sessionId}"}`],
+          ],
+          terminal: false,
+          requests: 3,
+        },
+        { responses: [[401, "{}"]], terminal: false, requests: 1 },
+        { responses: [[403, '{"error":"Session not found"}']], terminal: false, requests: 1 },
+        { responses: [[429, "{}"]], terminal: false, requests: 1 },
+        { responses: [[500, '{"error":"Session not found"}']], terminal: false, requests: 1 },
+        { responses: [[404, '{"error":"Route not found"}']], terminal: false, requests: 1 },
+        {
+          responses: [
+            [200, '{"status":"closing"}'],
+            [200, '{"sessionId":"b8b9c4b1-d1bf-4663-b4d8-a0b009cc8b99","endTime":1}'],
+          ],
+          terminal: false,
+          requests: 2,
+        },
+        { responses: [[200, "broken"]], terminal: false, requests: 1 },
+      ] as const) {
+        const calls: Array<string> = [];
+        const client = HttpClient.make((request, url) =>
+          Effect.sync(() => {
+            const response = scenario.responses[calls.length];
+            calls.push(request.method);
+            expect(url.origin).toBe("https://api.cloudflare.com");
+            expect(url.pathname).toBe(
+              `/client/v4/accounts/${accountId}/browser-rendering/devtools/${request.method === "DELETE" ? "browser" : "session"}/${sessionId}`,
+            );
+            if (response === undefined) throw new Error("Exceeded cleanup request budget");
+            return HttpClientResponse.fromWeb(
+              request,
+              new Response(response[1], {
+                status: response[0],
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }),
+        );
+        const result = yield* Effect.gen(function* () {
+          return yield* (yield* BrowserRunSessionLifecycle).close(Redacted.make(sessionId));
+        }).pipe(
+          Effect.provide(
+            BrowserRunSessionLifecycle.layer({
+              accountId,
+              apiToken: Redacted.make("fixture-token"),
+            }),
+          ),
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.exit,
+        );
+        expect(result._tag === "Success").toBe(scenario.terminal);
+        expect(calls.length).toBe(scenario.requests);
+        expect(calls.filter((method) => method === "DELETE")).toHaveLength(1);
+      }
+    }),
+);

--- a/packages/platform-cloudflare/test/interactive-browser-actions.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-actions.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Fiber, Layer, Logger } from "effect";
 import { afterEach, beforeEach, vi } from "vite-plus/test";
 
+import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 import {
   BrowserRunInteractiveBinding,
   browserRunInteractiveLayer,
@@ -103,7 +104,9 @@ const fixture = (
   };
   const layer = browserRunInteractiveLayer().pipe(
     Layer.provide(
-      BrowserRunInteractiveBinding.layer({ browser: { fetch: unused, quickAction: unused } }),
+      BrowserRunInteractiveBinding.layer({ browser: { fetch: unused, quickAction: unused } }).pipe(
+        Layer.provide(Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void })),
+      ),
     ),
   );
   return {

--- a/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-fill.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 import { vi } from "vite-plus/test";
 
+import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 import {
   BrowserRunInteractiveBinding,
   browserRunInteractiveLayer,
@@ -58,7 +59,9 @@ const nativeLayer = (element: object) => {
     Layer.provide(
       BrowserRunInteractiveBinding.layer({
         browser: { fetch: unusedRpc, quickAction: unusedRpc },
-      }),
+      }).pipe(
+        Layer.provide(Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void })),
+      ),
     ),
   );
 };

--- a/packages/platform-cloudflare/test/interactive-browser-native.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-native.test.ts
@@ -13,6 +13,7 @@ import { expect, it } from "@effect/vitest";
 import { Config, Effect, Layer, Logger, Option, Schema } from "effect";
 import { vi } from "vite-plus/test";
 
+import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 import {
   BrowserRunInteractiveBinding,
   browserRunInteractiveLayer,
@@ -125,7 +126,11 @@ it.live(
       const logs: Array<ReturnType<typeof Logger.formatStructured.log>> = [];
       const layer = browserRunInteractiveLayer().pipe(
         Layer.provide(
-          BrowserRunInteractiveBinding.layer({ browser: { fetch: unused, quickAction: unused } }),
+          BrowserRunInteractiveBinding.layer({
+            browser: { fetch: unused, quickAction: unused },
+          }).pipe(
+            Layer.provide(Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void })),
+          ),
         ),
       );
       yield* Effect.gen(function* () {

--- a/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Schema } from "effect";
 import { vi } from "vite-plus/test";
 
+import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 import {
   BrowserRunInteractiveBinding,
   BrowserRunInteractiveHost,
@@ -73,7 +74,11 @@ describe("Browser Run viewport boundary", () => {
     Effect.gen(function* () {
       sdk.launch.mockClear();
       const error = yield* BrowserRunInteractiveBinding.pipe(
-        Effect.provide(BrowserRunInteractiveBinding.layer({ browser, viewport })),
+        Effect.provide(
+          BrowserRunInteractiveBinding.layer({ browser, viewport }).pipe(
+            Layer.provide(Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void })),
+          ),
+        ),
         Effect.flip,
       );
       expect(error).toMatchObject({ _tag: "InteractiveBrowserPolicyDeniedError" });
@@ -90,7 +95,13 @@ describe("Browser Run viewport boundary", () => {
         Effect.scoped,
         Effect.provide(
           browserRunInteractiveHostLayer().pipe(
-            Layer.provide(BrowserRunInteractiveBinding.layer({ browser })),
+            Layer.provide(
+              BrowserRunInteractiveBinding.layer({ browser }).pipe(
+                Layer.provide(
+                  Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void }),
+                ),
+              ),
+            ),
           ),
         ),
       );
@@ -121,7 +132,11 @@ describe("Browser Run viewport boundary", () => {
                 BrowserRunInteractiveBinding.layer({
                   browser,
                   ...(viewport === undefined ? {} : { viewport }),
-                }),
+                }).pipe(
+                  Layer.provide(
+                    Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void }),
+                  ),
+                ),
               ),
             ),
           ),

--- a/packages/platform-cloudflare/test/interactive-browser.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser.test.ts
@@ -88,11 +88,6 @@ interface FixtureOptions {
   readonly connectionStateError?: unknown;
   readonly urlError?: unknown;
   readonly sessionId?: unknown;
-  readonly connectError?: unknown;
-  readonly connect?: (
-    sessionId: string,
-    browser: BrowserRunInteractiveBrowser,
-  ) => Promise<BrowserRunInteractiveBrowser>;
   readonly closeErrors?: ReadonlySet<CloseTarget>;
   readonly enableInterception?: (controls: FixtureControls) => Promise<void>;
   readonly launch?: (
@@ -357,11 +352,10 @@ const makeFixture = (options: FixtureOptions = {}): Fixture => {
       if (options.launchError !== undefined) throw options.launchError;
       return options.launch === undefined ? browser : options.launch(browser);
     },
-    connect: async (sessionId) => {
-      calls.push(`binding.connect:${sessionId}`);
-      if (options.connectError !== undefined) throw options.connectError;
-      return options.connect === undefined ? browser : options.connect(sessionId, browser);
-    },
+    closeSession: (sessionId) =>
+      Effect.sync(() => {
+        calls.push(`binding.terminate:${Redacted.value(sessionId)}`);
+      }),
   };
 
   return { binding, browser, calls, keepAliveMillis, controls };
@@ -1453,7 +1447,7 @@ describe("Browser Run interactive browser adapter", () => {
       }),
   );
 
-  it.effect("bounds each explicit cleanup step and continues reverse-order teardown", () =>
+  it.effect("does not let local teardown exceed the deadline or veto confirmed termination", () =>
     Effect.gen(function* () {
       const pageClose = makeGate<void>();
       const fixture = makeFixture({
@@ -1470,14 +1464,12 @@ describe("Browser Run interactive browser adapter", () => {
           const closing = yield* handle.close.pipe(Effect.forkChild);
           yield* awaitPromise(pageClose.started);
           yield* TestClock.adjust(Duration.seconds(10));
-          const error = yield* Fiber.join(closing).pipe(Effect.flip);
-          expect(error).toMatchObject({
-            _tag: "InteractiveBrowserActionError",
-            operation: "close",
-          });
+          yield* Fiber.join(closing);
+          expect(fixture.calls).toContain("binding.terminate:session-id");
+          pageClose.resolve(undefined);
         }),
       );
-      expectResourcesClosedOnce(fixture);
+      expect(fixture.calls.filter((call) => call === "page.close")).toHaveLength(1);
     }),
   );
 
@@ -1658,38 +1650,11 @@ describe("Browser Run interactive browser adapter", () => {
     }),
   );
 
-  it.effect("uses one finite cleanup-only connection and closes late acquisition", () =>
+  it.effect("closes the exact provider session without a browser connection", () =>
     Effect.gen(function* () {
-      const success = makeFixture();
-      yield* withHost(success, (host) => host.closeSession(Redacted.make("leaked_session")));
-      expect(success.calls).toContain("binding.connect:leaked_session");
-      expect(success.calls.filter((call) => call === "browser.close")).toHaveLength(1);
-
-      const gate = makeGate<BrowserRunInteractiveBrowser>();
-      const late = makeFixture({
-        connect: async () => {
-          gate.markStarted();
-          return gate.promise;
-        },
-      });
-      yield* withHost(late, (host) =>
-        Effect.gen(function* () {
-          const closing = yield* host
-            .closeSession(Redacted.make("late_session"))
-            .pipe(Effect.forkChild);
-          yield* awaitPromise(gate.started);
-          yield* TestClock.adjust(Duration.seconds(10));
-          expect(yield* Fiber.join(closing).pipe(Effect.flip)).toMatchObject({
-            _tag: "InteractiveBrowserActionError",
-            operation: "close",
-          });
-          gate.resolve(late.browser);
-          yield* Effect.yieldNow;
-          yield* Effect.yieldNow;
-        }),
-      );
-      expect(late.calls.filter((call) => call === "browser.close")).toHaveLength(1);
-      expect(late.calls.filter((call) => call.startsWith("binding.connect:"))).toHaveLength(1);
+      const fixture = makeFixture();
+      yield* withHost(fixture, (host) => host.closeSession(Redacted.make("leaked_session")));
+      expect(fixture.calls).toEqual(["binding.terminate:leaked_session"]);
     }),
   );
 


### PR DESCRIPTION
An evicted browser could remain blocked forever because cleanup tried to reconnect before closing. This adds exact-session lifecycle requests and reports success only after terminal provider evidence. Pending, unauthorized, and malformed results stay unresolved; local teardown failures cannot overturn confirmed termination.

The interactive binding now requires `BrowserRunSessionLifecycle` with an account-scoped Browser Rendering Write token. A changeset and partial/late-acquisition cleanup are included. The consumer must provide this Layer when upgrading.

A disposable deployed Worker passed capture, scrape, screenshot, interactive navigation/read/scroll, Live View, handoff, and confirmed remote cleanup; the Worker and its narrow token were deleted afterward. That proof found a workerd incompatibility with `redirect: error`. The transport now uses `manual` and rejects redirects, with a regression reproduced before the fix and passing afterward. A separate disposable session also passed positive identity lookup, termination, and repeated deletion. No merchant actions were performed.
