### PR TITLE
fix(pr-review): batch large changes under shared review limits

### DIFF
--- a/.changeset/batched-review-coverage.md
+++ b/.changeset/batched-review-coverage.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/pr-review": patch
+---
+
+Review large inputs in sequential batches under a shared host spending limit, preserving findings and execution allowances across batches. Report admitted paths that never reached the model when a review stops early.

--- a/action/README.md
+++ b/action/README.md
@@ -45,7 +45,11 @@ the check, including when no defects were found. Such an attempt cannot become
 an incremental baseline or clear an earlier change request. This preserves useful findings without
 claiming the full change was reviewed.
 The model's `incomplete` flag describes unfinished assessment of supplied patches. The Action
-separately discloses unavailable paths, even when assessment of the supplied patches completes.
+separately lists excluded paths and their reasons, including input limits, unreadable source, and
+batches that never started. Excluded paths prevent a complete review even when assessment of the
+supplied patches completes. The comment shows up to 30 exclusions; the Action log includes all of
+them. Paths excluded only by input capacity remain available to bounded source tools, while ignore
+rules and unsupported or unreadable entries continue to block access.
 
 ## Spending and prompt caching
 
@@ -93,9 +97,16 @@ cost. Raw provider failure causes, credentials, and
 repository source are excluded from the Action's diagnostics. Logs also count supplied tool
 definitions, returned function calls, and completion calls to diagnose protocol failures.
 
-Each admitted patch reaches the model once as literal unified diff text. The native Agent input
-projection keeps all supplied changes while avoiding JSON-escaped source and duplicated old/new
-context. A large remaining input can still prevent another call before the observed spend reaches
+The Action admits implementation and configuration changes before documentation paths and prose,
+with alphabetical order within each group. The reviewer divides admitted patches into sequential
+batches of at most 256,000 patch characters, with a fresh model context for each batch. Each patch
+belongs to one batch and remains complete. Every batch can read the same authorized base/head source
+to investigate interactions with other files. One spending ledger, 8-turn allowance, 64-tool-call
+allowance, 5-minute deadline, and 24-finding capacity cover the entire attempt. Findings survive a
+later batch's expected failure; stopping leaves the remaining batches explicitly unreviewed.
+
+The native Agent input projection uses literal unified diff text, avoiding JSON-escaped source and
+duplicated old/new context. A large remaining input can still prevent another call before the observed spend reaches
 $1, because admission must cover a cache miss. Refusal logs report the counted input, remaining
 balance, and minimum possible request reservation. The Action's spending admission replaces the
 reviewer's cumulative token quota, so reusing cached context does not force early finalization.
@@ -111,6 +122,7 @@ the research tool definitions and their order in the encoded request.
 Compaction can change prefixes, and routing and cache availability still affect hits. See
 [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching).
 
-Input admission allows at most 100 files, 256,000 aggregate patch characters, 80,000 characters per
-patch, and 8 MB of hydrated base/head source. These bounds decide which files are supplied, not how
-much inference may spend. Unavailable paths remain explicit coverage gaps.
+Input admission allows at most 100 candidate files, 80,000 characters per patch, and 8 MB of hydrated
+base/head source. The batch size does not exclude later patches. A file that exceeds the remaining
+source allowance is excluded without preventing smaller later files from fitting. These bounds
+limit input preparation independently of the shared inference spending ceiling.

