### PR TITLE
feat(memory): process committed Thread activity resumably

### DIFF
--- a/.changeset/activity-progress-integrity.md
+++ b/.changeset/activity-progress-integrity.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/thread": patch
+---
+
+Reject oversized activity progress before persisting it and reject pending work beyond the captured Thread tail. Keep prior progress intact on rejected writes and release the pass's claim on inconsistent tails.

--- a/.changeset/committed-memory-processing.md
+++ b/.changeset/committed-memory-processing.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/thread": minor
+"@effect-agent/storage-sqlite": minor
+---
+
+Process application-selected committed Thread activity in bounded, resumable passes with durable extraction output and fenced progress. Use the optional SQLite adapter to resume memory ingestion safely after interrupted application or lost acknowledgments.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -297,6 +297,12 @@ past outputs, idempotency receipts, and backups have separate retention policies
 An immutable, schema-versioned fact in the Thread Log. Canonical Records are the only
 recovery truth.
 
+**Activity processor**
+
+An optional application-invoked consumer of committed Thread records. Its versioned, per-Thread
+progress and prepared output are separate from canonical history, engine checkpoints, and
+submission ownership. The application owns extraction, destination idempotency, and sharing.
+
 **Thread Log**
 The ordered, append-only sequence of Canonical Records for one Thread.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Effect Agent uses Effect AI's tools, models, and provider integrations directly.
 - [Transient recall](docs/guide/context-management.md) from application-owned readable sources.
 - [Revision-aware memory stores](docs/guide/context-management.md) with conditional corrections and
   withdrawal.
+- [Resumable processing of committed Thread activity](docs/guide/context-management.md).
 - [Attached subagents](docs/guide/subagents.md) with explicit permissions and budgets.
 - [Scheduled input](docs/guide/operations.md#scheduled-input) and
   [event subscriptions](docs/guide/operations.md#event-subscriptions).

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -425,7 +425,9 @@ is imported. A read-only corpus or direct Markdown recall needs none of these se
 The pass claims its own processor lease and receives any pending output atomically with that
 claim. It captures `ThreadStore.inspectTail` once and reads
 bounded, contiguous pages through that prefix. Records appended afterward belong to a later
-pass. `PersistentHistory` exposes the batch from a successful Run together; durable Runs expose
+pass. Pending work beyond the captured tail fails as `noncontiguous`, including when progress and
+Thread storage were restored to different points. `PersistentHistory` exposes the batch from a
+successful Run together; durable Runs expose
 incremental committed records. A record's presence is evidence of its commit, not evidence that
 the whole Run succeeded. Eligibility rules must account for that distinction.
 
@@ -552,6 +554,8 @@ idempotency and conditional writes remain required. Extraction and application e
 the pass has a deadline and release gets at most another 500ms. If release fails, the lease
 expires. The failpoint-enabled Layer exposes initialization and each mutation before, inside,
 and after its transaction for recovery tests.
+SQLite rejects activity progress whose JSON exceeds 16,777,216 JavaScript string code units before
+writing, with `ActivityStoreError` reason `invalid-input`. Rejected writes leave prior progress intact.
 
 `ActivityProcessorStore.inspect` exposes the per-processor, per-version, per-Thread cursor,
 pending work, and last advancement time. A successful pass reports its captured tail, through

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -422,7 +422,8 @@ The host chooses the processor ID and version, eligible records, extractor, dest
 scope, invocation schedule, and Thread discovery. No background worker starts when the package
 is imported. A read-only corpus or direct Markdown recall needs none of these services.
 
-The pass claims its own processor lease, captures `ThreadStore.inspectTail` once, and reads
+The pass claims its own processor lease and receives any pending output atomically with that
+claim. It captures `ThreadStore.inspectTail` once and reads
 bounded, contiguous pages through that prefix. Records appended afterward belong to a later
 pass. `PersistentHistory` exposes the batch from a successful Run together; durable Runs expose
 incremental committed records. A record's presence is evidence of its commit, not evidence that
@@ -430,7 +431,8 @@ the whole Run succeeded. Eligibility rules must account for that distinction.
 
 For each record the processor saves a Schema-encoded extraction, applies that saved output, and
 then advances its separate cursor. The work ID depends on processor, version, Thread, and
-sequence, never the worker or clock. A saved output wins over re-extraction after restart. Its
+sequence, never the worker or clock. Advancing clears pending output in the same transaction;
+there is no separate pending-work read per record. A saved output wins over re-extraction after restart. Its
 canonical record digest excludes the adapter's opaque observation cursor. Another processor
 version has independent progress; changing a version is an application decision about
 reprocessing and destination identities.

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -415,6 +415,154 @@ the host decides which diagnostics to retain and who can inspect them.
 
 <a id="tool-results-are-bounded-at-the-source"></a>
 
+### Process committed Thread activity {#committed-memory}
+
+`processCommittedActivity` is an optional, finite pass over one application-selected Thread.
+The host chooses the processor ID and version, eligible records, extractor, destination, sharing
+scope, invocation schedule, and Thread discovery. No background worker starts when the package
+is imported. A read-only corpus or direct Markdown recall needs none of these services.
+
+The pass claims its own processor lease, captures `ThreadStore.inspectTail` once, and reads
+bounded, contiguous pages through that prefix. Records appended afterward belong to a later
+pass. `PersistentHistory` exposes the batch from a successful Run together; durable Runs expose
+incremental committed records. A record's presence is evidence of its commit, not evidence that
+the whole Run succeeded. Eligibility rules must account for that distinction.
+
+For each record the processor saves a Schema-encoded extraction, applies that saved output, and
+then advances its separate cursor. The work ID depends on processor, version, Thread, and
+sequence, never the worker or clock. A saved output wins over re-extraction after restart. Its
+canonical record digest excludes the adapter's opaque observation cursor. Another processor
+version has independent progress; changing a version is an application decision about
+reprocessing and destination identities.
+
+The destination must reconcile the work ID durably before returning. If application and progress
+storage are separate, application can repeat after a lost acknowledgment. Keep its receipts for
+as long as pending output can return, including supported backup/restore windows. Conditional
+writes must prevent delayed work from overwriting later corrections or withdrawals. The SQLite
+memory writer supplies those properties; an ordinary non-idempotent external effect does not.
+
+This example opts a structured Dan–Chad discussion into a scope the host also grants Tim. Its
+extraction policy accepts only original user statements. An assistant repeating the statement
+does not become another witness. Applications that extract assistant references should retain
+the original `originId` instead of assigning independent evidence identity.
+
+```ts twoslash
+import { MemoryContent, MemoryKey, MemoryWrite, MemoryWriter, ThreadId } from "@effect-agent/core";
+import {
+  ActivityPassLimits,
+  ActivityProcessorKey,
+  processCommittedActivity,
+  type CanonicalRecordEnvelope,
+  type PreparedActivity,
+} from "@effect-agent/thread";
+import { Clock, DateTime, Effect, Schema } from "effect";
+
+// The application owns this message format and which Threads use it.
+const Statement = Schema.Struct({
+  speaker: Schema.NonEmptyString,
+  observer: Schema.NonEmptyString,
+  text: Schema.NonEmptyString,
+  activityAt: Schema.NullOr(Schema.Finite),
+  interpretation: Schema.NonEmptyString,
+});
+
+const extract = Effect.fn("extractDiscussion")(function* (entry: CanonicalRecordEnvelope) {
+  if (entry.record.payload._tag !== "UserInputRecorded") return null;
+  const statement = yield* Schema.decodeUnknownEffect(Statement)(entry.record.payload.input);
+  const locator = `thread://${entry.threadId}/records/${entry.record.recordId}`;
+  const content = yield* MemoryContent.makeEffect({
+    text: statement.text,
+    attributions: [
+      {
+        originId: `${entry.threadId}:${entry.record.recordId}`,
+        speaker: statement.speaker,
+        observers: [statement.observer],
+        locator,
+        activityAt: statement.activityAt,
+        interpretation: statement.interpretation,
+      },
+    ],
+    metadata: {
+      threadId: entry.threadId,
+      recordId: entry.record.recordId,
+      recordSchemaVersion: entry.record.schemaVersion,
+      sequence: entry.sequence,
+    },
+    recordedAt: DateTime.toEpochMillis(entry.record.createdAt),
+    extractedAt: yield* Clock.currentTimeMillis,
+  });
+  return yield* Schema.encodeEffect(MemoryContent)(content);
+});
+
+const apply = Effect.fn("applyDiscussion")(function* (work: PreparedActivity) {
+  const content = yield* Schema.decodeUnknownEffect(Schema.NullOr(MemoryContent))(work.output);
+  if (content === null) return;
+  const writer = yield* MemoryWriter;
+  const command = yield* Schema.decodeUnknownEffect(MemoryWrite)({
+    _tag: "Put",
+    key: MemoryKey.make({ namespace: "dan-discussions", id: work.workId }),
+    operationId: work.workId,
+    expectedRevision: null,
+    locator: `memory://dan-discussions/${work.workId}`,
+    content: {
+      ...content,
+      metadata: { ...content.metadata, sourceRecordDigest: work.recordDigest },
+    },
+    scopes: ["dan-approved-chad-and-tim"],
+  });
+  yield* writer.change(command);
+});
+
+const key = ActivityProcessorKey.make({
+  processorId: "discussion-statements",
+  processorVersion: "1",
+  threadId: Schema.decodeSync(ThreadId)("dan-chad"),
+});
+const limits = ActivityPassLimits.make({
+  maxRecords: 128,
+  pageSize: 16,
+  timeoutMillis: 30_000,
+  leaseMillis: 31_000,
+});
+
+// Supply a unique owner for each worker lifetime and the application's Layers.
+const ingest = (owner: string) => processCommittedActivity({ key, owner, limits, extract, apply });
+```
+
+The optional SQLite progress Layer can share a connection with the memory writer. Supply the
+host's existing `ThreadStore` and `Crypto` Layer to the pass as well; the processor never uses
+Thread ownership epochs, `SubmissionLedger`, or engine checkpoints for its own progress.
+
+```ts twoslash
+import { activityProcessorStoreLayer, memoryStoreLayer } from "@effect-agent/storage-sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { Layer } from "effect";
+
+const MemoryProcessing = Layer.mergeAll(activityProcessorStoreLayer, memoryStoreLayer).pipe(
+  Layer.provide(SqliteClient.layer({ filename: "memory.sqlite" })),
+);
+```
+
+Every claim acquisition allocates a fresh fencing epoch, including reacquisition by the same
+owner after release. Expired or superseded workers cannot replace pending output or advance
+progress. A destination invocation already in flight may finish the saved output, so its own
+idempotency and conditional writes remain required. Extraction and application each own a Scope;
+the pass has a deadline and release gets at most another 500ms. If release fails, the lease
+expires. The failpoint-enabled Layer exposes initialization and each mutation before, inside,
+and after its transaction for recovery tests.
+
+`ActivityProcessorStore.inspect` exposes the per-processor, per-version, per-Thread cursor,
+pending work, and last advancement time. A successful pass reports its captured tail, through
+sequence, and remaining records in that prefix. These are per-Thread watermarks, not a global
+freshness promise. Process selected Threads with bounded `Effect.forEach` and handle each pass's
+typed result independently when one failed Thread should not hold back others.
+
+For the example workflow, the healthy commit-to-recallable target is 60 seconds. Hosts must
+measure that interval from the source commit to successful authoritative recall and choose a
+schedule that meets it. Recorded, extracted, advanced, indexed, and accessed times describe
+different events; none replaces the original activity time. An embedding index has its own
+progress and readiness, and must not advance this extraction cursor.
+
 ## Limit tool output
 
 Every application tool result, including MCP output, passes through `toolResultBounds` once before

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -34,8 +34,8 @@ Before 1.0, APIs and stored data may change without a migration path.
 MCP validates connections and tool discovery through `McpConnector` and `connectMcp`.
 Your application implements the transport and remote handlers; no stdio or HTTP client is bundled.
 
-Nested delegation, handoff, detached subagents, runtime Skills, a framework-owned persistent agent
-memory service, arbitrary Thread metadata, and dynamic Turn Plans have no public APIs.
+Nested delegation, handoff, detached subagents, runtime Skills, a framework-owned memory
+extraction or sharing policy, arbitrary Thread metadata, and dynamic Turn Plans have no public APIs.
 Applications own domain state. `recallMemory` reads bounded passages from sources they select; it
 does not store them. Thread history and compaction summaries do not replace application state.
 
@@ -101,6 +101,9 @@ Follow the [local process walkthrough](../guide/sandbox#run-a-trusted-local-proc
 
 Thread records, storage contracts, recovery, durable execution, scheduling, and subscriptions.
 `compileRegistrations` hashes version declarations and captures agent services for workers.
+Optional `processCommittedActivity` runs bounded, resumable passes with separate processor
+progress. The host owns record eligibility, extraction, and durable output application. See
+[committed memory processing](../guide/context-management#committed-memory).
 
 | Import                            | Use                                                    |
 | --------------------------------- | ------------------------------------------------------ |
@@ -124,6 +127,10 @@ The independent `memoryStoreLayer` supplies optional `MemoryReader` and `MemoryW
 for conditional document updates and terminal withdrawal. It initializes only memory tables.
 Use `memoryReaderLayer` when the application needs no writer. See
 [memory lifecycle](../guide/context-management#memory-lifecycle).
+
+`activityProcessorStoreLayer` provides independent leases, prepared output, and per-Thread
+progress for finite committed-activity passes. Its tables and fencing epochs are separate from
+the Thread journal and submission ledger.
 
 ### `@effect-agent/platform-node`
 

--- a/packages/platform-node/test/memory-activity-fixtures.ts
+++ b/packages/platform-node/test/memory-activity-fixtures.ts
@@ -1,0 +1,78 @@
+import { MemoryContent, MemoryKey } from "@effect-agent/core";
+import { ActivityPassResult, ActivityProcessorKey, Digest } from "@effect-agent/thread";
+import { Schema } from "effect";
+
+export const MEMORY_NAMESPACE = "team-memory";
+export const MEMORY_SCOPE = "participating-channels";
+export const MEMORY_SOURCE_ID = "dan-chad-project-atlas";
+export const DAN_THREAD = "memory-source-dan-thread";
+export const TIM_THREAD = "memory-consumer-tim-thread";
+export const ORIGINAL_TEXT =
+  "Dan proposed that Chad lead Project Atlas. This remains a proposal, not a decision.";
+export const CORRECTED_TEXT =
+  "Dan proposed that Chad advise Project Atlas. This remains a proposal, not a decision.";
+export const DIVERGENT_TEXT = "Divergent restart extraction must never replace pinned output.";
+
+export const memoryKey = MemoryKey.make({
+  namespace: MEMORY_NAMESPACE,
+  id: MEMORY_SOURCE_ID,
+});
+
+export const activityKey = Schema.decodeSync(ActivityProcessorKey)({
+  processorId: "project-atlas-memory",
+  processorVersion: "v1",
+  threadId: DAN_THREAD,
+});
+
+export class DanStatement extends Schema.Class<DanStatement>(
+  "PlatformNodeMemoryActivity/DanStatement",
+)({
+  speaker: Schema.Literal("Dan"),
+  observer: Schema.Literal("Chad"),
+  text: Schema.NonEmptyString,
+  locator: Schema.NonEmptyString,
+  activityAt: Schema.Finite,
+  recordedAt: Schema.Finite,
+  interpretation: Schema.NonEmptyString,
+}) {}
+
+export const danStatement = DanStatement.make({
+  speaker: "Dan",
+  observer: "Chad",
+  text: ORIGINAL_TEXT,
+  locator: `thread://${DAN_THREAD}/dan-message`,
+  activityAt: 1_000,
+  recordedAt: 2_000,
+  interpretation: "proposal reported by Dan; not a decision",
+});
+
+export const ActivityMemoryOutput = Schema.Union([
+  Schema.TaggedStruct("Skip", {}),
+  Schema.TaggedStruct("Remember", {
+    key: MemoryKey,
+    locator: Schema.NonEmptyString,
+    content: MemoryContent,
+    scopes: Schema.Array(Schema.NonEmptyString),
+  }),
+]);
+export type ActivityMemoryOutput = typeof ActivityMemoryOutput.Type;
+
+export const MemoryActivityWorkerMode = Schema.Literals(["crash-after-apply", "recover-divergent"]);
+export type MemoryActivityWorkerMode = typeof MemoryActivityWorkerMode.Type;
+
+export const MemoryActivityWorkerConfig = Schema.Struct({
+  database: Schema.NonEmptyString,
+  mode: MemoryActivityWorkerMode,
+});
+
+export const MemoryActivityMarker = Schema.TaggedStruct("MemoryActivityMarker", {
+  point: Schema.Literal("memory:change:after"),
+});
+export type MemoryActivityMarker = typeof MemoryActivityMarker.Type;
+
+export const MemoryActivityWorkerResult = Schema.TaggedStruct("MemoryActivityWorkerResult", {
+  pass: ActivityPassResult,
+  appliedWorkIds: Schema.Array(Digest),
+  extractedUserRecords: Schema.Natural,
+});
+export type MemoryActivityWorkerResult = typeof MemoryActivityWorkerResult.Type;

--- a/packages/platform-node/test/memory-activity-restart.test.ts
+++ b/packages/platform-node/test/memory-activity-restart.test.ts
@@ -10,7 +10,11 @@ import {
   MemoryWriter,
   ThreadId,
 } from "@effect-agent/core";
-import { AgentRuntime, ThreadHistory } from "@effect-agent/engine";
+import {
+  AgentRuntime,
+  ThreadHistory,
+  RunContextPreparationPassthrough,
+} from "@effect-agent/engine";
 import {
   activityProcessorStoreLayer,
   layer as sqliteThreadStoreLayer,
@@ -257,7 +261,14 @@ const runTim = Effect.fn("MemoryActivityTest.runTim")(function* (
           ),
       },
     },
-  ).pipe(Effect.provide([historyLayer(filename), readerLayer(filename), IdGenerator.layer]));
+  ).pipe(
+    Effect.provide([
+      historyLayer(filename),
+      readerLayer(filename),
+      IdGenerator.layer,
+      RunContextPreparationPassthrough,
+    ]),
+  );
   return { prompts: yield* Ref.get(prompts), recalled: yield* Ref.get(recalled) };
 });
 
