### PR TITLE
fix(platform-cloudflare): export layerFromBindings

### DIFF
--- a/.changeset/cloudflare-layer-from-bindings.md
+++ b/.changeset/cloudflare-layer-from-bindings.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Export `layerFromBindings` from the package root to assemble a Cloudflare durable runtime from resolved Agent Bindings.

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -19,7 +19,7 @@ export * from "./alarm.ts";
 export * from "./wake-scheduler.ts";
 export * from "./progress-wait.ts";
 export * from "./transport.ts";
-export { ThreadObjectPorts } from "./layers.ts";
+export { layerFromBindings, ThreadObjectPorts } from "./layers.ts";
 export * as ThreadObject from "./thread-object.ts";
 export * from "./client.ts";
 export * from "./prepared-admission.ts";

--- a/packages/platform-cloudflare/src/layers.ts
+++ b/packages/platform-cloudflare/src/layers.ts
@@ -310,7 +310,12 @@ export const layer = <const Entries extends ReadonlyArray<AgentRegistration>>(
   registrations: Entries,
 ) => Layer.unwrap(Effect.map(compileRegistrations(registrations), layerFromBindings));
 
-/** Internal assembly shared by registration compilation and low-level adapter fixtures. */
+/**
+ * Assemble the durable runtime from already-resolved Agent Bindings.
+ * Use `ThreadObject.layer` to compile typed Agent registrations instead.
+ * Supply host services through `ThreadObject.make` or `ThreadObject.layerConfig` and
+ * the Durable Object context and namespace Layers when composing a custom host.
+ */
 export const layerFromBindings = (
   bindings: ReadonlyArray<ResolvedBinding>,
 ): Layer.Layer<

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -8,6 +8,7 @@ import {
   RunToolAuthorization,
   ToolExecutionClass,
 } from "@effect-agent/engine";
+import { layerFromBindings } from "@effect-agent/platform-cloudflare";
 import {
   type DoStorageFailpointHandler,
   type DoStorageFailpointLocation,
@@ -41,7 +42,6 @@ import type {
   ThreadMaintenanceFailpointHandler,
   ThreadMaintenanceFailpointLocation,
 } from "../src/index.ts";
-import { layerFromBindings } from "../src/layers.ts";
 
 /**
  * Workerd-safe eviction-harness fixtures (plan §3, §4 WP3). The vitest pool runs test files


### PR DESCRIPTION
Export `layerFromBindings` from `@effect-agent/platform-cloudflare` so consumers can assemble a durable runtime from resolved Agent Bindings. Update its API comment, use the package-root import in the existing runtime fixture, and add a patch changeset.

Static checks and all repository tests passed, including 373 Cloudflare tests. The Cloudflare package build also passed with the export present in JavaScript and declarations. Full `vp run ready` stopped during the demo build because `entities/escape` and `entities/decode` could not resolve.
