### PR TITLE
feat(platform): simplify adapter and host layer assembly

### DIFF
--- a/.changeset/quiet-browsers-read.md
+++ b/.changeset/quiet-browsers-read.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Compose WebCapture tool handlers and a Worker browser binding with `CloudflareBrowser.layer(ReadPage, { browser: env.BROWSER })`. Pass an explicit `workersAi` authorization and accounting policy to enable structured extraction.

--- a/.changeset/simple-platform-layers.md
+++ b/.changeset/simple-platform-layers.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/platform-node": patch
+---
+
+Assemble Cloudflare Code Mode, REST capture tools, interactive browsers, and thread clients with platform-owned Layer constructors. Register Node agents through `NodeDurableHost.layerRegistered(registrations, options)` while preserving application service requirements and host-scoped cleanup.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -56,7 +56,9 @@ The `remote` setting is for local development. Deployments use the binding norma
 documents the binding, compatibility date, and remote-mode requirement in its
 [Quick Actions guide](https://developers.cloudflare.com/browser-run/quick-actions/).
 
-Provide `BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })` to the adapter. Use
+For a WebCapture Tool, use `CloudflareBrowser.layer(ReadPage, { browser: env.BROWSER })` as shown
+below. For direct port access, provide
+`BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })` to the adapter. Use
 `browserQuickActionCaptureLayer` for `PageCapture` and
 `browserQuickActionScreenshotLayer` for `PageScreenshot`. The capture adapter supports rendered
 Markdown, links, selector scrape, and structured extraction. Structured extraction may invoke
@@ -154,8 +156,41 @@ or structured data.
 ## Give an agent a capture Tool
 
 Install `@effect-agent/capabilities@beta` to wrap capture in a native Effect AI Tool. Fix the allowed
-hosts, actions, and output size in the definition, then provide a `PageCapture` adapter to its
-handlers:
+hosts, actions, and output size in the definition. In a Worker, the Cloudflare package assembles
+the capture adapter, binding, and handlers in one Layer:
+
+```ts twoslash
+import { WebCapture } from "@effect-agent/capabilities";
+import {
+  CloudflareBrowser,
+  type CloudflareBrowserOptions,
+} from "@effect-agent/platform-cloudflare/browser-quick-action";
+import { Toolkit } from "effect/unstable/ai";
+
+declare const env: { BROWSER: CloudflareBrowserOptions["browser"] };
+
+const ReadPage = WebCapture.make("read_page", {
+  description: "Read example.com as rendered Markdown.",
+  urls: ["example.com"],
+  actions: ["markdown"],
+  maxResponseBytes: 16 * 1024,
+});
+
+export const BrowserTools = Toolkit.make(ReadPage.tool);
+export const ReadPageLive = CloudflareBrowser.layer(ReadPage, {
+  browser: env.BROWSER,
+});
+```
+
+Use `BrowserTools` as the agent's toolkit and provide `ReadPageLive` when running it.
+`CloudflareBrowser` is also exported from `@effect-agent/platform-cloudflare`. It accepts
+`WebCapture.makeScrape` and `WebCapture.makeExtract` definitions. Extraction requires an explicit
+`workersAi` option with an `authorizeAndAccount` Effect, using the same policy as
+`BrowserQuickActionWorkersAi.layer`. Without it, extraction fails before making a browser request.
+The constructor supplies only `PageCapture`; any schema decoding services remain required.
+It preserves the definition's host policy, output bounds, typed failures, and response cleanup.
+
+For REST capture or custom adapters, keep composing the handler Layer directly:
 
 ```ts twoslash
 import { WebCapture } from "@effect-agent/capabilities";

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -94,10 +94,11 @@ a general browsing session and cannot become an agent Tool.
 
 Install `@cloudflare/puppeteer@^1.1.0` alongside
 `@effect-agent/platform-cloudflare@beta` and `effect-cf@^0.37.0`. Then provide
-`BrowserRunInteractiveBinding.layer({ browser: env.BROWSER })` to
-`browserRunInteractiveLayer()` for browser actions. `browserRunInteractiveHostLayer()` adds trusted
-host controls for Live View and handoff. Both variants need `BrowserRunSessionLifecycle` with an
-account ID, a redacted Browser Run API token, and `FetchHttpClient.layer` for session cleanup.
+`CloudflareInteractiveBrowser.layer({ browser: env.BROWSER, accountId, apiToken })` with
+`FetchHttpClient.layer` for browser actions. `CloudflareInteractiveBrowser.hostLayer` opts into
+trusted host controls for Live View and handoff. Both variants assemble the browser binding and
+confirmed-session cleanup; the API token must be redacted. The lower-level binding, lifecycle,
+and adapter Layers remain available for custom composition.
 
 The policy is immutable when the pass opens:
 
@@ -190,13 +191,13 @@ Use `BrowserTools` as the agent's toolkit and provide `ReadPageLive` when runnin
 The constructor supplies only `PageCapture`; any schema decoding services remain required.
 It preserves the definition's host policy, output bounds, typed failures, and response cleanup.
 
-For REST capture or custom adapters, keep composing the handler Layer directly:
+For REST capture, use the Node-safe REST subpath and supply an HTTP client:
 
 ```ts twoslash
 import { WebCapture } from "@effect-agent/capabilities";
 import {
-  browserRestCaptureLayer,
-  type BrowserRestCaptureOptions,
+  CloudflareBrowserRest,
+  type CloudflareBrowserRestOptions,
 } from "@effect-agent/platform-cloudflare/browser-rest-capture";
 import { Layer } from "effect";
 import { Toolkit } from "effect/unstable/ai";
@@ -210,11 +211,8 @@ const readPage = WebCapture.make("read_page", {
 });
 
 export const BrowserTools = Toolkit.make(readPage.tool);
-export const browserToolsLive = (credentials: BrowserRestCaptureOptions) =>
-  readPage.handlers.pipe(
-    Layer.provide(browserRestCaptureLayer(credentials)),
-    Layer.provide(FetchHttpClient.layer),
-  );
+export const browserToolsLive = (credentials: CloudflareBrowserRestOptions) =>
+  CloudflareBrowserRest.layer(readPage, credentials).pipe(Layer.provide(FetchHttpClient.layer));
 ```
 
 Use `BrowserTools` as the agent's toolkit and provide `browserToolsLive(credentials)` when running
@@ -222,6 +220,10 @@ it. Use `WebCapture.makeScrape` for grouped selector results or `WebCapture.make
 Schema-validated extraction. Extraction also needs the adapter's explicit Workers AI authorization
 and accounting policy. Capture Tools have uncertain external outcomes because page rendering can
 execute JavaScript; they are not eligible for Code Mode's read-only allowlist.
+
+`CloudflareBrowserRest.layer` accepts the same optional `workersAi` policy as the Worker
+constructor. It preserves schema decoding requirements and leaves `HttpClient` injectable.
+For a custom capture adapter, provide its Layer directly to `readPage.handlers`.
 
 ## Capture and crawl {#capture-and-crawl}
 
@@ -298,11 +300,7 @@ an undispatched provider action can be identified without treating them as a suc
 
 ```ts twoslash
 // @types: @cloudflare/workers-types
-import {
-  BrowserRunInteractiveBinding,
-  BrowserRunSessionLifecycle,
-  browserRunInteractiveLayer,
-} from "@effect-agent/platform-cloudflare/interactive-browser";
+import { CloudflareInteractiveBrowser } from "@effect-agent/platform-cloudflare/interactive-browser";
 import {
   BrowserNavigateRequest,
   BrowserReadTextRequest,
@@ -327,15 +325,11 @@ declare global {
 const InteractiveLive = Layer.unwrap(
   Effect.gen(function* () {
     const env = yield* WorkerEnvironment;
-    const lifecycle = BrowserRunSessionLifecycle.layer({
+    return CloudflareInteractiveBrowser.layer({
+      browser: env.BROWSER,
       accountId: env.CLOUDFLARE_ACCOUNT_ID,
       apiToken: Redacted.make(env.BROWSER_RENDERING_API_TOKEN),
     }).pipe(Layer.provide(FetchHttpClient.layer));
-    const binding = BrowserRunInteractiveBinding.layer({ browser: env.BROWSER }).pipe(
-      Layer.provide(lifecycle),
-    );
-
-    return browserRunInteractiveLayer().pipe(Layer.provide(binding));
   }),
 );
 

--- a/docs/guide/code-mode.md
+++ b/docs/guide/code-mode.md
@@ -45,7 +45,7 @@ rows. The linked warehouse example replaces the fixed data with a brokered SQL q
 import { CodeMode } from "@effect-agent/capabilities";
 import { Agent, AgentPolicy, IdGenerator } from "@effect-agent/core";
 import { AgentRuntime, ThreadHistory, ToolExecutionClass } from "@effect-agent/engine";
-import { dynamicWorkerCodeExecutorLayer } from "@effect-agent/platform-cloudflare";
+import { CloudflareCodeMode } from "@effect-agent/platform-cloudflare";
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
 import { Effect, Layer, Redacted, Schema } from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
@@ -101,10 +101,10 @@ const analyst = Agent.make("invoice-analyst", {
 const AnalystLive = Layer.unwrap(
   Effect.gen(function* () {
     const env = yield* WorkerEnvironment;
-    const CodeModeLive = codeMode.handlers.pipe(
-      Layer.provide(InvoiceHandlers),
-      Layer.provide(dynamicWorkerCodeExecutorLayer({ loader: env.LOADER })),
-    );
+    const CodeModeLive = CloudflareCodeMode.layer(codeMode, {
+      loader: env.LOADER,
+      handlers: InvoiceHandlers,
+    });
     const ModelLive = OpenAiLanguageModel.model("gpt-4.1-mini").pipe(
       Layer.provide(
         OpenAiClient.layer({ apiKey: Redacted.make(env.OPENAI_API_KEY) }).pipe(
@@ -130,8 +130,10 @@ the [warehouse Worker](https://github.com/danieljvdm/effect-agent/blob/main/exam
 shows the example's HTTP behavior.
 
 `CodeMode.make` fixes the namespaces and methods visible to generated code. Include `codeMode.tool`
-in the agent's Toolkit and provide the selected Tool handlers and executor **to `codeMode.handlers`**.
-This captures the services used by the inner calls. The runtime supplies its own Tool broker.
+in the agent's Toolkit. `CloudflareCodeMode.layer` supplies the selected Tool handlers and executor
+at construction, capturing the services used by inner calls. Handler construction errors and
+remaining service requirements stay visible. The runtime supplies its own Tool broker.
+For a custom executor, provide it and the selected handlers directly to `codeMode.handlers`.
 
 Code Mode accepts only Tools annotated `readonly` and without approval requirements. That annotation
 does not make a database connection read-only. Enforce resource and tenant access inside handlers;
@@ -176,7 +178,8 @@ binding that gives a Worker access to `env.LOADER`.
 }
 ```
 
-The `dynamicWorkerCodeExecutorLayer({ loader })` in the example above uses that resolved binding.
+`CloudflareCodeMode.layer` uses that resolved binding. The lower-level
+`dynamicWorkerCodeExecutorLayer({ loader })` remains available for direct `CodeExecutor` access.
 
 See Cloudflare's [Dynamic Workers guide](https://developers.cloudflare.com/dynamic-workers/getting-started/)
 for Worker Loader setup and loading modes. This adapter uses `load()` for a fresh pass.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -133,16 +133,15 @@ for Workers using the older `migrations` array.
 
 ```ts twoslash
 // @types: @cloudflare/workers-types
-import { CloudflareThreadClient, threadNamespaceLayer } from "@effect-agent/platform-cloudflare";
-import { BrowserCrypto } from "@effect/platform-browser";
-import { Layer } from "effect";
+import { CloudflareThreadClient, type ThreadObjectRpc } from "@effect-agent/platform-cloudflare";
 
-export const threadClientLayer = (env: unknown) =>
-  CloudflareThreadClient.layer.pipe(
-    Layer.provide(threadNamespaceLayer(env, "THREADS")),
-    Layer.provide(BrowserCrypto.layer),
-  );
+export const threadClientLayer = (env: { THREADS: DurableObjectNamespace<ThreadObjectRpc> }) =>
+  CloudflareThreadClient.layerFromBinding({ namespace: env.THREADS });
 ```
+
+This constructor supplies the namespace and platform Crypto. Pass `rpcTracing: "THREADS"` only
+when the receiver also enables native RPC tracing. Keep `CloudflareThreadClient.layer` for
+custom Crypto or namespace composition, and `threadNamespaceLayer` for untyped environment lookup.
 
 In an authenticated handler, call `client.submit(agent, input, options)` with the thread ID,
 principal, idempotency key, and definition digests. Return its receipt after admission.

--- a/docs/platforms/node.md
+++ b/docs/platforms/node.md
@@ -23,11 +23,14 @@ Keep framework packages at one release and use compatible [Effect and provider p
 Use a persistent database path with one live host per SQLite file. Give each replacement host
 incarnation a distinct `producerId`.
 `workerConcurrency` limits worker loops and defaults to one.
-`NodeDurableHost.layerStack` checks storage and runs recovery before accepting work.
+`NodeDurableHost.layerRegistered` checks storage and runs recovery before accepting work.
 
-Create the `ResolvedBinding` values with `compileRegistrations` from `@effect-agent/thread`.
-Supply Crypto, provider clients, and tool handlers while compiling. Keep those Layers alive
-in the host's application Scope.
+Pass typed agent registrations to `NodeDurableHost.layerRegistered`. It computes definition
+digests and captures worker services in the host Layer's Scope. Node supplies Crypto; provide
+model clients, tool handlers, instruction services, and schema services to the returned Layer.
+Keep the concrete registration tuple inferred so its requirements remain visible.
+Use `NodeDurableHost.layerStack` when you already have `ResolvedBinding` values from
+`compileRegistrations` and own their application Scope yourself.
 
 Registrations include JSON descriptions and versions for the agent, model, and toolkit.
 Version tool implementations and other behavior JSON cannot represent.
@@ -41,36 +44,37 @@ Use `digestDefinitions` to compute submission digests.
 
 ```ts twoslash
 import { NodeDurableHost } from "@effect-agent/platform-node";
-import type { ResolvedBinding } from "@effect-agent/thread";
-import { NodeRuntime } from "@effect/platform-node";
+import type { AgentRegistration } from "@effect-agent/thread";
 import { Effect } from "effect";
 
-export const startWorkers = (bindings: ReadonlyArray<ResolvedBinding>) =>
+export const workers = <const Entries extends ReadonlyArray<AgentRegistration>>(
+  registrations: Entries,
+) =>
   Effect.gen(function* () {
     const host = yield* NodeDurableHost;
     yield* host.runResolvedWorkers;
   }).pipe(
     Effect.provide(
-      NodeDurableHost.layerStack({
+      NodeDurableHost.layerRegistered(registrations, {
         filename: "./agents.sqlite",
         deploymentId: "travel-planner",
         producerId: "worker-1",
         workerConcurrency: 4,
-        bindings,
       }),
     ),
     Effect.scoped,
-    NodeRuntime.runMain,
   );
 ```
 
-Call `startWorkers(bindings)` at the process entry point. Creating the host alone does not
-start workers. If the process also serves requests, share one host Layer between both effects.
+Provide the remaining application services to `workers(registrations)`, then call
+`NodeRuntime.runMain` at the process entry point. Creating the host alone does not start workers.
+If the process also serves requests, share one host Layer between both effects.
 Use `NodeDurableRuntime.layer` for custom lifecycle composition.
 
 ## Configure runtime services
 
-Pass service layers through `NodeDurableHost.layerStack` or `NodeDurableRuntime.layer`:
+Pass service layers through `NodeDurableHost.layerRegistered`, `NodeDurableHost.layerStack`,
+or `NodeDurableRuntime.layer`:
 
 | Option              | Service                 | Default                                                     |
 | ------------------- | ----------------------- | ----------------------------------------------------------- |

--- a/examples/browser-run-worker-proof/README.md
+++ b/examples/browser-run-worker-proof/README.md
@@ -8,7 +8,7 @@ do not need that optional peer dependency.
 
 This private class E example proves the shipped Cloudflare Browser Run binding path against one
 temporary deployed Worker. The Worker resolves `env.BROWSER` through
-`BrowserQuickActionBrowserBinding.layer`, provides `browserQuickActionCaptureLayer`, and invokes a
+`CloudflareBrowser.layer` and invokes a
 `WebCapture.make` handler directly. It captures `https://example.com/` as bounded Markdown and
 keeps the stable `Example Domain` fact. It then invokes `WebCapture.makeScrape` with the `h1` and
 `a` selectors, validates the grouped heading result, and discards the rendered records. During the

--- a/examples/browser-run-worker-proof/src/worker.ts
+++ b/examples/browser-run-worker-proof/src/worker.ts
@@ -7,11 +7,9 @@ import {
 import {
   BrowserRunHandoffRequest,
   BrowserRunCleanupError,
-  BrowserRunInteractiveBinding,
+  CloudflareInteractiveBrowser,
   BrowserRunInteractiveHost,
-  BrowserRunSessionLifecycle,
   BrowserRunLiveViewRequest,
-  browserRunInteractiveHostLayer,
 } from "@effect-agent/platform-cloudflare/interactive-browser";
 import {
   BrowserNavigateRequest,
@@ -107,14 +105,10 @@ const proofLayer = Layer.unwrap(
     const quickActionLayer = browserQuickActionScreenshotLayer().pipe(
       Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })),
     );
-    const interactiveLayer = browserRunInteractiveHostLayer().pipe(
-      Layer.provide(BrowserRunInteractiveBinding.layer({ browser: env.BROWSER })),
-      Layer.provide(
-        BrowserRunSessionLifecycle.layer(lifecycleConfig).pipe(
-          Layer.provide(FetchHttpClient.layer),
-        ),
-      ),
-    );
+    const interactiveLayer = CloudflareInteractiveBrowser.hostLayer({
+      browser: env.BROWSER,
+      ...lifecycleConfig,
+    }).pipe(Layer.provide(FetchHttpClient.layer));
     const browserRunLayer = Layer.merge(quickActionLayer, interactiveLayer);
     return Layer.merge(
       CloudflareBrowser.layer(proofCapture, { browser: env.BROWSER }),

--- a/examples/browser-run-worker-proof/src/worker.ts
+++ b/examples/browser-run-worker-proof/src/worker.ts
@@ -1,7 +1,7 @@
 import { WebCapture, WebCaptureScrapeSuccess, WebCaptureSuccess } from "@effect-agent/capabilities";
 import {
   BrowserQuickActionBrowserBinding,
-  browserQuickActionCaptureLayer,
+  CloudflareBrowser,
   browserQuickActionScreenshotLayer,
 } from "@effect-agent/platform-cloudflare/browser-quick-action";
 import {
@@ -104,10 +104,9 @@ const proofLayer = Layer.unwrap(
       accountId: Config.string("CLOUDFLARE_ACCOUNT_ID"),
       apiToken: Config.redacted("BROWSER_RENDERING_API_TOKEN"),
     }).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(env)));
-    const quickActionLayer = Layer.mergeAll(
-      browserQuickActionCaptureLayer(),
-      browserQuickActionScreenshotLayer(),
-    ).pipe(Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })));
+    const quickActionLayer = browserQuickActionScreenshotLayer().pipe(
+      Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })),
+    );
     const interactiveLayer = browserRunInteractiveHostLayer().pipe(
       Layer.provide(BrowserRunInteractiveBinding.layer({ browser: env.BROWSER })),
       Layer.provide(
@@ -117,9 +116,10 @@ const proofLayer = Layer.unwrap(
       ),
     );
     const browserRunLayer = Layer.merge(quickActionLayer, interactiveLayer);
-    return Layer.merge(proofCapture.handlers, proofScrape.handlers).pipe(
-      Layer.provideMerge(browserRunLayer),
-    );
+    return Layer.merge(
+      CloudflareBrowser.layer(proofCapture, { browser: env.BROWSER }),
+      CloudflareBrowser.layer(proofScrape, { browser: env.BROWSER }),
+    ).pipe(Layer.provideMerge(browserRunLayer));
   }),
 );
 

