### PR TITLE
fix(pr-review): continue affordable research under the dollar cap

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -55,12 +55,13 @@ reasoning. Admission never assumes a cache hit. The ledger releases unused reser
 validating the response's usage, model, tier, and counted bounds. Failed, interrupted, or unmetered
 requests retain their possible charge; the transport does not automatically retry them.
 
-Research retains the 32,000-token maximum output allowance. When another research request cannot
-fit, the Action permits at most one affordable request restricted to `submit_review`, with its
-output allowance reduced to the remaining balance. It counts the changed final request again.
-If even that request cannot fit, the host delivers already recorded findings with no further model
-call. Both paths report incomplete coverage. Large changes may therefore remain incomplete under
-the ceiling; the Action does not call a partial empty result a successful review.
+The output allowance starts at 32,000 tokens and is reduced before each request when needed to fit
+the remaining balance. Research can continue with that smaller allowance; the model, reasoning
+effort, tool definitions, and tool choice stay unchanged. Logs show the requested and admitted
+output allowances. If a response is truncated by the cost limit, or no further request fits, the
+host delivers already recorded findings without another paid call and reports incomplete coverage.
+Large changes may therefore remain incomplete under the ceiling. An incomplete empty result is
+labeled `None recorded · incomplete`, never given a green check or counted as a successful review.
 
 This is a client admission guarantee under the pinned pricing and token-count contracts, not an
 invoice audit or an OpenAI account spending limit. Usage estimates remain separate from outstanding

--- a/action/dist/index.manifest.json
+++ b/action/dist/index.manifest.json
@@ -1,1 +1,1 @@
-{"version":1,"inputsSha256":"d6b8a41ed81ac7bc4d87594ee8cb08f00e9e1dead75aa28a5eedf7407a82d905","bundleSha256":"f2db2bd3f07f24791cafd2ed74b2c6060b8df5412c071c72e0ce26d8630a74d2"}
+{"version":1,"inputsSha256":"b7383733cb7792df796ca1e8f02ed7399752efa1f009ebbc7aea6befa28e384c","bundleSha256":"9f8ab993262b13e0e4b93a1059685b5e6c2ed70c4e94c612893bdbc2af520b37"}

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -49312,14 +49312,18 @@ var severityCounts = (report2) => ({
   important: report2.findings.filter((finding) => finding.severity === "important").length,
   nit: report2.findings.filter((finding) => finding.severity === "nit").length
 });
