### PR TITLE
docs: clarify alpha capabilities and host responsibilities

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -150,8 +150,9 @@ A deterministically named sub-operation within one Durable Tool Call. Its result
 exactly-once-recorded but its external side effect is at-least-once-executed.
 
 **Skill**  
-A versioned package of instructions and bounded resources that can be activated for future Turns.
-A Skill is data, not ambient executable code.
+A deferred runtime concept for a versioned package of instructions and bounded resources that
+could be activated for future Turns. No runtime Skill API is implemented. Contributor skills in
+`.agents/skills` are repository tooling and are unrelated to Agent execution.
 
 **Subagent**  
 An Agent Definition invoked by another agent through a declared delegation capability. A durable

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ The working product thesis is:
 
 | Item         | Current state                                                             |
 | ------------ | ------------------------------------------------------------------------- |
-| Distribution | Private internal project                                                  |
-| Effect       | Effect v4, pinned exactly during pre-1.0 development                      |
-| Packages     | `@effect-agent/*`                                                         |
+| Distribution | Public alpha, published to npm on the opt-in `beta` dist-tag              |
+| Effect       | `effect` and OpenAI/Anthropic provider packages at exact `4.0.0-rc.111`   |
+| Packages     | `effect-agent` umbrella and optional `@effect-agent/*` packages           |
 | Workspace    | Vite+ monorepo with packages in `packages/*` and examples in `examples/*` |
 | Platforms    | Node.js with SQLite and Cloudflare Workers with Durable Objects           |
 
-The planned build through Phase 7 is implemented. Tests cover the ephemeral interpreter, durable
-Node runtime (`DN`), Cloudflare runtime (`DC`), Tool uncertainty, joined input, attached Subagents,
+Tests cover the ephemeral interpreter, durable Node runtime (`DN`), Cloudflare runtime (`DC`),
+Tool uncertainty, joined input, attached Subagents,
 adapter certification, formal models, failpoints, and soak behavior.
 
 `DN` and `DC` use the same coordinator. They provide durable admission, fenced Attempts, one
@@ -36,7 +36,13 @@ Completion is an engineering claim, not a stability claim. Cloudflare durability
 from workerd/Miniflare; an opt-in temporary deployment proves the Browser Run Worker binding
 against Cloudflare's hosted service. The sandbox also exposes bounded page capture, PNG screenshot,
 and scoped same-host Markdown crawl ports; Cloudflare supplies native-binding and REST adapters.
