### PR TITLE
fix(ci): refresh build caches and reuse Twoslash compiler state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # tests, build) with a fan-in `ready` job so the branch-protection check name
 # stays `ready`.
 #
-# Main runs only tests to publish a baseline that new PRs can restore.
+# Main runs tests and builds to publish baselines that new PRs can restore.
 # PR caches remain scoped to their merge refs. Each job has a separate cache
 # namespace, and Vite Task checks each task's inputs before replaying it.
 name: CI
@@ -146,7 +146,6 @@ jobs:
 
   build:
     name: Build
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -175,7 +174,7 @@ jobs:
             vite-task-build-${{ runner.os }}-
 
       - name: Build packages, examples, and docs
-        run: ./node_modules/.bin/vp run build
+        run: ./node_modules/.bin/vp run -v build
 
       - name: Save Vite Task cache
         if: success()

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,9 +65,10 @@ export default defineConfig({
           tsModule: ts,
           tsLibDirectory: dirname(ts.getDefaultLibFilePath({})),
           vfsRoot: resolve(import.meta.dirname, "../snippets/travel-planner"),
-          // Re-read imported snippets when the dev server rebuilds a page.
-          cache: false,
-          fsCache: false,
+          // VitePress sets production mode before loading build configuration.
+          // Reuse compiler state within a build, but re-read snippets in dev.
+          cache: process.env.NODE_ENV === "production",
+          fsCache: process.env.NODE_ENV === "production",
           compilerOptions: {
             target: ts.ScriptTarget.ES2023,
             module: ts.ModuleKind.ESNext,

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -122,7 +122,9 @@ Edit those files to change its examples. A `twoslash` fence enables type hovers 
 validation during `vp run docs:build`. Relative imports resolve from that snippet directory.
 
 Twoslash uses the pinned `typescript-twoslash` JavaScript compiler API; repository checks use
-TypeScript 7. Keep compiler validation enabled. Do not suppress errors with `noErrors` or
+TypeScript 7. Production builds reuse Twoslash compiler and filesystem caches within the process;
+the dev server disables both so imported snippet edits remain visible.
+Keep compiler validation enabled. Do not suppress errors with `noErrors` or
 `noErrorValidation`.
 
 Keep `yield*` inside a generator, such as `Effect.gen(function* () { ... })`.
@@ -266,8 +268,8 @@ The verified generated Changesets PR uses the release flow above.
 Explicit `@effect-agent review` comments still request review.
 
 Each test-matrix job has its own task-cache key. Successful task results are saved even when
-another task fails. Main pushes run tests to populate shared caches; static checks, builds, and
-the `ready` fan-in run on PRs. Main test runs are not cancelled by newer pushes.
+another task fails. Main pushes run tests and builds to populate shared caches; static checks and
+the `ready` fan-in run only on PRs. Main runs are not cancelled by newer pushes.
 Tests are reused only when task inputs match, never solely because paths did not change.
 
 The pre-commit hook runs `vp check --fix` on staged JavaScript and TypeScript.

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -901,7 +901,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       });
       expect(ciWorkflow.jobs.checks?.if).toBe("${{ github.event_name == 'pull_request' }}");
       expect(ciWorkflow.jobs.test?.if).toBeUndefined();
-      expect(ciWorkflow.jobs.build?.if).toBe("${{ github.event_name == 'pull_request' }}");
+      expect(ciWorkflow.jobs.build?.if).toBeUndefined();
       expect(ciWorkflow.jobs["release-integrity"]).toBeUndefined();
 
       const readyJob = ciWorkflow.jobs.ready;


### PR DESCRIPTION
Refresh the shared build cache on main so new PRs can reuse current task results instead of the August 15 baseline. Keep PR cache isolation and Vite Task input validation intact, and print detailed build cache diagnostics.

Reuse Twoslash compiler and filesystem caches within production docs builds. Dev-server caches remain disabled so imported snippet edits stay visible; snippet type-checking and link validation remain enabled.

Hosted measurements on fresh Ubuntu runners, one sample each:

| Build | Docs | Build step | Whole job |
| --- | --- | --- | --- |
| [Original](https://github.com/danieljvdm/effect-agent/actions/runs/33680497480/job/100415612492) | 205.83s | 239s | 267s |
| [Fix, cold cache](https://github.com/danieljvdm/effect-agent/actions/runs/33682202755/job/100421168412) | 67.30s | 93s | 122s |
| [Fix, restored cache](https://github.com/danieljvdm/effect-agent/actions/runs/33682456992/job/100421992169) | cache hit | 10s | 31s |

The restored run hit 18/22 tasks after a test-only follow-up commit. The changed test correctly invalidated its package build; docs reused its result. Two Wrangler tasks remain uncacheable, and the demo rebuilt after its output directory was absent. No changes to those tasks are included.

Local uncached docs dropped from 68.58s to 30.87s. Editing an imported snippet invalidated the docs task and failed with TypeScript error 2322; restoring it produced a successful cache hit. All 17 toolchain tests, the full `vp run ready` gate, and hosted CI pass. A local heap-soak failure passed on retry.

Main will run a build after each push to publish the shared baseline. Other PRs cannot reuse this PR's cache until the fix is merged and a main build completes.
