### PR TITLE
fix(ci): gate fork reviews on maintainer approval

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,10 +1,12 @@
 name: PR Review
 
 on:
-  pull_request:
+  # Run trusted code with repository secrets, including for fork PRs. The
+  # pr-review-forks environment requires maintainer approval before any step.
+  pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
-    # Match CI's generated-release filter before GitHub creates a run that
-    # needs approval. The Release workflow owns the release PR's ready check.
+    # Match CI's generated-release filter. The Release workflow owns the
+    # release PR's ready check.
     paths-ignore:
       - ".changeset/**"
       - "bun.lock"
@@ -15,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   review:
     if: >-
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
@@ -33,11 +33,18 @@ jobs:
         startsWith(github.event.comment.body, '@effect-agent review'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      # Configure required reviewers in repository settings before enabling
+      # this workflow. Same-repository PRs and authorized comments need no gate.
+      name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'pr-review-forks' || 'pr-review' }}
+      deployment: false
     steps:
       - name: Check out the trusted review channel
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          # Never check out or execute PR-head code in this privileged job.
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Mint the Effect Agent GitHub App token
         id: app-token
@@ -56,7 +63,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           pull-request: ${{ github.event.pull_request.number || github.event.issue.number }}
           review-author: effect-agent[bot]
-          mode: ${{ github.event_name == 'pull_request' && 'auto' || 'incremental' }}
+          mode: ${{ github.event_name == 'pull_request_target' && 'auto' || 'incremental' }}
           command: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
           comment-id: ${{ github.event.comment.id || 0 }}
           automatic-review-limit: 5

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -264,6 +264,28 @@ The remaining-workspace job includes every other package and runs one package ta
 The verified generated Changesets PR uses the release flow above.
 Explicit `@effect-agent review` comments still request review.
 
+PR Review uses `pull_request_target` and runs only trusted default-branch code.
+Fork reviews wait for approval before checkout, token creation, or model execution.
+Open the PR Review run from the PR's checks, select **Review deployments**, select
+`pr-review-forks`, then **Approve and deploy**. GitHub uses deployment wording for
+this approval gate, but the job does not deploy anything or create deployment records.
+Approving an ordinary fork workflow does not grant it repository secrets.
+
+Before enabling this workflow, configure **Settings → Environments → pr-review-forks**
+with repository maintainers as required reviewers. The current reviewer is `danieljvdm`;
+update this list when maintainers change. Allow self-review so a maintainer can approve
+their own fork PR. Keep this environment and its required-reviewer rule in place;
+a missing environment is automatically created without protection by GitHub.
+The separate `pr-review` environment has no approval requirement and is used for
+same-repository PRs and authorized review comments. Both environments use
+`deployment: false` to avoid adding review runs to deployment history.
+
+Each fork PR update requires approval. The Action's expected-head check skips an
+approved run if its PR head has since changed. Comment-triggered reviews retain their
+existing maintainer authorization and do not require a second approval. Never check
+out, install dependencies from, or execute the PR head in this secret-bearing workflow;
+the reviewer reads untrusted source through GitHub's API instead.
+
 Each test-matrix job has its own task-cache key. Successful task results are saved even when
 another task fails. Main pushes run static checks, tests, and builds to populate shared caches
 and validate Action releases. The `ready` fan-in runs only on PRs. Main runs are not cancelled

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -1087,7 +1087,7 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(readyStep?.run).toContain('test "$BUILD_RESULT" = "success"');
 
       expect(reviewWorkflow.on).toEqual({
-        pull_request: {
+        pull_request_target: {
           types: ["opened", "reopened", "ready_for_review", "synchronize"],
           "paths-ignore": generatedPaths,
         },


### PR DESCRIPTION
Fork PR reviews currently fail because `pull_request` runs cannot access the review bot's secrets. Run the trusted default-branch reviewer through `pull_request_target` and require environment approval for fork reviews. Maintainers can approve the waiting job in GitHub; same-repository reviews and authorized comment commands keep their existing behavior.

The approval environments are already configured in this repository. The workflow never checks out or executes PR-head code, disables checkout credential persistence, and removes unused write permissions from `GITHUB_TOKEN`. Ordinary fork-workflow approval cannot solve the missing-secret failure, so this uses GitHub's environment gate instead.

Formatting and `git diff --check` passed. `vp run ready` and the existing reviewer tests could not start because local workspace dependencies are missing. `vp env doctor` passed with warnings about other installed version managers. The approval UI still needs a live check after merge.