@@ -296,7 +307,11 @@ it.live(
         const filename = `${directory}/memory.sqlite`;
 
         yield* AgentRuntime.run(sourceAgent, danStatement, { threadId: danThreadId }).pipe(
-          Effect.provide([historyLayer(filename), IdGenerator.layer]),
+          Effect.provide([
+            historyLayer(filename),
+            IdGenerator.layer,
+            RunContextPreparationPassthrough,
+          ]),
         );
         const source = yield* exportThread(filename, danThreadId);
         expect(source.records.map(({ record }) => record.payload._tag)).toEqual([

--- a/packages/platform-node/test/memory-activity-restart.test.ts
+++ b/packages/platform-node/test/memory-activity-restart.test.ts
@@ -1,0 +1,487 @@
+import { recallMemory, revalidateMemoryLookup } from "@effect-agent/capabilities";
+import type { ActiveMemoryDocument } from "@effect-agent/core";
+import {
+  Agent,
+  AgentPolicy,
+  IdGenerator,
+  MemoryReader,
+  MemoryRecallLimits,
+  MemoryWrite,
+  MemoryWriter,
+  ThreadId,
+} from "@effect-agent/core";
+import { AgentRuntime, ThreadHistory } from "@effect-agent/engine";
+import {
+  activityProcessorStoreLayer,
+  layer as sqliteThreadStoreLayer,
+  memoryReaderLayer,
+  memoryStoreLayer,
+} from "@effect-agent/storage-sqlite";
+import {
+  ActivityProcessorStore,
+  PersistentHistory,
+  ThreadExportRequest,
+  ThreadStore,
+  type PreparedActivity,
+} from "@effect-agent/thread";
+import { NodeServices } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { expect, it } from "@effect/vitest";
+import {
+  Duration,
+  Effect,
+  Fiber,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  Ref,
+  Result,
+  Schema,
+  Stream,
+} from "effect";
+import { LanguageModel, Model, Prompt, type Response, Toolkit } from "effect/unstable/ai";
+import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process";
+
+import {
+  ActivityMemoryOutput,
+  CORRECTED_TEXT,
+  DAN_THREAD,
+  DIVERGENT_TEXT,
+  MEMORY_NAMESPACE,
+  MEMORY_SCOPE,
+  MemoryActivityMarker,
+  MemoryActivityWorkerResult,
+  ORIGINAL_TEXT,
+  TIM_THREAD,
+  activityKey,
+  DanStatement,
+  danStatement,
+  memoryKey,
+  type MemoryActivityWorkerMode,
+} from "./memory-activity-fixtures.ts";
+
+const danThreadId = Schema.decodeSync(ThreadId)(DAN_THREAD);
+const timThreadId = Schema.decodeSync(ThreadId)(TIM_THREAD);
+const recallLimits = MemoryRecallLimits.make({
+  maxSources: 2,
+  maxItems: 8,
+  maxBytes: 64_000,
+  maxTokens: 64_000,
+  timeoutMillis: 5_000,
+});
+const FIVE_MINUTES_MILLIS = 300_000;
+const policy = AgentPolicy.make({
+  maxTurns: 1,
+  maxToolCalls: 1,
+  maxDuration: "30 seconds",
+  toolConcurrency: 1,
+});
+const usage = { inputTokens: {}, outputTokens: {} };
+
+const finalParts = (text: string): ReadonlyArray<Response.StreamPartEncoded> => [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: JSON.stringify(text) },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage },
+];
+
+const model = (name: string, answer: string, prompts?: Ref.Ref<ReadonlyArray<Prompt.Prompt>>) =>
+  Model.make(
+    "scripted",
+    name,
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: ({ prompt }) =>
+          Stream.unwrap(
+            (prompts === undefined
+              ? Effect.void
+              : Ref.update(prompts, (seen) => [...seen, prompt])
+            ).pipe(Effect.as(Stream.fromIterable(finalParts(answer)))),
+          ),
+      }),
+    ),
+  );
+
+const sourceAgent = Agent.withModel(
+  Agent.make("memory-observer-chad", {
+    input: DanStatement,
+    output: Schema.String,
+    instructions: "Acknowledge Dan's statement without changing its status.",
+    toolkit: Toolkit.empty,
+    policy,
+  }),
+  model("memory-observer-chad", ORIGINAL_TEXT),
+);
+
+const timDefinition = Agent.make("memory-consumer-tim", {
+  input: Schema.Struct({ question: Schema.String, askedAt: Schema.Finite }),
+  output: Schema.String,
+  instructions: "Answer using supplied references, preserving attribution and uncertainty.",
+  toolkit: Toolkit.empty,
+  policy,
+});
+
+const historyLayer = (filename: string) =>
+  PersistentHistory.layer.pipe(Layer.provide(sqliteThreadStoreLayer({ filename })));
+
+const activityLayer = (filename: string) =>
+  activityProcessorStoreLayer.pipe(
+    Layer.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })),
+  );
+
+const memoryLayer = (filename: string) =>
+  memoryStoreLayer.pipe(Layer.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })));
+
+const readerLayer = (filename: string) =>
+  memoryReaderLayer.pipe(Layer.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })));
+
+const readMemory = (filename: string, key = memoryKey) =>
+  Effect.flatMap(MemoryReader, (reader) => reader.get(key)).pipe(
+    Effect.provide(readerLayer(filename)),
+  );
+
+const inspectActivity = (filename: string) =>
+  Effect.flatMap(ActivityProcessorStore, (store) => store.inspect(activityKey)).pipe(
+    Effect.provide(activityLayer(filename)),
+  );
+
+const exportThread = (filename: string, threadId: ThreadId) =>
+  Effect.flatMap(ThreadStore, (store) => store.export(ThreadExportRequest.make({ threadId }))).pipe(
+    Effect.provide(sqliteThreadStoreLayer({ filename })),
+  );
+
+const spawnWorker = Effect.fn("MemoryActivityTest.spawnWorker")(function* (
+  filename: string,
+  mode: MemoryActivityWorkerMode,
+) {
+  const path = yield* Path.Path;
+  const entry = yield* path.fromFileUrl(
+    new URL("./memory-activity-worker-entry.ts", import.meta.url),
+  );
+  return yield* ChildProcess.make("node", ["--experimental-transform-types", entry], {
+    cwd: path.dirname(entry),
+    env: {
+      EFFECT_AGENT_MEMORY_ACTIVITY_DB: filename,
+      EFFECT_AGENT_MEMORY_ACTIVITY_MODE: mode,
+    },
+    extendEnv: true,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+});
+
+const decodeFirstLine = <A, I>(
+  child: ChildProcessSpawner.ChildProcessHandle,
+  schema: Schema.Codec<A, I, never>,
+) =>
+  child.stdout.pipe(
+    Stream.decodeText(),
+    Stream.splitLines,
+    Stream.mapEffect((line) => Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(line)),
+    Stream.runHead,
+    Effect.timeout(Duration.seconds(15)),
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.die("Child exited without a protocol message"),
+        onSome: Effect.succeed,
+      }),
+    ),
+  );
+
+const runWorker = (filename: string, mode: MemoryActivityWorkerMode) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const child = yield* spawnWorker(filename, mode);
+      const stderr = yield* Effect.forkScoped(
+        child.stderr.pipe(Stream.decodeText(), Stream.mkString),
+      );
+      const output = yield* decodeFirstLine(child, MemoryActivityWorkerResult);
+      const exitCode = yield* child.exitCode;
+      const errorText = yield* Fiber.join(stderr);
+      if (Number(exitCode) !== 0) return yield* Effect.die(`Worker failed: ${errorText}`);
+      return output;
+    }),
+  );
+
+const candidateFrom = (document: ActiveMemoryDocument) => ({
+  _tag: "Found" as const,
+  passages: [
+    {
+      version: 1 as const,
+      source: document.source,
+      passageId: "document",
+      content: document.content,
+    },
+  ],
+});
+
+const runTim = Effect.fn("MemoryActivityTest.runTim")(function* (
+  filename: string,
+  question: string,
+  askedAt: number,
+  candidates: ReturnType<typeof candidateFrom>,
+) {
+  const prompts = yield* Ref.make<ReadonlyArray<Prompt.Prompt>>([]);
+  const recalled = yield* Ref.make<ReadonlyArray<string>>([]);
+  const agent = Agent.withModel(timDefinition, model(`tim-${question}`, "acknowledged", prompts));
+  yield* AgentRuntime.run(
+    agent,
+    { question, askedAt },
+    {
+      threadId: timThreadId,
+      transientContext: {
+        load: () =>
+          recallMemory(
+            [
+              {
+                id: "authoritative-team-memory",
+                essential: false,
+                read: revalidateMemoryLookup(candidates, {
+                  namespace: MEMORY_NAMESPACE,
+                  scope: MEMORY_SCOPE,
+                }),
+              },
+            ],
+            recallLimits,
+          ).pipe(
+            Effect.tap((result) => Ref.update(recalled, (texts) => [...texts, result.text])),
+            Effect.map((result) =>
+              result.text.length === 0
+                ? Prompt.empty
+                : Prompt.make([{ role: "user", content: result.text }]),
+            ),
+          ),
+      },
+    },
+  ).pipe(Effect.provide([historyLayer(filename), readerLayer(filename), IdGenerator.layer]));
+  return { prompts: yield* Ref.get(prompts), recalled: yield* Ref.get(recalled) };
+});
+
+const originalWriteFrom = Effect.fn("MemoryActivityTest.originalWriteFrom")(function* (
+  pending: PreparedActivity,
+) {
+  const output = yield* Schema.decodeUnknownEffect(ActivityMemoryOutput)(pending.output);
+  if (output._tag !== "Remember") return yield* Effect.die("Expected remembered activity");
+  return yield* Schema.decodeUnknownEffect(MemoryWrite)({
+    _tag: "Put",
+    key: output.key,
+    operationId: pending.workId,
+    expectedRevision: null,
+    locator: output.locator,
+    content: {
+      ...output.content,
+      metadata: {
+        ...output.content.metadata,
+        sourceRecordDigest: pending.recordDigest,
+        sourceWorkId: pending.workId,
+      },
+    },
+    scopes: output.scopes,
+  });
+});
+
+it.live(
+  "replays pinned cross-Thread memory after SIGKILL, then honors correction and withdrawal",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({
+          prefix: "effect-agent-memory-activity-restart-",
+        });
+        const filename = `${directory}/memory.sqlite`;
+
+        yield* AgentRuntime.run(sourceAgent, danStatement, { threadId: danThreadId }).pipe(
+          Effect.provide([historyLayer(filename), IdGenerator.layer]),
+        );
+        const source = yield* exportThread(filename, danThreadId);
+        expect(source.records.map(({ record }) => record.payload._tag)).toEqual([
+          "UserInputRecorded",
+          "ModelCompleted",
+          "RunCompleted",
+        ]);
+        expect(JSON.stringify(source.records[1])).toContain(ORIGINAL_TEXT);
+
+        const first = yield* spawnWorker(filename, "crash-after-apply");
+        const stderr = yield* Effect.forkScoped(
+          first.stderr.pipe(Stream.decodeText(), Stream.mkString),
+        );
+        expect(yield* decodeFirstLine(first, MemoryActivityMarker)).toEqual({
+          _tag: "MemoryActivityMarker",
+          point: "memory:change:after",
+        });
+        yield* first.kill({ killSignal: "SIGKILL" });
+        const killed = yield* first.exitCode.pipe(Effect.result);
+        yield* Fiber.join(stderr);
+        expect(Result.isFailure(killed)).toBe(true);
+
+        const crashedProgress = yield* inspectActivity(filename);
+        expect(crashedProgress?.throughSequence).toBe(0);
+        expect(crashedProgress?.pending?.sequence).toBe(1);
+        const pending = crashedProgress?.pending;
+        if (pending === null || pending === undefined) {
+          return yield* Effect.die("Expected pinned activity after process death");
+        }
+        const firstDocument = yield* readMemory(filename);
+        expect(firstDocument).toMatchObject({
+          _tag: "ActiveMemoryDocument",
+          generation: 1,
+          predecessor: null,
+          content: { text: ORIGINAL_TEXT },
+        });
+
+        // SIGKILL skips claim release, so the restarted process must wait out the real lease.
+        yield* Effect.sleep(Duration.millis(2_500));
+        const recovered = yield* runWorker(filename, "recover-divergent");
+        expect(recovered.pass).toMatchObject({
+          capturedTail: 3,
+          throughSequence: 3,
+          processed: 3,
+          pendingRecords: 0,
+        });
+        expect(recovered.appliedWorkIds[0]).toBe(pending.workId);
+        expect(recovered.extractedUserRecords).toBe(0);
+        const progress = yield* inspectActivity(filename);
+        expect(progress).toMatchObject({ throughSequence: 3, pending: null });
+
+        const original = yield* readMemory(filename);
+        expect(original?._tag).toBe("ActiveMemoryDocument");
+        if (original === null || original._tag !== "ActiveMemoryDocument") {
+          return yield* Effect.die("Expected active recovered memory");
+        }
+        expect(original.generation).toBe(1);
+        expect(original.content.text).toBe(ORIGINAL_TEXT);
+        expect(original.content.text).not.toBe(DIVERGENT_TEXT);
+        expect(original.content.attributions).toEqual([
+          {
+            originId: source.records[0].record.recordId,
+            speaker: "Dan",
+            observers: ["Chad"],
+            locator: danStatement.locator,
+            activityAt: 1_000,
+            interpretation: "proposal reported by Dan; not a decision",
+          },
+        ]);
+        expect(original.content).toMatchObject({ recordedAt: 2_000, extractedAt: 3_000 });
+        expect(original.content.metadata).toMatchObject({
+          sourceThreadId: DAN_THREAD,
+          sourceSequence: 1,
+          sourceRecordId: source.records[0].record.recordId,
+          sourceSchemaVersion: 1,
+          sourceRecordDigest: pending.recordDigest,
+          sourceWorkId: pending.workId,
+        });
+
+        const staleCandidates = candidateFrom(original);
+        const askedAt = danStatement.activityAt + FIVE_MINUTES_MILLIS;
+        const initialRecall = yield* runTim(
+          filename,
+          "What did Dan say about Chad?",
+          askedAt,
+          staleCandidates,
+        );
+        const initialPrompt = JSON.stringify(initialRecall.prompts[0]);
+        const recalledText = initialRecall.recalled[0] ?? "";
+        expect(recalledText).toContain(ORIGINAL_TEXT);
+        expect(recalledText).toContain('"speaker":"Dan"');
+        expect(recalledText).toContain('"observers":["Chad"]');
+        expect(recalledText).toContain(danStatement.locator);
+        expect(recalledText).toContain('"activityAt":1000');
+        expect(recalledText).toContain('"revision":"1"');
+        expect(recalledText).toContain('"sourceSchemaVersion":1');
+        expect(recalledText).toContain(source.records[0].record.recordId);
+        expect(recalledText).toContain("proposal reported by Dan; not a decision");
+        expect(recalledText).toContain(pending.recordDigest);
+        expect(initialPrompt).toContain(ORIGINAL_TEXT);
+        expect(initialPrompt).toContain(String(askedAt));
+
+        const wrongNamespace = yield* revalidateMemoryLookup(staleCandidates, {
+          namespace: "another-team",
+          scope: MEMORY_SCOPE,
+        }).pipe(Effect.provide(readerLayer(filename)));
+        const wrongScope = yield* revalidateMemoryLookup(staleCandidates, {
+          namespace: MEMORY_NAMESPACE,
+          scope: "unshared-channel",
+        }).pipe(Effect.provide(readerLayer(filename)));
+        expect(wrongNamespace).toEqual({ _tag: "NoMatch" });
+        expect(wrongScope).toEqual({ _tag: "NoMatch" });
+
+        const corrected = yield* Effect.flatMap(MemoryWriter, (writer) =>
+          writer.change({
+            _tag: "Put",
+            key: memoryKey,
+            operationId: "correct-project-atlas",
+            expectedRevision: original.source.revision,
+            locator: original.source.locator,
+            content: {
+              ...original.content,
+              text: CORRECTED_TEXT,
+              recordedAt: 4_000,
+              extractedAt: 4_500,
+            },
+            scopes: [MEMORY_SCOPE],
+          }),
+        ).pipe(Effect.provide(memoryLayer(filename)));
+        expect(corrected).toMatchObject({
+          _tag: "ActiveMemoryDocument",
+          generation: 2,
+          predecessor: original.source,
+        });
+        const correctedRecall = yield* runTim(
+          filename,
+          "Was the Project Atlas statement corrected?",
+          askedAt + 1_000,
+          staleCandidates,
+        );
+        expect(correctedRecall.recalled[0]).toContain(CORRECTED_TEXT);
+        expect(correctedRecall.recalled[0]).not.toContain(ORIGINAL_TEXT);
+
+        const withdrawn = yield* Effect.flatMap(MemoryWriter, (writer) =>
+          writer.change({
+            _tag: "Withdraw",
+            key: memoryKey,
+            operationId: "withdraw-project-atlas",
+            expectedRevision: corrected.source.revision,
+            reason: "Dan withdrew the source statement",
+          }),
+        ).pipe(Effect.provide(memoryLayer(filename)));
+        expect(withdrawn).toMatchObject({ _tag: "WithdrawnMemoryDocument", generation: 3 });
+
+        const replayed = yield* Effect.flatMap(MemoryWriter, (writer) =>
+          Effect.flatMap(originalWriteFrom(pending), writer.change),
+        ).pipe(Effect.provide(memoryLayer(filename)));
+        expect(replayed).toMatchObject({
+          _tag: "ActiveMemoryDocument",
+          generation: 1,
+          source: { revision: "1" },
+        });
+        expect(yield* readMemory(filename)).toMatchObject({
+          _tag: "WithdrawnMemoryDocument",
+          generation: 3,
+        });
+
+        const withdrawnRecall = yield* runTim(
+          filename,
+          "What remains recallable after withdrawal?",
+          askedAt + 2_000,
+          staleCandidates,
+        );
+        expect(withdrawnRecall.recalled[0]).toBe("");
+        expect(JSON.stringify(withdrawnRecall.prompts[0])).not.toContain(CORRECTED_TEXT);
+
+        const timHistory = yield* Effect.flatMap(ThreadHistory, (history) =>
+          history.load(timThreadId),
+        ).pipe(Effect.provide(historyLayer(filename)));
+        const canonicalTim = JSON.stringify(timHistory);
+        expect(canonicalTim).not.toContain(ORIGINAL_TEXT);
+        expect(canonicalTim).not.toContain(CORRECTED_TEXT);
+        expect(canonicalTim).not.toContain(pending.recordDigest);
+        expect((yield* exportThread(filename, timThreadId)).records).toHaveLength(9);
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
+  60_000,
+);