--- a/examples/code-mode-cloudflare/src/agent.ts
+++ b/examples/code-mode-cloudflare/src/agent.ts
@@ -1,7 +1,8 @@
 import { CodeMode } from "@effect-agent/capabilities";
 import { Agent, AgentPolicy } from "@effect-agent/core";
 import { ToolExecutionClass } from "@effect-agent/engine";
-import { Effect, Layer, Schema } from "effect";
+import type { Layer } from "effect";
+import { Effect, Schema } from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import { Warehouse } from "./warehouse-object.ts";
@@ -101,6 +102,3 @@ export const codeModeAgent = Agent.make("warehouse-analyst", {
     toolConcurrency: 1,
   }),
 });
-
-/** The composed handler Layer, minus the `CodeExecutor` (supplied by the host). */
-export const codeModeHandlersLayer = codeMode.handlers.pipe(Layer.provide(warehouseHandlersLayer));

--- a/examples/code-mode-cloudflare/src/worker.ts
+++ b/examples/code-mode-cloudflare/src/worker.ts
@@ -1,12 +1,9 @@
 import { IdGenerator } from "@effect-agent/core";
 import { AgentRuntime, ThreadHistory } from "@effect-agent/engine";
-import {
-  dynamicWorkerCodeExecutorLayer,
-  dynamicWorkerImplementation,
-} from "@effect-agent/platform-cloudflare";
+import { CloudflareCodeMode, dynamicWorkerImplementation } from "@effect-agent/platform-cloudflare";
 import { Effect, Layer, Stream } from "effect";
 
