### PR TITLE
refactor(thread): remove conversation migration leftovers

### DIFF
--- a/.changeset/direct-thread-storage.md
+++ b/.changeset/direct-thread-storage.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/storage-sqlite": patch
+---
+
+Initialize SQLite storage directly with the complete Thread schema.

--- a/docs/guide/threads.md
+++ b/docs/guide/threads.md
@@ -139,14 +139,3 @@ may require a reset. See [Persistence & durability](../concepts/durability) befo
 active execution survives process loss.
 
 For a custom adapter, follow the [store contract and certification guide](./certify-adapters#store-contract).
-
-## Upgrade from conversations
-
-Rename imports from `@effect-agent/session` to `@effect-agent/thread`. Rename
-`ConversationId`, `conversationId`, `ConversationHistory`, and `ConversationStore` to
-`ThreadId`, `threadId`, `ThreadHistory`, and `ThreadStore`. The durable-admin CLI now
-uses `--thread`.
-
-Canonical records now use the `thread` family, `ThreadCreated`, and
-`@effect-agent/thread/*` Schema identifiers and tags. Reset incompatible alpha storage and use
-a fresh Durable Object namespace before upgrading. The framework does not migrate stored data.

--- a/packages/storage-cloudflare/src/migrations.ts
+++ b/packages/storage-cloudflare/src/migrations.ts
@@ -2,19 +2,12 @@ import { SqliteMigrator } from "@effect/sql-sqlite-do";
 import { Effect } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
-/**
- * The exact-or-fresh storage version recorded in `effect_agent_meta`. Cloudflare is a fresh
- * platform, so there is exactly ONE migration carrying the complete current schema — no
- * v1→v4 history to replay (deployment spec §9: no rolling data-version promise during
- * private development).
- */
+/** The current storage version recorded in `effect_agent_meta`. */
 export const CurrentDoStorageVersion = 2;
 
 /**
- * The Thread Durable Object schema. Table names and columns mirror the Node/SQLite v4
- * schema byte-for-byte (`packages/storage-sqlite/src/migrations.ts`, migrations 1–4 collapsed
- * into their final shape) so the shared conformance suites and crash-matrix rows address
- * identical durable state. Two DC-specific additions:
+ * The Thread Durable Object schema shares its thread and ledger tables with Node/SQLite.
+ * Schedules and subscriptions use separate Durable Objects. Two DC-specific additions:
  *
  * 1. `effect_agent_meta` replaces `PRAGMA user_version` as the exact-or-fresh version gate —
  *    a meta table is portable regardless of which PRAGMAs Durable Object SQL storage allows.

--- a/packages/storage-cloudflare/test/do-schedule-store.test.ts
+++ b/packages/storage-cloudflare/test/do-schedule-store.test.ts
@@ -42,9 +42,9 @@ describe("Durable Object ScheduleStore conformance", () => {
     });
   }
 
-  it("rejects the Conversation-era schedule version without mutation", () =>
+  it("rejects an unsupported schedule version without mutation", () =>
     expect(
-      withScheduleStorage("schedule-store-conversation-era-version", (storage) =>
+      withScheduleStorage("schedule-store-unsupported-version", (storage) =>
         Effect.gen(function* () {
           const sql = yield* SqlClientService.SqlClient;
           yield* sql`

--- a/packages/storage-cloudflare/test/do-storage.test.ts
+++ b/packages/storage-cloudflare/test/do-storage.test.ts
@@ -173,8 +173,8 @@ describe("DoThreadStore", () => {
       }),
     ));
 
-  it("rejects the Conversation-era storage version without mutating its tables", () =>
-    withThreadStorage("wp1-store-conversation-era-version", (storage) =>
+  it("rejects an unsupported storage version without mutating its tables", () =>
+    withThreadStorage("wp1-store-unsupported-version", (storage) =>
       Effect.gen(function* () {
         const previousVersion = CurrentDoStorageVersion - 1;
         storage.sql.exec(`
@@ -184,11 +184,11 @@ describe("DoThreadStore", () => {
           );
           INSERT INTO effect_agent_meta (key, value)
           VALUES ('storage_version', '${previousVersion}');
-          CREATE TABLE effect_agent_conversations (
-            conversation_id TEXT PRIMARY KEY NOT NULL
+          CREATE TABLE effect_agent_threads (
+            thread_id TEXT PRIMARY KEY NOT NULL
           );
-          INSERT INTO effect_agent_conversations (conversation_id)
-          VALUES ('legacy-conversation');
+          INSERT INTO effect_agent_threads (thread_id)
+          VALUES ('retained-thread');
         `);
 
         const opened = yield* ThreadStore.pipe(
@@ -212,11 +212,9 @@ describe("DoThreadStore", () => {
         }
 
         const rows = storage.sql
-          .exec<{ conversation_id: string }>(
-            "SELECT conversation_id FROM effect_agent_conversations",
-          )
+          .exec<{ thread_id: string }>("SELECT thread_id FROM effect_agent_threads")
           .toArray();
-        expect(rows).toEqual([{ conversation_id: "legacy-conversation" }]);
+        expect(rows).toEqual([{ thread_id: "retained-thread" }]);
       }),
     ));
 

--- a/packages/storage-cloudflare/test/do-subscription-store.test.ts
+++ b/packages/storage-cloudflare/test/do-subscription-store.test.ts
@@ -49,9 +49,9 @@ describe("Durable Object SubscriptionStore conformance", () => {
     );
   }
 
-  it("rejects the Conversation-era subscription version without mutation", () =>
+  it("rejects an unsupported subscription version without mutation", () =>
     expect(
-      withScheduleStorage("subscription-store-conversation-era-version", (storage) =>
+      withScheduleStorage("subscription-store-unsupported-version", (storage) =>
         Effect.gen(function* () {
           const sql = yield* SqlClientService.SqlClient;
           yield* sql`

--- a/packages/storage-sqlite/src/migrations.ts
+++ b/packages/storage-sqlite/src/migrations.ts
@@ -4,8 +4,9 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 export const CurrentSqliteStorageVersion = 7;
 
+/** Initialize empty storage with the complete current schema. */
 export const sqliteMigrations = SqliteMigrator.fromRecord({
-  "1_current_persistent_thread_foundation": Effect.gen(function* () {
+  "1_current_thread_storage": Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
 
     yield* sql`
@@ -67,11 +68,6 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       )
     `.withoutTransform;
 
-    yield* sql`PRAGMA user_version = 1`.withoutTransform;
-  }),
-  "2_durable_submission_ledger": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-
     // Admission rows exist before Thread materialization (durability §4), so
     // thread_id intentionally carries no foreign key into effect_agent_threads.
     yield* sql`
@@ -93,6 +89,13 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
         ready_at TEXT,
         input_applied_record_id TEXT,
         input_applied_sequence INTEGER,
+        joined_host_submission_id TEXT,
+        suspended_reason_json TEXT,
+        suspended_at TEXT,
+        unknown_reason TEXT,
+        unknown_tool_call_ids_json TEXT,
+        parent_submission_id TEXT,
+        parent_tool_call_id TEXT,
         UNIQUE (thread_id, principal, idempotency_key),
         UNIQUE (thread_id, queue_sequence)
       )
@@ -155,42 +158,6 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       )
     `.withoutTransform;
 
-    yield* sql`PRAGMA user_version = 2`.withoutTransform;
-  }),
-  "3_durable_tools_and_joined_input": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-
-    // Joined queued input (plan §2.5, DUR-016): a joining/joined Submission records which host
-    // Run claimed it. The canonical input marker reuses input_applied_record_id/_sequence
-    // because the joined input IS the Submission's own canonical `input:{sid}` record.
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN joined_host_submission_id TEXT
-    `.withoutTransform;
-
-    // Durable approval suspension (plan §2.6): the reason is the Schema-encoded
-    // SuspensionReason union so later suspension families stay additive.
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN suspended_reason_json TEXT
-    `.withoutTransform;
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN suspended_at TEXT
-    `.withoutTransform;
-
-    // Unknown Outcome marking (DUR-009/DUR-017): the marked open Tool Call identities are
-    // stored so `recordUnknownResolution` can reopen the lane only when every marked call
-    // has a durable resolution intent.
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN unknown_reason TEXT
-    `.withoutTransform;
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN unknown_tool_call_ids_json TEXT
-    `.withoutTransform;
-
     yield* sql`
       CREATE INDEX effect_agent_submissions_joined_host
         ON effect_agent_submissions (joined_host_submission_id)
@@ -226,21 +193,8 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       )
     `.withoutTransform;
 
-    yield* sql`PRAGMA user_version = 3`.withoutTransform;
-  }),
-  "4_durable_subagents": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-
     // Durable attached children (spec §12, SUB-004): a child Submission records its immutable
     // parent linkage at admission; the parent-side index serves the recovery attachment view.
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN parent_submission_id TEXT
-    `.withoutTransform;
-    yield* sql`
-      ALTER TABLE effect_agent_submissions
-        ADD COLUMN parent_tool_call_id TEXT
-    `.withoutTransform;
     yield* sql`
       CREATE INDEX effect_agent_submissions_parent
         ON effect_agent_submissions (parent_submission_id)
@@ -270,11 +224,6 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       )
     `.withoutTransform;
 