--- a/packages/platform-node/test/memory-activity-worker-entry.ts
+++ b/packages/platform-node/test/memory-activity-worker-entry.ts
@@ -1,0 +1,8 @@
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Effect } from "effect";
+
+import { memoryActivityWorker } from "./memory-activity-worker.ts";
+
+NodeRuntime.runMain(memoryActivityWorker.pipe(Effect.provide(NodeServices.layer)), {
+  disableErrorReporting: false,
+});

--- a/packages/platform-node/test/memory-activity-worker.ts
+++ b/packages/platform-node/test/memory-activity-worker.ts
@@ -1,0 +1,159 @@
+import {
+  MemoryMutationFailpoint,
+  MemoryWrite,
+  MemoryWriter,
+  type MemoryMutationPoint,
+} from "@effect-agent/core";
+import {
+  activityProcessorStoreLayer,
+  memoryStoreLayerWithFailpoints,
+  layer as sqliteThreadStoreLayer,
+} from "@effect-agent/storage-sqlite";
+import {
+  processCommittedActivity,
+  type CanonicalRecordEnvelope,
+  type PreparedActivity,
+} from "@effect-agent/thread";
+import { NodeCrypto } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { Config, Console, Effect, Layer, Ref, Schema } from "effect";
+
+import {
+  ActivityMemoryOutput,
+  DanStatement,
+  DIVERGENT_TEXT,
+  MEMORY_SCOPE,
+  MemoryActivityMarker,
+  MemoryActivityWorkerConfig,
+  MemoryActivityWorkerResult,
+  activityKey,
+  memoryKey,
+} from "./memory-activity-fixtures.ts";
+
+const decodeConfig = Effect.fn("MemoryActivityWorker.decodeConfig")(function* () {
+  const database = yield* Config.string("EFFECT_AGENT_MEMORY_ACTIVITY_DB");
+  const mode = yield* Config.string("EFFECT_AGENT_MEMORY_ACTIVITY_MODE");
+  return yield* Schema.decodeUnknownEffect(MemoryActivityWorkerConfig)({ database, mode });
+});
+
+const encodedLine = <A, I>(schema: Schema.Codec<A, I, never>, value: A) =>
+  Schema.encodeEffect(Schema.fromJsonString(schema))(value);
+
+const encodedMarker = Schema.encodeSync(Schema.fromJsonString(MemoryActivityMarker))({
+  _tag: "MemoryActivityMarker",
+  point: "memory:change:after",
+});
+
+const extractionOutput = (record: CanonicalRecordEnvelope, divergent: boolean) => {
+  if (record.record.payload._tag !== "UserInputRecorded") {
+    return Schema.decodeUnknownEffect(ActivityMemoryOutput)({ _tag: "Skip" });
+  }
+  return Schema.decodeUnknownEffect(DanStatement)(record.record.payload.input).pipe(
+    Effect.flatMap((statement) =>
+      Schema.decodeUnknownEffect(ActivityMemoryOutput)({
+        _tag: "Remember",
+        key: memoryKey,
+        locator: statement.locator,
+        content: {
+          text: divergent ? DIVERGENT_TEXT : statement.text,
+          attributions: [
+            {
+              originId: record.record.recordId,
+              speaker: statement.speaker,
+              observers: [statement.observer],
+              locator: statement.locator,
+              activityAt: statement.activityAt,
+              interpretation: statement.interpretation,
+            },
+          ],
+          metadata: {
+            sourceThreadId: record.threadId,
+            sourceSequence: record.sequence,
+            sourceRecordId: record.record.recordId,
+            sourceSchemaVersion: record.record.schemaVersion,
+          },
+          recordedAt: statement.recordedAt,
+          extractedAt: 3_000,
+        },
+        scopes: [MEMORY_SCOPE],
+      }),
+    ),
+  );
+};
+
+const applyPrepared = Effect.fn("MemoryActivityWorker.applyPrepared")(function* (
+  work: PreparedActivity,
+) {
+  const output = yield* Schema.decodeUnknownEffect(ActivityMemoryOutput)(work.output);
+  if (output._tag === "Skip") return;
+  const writer = yield* MemoryWriter;
+  yield* writer.change(
+    yield* Schema.decodeUnknownEffect(MemoryWrite)({
+      _tag: "Put",
+      key: output.key,
+      operationId: work.workId,
+      expectedRevision: null,
+      locator: output.locator,
+      content: {
+        ...output.content,
+        metadata: {
+          ...output.content.metadata,
+          sourceRecordDigest: work.recordDigest,
+          sourceWorkId: work.workId,
+        },
+      },
+      scopes: output.scopes,
+    }),
+  );
+});
+
+/** Fixed child workflow. The entrypoint owns only NodeRuntime process handling. */
+export const memoryActivityWorker = Effect.gen(function* () {
+  const config = yield* decodeConfig();
+  const appliedWorkIds = yield* Ref.make<ReadonlyArray<PreparedActivity["workId"]>>([]);
+  const extractedUserRecords = yield* Ref.make(0);
+  const failpoint = MemoryMutationFailpoint.of({
+    hit: (point: MemoryMutationPoint) =>
+      config.mode === "crash-after-apply" && point === "memory:change:after"
+        ? Effect.gen(function* () {
+            yield* Console.log(encodedMarker);
+            return yield* Effect.never;
+          })
+        : Effect.void,
+  });
+  const sql = SqliteClient.layer({ filename: config.database, busyTimeout: 5_000 });
+  const adapters = Layer.mergeAll(
+    activityProcessorStoreLayer.pipe(Layer.provide(sql)),
+    memoryStoreLayerWithFailpoints.pipe(
+      Layer.provide(Layer.merge(sql, Layer.succeed(MemoryMutationFailpoint, failpoint))),
+    ),
+    sqliteThreadStoreLayer({ filename: config.database, busyTimeout: 5_000 }),
+    NodeCrypto.layer,
+  );
+  const pass = yield* processCommittedActivity({
+    key: activityKey,
+    owner: config.mode === "crash-after-apply" ? "first-process" : "second-process",
+    limits: { maxRecords: 16, pageSize: 4, timeoutMillis: 1_000, leaseMillis: 2_200 },
+    extract: (record) =>
+      extractionOutput(record, config.mode === "recover-divergent").pipe(
+        Effect.tap(() =>
+          record.record.payload._tag === "UserInputRecorded"
+            ? Ref.update(extractedUserRecords, (count) => count + 1)
+            : Effect.void,
+        ),
+        Effect.flatMap(Schema.encodeEffect(ActivityMemoryOutput)),
+      ),
+    apply: (work) =>
+      applyPrepared(work).pipe(
+        Effect.tap(() => Ref.update(appliedWorkIds, (ids) => [...ids, work.workId])),
+      ),
+  }).pipe(Effect.provide(adapters));
+  yield* Console.log(
+    yield* encodedLine(MemoryActivityWorkerResult, {
+      _tag: "MemoryActivityWorkerResult",
+      pass,
+      appliedWorkIds: yield* Ref.get(appliedWorkIds),
+      extractedUserRecords: yield* Ref.get(extractedUserRecords),
+    }),
+  );
+});

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./errors.ts";
 export { CurrentSqliteStorageVersion } from "./migrations.ts";
+export * from "./sqlite-activity-store.ts";
 export * from "./sqlite-thread-store.ts";
 export * from "./sqlite-ledger.ts";
 export * from "./sqlite-memory-store.ts";

--- a/packages/storage-sqlite/src/sqlite-activity-store.ts
+++ b/packages/storage-sqlite/src/sqlite-activity-store.ts
@@ -142,6 +142,7 @@ const makeClaim = (progress: ActivityProgress): ActivityClaim | null =>
         epoch: progress.epoch,
         throughSequence: progress.throughSequence,
         leaseExpiresAt: progress.leaseExpiresAt,
+        pending: progress.pending,
       });
 
 const ownershipLost = (claim: ActivityClaim) =>
@@ -382,21 +383,6 @@ const makeActivityStore = Effect.fn("SqliteActivityStore.make")(function* () {
     },
   );
 
-  const loadPrepared: ActivityProcessorStore["Service"]["loadPrepared"] = Effect.fn(
-    "SqliteActivityStore.loadPrepared",
-  )(function* (claim) {
-    const operation = "load prepared activity";
-    const decoded = yield* decodeInput(ActivityClaim, claim, operation);
-    return yield* sql
-      .withTransaction(
-        Effect.gen(function* () {
-          const current = yield* readProgress(decoded.key, operation);
-          return (yield* requireLive(current, decoded, true)).pending;
-        }),
-      )
-      .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
-  });
-
   const prepare: ActivityProcessorStore["Service"]["prepare"] = Effect.fn(
     "SqliteActivityStore.prepare",
   )(function* (request) {
@@ -494,7 +480,7 @@ const makeActivityStore = Effect.fn("SqliteActivityStore.make")(function* () {
     yield* failpoint.hit("activity:release:after");
   });
 
-  return ActivityProcessorStore.of({ inspect, claim, loadPrepared, prepare, advance, release });
+  return ActivityProcessorStore.of({ inspect, claim, prepare, advance, release });
 });
 
 /** SQLite activity progress with mutation failpoints kept injectable for recovery tests. */