-var renderFindingTally = (report2) => {
-  const counts = severityCounts(report2);
+var renderFindingTally = (input) => {
+  const counts = severityCounts(input.report);
   const parts2 = [
     ...counts.blocking > 0 ? [`\uD83D\uDED1 ${String(counts.blocking)} blocking`] : [],
     ...counts.important > 0 ? [`⚠️ ${String(counts.important)} important`] : [],
     ...counts.nit > 0 ? [`\uD83D\uDC85 ${String(counts.nit)} nit`] : []
   ];
-  return parts2.length === 0 ? "✅ None" : parts2.join(" · ");
+  if (parts2.length > 0)
+    return parts2.join(" · ");
+  if (!input.complete || input.exhausted !== undefined)
+    return "None recorded · incomplete";
+  return input.unresolvedChangeRequests > 0 ? "None recorded" : "✅ None";
 };
 var renderVerdict = (report2, complete, unresolvedChangeRequests, exhausted) => {
   const counts = severityCounts(report2);
@@ -49395,7 +49399,7 @@ var renderReviewBody = (input) => {
     [
       "| Scope | Files | New findings |",
       "| :-- | :-- | :-- |",
-      `| **${input.scope === "full" ? "Full diff" : "Incremental"}** | ${renderCoverage(input)} | ${renderFindingTally(input.report)} |`
+      `| **${input.scope === "full" ? "Full diff" : "Incremental"}** | ${renderCoverage(input)} | ${renderFindingTally(input)} |`
     ].join(`
 `)
   ];
@@ -49574,7 +49578,7 @@ var withReviewPromptCache = (payload, key) => ({
   input: typeof payload.input === "string" ? [{ role: "user", content: cacheContent(payload.input) }] : payload.input?.map((item, index2, items) => {
     if ("role" in item && item.role !== "assistant") {
       const text2 = typeof item.content === "string" ? item.content : item.content.length === 1 && item.content[0]?.type === "input_text" ? item.content[0].text : "";
-      if (item.role === "user" && (text2.startsWith("<run-status>") || text2.startsWith("<review-cost-status>"))) {
+      if (item.role === "user" && text2.startsWith("<run-status>")) {
         return item;
       }
       return { ...item, content: cacheContent(item.content) };
@@ -49636,54 +49640,33 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
     const before = yield* exports_Ref.get(state);
     if (before.closed)
       return yield* refuse("Review spending admission has already stopped.");
-    let payload = withReviewPromptCache({ ...original, truncation: "disabled" }, options3.cacheKey);
-    let inputTokens = yield* count2(payload).pipe(exports_Effect.catch(() => refuse("Unable to count the review input before paid inference.")));
+    const payload = withReviewPromptCache({ ...original, truncation: "disabled" }, options3.cacheKey);
+    const inputTokens = yield* count2(payload).pipe(exports_Effect.catch(() => refuse("Unable to count the review input before paid inference.")));
     if (inputTokens > MAX_INPUT_TOKENS) {
       return yield* refuse("The counted review input exceeds the 128,000-token price boundary.");
     }
     const balance = REVIEW_COST_LIMIT_MICROUSD - before.cost - reservedCost(before);
-    let outputTokens = original.max_output_tokens ?? MAX_OUTPUT_TOKENS;
-    let finalizing = false;
-    if (Math.ceil((inputTokens * pricing.write + outputTokens * pricing.output) / 100) > balance) {
+    const requestedOutputTokens = original.max_output_tokens ?? MAX_OUTPUT_TOKENS;
+    const outputTokens = Math.min(requestedOutputTokens, Math.floor((balance * 100 - inputTokens * pricing.write) / pricing.output));
+    if (outputTokens < 16) {
       yield* exports_Ref.update(state, (current2) => ({ ...current2, stopped: true }));
-      if (!original.tools?.some((tool) => tool.type === "function" && tool.name === "submit_review")) {
-        return yield* refuse("The next model request cannot fit below the review's $1 ceiling.");
-      }
-      finalizing = true;
-      payload = {
-        ...payload,
-        tool_choice: {
-          type: "allowed_tools",
-          mode: "required",
-          tools: [{ type: "function", name: "submit_review" }]
-        },
-        input: [
-          ...typeof payload.input === "string" ? [{ role: "user", content: payload.input }] : payload.input ?? [],
-          {
-            role: "user",
-            content: [
-              {
-                type: "input_text",
-                text: "<review-cost-status>Research has stopped to keep this review below $1. Call submit_review alone with established findings. Coverage will be reported incomplete.</review-cost-status>"
-              }
-            ]
-          }
-        ]
-      };
-      inputTokens = yield* count2(payload).pipe(exports_Effect.catch(() => refuse("Unable to count the final review request before inference.")));
-      outputTokens = Math.min(outputTokens, Math.floor((balance * 100 - inputTokens * pricing.write) / pricing.output));
-      if (inputTokens > MAX_INPUT_TOKENS || outputTokens < 16) {
-        return yield* refuse("No paid completion fits; deliver recorded findings without inference.");
-      }
-      payload = { ...payload, max_output_tokens: outputTokens };
+      yield* exports_Effect.logInfo("Review spending limit reached before dispatch", {
+        modelCalls: before.modelCalls,
+        inputTokens,
+        remainingCostMicrousd: balance,
+        minimumRequestCostMicrousd: Math.ceil((inputTokens * pricing.write + 16 * pricing.output) / 100),
+        costLimitMicrousd: REVIEW_COST_LIMIT_MICROUSD
+      });
+      return yield* refuse("No paid request fits; deliver recorded findings without inference.");
     }
+    const outputLimitedByCost = outputTokens < requestedOutputTokens;
     const microusd = Math.ceil((inputTokens * pricing.write + outputTokens * pricing.output) / 100);
     const reservation = {
       id: before.modelCalls + 1,
       inputTokens,
       outputTokens,
       microusd,
-      finalizing
+      outputLimitedByCost
     };
     const current = yield* exports_Ref.get(state);
     if (current.closed || current.cost + reservedCost(current) + microusd > REVIEW_COST_LIMIT_MICROUSD) {
@@ -49691,23 +49674,23 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
     }
     yield* exports_Ref.update(state, (current2) => ({
       ...current2,
-      closed: current2.closed || finalizing,
       modelCalls: reservation.id,
       pending: new Map([...current2.pending, [reservation.id, reservation]])
     }));
     yield* exports_Effect.logInfo("Review request admitted", {
       modelCall: reservation.id,
       inputTokens,
+      requestedMaxOutputTokens: requestedOutputTokens,
       maxOutputTokens: outputTokens,
+      outputLimitedByCost,
       reservedCostMicrousd: microusd,
       remainingCostMicrousd: balance - microusd,
       costLimitMicrousd: REVIEW_COST_LIMIT_MICROUSD,
-      finalizing,
       cacheMode: "explicit",
       serviceTier: "default",
       pricingVersion: PRICING_VERSION
     });
-    return { payload, reservation };
+    return { payload: { ...payload, max_output_tokens: outputTokens }, reservation };
   }, admissions.withPermit);
   const settle = exports_Effect.fn("ReviewOpenAi.settle")(function* (reservation, response) {
     const usage2 = yield* exports_Schema.decodeUnknownEffect(ChargedUsage)(response.usage).pipe(exports_Effect.catch(() => refuse("Provider usage is missing or invalid; retain its full reservation.")));
@@ -49719,6 +49702,7 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
     const write2 = usage2.input_tokens_details.cache_write_tokens;
     const ordinary = usage2.input_tokens - read2 - write2;
     const cost = Math.ceil((ordinary * pricing.input + read2 * pricing.read + write2 * pricing.write + usage2.output_tokens * pricing.output) / 100);
+    const outputLimitReached = reservation.outputLimitedByCost && response.incomplete_details?.reason === "max_output_tokens";
     const updated = yield* exports_Ref.modify(state, (current) => {
       if (!current.pending.has(reservation.id))
         return [false, current];
@@ -49729,6 +49713,8 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
         {
           ...current,
           pending,
+          stopped: current.stopped || outputLimitReached,
+          closed: current.closed || outputLimitReached,
           input: current.input + usage2.input_tokens,
           read: current.read + read2,
           write: current.write + write2,
@@ -49747,18 +49733,13 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
       cachedInputTokens: read2,
       cacheWriteInputTokens: write2,
       outputTokens: usage2.output_tokens,
+      outputLimitReached,
       cacheHitRatio: usage2.input_tokens === 0 ? 0 : read2 / usage2.input_tokens,
       estimatedCostMicrousd: cost,
       cumulativeCostMicrousd: totals.cost,
       reservedCostMicrousd: reservedCost(totals),
       remainingCostMicrousd: REVIEW_COST_LIMIT_MICROUSD - totals.cost - reservedCost(totals)
     });
-    if (reservation.finalizing) {
-      const calls = response.output.filter((item) => item.type === "function_call");
-      if (calls.length !== 1 || calls[0]?.name !== "submit_review") {
-        return yield* refuse("A cost-constrained completion may only submit the review.");
-      }
-    }
   });
   const costControl = {
     snapshot: exports_Effect.map(exports_Ref.get(state), (current) => ReviewCostSnapshot.make({

--- a/packages/pr-review-action/src/presentation.ts
+++ b/packages/pr-review-action/src/presentation.ts
@@ -33,14 +33,16 @@ const severityCounts = (report: ReviewReport) => ({
   nit: report.findings.filter((finding) => finding.severity === "nit").length,
 });
 
-const renderFindingTally = (report: ReviewReport): string => {
-  const counts = severityCounts(report);
+const renderFindingTally = (input: ReviewPresentationInput): string => {
+  const counts = severityCounts(input.report);
   const parts = [
     ...(counts.blocking > 0 ? [`🛑 ${String(counts.blocking)} blocking`] : []),
     ...(counts.important > 0 ? [`⚠️ ${String(counts.important)} important`] : []),
     ...(counts.nit > 0 ? [`💅 ${String(counts.nit)} nit`] : []),
   ];
-  return parts.length === 0 ? "✅ None" : parts.join(" · ");
+  if (parts.length > 0) return parts.join(" · ");
+  if (!input.complete || input.exhausted !== undefined) return "None recorded · incomplete";
+  return input.unresolvedChangeRequests > 0 ? "None recorded" : "✅ None";
 };
 
 const renderVerdict = (
@@ -160,7 +162,7 @@ export const renderReviewBody = (input: ReviewPresentationInput): string => {
     [
       "| Scope | Files | New findings |",
       "| :-- | :-- | :-- |",
-      `| **${input.scope === "full" ? "Full diff" : "Incremental"}** | ${renderCoverage(input)} | ${renderFindingTally(input.report)} |`,
+      `| **${input.scope === "full" ? "Full diff" : "Incremental"}** | ${renderCoverage(input)} | ${renderFindingTally(input)} |`,
     ].join("\n"),
   ];
   const automaticPause = renderAutomaticPause(input.automaticReviewsRemaining);

--- a/packages/pr-review-action/src/review-openai.ts
+++ b/packages/pr-review-action/src/review-openai.ts
@@ -148,17 +148,14 @@ export const withReviewPromptCache = (payload: Payload, key: string) => ({
                 : item.content.length === 1 && item.content[0]?.type === "input_text"
                   ? item.content[0].text
                   : "";
-            if (
-              item.role === "user" &&
-              (text.startsWith("<run-status>") || text.startsWith("<review-cost-status>"))
-            ) {
+            if (item.role === "user" && text.startsWith("<run-status>")) {
               return item;
             }
             return { ...item, content: cacheContent(item.content) };
           }
           if (item.type === "function_call_output") {
             // One boundary per committed batch keeps earlier useful boundaries
-            // inside the provider's 50-breakpoint lookup window on wide batches.
+            // inside the provider's breakpoint lookup window on wide batches.
             return {
               ...item,
               output: cacheContent(item.output, items[index + 1]?.type !== "function_call_output"),
@@ -180,7 +177,7 @@ interface Reservation {
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly microusd: number;
-  readonly finalizing: boolean;
+  readonly outputLimitedByCost: boolean;
 }
 
 interface Spending {
@@ -260,71 +257,45 @@ export const makeReviewOpenAi = Effect.fn("makeReviewOpenAi")(function* (options
     }
     const before = yield* Ref.get(state);
     if (before.closed) return yield* refuse("Review spending admission has already stopped.");
-    let payload: Payload = withReviewPromptCache(
+    const payload: Payload = withReviewPromptCache(
       { ...original, truncation: "disabled" },
       options.cacheKey,
     );
-    let inputTokens = yield* count(payload).pipe(
+    const inputTokens = yield* count(payload).pipe(
       Effect.catch(() => refuse("Unable to count the review input before paid inference.")),
     );
     if (inputTokens > MAX_INPUT_TOKENS) {
       return yield* refuse("The counted review input exceeds the 128,000-token price boundary.");
     }
     const balance = REVIEW_COST_LIMIT_MICROUSD - before.cost - reservedCost(before);
-    let outputTokens = original.max_output_tokens ?? MAX_OUTPUT_TOKENS;
-    let finalizing = false;
-    if (Math.ceil((inputTokens * pricing.write + outputTokens * pricing.output) / 100) > balance) {
+    const requestedOutputTokens = original.max_output_tokens ?? MAX_OUTPUT_TOKENS;
+    const outputTokens = Math.min(
+      requestedOutputTokens,
+      Math.floor((balance * 100 - inputTokens * pricing.write) / pricing.output),
+    );
+    if (outputTokens < 16) {
       yield* Ref.update(state, (current) => ({ ...current, stopped: true }));
-      if (
-        !original.tools?.some((tool) => tool.type === "function" && tool.name === "submit_review")
-      ) {
-        return yield* refuse("The next model request cannot fit below the review's $1 ceiling.");
-      }
-      finalizing = true;
-      payload = {
-        ...payload,
-        tool_choice: {
-          type: "allowed_tools",
-          mode: "required",
-          tools: [{ type: "function", name: "submit_review" }],
-        },
-        input: [
-          ...(typeof payload.input === "string"
-            ? [{ role: "user" as const, content: payload.input }]
-            : (payload.input ?? [])),
-          {
-            role: "user",
-            content: [
-              {
-                type: "input_text",
-                text: "<review-cost-status>Research has stopped to keep this review below $1. Call submit_review alone with established findings. Coverage will be reported incomplete.</review-cost-status>",
-              },
-            ],
-          },
-        ],
-      };
-      // Tool choice and delivery instructions can change the counted context.
-      inputTokens = yield* count(payload).pipe(
-        Effect.catch(() => refuse("Unable to count the final review request before inference.")),
-      );
-      outputTokens = Math.min(
-        outputTokens,
-        Math.floor((balance * 100 - inputTokens * pricing.write) / pricing.output),
-      );
-      if (inputTokens > MAX_INPUT_TOKENS || outputTokens < 16) {
-        return yield* refuse(
-          "No paid completion fits; deliver recorded findings without inference.",
-        );
-      }
-      payload = { ...payload, max_output_tokens: outputTokens };
+      yield* Effect.logInfo("Review spending limit reached before dispatch", {
+        modelCalls: before.modelCalls,
+        inputTokens,
+        remainingCostMicrousd: balance,
+        minimumRequestCostMicrousd: Math.ceil(
+          (inputTokens * pricing.write + 16 * pricing.output) / 100,
+        ),
+        costLimitMicrousd: REVIEW_COST_LIMIT_MICROUSD,
+      });
+      return yield* refuse("No paid request fits; deliver recorded findings without inference.");
     }
+    // A smaller output allowance still permits research. Only a refused request or a
+    // response truncated by this cost limit stops the review; tool choice stays native.
+    const outputLimitedByCost = outputTokens < requestedOutputTokens;
     const microusd = Math.ceil((inputTokens * pricing.write + outputTokens * pricing.output) / 100);
     const reservation: Reservation = {
       id: before.modelCalls + 1,
       inputTokens,
       outputTokens,
       microusd,
-      finalizing,
+      outputLimitedByCost,
     };
     const current = yield* Ref.get(state);
     if (
@@ -335,23 +306,23 @@ export const makeReviewOpenAi = Effect.fn("makeReviewOpenAi")(function* (options
     }
     yield* Ref.update(state, (current) => ({
       ...current,
-      closed: current.closed || finalizing,
       modelCalls: reservation.id,
       pending: new Map([...current.pending, [reservation.id, reservation]]),
     }));
     yield* Effect.logInfo("Review request admitted", {
       modelCall: reservation.id,
       inputTokens,
+      requestedMaxOutputTokens: requestedOutputTokens,
       maxOutputTokens: outputTokens,
+      outputLimitedByCost,
       reservedCostMicrousd: microusd,
       remainingCostMicrousd: balance - microusd,
       costLimitMicrousd: REVIEW_COST_LIMIT_MICROUSD,
-      finalizing,
       cacheMode: "explicit",
       serviceTier: "default",
       pricingVersion: PRICING_VERSION,
     });
-    return { payload, reservation };
+    return { payload: { ...payload, max_output_tokens: outputTokens }, reservation };
   }, admissions.withPermit);
 
   const settle = Effect.fn("ReviewOpenAi.settle")(function* (
@@ -386,6 +357,9 @@ export const makeReviewOpenAi = Effect.fn("makeReviewOpenAi")(function* (options
         usage.output_tokens * pricing.output) /
         100,
     );
+    const outputLimitReached =
+      reservation.outputLimitedByCost &&
+      response.incomplete_details?.reason === "max_output_tokens";
     const updated = yield* Ref.modify(state, (current) => {
       if (!current.pending.has(reservation.id)) return [false, current] as const;
       const pending = new Map(current.pending);
@@ -395,6 +369,8 @@ export const makeReviewOpenAi = Effect.fn("makeReviewOpenAi")(function* (options
         {
           ...current,
           pending,
+          stopped: current.stopped || outputLimitReached,
+          closed: current.closed || outputLimitReached,
           input: current.input + usage.input_tokens,
           read: current.read + read,
           write: current.write + write,
@@ -412,18 +388,13 @@ export const makeReviewOpenAi = Effect.fn("makeReviewOpenAi")(function* (options
       cachedInputTokens: read,
       cacheWriteInputTokens: write,
       outputTokens: usage.output_tokens,
+      outputLimitReached,
       cacheHitRatio: usage.input_tokens === 0 ? 0 : read / usage.input_tokens,
       estimatedCostMicrousd: cost,
       cumulativeCostMicrousd: totals.cost,
       reservedCostMicrousd: reservedCost(totals),
       remainingCostMicrousd: REVIEW_COST_LIMIT_MICROUSD - totals.cost - reservedCost(totals),
     });
-    if (reservation.finalizing) {
-      const calls = response.output.filter((item) => item.type === "function_call");
-      if (calls.length !== 1 || calls[0]?.name !== "submit_review") {
-        return yield* refuse("A cost-constrained completion may only submit the review.");
-      }
-    }
   });
 
   const costControl: ReviewCostControl = {

--- a/packages/pr-review-action/test/presentation.test.ts
+++ b/packages/pr-review-action/test/presentation.test.ts
@@ -206,12 +206,16 @@ describe("review presentation", () => {
       });
 
     expect(render(false, 0)).toContain("Review coverage is incomplete");
+    expect(render(false, 0)).not.toContain("✅ None");
     expect(render(true, 2)).toContain("2 earlier change requests");
     expect(render(true, 2)).not.toContain("No actionable findings");
+    expect(render(true, 2)).not.toContain("✅ None");
     for (const exhausted of ["tokens", "turns", "tool-calls", "cost"] as const) {
       const body = render(false, 0, exhausted);
       expect(body).toContain(`Review stopped at the ${exhausted} budget`);
       expect(body).not.toContain("No actionable findings");
+      expect(body).not.toContain("✅ None");
+      expect(body).toContain("None recorded · incomplete");
     }
   });
 

--- a/packages/pr-review-action/test/review-openai.test.ts
+++ b/packages/pr-review-action/test/review-openai.test.ts
@@ -122,6 +122,7 @@ const sse = (
   call: number,
   calls: ReadonlyArray<{ readonly name: string; readonly parameters: Schema.Json }>,
   usage: unknown,
+  finish: "completed" | "incomplete" = "completed",
 ) => {
   const reasoning = {
     type: "reasoning",
@@ -152,8 +153,12 @@ const sse = (
       { type: "response.output_item.done", output_index: index + 1, item },
     ]),
     {
-      type: "response.completed",
-      response: { ...response(usage), output: [reasoning, ...output] },
+      type: `response.${finish}`,
+      response: {
+        ...response(usage),
+        output: [reasoning, ...output],
+        ...(finish === "incomplete" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
+      },
     },
   ];
   return HttpClientResponse.fromWeb(
@@ -189,6 +194,63 @@ const payload: OpenAiSchema.CreateResponse = {
 };
 
 describe("review provider boundary", () => {
+  it.effect("continues research with the remaining allowance after PR #252's usage", () =>
+    Effect.gen(function* () {
+      const sent: Array<WireRequest> = [];
+      // Production counts and usage for the first two calls; the third is scripted continuation.
+      const usage = [
+        rawUsage(39_532, 430, 0, 39_351),
+        rawUsage(51_735, 1_647, 39_338, 12_163),
+        rawUsage(60_000, 1_000, 51_500, 8_000),
+      ];
+      const native = yield* makeNative(
+        HttpClient.make((httpRequest, url) =>
+          Effect.sync(() => {
+            const current = usage[sent.length];
+            if (current === undefined) throw new Error("Unexpected additional model request");
+            if (url.pathname.endsWith("/input_tokens"))
+              return json(httpRequest, {
+                object: "response.input_tokens",
+                input_tokens: current.input_tokens,
+              });
+            sent.push(decodeWire(httpRequest));
+            return sse(
+              httpRequest,
+              sent.length,
+              sent.length === 1 ? [read] : sent.length === 2 ? [record, read] : [submit],
+              current,
+            );
+          }),
+        ),
+      );
+      const provider = yield* makeReviewOpenAi({
+        client: native,
+        model: "gpt-5.6-sol",
+        cacheKey: "affordable-research",
+      });
+      const result = yield* makeReviewer({ model, costControl: provider.costControl })
+        .review(request)
+        .pipe(
+          Effect.provideService(OpenAiClient.OpenAiClient, provider.client),
+          Effect.provideService(ReviewRepository, repository),
+        );
+
+      expect(sent).toHaveLength(3);
+      expect(sent.map((wire) => wire.max_output_tokens)).toEqual([32_000, 26_762, 19_174]);
+      for (const wire of sent) {
+        expect(wire.model).toBe("gpt-5.6-sol");
+        expect(wire.reasoning).toEqual({ effort: "xhigh" });
+        expect(wire.tools).toEqual(sent[0]?.tools);
+        expect(wire.tool_choice).toEqual(sent[0]?.tool_choice);
+      }
+      expect(result.exhausted).toBeUndefined();
+      expect(result.incomplete).toBeUndefined();
+      expect(result.report.findings.map((item) => item.title)).toEqual([finding.title]);
+      expect(result.usage.estimatedCostMicrousd).toBe(399_106);
+      expect(result.usage.reservedCostMicrousd).toBe(0);
+    }),
+  );
+
   it.effect.each([false, true])(
     "publishes a head-bound incomplete cost stop, with blocking finding=%s",
     (hasFinding) =>
@@ -494,9 +556,9 @@ describe("review provider boundary", () => {
       }),
   );
 
-  it.effect.each([true, false])(
-    "prices the only final request and enforces completion-only delivery: %s",
-    (validCompletion) =>
+  it.effect.each(["submit", "research", "truncated"] as const)(
+    "admits capped research and final responses without overspending: %s",
+    (completion) =>
       Effect.gen(function* () {
         const sent: Array<WireRequest> = [];
         const native = yield* makeNative(
@@ -512,11 +574,12 @@ describe("review provider boundary", () => {
               return sse(
                 httpRequest,
                 sent.length,
-                sent.length === 1 ? [record, read] : validCompletion ? [submit] : [read],
+                sent.length === 1 ? [record, read] : completion === "research" ? [read] : [submit],
                 rawUsage(
                   sent.length === 1 ? 70_000 : 72_000,
                   sent.length === 1 ? 1_000 : (wire.max_output_tokens ?? 0),
                 ),
+                sent.length === 2 && completion === "truncated" ? "incomplete" : "completed",
               );
             }),
           ),
@@ -542,15 +605,20 @@ describe("review provider boundary", () => {
           );
         expect(sent).toHaveLength(2);
         expect(sent[1]?.max_output_tokens).toBe(13_499);
-        expect(sent[1]?.tool_choice).toEqual({
-          type: "allowed_tools",
-          mode: "required",
-          tools: [{ type: "function", name: "submit_review" }],
-        });
+        expect(sent[1]?.tool_choice).toEqual(sent[0]?.tool_choice);
         expect(sent[1]?.tools).toEqual(sent[0]?.tools);
-        expect(result.exhausted).toBe("cost");
+        expect(result.exhausted).toBe(completion === "submit" ? undefined : "cost");
+        const failure = reviewPublicationFailure({
+          blockingFindings: 0,
+          unreviewedPaths: 0,
+          unresolvedChangeRequests: 0,
+          exhausted: result.exhausted,
+          incomplete: result.incomplete,
+        });
+        if (completion === "submit") expect(failure).toBeUndefined();
+        else expect(failure).toMatchObject({ _tag: "ReviewAttemptIncomplete" });
         expect(result.report.findings).toHaveLength(1);
-        expect(reads).toBe(1);
+        expect(reads).toBe(completion === "research" ? 2 : 1);
         expect(result.usage.estimatedCostMicrousd).toBe(999_980);
         expect(result.usage.estimatedCostMicrousd).toBeLessThan(1_000_000);
         yield* provider.client.createResponse(payload).pipe(Effect.flip);
@@ -602,7 +670,7 @@ describe("review provider boundary", () => {
   );
 
   it.effect.each(["http", "missing-usage", "malformed-count", "stream-eof"])(
-    "fails closed on %s without refunding unknown charges",
+    "fails closed on %s without refunding capped requests with unknown charges",
     (failure) =>
       Effect.gen(function* () {
         let sends = 0;
@@ -612,9 +680,10 @@ describe("review provider boundary", () => {
               if (url.pathname.endsWith("/input_tokens"))
                 return json(httpRequest, {
                   object: "response.input_tokens",
-                  input_tokens: failure === "malformed-count" ? -1 : 70_000,
+                  input_tokens: failure === "malformed-count" ? -1 : 100_000,
                 });
               sends += 1;
+              expect(decodeWire(httpRequest).max_output_tokens).toBe(24_999);
               if (failure === "http")
                 return json(httpRequest, { error: { message: "private-source-fixture" } }, 500);
               if (failure === "stream-eof")
@@ -641,7 +710,7 @@ describe("review provider boundary", () => {
         expect(snapshot.stopped).toBe(false);
         expect(snapshot.usage.estimatedCostMicrousd).toBe(0);
         expect(snapshot.usage.reservedCostMicrousd).toBe(
-          failure === "malformed-count" ? 0 : 990_000,
+          failure === "malformed-count" ? 0 : 999_980,
         );
         yield* provider.client.createResponse(payload).pipe(Effect.flip);
         expect(sends).toBe(failure === "malformed-count" ? 0 : 1);


### PR DESCRIPTION
The cost controller forced PR #252 to submit after one research turn because another full 32,000-token output allowance no longer fit. It then admitted a smaller response but restricted it to submission and permanently stopped research. The [production log](https://github.com/danieljvdm/effect-agent/actions/runs/33399890190/job/99513336613) shows $0.206079 spent before that decision, a 26,762-token allowance on the forced final request, and $0.683493 still available afterward. Cache reuse was working: the second request read 39,338 cached tokens, a 76% hit rate.

Remove that forced-finalization transition. Before every request, reserve counted input at the cache-write price and set `max_output_tokens` to the largest allowance that fits the remaining balance, up to the configured maximum. Preserve native tool choice, tool schemas, model, and reasoning effort. The fixed $0.999999 ceiling, conservative settlement, and outstanding-charge accounting stay in place. A refused request or response truncated by the cost allowance leaves coverage incomplete and delivers recorded findings without another paid request.

Incomplete empty results now say **None recorded · incomplete**. Empty follow-ups with unresolved change requests also lose the green check. Admission logs show requested and admitted output allowances; refusal logs show the remaining balance and minimum request cost.

The provider-boundary regression uses PR #252's reported counts and usage for the first two responses, then a scripted third response. It fails on main and now permits continued research with output limits of 32,000, 26,762, and 19,174 tokens, retaining the finding at $0.399106. This is deterministic validation, not a live rerun or evidence that PR #252's coverage is complete. Cache-miss tests reach $0.999980, reject further spending, preserve findings on truncation, and retain capped reservations after HTTP failures, missing usage, or unfinished streams.

`vp run action:build` passed. `vp run ready` passed static checks and all test suites, then encountered the existing local demo-build Zod `optin` error; that failure was previously reproduced on unchanged main. The committed Action bundle is rebuilt. Full-review coverage still depends on fitting the dollar, token, tool, and turn limits.

[CI on this branch](https://github.com/danieljvdm/effect-agent/actions/runs/33409475256) passed every gate, including `ready` and the clean build. The separate [automated review](https://github.com/danieljvdm/effect-agent/pull/254#pullrequestreview-5068321380) is incomplete at $0.276875: its workflow ran `action@main` (`d004a36`) and reproduced the old `finalizing: true` stop. That run did not exercise this branch's admission code.