-    yield* sql`PRAGMA user_version = 4`.withoutTransform;
-  }),
-  "5_durable_schedules": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-
     // record_json is authoritative. The remaining columns support owner keyset paging and
     // deadline queries without decoding unrelated future schedules.
     yield* sql`
@@ -300,10 +249,6 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
         WHERE deadline_at_millis IS NOT NULL
     `.withoutTransform;
 
-    yield* sql`PRAGMA user_version = 5`.withoutTransform;
-  }),
-  "6_durable_subscriptions": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
     yield* sql`
       CREATE TABLE effect_agent_subscription_sequences (
         tenant_id TEXT NOT NULL,
@@ -377,10 +322,6 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       .withoutTransform;
     yield* sql`CREATE INDEX effect_agent_subscription_deliveries_registration ON effect_agent_subscription_deliveries (tenant_id, source_address, owner_id, subscription_id, delivery_key)`
       .withoutTransform;
-    yield* sql`PRAGMA user_version = 6`.withoutTransform;
-  }),
-  "7_thread_terminology_cutover": Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA user_version = 7`.withoutTransform;
   }),
 });

--- a/packages/storage-sqlite/test/sqlite-storage.test.ts
+++ b/packages/storage-sqlite/test/sqlite-storage.test.ts
@@ -48,7 +48,6 @@ import * as SqlClientService from "effect/unstable/sql/SqlClient";
 
 import {
   type SqliteStorageFailpoint,
-  CurrentSqliteStorageVersion,
   threadStoreLayer,
   layer,
   observationOffsetAt,
@@ -91,7 +90,6 @@ const id = <A>(schema: Schema.Codec<A, string>, value: string): A =>
 const sequence = (value: number) => Schema.decodeSync(CanonicalSequence)(value);
 const epoch = (value: number) => Schema.decodeSync(ProducerEpoch)(value);
 const isSqliteStorageError = Schema.is(SqliteStorageError);
-const isSqliteStorageCompatibilityError = Schema.is(SqliteStorageCompatibilityError);
 const isThreadStoreError = Schema.is(ThreadStoreError);
 
 const at = (millis: number) => DateTime.toUtc(DateTime.makeUnsafe(millis));
@@ -479,54 +477,6 @@ describe("SqliteThreadStore", () => {
           }),
         );
         expect(tables).toEqual([]);