--- a/packages/storage-sqlite/src/sqlite-activity-store.ts
+++ b/packages/storage-sqlite/src/sqlite-activity-store.ts
@@ -1,0 +1,512 @@
+import {
+  ActivityBusy,
+  ActivityClaim,
+  ActivityClaimRequest,
+  ActivityMutationFailpoint,
+  type ActivityMutationFailure,
+  ActivityOwnershipLost,
+  ActivityProcessorKey,
+  ActivityProcessorStore,
+  ActivityProgress,
+  ActivityStoreError,
+  ActivityWorkConflict,
+  Digest,
+  PreparedActivity,
+} from "@effect-agent/thread";
+import { Clock, Effect, Layer, Schema } from "effect";
+import * as SqlClientService from "effect/unstable/sql/SqlClient";
+import type { SqlError } from "effect/unstable/sql/SqlError";
+
+const STORAGE_VERSION = 1 as const;
+const METADATA_COMPONENT = "activity";
+const STATE_TABLE = "effect_agent_activity_processor_state_v1";
+const StoredJson = Schema.String.check(Schema.isMaxLength(16 * 1024 * 1024));
+const sameKey = Schema.toEquivalence(ActivityProcessorKey);
+const sameWork = Schema.toEquivalence(PreparedActivity);
+
+class ActivityMetadataRow extends Schema.Class<ActivityMetadataRow>(
+  "@effect-agent/storage-sqlite/ActivityMetadataRow",
+)({
+  version: Schema.Int,
+}) {}
+
+class ActivityTableRow extends Schema.Class<ActivityTableRow>(
+  "@effect-agent/storage-sqlite/ActivityTableRow",
+)({
+  name: Schema.NonEmptyString,
+}) {}
+
+class ActivityStateRow extends Schema.Class<ActivityStateRow>(
+  "@effect-agent/storage-sqlite/ActivityStateRow",
+)({
+  processor_id: ActivityProcessorKey.fields.processorId,
+  processor_version: ActivityProcessorKey.fields.processorVersion,
+  thread_id: ActivityProcessorKey.fields.threadId,
+  format_version: Schema.Int,
+  through_sequence: ActivityProgress.fields.throughSequence,
+  epoch: ActivityProgress.fields.epoch,
+  owner: ActivityProgress.fields.owner,
+  lease_expires_at: ActivityProgress.fields.leaseExpiresAt,
+  progress_json: StoredJson,
+}) {}
+
+class ActivityChangeCountRow extends Schema.Class<ActivityChangeCountRow>(
+  "@effect-agent/storage-sqlite/ActivityChangeCountRow",
+)({
+  changed: Schema.Int,
+}) {}
+
+const StoredVersionHeader = Schema.Struct({ version: Schema.Int });
+
+export type SqliteActivityInitializationError = ActivityStoreError | ActivityMutationFailure;
+
+const storeError = (
+  operation: string,
+  reason: ActivityStoreError["reason"] = "unavailable",
+): ActivityStoreError => ActivityStoreError.make({ operation, reason });
+
+const query = <A extends object>(
+  effect: Effect.Effect<ReadonlyArray<A>, SqlError>,
+  operation: string,
+) => effect.pipe(Effect.mapError(() => storeError(operation)));
+
+const decodeRows = Effect.fn("SqliteActivityStore.decodeRows")(function* <A, I>(
+  schema: Schema.Codec<A, I, never>,
+  rows: ReadonlyArray<unknown>,
+  operation: string,
+): Effect.fn.Return<ReadonlyArray<A>, ActivityStoreError> {
+  return yield* Schema.decodeUnknownEffect(Schema.Array(schema))(rows).pipe(
+    Effect.mapError(() => storeError(operation, "corrupt")),
+  );
+});
+
+const decodeInput = Effect.fn("SqliteActivityStore.decodeInput")(function* <A, I>(
+  schema: Schema.Codec<A, I, never>,
+  value: unknown,
+  operation: string,
+): Effect.fn.Return<A, ActivityStoreError> {
+  return yield* Schema.decodeUnknownEffect(schema)(value).pipe(
+    Effect.mapError(() => storeError(operation, "invalid-input")),
+  );
+});
+
+const encodeProgress = Effect.fn("SqliteActivityStore.encodeProgress")(function* (
+  progress: ActivityProgress,
+  operation: string,
+): Effect.fn.Return<string, ActivityStoreError> {
+  return yield* Schema.encodeEffect(Schema.fromJsonString(ActivityProgress))(progress).pipe(
+    Effect.mapError(() => storeError(operation, "corrupt")),
+  );
+});
+
+const decodeProgress = Effect.fn("SqliteActivityStore.decodeProgress")(function* (
+  value: string,
+  operation: string,
+): Effect.fn.Return<ActivityProgress, ActivityStoreError> {
+  const header = yield* Schema.decodeEffect(Schema.fromJsonString(StoredVersionHeader))(value).pipe(
+    Effect.mapError(() => storeError(operation, "corrupt")),
+  );
+  if (header.version !== STORAGE_VERSION) {
+    return yield* storeError(operation, "incompatible");
+  }
+  const progress = yield* Schema.decodeEffect(Schema.fromJsonString(ActivityProgress))(value).pipe(
+    Effect.mapError(() => storeError(operation, "corrupt")),
+  );
+  const canonical = yield* encodeProgress(progress, operation);
+  if (canonical !== value) return yield* storeError(operation, "corrupt");
+  return progress;
+});
+
+const validateProgress = Effect.fn("SqliteActivityStore.validateProgress")(function* (
+  progress: ActivityProgress,
+  operation: string,
+): Effect.fn.Return<ActivityProgress, ActivityStoreError> {
+  if (
+    progress.epoch < 1 ||
+    (progress.owner === null && progress.leaseExpiresAt !== 0) ||
+    (progress.pending !== null &&
+      (!sameKey(progress.pending.key, progress.key) ||
+        progress.pending.sequence !== progress.throughSequence + 1))
+  ) {
+    return yield* storeError(operation, "corrupt");
+  }
+  return progress;
+});
+
+const makeClaim = (progress: ActivityProgress): ActivityClaim | null =>
+  progress.owner === null
+    ? null
+    : ActivityClaim.make({
+        key: progress.key,
+        owner: progress.owner,
+        epoch: progress.epoch,
+        throughSequence: progress.throughSequence,
+        leaseExpiresAt: progress.leaseExpiresAt,
+      });
+
+const ownershipLost = (claim: ActivityClaim) =>
+  ActivityOwnershipLost.make({ key: claim.key, owner: claim.owner, epoch: claim.epoch });
+
+// The pinned Node SQLite client's writable withTransaction begins with BEGIN IMMEDIATE.
+// Each mutation therefore locks before reading progress, which serializes independent
+// connections without a deferred read-to-write upgrade.
+const makeActivityStore = Effect.fn("SqliteActivityStore.make")(function* () {
+  const sql = yield* SqlClientService.SqlClient;
+  const failpoint = yield* ActivityMutationFailpoint;
+
+  yield* failpoint.hit("activity:initialize:before");
+  yield* sql
+    .withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          CREATE TABLE IF NOT EXISTS effect_agent_activity_metadata (
+            component TEXT PRIMARY KEY NOT NULL,
+            version INTEGER NOT NULL
+          )
+        `;
+        const metadataRows = yield* sql<Record<string, unknown>>`
+          SELECT version FROM effect_agent_activity_metadata
+          WHERE component = ${METADATA_COMPONENT}
+        `;
+        const metadata = yield* decodeRows(
+          ActivityMetadataRow,
+          metadataRows,
+          "decode activity schema version",
+        );
+        if (metadata.length > 1) {
+          return yield* storeError("decode activity schema version", "corrupt");
+        }
+        const currentVersion = metadata[0]?.version;
+        if (currentVersion !== undefined && currentVersion !== STORAGE_VERSION) {
+          return yield* storeError("initialize activity schema", "incompatible");
+        }
+        if (currentVersion === undefined) {
+          const tableRows = yield* sql<Record<string, unknown>>`
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name = ${STATE_TABLE}
+          `;
+          const existing = yield* decodeRows(
+            ActivityTableRow,
+            tableRows,
+            "inspect activity schema",
+          );
+          if (existing.length > 0) {
+            return yield* storeError("initialize activity schema", "incompatible");
+          }
+          yield* sql`
+            CREATE TABLE effect_agent_activity_processor_state_v1 (
+              processor_id TEXT NOT NULL,
+              processor_version TEXT NOT NULL,
+              thread_id TEXT NOT NULL,
+              format_version INTEGER NOT NULL,
+              through_sequence INTEGER NOT NULL,
+              epoch INTEGER NOT NULL,
+              owner TEXT,
+              lease_expires_at REAL NOT NULL,
+              progress_json TEXT NOT NULL,
+              PRIMARY KEY (processor_id, processor_version, thread_id)
+            )
+          `;
+          yield* sql`
+            INSERT INTO effect_agent_activity_metadata (component, version)
+            VALUES (${METADATA_COMPONENT}, ${STORAGE_VERSION})
+          `;
+        }
+        yield* sql`
+          SELECT processor_id, processor_version, thread_id, format_version,
+            through_sequence, epoch, owner, lease_expires_at, progress_json
+          FROM effect_agent_activity_processor_state_v1
+          LIMIT 0
+        `;
+      }),
+    )
+    .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError("initialize activity schema"))));
+  yield* failpoint.hit("activity:initialize:after");
+
+  const readProgress = Effect.fn("SqliteActivityStore.readProgress")(function* (
+    key: ActivityProcessorKey,
+    operation: string,
+  ): Effect.fn.Return<ActivityProgress | null, ActivityStoreError> {
+    const rawRows = yield* query(
+      sql<Record<string, unknown>>`
+        SELECT processor_id, processor_version, thread_id, format_version,
+          through_sequence, epoch, owner, lease_expires_at, progress_json
+        FROM effect_agent_activity_processor_state_v1
+        WHERE processor_id = ${key.processorId}
+          AND processor_version = ${key.processorVersion}
+          AND thread_id = ${key.threadId}
+      `,
+      operation,
+    );
+    const rows = yield* decodeRows(ActivityStateRow, rawRows, operation);
+    if (rows.length === 0) return null;
+    if (rows.length !== 1) return yield* storeError(operation, "corrupt");
+    const row = rows[0];
+    if (row.format_version !== STORAGE_VERSION) {
+      return yield* storeError(operation, "incompatible");
+    }
+    const progress = yield* decodeProgress(row.progress_json, operation);
+    yield* validateProgress(progress, operation);
+    if (
+      !sameKey(progress.key, key) ||
+      row.processor_id !== key.processorId ||
+      row.processor_version !== key.processorVersion ||
+      row.thread_id !== key.threadId ||
+      row.through_sequence !== progress.throughSequence ||
+      row.epoch !== progress.epoch ||
+      row.owner !== progress.owner ||
+      row.lease_expires_at !== progress.leaseExpiresAt
+    ) {
+      return yield* storeError(operation, "corrupt");
+    }
+    return progress;
+  });
+
+  const checkChanged = Effect.fn("SqliteActivityStore.checkChanged")(function* (
+    operation: string,
+  ): Effect.fn.Return<void, ActivityStoreError> {
+    const rawRows = yield* query(
+      sql<Record<string, unknown>>`SELECT changes() AS changed`,
+      operation,
+    );
+    const rows = yield* decodeRows(ActivityChangeCountRow, rawRows, operation);
+    if (rows.length !== 1 || rows[0].changed !== 1) {
+      return yield* storeError(operation, "corrupt");
+    }
+  });
+
+  const insertProgress = Effect.fn("SqliteActivityStore.insertProgress")(function* (
+    progress: ActivityProgress,
+    operation: string,
+  ) {
+    const progressJson = yield* encodeProgress(progress, operation);
+    yield* sql`
+      INSERT INTO effect_agent_activity_processor_state_v1 (
+        processor_id, processor_version, thread_id, format_version, through_sequence,
+        epoch, owner, lease_expires_at, progress_json
+      ) VALUES (
+        ${progress.key.processorId}, ${progress.key.processorVersion}, ${progress.key.threadId},
+        ${STORAGE_VERSION}, ${progress.throughSequence}, ${progress.epoch}, ${progress.owner},
+        ${progress.leaseExpiresAt}, ${progressJson}
+      )
+    `;
+    yield* checkChanged(operation);
+  });
+
+  const updateProgress = Effect.fn("SqliteActivityStore.updateProgress")(function* (
+    current: ActivityProgress,
+    next: ActivityProgress,
+    operation: string,
+  ) {
+    const progressJson = yield* encodeProgress(next, operation);
+    yield* sql`
+      UPDATE effect_agent_activity_processor_state_v1
+      SET format_version = ${STORAGE_VERSION},
+          through_sequence = ${next.throughSequence},
+          epoch = ${next.epoch},
+          owner = ${next.owner},
+          lease_expires_at = ${next.leaseExpiresAt},
+          progress_json = ${progressJson}
+      WHERE processor_id = ${current.key.processorId}
+        AND processor_version = ${current.key.processorVersion}
+        AND thread_id = ${current.key.threadId}
+        AND through_sequence = ${current.throughSequence}
+        AND epoch = ${current.epoch}
+    `;
+    yield* checkChanged(operation);
+  });
+
+  const requireLive = Effect.fn("SqliteActivityStore.requireLive")(function* (
+    progress: ActivityProgress | null,
+    claim: ActivityClaim,
+    requireSequence: boolean,
+  ): Effect.fn.Return<ActivityProgress, ActivityOwnershipLost> {
+    const now = yield* Clock.currentTimeMillis;
+    if (
+      progress === null ||
+      !sameKey(progress.key, claim.key) ||
+      progress.owner !== claim.owner ||
+      progress.epoch !== claim.epoch ||
+      progress.leaseExpiresAt <= now ||
+      (requireSequence && progress.throughSequence !== claim.throughSequence)
+    ) {
+      return yield* ownershipLost(claim);
+    }
+    return progress;
+  });
+
+  const inspect: ActivityProcessorStore["Service"]["inspect"] = Effect.fn(
+    "SqliteActivityStore.inspect",
+  )(function* (key) {
+    const decodedKey = yield* decodeInput(ActivityProcessorKey, key, "inspect activity progress");
+    return yield* readProgress(decodedKey, "inspect activity progress");
+  });
+
+  const claim: ActivityProcessorStore["Service"]["claim"] = Effect.fn("SqliteActivityStore.claim")(
+    function* (request) {
+      const operation = "claim activity progress";
+      const decoded = yield* decodeInput(ActivityClaimRequest, request, operation);
+      yield* failpoint.hit("activity:claim:before");
+      const claimed = yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const current = yield* readProgress(decoded.key, operation);
+            const now = yield* Clock.currentTimeMillis;
+            if (current !== null && current.owner !== null && current.leaseExpiresAt > now) {
+              return yield* ActivityBusy.make({
+                key: decoded.key,
+                leaseExpiresAt: current.leaseExpiresAt,
+              });
+            }
+            const next = yield* Schema.decodeUnknownEffect(ActivityProgress)({
+              version: STORAGE_VERSION,
+              key: decoded.key,
+              throughSequence: current?.throughSequence ?? 0,
+              epoch: (current?.epoch ?? 0) + 1,
+              owner: decoded.owner,
+              leaseExpiresAt: now + decoded.leaseMillis,
+              pending: current?.pending ?? null,
+              advancedAt: current?.advancedAt ?? null,
+            }).pipe(Effect.mapError(() => storeError(operation, "corrupt")));
+            if (current === null) yield* insertProgress(next, operation);
+            else yield* updateProgress(current, next, operation);
+            yield* failpoint.hit("activity:claim:after-state");
+            const result = makeClaim(next);
+            if (result === null) return yield* storeError(operation, "corrupt");
+            return result;
+          }),
+        )
+        .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
+      yield* failpoint.hit("activity:claim:after");
+      return claimed;
+    },
+  );
+
+  const loadPrepared: ActivityProcessorStore["Service"]["loadPrepared"] = Effect.fn(
+    "SqliteActivityStore.loadPrepared",
+  )(function* (claim) {
+    const operation = "load prepared activity";
+    const decoded = yield* decodeInput(ActivityClaim, claim, operation);
+    return yield* sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const current = yield* readProgress(decoded.key, operation);
+          return (yield* requireLive(current, decoded, true)).pending;
+        }),
+      )
+      .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
+  });
+
+  const prepare: ActivityProcessorStore["Service"]["prepare"] = Effect.fn(
+    "SqliteActivityStore.prepare",
+  )(function* (request) {
+    const operation = "prepare activity output";
+    const claim = yield* decodeInput(ActivityClaim, request.claim, operation);
+    const work = yield* decodeInput(PreparedActivity, request.work, operation);
+    yield* failpoint.hit("activity:prepare:before");
+    const result = yield* sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const current = yield* requireLive(
+            yield* readProgress(claim.key, operation),
+            claim,
+            true,
+          );
+          if (current.pending !== null) {
+            if (sameWork(current.pending, work)) {
+              return { work: current.pending, changed: false } as const;
+            }
+            return yield* ActivityWorkConflict.make({ key: claim.key, workId: work.workId });
+          }
+          if (!sameKey(work.key, claim.key) || work.sequence !== current.throughSequence + 1) {
+            return yield* ActivityWorkConflict.make({ key: claim.key, workId: work.workId });
+          }
+          const next = ActivityProgress.make({ ...current, pending: work });
+          yield* updateProgress(current, next, operation);
+          yield* failpoint.hit("activity:prepare:after-state");
+          return { work, changed: true } as const;
+        }),
+      )
+      .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
+    if (result.changed) yield* failpoint.hit("activity:prepare:after");
+    return result.work;
+  });
+
+  const advance: ActivityProcessorStore["Service"]["advance"] = Effect.fn(
+    "SqliteActivityStore.advance",
+  )(function* (request) {
+    const operation = "advance activity progress";
+    const claim = yield* decodeInput(ActivityClaim, request.claim, operation);
+    const workId = yield* decodeInput(Digest, request.workId, operation);
+    yield* failpoint.hit("activity:advance:before");
+    const nextClaim = yield* sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const current = yield* requireLive(
+            yield* readProgress(claim.key, operation),
+            claim,
+            true,
+          );
+          if (current.pending === null || current.pending.workId !== workId) {
+            return yield* ActivityWorkConflict.make({ key: claim.key, workId });
+          }
+          const next = ActivityProgress.make({
+            ...current,
+            throughSequence: current.pending.sequence,
+            pending: null,
+            advancedAt: yield* Clock.currentTimeMillis,
+          });
+          yield* updateProgress(current, next, operation);
+          yield* failpoint.hit("activity:advance:after-state");
+          const result = makeClaim(next);
+          if (result === null) return yield* storeError(operation, "corrupt");
+          return result;
+        }),
+      )
+      .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
+    yield* failpoint.hit("activity:advance:after");
+    return nextClaim;
+  });
+
+  const release: ActivityProcessorStore["Service"]["release"] = Effect.fn(
+    "SqliteActivityStore.release",
+  )(function* (claim) {
+    const operation = "release activity claim";
+    const decoded = yield* decodeInput(ActivityClaim, claim, operation);
+    yield* failpoint.hit("activity:release:before");
+    yield* sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const current = yield* readProgress(decoded.key, operation);
+          if (
+            current === null ||
+            current.owner !== decoded.owner ||
+            current.epoch !== decoded.epoch
+          ) {
+            return yield* ownershipLost(decoded);
+          }
+          const next = ActivityProgress.make({ ...current, owner: null, leaseExpiresAt: 0 });
+          yield* updateProgress(current, next, operation);
+          yield* failpoint.hit("activity:release:after-state");
+        }),
+      )
+      .pipe(Effect.catchTag("SqlError", () => Effect.fail(storeError(operation))));
+    yield* failpoint.hit("activity:release:after");
+  });
+
+  return ActivityProcessorStore.of({ inspect, claim, loadPrepared, prepare, advance, release });
+});
+
+/** SQLite activity progress with mutation failpoints kept injectable for recovery tests. */
+export const activityProcessorStoreLayerWithFailpoints: Layer.Layer<
+  ActivityProcessorStore,
+  SqliteActivityInitializationError,
+  SqlClientService.SqlClient | ActivityMutationFailpoint
+> = Layer.effect(ActivityProcessorStore, makeActivityStore());
+
+/** SQLite activity progress with the production no-op mutation failpoint. */
+export const activityProcessorStoreLayer: Layer.Layer<
+  ActivityProcessorStore,
+  SqliteActivityInitializationError,
+  SqlClientService.SqlClient
+> = activityProcessorStoreLayerWithFailpoints.pipe(Layer.provide(ActivityMutationFailpoint.layer));

--- a/packages/storage-sqlite/src/sqlite-activity-store.ts
+++ b/packages/storage-sqlite/src/sqlite-activity-store.ts
@@ -96,6 +96,11 @@ const encodeProgress = Effect.fn("SqliteActivityStore.encodeProgress")(function*
 ): Effect.fn.Return<string, ActivityStoreError> {
   return yield* Schema.encodeEffect(Schema.fromJsonString(ActivityProgress))(progress).pipe(
     Effect.mapError(() => storeError(operation, "corrupt")),
+    Effect.flatMap((encoded) =>
+      Schema.decodeEffect(StoredJson)(encoded).pipe(
+        Effect.mapError(() => storeError(operation, "invalid-input")),
+      ),
+    ),
   );
 });
 

--- a/packages/storage-sqlite/test/sqlite-activity-store.test.ts
+++ b/packages/storage-sqlite/test/sqlite-activity-store.test.ts
@@ -125,13 +125,19 @@ describe("SQLite activity processor store", () => {
                 ...boundary,
                 recordId: yield* Schema.decodeEffect(RecordId)(`${boundary.recordId}x`),
               });
-              expect(yield* store.prepare({ claim, work: oversized }).pipe(Effect.flip)).toEqual(
-                ActivityStoreError.make({
-                  operation: "prepare activity output",
-                  reason: "invalid-input",
-                }),
-              );
-              expect(yield* store.inspect(key)).toEqual(before);
+              const escaped = PreparedActivity.make({
+                ...initial,
+                recordId: yield* Schema.decodeEffect(RecordId)("\0".repeat(3 * 1024 * 1024)),
+              });
+              for (const rejected of [oversized, escaped]) {
+                expect(yield* store.prepare({ claim, work: rejected }).pipe(Effect.flip)).toEqual(
+                  ActivityStoreError.make({
+                    operation: "prepare activity output",
+                    reason: "invalid-input",
+                  }),
+                );
+                expect(yield* store.inspect(key)).toEqual(before);
+              }
               yield* store.prepare({ claim, work: boundary });
               expect(yield* store.prepare({ claim, work: boundary })).toEqual(boundary);
               yield* store.release(claim);

--- a/packages/storage-sqlite/test/sqlite-activity-store.test.ts
+++ b/packages/storage-sqlite/test/sqlite-activity-store.test.ts
@@ -1,0 +1,431 @@
+import {
+  ActivityBusy,
+  ActivityClaimRequest,
+  ActivityMutationFailpoint,
+  ActivityMutationFailure,
+  ActivityOwnershipLost,
+  ActivityProcessorKey,
+  ActivityProcessorStore,
+  ActivityStoreError,
+  ActivityWorkConflict,
+  PreparedActivity,
+} from "@effect-agent/thread";
+import { NodeFileSystem } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { describe, expect, it } from "@effect/vitest";
+import type { PlatformError } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber, FileSystem, Layer, Result, Schema } from "effect";
+import { TestClock } from "effect/testing";
+import * as SqlClientService from "effect/unstable/sql/SqlClient";
+
+import {
+  activityProcessorStoreLayer,
+  activityProcessorStoreLayerWithFailpoints,
+} from "../src/index.ts";
+
+const key = Schema.decodeSync(ActivityProcessorKey)({
+  processorId: "profile",
+  processorVersion: "v1",
+  threadId: "thread-1",
+});
+const independentKeys = [
+  key,
+  Schema.decodeSync(ActivityProcessorKey)({ ...key, threadId: "thread-2" }),
+  Schema.decodeSync(ActivityProcessorKey)({ ...key, processorId: "audit" }),
+  Schema.decodeSync(ActivityProcessorKey)({ ...key, processorVersion: "v2" }),
+];
+
+const request = (owner: string, activityKey = key, leaseMillis = 10_000) =>
+  ActivityClaimRequest.make({ key: activityKey, owner, leaseMillis });
+
+const work = (
+  sequence: number,
+  marker: string,
+  activityKey = key,
+  output: Schema.Json = { marker },
+) =>
+  Schema.decodeSync(PreparedActivity)({
+    version: 1,
+    key: activityKey,
+    sequence,
+    workId: marker.repeat(64),
+    recordId: `record-${sequence}`,
+    recordDigest: marker.toUpperCase().repeat(64).toLowerCase(),
+    output,
+  });
+
+const storeLayer = (filename: string) =>
+  activityProcessorStoreLayer.pipe(
+    Layer.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })),
+  );
+
+const failpointLayer = (filename: string, handler: ActivityMutationFailpoint["Service"]["hit"]) =>
+  activityProcessorStoreLayerWithFailpoints.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        SqliteClient.layer({ filename, busyTimeout: 5_000 }),
+        Layer.succeed(ActivityMutationFailpoint)({ hit: handler }),
+      ),
+    ),
+  );
+
+const withTemporaryDatabase = <A, E>(
+  use: (filename: string) => Effect.Effect<A, E>,
+): Effect.Effect<A, E | PlatformError.PlatformError> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({
+        prefix: "effect-agent-activity-sqlite-",
+      });
+      return yield* use(`${directory}/activity.sqlite`);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer));
+
+const runStore = <A, E>(filename: string, effect: Effect.Effect<A, E, ActivityProcessorStore>) =>
+  effect.pipe(Effect.provide(storeLayer(filename)));
+
+const inspect = (filename: string, activityKey = key) =>
+  runStore(
+    filename,
+    Effect.gen(function* () {
+      const store = yield* ActivityProcessorStore;
+      return yield* store.inspect(activityKey);
+    }),
+  );
+
+const runRaw = <A, E>(filename: string, effect: Effect.Effect<A, E, SqlClientService.SqlClient>) =>
+  effect.pipe(Effect.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })));
+
+describe("SQLite activity processor store", () => {
+  it.effect("preserves pending output across takeover and release, then fences reacquisition", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        expect(yield* inspect(filename)).toBeNull();
+        yield* TestClock.setTime(1_000);
+        const first = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            const claim = yield* store.claim(request("worker"));
+            const prepared = yield* store.prepare({ claim, work: work(1, "a") });
+            return { claim, prepared };
+          }),
+        );
+        yield* TestClock.setTime(12_000);
+        const takeover = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            const claim = yield* store.claim(request("takeover"));
+            expect(claim.epoch).toBe(first.claim.epoch + 1);
+            expect(yield* store.loadPrepared(claim)).toEqual(first.prepared);
+            yield* store.release(claim);
+            return claim;
+          }),
+        );
+        const released = yield* inspect(filename);
+        expect(released?.owner).toBeNull();
+        expect(released?.pending).toEqual(first.prepared);
+
+        const second = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            const claim = yield* store.claim(request("takeover"));
+            expect(claim.epoch).toBe(takeover.epoch + 1);
+            expect(yield* store.loadPrepared(claim)).toEqual(first.prepared);
+            yield* TestClock.setTime(13_000);
+            const advanced = yield* store.advance({ claim, workId: first.prepared.workId });
+            yield* store.release(claim);
+            return { claim, advanced };
+          }),
+        );
+        expect(second.advanced.throughSequence).toBe(1);
+        const progressed = yield* inspect(filename);
+        expect(progressed?.throughSequence).toBe(1);
+        expect(progressed?.pending).toBeNull();
+        expect(progressed?.advancedAt).toBe(13_000);
+
+        const third = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            const claim = yield* store.claim(request("takeover"));
+            const stale = yield* store.loadPrepared(second.claim).pipe(Effect.flip);
+            return { claim, stale };
+          }),
+        );
+        expect(third.claim.epoch).toBe(second.claim.epoch + 1);
+        expect(third.stale).toEqual(
+          ActivityOwnershipLost.make({
+            key,
+            owner: second.claim.owner,
+            epoch: second.claim.epoch,
+          }),
+        );
+      }),
+    ),
+  );
+
+  it.effect("pins one exact next output and rejects divergent preparation", () =>
+    withTemporaryDatabase((filename) =>
+      runStore(
+        filename,
+        Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          const claim = yield* store.claim(request("worker"));
+          const wrongSequence = work(2, "1");
+          expect(yield* store.prepare({ claim, work: wrongSequence }).pipe(Effect.flip)).toEqual(
+            ActivityWorkConflict.make({ key, workId: wrongSequence.workId }),
+          );
+          const wrongKey = independentKeys[1];
+          const wrongOwner = work(1, "2", wrongKey);
+          expect(yield* store.prepare({ claim, work: wrongOwner }).pipe(Effect.flip)).toEqual(
+            ActivityWorkConflict.make({ key, workId: wrongOwner.workId }),
+          );
+          const pinned = work(1, "b", key, { value: "pinned" });
+          expect(yield* store.prepare({ claim, work: pinned })).toEqual(pinned);
+          expect(yield* store.prepare({ claim, work: pinned })).toEqual(pinned);
+          const divergent = work(1, "c", key, { value: "different" });
+          expect(yield* store.prepare({ claim, work: divergent }).pipe(Effect.flip)).toEqual(
+            ActivityWorkConflict.make({ key, workId: divergent.workId }),
+          );
+          const wrongWorkId = work(1, "3").workId;
+          expect(yield* store.advance({ claim, workId: wrongWorkId }).pipe(Effect.flip)).toEqual(
+            ActivityWorkConflict.make({ key, workId: wrongWorkId }),
+          );
+        }),
+      ),
+    ),
+  );
+
+  it.effect("keeps thread, processor, and processor-version progress independent", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            for (const [index, activityKey] of independentKeys.entries()) {
+              const claim = yield* store.claim(request(`worker-${index}`, activityKey));
+              if (index === 0) {
+                const prepared = work(1, "d", activityKey);
+                yield* store.prepare({ claim, work: prepared });
+                yield* store.advance({ claim, workId: prepared.workId });
+              }
+            }
+          }),
+        );
+        expect((yield* inspect(filename, independentKeys[0]))?.throughSequence).toBe(1);
+        for (const activityKey of independentKeys.slice(1)) {
+          expect((yield* inspect(filename, activityKey))?.throughSequence).toBe(0);
+        }
+      }),
+    ),
+  );
+
+  it.effect("serializes competing claims across independent clients", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        yield* TestClock.setTime(1_000);
+        const claim = (owner: string) =>
+          runStore(
+            filename,
+            Effect.gen(function* () {
+              const store = yield* ActivityProcessorStore;
+              return yield* store.claim(request(owner));
+            }),
+          ).pipe(Effect.result);
+        const outcomes = yield* Effect.all([claim("one"), claim("two")], {
+          concurrency: "unbounded",
+        });
+        expect(outcomes.filter(Result.isSuccess)).toHaveLength(1);
+        expect(outcomes.filter(Result.isFailure)).toHaveLength(1);
+        const failure = outcomes.find(Result.isFailure);
+        expect(failure?.failure).toEqual(ActivityBusy.make({ key, leaseExpiresAt: 11_000 }));
+      }),
+    ),
+  );
+
+  it.effect("recovers prepared output and an advanced cursor after lost acknowledgements", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        yield* TestClock.setTime(1_000);
+        const claim = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            return yield* store.claim(request("worker"));
+          }),
+        );
+        const prepared = work(1, "e");
+        const prepareFailure = yield* Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          return yield* store.prepare({ claim, work: prepared });
+        }).pipe(
+          Effect.provide(
+            failpointLayer(filename, (point) =>
+              point === "activity:prepare:after"
+                ? Effect.fail(ActivityMutationFailure.make({ point }))
+                : Effect.void,
+            ),
+          ),
+          Effect.flip,
+        );
+        expect(prepareFailure).toEqual(
+          ActivityMutationFailure.make({ point: "activity:prepare:after" }),
+        );
+        expect(
+          yield* runStore(
+            filename,
+            Effect.gen(function* () {
+              const store = yield* ActivityProcessorStore;
+              return yield* store.loadPrepared(claim);
+            }),
+          ),
+        ).toEqual(prepared);
+
+        yield* TestClock.setTime(2_000);
+        const advanceFailure = yield* Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          return yield* store.advance({ claim, workId: prepared.workId });
+        }).pipe(
+          Effect.provide(
+            failpointLayer(filename, (point) =>
+              point === "activity:advance:after"
+                ? Effect.fail(ActivityMutationFailure.make({ point }))
+                : Effect.void,
+            ),
+          ),
+          Effect.flip,
+        );
+        expect(advanceFailure).toEqual(
+          ActivityMutationFailure.make({ point: "activity:advance:after" }),
+        );
+        const recovered = yield* inspect(filename);
+        expect(recovered?.throughSequence).toBe(1);
+        expect(recovered?.pending).toBeNull();
+        expect(recovered?.advancedAt).toBe(2_000);
+        expect(
+          yield* runStore(
+            filename,
+            Effect.gen(function* () {
+              const store = yield* ActivityProcessorStore;
+              return yield* store.advance({ claim, workId: prepared.workId });
+            }),
+          ).pipe(Effect.flip),
+        ).toEqual(ActivityOwnershipLost.make({ key, owner: claim.owner, epoch: claim.epoch }));
+      }),
+    ),
+  );
+
+  it.effect("rolls back defects, timeout, and interruption inside state transactions", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const claim = yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            return yield* store.claim(request("worker"));
+          }),
+        );
+        const prepared = work(1, "f");
+        const defect = yield* Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          return yield* store.prepare({ claim, work: prepared });
+        }).pipe(
+          Effect.provide(
+            failpointLayer(filename, (point) =>
+              point === "activity:prepare:after-state" ? Effect.die("prepare defect") : Effect.void,
+            ),
+          ),
+          Effect.exit,
+        );
+        expect(Exit.isFailure(defect) && Cause.hasDies(defect.cause)).toBe(true);
+        expect((yield* inspect(filename))?.pending).toBeNull();
+
+        yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            yield* store.prepare({ claim, work: prepared });
+          }),
+        );
+        const reached = yield* Deferred.make<void>();
+        const advancing = yield* Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          return yield* store.advance({ claim, workId: prepared.workId });
+        }).pipe(
+          Effect.provide(
+            failpointLayer(filename, (point) =>
+              point === "activity:advance:after-state"
+                ? Deferred.succeed(reached, undefined).pipe(Effect.andThen(Effect.never))
+                : Effect.void,
+            ),
+          ),
+          Effect.timeout("1 second"),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(reached);
+        yield* TestClock.adjust("1 second");
+        expect(Exit.isFailure(yield* Fiber.await(advancing))).toBe(true);
+        const afterTimeout = yield* inspect(filename);
+        expect(afterTimeout?.throughSequence).toBe(0);
+        expect(afterTimeout?.pending).toEqual(prepared);
+
+        const releaseReached = yield* Deferred.make<void>();
+        const releasing = yield* Effect.gen(function* () {
+          const store = yield* ActivityProcessorStore;
+          return yield* store.release(claim);
+        }).pipe(
+          Effect.provide(
+            failpointLayer(filename, (point) =>
+              point === "activity:release:after-state"
+                ? Deferred.succeed(releaseReached, undefined).pipe(Effect.andThen(Effect.never))
+                : Effect.void,
+            ),
+          ),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(releaseReached);
+        yield* Fiber.interrupt(releasing);
+        expect(Exit.isFailure(yield* Fiber.await(releasing))).toBe(true);
+        expect((yield* inspect(filename))?.owner).toBe(claim.owner);
+      }),
+    ),
+  );
+
+  it.effect("rejects incompatible stored formats", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        yield* runStore(
+          filename,
+          Effect.gen(function* () {
+            const store = yield* ActivityProcessorStore;
+            yield* store.claim(request("worker"));
+          }),
+        );
+        yield* runRaw(
+          filename,
+          Effect.gen(function* () {
+            const sql = yield* SqlClientService.SqlClient;
+            yield* sql`
+              UPDATE effect_agent_activity_processor_state_v1
+              SET format_version = 2
+              WHERE processor_id = ${key.processorId}
+                AND processor_version = ${key.processorVersion}
+                AND thread_id = ${key.threadId}
+            `;
+          }),
+        );
+        expect(yield* inspect(filename).pipe(Effect.flip)).toEqual(
+          ActivityStoreError.make({
+            operation: "inspect activity progress",
+            reason: "incompatible",
+          }),
+        );
+      }),
+    ),
+  );
+});

--- a/packages/storage-sqlite/test/sqlite-activity-store.test.ts
+++ b/packages/storage-sqlite/test/sqlite-activity-store.test.ts
@@ -6,9 +6,11 @@ import {
   ActivityOwnershipLost,
   ActivityProcessorKey,
   ActivityProcessorStore,
+  ActivityProgress,
   ActivityStoreError,
   ActivityWorkConflict,
   PreparedActivity,
+  RecordId,
 } from "@effect-agent/thread";
 import { NodeFileSystem } from "@effect/platform-node";
 import { SqliteClient } from "@effect/sql-sqlite-node";
@@ -98,6 +100,60 @@ const runRaw = <A, E>(filename: string, effect: Effect.Effect<A, E, SqlClientSer
   effect.pipe(Effect.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })));
 
 describe("SQLite activity processor store", () => {
+  it.effect(
+    "rejects oversized encoded progress without mutation and reopens the exact boundary",
+    () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const prepared = yield* runStore(
+            filename,
+            Effect.gen(function* () {
+              const store = yield* ActivityProcessorStore;
+              const claim = yield* store.claim(request("worker"));
+              const before = yield* store.inspect(key);
+              const initial = work(1, "a");
+              const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(ActivityProgress))(
+                ActivityProgress.make({ ...claim, version: 1, pending: initial, advancedAt: null }),
+              );
+              const boundary = PreparedActivity.make({
+                ...initial,
+                recordId: yield* Schema.decodeEffect(RecordId)(
+                  "r".repeat(16 * 1024 * 1024 - encoded.length + initial.recordId.length),
+                ),
+              });
+              const oversized = PreparedActivity.make({
+                ...boundary,
+                recordId: yield* Schema.decodeEffect(RecordId)(`${boundary.recordId}x`),
+              });
+              expect(yield* store.prepare({ claim, work: oversized }).pipe(Effect.flip)).toEqual(
+                ActivityStoreError.make({
+                  operation: "prepare activity output",
+                  reason: "invalid-input",
+                }),
+              );
+              expect(yield* store.inspect(key)).toEqual(before);
+              yield* store.prepare({ claim, work: boundary });
+              expect(yield* store.prepare({ claim, work: boundary })).toEqual(boundary);
+              yield* store.release(claim);
+              return boundary;
+            }),
+          );
+          expect((yield* inspect(filename))?.pending).toEqual(prepared);
+          yield* runStore(
+            filename,
+            Effect.gen(function* () {
+              const store = yield* ActivityProcessorStore;
+              const claim = yield* store.claim(request("worker"));
+              expect(claim.pending).toEqual(prepared);
+              const next = yield* store.advance({ claim, workId: prepared.workId });
+              expect(next.throughSequence).toBe(1);
+              expect(next.pending).toBeNull();
+            }),
+          );
+        }),
+      ),
+  );
+
   it.effect("preserves pending output across takeover and release, then fences reacquisition", () =>
     withTemporaryDatabase((filename) =>
       Effect.gen(function* () {

--- a/packages/storage-sqlite/test/sqlite-activity-store.test.ts
+++ b/packages/storage-sqlite/test/sqlite-activity-store.test.ts
@@ -119,7 +119,7 @@ describe("SQLite activity processor store", () => {
             const store = yield* ActivityProcessorStore;
             const claim = yield* store.claim(request("takeover"));
             expect(claim.epoch).toBe(first.claim.epoch + 1);
-            expect(yield* store.loadPrepared(claim)).toEqual(first.prepared);
+            expect(claim.pending).toEqual(first.prepared);
             yield* store.release(claim);
             return claim;
           }),
@@ -134,7 +134,7 @@ describe("SQLite activity processor store", () => {
             const store = yield* ActivityProcessorStore;
             const claim = yield* store.claim(request("takeover"));
             expect(claim.epoch).toBe(takeover.epoch + 1);
-            expect(yield* store.loadPrepared(claim)).toEqual(first.prepared);
+            expect(claim.pending).toEqual(first.prepared);
             yield* TestClock.setTime(13_000);
             const advanced = yield* store.advance({ claim, workId: first.prepared.workId });
             yield* store.release(claim);
@@ -142,6 +142,7 @@ describe("SQLite activity processor store", () => {
           }),
         );
         expect(second.advanced.throughSequence).toBe(1);
+        expect(second.advanced.pending).toBeNull();
         const progressed = yield* inspect(filename);
         expect(progressed?.throughSequence).toBe(1);
         expect(progressed?.pending).toBeNull();
@@ -152,7 +153,9 @@ describe("SQLite activity processor store", () => {
           Effect.gen(function* () {
             const store = yield* ActivityProcessorStore;
             const claim = yield* store.claim(request("takeover"));
-            const stale = yield* store.loadPrepared(second.claim).pipe(Effect.flip);
+            const stale = yield* store
+              .advance({ claim: second.claim, workId: first.prepared.workId })
+              .pipe(Effect.flip);
             return { claim, stale };
           }),
         );
@@ -276,15 +279,7 @@ describe("SQLite activity processor store", () => {
         expect(prepareFailure).toEqual(
           ActivityMutationFailure.make({ point: "activity:prepare:after" }),
         );
-        expect(
-          yield* runStore(
-            filename,
-            Effect.gen(function* () {
-              const store = yield* ActivityProcessorStore;
-              return yield* store.loadPrepared(claim);
-            }),
-          ),
-        ).toEqual(prepared);
+        expect((yield* inspect(filename))?.pending).toEqual(prepared);
 
         yield* TestClock.setTime(2_000);
         const advanceFailure = yield* Effect.gen(function* () {

--- a/packages/thread/src/activity.ts
+++ b/packages/thread/src/activity.ts
@@ -38,6 +38,8 @@ export class ActivityClaim extends Schema.Class<ActivityClaim>(
   epoch: Epoch,
   throughSequence: CanonicalSequence,
   leaseExpiresAt: Timestamp,
+  /** Pending output captured atomically at acquisition; advance returns null here. */
+  pending: Schema.NullOr(PreparedActivity),
 }) {}
 
 export class ActivityProgress extends Schema.Class<ActivityProgress>(
@@ -126,7 +128,7 @@ export class ActivityClaimRequest extends Schema.Class<ActivityClaimRequest>(
  * Optional durable progress for finite committed-activity passes. Every mutation is atomic.
  * claim rejects an unexpired owner and allocates a strictly newer epoch on every successful
  * acquisition, including an initial grant and reacquisition after release with the same owner. It preserves
- * pending output. loadPrepared, prepare, and advance reject expired or superseded claims and
+ * pending output and returns it with the claim. prepare and advance reject expired or superseded claims and
  * require the claim's throughSequence to equal current progress. prepare accepts only the next
  * sequence, pins one output, and rejects divergent reuse. advance requires its pending work ID,
  * increments progress by exactly one, and clears pending in the same transaction.
@@ -144,9 +146,6 @@ export class ActivityProcessorStore extends Context.Service<
     readonly claim: (
       request: ActivityClaimRequest,
     ) => Effect.Effect<ActivityClaim, ActivityStoreFailure>;
-    readonly loadPrepared: (
-      claim: ActivityClaim,
-    ) => Effect.Effect<PreparedActivity | null, ActivityStoreFailure>;
     readonly prepare: (request: {
       readonly claim: ActivityClaim;
       readonly work: PreparedActivity;

--- a/packages/thread/src/activity.ts
+++ b/packages/thread/src/activity.ts
@@ -1,0 +1,160 @@
+import { ThreadId } from "@effect-agent/core";
+import { Context, Effect, Layer, Schema } from "effect";
+
+import { CanonicalSequence, Digest, PersistedJson, RecordId } from "./records.ts";
+
+const Identity = Schema.NonEmptyString.check(Schema.isMaxLength(256));
+const Epoch = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }));
+const Timestamp = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0));
+
+/** Application-owned processor identity. Changing the version starts independent progress. */
+export class ActivityProcessorKey extends Schema.Class<ActivityProcessorKey>(
+  "@effect-agent/thread/ActivityProcessorKey",
+)({
+  processorId: Identity,
+  processorVersion: Identity,
+  threadId: ThreadId.check(Schema.isMaxLength(1_024)),
+}) {}
+
+/** Durable extraction output, pinned before any external application of that output. */
+export class PreparedActivity extends Schema.Class<PreparedActivity>(
+  "@effect-agent/thread/PreparedActivity",
+)({
+  version: Schema.Literal(1),
+  key: ActivityProcessorKey,
+  sequence: CanonicalSequence.check(Schema.isGreaterThan(0)),
+  workId: Digest,
+  recordId: RecordId,
+  recordDigest: Digest,
+  output: PersistedJson,
+}) {}
+
+/** Independent from Thread ownership, submission delivery, and canonical checkpoints. */
+export class ActivityClaim extends Schema.Class<ActivityClaim>(
+  "@effect-agent/thread/ActivityClaim",
+)({
+  key: ActivityProcessorKey,
+  owner: Identity,
+  epoch: Epoch,
+  throughSequence: CanonicalSequence,
+  leaseExpiresAt: Timestamp,
+}) {}
+
+export class ActivityProgress extends Schema.Class<ActivityProgress>(
+  "@effect-agent/thread/ActivityProgress",
+)({
+  version: Schema.Literal(1),
+  key: ActivityProcessorKey,
+  throughSequence: CanonicalSequence,
+  epoch: Epoch,
+  owner: Schema.NullOr(Identity),
+  leaseExpiresAt: Timestamp,
+  pending: Schema.NullOr(PreparedActivity),
+  /** Time of the last cursor advance, not the activity time or a global freshness clock. */
+  advancedAt: Schema.NullOr(Timestamp),
+}) {}
+
+export class ActivityStoreError extends Schema.TaggedError<ActivityStoreError>()(
+  "ActivityStoreError",
+  {
+    operation: Schema.NonEmptyString,
+    reason: Schema.Literals(["invalid-input", "unavailable", "corrupt", "incompatible"]),
+  },
+) {}
+
+export class ActivityBusy extends Schema.TaggedError<ActivityBusy>()("ActivityBusy", {
+  key: ActivityProcessorKey,
+  leaseExpiresAt: Timestamp,
+}) {}
+
+export class ActivityOwnershipLost extends Schema.TaggedError<ActivityOwnershipLost>()(
+  "ActivityOwnershipLost",
+  { key: ActivityProcessorKey, owner: Identity, epoch: Epoch },
+) {}
+
+export class ActivityWorkConflict extends Schema.TaggedError<ActivityWorkConflict>()(
+  "ActivityWorkConflict",
+  { key: ActivityProcessorKey, workId: Digest },
+) {}
+
+export const ActivityMutationPoint = Schema.Literals([
+  "activity:initialize:before",
+  "activity:initialize:after",
+  "activity:claim:before",
+  "activity:claim:after-state",
+  "activity:claim:after",
+  "activity:prepare:before",
+  "activity:prepare:after-state",
+  "activity:prepare:after",
+  "activity:advance:before",
+  "activity:advance:after-state",
+  "activity:advance:after",
+  "activity:release:before",
+  "activity:release:after-state",
+  "activity:release:after",
+]);
+export type ActivityMutationPoint = typeof ActivityMutationPoint.Type;
+
+export class ActivityMutationFailure extends Schema.TaggedError<ActivityMutationFailure>()(
+  "ActivityMutationFailure",
+  { point: ActivityMutationPoint },
+) {}
+
+export class ActivityMutationFailpoint extends Context.Service<
+  ActivityMutationFailpoint,
+  { readonly hit: (point: ActivityMutationPoint) => Effect.Effect<void, ActivityMutationFailure> }
+>()("@effect-agent/thread/ActivityMutationFailpoint") {
+  static readonly layer = Layer.succeed(this, { hit: () => Effect.void });
+}
+
+export type ActivityStoreFailure =
+  | ActivityStoreError
+  | ActivityBusy
+  | ActivityOwnershipLost
+  | ActivityWorkConflict
+  | ActivityMutationFailure;
+
+export class ActivityClaimRequest extends Schema.Class<ActivityClaimRequest>(
+  "@effect-agent/thread/ActivityClaimRequest",
+)({
+  key: ActivityProcessorKey,
+  owner: Identity,
+  leaseMillis: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 600_000 })),
+}) {}
+
+/**
+ * Optional durable progress for finite committed-activity passes. Every mutation is atomic.
+ * claim rejects an unexpired owner and allocates a strictly newer epoch on every successful
+ * acquisition, including an initial grant and reacquisition after release with the same owner. It preserves
+ * pending output. loadPrepared, prepare, and advance reject expired or superseded claims and
+ * require the claim's throughSequence to equal current progress. prepare accepts only the next
+ * sequence, pins one output, and rejects divergent reuse. advance requires its pending work ID,
+ * increments progress by exactly one, and clears pending in the same transaction.
+ *
+ * release checks owner/epoch, independent of the cursor, and never discards pending output.
+ * The adapter owns its lease clock. A failed release leaves only a bounded lease to expire.
+ * This port never owns, mutates, or checkpoints the canonical Thread log.
+ */
+export class ActivityProcessorStore extends Context.Service<
+  ActivityProcessorStore,
+  {
+    readonly inspect: (
+      key: ActivityProcessorKey,
+    ) => Effect.Effect<ActivityProgress | null, ActivityStoreError>;
+    readonly claim: (
+      request: ActivityClaimRequest,
+    ) => Effect.Effect<ActivityClaim, ActivityStoreFailure>;
+    readonly loadPrepared: (
+      claim: ActivityClaim,
+    ) => Effect.Effect<PreparedActivity | null, ActivityStoreFailure>;
+    readonly prepare: (request: {
+      readonly claim: ActivityClaim;
+      readonly work: PreparedActivity;
+    }) => Effect.Effect<PreparedActivity, ActivityStoreFailure>;
+    readonly advance: (request: {
+      readonly claim: ActivityClaim;
+      readonly workId: Digest;
+    }) => Effect.Effect<ActivityClaim, ActivityStoreFailure>;
+    readonly release: (claim: ActivityClaim) => Effect.Effect<void, ActivityStoreFailure>;
+  }
+>()("@effect-agent/thread/ActivityProcessorStore") {}

--- a/packages/thread/src/committed-activity.ts
+++ b/packages/thread/src/committed-activity.ts
@@ -1,0 +1,268 @@
+import { Clock, Effect, Schema, Stream, type Crypto, type Scope } from "effect";
+
+import {
+  ActivityClaim,
+  ActivityClaimRequest,
+  ActivityProcessorKey,
+  ActivityProcessorStore,
+  PreparedActivity,
+  type ActivityStoreFailure,
+} from "./activity.ts";
+import { digestJson, type DigestError } from "./digest.ts";
+import {
+  CanonicalRecordEnvelope,
+  CanonicalSequence,
+  PersistedJson,
+  RecordEnvelope,
+} from "./records.ts";
+import {
+  ThreadRead,
+  ThreadStore,
+  ThreadTail,
+  ThreadTailRequest,
+  type ThreadNotMaterialized,
+  type ThreadStoreError,
+} from "./store.ts";
+
+export class ActivityPassLimits extends Schema.Class<ActivityPassLimits>(
+  "@effect-agent/thread/ActivityPassLimits",
+)({
+  maxRecords: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 4_096 })),
+  pageSize: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 128 })),
+  timeoutMillis: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 300_000 })),
+  leaseMillis: ActivityClaimRequest.fields.leaseMillis,
+}) {}
+
+export class ActivityProcessingError extends Schema.TaggedError<ActivityProcessingError>()(
+  "ActivityProcessingError",
+  {
+    reason: Schema.Literals(["invalid-input", "noncontiguous", "timeout"]),
+    message: Schema.String.check(Schema.isMaxLength(1_024)),
+  },
+) {}
+
+export class ActivityPassResult extends Schema.Class<ActivityPassResult>(
+  "@effect-agent/thread/ActivityPassResult",
+)({
+  key: ActivityProcessorKey,
+  capturedTail: CanonicalSequence,
+  throughSequence: CanonicalSequence,
+  processed: Schema.Natural,
+  pendingRecords: Schema.Natural,
+  startedAt: Schema.Finite,
+  finishedAt: Schema.Finite,
+}) {}
+
+export interface CommittedActivityProcessor<E = never, R = never, EApply = never, RApply = never> {
+  readonly key: ActivityProcessorKey;
+  /** Unique to this worker lifetime; it is not canonical Thread ownership. */
+  readonly owner: string;
+  readonly limits: ActivityPassLimits;
+  /** Select eligibility and encode an application Schema; null can represent no output. */
+  readonly extract: (record: CanonicalRecordEnvelope) => Effect.Effect<PersistedJson, E, R>;
+  /**
+   * Must durably reconcile workId before returning, using atomic idempotency and conditional
+   * writes. This may run again after any lost acknowledgement. A stale invocation can finish
+   * only the already pinned output; it must not overwrite a later correction or withdrawal.
+   * Retain reconciliation evidence for the lifetime of pending work, including any supported
+   * backup/restore window. Returning before durable application would permit skipped output.
+   */
+  readonly apply: (work: PreparedActivity) => Effect.Effect<void, EApply, RApply>;
+}
+
+const invalid = (message: string) =>
+  ActivityProcessingError.make({ reason: "invalid-input", message });
+const contiguous = () =>
+  ActivityProcessingError.make({
+    reason: "noncontiguous",
+    message: "Committed activity does not match its captured Thread prefix or pinned record",
+  });
+
+/** Stable work identity independent of worker claims, retry count, extraction, and clocks. */
+export const activityWorkId = Effect.fn("activityWorkId")(function* (
+  key: ActivityProcessorKey,
+  sequence: CanonicalSequence,
+) {
+  return yield* digestJson([
+    "effect-agent/activity@1",
+    key.processorId,
+    key.processorVersion,
+    key.threadId,
+    sequence,
+  ]);
+});
+
+/**
+ * Process one bounded committed prefix of one application-selected Thread. Nothing runs until
+ * invoked, and no daemon, global Thread directory, admission ledger, or engine checkpoint is
+ * involved. PersistentHistory makes a successful Run's batch visible together; durable Runs
+ * expose incremental committed records. The application decides what each record means.
+ *
+ * A durable pending output wins over a new extraction after restart. Apply finishes before
+ * progress advances, so separate output stores require durable idempotency. This does not
+ * promise exactly-once external side effects. Each callback owns a Scope; the finite pass has
+ * a timeout and a longer lease. Claim release has a separate 500ms deadline; failure leaves
+ * the bounded lease to expire.
+ */
+export const processCommittedActivity = Effect.fn("processCommittedActivity")(function* <
+  E = never,
+  R = never,
+  EApply = never,
+  RApply = never,
+>(
+  processor: CommittedActivityProcessor<E, R, EApply, RApply>,
+): Effect.fn.Return<
+  ActivityPassResult,
+  | E
+  | EApply
+  | ActivityStoreFailure
+  | ActivityProcessingError
+  | DigestError
+  | ThreadStoreError
+  | ThreadNotMaterialized,
+  ActivityProcessorStore | ThreadStore | Crypto.Crypto | Exclude<R | RApply, Scope.Scope>
+> {
+  const key = yield* Schema.decodeUnknownEffect(ActivityProcessorKey)(processor.key).pipe(
+    Effect.mapError(() => invalid("Invalid activity processor key")),
+  );
+  const limits = yield* Schema.decodeUnknownEffect(ActivityPassLimits)(processor.limits).pipe(
+    Effect.mapError(() => invalid("Invalid activity pass limits")),
+  );
+  if (limits.leaseMillis < limits.timeoutMillis + 1_000) {
+    return yield* invalid("The activity lease must exceed the pass timeout by at least 1000ms");
+  }
+  const request = yield* ActivityClaimRequest.makeEffect({
+    key,
+    owner: processor.owner,
+    leaseMillis: limits.leaseMillis,
+  }).pipe(Effect.mapError(() => invalid("Invalid activity worker identity")));
+  const progress = yield* ActivityProcessorStore;
+  const threads = yield* ThreadStore;
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const acquired = yield* Effect.acquireRelease(
+        progress.claim(request).pipe(Effect.interruptible),
+        (claim) =>
+          progress
+            .release(claim)
+            .pipe(Effect.interruptible, Effect.timeoutOption(500), Effect.ignore),
+      );
+      let claim = yield* Schema.decodeUnknownEffect(ActivityClaim)(acquired).pipe(
+        Effect.mapError(() => invalid("Malformed activity claim")),
+      );
+      if (
+        !Schema.toEquivalence(ActivityProcessorKey)(claim.key, key) ||
+        claim.owner !== request.owner
+      )
+        return yield* invalid("Activity claim identity does not match its request");
+      const startedAt = yield* Clock.currentTimeMillis;
+      const tail = yield* threads
+        .inspectTail(ThreadTailRequest.make({ threadId: key.threadId }))
+        .pipe(
+          Effect.flatMap((value) =>
+            Schema.decodeUnknownEffect(ThreadTail)(value).pipe(Effect.mapError(contiguous)),
+          ),
+        );
+      if (tail.threadId !== key.threadId || tail.tailSequence < claim.throughSequence) {
+        return yield* contiguous();
+      }
+      const through = Math.min(tail.tailSequence, claim.throughSequence + limits.maxRecords);
+      let processed = 0;
+      while (claim.throughSequence < through) {
+        const limit = Math.min(limits.pageSize, through - claim.throughSequence);
+        const page = yield* threads
+          .read(
+            ThreadRead.make({
+              threadId: key.threadId,
+              afterSequence: claim.throughSequence,
+              limit,
+            }),
+          )
+          .pipe(Stream.take(limit + 1), Stream.runCollect);
+        if (page.length !== limit) return yield* contiguous();
+        for (const rawRecord of page) {
+          const record = yield* Schema.decodeUnknownEffect(Schema.toType(CanonicalRecordEnvelope))(
+            rawRecord,
+          ).pipe(Effect.mapError(contiguous));
+          if (record.threadId !== key.threadId || record.sequence !== claim.throughSequence + 1) {
+            return yield* contiguous();
+          }
+          const workId = yield* activityWorkId(key, record.sequence);
+          const encodedRecord = yield* Schema.encodeEffect(RecordEnvelope)(record.record).pipe(
+            Effect.mapError(contiguous),
+          );
+          const recordDigest = yield* digestJson(encodedRecord);
+          let work = yield* progress.loadPrepared(claim);
+          if (work === null) {
+            const output = yield* Effect.scoped(processor.extract(record)).pipe(
+              Effect.flatMap((value) =>
+                Schema.decodeUnknownEffect(PersistedJson)(value).pipe(
+                  Effect.mapError(() => invalid("Malformed activity output")),
+                ),
+              ),
+            );
+            work = yield* progress.prepare({
+              claim,
+              work: PreparedActivity.make({
+                version: 1,
+                key,
+                sequence: record.sequence,
+                workId,
+                recordId: record.record.recordId,
+                recordDigest,
+                output,
+              }),
+            });
+          }
+          const prepared = yield* Schema.decodeUnknownEffect(PreparedActivity)(work).pipe(
+            Effect.mapError(() => invalid("Malformed prepared activity")),
+          );
+          if (
+            !Schema.toEquivalence(ActivityProcessorKey)(prepared.key, key) ||
+            prepared.sequence !== record.sequence ||
+            prepared.workId !== workId ||
+            prepared.recordId !== record.record.recordId ||
+            prepared.recordDigest !== recordDigest
+          )
+            return yield* contiguous();
+          yield* Effect.scoped(processor.apply(prepared));
+          const next = yield* progress
+            .advance({ claim, workId })
+            .pipe(
+              Effect.flatMap((value) =>
+                Schema.decodeUnknownEffect(ActivityClaim)(value).pipe(
+                  Effect.mapError(() => invalid("Malformed activity progress")),
+                ),
+              ),
+            );
+          if (
+            !Schema.toEquivalence(ActivityProcessorKey)(next.key, key) ||
+            next.owner !== claim.owner ||
+            next.epoch !== claim.epoch ||
+            next.throughSequence !== record.sequence
+          )
+            return yield* invalid("Activity progress advanced outside the claimed record");
+          claim = next;
+          processed += 1;
+        }
+      }
+      return ActivityPassResult.make({
+        key,
+        capturedTail: tail.tailSequence,
+        throughSequence: claim.throughSequence,
+        processed,
+        pendingRecords: tail.tailSequence - claim.throughSequence,
+        startedAt,
+        finishedAt: yield* Clock.currentTimeMillis,
+      });
+    }),
+  ).pipe(
+    Effect.timeoutOrElse({
+      duration: limits.timeoutMillis,
+      orElse: () =>
+        Effect.fail(
+          ActivityProcessingError.make({ reason: "timeout", message: "Activity pass timed out" }),
+        ),
+    }),
+  );
+});

--- a/packages/thread/src/committed-activity.ts
+++ b/packages/thread/src/committed-activity.ts
@@ -192,7 +192,7 @@ export const processCommittedActivity = Effect.fn("processCommittedActivity")(fu
             Effect.mapError(contiguous),
           );
           const recordDigest = yield* digestJson(encodedRecord);
-          let work = yield* progress.loadPrepared(claim);
+          let work = claim.pending;
           if (work === null) {
             const output = yield* Effect.scoped(processor.extract(record)).pipe(
               Effect.flatMap((value) =>
@@ -239,7 +239,8 @@ export const processCommittedActivity = Effect.fn("processCommittedActivity")(fu
             !Schema.toEquivalence(ActivityProcessorKey)(next.key, key) ||
             next.owner !== claim.owner ||
             next.epoch !== claim.epoch ||
-            next.throughSequence !== record.sequence
+            next.throughSequence !== record.sequence ||
+            next.pending !== null
           )
             return yield* invalid("Activity progress advanced outside the claimed record");
           claim = next;

--- a/packages/thread/src/committed-activity.ts
+++ b/packages/thread/src/committed-activity.ts
@@ -163,7 +163,11 @@ export const processCommittedActivity = Effect.fn("processCommittedActivity")(fu
             Schema.decodeUnknownEffect(ThreadTail)(value).pipe(Effect.mapError(contiguous)),
           ),
         );
-      if (tail.threadId !== key.threadId || tail.tailSequence < claim.throughSequence) {
+      if (
+        tail.threadId !== key.threadId ||
+        tail.tailSequence < claim.throughSequence ||
+        (claim.pending !== null && tail.tailSequence < claim.pending.sequence)
+      ) {
         return yield* contiguous();
       }
       const through = Math.min(tail.tailSequence, claim.throughSequence + limits.maxRecords);

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./admin.ts";
+export * from "./activity.ts";
+export * from "./committed-activity.ts";
 export {
   BindingUnavailable,
   BindingDigestMismatch,

--- a/packages/thread/test/committed-activity-types.test.ts
+++ b/packages/thread/test/committed-activity-types.test.ts
@@ -1,0 +1,90 @@
+import { ThreadId } from "@effect-agent/core";
+import { describe, expect, it } from "@effect/vitest";
+import { Context, Effect, Schema, type Crypto, type Scope } from "effect";
+
+import {
+  ActivityPassLimits,
+  ActivityProcessorKey,
+  processCommittedActivity,
+  type ActivityProcessingError,
+  type ActivityProcessorStore,
+  type ActivityStoreFailure,
+  type DigestError,
+  type PersistedJson,
+  type PreparedActivity,
+  type ThreadNotMaterialized,
+  type ThreadStore,
+  type ThreadStoreError,
+} from "../src/index.ts";
+
+type Equal<L, R> =
+  (<T>() => T extends L ? 1 : 2) extends <T>() => T extends R ? 1 : 2
+    ? (<T>() => T extends R ? 1 : 2) extends <T>() => T extends L ? 1 : 2
+      ? true
+      : false
+    : false;
+type Assert<T extends true> = T;
+
+class ExtractFailure extends Schema.TaggedError<ExtractFailure>()("ExtractFailure", {}) {}
+class ApplyFailure extends Schema.TaggedError<ApplyFailure>()("ApplyFailure", {}) {}
+class Extractor extends Context.Service<
+  Extractor,
+  {
+    readonly read: Effect.Effect<PersistedJson, ExtractFailure, Scope.Scope>;
+  }
+>()("test/activity/Extractor") {}
+class Destination extends Context.Service<
+  Destination,
+  {
+    readonly apply: (work: PreparedActivity) => Effect.Effect<void, ApplyFailure, Scope.Scope>;
+  }
+>()("test/activity/Destination") {}
+
+const pass = processCommittedActivity({
+  key: ActivityProcessorKey.make({
+    processorId: "test",
+    processorVersion: "1",
+    threadId: Schema.decodeSync(ThreadId)("test"),
+  }),
+  owner: "worker",
+  limits: ActivityPassLimits.make({
+    maxRecords: 1,
+    pageSize: 1,
+    timeoutMillis: 100,
+    leaseMillis: 1_100,
+  }),
+  extract: () =>
+    Effect.gen(function* () {
+      return yield* (yield* Extractor).read;
+    }),
+  apply: (work) =>
+    Effect.gen(function* () {
+      yield* (yield* Destination).apply(work);
+    }),
+});
+
+type Errors = Assert<
+  Equal<
+    Effect.Error<typeof pass>,
+    | ExtractFailure
+    | ApplyFailure
+    | ActivityStoreFailure
+    | ActivityProcessingError
+    | DigestError
+    | ThreadStoreError
+    | ThreadNotMaterialized
+  >
+>;
+type Requirements = Assert<
+  Equal<
+    Effect.Services<typeof pass>,
+    Extractor | Destination | ActivityProcessorStore | ThreadStore | Crypto.Crypto
+  >
+>;
+
+describe("committed activity public composition", () => {
+  it("preserves application failures and requirements while owning callback scopes", () => {
+    const proof: readonly [Errors, Requirements] = [true, true];
+    expect(proof).toEqual([true, true]);
+  });
+});

--- a/packages/thread/test/committed-activity.test.ts
+++ b/packages/thread/test/committed-activity.test.ts
@@ -1,0 +1,430 @@
+import { ThreadId } from "@effect-agent/core";
+import { NodeCrypto } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import {
+  Cause,
+  Clock,
+  DateTime,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Schema,
+  Stream,
+} from "effect";
+import { TestClock } from "effect/testing";
+
+import type { PreparedActivity } from "../src/index.ts";
+import {
+  ActivityClaim,
+  ActivityMutationFailure,
+  ActivityPassLimits,
+  ActivityProcessingError,
+  ActivityProcessorKey,
+  ActivityProcessorStore,
+  BatchId,
+  CanonicalRecordEnvelope,
+  CanonicalSequence,
+  DeploymentId,
+  EMPTY_TAIL_DIGEST,
+  ObservationOffset,
+  ProducerEpoch,
+  RecordEnvelope,
+  RecordId,
+  ThreadStore,
+  ThreadTail,
+  UserInputRecorded,
+  processCommittedActivity,
+} from "../src/index.ts";
+
+const threadId = Schema.decodeSync(ThreadId)("dan-chad");
+const sequence = Schema.decodeSync(CanonicalSequence);
+const key = ActivityProcessorKey.make({
+  processorId: "discussion",
+  processorVersion: "1",
+  threadId,
+});
+const limits = ActivityPassLimits.make({
+  maxRecords: 2,
+  pageSize: 1,
+  timeoutMillis: 1_000,
+  leaseMillis: 2_000,
+});
+const record = (number: number, text = `statement ${number}`, offset = `offset:${number}`) =>
+  CanonicalRecordEnvelope.make({
+    threadId,
+    batchId: Schema.decodeSync(BatchId)(`batch:${number}`),
+    sequence: sequence(number),
+    offset: Schema.decodeSync(ObservationOffset)(offset),
+    record: RecordEnvelope.make({
+      recordId: Schema.decodeSync(RecordId)(`record:${number}`),
+      family: "thread",
+      schemaVersion: 1,
+      createdAt: DateTime.makeUnsafe(10),
+      deploymentId: Schema.decodeSync(DeploymentId)("test"),
+      payload: UserInputRecorded.make({ kind: "user", input: text }),
+    }),
+  });
+
+class ExtractionUnavailable extends Schema.TaggedError<ExtractionUnavailable>()(
+  "ExtractionUnavailable",
+  {},
+) {}
+
+/** A workflow probe, not a storage implementation. SQLite tests own transaction/fencing semantics. */
+const probe = (initial: ReadonlyArray<CanonicalRecordEnvelope> = [record(1)]) => {
+  const state = {
+    records: [...initial],
+    through: sequence(0),
+    pending: null as PreparedActivity | null,
+    epoch: 0,
+    prepared: [] as Array<PreparedActivity>,
+    released: 0,
+    pages: [] as Array<number>,
+    prepareLostAck: false,
+    advanceLostAck: false,
+  };
+  const store = ActivityProcessorStore.of({
+    inspect: () => Effect.die("The processor must use its claim, not a separate progress read"),
+    claim: (request) =>
+      Effect.gen(function* () {
+        state.epoch += 1;
+        return ActivityClaim.make({
+          ...request,
+          epoch: state.epoch,
+          throughSequence: state.through,
+          leaseExpiresAt: (yield* Clock.currentTimeMillis) + request.leaseMillis,
+        });
+      }),
+    loadPrepared: () => Effect.sync(() => state.pending),
+    prepare: ({ work }) =>
+      Effect.gen(function* () {
+        state.pending = work;
+        state.prepared.push(work);
+        if (state.prepareLostAck) {
+          state.prepareLostAck = false;
+          return yield* ActivityMutationFailure.make({ point: "activity:prepare:after" });
+        }
+        return work;
+      }),
+    advance: ({ claim }) =>
+      Effect.gen(function* () {
+        state.through = sequence(claim.throughSequence + 1);
+        state.pending = null;
+        if (state.advanceLostAck) {
+          state.advanceLostAck = false;
+          return yield* ActivityMutationFailure.make({ point: "activity:advance:after" });
+        }
+        return ActivityClaim.make({ ...claim, throughSequence: state.through });
+      }),
+    release: () =>
+      Effect.sync(() => {
+        state.released += 1;
+      }),
+  });
+  const threads = ThreadStore.of({
+    materialize: () => Effect.die("Ingestion must not materialize Threads"),
+    append: () => Effect.die("Ingestion must not append canonical records"),
+    export: () => Effect.die("Ingestion must use bounded reads"),
+    observe: () => Stream.die("Ingestion must not start an unbounded observation"),
+    inspectTail: () =>
+      Effect.succeed(
+        ThreadTail.make({
+          threadId,
+          tailSequence: sequence(state.records.length),
+          tailDigest: EMPTY_TAIL_DIGEST,
+          producerEpoch: Schema.decodeSync(ProducerEpoch)(0),
+        }),
+      ),
+    read: (request) => {
+      state.pages.push(request.limit);
+      return Stream.fromIterable(
+        state.records.slice(
+          request.afterSequence ?? 0,
+          (request.afterSequence ?? 0) + request.limit,
+        ),
+      );
+    },
+  });
+  const layer = Layer.mergeAll(
+    Layer.succeed(ActivityProcessorStore, store),
+    Layer.succeed(ThreadStore, threads),
+    NodeCrypto.layer,
+  );
+  return { state, store, threads, layer };
+};
+
+describe("finite committed activity processing", () => {
+  it.effect("captures a bounded prefix and leaves later commits for another pass", () => {
+    const p = probe([record(1), record(2), record(3)]);
+    const applied: Array<number> = [];
+    const options = {
+      key,
+      owner: "worker",
+      limits,
+      extract: (value: CanonicalRecordEnvelope) =>
+        Effect.sync(() => {
+          if (value.sequence === 1) p.state.records.push(record(4));
+          return value.record.payload._tag;
+        }),
+      apply: (work: PreparedActivity) =>
+        Effect.sync(() => {
+          applied.push(work.sequence);
+        }),
+    };
+    return Effect.gen(function* () {
+      const first = yield* processCommittedActivity(options);
+      expect(first).toMatchObject({
+        capturedTail: 3,
+        throughSequence: 2,
+        processed: 2,
+        pendingRecords: 1,
+      });
+      expect(applied).toEqual([1, 2]);
+      const second = yield* processCommittedActivity(options);
+      expect(second).toMatchObject({
+        capturedTail: 4,
+        throughSequence: 4,
+        processed: 2,
+        pendingRecords: 0,
+      });
+      expect(p.state.pages).toEqual([1, 1, 1, 1]);
+      expect(applied).toEqual([1, 2, 3, 4]);
+      expect(p.state.released).toBe(2);
+    }).pipe(Effect.provide(p.layer));
+  });
+
+  it.effect(
+    "reuses pinned output after lost prepare acknowledgement even when the observation cursor changes",
+    () => {
+      const p = probe();
+      p.state.prepareLostAck = true;
+      let extractions = 0;
+      const applied: Array<PreparedActivity> = [];
+      const options = {
+        key,
+        owner: "worker",
+        limits,
+        extract: () =>
+          Effect.sync(() => {
+            extractions += 1;
+            return `extraction ${extractions}`;
+          }),
+        apply: (work: PreparedActivity) =>
+          Effect.sync(() => {
+            applied.push(work);
+          }),
+      };
+      return Effect.gen(function* () {
+        expect(yield* processCommittedActivity(options).pipe(Effect.flip)).toEqual(
+          ActivityMutationFailure.make({ point: "activity:prepare:after" }),
+        );
+        expect(p.state.through).toBe(0);
+        p.state.records = [record(1, "statement 1", "restored-cursor")];
+        yield* processCommittedActivity(options);
+        expect(extractions).toBe(1);
+        expect(applied).toEqual(p.state.prepared);
+        expect(applied[0].output).toBe("extraction 1");
+      }).pipe(Effect.provide(p.layer));
+    },
+  );
+
+  it.effect(
+    "replays applied work before progress and resumes beyond an acknowledged-lost advance",
+    () => {
+      const p = probe();
+      let extractions = 0;
+      let attempts = 0;
+      const receipts = new Map<string, PreparedActivity>();
+      const options = {
+        key,
+        owner: "worker",
+        limits,
+        extract: () =>
+          Effect.sync(() => {
+            extractions += 1;
+            return "pinned";
+          }),
+        apply: (work: PreparedActivity) =>
+          Effect.gen(function* () {
+            attempts += 1;
+            receipts.set(work.workId, work);
+            if (attempts === 1) return yield* new ExtractionUnavailable();
+          }),
+      };
+      return Effect.gen(function* () {
+        expect(yield* processCommittedActivity(options).pipe(Effect.flip)).toEqual(
+          new ExtractionUnavailable(),
+        );
+        expect(p.state.through).toBe(0);
+        p.state.advanceLostAck = true;
+        expect(yield* processCommittedActivity(options).pipe(Effect.flip)).toEqual(
+          ActivityMutationFailure.make({ point: "activity:advance:after" }),
+        );
+        const resumed = yield* processCommittedActivity(options);
+        expect(resumed.processed).toBe(0);
+        expect(resumed.throughSequence).toBe(1);
+        expect(extractions).toBe(1);
+        expect(attempts).toBe(2);
+        expect(receipts.size).toBe(1);
+      }).pipe(Effect.provide(p.layer));
+    },
+  );
+
+  it.effect("rejects gaps and changed canonical content before applying pinned output", () =>
+    Effect.gen(function* () {
+      const gap = probe([record(2)]);
+      let applied = 0;
+      const options = {
+        key,
+        owner: "worker",
+        limits,
+        extract: () => Effect.succeed(null),
+        apply: () =>
+          Effect.sync(() => {
+            applied += 1;
+          }),
+      };
+      const gapError = yield* processCommittedActivity(options).pipe(
+        Effect.provide(gap.layer),
+        Effect.flip,
+      );
+      expect(gapError).toMatchObject({ _tag: "ActivityProcessingError", reason: "noncontiguous" });
+      const changed = probe();
+      changed.state.prepareLostAck = true;
+      yield* processCommittedActivity(options).pipe(Effect.provide(changed.layer), Effect.exit);
+      changed.state.records = [record(1, "mutated canonical source")];
+      const changedError = yield* processCommittedActivity(options).pipe(
+        Effect.provide(changed.layer),
+        Effect.flip,
+      );
+      expect(changedError).toMatchObject({
+        _tag: "ActivityProcessingError",
+        reason: "noncontiguous",
+      });
+      expect(applied).toBe(0);
+      expect(changed.state.through).toBe(0);
+    }),
+  );
+
+  it.effect(
+    "keeps expected failures and defects visible and rejects malformed callback output",
+    () =>
+      Effect.gen(function* () {
+        for (const scenario of [
+          {
+            extract: () => Effect.fail(new ExtractionUnavailable()),
+            expected: new ExtractionUnavailable(),
+          },
+          { extract: () => Effect.die("extract defect"), expected: "extract defect" },
+          {
+            extract: () => Effect.succeed(Number.NaN),
+            expected: ActivityProcessingError.make({
+              reason: "invalid-input",
+              message: "Malformed activity output",
+            }),
+          },
+        ]) {
+          const p = probe();
+          const exit = yield* processCommittedActivity({
+            key,
+            owner: "worker",
+            limits,
+            extract: scenario.extract,
+            apply: () => Effect.die("No invalid output may apply"),
+          }).pipe(Effect.provide(p.layer), Effect.exit);
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toEqual(scenario.expected);
+          expect(p.state.prepared).toHaveLength(0);
+          expect(p.state.through).toBe(0);
+          expect(p.state.released).toBe(1);
+        }
+      }),
+  );
+
+  it.effect("finalizes scoped callbacks on timeout and interruption without advancing", () =>
+    Effect.gen(function* () {
+      for (const boundary of ["extract", "apply"] as const) {
+        for (const mode of ["timeout", "interrupt"] as const) {
+          const p = probe();
+          const entered = yield* Deferred.make<void>();
+          let released = 0;
+          const waiting = Effect.gen(function* () {
+            yield* Effect.acquireRelease(Deferred.succeed(entered, undefined), () =>
+              Effect.sync(() => {
+                released += 1;
+              }),
+            );
+            return yield* Effect.never;
+          });
+          const fiber = yield* processCommittedActivity({
+            key,
+            owner: "worker",
+            limits,
+            extract: () => (boundary === "extract" ? waiting : Effect.succeed(null)),
+            apply: () =>
+              boundary === "apply" ? waiting : Effect.die("No interrupted extraction may apply"),
+          }).pipe(Effect.provide(p.layer), Effect.forkChild);
+          yield* Deferred.await(entered);
+          if (mode === "timeout") yield* TestClock.adjust(1_000);
+          else yield* Fiber.interrupt(fiber);
+          const exit = yield* Fiber.await(fiber);
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            if (mode === "interrupt") expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+            else
+              expect(Cause.squash(exit.cause)).toMatchObject({
+                _tag: "ActivityProcessingError",
+                reason: "timeout",
+              });
+          }
+          expect(released).toBe(1);
+          expect(p.state.released).toBe(1);
+          expect(p.state.through).toBe(0);
+          expect(p.state.pending !== null).toBe(boundary === "apply");
+        }
+      }
+    }),
+  );
+
+  it.effect("bounds a hanging release independently of the pass timeout", () =>
+    Effect.gen(function* () {
+      const p = probe();
+      const entered = yield* Deferred.make<void>();
+      let releaseFinalized = false;
+      const service = ActivityProcessorStore.of({
+        ...p.store,
+        release: () =>
+          Deferred.succeed(entered, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(
+              Effect.sync(() => {
+                releaseFinalized = true;
+              }),
+            ),
+          ),
+      });
+      const fiber = yield* processCommittedActivity({
+        key,
+        owner: "worker",
+        limits,
+        extract: () => Effect.succeed(null),
+        apply: () => Effect.void,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(ActivityProcessorStore, service),
+            Layer.succeed(ThreadStore, p.threads),
+            NodeCrypto.layer,
+          ),
+        ),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(entered);
+      yield* TestClock.adjust(500);
+      expect((yield* Fiber.join(fiber)).throughSequence).toBe(1);
+      expect(releaseFinalized).toBe(true);
+    }),
+  );
+});

--- a/packages/thread/test/committed-activity.test.ts
+++ b/packages/thread/test/committed-activity.test.ts
@@ -272,40 +272,54 @@ describe("finite committed activity processing", () => {
     },
   );
 
-  it.effect("rejects gaps and changed canonical content before applying pinned output", () =>
-    Effect.gen(function* () {
-      const gap = probe([record(2)]);
-      let applied = 0;
-      const options = {
-        key,
-        owner: "worker",
-        limits,
-        extract: () => Effect.succeed(null),
-        apply: () =>
-          Effect.sync(() => {
-            applied += 1;
-          }),
-      };
-      const gapError = yield* processCommittedActivity(options).pipe(
-        Effect.provide(gap.layer),
-        Effect.flip,
-      );
-      expect(gapError).toMatchObject({ _tag: "ActivityProcessingError", reason: "noncontiguous" });
-      const changed = probe();
-      changed.state.prepareLostAck = true;
-      yield* processCommittedActivity(options).pipe(Effect.provide(changed.layer), Effect.exit);
-      changed.state.records = [record(1, "mutated canonical source")];
-      const changedError = yield* processCommittedActivity(options).pipe(
-        Effect.provide(changed.layer),
-        Effect.flip,
-      );
-      expect(changedError).toMatchObject({
-        _tag: "ActivityProcessingError",
-        reason: "noncontiguous",
-      });
-      expect(applied).toBe(0);
-      expect(changed.state.through).toBe(0);
-    }),
+  it.effect(
+    "rejects gaps, truncated tails, and changed content before applying pinned output",
+    () =>
+      Effect.gen(function* () {
+        const gap = probe([record(2)]);
+        let applied = 0;
+        const options = {
+          key,
+          owner: "worker",
+          limits,
+          extract: () => Effect.succeed(null),
+          apply: () =>
+            Effect.sync(() => {
+              applied += 1;
+            }),
+        };
+        const gapError = yield* processCommittedActivity(options).pipe(
+          Effect.provide(gap.layer),
+          Effect.flip,
+        );
+        expect(gapError).toMatchObject({
+          _tag: "ActivityProcessingError",
+          reason: "noncontiguous",
+        });
+        const changed = probe();
+        changed.state.prepareLostAck = true;
+        yield* processCommittedActivity(options).pipe(Effect.provide(changed.layer), Effect.exit);
+        const pending = changed.state.pending;
+        changed.state.records = [];
+        expect(
+          yield* processCommittedActivity(options).pipe(Effect.provide(changed.layer), Effect.flip),
+        ).toMatchObject({ _tag: "ActivityProcessingError", reason: "noncontiguous" });
+        expect(changed.state.pending).toEqual(pending);
+        expect(changed.state.through).toBe(0);
+        expect(changed.state.released).toBe(2);
+        expect(changed.state.pages).toEqual([1]);
+        changed.state.records = [record(1, "mutated canonical source")];
+        const changedError = yield* processCommittedActivity(options).pipe(
+          Effect.provide(changed.layer),
+          Effect.flip,
+        );
+        expect(changedError).toMatchObject({
+          _tag: "ActivityProcessingError",
+          reason: "noncontiguous",
+        });
+        expect(applied).toBe(0);
+        expect(changed.state.through).toBe(0);
+      }),
   );
 
   it.effect(

--- a/packages/thread/test/committed-activity.test.ts
+++ b/packages/thread/test/committed-activity.test.ts
@@ -94,10 +94,10 @@ const probe = (initial: ReadonlyArray<CanonicalRecordEnvelope> = [record(1)]) =>
           ...request,
           epoch: state.epoch,
           throughSequence: state.through,
+          pending: state.pending,
           leaseExpiresAt: (yield* Clock.currentTimeMillis) + request.leaseMillis,
         });
       }),
-    loadPrepared: () => Effect.sync(() => state.pending),
     prepare: ({ work }) =>
       Effect.gen(function* () {
         state.pending = work;
@@ -116,7 +116,7 @@ const probe = (initial: ReadonlyArray<CanonicalRecordEnvelope> = [record(1)]) =>
           state.advanceLostAck = false;
           return yield* ActivityMutationFailure.make({ point: "activity:advance:after" });
         }
-        return ActivityClaim.make({ ...claim, throughSequence: state.through });
+        return ActivityClaim.make({ ...claim, throughSequence: state.through, pending: null });
       }),
     release: () =>
       Effect.sync(() => {


### PR DESCRIPTION
Project selected committed Thread records through finite, resumable passes. Each processor/version/Thread tuple reads a captured prefix in bounded pages and saves extraction before calling the host.

```ts
import type { ThreadId } from "@effect-agent/core";
import { NodeCrypto } from "@effect/platform-node";
import { SqliteClient } from "@effect/sql-sqlite-node";
import {
  activityProcessorStoreLayer,
  layer as sqliteThreadStoreLayer,
} from "@effect-agent/storage-sqlite";
import {
  ActivityPassLimits,
  ActivityProcessorKey,
  processCommittedActivity,
  type CanonicalRecordEnvelope,
  type PersistedJson,
  type PreparedActivity,
} from "@effect-agent/thread";
import { Effect, Layer } from "effect";

const filename = "agent.sqlite";
const ActivityInfrastructureLive = Layer.mergeAll(
  activityProcessorStoreLayer.pipe(Layer.provide(SqliteClient.layer({ filename }))),
  sqliteThreadStoreLayer({ filename }),
  NodeCrypto.layer,
);

export const processThreadActivity = <ExtractError, ExtractServices, ApplyError, ApplyServices>(
  threadId: ThreadId,
  owner: string,
  extract: (record: CanonicalRecordEnvelope) =>
    Effect.Effect<PersistedJson, ExtractError, ExtractServices>,
  apply: (work: PreparedActivity) => Effect.Effect<void, ApplyError, ApplyServices>,
) =>
  processCommittedActivity({
    key: ActivityProcessorKey.make({
      processorId: "project-memory",
      processorVersion: "1",
      threadId,
    }),
    owner,
    limits: ActivityPassLimits.make({
      maxRecords: 128,
      pageSize: 16,
      timeoutMillis: 30_000,
      leaseMillis: 31_000,
    }),
    extract,
    apply,
  }).pipe(Effect.provide(ActivityInfrastructureLive));
```

The Layer supplies `ActivityProcessorStore`, `ThreadStore`, and `Crypto`; the returned Effect still requires the services declared by `extract` and `apply` and retains their typed failures alongside processor and storage failures.

```mermaid
sequenceDiagram
    participant T as Thread log
    participant P as Processor
    participant S as Progress store
    participant A as Host apply
    P->>S: claim processor epoch + pending output
    T-->>P: committed record
    P->>S: save extraction + workId
    P->>A: apply(workId)
    A-->>P: durable acknowledgment
    alt normal completion
        P->>S: advance cursor
    else SIGKILL before advance
        Note over S: saved extraction remains pending
        P->>S: restart, claim fresh epoch + pending output
        P->>A: retry same workId
        A-->>P: reconcile durable receipt
        P->>S: advance cursor
    end
```

`claim` returns pending extraction in the same atomic acquisition. The processor reuses that snapshot, and `advance` returns a claim with `pending: null` after clearing it atomically. The separate `loadPrepared` method and its per-record read transaction are removed. Fencing remains on prepare and advance; destination idempotency still protects pinned work that finishes after ownership changes.

Fresh fencing epochs prevent expired workers from replacing pending output or moving progress. Recovery reuses the Schema-encoded extraction, stable work ID, and record digest even if a restarted extractor would disagree. The destination must make `apply(workId)` durably idempotent and use conditional writes. This processor does not promise exactly-once external execution. An application already in flight may finish the saved output after ownership changes, so it must not overwrite a later correction or withdrawal.

The process-level proof commits Dan's proposal through Chad's `PersistentHistory`, kills a real Node child with `SIGKILL` after SQLite memory application commits but before progress advances, then opens the same database in a second process with a deliberately divergent extractor. Recovery reuses the original work ID and output, creates no duplicate document revision, and completes the cursor. The proof also checks cross-Thread transient recall, attribution, correction, withdrawal, access isolation, stale candidates, and absence from canonical consumer history.

Freshness remains per Thread. Hosts schedule passes from each source commit and measure the documented healthy commit-to-authoritative-recall target of 60 seconds.

`vp run ready` passes, including SQLite and finite-pass suites, typed failure/timeout/interruption/finalizer coverage, lost acknowledgments, and the real `SIGKILL` restart.

Implements [KOM-17](https://linear.app/reve-ai/issue/KOM-17). Stacks on [PR #270](https://github.com/danieljvdm/effect-agent/pull/270).