-import { codeModeHandlersLayer } from "./agent.ts";
+import { codeMode, warehouseHandlersLayer } from "./agent.ts";
 import { liveAgent, scriptedAgent, scriptedWriteProbeAgent } from "./profiles.ts";
 import { isValidTenant, Warehouse, WarehouseObject, warehouseLayer } from "./warehouse-object.ts";
 
@@ -111,10 +108,10 @@ const runBound = (
   // provided INTO it (its handler runs with the captured construction
   // context); the Run additionally needs IdGenerator.
   const layers = Layer.mergeAll(
-    codeModeHandlersLayer.pipe(
-      Layer.provide(warehouseLayer(env.WAREHOUSE, tenant)),
-      Layer.provide(dynamicWorkerCodeExecutorLayer({ loader: env.LOADER })),
-    ),
+    CloudflareCodeMode.layer(codeMode, {
+      loader: env.LOADER,
+      handlers: warehouseHandlersLayer.pipe(Layer.provide(warehouseLayer(env.WAREHOUSE, tenant))),
+    }),
     IdGenerator.layer,
     ThreadHistory.layerTransient,
   );

--- a/examples/providers/test/browser-rest-node-import.test.ts
+++ b/examples/providers/test/browser-rest-node-import.test.ts
@@ -1,9 +1,10 @@
 import {
+  CloudflareBrowserRest,
   browserRestWorkersAiCaptureLayer,
   type browserRestCaptureLayer,
 } from "@effect-agent/platform-cloudflare/browser-rest-capture";
 import type { PageCapture } from "@effect-agent/sandbox";
-import { Redacted, type Layer } from "effect";
+import { Redacted, Layer } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 import { expect, it } from "vite-plus/test";
 
@@ -38,4 +39,5 @@ it("loads and composes the REST subpath in a Node-only consumer", async () => {
   expect(requirement && output).toBe(true);
   // This source imports no Worker globals; a cloudflare: runtime dependency would fail this Node test.
   expect(browserRestWorkersAiCaptureLayer(options)).toBeDefined();
+  expect(CloudflareBrowserRest.layer({ handlers: Layer.empty }, options)).toBeDefined();
 });

--- a/packages/platform-cloudflare/src/bindings.ts
+++ b/packages/platform-cloudflare/src/bindings.ts
@@ -66,8 +66,12 @@ export class ThreadObjectNamespace extends Context.Service<
 >()("@effect-agent/platform-cloudflare/ThreadObjectNamespace") {
   static layer(
     namespace: DurableObjectNamespace<ThreadObjectRpc>,
+    options: { readonly rpcTracing?: string } = {},
   ): Layer.Layer<ThreadObjectNamespace> {
-    return Layer.succeed(ThreadObjectNamespace)({ namespace });
+    return Layer.succeed(ThreadObjectNamespace)({
+      namespace,
+      ...(options.rpcTracing === undefined ? {} : { rpcTracing: options.rpcTracing }),
+    });
   }
 }
 

--- a/packages/platform-cloudflare/src/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/browser-quick-action.ts
@@ -547,6 +547,37 @@ export const browserQuickActionWorkersAiCaptureLayer = (): Layer.Layer<
     }),
   );
 