-Live-model and live-provider suites remain opt-in, and open-source preparation remains pending.
+Live-model and live-provider suites remain opt-in.
+
+"Alpha" describes product maturity; npm versions use `X.Y.Z-beta.N` and the `beta` dist-tag.
+APIs and stored data may change incompatibly before 1.0. There is no compatibility window or
+stored-data migration promise; incompatible data must fail clearly and may need a reset.
+Keep framework packages at one exact release and Effect/provider dependencies at that release's
+exact pins. See [installation and compatibility](docs/guide/getting-started.md#installation-and-compatibility).
 
 Normative words such as **MUST**, **SHOULD**, and **MAY** are used in their usual RFC sense.
 
@@ -48,6 +54,19 @@ The documentation site lives in [`docs/`](docs/index.md); run it locally with
 1. [Domain glossary](GLOSSARY.md)
 2. [Repository toolchain](docs/TOOLCHAIN.md)
 3. [Instructions for implementation agents](AGENTS.md)
+
+## Install
+
+The platform-neutral umbrella includes core, engine, and capabilities:
+
+```sh
+npm install --save-exact effect-agent@beta effect@4.0.0-rc.111 @effect/ai-openai@4.0.0-rc.111
+```
+
+Provider Layers, credentials, and Tool handlers come from the application. Persistent history,
+durable hosts, storage, and sandbox adapters are separate installs. See the
+[package map](docs/reference/packages.md#capability-inventory) for implemented APIs, bundled
+adapters, host requirements, and unsupported capabilities.
 
 ## Architecture decisions
 
@@ -90,23 +109,26 @@ repository owner.
 ## Repository commands
 
 ```sh
-bun install
-bun run sync:agent-skills
-bun run docs:dev
-bun run ready
+vp install
+vp run docs:dev
+vp run ready
 ```
 
-`bun run ready` runs the repository checks, package tests, and library builds. See the
-[toolchain guide](docs/TOOLCHAIN.md) for version synchronization, the Effect source checkout,
+`vp run ready` runs static checks, tests, package builds, and the documentation build with link
+validation. Vite+ is the command authority; Bun is its package manager. See the
+[toolchain guide](docs/TOOLCHAIN.md) for version synchronization, installed Effect source,
 package creation, hooks, and CI.
 
 ## Product boundaries
 
-The first release is the bounded Effect-native runtime described by the roadmap. Hosted execution,
-channels, a chat UI, a visual builder, an embedded coding sandbox, Subagent extensions beyond the
-implemented attached S1/S2 slices (nested delegation, handoff, detachment), and a marketplace
-remain outside that first release. Later packages may add them after the core loop is
-deterministic, typed, testable, and resource-safe.
+The alpha includes bounded execution, persistent history, durable accepted work, scheduled input,
+and event subscriptions. It does not provide hosted execution, a turnkey chat UI, a visual builder,
+runtime Skills, separate persistent agent memory/state, SessionStore metadata, or generic dynamic
+Turn Plans. Nested Subagent delegation, handoff, detachment, and a marketplace remain unsupported.
+MCP exposes a validated connector port whose transport the application implements. The local
+sandbox runs trusted code without isolation. See the
+[capability inventory](docs/reference/packages.md#capability-inventory) and
+[host isolation responsibilities](docs/guide/operations.md#authorization-and-isolation).
 
 Likewise, conversation persistence is not the same as durable execution. The framework may only
 claim durable execution after it can demonstrate:

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -1,6 +1,6 @@
 # Repository toolchain
 
-Status: **Accepted for private development**
+Status: **Public alpha, distributed on npm's beta channel**
 
 This repository is a Vite+ monorepo derived from
 [`danieljvdm/vp-effect-cf-template`](https://github.com/danieljvdm/vp-effect-cf-template).
@@ -26,10 +26,13 @@ The root `package.json` is the only version source for shared dependencies.
 | Vite+                             |              `0.2.6` | Formatting, linting, tests, library builds, staged checks, and task orchestration |
 | Vitest                            |             `4.1.10` | Vite+ test runtime, pinned through an override so integrations share one instance |
 | Effect                            |       `4.0.0-rc.111` | Runtime, Schema, services, and Effect AI                                          |
+| `@effect/ai-openai`               |       `4.0.0-rc.111` | Upstream OpenAI provider used by examples and the review Action                   |
+| `@effect/ai-anthropic`            |       `4.0.0-rc.111` | Upstream Anthropic provider used by examples                                      |
 | `@effect/platform-node`           |       `4.0.0-rc.111` | Node services used by repository scripts                                          |
 | `@effect/platform-browser`        |       `4.0.0-rc.111` | `BrowserCrypto` for the workerd runtime (Cloudflare packages)                     |
 | `@effect/sql-d1`                  |       `4.0.0-rc.111` | Required D1 peer of the Cloudflare runtime boundary                               |
 | `@effect/sql-sqlite-do`           |       `4.0.0-rc.111` | Durable Object SQLite `SqlClient` and Migrator (Cloudflare packages)              |
+| `@effect/sql-sqlite-node`         |       `4.0.0-rc.111` | Node SQLite storage adapter                                                       |
 | `@effect/vitest`                  |       `4.0.0-rc.111` | Effect-aware test execution and scoped Layer composition                          |
 | `effect-cf`                       |             `0.37.0` | Effect-native Cloudflare runtime boundary used by `platform-cloudflare`           |
 | `@cloudflare/vitest-pool-workers` |             `0.21.3` | In-workerd Vitest pool for the Cloudflare package suites (vendors wrangler)       |
@@ -46,6 +49,12 @@ The root `package.json` is the only version source for shared dependencies.
 
 Workspace packages refer to shared versions with `catalog:`. They must not introduce a second
 Effect version. The Bun lockfile is committed and CI installs it with `--frozen-lockfile`.
+
+These are exact compatibility pins, not ranges covering other Effect prereleases. Public
+consumers keep all framework packages at one exact release and use that release's Effect/provider
+versions. The public alpha permits breaking API and stored-schema changes before 1.0. There is no
+compatibility window or migration tooling promise; incompatible data fails clearly and disposable
+development data may be reset. See [installation and compatibility](guide/getting-started.md#installation-and-compatibility).
 
 The root catalog selects one exact `effect-cf` version for reproducible workspace installs.
 `@effect-agent/platform-cloudflare` publishes `effect-cf` as the compatible `^0.37.0` host peer
@@ -123,6 +132,11 @@ them, and they add no deployment or durability claim.
 
 Run commands from the repository root:
 
+Vite+ is the command authority and is distinct from Vite. Use `vp help` and
+`vp <command> --help` to inspect commands. Bun remains the package manager and script runtime
+behind these tasks. Do not invoke `bun run`, `npm run`, `pnpm run`, `yarn run`, or the underlying
+compiler, test, lint, or formatting binaries directly.
+
 | Command                                    | Meaning                                                                        |
 | ------------------------------------------ | ------------------------------------------------------------------------------ |
 | `vp install`                               | Install dependencies and run repository setup                                  |
@@ -135,6 +149,11 @@ Run commands from the repository root:
 | `vp run -F @effect-agent/example-demo dev` | Run the chat-first demo and Phase 2 simulator on port 4173                     |
 | `vp run ready`                             | Run check, test, and build; this is the local and CI handoff gate              |
 | `vp fmt`                                   | Apply repository formatting                                                    |
+
+Use `vp check` for static checks, `vp fmt --check` for formatting, `vp lint` for linting, and
+`vp test` for the root test runner. `vp run test` dispatches all workspace suites, including the
+Cloudflare pool tasks. `vp run ready` is the required handoff gate. If command or runtime setup
+fails, run `vp env doctor` and include its output when asking for help.
 
 Vite+ owns shared configuration in `vite.config.ts`. Package commands remain in their manifests
 or Vite task configs so Vite+ can discover and cache them from the workspace dependency graph.
@@ -160,24 +179,27 @@ and `vp run --no-cache test` to execute every suite again.
 
 ## Releasing to npm
 
-Versioning uses changesets (`bun run changeset`, `bun run changeset:version`);
-publishing uses `bun run release:publish`, NOT `changeset publish`. In a
+Versioning uses changesets (`vp run changeset`, `vp run changeset:version`);
+publishing uses `vp run release:publish`, not `changeset publish`. In a
 non-pnpm repository changesets shells out to `npm publish`, which ships
 `workspace:*` and `catalog:` protocol ranges verbatim; `bun publish` resolves
 both at publish time. The release script also swaps each manifest's
-source-first export map (a private-development convention, see below) for the
+source-first export map used in the workspace for the
 built `dist` entries during the publish, restores it afterwards, and skips
 versions already on the registry during manual publication. CI pack mode still
 builds those tarballs so the isolated publisher can compare their integrity and
 safely resume a partial release.
 
-Releases currently ship on the **beta channel**: the repository is in
+The public alpha ships on the **beta channel**. "Alpha" describes product maturity; it does not
+select a different npm tag. The repository is in
 changesets pre mode (`.changeset/pre.json`, tag `beta`), so `changeset
 version` produces `X.Y.Z-beta.N` versions, and the release script publishes
-any prerelease under the matching npm dist-tag (never `latest`). Consumers
-install with `bun add @effect-agent/core@beta` (or an exact version).
-Leaving the channel for a stable release is `bun x changeset pre exit`
-followed by the normal sequence.
+any prerelease under the matching npm dist-tag, never `latest`. Consumers install the
+platform-neutral `effect-agent@beta` umbrella or individual scoped packages, with optional
+adapters installed separately, as described in the [getting-started guide](guide/getting-started.md).
+Leaving prerelease mode for a future stable release requires an explicit release decision and
+`vp run changeset pre exit` before the normal sequence. Alpha documentation changes do not change
+tags or publish a release.
 
 All public framework workspaces form one Changesets `fixed` group. Any package changeset advances
 all fourteen packages to one shared version, including packages with no behavioral change in that
@@ -256,12 +278,12 @@ the OIDC exchange.
 The manual fallback from an authenticated npm session (`bunx npm login`, an
 owner of the `@effect-agent` scope):
 
-1. `bun run changeset` describes the change. One exists for `0.0.1-beta.0`;
-2. `bun run changeset:version && bun install` cuts versions and changelogs;
-3. `bun run ready`;
-4. `bun run release:publish -- --dry-run`, then without `--dry-run`
+1. `vp run changeset` describes the consumer-visible change;
+2. `vp run changeset:version` cuts versions and changelogs, then `vp install` updates the lockfile;
+3. `vp run ready`;
+4. `vp run release:publish --dry-run`, then without `--dry-run`
    (append `--otp <code>` when npm 2FA asks);
-5. `bun x changeset tag && git push --follow-tags`.
+5. `vp run changeset tag`, then `git push --follow-tags`.
 
 All fourteen packages publish under the MIT license (owner decision
 2026-08-14). The Cloudflare pair
@@ -274,7 +296,8 @@ zero-config defaults.
 
 ## Script runners
 
-Repository scripts run under **Bun** with `bun scripts/<name>.ts`. There is no
+Run repository scripts through `vp run <task>`. Their package-script entrypoints use **Bun**
+with `bun scripts/<name>.ts`. There is no
 `tsx` in this repository. The one exception is anything that imports
 `@effect-agent/storage-sqlite`: Bun does not implement `node:sqlite`, so
 `admin:durable` runs under `node --experimental-transform-types` (plain
@@ -285,15 +308,15 @@ transform-mode workers).
 
 ## Post-install setup
 
-`bun install` runs `vp config --no-agent --hooks-dir .vite-hooks` (the root `prepare` script),
+`vp install` runs `vp config --no-agent --hooks-dir .vite-hooks` through the root `prepare` script,
 which materializes the repository's `.vite-hooks` Git hook dispatcher. It does not touch the
 compiler patch; that remains a separate, explicit step.
 
-`bun run patch:tsgo` (`scripts/patch-effect-tsgo.ts`) applies the Effect TypeScript-Go compiler
+`vp run patch:tsgo` (`scripts/patch-effect-tsgo.ts`) applies the Effect TypeScript-Go compiler
 patch standalone, verifying the installed `@effect/tsgo` and `typescript` versions are the exact
 pinned pair before patching.
 
-CI installs with lifecycle scripts suppressed and then runs `bun run patch:tsgo` explicitly in
+CI installs with lifecycle scripts suppressed and then runs the `patch:tsgo` task explicitly in
 every job that checks, tests, or builds TypeScript. This preserves the compiler-patch invariant
 without any source checkout. Contributor tooling reads the installed Effect source from
 `node_modules/effect` when it needs to verify current Effect v4 or Effect AI behavior.
@@ -306,9 +329,9 @@ it once a fixed tsgo lands.
 To upgrade Effect:
 
 1. update every Effect-family catalog entry in root `package.json` as one change;
-2. run `bun install`;
-3. run `bun run ready`;
-4. run the Effect AI semantic/provider suite once it exists;
+2. run `vp install`;
+3. run `vp run ready`, including the provider example's compilation;
+4. run any relevant opt-in live-provider checks with host credentials, as described by their examples;
 5. commit the catalog and lockfile together.
 
 ## Contributor agent skills
@@ -321,8 +344,8 @@ updates with `bunx @danieljvdm/dev-kit@latest skills status`; fast-forward an un
 overwriting it. Add a new skill from the approved catalog with `skills add <name>`. Use the
 `dev-kit` skill before changing these outputs.
 
-These are contributor instructions. They are not the runtime Skill abstraction described in the
-capabilities API and must not be imported by a framework package.
+These are contributor instructions and must not be imported by a framework package. No runtime
+Skill API is currently implemented.
 
 ## Adding a package
 
@@ -341,11 +364,12 @@ the pull request that introduces it:
 6. declare only inward workspace dependencies;
 7. provide `check`, `test`, and `build` scripts when the package has those behaviors;
 8. update existing guides and API comments affected by the change;
-9. run `bun run ready`.
+9. run `vp run ready`.
 
-Package export maps point to source during private development. Distribution builds are produced
-with `vp pack`; final `dist` export maps, publication files, versioning, provenance, and release
-automation are deferred until open-source preparation.
+Workspace export maps point to source. `vp run build` dispatches package builds through `vp pack`.
+The release script installs `dist` export maps while packing or publishing and restores the
+workspace manifests afterwards. Public files, Changesets versioning, provenance, and release
+automation are already configured as described above.
 
 ## CI and hooks
 

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -5,7 +5,9 @@ to each request, pays for the larger prompt on every later call, and may exceed 
 model's context window before it answers. Context management bounds the prompt, reports remaining
 capacity, and gives the model one constrained chance to answer when a limit is exhausted.
 
-Everything on this page is policy-driven and on by default. The knobs live on `AgentPolicy`:
+The interpreter supplies bounded Tool results, Run status, and a default compaction strategy.
+Set context and cumulative budget limits for your Model and workload; they are not inferred from
+the provider. The knobs live on `AgentPolicy`:
 
 ```ts
 AgentPolicy.make({
@@ -156,6 +158,10 @@ typed with `ContextOverflowError` instead of an opaque provider error.
 umbrella package. Install it with a Layer to replace the strategy and token estimator without
 changing the Run loop. `ContextCompactor.layer` supplies the bounded default. Existing Runs that
 do not install a compactor select that same default at the Run boundary.
+
+The examples below assume the application also provides a
+[Conversation history policy](./conversations#history-policy-and-append-ownership), as required by
+all `AgentRuntime` entry points.
 
 To keep the default strategy but use another upstream Effect AI Model:
 
@@ -314,6 +320,24 @@ above. `contextCompactorRunContextLayer` installs `RunContextPreparation.compact
 a per-Turn prompt hook. Digest-bound `CompactionArtifact`, `digestCompactionSource`, and
 `applyCompaction` remain explicit data utilities; the interpreter does not invoke a second
 artifact compaction path. General prompt transformations still use `RunContextPreparation.hook`.
+
+### Explicit compaction artifacts
+
+The capabilities package also exposes an application-managed data path:
+`prepareModelContext` derives a bounded text view of a `ConversationSnapshot`, and
+`applyCompaction` validates a `CompactionArtifact` against that exact snapshot before replacing
+covered view messages with its summary. `digestCompactionSource` binds the artifact to its source
+range. The application creates the artifact, chooses when to apply it, and owns any storage.
+
+`RetainedFact` values preserve bounded facts and their source sequences inside the artifact.
+`applyCompaction` retains those values as artifact metadata; it does not insert each fact into the
+prompt or write to an independent memory store. The application decides how to use them.
+
+This is separate from the automatic `ContextCompactor` decision path above. The interpreter does
+not call `applyCompaction` or automatically persist these artifacts. Durable assemblies record
+native decisions as `CompactionCreated`; `PersistentHistory.layer` retains successful Run source
+history without persisting compaction decisions. Neither summaries, retained facts, nor canonical
+history provide a separate persistent agent memory/state API.
 
 ## Observing usage
 

--- a/docs/guide/conversations.md
+++ b/docs/guide/conversations.md
@@ -104,7 +104,8 @@ Use separate Conversation IDs for retained interaction and durable admission. Th
 owns its journal and supplies transient history policy internally. It continues to provide the
 accepted-work and recovery contract described by `@effect-agent/session/durability`.
 
-Applications enforce tenant and Conversation access before execution. Engine Tool authorization
+Applications enforce tenant and Conversation access before execution, following the host's
+[storage and addressing policy](./operations#storage-and-addressing). Engine Tool authorization
 and tracing still apply. The history adapter adds no transcript content to telemetry.
 
 ## Advanced history integrations

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,12 +6,64 @@ description: Define, bind, and run a bounded Effect-native Agent.
 # Getting started
 
 An Effect Agent has five pieces: input and output Schemas, instructions, an Effect AI Toolkit, a
-finite policy, and an explicit Model Binding. This page builds one from scratch. The packages
-publish to npm on the opt-in `beta` dist-tag:
+finite policy, and an explicit Model Binding. This page builds one from scratch.
+
+## Installation and compatibility
+
+The public alpha publishes npm prereleases on the opt-in `beta` dist-tag. "Alpha" describes
+product maturity; install it through `beta`, with package versions shaped as `X.Y.Z-beta.N`.
+
+For the platform-neutral umbrella and the OpenAI provider used below:
 
 ```sh
-npm install @effect-agent/core@beta @effect-agent/engine@beta effect
+npm install --save-exact effect-agent@beta effect@4.0.0-rc.111 @effect/ai-openai@4.0.0-rc.111
 ```
+
+`effect-agent` re-exports core, engine, and capabilities. The examples on this page use their
+scoped imports so the owning package is visible. To use those imports directly, declare the
+packages you import:
+
+```sh
+npm install --save-exact @effect-agent/core@beta @effect-agent/engine@beta effect@4.0.0-rc.111 @effect/ai-openai@4.0.0-rc.111
+```
+
+Choose optional packages for the capabilities your application needs:
+
+| Need                             | Install separately                                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Anthropic instead of OpenAI      | `@effect/ai-anthropic@4.0.0-rc.111`                                                                       |
+| Persistent history with SQLite   | `@effect-agent/session@beta` and `@effect-agent/storage-sqlite@beta`                                      |
+| Node durable accepted work       | `@effect-agent/platform-node@beta`, plus any scoped packages imported directly                            |
+| Cloudflare durable accepted work | `@effect-agent/platform-cloudflare@beta` and its `effect-cf` host peer, tested at `0.37.0`                |
+| Cloudflare interactive browser   | `@effect-agent/platform-cloudflare@beta` and its optional `@cloudflare/puppeteer` peer, tested at `1.1.0` |
+| Trusted local sandbox            | `@effect-agent/sandbox-local@beta`                                                                        |
+| Deterministic test Model         | `@effect-agent/testing@beta`                                                                              |
+
+Use the same exact release for all `effect-agent` and `@effect-agent/*` packages. The commands
+above resolve `beta` and save exact versions; retain the lockfile. This source tree supports
+`effect`, `@effect/ai-openai`, and `@effect/ai-anthropic` at exactly `4.0.0-rc.111`, not Effect v3
+or an arbitrary v4 prerelease. Effect platform, SQL, Atom, and test packages share that pin;
+the contributor compiler plugin `@effect/tsgo` has its own version.
+The `beta` tag moves, so check the selected release's manifests before upgrading and align your
+Effect/provider versions with that release. See the
+[provider example](https://github.com/danieljvdm/effect-agent/tree/main/examples/providers)
+for direct upstream Model bindings.
+
+Before 1.0, APIs and stored schemas may change incompatibly. No compatibility window or stored-data
+migration path is promised. Adapters reject incompatible versions; disposable development data may
+be reset. Retaining Conversation history is separate from
+[durable accepted work](../concepts/durability).
+
+The umbrella does not acquire provider clients, install Tool handlers, or run a host. Supply those
+Layers and credentials in the application. Storage and transport authority also belongs to the
+host; read [Authorization and isolation](./operations#authorization-and-isolation) before exposing
+Conversation operations to external callers. The [package map](../reference/packages) lists the
+available adapters and their limits.
+
+These npm commands are consumer installation examples. Contributors to this repository use
+`vp install` and `vp run <task>`; the
+[toolchain guide](https://github.com/danieljvdm/effect-agent/blob/main/docs/TOOLCHAIN.md)
+defines the Vite+ commands.
 
 ## 1. Model the boundary
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -131,10 +131,15 @@ Tool Calls, interruption, semantic events, steering, follow-up, approval, budget
 [context management](./context-management), MCP, and a local sandbox adapter. If the process
 disappears, active work disappears with it.
 
-**Persistent Conversations.** Canonical Conversation records survive restart through memory or
-SQLite adapters. History can be replayed, projected, exported, checkpointed, and observed from an
-opaque offset. Persistence does not mean the runtime has accepted an obligation to finish active
-work.
+**Persistent Conversations.** `ConversationHistory` is the history policy required by all
+`AgentRuntime` entry points. `PersistentHistory.layer` from `@effect-agent/session/history` retains
+successful Runs through a supplied `ConversationStore`; `ConversationHistory.layerTransient`
+selects execution without retained history. Load retained history through the service's `load` method.
+SQLite and Cloudflare storage survive restart; the memory adapter is process-local. History can
+be replayed, projected, exported, and observed. Checkpoint storage is optional and unused by
+execution or recovery. An interrupted Run has no completion obligation. See
+[Conversations](./conversations#retain-completed-runs) for the two-input SQLite example and
+concurrent-writer limits.
 
 **Durable accepted work.** The durable runtime first commits a Submission obligation, then
 returns a Receipt. Attempts may be replaced after a crash, but exactly one terminal Settlement is
@@ -142,6 +147,28 @@ eventually recorded. Unresolved external Tool effects stop at an explicit Unknow
 of replaying, and the same contract runs on Node/SQLite and on Cloudflare Durable Objects. No
 level claims exactly-once external side effects. See
 [Persistence & durability](../concepts/durability).
+
+## Capabilities and host responsibilities
+
+The [capability inventory](../reference/packages#capability-inventory) distinguishes public APIs,
+bundled defaults and adapters, and application-owned implementations. Installing the umbrella
+does not install a provider or a durable host. Applications supply Model Layers and credentials,
+Tool handlers, authorization, storage, and any external transports they use.
+
+Time-based [Scheduling](./operations#scheduled-input) and durable
+[event subscriptions](./operations#event-subscriptions) deliver new input through ordinary
+admission after the registering Run has ended. Neither keeps a Run alive or promises one Run per
+delivery. Their owner scoping does not establish tenant isolation for Conversation storage; hosts
+must enforce the [addressing and access boundary](./operations#authorization-and-isolation).
+
+MCP provides `McpConnector` and `connectMcp` for scoped connection and bounded discovery validation.
+The application implements the transport and supplies remote Tool handlers. There is no bundled
+stdio or HTTP MCP client adapter.
+
+Runtime Skills, a separate persistent agent memory/state service, SessionStore metadata, and
+generic dynamic Turn Plans are unsupported. Conversation history and compaction summaries are
+implemented, but neither supplies those missing APIs. [Context management](./context-management)
+explains automatic interpreter compaction and the separate, explicitly applied artifact utilities.
 
 ## What the framework optimizes for
 
@@ -155,8 +182,12 @@ adopting a second application runtime. It is especially opinionated about:
 - refusing to label ambiguous external effects "exactly once."
 
 It is not a hosted control plane, visual builder, turnkey chat product, generic workflow engine,
-or secure remote code sandbox. The project is pre-1.0: packages are private, Effect v4 is pinned
-to a beta release, and there is no compatibility window yet.
+or a general secure remote code sandbox. The public alpha is distributed as npm prereleases on
+the `beta` dist-tag, with versions shaped as `X.Y.Z-beta.N`. "Alpha" describes maturity, not an
+additional npm channel. This source tree pins Effect and the OpenAI/Anthropic provider packages to
+`4.0.0-rc.111`. APIs and stored data may break before 1.0; no compatibility window or migrations are
+promised. Incompatible data fails clearly and may need a reset. Follow the
+[installation and compatibility guidance](./getting-started#installation-and-compatibility).
 
 ## Next steps
 

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -27,14 +27,15 @@ and `ConversationStore` ports only, so they behave identically on `DN` and `DC`:
 - `scanObligations(thresholds)` returns the obligation report described below.
 
 On `DN`, `NodeDurableHost` re-exposes all five, and
-`bun run admin:durable -- <explain|verify|retry|wake|obligations> --database <file>` is the CLI.
+`vp run admin:durable <explain|verify|retry|wake|obligations> --database <file>` is the CLI.
 On `DC`, the Conversation Object exposes Schema-encoded entry points (`explainEncoded`,
 `verifyEncoded`, `retryEncoded`, `obligationsEncoded`, `wake`); deployments reach them through
 their own Worker. Every operation, including `observe`, `awaitSettlement`, `abort`,
 `resolveUnknown`, and `resolveApproval`,
-consults the `OperationAuthorizer` fail-closed: the default Layer preserves service-possession
-behavior, and a host-supplied authorizer turns denials into the typed `OperationDenied` before
-any read or write.
+consults `OperationAuthorizer`. Its default permits trusted service holders; it does not
+authenticate callers or enforce tenant policy. An installed authorizer's denials become typed
+`OperationDenied` failures before the operation reads or writes. See
+[Authorization and isolation](#authorization-and-isolation) before exposing these operations.
 
 ## Obligation monitoring
 
@@ -223,11 +224,72 @@ is a manual runbook, not an executed claim:
 
 ## Authorization and isolation
 
-Hosts authenticate external callers before admission and preserve tenant scope in storage,
-authorization, and telemetry. A Layer supplies a capability; it does not authorize its use.
-Recheck policy at action time, including after durable suspension, and audit administrative
-mutations with their author and reason. Approval is bound to the exact action and expires; parent
-approval never authorizes a child's later actions.
+The supported boundary is a host-controlled storage domain and trusted runtime services behind
+authenticated ingress. The framework does not provide general tenant authentication or row-level
+tenant isolation. A Receipt, Conversation ID, Submission ID, principal string, or audit author
+identifies something; none proves that a caller may access it.
+
+### Storage and addressing
+
+[`ScheduleOwner`](https://github.com/danieljvdm/effect-agent/blob/main/packages/session/src/schedule.ts)
+contains `tenantId` and `ownerId`. Subscription owners and source partitions are also
+tenant-qualified. Those scopes govern their own registrations, management, and delivery state.
+They do not qualify ordinary Conversation operations:
+[`AdmissionRequest`](https://github.com/danieljvdm/effect-agent/blob/main/packages/session/src/ledger.ts)
+and [`CanonicalRecordEnvelope`](https://github.com/danieljvdm/effect-agent/blob/main/packages/session/src/records.ts)
+have no tenant field. Admission keys are scoped by Conversation, principal, and idempotency key;
+a different principal does not create a separate Conversation log.
+
+For tenant isolation, the host must choose and enforce database or namespace separation:
+
+- On Node, bind each tenant's runtime to its own SQLite database/storage domain. One process owns
+  each database. Sharing a database across tenants requires additional application isolation for
+  every read, mutation, scan, worker, and administration path; the adapters do not supply it.
+- On Cloudflare, select the permitted Durable Object namespace and derive a tenant-qualified
+  Conversation address in trusted Worker code. Separate namespaces can provide a stronger host
+  boundary. `CloudflareConversationClient` routes with `namespace.idFromName(conversationId)`;
+  it does not infer a tenant or authorize an arbitrary name supplied by a caller. A private Object
+  database isolates that Object's storage, not access through a Worker holding its namespace.
+
+Keep the tenant-to-storage/address mapping stable across restarts, and apply it to admission,
+history, child Conversations, schedule/subscription destinations, and administration. Check the
+relationship between a Submission and its owning Conversation; a guessed or copied ID must not
+select another tenant's runtime. Scope logs, exports, backups, and operator access to that same
+boundary. Owner-scoped scheduling alone is insufficient.
+
+### Authorize each operation
+
+| Operation                                                  | Host responsibility                                                                                                                                                    | Framework boundary                                                                                                                                                                                   |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admission, including retries and prepared deliveries       | Authenticate ingress, derive the principal from trusted identity, authorize the Agent and destination, and select the permitted storage domain before calling `submit` | Schema validation, admission idempotency, and durability do not grant access. `OperationAuthorizer` is not an admission hook.                                                                        |
+| Reads, exports, observation, progress and Settlement waits | Authorize the Conversation/Submission and filter the accessible storage domain before returning any records or status                                                  | Durable observation/wait paths consult the operation authorizer. Direct `ConversationStore` reads/exports and `PersistentHistory.layer` use the supplied store's authority and add no access policy. |
+| Abort and approval/Unknown Outcome resolution              | Authenticate the decision maker, verify target ownership and action permission, and supply trusted author/reason audit fields                                          | The runtime consults the operation authorizer before reading or mutating the target. Audit fields alone do not authorize the command.                                                                |
+| Explain, verify, retry, wake and obligation scans          | Restrict administration to authorized operators in the selected storage domain; scans can expose multiple Conversations                                                | The operation authorizer covers these commands, but the default allows them. A scan is not automatically filtered by tenant.                                                                         |
+
+[`OperationAuthorizer`](https://github.com/danieljvdm/effect-agent/blob/main/packages/session/src/operation-authorizer.ts)
+defaults to `possessionOperationAuthorizer`, which allows every request. This is suitable only
+inside a trusted host boundary. Install a real policy through `operationAuthorizerLayer` when
+constructing the durable runtime; denials propagate as `OperationDenied` before protected I/O.
+The runtime captures the authorizer during Layer acquisition. Adding an override around a later
+method call does not replace that captured policy.
+
+The framework does not parse tokens or verify a `Principal` string. Some operation requests have
+no principal, and observation/wait wire APIs do not carry authenticated caller identity. Authorize
+in the host before invoking them and provide any identity needed by the installed policy through
+trusted host context. Do not expose raw storage, ledger, runtime, or Durable Object RPC services
+to untrusted callers. An authorizer cannot reconstruct identity that ingress never authenticated.
+
+An observation or Settlement wait authorizes once for its lifetime. To enforce later revocation,
+interrupt it and begin a new authorized operation. Use host credentials and policy for scheduled
+or subscription recovery; a retained principal is evidence of identity, not continuing permission.
+
+### Tools, delegation, and external resources
+
+Operation authorization is separate from Tool authorization. Default durable assemblies use
+`RunToolAuthorization.allowAll`; install a host Tool policy through the
+[independent authorization Layer](./context-management#composing-preparation-and-tool-authorization).
+Recheck action policy after durable suspension. Approval is bound to the exact action and expires;
+parent approval never authorizes a child's later actions.
 
 Delegation grants are immutable ceilings. Each child action must satisfy current policy, its
 grant, target requirements, and normalized resource scope. The model supplies decoded task
@@ -284,6 +346,11 @@ and [Cloudflare](https://github.com/danieljvdm/effect-agent/blob/main/packages/p
 examples for host setup and typed registration.
 
 ## Event subscriptions
+
+The bounded subscription implementation tracked by
+[#223](https://github.com/danieljvdm/effect-agent/issues/223) is available. It includes trusted
+application events and the GitHub workflow-attempt source below; it is not a general event bus or
+provider catalog.
 
 `Subscriptions` is the event-driven sibling of `Scheduling`. A subscription can outlive its Run.
 `SubscriptionIntake` first retains a normalized event and its unfinished routing work, then returns

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ const result = AgentRuntime.run(Triage, { repo: "acme/api", issueNumber: 123 }).
   </section>
 
   <footer class="ea-home__footer">
-    <strong>Pre-1.0. Tests cover every documented API and runtime contract.</strong>
+    <strong>Public alpha. Install from the beta channel; APIs and stored data may change.</strong>
     <a class="ea-button" href="/guide/getting-started">Build an agent →</a>
   </footer>
 </main>

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -1,13 +1,60 @@
 ---
 title: Package map
-description: Current private workspace packages and their boundaries.
+description: Public alpha packages, implemented capabilities, adapters, and host responsibilities.
 ---
 
 # Package map
 
-Fourteen framework packages publish to npm on the opt-in `beta` dist-tag. Provider wrapper
-packages are deliberately absent: provider integration remains upstream Effect AI Models and
-Layers.
+Fourteen framework packages publish to npm on the opt-in `beta` dist-tag. The product is a public
+alpha; package versions use `X.Y.Z-beta.N`. Keep all framework packages at one exact release.
+This source tree pins Effect and the OpenAI/Anthropic providers to `4.0.0-rc.111`. APIs and stored
+data may change incompatibly before 1.0, with no compatibility window or migration promise.
+See [installation and compatibility](../guide/getting-started#installation-and-compatibility).
+Provider integration remains upstream Effect AI Models and Layers.
+
+## Capability inventory
+
+An exported port is an integration contract; its implementation may still belong to the host.
+Optional Layers must be composed explicitly. The following entries link to their guides or APIs.
+
+| Capability and public API                                                                                                        | Bundled behavior or adapters                                                                                      | Host requirements and limits                                                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Agent execution](../guide/run-agents), `AgentRuntime.run`, `.stream`, `.start`                                                  | Bounded interpreter, finite policy, deterministic Tool-result order, scoped resources                             | Supply Model, Tool-handler, and history policy Layers. Ephemeral work ends with its Scope; it has no restart recovery.                                                                                                                               |
+| [Process-local Conversations](../guide/conversations#advanced-history-integrations), `EphemeralConversations`, `RunCommandQueue` | Bounded incremental history, steering and follow-up queues, engine adapters                                       | Wire the Conversation/input hooks with `ConversationHistory.layerTransient`. Partial Runs remain visible; history and commands disappear with the process.                                                                                           |
+| [Persistent history](../guide/conversations#retain-completed-runs), `ConversationHistory`, `PersistentHistory.layer`             | Successful-Run retention through the normal runtime; SQLite and Cloudflare stores; nonpersistent memory reference | Supply a store and unique identities. Concurrent Runs can both execute, but conflicting commits fail. No accepted-work recovery; checkpoints are optional.                                                                                           |
+| [Durable execution](../concepts/durability), `DurableAgentRuntime`                                                               | Node/SQLite and Cloudflare Durable Object assemblies, fenced Attempts, Settlements, conservative Tool recovery    | Operate workers and storage; register exact Agent Bindings; authorize admission and operations. Unknown ordinary Tool outcomes need explicit resolution.                                                                                             |
+| [Context management](../guide/context-management#compaction), `ContextCompactor`                                                 | Default pruning and metered summarization at the interpreter seam; replaceable Layer                              | Configure context limits and optional strategy/Model. Durable compaction must map to complete prior-Run records. Explicit artifact utilities are separate, as described below.                                                                       |
+| [Approval and budgets](../guide/run-agents#operational-hooks), `toRunApprovalHook`, `toRunBudgetHook`                            | Approval Schemas, deny-all resolver, memory audit, structural redactor, hierarchical usage accounting             | Supply resolver, audit/redaction policy, budget hooks, and cost estimates. Local audit/budget services are not a persistent tenant billing system.                                                                                                   |
+| [MCP](https://github.com/danieljvdm/effect-agent/blob/main/packages/capabilities/src/mcp.ts), `McpConnector`, `connectMcp`       | Scoped timeout and validation of discovery identity, counts, bytes, Toolkit names, and schema digests             | Implement transport, credentials, connection cleanup, and native Toolkit handlers. No bundled stdio/HTTP client transport. Remote execution is uncertain.                                                                                            |
+| [Subagents](../concepts/durability#attached-subagents), `Subagent.define`, `SubagentRuntime.layer`                               | Bounded ephemeral children and durable attached child protocol                                                    | Supply targets, Bindings, grants, projections, and action policy. Nested delegation, handoff, and detachment are unsupported.                                                                                                                        |
+| [Scheduled input](../guide/operations#scheduled-input), `Scheduling`                                                             | One-shot, interval, and cron delivery; memory reference, SQLite, and Cloudflare adapters/drivers                  | Supply owner policy, `ScheduleAuthorizer`, registered inputs/Bindings, and a running driver. Delivery uses ordinary admission, not a sleeping Run.                                                                                                   |
+| [Event subscriptions](../guide/operations#event-subscriptions), `Subscriptions`, `SubscriptionIntake`                            | Partitioned once/continuous delivery, restricted Tools, storage/drivers, GitHub workflow-attempt source           | Supply source/preparation bindings, authorizer, authenticated intake, and recovery. Records consume lifetime quota; no automatic pruning or generic historical replay. Implemented in [#223](https://github.com/danieljvdm/effect-agent/issues/223). |
+| [Sandbox and Code Mode](../guide/tools), `Sandbox`, `CodeExecutor`, `CodeMode.make`                                              | Trusted local process adapter; Cloudflare Code Mode adapter over the broker                                       | Supply execution policy and host Tool authority. Local processes are unisolated; generated programs require an isolated executor. No durable execution claim for a Code Mode pass.                                                                   |
+| [Web and browser ports](#effect-agent-platform-cloudflare), `PageCapture`, `PageScreenshot`, `PageCrawl`, `InteractiveBrowser`   | Cloudflare capture, REST crawl, and interactive browser adapters; `WebCapture` Tool helpers                       | Supply browser bindings or credentials and network policy. Browser handles are ephemeral; exact-host checks do not isolate hostile networks.                                                                                                         |
+
+### Compaction and unsupported capabilities
+
+Automatic compaction uses the engine's `ContextCompactor` decision stream. The capabilities package
+also exports `prepareModelContext`, `CompactionArtifact`, `RetainedFact`, `digestCompactionSource`,
+and `applyCompaction` for application-managed views. These explicit utilities validate an artifact
+against a source snapshot. They do not run automatically, store artifacts, or provide a second
+interpreter compactor. See [explicit compaction artifacts](../guide/context-management#explicit-compaction-artifacts).
+
+The following APIs are absent or deferred:
+
+- Runtime Skills have no registration, activation, loading, or resource API. `.agents/skills` is
+  contributor tooling, not a runtime capability.
+- Separate persistent agent memory/state has no framework service or store. Applications own such
+  domain state. Conversation history and source-bound retained compaction facts do not provide it.
+- SessionStore metadata has no public `SessionStore` API. A Session is an interaction handle in
+  the glossary; `ConversationStore` retains canonical history, not arbitrary session metadata.
+- Generic dynamic Turn Plans have no public API. Existing prompt-preparation hooks, Tool
+  authorization, and scheduling overrides are narrower contracts, not per-Turn replanning of
+  Models, Toolkits, policy, and resources.
+
+Scheduling and subscription tenant scopes apply to those registrations. They do not add tenant
+fields to Conversation records or establish general storage isolation. Hosts must enforce
+[database/namespace separation, addressing, and authorization](../guide/operations#authorization-and-isolation).
 
 ## Packages
 
@@ -16,7 +63,8 @@ Layers.
 Re-exports schema-first authoring from core, the bounded interpreter from engine, and operational
 capabilities as one platform-neutral root package,
 mirroring how `effect` fronts the `@effect/*` satellites. Platform adapters stay scoped, and the
-umbrella is version-fixed to its three constituents.
+umbrella shares the fixed release version of all framework packages. Session/history, storage,
+platform hosts, sandbox adapters, and testing are separate packages.
 
 ### `@effect-agent/core`
 
@@ -42,7 +90,7 @@ persisted or automatically exported. See [Tool failure observation](../guide/run
 ### `@effect-agent/capabilities`
 
 Adapts richer optional services to the engine: process-local Conversations, command queues,
-approval and audit, budgets, context/compaction, scheduling, MCP, structural redaction, web
+approval and audit, budgets, context/compaction, Tool-batch scheduling overrides, MCP, structural redaction, web
 capture through `WebCapture.make` and `WebCapture.makeExtract` over the `PageCapture` port, and
 Subagent authoring through `Subagent.define`, `SubagentPolicy`, `SubagentGrant`, and
 `SubagentRuntime.layer`. Capture Tools have uncertain execution class; extraction handler Layers
@@ -88,7 +136,12 @@ host-supplied `AgentBindingResolver` port for exact-digest Binding resolution.
 Adapter certification reports, port runners, and the TestClock-dependent conformance case arrays
 are available only from `@effect-agent/session/testing`; the package root has no transitive
 test-runtime dependency. Mutable coordinator failpoint controls and their test Layer also live
-in `@effect-agent/session/testing`; scheduling APIs remain on the production root.
+in `@effect-agent/session/testing`. Durable `Scheduling`, `Subscriptions`, event sources, and
+preparation bindings are on the production root; the GitHub source uses `@effect-agent/session/github`.
+
+`@effect-agent/session/history` exports `PersistentHistory`, `ConversationHistory`, and the history contracts;
+`@effect-agent/session/durability` exports the coordinator and accepted-work contracts. These
+focused entry points do not change the distinction between retained history and durable execution.
 
 ### `@effect-agent/storage-memory`
 
@@ -103,7 +156,8 @@ observation, typed compatibility/corruption/conflict/contention errors, and befo
 failpoints on every durable mutation.
 
 `@effect-agent/storage-sqlite/testing` exposes `SqliteStorageFailpointTestControl.layer` for tests.
-The production root exports `CurrentSqliteStorageVersion`; the migration loader is internal.
+The production root exports `CurrentSqliteStorageVersion`; schema initialization is internal.
+Only the current stored version is supported, with no upgrade migration promise.
 
 ### `@effect-agent/platform-node`
 
@@ -131,7 +185,8 @@ construction values.
 
 `@effect-agent/storage-cloudflare/testing` exposes `DoStorageFailpointTestControl.layer` and
 `evictionFailpointHandler` for adapter tests. The production root retains
-`CurrentDoStorageVersion`; the migration loader is internal.
+`CurrentDoStorageVersion`; schema initialization is internal. Incompatible stored versions fail
+clearly, with no upgrade migration promise.
 
 ### `@effect-agent/platform-cloudflare`
 


### PR DESCRIPTION
Public docs still described private packages and blurred integration ports, bundled adapters, and application responsibilities. Clarify the alpha capability inventory, tenant storage and authorization boundary, exact Effect/provider compatibility, optional installs, and the existing beta release channel. Remove obsolete publication and roadmap claims and align contributor commands with Vite+.

Document `ConversationHistory` and `PersistentHistory.layer` from the merged #252. Subscriptions are documented as implemented because #223 has closed and its APIs, adapters, and recovery tests are present; this supersedes KOM-10's older planned-subscriptions wording. Runtime Skills, separate agent memory/state, SessionStore metadata, and generic dynamic Turn Plans remain unsupported.

Closes [KOM-10](https://linear.app/reve-ai/issue/KOM-10).