-      }),
-    ),
-  );
-
-  it.effect("rejects the Conversation-era storage version without mutating its tables", () =>
-    withTemporaryDatabase((filename) =>
-      Effect.gen(function* () {
-        const previousVersion = CurrentSqliteStorageVersion - 1;
-        yield* withSql(
-          filename,
-          Effect.gen(function* () {
-            const sql = yield* SqlClientService.SqlClient;
-            yield* sql.unsafe(`PRAGMA user_version = ${previousVersion}`);
-            yield* sql`
-              CREATE TABLE effect_agent_conversations (
-                conversation_id TEXT PRIMARY KEY NOT NULL
-              )
-            `;
-            yield* sql`
-              INSERT INTO effect_agent_conversations (conversation_id)
-              VALUES ('legacy-conversation')
-            `;
-          }),
-        );
-
-        const opened = yield* withStorage(filename, ThreadStore).pipe(Effect.exit);
-        expect(Exit.isFailure(opened)).toBe(true);
-        if (Exit.isFailure(opened)) {
-          const error = Cause.squash(opened.cause);
-          expect(error).toBeInstanceOf(SqliteStorageCompatibilityError);
-          if (isSqliteStorageCompatibilityError(error)) {
-            expect(error.actualVersion).toBe(previousVersion);
-            expect(error.supportedVersion).toBe(CurrentSqliteStorageVersion);
-            expect(error.message).toContain("Reset the database file explicitly");
-          }
-        }
-
-        const rows = yield* withSql(
-          filename,
-          Effect.gen(function* () {
-            const sql = yield* SqlClientService.SqlClient;
-            return yield* sql<Record<string, unknown>>`
-              SELECT conversation_id
-              FROM effect_agent_conversations
-            `;
-          }),
-        );
-        expect(rows).toEqual([{ conversation_id: "legacy-conversation" }]);
       }),
     ),
   );

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -213,12 +213,12 @@ describe("thread canonical contracts", () => {
     );
   });
 
-  it("rejects unsupported canonical versions and retired Conversation records", () => {
+  it("rejects unsupported canonical versions, families, and payload tags", () => {
     const encoded = Schema.encodeSync(RecordEnvelope)(createdRecord);
     for (const incompatible of [
       { ...encoded, schemaVersion: 2 },
-      { ...encoded, family: "conversation" },
-      { ...encoded, payload: { ...encoded.payload, _tag: "ConversationCreated" } },
+      { ...encoded, family: "invalid" },
+      { ...encoded, payload: { ...encoded.payload, _tag: "InvalidRecord" } },
     ]) {
       expect(Schema.decodeUnknownExit(RecordEnvelope)(incompatible)._tag).toBe("Failure");
     }


### PR DESCRIPTION
The conversation-to-thread rename left upgrade instructions, retired conversation fixtures, and a SQLite cutover step despite there being no existing consumers. Remove those leftovers and initialize SQLite directly with the complete Thread schema in one step.

Keep the current storage version and strict version rejection checks so incompatible data still fails clearly. Existing schema and storage tests cover unsupported data without recreating the retired conversation format.