+/** Host-owned Quick Action binding and optional, separately billed extraction authority. */
+export interface CloudflareBrowserOptions extends BrowserQuickActionCaptureOptions {
+  readonly workersAi?: BrowserQuickActionWorkersAiPolicy;
+}
+
+/** Compose WebCapture handlers with the Cloudflare Quick Action adapter. */
+export const CloudflareBrowser = {
+  /**
+   * Supply a WebCapture definition and the resolved Worker browser binding.
+   * Supports capture, scrape, and extraction definitions without importing capabilities.
+   * Only PageCapture is provided; other handler requirements and errors stay visible.
+   * Extraction fails closed unless workersAi explicitly authorizes and accounts for it.
+   * Capture limits, typed failures, tracing, and scoped response cleanup are unchanged.
+   */
+  layer: <A, E, R>(
+    definition: { readonly handlers: Layer.Layer<A, E, R> },
+    options: CloudflareBrowserOptions,
+  ): Layer.Layer<A, E, Exclude<R, PageCapture>> => {
+    const capture =
+      options.workersAi === undefined
+        ? browserQuickActionCaptureLayer()
+        : browserQuickActionWorkersAiCaptureLayer().pipe(
+            Layer.provide(BrowserQuickActionWorkersAi.layer(options.workersAi)),
+          );
+
+    return definition.handlers.pipe(
+      Layer.provide(capture.pipe(Layer.provide(BrowserQuickActionBrowserBinding.layer(options)))),
+    );
+  },
+};
+
 const screenshotOptions = (request: PageScreenshotRequest): BrowserRunScreenshotOptions => {
   const options: BrowserRunBaseOptions = {};
   if (

--- a/packages/platform-cloudflare/src/browser-rest-capture.ts
+++ b/packages/platform-cloudflare/src/browser-rest-capture.ts
@@ -418,3 +418,30 @@ export const browserRestWorkersAiCaptureLayer = (
       return PageCapture.of({ capture: makeCapture(client, options, workersAi) });
     }),
   );
+
+/** Explicit REST credentials and optional authorization for separately billed extraction. */
+export interface CloudflareBrowserRestOptions extends BrowserRestCaptureOptions {
+  readonly workersAi?: BrowserQuickActionWorkersAiPolicy;
+}
+
+/** Node-safe WebCapture handler assembly; the application supplies its HttpClient. */
+export const CloudflareBrowserRest = {
+  /**
+   * Supports capture, scrape, and extraction definitions. Only PageCapture is supplied;
+   * handler errors and other services remain visible. Extraction fails closed without
+   * workersAi. Existing host policies, response limits, and scoped cleanup are unchanged.
+   */
+  layer: <A, E, R>(
+    definition: { readonly handlers: Layer.Layer<A, E, R> },
+    options: CloudflareBrowserRestOptions,
+  ): Layer.Layer<A, E, Exclude<R, PageCapture> | HttpClient.HttpClient> => {
+    const capture =
+      options.workersAi === undefined
+        ? browserRestCaptureLayer(options)
+        : browserRestWorkersAiCaptureLayer(options).pipe(
+            Layer.provide(BrowserQuickActionWorkersAi.layer(options.workersAi)),
+          );
+
+    return definition.handlers.pipe(Layer.provide(capture));
+  },
+};

--- a/packages/platform-cloudflare/src/client.ts
+++ b/packages/platform-cloudflare/src/client.ts
@@ -30,6 +30,7 @@ import {
   type DurableSubmitAgent,
   type DurableSubmitOptions,
 } from "@effect-agent/thread";
+import { BrowserCrypto } from "@effect/platform-browser";
 import { Context, Crypto, Duration, Effect, Layer, Schema } from "effect";
 import { RpcTracing } from "effect-cf";
 
@@ -387,6 +388,20 @@ export class CloudflareThreadClient extends Context.Service<
     ) => Effect.Effect<UnknownResolutionIntent, ClientUnknownFailure>;
   }
 >()("@effect-agent/platform-cloudflare/CloudflareThreadClient") {
+  /**
+   * Assemble the client from a resolved namespace and the platform Crypto implementation.
+   * rpcTracing is the binding name and remains opt-in. Caller authentication, principals,
+   * idempotency keys, and definition digests are still explicit submission inputs.
+   */
+  static layerFromBinding(options: {
+    readonly namespace: DurableObjectNamespace<ThreadObjectRpc>;
+    readonly rpcTracing?: string;
+  }): Layer.Layer<CloudflareThreadClient> {
+    return CloudflareThreadClient.layer.pipe(
+      Layer.provide([ThreadObjectNamespace.layer(options.namespace, options), BrowserCrypto.layer]),
+    );
+  }
+
   static readonly layer: Layer.Layer<
     CloudflareThreadClient,
     never,

--- a/packages/platform-cloudflare/src/code-mode-executor.ts
+++ b/packages/platform-cloudflare/src/code-mode-executor.ts
@@ -814,3 +814,22 @@ export const dynamicWorkerCodeExecutorLayer = (
       return CodeExecutor.of({ execute: makeExecute(options, clock) });
     }),
   );
+
+/** Assemble Code Mode handlers with the isolated Dynamic Worker executor. */
+export const CloudflareCodeMode = {
+  /**
+   * Provide the selected tool handlers at construction, where Code Mode captures them.
+   * Their errors and remaining dependencies stay visible. The definition still owns the
+   * allowlist and limits; the runtime supplies the live Tool broker for each scoped pass.
+   */
+  layer: <A, E, R, Handlers, HandlerError, HandlerRequirements>(
+    definition: { readonly handlers: Layer.Layer<A, E, R> },
+    options: DynamicWorkerCodeExecutorOptions & {
+      readonly handlers: Layer.Layer<Handlers, HandlerError, HandlerRequirements>;
+    },
+  ) =>
+    definition.handlers.pipe(
+      Layer.provide(options.handlers),
+      Layer.provide(dynamicWorkerCodeExecutorLayer(options)),
+    ),
+};

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -26,3 +26,4 @@ export * from "./prepared-admission.ts";
 export * from "./scheduling.ts";
 export * from "./subscriptions.ts";
 export * from "./code-mode-executor.ts";
+export { CloudflareBrowser, type CloudflareBrowserOptions } from "./browser-quick-action.ts";

--- a/packages/platform-cloudflare/src/interactive-browser.ts
+++ b/packages/platform-cloudflare/src/interactive-browser.ts
@@ -44,7 +44,10 @@ import {
   type Scope,
 } from "effect";
 
-import { BrowserRunSessionLifecycle } from "./browser-session-lifecycle.ts";
+import {
+  BrowserRunSessionLifecycle,
+  type BrowserRunLifecycleOptions,
+} from "./browser-session-lifecycle.ts";
 export { BrowserRunCleanupError, BrowserRunSessionLifecycle } from "./browser-session-lifecycle.ts";
 
 export const browserRunInteractiveImplementation = SandboxImplementation.make({
@@ -2145,3 +2148,28 @@ export const browserRunInteractiveLayer = (): Layer.Layer<
       });
     }),
   );