--- a/action/dist/index.manifest.json
+++ b/action/dist/index.manifest.json
@@ -1,1 +1,1 @@
-{"version":1,"inputsSha256":"eab45dbb9b64025f14297c85f3ae56f96dd1df61d0e4cbccb09a3be4f593c04b","bundleSha256":"bff5e6914a7db0a988388eb3cca54b4f9d59e59aa356d3399c3fe8cf13e6db4b"}
+{"version":1,"inputsSha256":"f650ded55978cc7c6e0aa4bbde56c8de660959cff8f09b7a03615cb413657375","bundleSha256":"42ab4df062c3bddf6ba3b3a35d7924e5aba08833b9be74df24484c24c86c8e67"}

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -44016,6 +44016,7 @@ class ReviewOutcome extends exports_Schema.Class("@effect-agent/pr-review/Review
   report: ReviewReport,
   turns: exports_Schema.Natural,
   usage: ReviewUsage,
+  pendingPaths: exports_Schema.optionalKey(exports_Schema.Array(ReviewPath).check(exports_Schema.isMaxLength(100))),
   exhausted: exports_Schema.optionalKey(exports_Schema.Literals(["tokens", "tool-calls", "turns", "cost"])),
   incomplete: exports_Schema.optionalKey(exports_Schema.Literal(true))
 }) {
@@ -44141,7 +44142,24 @@ var isCommentableLine = (patch3, line) => commentableLines(patch3).has(line);
 var reviewSummary = (request3, findings) => {
   const blocking = findings.filter((finding) => finding.severity === "blocking").length;
   const summary2 = findings.length === 0 ? "No concrete defects found in the supplied change." : `Reported ${findings.length} finding(s), including ${blocking} blocking finding(s).`;
-  return `${summary2}${request3.scope === "incremental" ? " This incremental review does not resolve earlier findings or establish that merging is safe." : ""}${request3.unreviewedPaths.length > 0 ? " Coverage is incomplete because some changed paths were unavailable." : ""}`;
+  return `${summary2}${request3.scope === "incremental" ? " This incremental review does not resolve earlier findings or establish that merging is safe." : ""}${request3.unreviewedPaths.length > 0 ? " Coverage is incomplete because some changed paths were excluded from review input." : ""}`;
+};
+var batchChanges = (changes2) => {
+  const batches = [];
+  let batch = [];
+  let chars = 0;
+  for (const change of changes2) {
+    if (batch.length > 0 && chars + change.patch.length > 256000) {
+      batches.push(batch);
+      batch = [];
+      chars = 0;
+    }
+    batch.push(change);
+    chars += change.patch.length;
+  }
+  if (batch.length > 0 || batches.length === 0)
+    batches.push(batch);
+  return batches;
 };
 var validatedFindings = exports_Effect.fn("validatedFindings")(function* (request3, submitted) {
   const patches = new Map(request3.changes.map((change) => [change.path, change.patch]));
@@ -44194,9 +44212,11 @@ var makeReviewer = (options3) => {
     const budget2 = yield* makeUsageBudget(UsageBudgetLimits.make({}));
     const modelCalls = yield* exports_Ref.make(0);
     const recorded = yield* exports_Ref.make([]);
-    const recordingLayer = reviewRecording.toLayer({
+    const startedAt = yield* exports_DateTime.now;
+    const deadline = exports_DateTime.add(startedAt, { minutes: 5 });
+    const recordingLayer = (batch) => reviewRecording.toLayer({
       record_finding: exports_Effect.fn("Reviewer.recordFinding")(function* (finding) {
-        const report3 = yield* validatedFindings(request3, [finding]);
+        const report3 = yield* validatedFindings(batch, [finding]);
         const accepted = yield* exports_Ref.modify(recorded, (current) => {
           const additions = report3.findings.filter((entry) => !current.some((prior) => JSON.stringify(prior) === JSON.stringify(entry)));
           if (current.length + additions.length > 24)
@@ -44212,6 +44232,8 @@ var makeReviewer = (options3) => {
     });
     const accounting = toRunBudgetHook(budget2);
     const runOptions = {
+      runStartedAt: startedAt,
+      durationDeadline: deadline,
       budget: {
         ...accounting,
         consume: exports_Effect.fn("Reviewer.consumeUsage")(function* (delta) {
@@ -44232,39 +44254,82 @@ var makeReviewer = (options3) => {
       },
       ...options3.estimateCostMicrousd === undefined ? {} : { estimateCostMicrousd: options3.estimateCostMicrousd }
     };
-    const result4 = yield* AgentRuntime.run(reviewer, request3, runOptions).pipe(exports_Effect.provide(recordingLayer), exports_Effect.result);
-    const saved = yield* exports_Ref.get(recorded);
-    const cost = options3.costControl === undefined ? undefined : yield* options3.costControl.snapshot;
-    const preserveAttempt = cost?.stopped === true || (cost?.modelCalls ?? 0) > 0 || saved.length > 0;
-    if (exports_Result.isFailure(result4) && !preserveAttempt) {
-      return yield* result4.failure;
-    }
-    const submitted = exports_Result.isSuccess(result4) ? yield* validatedFindings(request3, result4.success.output.findings).pipe(exports_Effect.result) : exports_Result.succeed(ReviewReport.make({ summary: "Research stopped before completion.", findings: [] }));
-    if (exports_Result.isFailure(submitted) && !preserveAttempt)
-      return yield* submitted.failure;
-    const failure = exports_Result.isFailure(result4) ? result4.failure : exports_Result.isFailure(submitted) ? submitted.failure : undefined;
-    if (failure !== undefined)
-      yield* exports_Effect.logWarning("Review stopped before completion", { failureType: failure._tag });
-    const combined = [...saved];
-    if (exports_Result.isSuccess(submitted)) {
-      for (const finding of submitted.success.findings) {
-        if (!combined.some((prior) => JSON.stringify(prior) === JSON.stringify(finding)))
-          combined.push(finding);
+    const runBatch2 = exports_Effect.fn("Reviewer.reviewBatch")(function* (batch) {
+      const totals = yield* budget2.snapshot;
+      const usedTurns = yield* exports_Ref.get(modelCalls);
+      const priorCost = options3.costControl === undefined ? undefined : yield* options3.costControl.snapshot;
+      const result4 = yield* AgentRuntime.run(reviewer, batch, {
+        ...runOptions,
+        turnAllowance: 8 - usedTurns,
+        toolCallAllowance: 64 - totals.toolCalls
+      }).pipe(exports_Effect.provide(recordingLayer(batch)), exports_Effect.result);
+      const saved = yield* exports_Ref.get(recorded);
+      const cost2 = options3.costControl === undefined ? undefined : yield* options3.costControl.snapshot;
+      const preserveAttempt = cost2?.stopped === true || (cost2?.modelCalls ?? 0) > 0 || saved.length > 0;
+      if (exports_Result.isFailure(result4) && !preserveAttempt) {
+        return yield* result4.failure;
       }
+      const submitted = exports_Result.isSuccess(result4) ? yield* validatedFindings(batch, result4.success.output.findings).pipe(exports_Effect.result) : exports_Result.succeed(ReviewReport.make({ summary: "Research stopped before completion.", findings: [] }));
+      if (exports_Result.isFailure(submitted) && !preserveAttempt)
+        return yield* submitted.failure;
+      const failure = exports_Result.isFailure(result4) ? result4.failure : exports_Result.isFailure(submitted) ? submitted.failure : undefined;
+      if (failure !== undefined)
+        yield* exports_Effect.logWarning("Review stopped before completion", {
+          failureType: failure._tag
+        });
+      const combined2 = [...saved];
+      if (exports_Result.isSuccess(submitted)) {
+        for (const finding of submitted.success.findings) {
+          if (!combined2.some((prior) => JSON.stringify(prior) === JSON.stringify(finding)))
+            combined2.push(finding);
+        }
+      }
+      const incomplete2 = exports_Result.isFailure(result4) || exports_Result.isFailure(submitted) || combined2.length > 24 || result4.success.output.incomplete === true;
+      const exhausted2 = cost2?.stopped === true ? "cost" : exports_Result.isSuccess(result4) ? result4.success.exhausted : undefined;
+      yield* exports_Ref.set(recorded, combined2.slice(0, 24));
+      return {
+        incomplete: incomplete2,
+        exhausted: exhausted2,
+        protocolError: failure?._tag === "ModelProtocolError",
+        attempted: (yield* exports_Ref.get(modelCalls)) > usedTurns || (cost2?.modelCalls ?? 0) > (priorCost?.modelCalls ?? 0)
+      };
+    });
+    const batches = options3.costControl === undefined ? [request3.changes] : batchChanges(request3.changes);
+    let incomplete = false;
+    let exhausted;
+    let protocolError = false;
+    let supplied = 0;
+    for (const changes2 of batches) {
+      const totals = yield* budget2.snapshot;
+      if ((yield* exports_Ref.get(modelCalls)) >= 8 || totals.toolCalls >= 64) {
+        exhausted = totals.toolCalls >= 64 ? "tool-calls" : "turns";
+        incomplete = true;
+        break;
+      }
+      const batch = yield* runBatch2(ReviewRequest.make({ ...request3, changes: changes2 }));
+      if (batch.attempted)
+        supplied += changes2.length;
+      incomplete = batch.incomplete;
+      exhausted = batch.exhausted;
+      protocolError = batch.protocolError;
+      if (incomplete || exhausted !== undefined)
+        break;
     }
-    const incomplete = exports_Result.isFailure(result4) || exports_Result.isFailure(submitted) || combined.length > 24 || result4.success.output.incomplete === true;
-    const exhausted = cost?.stopped === true ? "cost" : exports_Result.isSuccess(result4) ? result4.success.exhausted : undefined;
+    const combined = yield* exports_Ref.get(recorded);
+    const pendingPaths = request3.changes.slice(supplied).map((change) => change.path);
     const report2 = ReviewReport.make({
       findings: combined.slice(0, 24),
-      summary: exhausted !== undefined ? `Review stopped at the ${exhausted} budget. These findings cover the investigation completed before finalization; the remaining change has not been verified.` : incomplete ? `${failure?._tag === "ModelProtocolError" ? "The review stopped after a model protocol error." : "The investigation did not complete."} Recorded findings are preserved; the remaining change has not been verified.` : reviewSummary(request3, combined)
+      summary: exhausted !== undefined ? `Review stopped at the ${exhausted} budget. These findings cover the investigation completed before finalization; the remaining change has not been verified.` : incomplete ? `${protocolError ? "The review stopped after a model protocol error." : "The investigation did not complete."} Recorded findings are preserved; the remaining change has not been verified.` : reviewSummary(request3, combined)
     });
     yield* exports_Effect.logDebug("Review completed", { findingCount: report2.findings.length });
     const usage2 = yield* budget2.snapshot;
+    const cost = options3.costControl === undefined ? undefined : yield* options3.costControl.snapshot;
     return ReviewOutcome.make({
       report: report2,
+      ...pendingPaths.length === 0 ? {} : { pendingPaths },
       ...exhausted === undefined ? {} : { exhausted },
       ...incomplete ? { incomplete: true } : {},
-      turns: cost?.modelCalls ?? (exports_Result.isSuccess(result4) ? result4.success.turns : yield* exports_Ref.get(modelCalls)),
+      turns: cost?.modelCalls ?? (yield* exports_Ref.get(modelCalls)),
       usage: cost?.usage ?? ReviewUsage.make({
         inputTokens: usage2.inputTokens,
         uncachedInputTokens: Math.max(0, usage2.inputTokens - usage2.cacheReadInputTokens - usage2.cacheWriteInputTokens),
@@ -49418,7 +49483,7 @@ var renderVerdict = (report2, complete, unresolvedChangeRequests, exhausted) => 
   }
   if (!complete) {
     return `> [!CAUTION]
-> **Review coverage is incomplete.** Not all supplied changes were verified, so this result does not clear the change.`;
+> **Review coverage is incomplete.** Not all changes were verified, so this result does not clear the change.`;
   }
   if (unresolvedChangeRequests > 0) {
     return `> [!CAUTION]
@@ -49455,9 +49520,34 @@ var fencedPlainText = (text2) => {
 ${text2}
 ${fence}`;
 };
+
+class ReviewExclusion extends exports_Schema.Class("ReviewExclusion")({
+  path: exports_Schema.String,
+  reason: exports_Schema.Literals([
+    "path-limit",
+    "file-limit",
+    "source-limit",
+    "unsupported-entry",
+    "source-read-failed",
+    "patch-unavailable",
+    "patch-limit",
+    "review-stopped"
+  ])
+}) {
+}
+var exclusionReason = {
+  "path-limit": "Path exceeds 512 characters",
+  "file-limit": "100-file input limit",
+  "source-limit": "8 MB source hydration limit",
+  "unsupported-entry": "Not a regular file",
+  "source-read-failed": "Source could not be read as bounded UTF-8 text",
+  "patch-unavailable": "Exact patch could not be generated within the diff bounds",
+  "patch-limit": "Patch exceeds 80,000 characters",
+  "review-stopped": "Review stopped before this batch started"
+};
 var renderCoverage = (input) => [
   `${String(input.reviewedFiles)} ${input.complete ? "reviewed" : "supplied"}`,
-  ...input.unreviewedFiles > 0 ? [`${String(input.unreviewedFiles)} unavailable`] : [],
+  ...input.unreviewedFiles > 0 ? [`${String(input.unreviewedFiles)} excluded`] : [],
   ...input.ignoredFiles > 0 ? [`${String(input.ignoredFiles)} ignored`] : []
 ].join(" · ");
 var formatEstimatedUsd = (microusd) => {
@@ -49488,6 +49578,31 @@ var renderReviewBody = (input) => {
   if (automaticPause !== undefined)
     parts2.push(automaticPause);
   parts2.push("### Summary", input.report.summary);
+  if (input.exclusions !== undefined && input.exclusions.length > 0) {
+    const shown = [];
+    let chars = 0;
+    for (const { path, reason } of input.exclusions.slice(0, 30)) {
+      const line = `${JSON.stringify(path.slice(0, 512))}: ${exclusionReason[reason]}`;
+      if (chars + line.length + 1 > 1e4)
+        break;
+      shown.push(line);
+      chars += line.length + 1;
+    }
+    parts2.push([
+      "<details>",
+      `<summary>Files excluded from review input (${String(input.exclusions.length)})</summary>`,
+      "",
+      fencedPlainText(shown.join(`
+`)),
+      ...shown.length < input.exclusions.length ? [
+        `
+${String(input.exclusions.length - shown.length)} more excluded paths. See the Action log for the full list.`
+      ] : [],
+      "",
+      "</details>"
+    ].join(`
+`));
+  }
   if (unanchored.length > 0) {
     const findingText = unanchored.map(renderUnanchoredFindingText).join(`
 
@@ -49893,7 +50008,6 @@ var makeReviewOpenAi = exports_Effect.fn("makeReviewOpenAi")(function* (options3
 });
 
 // packages/pr-review-action/src/action.ts
-var MAX_REVIEW_PATCH_CHARS = 256000;
 var MAX_PATCH_CHARS = 80000;
 var MAX_REVIEW_FILES = 100;
 var MAX_HYDRATED_SOURCE_BYTES = 8000000;
@@ -50016,6 +50130,7 @@ var matchesIgnore = (path, rawPattern) => {
   }
   return false;
 };
+var documentationPath = (path) => /(^|\/)(docs?|\.changeset)(\/|$)|\.(md|mdx|rst|txt|adoc)$/i.test(path);
 var hydrateExactChanges = exports_Effect.fn("hydrateExactChanges")(function* (input) {
   const metadata = new Map(input.files.map((file2) => [file2.path, file2]));
   const activeRenames = new Map;
@@ -50042,40 +50157,41 @@ var hydrateExactChanges = exports_Effect.fn("hydrateExactChanges")(function* (in
   const changes2 = [];
   const unreviewedPaths = [];
   const ignoredPaths = [];
+  const exclusions = [];
   const unavailablePaths = new Set;
-  const exclude = (paths, file2, basePath) => {
+  const exclude = (paths, file2, basePath, reason) => {
     paths.push(file2.path);
-    unavailablePaths.add(file2.path).add(basePath);
-    if (file2.previousPath !== undefined)
-      unavailablePaths.add(file2.previousPath);
+    if (reason !== undefined)
+      exclusions.push(ReviewExclusion.make({ path: file2.path, reason }));
+    if (reason === undefined || reason === "unsupported-entry" || reason === "source-read-failed") {
+      unavailablePaths.add(file2.path).add(basePath);
+      if (file2.previousPath !== undefined)
+        unavailablePaths.add(file2.previousPath);
+    }
   };
   let admittedPaths = 0;
-  let patchChars = 0;
-  let patchBudgetExhausted = false;
   let hydratedSourceBytes = 0;
-  let sourceBudgetExhausted = false;
-  for (const { file: file2, basePath } of [...candidates.values()].sort((left, right) => left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0)) {
+  for (const { file: file2, basePath } of [...candidates.values()].sort((left, right) => Number(documentationPath(left.file.path)) - Number(documentationPath(right.file.path)) || (left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0))) {
     const ignored = [file2.path, ...basePath === file2.path ? [] : [basePath]].some((path) => input.ignore.some((pattern) => matchesIgnore(path, pattern)));
     if (ignored) {
       exclude(ignoredPaths, file2, basePath);
       continue;
     }
-    if (file2.path.length > 512 || admittedPaths >= MAX_REVIEW_FILES || patchBudgetExhausted || sourceBudgetExhausted) {
-      exclude(unreviewedPaths, file2, basePath);
+    if (file2.path.length > 512 || admittedPaths >= MAX_REVIEW_FILES) {
+      exclude(unreviewedPaths, file2, basePath, file2.path.length > 512 ? "path-limit" : "file-limit");
       continue;
     }
     admittedPaths += 1;
     const beforeEntry = input.base.entry(basePath);
     const afterEntry = input.head.entry(file2.path);
-    if (beforeEntry !== undefined && beforeEntry.type !== "blob" || afterEntry !== undefined && afterEntry.type !== "blob") {
-      exclude(unreviewedPaths, file2, basePath);
+    if (beforeEntry !== undefined && (beforeEntry.type !== "blob" || beforeEntry.mode === "120000") || afterEntry !== undefined && (afterEntry.type !== "blob" || afterEntry.mode === "120000")) {
+      exclude(unreviewedPaths, file2, basePath, "unsupported-entry");
       continue;
     }
     const sourceSizesKnown = (beforeEntry === undefined || beforeEntry.size !== undefined) && (afterEntry === undefined || afterEntry.size !== undefined);
     const estimatedSourceBytes = (beforeEntry?.size ?? 0) + (afterEntry?.size ?? 0);
-    if (sourceSizesKnown && hydratedSourceBytes + estimatedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
-      exclude(unreviewedPaths, file2, basePath);
-      sourceBudgetExhausted = true;
+    if (hydratedSourceBytes >= MAX_HYDRATED_SOURCE_BYTES || sourceSizesKnown && hydratedSourceBytes + estimatedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
+      exclude(unreviewedPaths, file2, basePath, "source-limit");
       continue;
     }
     const contents = yield* exports_Effect.all({
@@ -50084,13 +50200,12 @@ var hydrateExactChanges = exports_Effect.fn("hydrateExactChanges")(function* (in
     }, { concurrency: 2 }).pipe(exports_Effect.result);
     if (exports_Result.isFailure(contents)) {
       hydratedSourceBytes += estimatedSourceBytes;
-      exclude(unreviewedPaths, file2, basePath);
+      exclude(unreviewedPaths, file2, basePath, "source-read-failed");
       continue;
     }
     hydratedSourceBytes += sourceSizesKnown ? estimatedSourceBytes : contents.success.before.length + contents.success.after.length;
     if (hydratedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
-      exclude(unreviewedPaths, file2, basePath);
-      sourceBudgetExhausted = true;
+      exclude(unreviewedPaths, file2, basePath, "source-limit");
       continue;
     }
     const patch3 = basePath === file2.path && contents.success.before === contents.success.after && beforeEntry !== undefined && afterEntry !== undefined && beforeEntry.mode !== afterEntry.mode ? [
@@ -50115,20 +50230,12 @@ var hydrateExactChanges = exports_Effect.fn("hydrateExactChanges")(function* (in
     ].join(`
 `) : patch3;
     if (exactPatch === undefined || exactPatch.length === 0 || exactPatch.length > MAX_PATCH_CHARS) {
-      exclude(unreviewedPaths, file2, basePath);
-      continue;
-    }
-    if (patchChars + exactPatch.length > MAX_REVIEW_PATCH_CHARS) {
-      exclude(unreviewedPaths, file2, basePath);
-      patchBudgetExhausted = true;
+      exclude(unreviewedPaths, file2, basePath, exactPatch !== undefined && exactPatch.length > MAX_PATCH_CHARS ? "patch-limit" : "patch-unavailable");
       continue;
     }
     changes2.push(ReviewChange.make({ path: file2.path, patch: exactPatch }));
-    patchChars += exactPatch.length;
-    if (patchChars === MAX_REVIEW_PATCH_CHARS)
-      patchBudgetExhausted = true;
   }
-  return { changes: changes2, unreviewedPaths, ignoredPaths, unavailablePaths };
+  return { changes: changes2, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions };
 });
 var reviewContextFailure = (message) => ReviewContextError.make({ message });
 var makeReviewRepository = (input) => {
@@ -50341,8 +50448,14 @@ var reviewActionProgram = exports_Effect.gen(function* () {
       ...snapshot3.usage,
       costLimitMicrousd: REVIEW_COST_LIMIT_MICROUSD
     })))));
+    const pending = new Set(result4.pendingPaths ?? []);
+    surface2.unreviewedPaths.push(...pending);
+    surface2.exclusions.push(...[...pending].map((path) => ReviewExclusion.make({ path, reason: "review-stopped" })));
     return {
-      surface: surface2,
+      surface: {
+        ...surface2,
+        changes: surface2.changes.filter((change) => !pending.has(change.path))
+      },
       modelTurns: result4.turns,
       exhausted: result4.exhausted,
       incomplete: result4.incomplete === true,
@@ -50426,6 +50539,7 @@ var reviewActionProgram = exports_Effect.gen(function* () {
     scope: scope3,
     reviewedFiles: surface.changes.length,
     unreviewedFiles: surface.unreviewedPaths.length,
+    exclusions: surface.exclusions,
     ignoredFiles: surface.ignoredPaths.length,
     modelTurns,
     complete,
@@ -50475,6 +50589,12 @@ var reviewActionProgram = exports_Effect.gen(function* () {
     ["review-url", reviewUrl]
   ]);
   yield* exports_Console.log(`Posted PR review: ${reviewUrl}`);
+  for (const exclusion of surface.exclusions) {
+    yield* exports_Effect.logInfo("Review input excluded", {
+      path: exclusion.path,
+      reason: exclusion.reason
+    });
+  }
   const publicationFailure = reviewPublicationFailure({
     blockingFindings: blocking,
     unreviewedPaths: surface.unreviewedPaths.length,

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -34,6 +34,7 @@ import {
 } from "./github.ts";
 import {
   type ReviewCostEstimate,
+  ReviewExclusion,
   ReviewPresentation,
   withReviewMarker,
   withReviewPauseMarker,
@@ -48,7 +49,6 @@ import { reviewModeFromCommand, selectReview, unresolvedChangeRequestCount } fro
 
 export { estimateGpt56CostMicrousd } from "./review-openai.ts";
 
-const MAX_REVIEW_PATCH_CHARS = 256_000;
 const MAX_PATCH_CHARS = 80_000;
 const MAX_REVIEW_FILES = 100;
 const MAX_HYDRATED_SOURCE_BYTES = 8_000_000;
@@ -234,7 +234,12 @@ const matchesIgnore = (path: string, rawPattern: string): boolean => {
   return false;
 };
 
-/** Admit sorted metadata before hydrating exact baseline-to-head patches. */
+// Spend limited review capacity on implementation and configuration before prose
+// and documentation assets. Preserve alphabetical order within each group.
+const documentationPath = (path: string): boolean =>
+  /(^|\/)(docs?|\.changeset)(\/|$)|\.(md|mdx|rst|txt|adoc)$/i.test(path);
+
+/** Hydrate exact patches in implementation-first order; the reviewer batches large input. */
 export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (input: {
   readonly files: ReadonlyArray<ChangedFile>;
   readonly changedPaths: ReadonlyArray<string>;
@@ -278,19 +283,29 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
   const changes: Array<ReviewChange> = [];
   const unreviewedPaths: Array<string> = [];
   const ignoredPaths: Array<string> = [];
+  const exclusions: Array<ReviewExclusion> = [];
   const unavailablePaths = new Set<string>();
-  const exclude = (paths: Array<string>, file: ChangedFile, basePath: string) => {
+  const exclude = (
+    paths: Array<string>,
+    file: ChangedFile,
+    basePath: string,
+    reason?: ReviewExclusion["reason"],
+  ) => {
     paths.push(file.path);
-    unavailablePaths.add(file.path).add(basePath);
-    if (file.previousPath !== undefined) unavailablePaths.add(file.previousPath);
+    if (reason !== undefined) exclusions.push(ReviewExclusion.make({ path: file.path, reason }));
+    // Input capacity does not revoke source access. Ignore rules and genuinely
+    // unreadable entries still exclude both sides of a rename from source tools.
+    if (reason === undefined || reason === "unsupported-entry" || reason === "source-read-failed") {
+      unavailablePaths.add(file.path).add(basePath);
+      if (file.previousPath !== undefined) unavailablePaths.add(file.previousPath);
+    }
   };
   let admittedPaths = 0;
-  let patchChars = 0;
-  let patchBudgetExhausted = false;
   let hydratedSourceBytes = 0;
-  let sourceBudgetExhausted = false;
-  for (const { file, basePath } of [...candidates.values()].sort((left, right) =>
-    left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0,
+  for (const { file, basePath } of [...candidates.values()].sort(
+    (left, right) =>
+      Number(documentationPath(left.file.path)) - Number(documentationPath(right.file.path)) ||
+      (left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0),
   )) {
     const ignored = [file.path, ...(basePath === file.path ? [] : [basePath])].some((path) =>
       input.ignore.some((pattern) => matchesIgnore(path, pattern)),
@@ -299,23 +314,24 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       exclude(ignoredPaths, file, basePath);
       continue;
     }
-    if (
-      file.path.length > 512 ||
-      admittedPaths >= MAX_REVIEW_FILES ||
-      patchBudgetExhausted ||
-      sourceBudgetExhausted
-    ) {
-      exclude(unreviewedPaths, file, basePath);
+    if (file.path.length > 512 || admittedPaths >= MAX_REVIEW_FILES) {
+      exclude(
+        unreviewedPaths,
+        file,
+        basePath,
+        file.path.length > 512 ? "path-limit" : "file-limit",
+      );
       continue;
     }
     admittedPaths += 1;
     const beforeEntry = input.base.entry(basePath);
     const afterEntry = input.head.entry(file.path);
     if (
-      (beforeEntry !== undefined && beforeEntry.type !== "blob") ||
-      (afterEntry !== undefined && afterEntry.type !== "blob")
+      (beforeEntry !== undefined &&
+        (beforeEntry.type !== "blob" || beforeEntry.mode === "120000")) ||
+      (afterEntry !== undefined && (afterEntry.type !== "blob" || afterEntry.mode === "120000"))
     ) {
-      exclude(unreviewedPaths, file, basePath);
+      exclude(unreviewedPaths, file, basePath, "unsupported-entry");
       continue;
     }
     const sourceSizesKnown =
@@ -323,11 +339,10 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       (afterEntry === undefined || afterEntry.size !== undefined);
     const estimatedSourceBytes = (beforeEntry?.size ?? 0) + (afterEntry?.size ?? 0);
     if (
-      sourceSizesKnown &&
-      hydratedSourceBytes + estimatedSourceBytes > MAX_HYDRATED_SOURCE_BYTES
+      hydratedSourceBytes >= MAX_HYDRATED_SOURCE_BYTES ||
+      (sourceSizesKnown && hydratedSourceBytes + estimatedSourceBytes > MAX_HYDRATED_SOURCE_BYTES)
     ) {
-      exclude(unreviewedPaths, file, basePath);
-      sourceBudgetExhausted = true;
+      exclude(unreviewedPaths, file, basePath, "source-limit");
       continue;
     }
     const contents = yield* Effect.all(
@@ -339,15 +354,14 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
     ).pipe(Effect.result);
     if (Result.isFailure(contents)) {
       hydratedSourceBytes += estimatedSourceBytes;
-      exclude(unreviewedPaths, file, basePath);
+      exclude(unreviewedPaths, file, basePath, "source-read-failed");
       continue;
     }
     hydratedSourceBytes += sourceSizesKnown
       ? estimatedSourceBytes
       : contents.success.before.length + contents.success.after.length;
     if (hydratedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
-      exclude(unreviewedPaths, file, basePath);
-      sourceBudgetExhausted = true;
+      exclude(unreviewedPaths, file, basePath, "source-limit");
       continue;
     }
     const patch =
@@ -384,19 +398,19 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       exactPatch.length === 0 ||
       exactPatch.length > MAX_PATCH_CHARS
     ) {
-      exclude(unreviewedPaths, file, basePath);
-      continue;
-    }
-    if (patchChars + exactPatch.length > MAX_REVIEW_PATCH_CHARS) {
-      exclude(unreviewedPaths, file, basePath);
-      patchBudgetExhausted = true;
+      exclude(
+        unreviewedPaths,
+        file,
+        basePath,
+        exactPatch !== undefined && exactPatch.length > MAX_PATCH_CHARS
+          ? "patch-limit"
+          : "patch-unavailable",
+      );
       continue;
     }
     changes.push(ReviewChange.make({ path: file.path, patch: exactPatch }));
-    patchChars += exactPatch.length;
-    if (patchChars === MAX_REVIEW_PATCH_CHARS) patchBudgetExhausted = true;
   }
-  return { changes, unreviewedPaths, ignoredPaths, unavailablePaths };
+  return { changes, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions };
 });
 
 const reviewContextFailure = (message: string): ReviewContextError =>
@@ -717,8 +731,16 @@ export const reviewActionProgram = Effect.gen(function* () {
           ),
         ),
       );
+    const pending = new Set(result.pendingPaths ?? []);
+    surface.unreviewedPaths.push(...pending);
+    surface.exclusions.push(
+      ...[...pending].map((path) => ReviewExclusion.make({ path, reason: "review-stopped" })),
+    );
     return {
-      surface,
+      surface: {
+        ...surface,
+        changes: surface.changes.filter((change) => !pending.has(change.path)),
+      },
       modelTurns: result.turns,
       exhausted: result.exhausted,
       incomplete: result.incomplete === true,
@@ -820,6 +842,7 @@ export const reviewActionProgram = Effect.gen(function* () {
       scope,
       reviewedFiles: surface.changes.length,
       unreviewedFiles: surface.unreviewedPaths.length,
+      exclusions: surface.exclusions,
       ignoredFiles: surface.ignoredPaths.length,
       modelTurns,
       complete,
@@ -881,6 +904,12 @@ export const reviewActionProgram = Effect.gen(function* () {
     ["review-url", reviewUrl],
   ]);
   yield* Console.log(`Posted PR review: ${reviewUrl}`);
+  for (const exclusion of surface.exclusions) {
+    yield* Effect.logInfo("Review input excluded", {
+      path: exclusion.path,
+      reason: exclusion.reason,
+    });
+  }
   const publicationFailure = reviewPublicationFailure({
     blockingFindings: blocking,
     unreviewedPaths: surface.unreviewedPaths.length,

--- a/packages/pr-review-action/src/presentation.ts
+++ b/packages/pr-review-action/src/presentation.ts
@@ -4,7 +4,7 @@ import type {
   ReviewReport,
   ReviewSeverity,
 } from "@effect-agent/pr-review";
-import { Context } from "effect";
+import { Context, Schema } from "effect";
 
 import { reviewMarker, reviewPauseMarker } from "./selection.ts";
 
@@ -59,7 +59,7 @@ const renderVerdict = (
     return `> [!CAUTION]\n> **Review stopped at the ${exhausted} budget.** Findings are preserved, but coverage is incomplete and this result does not clear the change.`;
   }
   if (!complete) {
-    return "> [!CAUTION]\n> **Review coverage is incomplete.** Not all supplied changes were verified, so this result does not clear the change.";
+    return "> [!CAUTION]\n> **Review coverage is incomplete.** Not all changes were verified, so this result does not clear the change.";
   }
   if (unresolvedChangeRequests > 0) {
     return `> [!CAUTION]\n> **No new blocking finding clears ${countNoun(unresolvedChangeRequests, "earlier change request")}.** A maintainer must dismiss it explicitly after verifying the fix.`;
@@ -96,12 +96,38 @@ const fencedPlainText = (text: string): string => {
   return `${fence}text\n${text}\n${fence}`;
 };
 
+export class ReviewExclusion extends Schema.Class<ReviewExclusion>("ReviewExclusion")({
+  path: Schema.String,
+  reason: Schema.Literals([
+    "path-limit",
+    "file-limit",
+    "source-limit",
+    "unsupported-entry",
+    "source-read-failed",
+    "patch-unavailable",
+    "patch-limit",
+    "review-stopped",
+  ]),
+}) {}
+
+const exclusionReason: Record<ReviewExclusion["reason"], string> = {
+  "path-limit": "Path exceeds 512 characters",
+  "file-limit": "100-file input limit",
+  "source-limit": "8 MB source hydration limit",
+  "unsupported-entry": "Not a regular file",
+  "source-read-failed": "Source could not be read as bounded UTF-8 text",
+  "patch-unavailable": "Exact patch could not be generated within the diff bounds",
+  "patch-limit": "Patch exceeds 80,000 characters",
+  "review-stopped": "Review stopped before this batch started",
+};
+
 export interface ReviewPresentationInput {
   readonly report: ReviewReport;
   readonly automaticReviewsRemaining: number;
   readonly scope: "full" | "incremental";
   readonly reviewedFiles: number;
   readonly unreviewedFiles: number;
+  readonly exclusions?: ReadonlyArray<ReviewExclusion>;
   readonly ignoredFiles: number;
   readonly modelTurns: number;
   readonly complete: boolean;
@@ -127,7 +153,7 @@ export interface ReviewCostEstimate {
 const renderCoverage = (input: ReviewPresentationInput): string =>
   [
     `${String(input.reviewedFiles)} ${input.complete ? "reviewed" : "supplied"}`,
-    ...(input.unreviewedFiles > 0 ? [`${String(input.unreviewedFiles)} unavailable`] : []),
+    ...(input.unreviewedFiles > 0 ? [`${String(input.unreviewedFiles)} excluded`] : []),
     ...(input.ignoredFiles > 0 ? [`${String(input.ignoredFiles)} ignored`] : []),
   ].join(" · ");
 
@@ -168,6 +194,33 @@ export const renderReviewBody = (input: ReviewPresentationInput): string => {
   const automaticPause = renderAutomaticPause(input.automaticReviewsRemaining);
   if (automaticPause !== undefined) parts.push(automaticPause);
   parts.push("### Summary", input.report.summary);
+  if (input.exclusions !== undefined && input.exclusions.length > 0) {
+    // Leave room for the maximum finding report and summary in GitHub's body
+    // bound, including paths whose JSON escaping expands every character.
+    const shown: Array<string> = [];
+    let chars = 0;
+    for (const { path, reason } of input.exclusions.slice(0, 30)) {
+      const line = `${JSON.stringify(path.slice(0, 512))}: ${exclusionReason[reason]}`;
+      if (chars + line.length + 1 > 10_000) break;
+      shown.push(line);
+      chars += line.length + 1;
+    }
+    parts.push(
+      [
+        "<details>",
+        `<summary>Files excluded from review input (${String(input.exclusions.length)})</summary>`,
+        "",
+        fencedPlainText(shown.join("\n")),
+        ...(shown.length < input.exclusions.length
+          ? [
+              `\n${String(input.exclusions.length - shown.length)} more excluded paths. See the Action log for the full list.`,
+            ]
+          : []),
+        "",
+        "</details>",
+      ].join("\n"),
+    );
+  }
 
   if (unanchored.length > 0) {
     const findingText = unanchored.map(renderUnanchoredFindingText).join("\n\n---\n\n");

--- a/packages/pr-review-action/test/action.test.ts
+++ b/packages/pr-review-action/test/action.test.ts
@@ -931,6 +931,7 @@ describe("exact review delta", () => {
       });
 
       expect(surface.unreviewedPaths).toEqual(["src/a.ts"]);
+      expect(surface.exclusions).toEqual([{ path: "src/a.ts", reason: "source-read-failed" }]);
       expect([...surface.unavailablePaths]).toEqual(["src/a.ts"]);
       expect(surface.changes.map((change) => change.path)).toEqual(["src/b.ts"]);
     }),
@@ -1051,36 +1052,68 @@ describe("exact review delta", () => {
       expect(surface.changes).toHaveLength(100);
       expect(surface.ignoredPaths).toEqual([ignored]);
       expect(surface.unreviewedPaths).toEqual([afterCap]);
+      expect(surface.exclusions).toEqual([{ path: afterCap, reason: "file-limit" }]);
     }),
   );
 
-  it.effect("stops blob hydration after the aggregate patch budget is exhausted", () =>
+  it.effect(
+    "admits large documentation changes without excluding implementation or later patches",
+    () =>
+      Effect.gen(function* () {
+        const paths = ["docs/a.md", "docs/b.md", "docs/c.md", "docs/d.md", "src/e.ts"];
+        const surface = yield* hydrateExactChanges({
+          files: paths.map((path) => file(path, undefined)),
+          changedPaths: paths,
+          base: treeSnapshot("base", {}),
+          head: treeSnapshot("head", {
+            "docs/a.md": "a".repeat(70_000),
+            "docs/b.md": "b".repeat(70_000),
+            "docs/c.md": "c".repeat(70_000),
+            "docs/d.md": "d".repeat(70_000),
+            "src/e.ts": "export const corrected = true;",
+          }),
+          ignore: [],
+        });
+
+        expect(surface.changes.map((change) => change.path)).toEqual([
+          "src/e.ts",
+          "docs/a.md",
+          "docs/b.md",
+          "docs/c.md",
+          "docs/d.md",
+        ]);
+        expect(surface.unreviewedPaths).toEqual([]);
+        expect(surface.exclusions).toEqual([]);
+      }),
+  );
+
+  it.effect("keeps oversized patches readable as context without claiming they were reviewed", () =>
     Effect.gen(function* () {
-      const paths = ["src/a.ts", "src/b.ts", "src/c.ts", "src/d.ts", "src/e.ts"];
+      const path = "src/large.ts";
+      const base = treeSnapshot("base", {});
+      const head = treeSnapshot("head", { [path]: "export const large = true;\n".repeat(4_000) });
       const surface = yield* hydrateExactChanges({
-        files: paths.map((path) => file(path, undefined)),
-        changedPaths: paths,
-        base: treeSnapshot("base", {}),
-        head: treeSnapshot(
-          "head",
-          {
-            "src/a.ts": "a".repeat(70_000),
-            "src/b.ts": "b".repeat(70_000),
-            "src/c.ts": "c".repeat(70_000),
-            "src/d.ts": "d".repeat(70_000),
-            "src/e.ts": "must not be read",
-          },
-          new Set(["src/e.ts"]),
-        ),
+        files: [file(path, undefined)],
+        changedPaths: [path],
+        base,
+        head,
         ignore: [],
       });
-
-      expect(surface.changes.map((change) => change.path)).toEqual([
-        "src/a.ts",
-        "src/b.ts",
-        "src/c.ts",
+      const repository = makeReviewRepository({
+        base,
+        head,
+        ignore: [],
+        unavailablePaths: surface.unavailablePaths,
+      });
+      expect(surface.changes).toEqual([]);
+      expect(surface.exclusions).toEqual([{ path, reason: "patch-limit" }]);
+      expect((yield* repository.findFiles({ revision: "head", query: "large" })).paths).toEqual([
+        path,
       ]);
-      expect(surface.unreviewedPaths).toEqual(["src/d.ts", "src/e.ts"]);
+      expect(
+        (yield* repository.readFile({ path, revision: "head", startLine: 1, lineCount: 1 }))
+          .content,
+      ).toBe("export const large = true;");
     }),
   );
 

--- a/packages/pr-review-action/test/presentation.test.ts
+++ b/packages/pr-review-action/test/presentation.test.ts
@@ -7,6 +7,7 @@ import {
   renderReviewPauseBody,
   renderReviewBody,
   renderReviewFailureBody,
+  ReviewExclusion,
   withReviewMarker,
   withReviewPauseMarker,
 } from "../src/presentation.ts";
@@ -48,6 +49,7 @@ describe("review presentation", () => {
       scope: "full",
       reviewedFiles: 2,
       unreviewedFiles: 1,
+      exclusions: [ReviewExclusion.make({ path: "docs/large.md", reason: "patch-limit" })],
       ignoredFiles: 3,
       modelTurns: 5,
       complete: true,
@@ -67,8 +69,9 @@ describe("review presentation", () => {
 
     expect(body).toContain("> [!CAUTION]\n> **1 blocking finding.** Do not merge");
     expect(body).toContain(
-      "| **Full diff** | 2 reviewed · 1 unavailable · 3 ignored | 🛑 1 blocking · ⚠️ 1 important |",
+      "| **Full diff** | 2 reviewed · 1 excluded · 3 ignored | 🛑 1 blocking · ⚠️ 1 important |",
     );
+    expect(body).toContain('"docs/large.md": Patch exceeds 80,000 characters');
     expect(body).toContain("### Findings without an inline anchor (1)");
     expect(body).toContain("```text\n[⚠️ important · security] Authorization is not enforced");
     expect(body).toContain(
@@ -219,22 +222,25 @@ describe("review presentation", () => {
     }
   });
 
-  it("renders all twenty-four unanchored findings once within the publication bound", () => {
+  it("keeps maximum findings and adversarial excluded paths within the publication bound", () => {
     const findings = Array.from({ length: 24 }, (_, index) =>
       ReviewFinding.make({
-        path: `src/finding-${String(index).padStart(2, "0")}.ts`,
+        path: `src/${String(index).padStart(2, "0")}${"x".repeat(506)}`,
         severity: "blocking",
         category: "correctness",
-        title: `Distinct blocker ${String(index).padStart(2, "0")}`,
-        body: "<".repeat(2_000),
+        title: `Title ${String(index).padStart(2, "0")}${"x".repeat(192)}`,
+        body: "`".repeat(2_000),
       }),
     );
     const body = renderReviewBody({
-      report: ReviewReport.make({ summary: "Twenty-four distinct blockers.", findings }),
+      report: ReviewReport.make({ summary: "x".repeat(6_000), findings }),
       automaticReviewsRemaining: 1,
       scope: "full",
       reviewedFiles: 24,
-      unreviewedFiles: 0,
+      unreviewedFiles: 100,
+      exclusions: Array.from({ length: 100 }, () =>
+        ReviewExclusion.make({ path: "\u0001".repeat(512), reason: "patch-limit" }),
+      ),
       ignoredFiles: 0,
       modelTurns: 9,
       complete: true,
@@ -248,6 +254,7 @@ describe("review presentation", () => {
     });
 
     expect(body.length).toBeLessThanOrEqual(100_000);
+    expect(body).toContain("more excluded paths. See the Action log for the full list.");
     for (const finding of findings) {
       expect(body.split(finding.title)).toHaveLength(2);
     }

--- a/packages/pr-review-action/test/review-openai.test.ts
+++ b/packages/pr-review-action/test/review-openai.test.ts
@@ -329,6 +329,78 @@ describe("review provider boundary", () => {
       }),
   );
 
+  it.effect.each(["complete", "cost", "protocol"] as const)(
+    "reviews large input in fresh batches under one spending ledger: %s",
+    (outcome) =>
+      Effect.gen(function* () {
+        const changes = [
+          ...request.changes,
+          ...Array.from({ length: 10 }, (_, index) =>
+            ReviewChange.make({
+              path: `docs/page-${String(index)}.md`,
+              patch: `@@ -0,0 +1 @@\n+${"x".repeat(70_000)}`,
+            }),
+          ),
+        ];
+        const sent: Array<WireRequest> = [];
+        const input = outcome === "cost" ? 70_000 : 20_000;
+        const native = yield* makeNative(
+          HttpClient.make((httpRequest, url) =>
+            Effect.sync(() => {
+              if (url.pathname.endsWith("/input_tokens"))
+                return json(httpRequest, { object: "response.input_tokens", input_tokens: input });
+              sent.push(decodeWire(httpRequest));
+              const calls =
+                sent.length === 1
+                  ? [{ name: "submit_review", parameters: { findings: [finding] } }]
+                  : outcome === "protocol"
+                    ? [{ name: "unknown_tool", parameters: {} }]
+                    : [submit];
+              return sse(
+                httpRequest,
+                sent.length,
+                calls,
+                rawUsage(input, outcome === "cost" ? 32_000 : 100),
+              );
+            }),
+          ),
+        );
+        const provider = yield* makeReviewOpenAi({
+          client: native,
+          model: "gpt-5.6-sol",
+          cacheKey: "large-review",
+        });
+        const result = yield* makeReviewer({ model, costControl: provider.costControl })
+          .review(ReviewRequest.make({ ...request, changes }))
+          .pipe(
+            Effect.provideService(OpenAiClient.OpenAiClient, provider.client),
+            Effect.provideService(ReviewRepository, repository),
+          );
+        expect(result.report.findings.map((item) => item.title)).toEqual([finding.title]);
+        expect(result.turns).toBe(sent.length);
+        expect(result.usage).toEqual((yield* provider.costControl.snapshot).usage);
+        expect(result.usage.estimatedCostMicrousd).toBeLessThan(1_000_000);
+        if (outcome === "complete") {
+          expect(sent).toHaveLength(4);
+          expect(result.pendingPaths).toBeUndefined();
+          expect(result.incomplete).toBeUndefined();
+          expect(result.exhausted).toBeUndefined();
+          for (const change of changes) {
+            expect(
+              sent.filter((wire) => JSON.stringify(wire.input).includes(change.path)),
+            ).toHaveLength(1);
+          }
+        } else {
+          expect(sent).toHaveLength(outcome === "cost" ? 1 : 2);
+          expect(result.exhausted).toBe(outcome === "cost" ? "cost" : undefined);
+          expect(result.incomplete).toBe(true);
+          expect(result.pendingPaths).toEqual(
+            changes.slice(outcome === "cost" ? 4 : 7).map((change) => change.path),
+          );
+        }
+      }),
+  );
+
   it.effect("preserves cached tool schemas through the required completion turn", () =>
     Effect.gen(function* () {
       const sent: Array<WireRequest> = [];

--- a/packages/pr-review/README.md
+++ b/packages/pr-review/README.md
@@ -1,8 +1,8 @@
 # @effect-agent/pr-review
 
-A small, provider-neutral review agent. One bounded model run receives every admitted patch as
-a literal unified diff, reads immutable base or head source when needed, records established
-findings with `record_finding`, and returns findings through a required native completion Tool.
+A small, provider-neutral review agent. Bounded model runs receive admitted patches as
+literal unified diffs, read immutable base or head source when needed, record established
+findings with `record_finding`, and return findings through a required native completion Tool.
 There is no voting, candidate cache, private hypothesis
 handoff, or repository code execution.
 
@@ -56,6 +56,13 @@ The 8-turn, 64-tool-call, 5-minute, and 128,000-token context bounds remain in f
 estimator alone does not disable the token quota. Capped hosts own model-visible spending feedback
 at their provider boundary; the generic turn/tool status is disabled for these runs. The Action
 counts its outgoing spending status before admission and keeps it outside the reusable cache prefix.
+With `costControl`, large requests run in sequential batches of at most 256,000 patch characters,
+preserving the host's file order and keeping each patch complete. Each batch has a fresh context
+and the same source service. All batches share the host ledger, turn and tool allowances, deadline,
+and 24-finding capacity. They stop on an incomplete result or exhaustion. `pendingPaths` identifies
+admitted patches never sent to a model, including a batch refused before paid inference. Hosts
+must disclose those paths as unreviewed. Without `costControl`, the reviewer retains one run and its
+cumulative token policy.
 When the host stops research for cost, the reviewer returns `exhausted: "cost"` and delivers
 recorded findings without requiring another paid call. Hosts must reserve the full possible charge
 before sending each request; the port itself does not enforce a cap. The

--- a/packages/pr-review/src/review.ts
+++ b/packages/pr-review/src/review.ts
@@ -1,4 +1,4 @@
-import { Effect, Ref, Result, Schema } from "effect";
+import { DateTime, Effect, Ref, Result, Schema } from "effect";
 import {
   Agent,
   AgentPolicy,
@@ -132,6 +132,8 @@ export class ReviewOutcome extends Schema.Class<ReviewOutcome>(
   report: ReviewReport,
   turns: Schema.Natural,
   usage: ReviewUsage,
+  /** Admitted patches in batches that never started. These are not reviewed files. */
+  pendingPaths: Schema.optionalKey(Schema.Array(ReviewPath).check(Schema.isMaxLength(100))),
   /** A constrained final answer preserves findings but cannot establish complete coverage. */
   exhausted: Schema.optionalKey(Schema.Literals(["tokens", "tool-calls", "turns", "cost"])),
   /** Unfinished coverage, reported by the model or caused by failure or the report capacity bound. */
@@ -301,7 +303,25 @@ const reviewSummary = (request: ReviewRequest, findings: ReadonlyArray<ReviewFin
     findings.length === 0
       ? "No concrete defects found in the supplied change."
       : `Reported ${findings.length} finding(s), including ${blocking} blocking finding(s).`;
-  return `${summary}${request.scope === "incremental" ? " This incremental review does not resolve earlier findings or establish that merging is safe." : ""}${request.unreviewedPaths.length > 0 ? " Coverage is incomplete because some changed paths were unavailable." : ""}`;
+  return `${summary}${request.scope === "incremental" ? " This incremental review does not resolve earlier findings or establish that merging is safe." : ""}${request.unreviewedPaths.length > 0 ? " Coverage is incomplete because some changed paths were excluded from review input." : ""}`;
+};
+
+/** Keep complete patches together; the shared host ledger still bounds the whole review. */
+const batchChanges = (changes: ReadonlyArray<ReviewChange>): Array<Array<ReviewChange>> => {
+  const batches: Array<Array<ReviewChange>> = [];
+  let batch: Array<ReviewChange> = [];
+  let chars = 0;
+  for (const change of changes) {
+    if (batch.length > 0 && chars + change.patch.length > 256_000) {
+      batches.push(batch);
+      batch = [];
+      chars = 0;
+    }
+    batch.push(change);
+    chars += change.patch.length;
+  }
+  if (batch.length > 0 || batches.length === 0) batches.push(batch);
+  return batches;
 };
 
 /** Fail on unknown paths, demote invalid anchors, and remove only exact duplicates. */
@@ -342,7 +362,7 @@ const validatedFindings = Effect.fn("validatedFindings")(function* (
   });
 });
 
-/** One bounded, source-backed review of the complete admitted delta. */
+/** A bounded review, with sequential patch batches when a shared spending ledger is supplied. */
 export const makeReviewer = <Provider, ModelProvides, ModelRequires>(
   options: ReviewerOptions<Provider, ModelProvides, ModelRequires>,
 ) => {
@@ -370,26 +390,32 @@ export const makeReviewer = <Provider, ModelProvides, ModelRequires>(
       const budget = yield* makeUsageBudget(UsageBudgetLimits.make({}));
       const modelCalls = yield* Ref.make(0);
       const recorded = yield* Ref.make<ReadonlyArray<ReviewFinding>>([]);
-      const recordingLayer = reviewRecording.toLayer({
-        record_finding: Effect.fn("Reviewer.recordFinding")(function* (finding) {
-          const report = yield* validatedFindings(request, [finding]);
-          const accepted = yield* Ref.modify(recorded, (current) => {
-            const additions = report.findings.filter(
-              (entry) => !current.some((prior) => JSON.stringify(prior) === JSON.stringify(entry)),
-            );
-            if (current.length + additions.length > 24) return [false, current] as const;
-            return [true, [...current, ...additions]] as const;
-          });
-          if (!accepted)
-            return yield* ReviewVerificationError.make({
-              message:
-                "The review already contains 24 recorded findings; submit those findings now.",
+      const startedAt = yield* DateTime.now;
+      const deadline = DateTime.add(startedAt, { minutes: 5 });
+      const recordingLayer = (batch: ReviewRequest) =>
+        reviewRecording.toLayer({
+          record_finding: Effect.fn("Reviewer.recordFinding")(function* (finding) {
+            const report = yield* validatedFindings(batch, [finding]);
+            const accepted = yield* Ref.modify(recorded, (current) => {
+              const additions = report.findings.filter(
+                (entry) =>
+                  !current.some((prior) => JSON.stringify(prior) === JSON.stringify(entry)),
+              );
+              if (current.length + additions.length > 24) return [false, current] as const;
+              return [true, [...current, ...additions]] as const;
             });
-          return null;
-        }),
-      });
+            if (!accepted)
+              return yield* ReviewVerificationError.make({
+                message:
+                  "The review already contains 24 recorded findings; submit those findings now.",
+              });
+            return null;
+          }),
+        });
       const accounting = toRunBudgetHook(budget);
       const runOptions = {
+        runStartedAt: startedAt,
+        durationDeadline: deadline,
         budget: {
           ...accounting,
           consume: Effect.fn("Reviewer.consumeUsage")(function* (delta: RunUsageDelta) {
@@ -412,68 +438,112 @@ export const makeReviewer = <Provider, ModelProvides, ModelRequires>(
           ? {}
           : { estimateCostMicrousd: options.estimateCostMicrousd }),
       };
-      const result = yield* AgentRuntime.run(reviewer, request, runOptions).pipe(
-        Effect.provide(recordingLayer),
-        Effect.result,
-      );
-      const saved = yield* Ref.get(recorded);
-      const cost =
-        options.costControl === undefined ? undefined : yield* options.costControl.snapshot;
-      const preserveAttempt =
-        cost?.stopped === true || (cost?.modelCalls ?? 0) > 0 || saved.length > 0;
-      if (Result.isFailure(result) && !preserveAttempt) {
-        return yield* result.failure;
-      }
-      const submitted = Result.isSuccess(result)
-        ? yield* validatedFindings(request, result.success.output.findings).pipe(Effect.result)
-        : Result.succeed(
-            ReviewReport.make({ summary: "Research stopped before completion.", findings: [] }),
-          );
-      if (Result.isFailure(submitted) && !preserveAttempt) return yield* submitted.failure;
-      const failure = Result.isFailure(result)
-        ? result.failure
-        : Result.isFailure(submitted)
-          ? submitted.failure
-          : undefined;
-      if (failure !== undefined)
-        yield* Effect.logWarning("Review stopped before completion", { failureType: failure._tag });
-      const combined = [...saved];
-      if (Result.isSuccess(submitted)) {
-        for (const finding of submitted.success.findings) {
-          if (!combined.some((prior) => JSON.stringify(prior) === JSON.stringify(finding)))
-            combined.push(finding);
+      const runBatch = Effect.fn("Reviewer.reviewBatch")(function* (batch: ReviewRequest) {
+        const totals = yield* budget.snapshot;
+        const usedTurns = yield* Ref.get(modelCalls);
+        const priorCost =
+          options.costControl === undefined ? undefined : yield* options.costControl.snapshot;
+        const result = yield* AgentRuntime.run(reviewer, batch, {
+          ...runOptions,
+          turnAllowance: 8 - usedTurns,
+          toolCallAllowance: 64 - totals.toolCalls,
+        }).pipe(Effect.provide(recordingLayer(batch)), Effect.result);
+        const saved = yield* Ref.get(recorded);
+        const cost =
+          options.costControl === undefined ? undefined : yield* options.costControl.snapshot;
+        const preserveAttempt =
+          cost?.stopped === true || (cost?.modelCalls ?? 0) > 0 || saved.length > 0;
+        if (Result.isFailure(result) && !preserveAttempt) {
+          return yield* result.failure;
         }
-      }
-      const incomplete =
-        Result.isFailure(result) ||
-        Result.isFailure(submitted) ||
-        combined.length > 24 ||
-        result.success.output.incomplete === true;
-      const exhausted =
-        cost?.stopped === true
-          ? "cost"
-          : Result.isSuccess(result)
-            ? result.success.exhausted
+        const submitted = Result.isSuccess(result)
+          ? yield* validatedFindings(batch, result.success.output.findings).pipe(Effect.result)
+          : Result.succeed(
+              ReviewReport.make({ summary: "Research stopped before completion.", findings: [] }),
+            );
+        if (Result.isFailure(submitted) && !preserveAttempt) return yield* submitted.failure;
+        const failure = Result.isFailure(result)
+          ? result.failure
+          : Result.isFailure(submitted)
+            ? submitted.failure
             : undefined;
+        if (failure !== undefined)
+          yield* Effect.logWarning("Review stopped before completion", {
+            failureType: failure._tag,
+          });
+        const combined = [...saved];
+        if (Result.isSuccess(submitted)) {
+          for (const finding of submitted.success.findings) {
+            if (!combined.some((prior) => JSON.stringify(prior) === JSON.stringify(finding)))
+              combined.push(finding);
+          }
+        }
+        const incomplete =
+          Result.isFailure(result) ||
+          Result.isFailure(submitted) ||
+          combined.length > 24 ||
+          result.success.output.incomplete === true;
+        const exhausted: ReviewOutcome["exhausted"] =
+          cost?.stopped === true
+            ? "cost"
+            : Result.isSuccess(result)
+              ? result.success.exhausted
+              : undefined;
+        yield* Ref.set(recorded, combined.slice(0, 24));
+        return {
+          incomplete,
+          exhausted,
+          protocolError: failure?._tag === "ModelProtocolError",
+          attempted:
+            (yield* Ref.get(modelCalls)) > usedTurns ||
+            (cost?.modelCalls ?? 0) > (priorCost?.modelCalls ?? 0),
+        };
+      });
+      // Uncapped hosts retain one run and its cumulative token policy. Capped
+      // hosts share their existing ledger across fresh contexts without resetting
+      // the review's turn, tool, deadline, finding, or spending allowances.
+      const batches =
+        options.costControl === undefined ? [request.changes] : batchChanges(request.changes);
+      let incomplete = false;
+      let exhausted: ReviewOutcome["exhausted"];
+      let protocolError = false;
+      let supplied = 0;
+      for (const changes of batches) {
+        const totals = yield* budget.snapshot;
+        if ((yield* Ref.get(modelCalls)) >= 8 || totals.toolCalls >= 64) {
+          exhausted = totals.toolCalls >= 64 ? "tool-calls" : "turns";
+          incomplete = true;
+          break;
+        }
+        const batch = yield* runBatch(ReviewRequest.make({ ...request, changes }));
+        if (batch.attempted) supplied += changes.length;
+        incomplete = batch.incomplete;
+        exhausted = batch.exhausted;
+        protocolError = batch.protocolError;
+        if (incomplete || exhausted !== undefined) break;
+      }
+      const combined = yield* Ref.get(recorded);
+      const pendingPaths = request.changes.slice(supplied).map((change) => change.path);
       const report = ReviewReport.make({
         findings: combined.slice(0, 24),
         summary:
           exhausted !== undefined
             ? `Review stopped at the ${exhausted} budget. These findings cover the investigation completed before finalization; the remaining change has not been verified.`
             : incomplete
-              ? `${failure?._tag === "ModelProtocolError" ? "The review stopped after a model protocol error." : "The investigation did not complete."} Recorded findings are preserved; the remaining change has not been verified.`
+              ? `${protocolError ? "The review stopped after a model protocol error." : "The investigation did not complete."} Recorded findings are preserved; the remaining change has not been verified.`
               : reviewSummary(request, combined),
       });
       // Diagnostics deliberately contain counts only, never source or model-authored prose.
       yield* Effect.logDebug("Review completed", { findingCount: report.findings.length });
       const usage = yield* budget.snapshot;
+      const cost =
+        options.costControl === undefined ? undefined : yield* options.costControl.snapshot;
       return ReviewOutcome.make({
         report,
+        ...(pendingPaths.length === 0 ? {} : { pendingPaths }),
         ...(exhausted === undefined ? {} : { exhausted }),
         ...(incomplete ? { incomplete: true } : {}),
-        turns:
-          cost?.modelCalls ??
-          (Result.isSuccess(result) ? result.success.turns : yield* Ref.get(modelCalls)),
+        turns: cost?.modelCalls ?? (yield* Ref.get(modelCalls)),
         usage:
           cost?.usage ??
           ReviewUsage.make({

--- a/packages/pr-review/test/review.test.ts
+++ b/packages/pr-review/test/review.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Layer, Ref, Result, Stream, Struct } from "effect";
+import { TestClock } from "effect/testing";
 import {
   type AiError,
   LanguageModel,
@@ -78,6 +79,35 @@ const scriptedModel = (
 const emptyRepository = ReviewRepository.of({
   readFile: () => Effect.fail(ReviewContextError.make({ message: "Source unavailable" })),
   findFiles: () => Effect.succeed(ReviewFileList.make({ paths: [], truncated: false })),
+});
+
+const largeRequest = (count: number) =>
+  ReviewRequest.make({
+    ...request,
+    changes: Array.from({ length: count }, (_, index) =>
+      ReviewChange.make({
+        path: `src/part-${String(index)}.ts`,
+        patch: `@@ -0,0 +1 @@\n+${"x".repeat(70_000)}`,
+      }),
+    ),
+  });
+
+const costControl = (calls: Ref.Ref<number>) => ({
+  snapshot: Ref.get(calls).pipe(
+    Effect.map((modelCalls) =>
+      ReviewCostSnapshot.make({
+        stopped: false,
+        modelCalls,
+        usage: ReviewUsage.make({
+          inputTokens: modelCalls * 10,
+          uncachedInputTokens: modelCalls * 7,
+          cachedInputTokens: modelCalls * 2,
+          cacheWriteInputTokens: modelCalls,
+          outputTokens: modelCalls * 4,
+        }),
+      }),
+    ),
+  ),
 });
 
 const blocker = ReviewFinding.make({
@@ -626,24 +656,136 @@ new mode 100755`;
     }),
   );
 
-  it.effect("PRR-002 closes the single run on interruption", () =>
+  it.effect("shares the turn allowance across batches and reports patches it never supplied", () =>
     Effect.gen(function* () {
-      const finalized = yield* Ref.make(false);
-      const started = yield* Deferred.make<void>();
-      const model = scriptedModel(() =>
-        Stream.fromEffect(Deferred.succeed(started, undefined)).pipe(
-          Stream.flatMap(() => Stream.never),
-          Stream.ensuring(Ref.set(finalized, true)),
+      const calls = yield* Ref.make(0);
+      const input = largeRequest(27);
+      const review = makeReviewer({
+        model: scriptedModel(() =>
+          Stream.unwrap(
+            Ref.update(calls, (count) => count + 1).pipe(Effect.as(response({ findings: [] }))),
+          ),
+        ),
+        costControl: costControl(calls),
+      }).review(input);
+      expectTypeOf<Effect.Services<typeof review>>().toEqualTypeOf<ReviewRepository>();
+      expectTypeOf<Effect.Error<typeof review>>().not.toBeAny();
+      const outcome = yield* review.pipe(Effect.provideService(ReviewRepository, emptyRepository));
+      expect(yield* Ref.get(calls)).toBe(8);
+      expect(outcome.exhausted).toBe("turns");
+      expect(outcome.incomplete).toBe(true);
+      expect(outcome.pendingPaths).toEqual(input.changes.slice(24).map((change) => change.path));
+    }),
+  );
+
+  it.effect("does not renew the tool allowance when the next patch batch starts", () =>
+    Effect.gen(function* () {
+      const calls = yield* Ref.make(0);
+      const reads = yield* Ref.make(0);
+      const input = largeRequest(9);
+      const model = scriptedModel((_prompt, _tools, choice) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const call = yield* Ref.updateAndGet(calls, (count) => count + 1);
+            if (call === 2 || typeof choice === "object") return response({ findings: [] });
+            return Stream.fromIterable<Response.StreamPartEncoded>([
+              ...Array.from(
+                { length: 32 },
+                (_, index): Response.StreamPartEncoded => ({
+                  type: "tool-call",
+                  id: `read-${String(call)}-${String(index)}`,
+                  name: "find_files",
+                  params: { revision: "head", query: "part" },
+                }),
+              ),
+              { type: "finish", reason: "tool-calls", usage },
+            ]);
+          }),
         ),
       );
-      const fiber = yield* makeReviewer({ model })
-        .review(request)
-        .pipe(Effect.provideService(ReviewRepository, emptyRepository), Effect.forkChild);
-      yield* Deferred.await(started);
-      yield* Fiber.interrupt(fiber);
-      expect(Exit.isFailure(yield* Fiber.await(fiber))).toBe(true);
-      expect(yield* Ref.get(finalized)).toBe(true);
+      const outcome = yield* makeReviewer({ model, costControl: costControl(calls) })
+        .review(input)
+        .pipe(
+          Effect.provideService(ReviewRepository, {
+            ...emptyRepository,
+            findFiles: () =>
+              Ref.update(reads, (count) => count + 1).pipe(
+                Effect.as(ReviewFileList.make({ paths: [], truncated: false })),
+              ),
+          }),
+        );
+      expect(yield* Ref.get(reads)).toBe(32);
+      expect(outcome.exhausted).toBe("tool-calls");
+      expect(outcome.pendingPaths).toEqual(input.changes.slice(6).map((change) => change.path));
     }),
+  );
+
+  it.effect("keeps one deadline across batches and closes each model stream", () =>
+    Effect.gen(function* () {
+      const calls = yield* Ref.make(0);
+      const finalized = yield* Ref.make(0);
+      const firstStarted = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const input = largeRequest(9);
+      const model = scriptedModel(() =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const call = yield* Ref.updateAndGet(calls, (count) => count + 1);
+            yield* Deferred.succeed(call === 1 ? firstStarted : secondStarted, undefined);
+            return Stream.fromEffect(Effect.sleep("4 minutes")).pipe(
+              Stream.flatMap(() => response({ findings: [] })),
+              Stream.ensuring(Ref.update(finalized, (count) => count + 1)),
+            );
+          }),
+        ),
+      );
+      const fiber = yield* makeReviewer({ model, costControl: costControl(calls) })
+        .review(input)
+        .pipe(Effect.provideService(ReviewRepository, emptyRepository), Effect.forkChild);
+      yield* Deferred.await(firstStarted);
+      yield* TestClock.adjust("4 minutes");
+      yield* Deferred.await(secondStarted);
+      yield* TestClock.adjust("1 minute");
+      const outcome = yield* Fiber.join(fiber);
+      expect(yield* Ref.get(calls)).toBe(2);
+      expect(yield* Ref.get(finalized)).toBe(2);
+      expect(outcome.incomplete).toBe(true);
+      expect(outcome.pendingPaths).toEqual(input.changes.slice(6).map((change) => change.path));
+    }),
+  );
+
+  it.effect.each(["interrupt", "defect"] as const)(
+    "closes batch streams on %s without returning a review",
+    (failure) =>
+      Effect.gen(function* () {
+        const finalized = yield* Ref.make(0);
+        const calls = yield* Ref.make(0);
+        const started = yield* Deferred.make<void>();
+        const model = scriptedModel(() =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const call = yield* Ref.updateAndGet(calls, (count) => count + 1);
+              const stream =
+                call === 1
+                  ? response({ findings: [] })
+                  : Stream.fromEffect(Deferred.succeed(started, undefined)).pipe(
+                      Stream.flatMap(() =>
+                        failure === "interrupt" ? Stream.never : Stream.die("batch defect"),
+                      ),
+                    );
+              return stream.pipe(Stream.ensuring(Ref.update(finalized, (count) => count + 1)));
+            }),
+          ),
+        );
+        const fiber = yield* makeReviewer({ model, costControl: costControl(calls) })
+          .review(largeRequest(9))
+          .pipe(Effect.provideService(ReviewRepository, emptyRepository), Effect.forkChild);
+        yield* Deferred.await(started);
+        if (failure === "interrupt") yield* Fiber.interrupt(fiber);
+        expect(Exit.isFailure(yield* Fiber.await(fiber))).toBe(true);
+        expect(yield* Ref.get(calls)).toBe(2);
+        expect(yield* Ref.get(finalized)).toBe(2);
+      }),
   );
 
   it.effect("PRR-003 shares exact source range bounds", () =>


### PR DESCRIPTION
PR #262 supplied only 22 files to the reviewer because documentation exhausted the alphabetical 256,000-character patch allowance. The Action excluded the remaining 45 files, including every runtime change, and reported them as unavailable.

Replace that aggregate cutoff with implementation-first admission and sequential batches of complete patches. Batches use fresh contexts while sharing the existing spending ledger, turn and tool allowances, deadline, and finding capacity. Preserve findings after a later expected failure and report `pendingPaths` for batches that never reached the model. Files excluded only by input capacity remain available to bounded source tools; ignore rules still apply.

Review comments now list exclusion reasons, with bounded rendering to fit GitHub's publication limit. The updated Action bundle and consumer documentation are included.

The exact PR #262 revisions now admit all 67 nonignored files in an offline scripted review across three batches. All 17 package changes enter the first batch. This verifies coverage and execution flow; a live review can still stop under the shared $0.999999 ceiling. Increasing that ceiling alone would leave the old input cutoff in place, while sending the entire diff in one context could exceed the model input bound.

Validation: `vp run ready` on the branch rebased onto current main. Regression tests cover shared spending, turn, tool, and time limits; retained findings; interruption and defect cleanup; source access after input exclusion; and comment-size bounds.
