### PR TITLE
fix(review): flag dependency drilling as P1

### DIFF
--- a/.github/review-guidance.md
+++ b/.github/review-guidance.md
@@ -10,4 +10,13 @@ Review this Effect v4 framework for concrete defects, not style.
 - Flag a new abstraction only when deleting it would remove real ownership, policy, or behavior.
 - Tests must cover a concrete regression. Do not request speculative cleanup or unrelated hardening.
 
-Severity: blocking only for a real ship-stopper; important for an actionable non-blocking defect; nit sparingly. Prefer no finding to a weak one.
+## Dependencies passed as parameters
+
+Treat dependency drilling introduced or extended by the diff as an actionable architecture defect, not a style nit. Inspect changed function signatures, options objects, and helper factories for service instances, clients, stores, runtime bindings, or effectful callbacks passed as dependencies. A single dependency parameter counts; it need not be a large `deps` bag or pass through multiple helpers.
+
+- Operations acquire required services with `yield* Service`, keeping requirements visible in `Effect` or `Stream`'s `R` channel. Flag helpers that take a service as an argument even when their caller yielded it first. Moving the same dependency into an options object or factory closure does not fix the problem.
+- Recommend the existing service or inward port, with concrete implementations provided at the composition root. Do not introduce a wrapper service solely to hold a dependency bag.
+- Keep request/domain data and pure transformation callbacks as explicit arguments. Layer configuration and foreign runtime values entering an adapter's construction boundary are legitimate. A service implementation may acquire dependencies during Layer construction and close over them when those requirements remain visible in the Layer's input type. These exceptions do not justify passing services through business operations or internal helpers.
+- Cite the changed parameter and its use, explain the requirement hidden from `R` and the caller burden, and name where the dependency should be yielded or provided. Report dependency drilling as P1, a merge-blocking architecture contract violation: it bypasses Effect's requirement tracking and Layer composition. Working runtime behavior does not lower its priority. No production crash or separate behavioral failure is required. Do not audit unrelated pre-existing signatures.
+
+Severity: dependency drilling is explicitly P1 as defined above. For other findings, blocking only for a real ship-stopper; important for an actionable non-blocking defect; nit sparingly. Prefer no finding to a weak one.


### PR DESCRIPTION
Make the repository reviewer flag dependencies passed through function parameters, options bags, and helper factories as P1 architecture violations. Require findings to identify the hidden Effect requirement and where it belongs, while preserving legitimate data arguments and Layer construction.

P2 was rejected because dependency drilling violates the repository's dependency contract even when runtime behavior works. This is a merge-blocking rule, not a style preference.

Formatting and diff checks pass. The full `vp run ready` gate could not start because `@cloudflare/vitest-pool-workers` is missing from the local dependency installation.