+
+/** Resolved Worker binding, cleanup credentials, and optional initial viewport. */
+export interface CloudflareInteractiveBrowserOptions extends BrowserRunLifecycleOptions {
+  readonly browser: BrowserRun;
+  readonly viewport?: BrowserRunViewport;
+}
+
+const interactiveBindingLayer = (options: CloudflareInteractiveBrowserOptions) =>
+  BrowserRunInteractiveBinding.layer(options).pipe(
+    Layer.provide(BrowserRunSessionLifecycle.layer(options)),
+  );
+
+/** Worker-only assembly; importing ordinary capture never loads Puppeteer. */
+export const CloudflareInteractiveBrowser = {
+  /**
+   * Assemble binding, confirmed-session cleanup, and the generic browser service.
+   * HttpClient and construction errors remain visible. Opening a pass still requires
+   * an explicit policy and Scope; no browser is launched during Layer construction.
+   */
+  layer: (options: CloudflareInteractiveBrowserOptions) =>
+    browserRunInteractiveLayer().pipe(Layer.provide(interactiveBindingLayer(options))),
+  /** Opt into private host controls instead of exposing them through the generic service. */
+  hostLayer: (options: CloudflareInteractiveBrowserOptions) =>
+    browserRunInteractiveHostLayer().pipe(Layer.provide(interactiveBindingLayer(options))),
+};

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -1,3 +1,4 @@
+import { WebCapture } from "@effect-agent/capabilities";
 import {
   CapturePageContent,
   CapturePageLinks,
@@ -12,14 +13,17 @@ import {
   type PageCaptureError,
   type PageCaptureResult,
 } from "@effect-agent/sandbox";
-import { Deferred, Effect, Fiber, Layer } from "effect";
-import { describe, expect, it } from "vite-plus/test";
+import { Context, Deferred, Effect, Fiber, Layer, Schema, SchemaGetter, Stream } from "effect";
+import type { Tool } from "effect/unstable/ai";
+import { Toolkit } from "effect/unstable/ai";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
 
 import {
   BrowserQuickActionBrowserBinding,
   BrowserQuickActionRpcError,
   BrowserQuickActionWorkersAi,
   BrowserQuickActionWorkersAiPolicyError,
+  CloudflareBrowser,
   browserQuickActionCaptureLayer,
   browserQuickActionWorkersAiCaptureLayer,
   type BrowserQuickActionCaptureOptions,
@@ -152,6 +156,121 @@ type WorkersAiAuthorityIsVisible = Equal<
 type NativeBrowserRunIsLayerInput = Equal<BrowserQuickActionCaptureOptions["browser"], BrowserRun>;
 
 describe("Browser Run Quick Action PageCapture adapter", () => {
+  it("assembles named handlers and enforces their host policy through the native binding", async () => {
+    const calls: Array<unknown> = [];
+    const browser: BrowserRun = {
+      fetch: () => Promise.reject(new Error("Unexpected fetch")),
+      quickAction: (action, options) => {
+        calls.push({ action, options });
+        return Promise.resolve(jsonResponse({ success: true, result: "# Pricing" }));
+      },
+    };
+    const ReadPage = WebCapture.make("read_page", {
+      description: "Read pricing",
+      urls: ["docs.example.com"],
+      actions: ["markdown"],
+    });
+    const live = CloudflareBrowser.layer(ReadPage, { browser });
+
+    expectTypeOf(live).toEqualTypeOf<
+      Layer.Layer<Tool.HandlersFor<{ read_page: typeof ReadPage.tool }>>
+    >();
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const toolkit = yield* Toolkit.make(ReadPage.tool);
+        const allowed = yield* toolkit.handle("read_page", {
+          url: "https://docs.example.com/pricing",
+          action: "markdown",
+        });
+        const denied = yield* toolkit.handle("read_page", {
+          url: "https://attacker.example/pricing",
+          action: "markdown",
+        });
+        return [yield* Stream.runCollect(allowed), yield* Stream.runCollect(denied)];
+      }).pipe(Effect.provide(live)),
+    );
+
+    expect(results).toMatchObject([
+      [{ result: { markdown: "# Pricing" } }],
+      [{ result: { _tag: "WebCaptureFailure", errorTag: "WebCaptureUrlDenied" } }],
+    ]);
+    expect(calls).toMatchObject([
+      { action: "markdown", options: { url: "https://docs.example.com/pricing" } },
+    ]);
+  });
+
+  it("requires explicit Workers AI authority and preserves extraction decoder requirements", async () => {
+    class Decoder extends Context.Service<Decoder, { readonly value: string }>()("test/Decoder") {}
+    const Extract = WebCapture.makeExtract("extract_page", {
+      description: "Extract pricing",
+      urls: ["docs.example.com"],
+      schema: Schema.Struct({
+        name: Schema.String.pipe(
+          Schema.decodeTo(Schema.String, {
+            decode: SchemaGetter.transformOrFail((value) =>
+              Effect.map(Decoder, (decoder) => value + decoder.value),
+            ),
+            encode: SchemaGetter.transform((value) => value),
+          }),
+        ),
+      }),
+    });
+    const events: Array<string> = [];
+    const browser: BrowserRun = {
+      fetch: () => Promise.reject(new Error("Unexpected fetch")),
+      quickAction: (action) => {
+        events.push(action);
+        return Promise.resolve(jsonResponse({ success: true, result: { name: "Pro" } }));
+      },
+    };
+    const denied = CloudflareBrowser.layer(Extract, { browser });
+    const allowed = CloudflareBrowser.layer(Extract, {
+      browser,
+      workersAi: {
+        authorizeAndAccount: () =>
+          Effect.sync(() => {
+            events.push("authorize");
+          }),
+      },
+    });
+
+    expectTypeOf(allowed).toEqualTypeOf<
+      Layer.Layer<Tool.HandlersFor<{ extract_page: typeof Extract.tool }>, never, Decoder>
+    >();
+    const invoke = Effect.gen(function* () {
+      const toolkit = yield* Toolkit.make(Extract.tool);
+      const output = yield* toolkit.handle("extract_page", { url: "https://docs.example.com/" });
+      return yield* Stream.runCollect(output);
+    });
+    const decoder = Layer.succeed(Decoder, { value: " plan" });
+    const refused = await Effect.runPromise(
+      invoke.pipe(Effect.provide(denied.pipe(Layer.provideMerge(decoder)))),
+    );
+
+    expect(refused).toMatchObject([
+      { result: { _tag: "WebCaptureFailure", errorTag: "PageCaptureUnsupportedError" } },
+    ]);
+    expect(events).toEqual([]);
+    const result = await Effect.runPromise(
+      invoke.pipe(Effect.provide(allowed.pipe(Layer.provideMerge(decoder)))),
+    );
+
+    expect(result).toMatchObject([{ result: { name: "Pro plan" } }]);
+    expect(events).toEqual(["authorize", "json"]);
+
+    const fallible = CloudflareBrowser.layer(
+      {
+        handlers: Extract.handlers.pipe(
+          Layer.provide(Layer.effect(Decoder, Effect.fail("setup" as const))),
+        ),
+      },
+      { browser },
+    );
+    expectTypeOf(fallible).toEqualTypeOf<
+      Layer.Layer<Tool.HandlersFor<{ extract_page: typeof Extract.tool }>, "setup">
+    >();
+  });
+
   it("keeps browser RPC and separately billed Workers AI authority visible in adapter Layers", () => {
     const browserProof: BrowserBindingAuthorityIsVisible = true;
     const workersAiProof: WorkersAiAuthorityIsVisible = true;

--- a/packages/platform-cloudflare/test/browser-rest-capture.test.ts
+++ b/packages/platform-cloudflare/test/browser-rest-capture.test.ts
@@ -1,3 +1,4 @@
+import { WebCapture } from "@effect-agent/capabilities";
 import {
   CapturePageMarkdown,
   CapturePageScrape,
@@ -8,8 +9,10 @@ import {
   PageUrlTarget,
 } from "@effect-agent/sandbox";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Logger, Redacted, Ref, type Layer } from "effect";
+import { Effect, Logger, Redacted, Ref, Schema, Stream, type Layer } from "effect";
+import { Toolkit } from "effect/unstable/ai";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { expectTypeOf } from "vite-plus/test";
 
 import {
   BrowserQuickActionWorkersAi,
@@ -19,6 +22,7 @@ import {
   browserRestCaptureImplementation,
   browserRestCaptureLayer,
   browserRestWorkersAiCaptureLayer,
+  CloudflareBrowserRest,
 } from "../src/browser-rest-capture.ts";
 
 type Equal<Left, Right> =
@@ -69,6 +73,57 @@ const captureWith = (client: HttpClient.HttpClient, input = request()) =>
   );
 
 describe("Browser Run REST PageCapture adapter", () => {
+  it.effect(
+    "assembles extraction handlers while retaining HTTP injection and explicit AI authority",
+    () =>
+      Effect.gen(function* () {
+        const definition = WebCapture.makeExtract("extract_plan", {
+          description: "Read plan",
+          urls: ["docs.example.com"],
+          schema: Schema.Struct({ name: Schema.String }),
+        });
+        const calls: Array<string> = [];
+        const client = HttpClient.make((request) =>
+          Effect.sync(() => {
+            calls.push("request");
+            return HttpClientResponse.fromWeb(
+              request,
+              response('{"success":true,"result":{"name":"Pro"}}'),
+            );
+          }),
+        );
+        const options = { accountId: "account", apiToken: Redacted.make("token") };
+        const denied = CloudflareBrowserRest.layer(definition, options);
+        const allowed = CloudflareBrowserRest.layer(definition, {
+          ...options,
+          workersAi: {
+            authorizeAndAccount: () =>
+              Effect.sync(() => {
+                calls.push("authorize");
+              }),
+          },
+        });
+        expectTypeOf<Layer.Services<typeof allowed>>().toEqualTypeOf<HttpClient.HttpClient>();
+        const invoke = Effect.gen(function* () {
+          const toolkit = yield* Toolkit.make(definition.tool);
+          return yield* Stream.runCollect(
+            yield* toolkit.handle("extract_plan", { url: "https://docs.example.com/" }),
+          );
+        });
+        const refused = yield* invoke.pipe(
+          Effect.provide(denied),
+          Effect.provideService(HttpClient.HttpClient, client),
+        );
+        expect(refused).toMatchObject([{ result: { errorTag: "PageCaptureUnsupportedError" } }]);
+        expect(calls).toEqual([]);
+        const result = yield* invoke.pipe(
+          Effect.provide(allowed),
+          Effect.provideService(HttpClient.HttpClient, client),
+        );
+        expect(result).toMatchObject([{ result: { name: "Pro" } }]);
+        expect(calls).toEqual(["authorize", "request"]);
+      }),
+  );
   it("keeps its Node-safe Layer requirements visible", () => {
     const httpClient: RestRequiresHttpClient = true;
     const workersAi: RestWorkersAiRequiresVisibleAuthorities = true;

--- a/packages/platform-cloudflare/test/code-mode-layer.test.ts
+++ b/packages/platform-cloudflare/test/code-mode-layer.test.ts
@@ -1,0 +1,60 @@
+import { CodeMode } from "@effect-agent/capabilities";
+import { ToolExecutionClass } from "@effect-agent/engine";
+import { Context, Effect, Layer, Schema } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+
+import { CloudflareCodeMode } from "../src/index.ts";
+
+class Database extends Context.Service<Database, { readonly count: number }>()("test/Database") {}
+class SetupError extends Schema.TaggedError<SetupError>()("SetupError", {}) {}
+const Read = Tool.make("read_count", {
+  parameters: Schema.Struct({ key: Schema.String }),
+  success: Schema.Number,
+}).annotate(ToolExecutionClass, "readonly");
+const Other = Tool.make("read_other", {
+  parameters: Schema.Struct({ key: Schema.String }),
+  success: Schema.String,
+}).annotate(ToolExecutionClass, "readonly");
+const definition = CodeMode.make("run_code", {
+  description: "Read counts",
+  tools: { first: { read: Read }, second: { read: Other } },
+});
+const loader: WorkerLoader = {
+  get: () => {
+    throw new Error("Unexpected worker get");
+  },
+  load: () => {
+    throw new Error("Unexpected worker load");
+  },
+};
+
+describe("Cloudflare Code Mode assembly", () => {
+  it("preserves missing handlers, application dependencies, and handler setup failures", async () => {
+    const handlers = Toolkit.make(Read).toLayer(
+      Effect.gen(function* () {
+        const database = yield* Database;
+        if (database.count < 0) return yield* SetupError.make({});
+        return { read_count: () => Effect.succeed(database.count) };
+      }),
+    );
+    const partial = CloudflareCodeMode.layer(definition, { loader, handlers });
+    expectTypeOf<Layer.Services<typeof partial>>().toEqualTypeOf<
+      Database | Tool.Handler<"read_other">
+    >();
+    expectTypeOf<Layer.Error<typeof partial>>().toEqualTypeOf<SetupError>();
+    expectTypeOf<Layer.Success<typeof partial>>().toEqualTypeOf<Tool.Handler<"run_code">>();
+
+    const complete = CloudflareCodeMode.layer(definition, {
+      loader,
+      handlers: Layer.merge(
+        handlers,
+        Toolkit.make(Other).toLayer({ read_other: () => Effect.succeed("other") }),
+      ),
+    });
+    expectTypeOf<Layer.Services<typeof complete>>().toEqualTypeOf<Database>();
+    const build = Layer.build(complete.pipe(Layer.provide(Layer.succeed(Database, { count: -1 }))));
+    const error = await Effect.runPromise(build.pipe(Effect.scoped, Effect.flip));
+    expect(error).toBeInstanceOf(SetupError);
+  });
+});

--- a/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
+++ b/packages/platform-cloudflare/test/interactive-browser-viewport.test.ts
@@ -1,13 +1,15 @@
-import { InteractiveBrowserPolicy } from "@effect-agent/sandbox";
+import { InteractiveBrowser, InteractiveBrowserPolicy } from "@effect-agent/sandbox";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Schema } from "effect";
-import { vi } from "vite-plus/test";
+import { Effect, Layer, Redacted, Schema } from "effect";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { expectTypeOf, vi } from "vite-plus/test";
 
 import { BrowserRunSessionLifecycle } from "../src/browser-session-lifecycle.ts";
 import {
   BrowserRunInteractiveBinding,
   BrowserRunInteractiveHost,
   BrowserRunViewport,
+  CloudflareInteractiveBrowser,
   browserRunInteractiveHostLayer,
 } from "../src/interactive-browser.ts";
 
@@ -32,6 +34,27 @@ const open = Effect.gen(function* () {
 });
 
 describe("Browser Run viewport boundary", () => {
+  it.effect("assembles generic browser access without host controls or an eager launch", () =>
+    Effect.gen(function* () {
+      sdk.launch.mockClear();
+      const live = CloudflareInteractiveBrowser.layer({
+        browser,
+        accountId: "1234567890abcdef1234567890abcdef",
+        apiToken: Redacted.make("token"),
+      });
+      expectTypeOf<Layer.Success<typeof live>>().toEqualTypeOf<InteractiveBrowser>();
+      expectTypeOf<Layer.Services<typeof live>>().toEqualTypeOf<HttpClient.HttpClient>();
+      const service = yield* InteractiveBrowser.pipe(
+        Effect.provide(live),
+        Effect.provideService(
+          HttpClient.HttpClient,
+          HttpClient.make(() => Effect.die("Unexpected HTTP request")),
+        ),
+      );
+      expect(service.open).toBeTypeOf("function");
+      expect(sdk.launch).not.toHaveBeenCalled();
+    }),
+  );
   it.effect.each([
     { width: 1, height: 1 },
     { width: 2_048, height: 2_048 },
@@ -120,6 +143,18 @@ describe("Browser Run viewport boundary", () => {
         sdk.launch.mockClear();
         const setViewport = vi.fn<(...args: Array<unknown>) => Promise<void>>(async () => {});
         mockBrowser(setViewport);
+        const cleanupCalls: Array<string> = [];
+        const client = HttpClient.make((request, url) =>
+          Effect.sync(() => {
+            cleanupCalls.push(`${request.method} ${url.pathname}`);
+            return HttpClientResponse.fromWeb(
+              request,
+              new Response('{"status":"closed"}', {
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }),
+        );
         yield* Effect.gen(function* () {
           const session = yield* open;
           yield* session.resizeViewport({ width: 960, height: 720, deviceScaleFactor: 2 });
@@ -127,20 +162,18 @@ describe("Browser Run viewport boundary", () => {
         }).pipe(
           Effect.scoped,
           Effect.provide(
-            browserRunInteractiveHostLayer().pipe(
-              Layer.provide(
-                BrowserRunInteractiveBinding.layer({
-                  browser,
-                  ...(viewport === undefined ? {} : { viewport }),
-                }).pipe(
-                  Layer.provide(
-                    Layer.succeed(BrowserRunSessionLifecycle)({ close: () => Effect.void }),
-                  ),
-                ),
-              ),
-            ),
+            CloudflareInteractiveBrowser.hostLayer({
+              browser,
+              accountId: "1234567890abcdef1234567890abcdef",
+              apiToken: Redacted.make("token"),
+              ...(viewport === undefined ? {} : { viewport }),
+            }),
           ),
+          Effect.provideService(HttpClient.HttpClient, client),
         );
+        expect(cleanupCalls).toEqual([
+          "DELETE /client/v4/accounts/1234567890abcdef1234567890abcdef/browser-rendering/devtools/browser/c8b9c4b1-d1bf-4663-b4d8-a0b009cc8b99",
+        ]);
         expect(sdk.launch).toHaveBeenCalledExactlyOnceWith(browser, {
           keep_alive: 10_000,
           ...(viewport === undefined
@@ -173,7 +206,7 @@ const mockBrowser = (setViewport: (viewport: unknown) => Promise<void>) => {
   };
   sdk.launch.mockResolvedValue({
     createBrowserContext: async () => ({ newPage: async () => page, close: async () => {} }),
-    sessionId: () => "viewport-regression",
+    sessionId: () => "c8b9c4b1-d1bf-4663-b4d8-a0b009cc8b99",
     isConnected: () => true,
     on: () => {},
     off: () => {},

--- a/packages/platform-cloudflare/test/rpc-tracing.test.ts
+++ b/packages/platform-cloudflare/test/rpc-tracing.test.ts
@@ -1,9 +1,8 @@
-import { BrowserCrypto } from "@effect/platform-browser";
 import { describe, expect, it } from "@effect/vitest";
 import { env, runInDurableObject } from "cloudflare:test";
-import { Effect, Layer, Option, Tracer } from "effect";
+import { Effect, Option, Tracer } from "effect";
 
-import { CloudflareThreadClient, threadNamespaceLayer } from "../src/index.ts";
+import { CloudflareThreadClient } from "../src/index.ts";
 import { decodeThreadId } from "./fixtures.ts";
 import { telemetryProbe } from "./observability-fixture.ts";
 
@@ -24,9 +23,10 @@ describe("DEPLOY-016 native receiver invocation contract", () => {
           return span;
         },
       });
-      const clientLayer = CloudflareThreadClient.layer.pipe(
-        Layer.provide([threadNamespaceLayer(env, "TELEMETRY", options), BrowserCrypto.layer]),
-      );
+      const clientLayer = CloudflareThreadClient.layerFromBinding({
+        namespace: env.TELEMETRY,
+        ...(options.rpcTracing ? { rpcTracing: "TELEMETRY" } : {}),
+      });
       const failure = yield* Effect.gen(function* () {
         const client = yield* CloudflareThreadClient;
         return yield* client.readPage(threadId, request).pipe(Effect.flip);

--- a/packages/platform-node/src/host.ts
+++ b/packages/platform-node/src/host.ts
@@ -1,5 +1,7 @@
 import type { ThreadId, SubmissionId } from "@effect-agent/core";
 import {
+  compileRegistrations,
+  type AgentRegistration,
   DurableAgentRuntime,
   type AbortCommand,
   type AbortIntent,
@@ -29,8 +31,8 @@ import {
   type RetryCommand,
   type Settlement,
 } from "@effect-agent/thread";
-import type { Stream } from "effect";
-import { Context, type Crypto, Effect, Layer, Ref, Schema } from "effect";
+import { NodeCrypto } from "@effect/platform-node";
+import { type Stream, Context, type Crypto, Effect, Layer, Ref, Schema } from "effect";
 
 import {
   NodeDurableRuntime,
@@ -193,6 +195,34 @@ export class NodeDurableHost extends Context.Service<
     readonly runResolvedWorkers: Effect.Effect<void, DurableWorkerFailure | DurableBindingFailure>;
   }
 >()("@effect-agent/platform-node/NodeDurableHost") {
+  /**
+   * Compile typed registrations and acquire the complete host in one Layer Scope.
+   * Node supplies Crypto; model, tool, instruction, and schema services remain required.
+   * Startup recovery and shutdown gates are unchanged. Workers start only when the caller
+   * runs runResolvedWorkers; this constructor never starts a background worker.
+   */
+  static layerRegistered<
+    const Entries extends ReadonlyArray<AgentRegistration>,
+    ContextError = never,
+    ContextRequirements = never,
+    AuthorizationError = never,
+    AuthorizationRequirements = never,
+  >(
+    registrations: Entries,
+    options: NodeDurableRuntimeOptions<
+      ContextError,
+      ContextRequirements,
+      AuthorizationError,
+      AuthorizationRequirements
+    >,
+  ) {
+    return Layer.unwrap(
+      Effect.map(compileRegistrations(registrations), (bindings) =>
+        NodeDurableHost.layerStack({ ...options, bindings }),
+      ),
+    ).pipe(Layer.provide(NodeCrypto.layer));
+  }
+
   /**
    * Host gates over an assembled `NodeDurableRuntime` stack. Bindings must carry the exact
    * digests stored by submitters. Omission registers no Agents, so resolved work fails closed.

--- a/packages/platform-node/test/layers.test.ts
+++ b/packages/platform-node/test/layers.test.ts
@@ -18,7 +18,10 @@ import {
   ThreadRead,
   ThreadStore,
   DefinitionDigests,
+  DefinitionDigestInput,
   Digest,
+  type DigestError,
+  digestDefinitions,
   digestJson,
   DurableAgentRuntime,
   DurableRuntimeConfig,
@@ -261,6 +264,155 @@ const readLogTags = (threadId: ThreadId) =>
   });
 
 describe("NodeDurableRuntime", () => {
+  it.effect(
+    "compiles registrations in the host Scope and retains their services until shutdown",
+    () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          class Instructions extends Context.Service<
+            Instructions,
+            { readonly text: Effect.Effect<string> }
+          >()("test/RegisteredInstructions") {}
+          const active = yield* Ref.make(false);
+          const reads = yield* Ref.make(0);
+          const settled = yield* Deferred.make<void>();
+          const instructions = Layer.effect(
+            Instructions,
+            Effect.acquireRelease(
+              Ref.set(active, true).pipe(
+                Effect.as({
+                  text: Effect.gen(function* () {
+                    expect(yield* Ref.get(active)).toBe(true);
+                    yield* Ref.update(reads, (n) => n + 1);
+                    return "Answer as JSON.";
+                  }),
+                }),
+              ),
+              () => Ref.set(active, false),
+            ),
+          );
+          const model = yield* makeScriptedModel(() => finalParts('{"answer":"registered"}'));
+          const agent = Agent.withModel(
+            Agent.make("registered-node-agent", {
+              input: plannerDefinition.input,
+              output: plannerDefinition.output,
+              instructions: () => Effect.flatMap(Instructions, (service) => service.text),
+              toolkit: Toolkit.empty,
+              policy: plannerDefinition.policy,
+            }),
+            model,
+          );
+          const definitions = DefinitionDigestInput.make({
+            agent: { id: agent.definition.id, revision: 1 },
+            model: { provider: "scripted", name: "platform-node-test" },
+            tools: [],
+          });
+          const live = NodeDurableHost.layerRegistered(
+            [{ agent, definitions }],
+            runtimeOptions(filename, {
+              storageFailpoint: (location) =>
+                location === "ledger:finalize-settlement:after"
+                  ? Deferred.succeed(settled, undefined).pipe(Effect.asVoid)
+                  : Effect.void,
+            }),
+          );
+          const requirements: Assert<Equal<Layer.Services<typeof live>, Instructions>> = true;
+          const errors: Assert<
+            Equal<
+              Layer.Error<typeof live>,
+              DigestError | DurableWorkerFailure | NodeDurableRuntimeInitializationError
+            >
+          > = true;
+          expect(requirements && errors).toBe(true);
+          const digests = yield* digestDefinitions(definitions).pipe(
+            Effect.provide(NodeCrypto.layer),
+          );
+          const host = yield* Effect.gen(function* () {
+            const host = yield* NodeDurableHost;
+            expect(yield* Ref.get(reads)).toBe(0);
+            const receipt = yield* host.submit(
+              agent,
+              { question: "registered?" },
+              {
+                ...submitOptions("registered-node-thread", "registered-node-input"),
+                definitions: digests,
+              },
+            );
+            const worker = yield* host.runResolvedWorkers.pipe(Effect.forkChild);
+            yield* Deferred.await(settled);
+            const settlement = yield* host.awaitSettlement(receipt);
+            expect(settlement.outcome).toBe("completed");
+            yield* Fiber.interrupt(worker);
+            expect(yield* Ref.get(active)).toBe(true);
+            return host;
+          }).pipe(Effect.provide(live.pipe(Layer.provide(instructions))));
+          expect(yield* Ref.get(reads)).toBeGreaterThan(0);
+          expect(yield* Ref.get(active)).toBe(false);
+          expect(yield* host.admissionOpen).toBe(false);
+        }),
+      ),
+  );
+
+  it.effect.each(["failure", "defect", "timeout", "interruption"] as const)(
+    "releases registration dependencies when host setup ends in %s",
+    (mode) =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          class Resource extends Context.Service<Resource, {}>()("test/RegistrationResource") {}
+          const released = yield* Ref.make(false);
+          const started = yield* Deferred.make<void>();
+          const model = yield* makeScriptedModel(() => finalParts('{"answer":"unused"}'));
+          const agent = Agent.withModel(
+            Agent.make("registered-setup", {
+              input: plannerDefinition.input,
+              output: plannerDefinition.output,
+              instructions: () => Resource.pipe(Effect.as("unused")),
+              toolkit: Toolkit.empty,
+              policy: plannerDefinition.policy,
+            }),
+            model,
+          );
+          const preparation = Layer.effect(
+            RunContextPreparation,
+            Effect.gen(function* () {
+              yield* Deferred.succeed(started, undefined);
+              if (mode === "failure") return yield* ContextSetupError.make({});
+              if (mode === "defect") return yield* Effect.die("setup defect");
+              return yield* Effect.never;
+            }),
+          );
+          const resource = Layer.effect(
+            Resource,
+            Effect.acquireRelease(Effect.succeed({}), () => Ref.set(released, true)),
+          );
+          const live = NodeDurableHost.layerRegistered(
+            [
+              {
+                agent,
+                definitions: DefinitionDigestInput.make({ agent: {}, model: {}, tools: [] }),
+              },
+            ],
+            { ...runtimeOptions(filename), runContext: preparation },
+          ).pipe(Layer.provide(resource));
+          const build = NodeDurableHost.pipe(Effect.provide(live));
+          const fiber = yield* (
+            mode === "timeout" ? build.pipe(Effect.timeout("1 second")) : build
+          ).pipe(Effect.forkChild);
+          yield* Deferred.await(started);
+          if (mode === "timeout") yield* TestClock.adjust("1 second");
+          if (mode === "interruption") yield* Fiber.interrupt(fiber);
+          const exit = yield* Fiber.await(fiber);
+          expect(Exit.isFailure(exit)).toBe(true);
+          expect(yield* Ref.get(released)).toBe(true);
+          if (mode === "failure")
+            expect(failureOf(exit)).toMatchObject({ _tag: "ContextSetupError" });
+          if (mode === "defect") expect(failureOf(exit)).toBe("setup defect");
+          if (mode === "interruption") expect(Exit.hasInterrupts(exit)).toBe(true);
+          if (mode === "timeout") expect(failureOf(exit)).toMatchObject({ _tag: "TimeoutError" });
+        }),
+      ),
+  );
+
   it("preserves independent service construction errors and requirements through runtime and host assembly", () => {
     const contextOnly = NodeDurableRuntime.layer({
       ...runtimeOptions("unused.sqlite"),
@@ -270,7 +422,7 @@ describe("NodeDurableRuntime", () => {
       ...runtimeOptions("unused.sqlite"),
       toolAuthorization: configuredAuthorization,
     });
-    const both = NodeDurableHost.layerStack({
+    const both = NodeDurableHost.layerRegistered([], {
       ...runtimeOptions("unused.sqlite"),
       runContext: configuredContext,
       toolAuthorization: configuredAuthorization,
@@ -294,6 +446,7 @@ describe("NodeDurableRuntime", () => {
     const hostErrors: Assert<
       Equal<
         Layer.Error<typeof both>,
+        | DigestError
         | NodeDurableRuntimeInitializationError
         | DurableWorkerFailure
         | ContextSetupError


### PR DESCRIPTION
Move common adapter and service wiring into the platform packages while keeping definitions pure and low-level Layers available.

For example, Code Mode previously required consumers to wire its executor into the handler Layer:

```ts
const CodeModeLive = codeMode.handlers.pipe(
  Layer.provide(InvoiceHandlers),
  Layer.provide(dynamicWorkerCodeExecutorLayer({ loader: env.LOADER })),
);
```

Now:

```ts
const CodeModeLive = CloudflareCodeMode.layer(codeMode, {
  loader: env.LOADER,
  handlers: InvoiceHandlers,
});
```

The PR adds these constructors:

| Constructor | Assembles |
| --- | --- |
| `CloudflareBrowser.layer(ReadPage, { browser })` | Quick Action binding, capture adapter, and tool handlers |
| `CloudflareBrowserRest.layer(ReadPage, { accountId, apiToken })` | REST capture adapter and tool handlers |
| `CloudflareCodeMode.layer(codeMode, { loader, handlers })` | Dynamic Worker executor and selected tool handlers |
| `CloudflareInteractiveBrowser.layer({ browser, accountId, apiToken })` | Browser binding, confirmed-session cleanup, and generic browser access |
| `CloudflareThreadClient.layerFromBinding({ namespace })` | Thread namespace and platform Crypto |
| `NodeDurableHost.layerRegistered(registrations, options)` | Registration compilation and complete Node host |

REST and interactive browser constructors leave `HttpClient` injectable. Extraction requires an explicit `workersAi` authorization/accounting policy. Interactive operator controls require `hostLayer`; its Puppeteer dependency stays in the interactive-browser subpath. RPC tracing remains opt-in.

Node registration compilation captures model, tool, instruction, and schema services in the host Layer's Scope. It supplies Crypto without erasing application dependencies or construction errors. Worker startup remains explicit. Lifecycle tests exercise successful resolved execution and dependency cleanup after setup failure, defect, timeout, and interruption.

Keep provider-specific assembly out of pure capability definitions. Reuse existing adapters instead of adding automatic dependency discovery or changing security and durability policies. Existing low-level APIs remain supported, so no migration is required. Update the guides and runnable Worker examples to use the constructors.

Hosted Browser Run smoke tests were not run. The Worker proof is checked through a deployment dry-run; the Code Mode example executes through local workerd.
