### PR TITLE
fix(pr-review): ignore binary assets automatically

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -24,6 +24,9 @@ not incomplete coverage, and are unavailable to source tools. A binary-only PR n
 model call. SVG, JSON, XML, and other text assets remain reviewable. API failures, malformed
 responses, invalid UTF-8 without NUL bytes, and source-size limits still fail coverage checks.
 Binary detection by content retains the existing file and byte read limits.
+When a rename or content replacement crosses between binary and text, the textual side
+is still reviewed as an addition or deletion. Explicit ignore rules continue to exclude
+an entire rename when either path matches.
 
 One bounded review run assesses every admitted patch before using immutable base and head source
 to resolve specific questions about plausible defects. Straightforward changes can finish from

--- a/action/README.md
+++ b/action/README.md
@@ -17,6 +17,14 @@ source conflicts, rebuild the bundle instead of hand-merging generated JavaScrip
 
 ## Review behavior
 
+The reviewer automatically ignores known binary asset formats, including raster images,
+fonts, audio/video, archives, PDFs, and compiled binaries, before fetching their contents.
+Other bounded blobs containing NUL bytes are also ignored. These files count as ignored,
+not incomplete coverage, and are unavailable to source tools. A binary-only PR needs no
+model call. SVG, JSON, XML, and other text assets remain reviewable. API failures, malformed
+responses, invalid UTF-8 without NUL bytes, and source-size limits still fail coverage checks.
+Binary detection by content retains the existing file and byte read limits.
+
 One bounded review run assesses every admitted patch before using immutable base and head source
 to resolve specific questions about plausible defects. Straightforward changes can finish from
 the diff; source tools are not an exhaustive repository audit. The host validates paths and

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -89563,7 +89563,11 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
   const activeRenames = /* @__PURE__ */ new Map();
   for (const file2 of input.files) {
     const previousPath = file2.previousPath;
-    if (file2.status === "renamed" && previousPath !== void 0 && input.base.entry(previousPath) !== void 0 && input.base.entry(file2.path) === void 0 && input.head.entry(previousPath) === void 0 && input.head.entry(file2.path) !== void 0) {
+    if (file2.status === "renamed" && previousPath !== void 0 && // A rename across binary/text formats is a textual addition or deletion,
+    // not one ignored change. Leave its two tree paths as separate candidates.
+    (isBinaryAssetPath(previousPath) === isBinaryAssetPath(file2.path) || [previousPath, file2.path].some(
+      (path) => input.ignore.some((pattern) => matchesIgnore(path, pattern))
+    )) && input.base.entry(previousPath) !== void 0 && input.base.entry(file2.path) === void 0 && input.head.entry(previousPath) === void 0 && input.head.entry(file2.path) !== void 0) {
       activeRenames.set(previousPath, file2);
       activeRenames.set(file2.path, file2);
     }
@@ -89591,7 +89595,6 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
     if (reason !== void 0) exclusions.push(ReviewExclusion.make({ path: file2.path, reason }));
     if (reason === void 0 || reason === "unsupported-entry" || reason === "source-read-failed") {
       unavailablePaths.add(file2.path).add(basePath);
-      if (file2.previousPath !== void 0) unavailablePaths.add(file2.previousPath);
     }
   };
   let admittedPaths = 0;
@@ -89600,7 +89603,7 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
     (left, right) => Number(documentationPath(left.file.path)) - Number(documentationPath(right.file.path)) || (left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0)
   )) {
     const ignored = [file2.path, ...basePath === file2.path ? [] : [basePath]].some(
-      (path) => isBinaryAssetPath(path) || input.ignore.some((pattern) => matchesIgnore(path, pattern))
+      (path2) => isBinaryAssetPath(path2) || input.ignore.some((pattern) => matchesIgnore(path2, pattern))
     );
     if (ignored) {
       exclude(ignoredPaths, file2, basePath);
@@ -89640,45 +89643,54 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
       exclude(unreviewedPaths, file2, basePath, "source-read-failed");
       continue;
     }
-    if (contents.success.before === void 0 || contents.success.after === void 0) {
+    const beforeBinary = contents.success.before === void 0;
+    const afterBinary = contents.success.after === void 0;
+    if ((beforeBinary || afterBinary) && (beforeBinary || beforeEntry === void 0) && (afterBinary || afterEntry === void 0)) {
       hydratedSourceBytes += estimatedSourceBytes;
       exclude(ignoredPaths, file2, basePath);
       continue;
     }
-    hydratedSourceBytes += sourceSizesKnown ? estimatedSourceBytes : contents.success.before.length + contents.success.after.length;
+    const before = contents.success.before ?? "";
+    const after = contents.success.after ?? "";
+    const path = afterBinary ? basePath : file2.path;
+    if (basePath !== file2.path) {
+      if (beforeBinary) unavailablePaths.add(basePath);
+      if (afterBinary) unavailablePaths.add(file2.path);
+    }
+    hydratedSourceBytes += sourceSizesKnown ? estimatedSourceBytes : before.length + after.length;
     if (hydratedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
       exclude(unreviewedPaths, file2, basePath, "source-limit");
       continue;
     }
-    const patch3 = basePath === file2.path && contents.success.before === contents.success.after && beforeEntry !== void 0 && afterEntry !== void 0 && beforeEntry.mode !== afterEntry.mode ? [
+    const patch3 = basePath === file2.path && !beforeBinary && !afterBinary && before === after && beforeEntry !== void 0 && afterEntry !== void 0 && beforeEntry.mode !== afterEntry.mode ? [
       `diff --git a/${file2.path} b/${file2.path}`,
       `old mode ${beforeEntry.mode}`,
       `new mode ${afterEntry.mode}`
     ].join("\n") : makeExactPatch({
-      path: file2.path,
-      basePath,
-      headPath: file2.path,
+      path,
+      basePath: beforeBinary || afterBinary ? path : basePath,
+      headPath: path,
       baseRevision: input.base.revision,
       headRevision: input.head.revision,
-      before: contents.success.before,
-      after: contents.success.after
+      before,
+      after
     });
-    const exactPatch = patch3 !== void 0 && basePath !== file2.path ? [
+    const exactPatch = patch3 !== void 0 && basePath !== file2.path && !beforeBinary && !afterBinary ? [
       `diff --git a/${basePath} b/${file2.path}`,
       `rename from ${basePath}`,
       `rename to ${file2.path}`,
       patch3
     ].join("\n") : patch3;
-    if (exactPatch === void 0 || exactPatch.length === 0 || exactPatch.length > MAX_REVIEW_PATCH_CHARS) {
+    if (path.length > 512 || exactPatch === void 0 || exactPatch.length === 0 || exactPatch.length > MAX_REVIEW_PATCH_CHARS) {
       exclude(
         unreviewedPaths,
         file2,
         basePath,
-        exactPatch !== void 0 && exactPatch.length > MAX_REVIEW_PATCH_CHARS ? "patch-limit" : "patch-unavailable"
+        path.length > 512 ? "path-limit" : exactPatch !== void 0 && exactPatch.length > MAX_REVIEW_PATCH_CHARS ? "patch-limit" : "patch-unavailable"
       );
       continue;
     }
-    changes2.push(ReviewChange.make({ path: file2.path, patch: exactPatch }));
+    changes2.push(ReviewChange.make({ path, patch: exactPatch }));
   }
   return { changes: changes2, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions };
 });

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -88371,6 +88371,13 @@ var GitHubApiFailure = class extends Schema_exports.TaggedError()("GitHubApiFail
   reason: Schema_exports.String
 }) {
 };
+var BinaryBlob = class extends Schema_exports.TaggedError()("BinaryBlob", {
+  sha: Revision3
+}) {
+};
+var isBinaryAssetPath = (path) => /\.(png|jpe?g|gif|webp|avif|heic|heif|ico|icns|bmp|tiff?|psd|woff2?|ttf|otf|eot|mp3|mp4|m4[av]|wav|ogg|flac|aac|aiff|mov|webm|avi|mkv|pdf|zip|gz|bz2|xz|7z|rar|tar|jar|wasm|exe|dll|so|dylib|class|pyc|sqlite3?|db)$/i.test(
+  path
+);
 var StaleReviewHead = class extends Schema_exports.TaggedError()("StaleReviewHead", {
   inspectedHead: Revision3,
   currentHead: Revision3
@@ -88628,10 +88635,7 @@ ${input.evidence}`
       });
     }
     if (bytes2.includes(0)) {
-      return yield* GitHubApiFailure.make({
-        operation: "decode Git blob",
-        reason: `blob ${sha} is not textual`
-      });
+      return yield* BinaryBlob.make({ sha });
     }
     const content = yield* Effect_exports.try({
       try: () => new TextDecoder("utf-8", { fatal: true }).decode(bytes2),
@@ -89596,7 +89600,7 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
     (left, right) => Number(documentationPath(left.file.path)) - Number(documentationPath(right.file.path)) || (left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0)
   )) {
     const ignored = [file2.path, ...basePath === file2.path ? [] : [basePath]].some(
-      (path) => input.ignore.some((pattern) => matchesIgnore(path, pattern))
+      (path) => isBinaryAssetPath(path) || input.ignore.some((pattern) => matchesIgnore(path, pattern))
     );
     if (ignored) {
       exclude(ignoredPaths, file2, basePath);
@@ -89626,14 +89630,19 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
     }
     const contents = yield* Effect_exports.all(
       {
-        before: beforeEntry === void 0 ? Effect_exports.succeed("") : input.base.readTextFile(basePath),
-        after: afterEntry === void 0 ? Effect_exports.succeed("") : input.head.readTextFile(file2.path)
+        before: beforeEntry === void 0 ? Effect_exports.succeed("") : input.base.readTextFile(basePath).pipe(Effect_exports.catchTag("BinaryBlob", () => Effect_exports.succeed(void 0))),
+        after: afterEntry === void 0 ? Effect_exports.succeed("") : input.head.readTextFile(file2.path).pipe(Effect_exports.catchTag("BinaryBlob", () => Effect_exports.succeed(void 0)))
       },
       { concurrency: 2 }
     ).pipe(Effect_exports.result);
     if (Result_exports.isFailure(contents)) {
       hydratedSourceBytes += estimatedSourceBytes;
       exclude(unreviewedPaths, file2, basePath, "source-read-failed");
+      continue;
+    }
+    if (contents.success.before === void 0 || contents.success.after === void 0) {
+      hydratedSourceBytes += estimatedSourceBytes;
+      exclude(ignoredPaths, file2, basePath);
       continue;
     }
     hydratedSourceBytes += sourceSizesKnown ? estimatedSourceBytes : contents.success.before.length + contents.success.after.length;
@@ -89676,7 +89685,7 @@ var hydrateExactChanges = Effect_exports.fn("hydrateExactChanges")(function* (in
 var reviewContextFailure = (message) => ReviewContextError.make({ message });
 var makeReviewRepository = (input) => {
   const snapshot3 = (revision) => revision === "base" ? input.base : input.head;
-  const outsideScope = (path) => input.unavailablePaths.has(path) || input.ignore.some((pattern) => matchesIgnore(path, pattern));
+  const outsideScope = (path) => isBinaryAssetPath(path) || input.unavailablePaths.has(path) || input.ignore.some((pattern) => matchesIgnore(path, pattern));
   const isReadableEntry = (entry) => entry?.type === "blob" && entry.mode !== "120000";
   const readFile3 = Effect_exports.fn("ReviewRepository.readFile")(function* (request3) {
     if (outsideScope(request3.path)) {

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -29,6 +29,7 @@ import {
 import {
   type ChangedFile,
   GitHubApiFailure,
+  isBinaryAssetPath,
   makeExactPatch,
   makeGitHubClient,
   type RepositorySnapshot,
@@ -313,8 +314,9 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       Number(documentationPath(left.file.path)) - Number(documentationPath(right.file.path)) ||
       (left.file.path < right.file.path ? -1 : left.file.path > right.file.path ? 1 : 0),
   )) {
-    const ignored = [file.path, ...(basePath === file.path ? [] : [basePath])].some((path) =>
-      input.ignore.some((pattern) => matchesIgnore(path, pattern)),
+    const ignored = [file.path, ...(basePath === file.path ? [] : [basePath])].some(
+      (path) =>
+        isBinaryAssetPath(path) || input.ignore.some((pattern) => matchesIgnore(path, pattern)),
     );
     if (ignored) {
       exclude(ignoredPaths, file, basePath);
@@ -353,14 +355,31 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
     }
     const contents = yield* Effect.all(
       {
-        before: beforeEntry === undefined ? Effect.succeed("") : input.base.readTextFile(basePath),
-        after: afterEntry === undefined ? Effect.succeed("") : input.head.readTextFile(file.path),
+        before:
+          beforeEntry === undefined
+            ? Effect.succeed("")
+            : input.base
+                .readTextFile(basePath)
+                .pipe(Effect.catchTag("BinaryBlob", () => Effect.succeed(undefined))),
+        after:
+          afterEntry === undefined
+            ? Effect.succeed("")
+            : input.head
+                .readTextFile(file.path)
+                .pipe(Effect.catchTag("BinaryBlob", () => Effect.succeed(undefined))),
       },
       { concurrency: 2 },
     ).pipe(Effect.result);
     if (Result.isFailure(contents)) {
       hydratedSourceBytes += estimatedSourceBytes;
       exclude(unreviewedPaths, file, basePath, "source-read-failed");
+      continue;
+    }
+    // Wait for both reads so a binary side cannot hide a real failure on the
+    // other side. Unknown binary formats still consume the bounded read budget.
+    if (contents.success.before === undefined || contents.success.after === undefined) {
+      hydratedSourceBytes += estimatedSourceBytes;
+      exclude(ignoredPaths, file, basePath);
       continue;
     }
     hydratedSourceBytes += sourceSizesKnown
@@ -434,6 +453,7 @@ export const makeReviewRepository = (input: {
 }): ReviewRepository["Service"] => {
   const snapshot = (revision: "base" | "head") => (revision === "base" ? input.base : input.head);
   const outsideScope = (path: string) =>
+    isBinaryAssetPath(path) ||
     input.unavailablePaths.has(path) ||
     input.ignore.some((pattern) => matchesIgnore(path, pattern));
   const isReadableEntry = (entry: ReturnType<RepositorySnapshot["entry"]>) =>

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -261,6 +261,12 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
     if (
       file.status === "renamed" &&
       previousPath !== undefined &&
+      // A rename across binary/text formats is a textual addition or deletion,
+      // not one ignored change. Leave its two tree paths as separate candidates.
+      (isBinaryAssetPath(previousPath) === isBinaryAssetPath(file.path) ||
+        [previousPath, file.path].some((path) =>
+          input.ignore.some((pattern) => matchesIgnore(path, pattern)),
+        )) &&
       input.base.entry(previousPath) !== undefined &&
       input.base.entry(file.path) === undefined &&
       input.head.entry(previousPath) === undefined &&
@@ -304,7 +310,6 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
     // unreadable entries still exclude both sides of a rename from source tools.
     if (reason === undefined || reason === "unsupported-entry" || reason === "source-read-failed") {
       unavailablePaths.add(file.path).add(basePath);
-      if (file.previousPath !== undefined) unavailablePaths.add(file.previousPath);
     }
   };
   let admittedPaths = 0;
@@ -375,23 +380,36 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       exclude(unreviewedPaths, file, basePath, "source-read-failed");
       continue;
     }
-    // Wait for both reads so a binary side cannot hide a real failure on the
-    // other side. Unknown binary formats still consume the bounded read budget.
-    if (contents.success.before === undefined || contents.success.after === undefined) {
+    // Both reads have settled, so a binary side cannot hide a real read failure.
+    // Preserve any textual side as an addition/deletion instead of dropping it.
+    const beforeBinary = contents.success.before === undefined;
+    const afterBinary = contents.success.after === undefined;
+    if (
+      (beforeBinary || afterBinary) &&
+      (beforeBinary || beforeEntry === undefined) &&
+      (afterBinary || afterEntry === undefined)
+    ) {
       hydratedSourceBytes += estimatedSourceBytes;
       exclude(ignoredPaths, file, basePath);
       continue;
     }
-    hydratedSourceBytes += sourceSizesKnown
-      ? estimatedSourceBytes
-      : contents.success.before.length + contents.success.after.length;
+    const before = contents.success.before ?? "";
+    const after = contents.success.after ?? "";
+    const path = afterBinary ? basePath : file.path;
+    if (basePath !== file.path) {
+      if (beforeBinary) unavailablePaths.add(basePath);
+      if (afterBinary) unavailablePaths.add(file.path);
+    }
+    hydratedSourceBytes += sourceSizesKnown ? estimatedSourceBytes : before.length + after.length;
     if (hydratedSourceBytes > MAX_HYDRATED_SOURCE_BYTES) {
       exclude(unreviewedPaths, file, basePath, "source-limit");
       continue;
     }
     const patch =
       basePath === file.path &&
-      contents.success.before === contents.success.after &&
+      !beforeBinary &&
+      !afterBinary &&
+      before === after &&
       beforeEntry !== undefined &&
       afterEntry !== undefined &&
       beforeEntry.mode !== afterEntry.mode
@@ -401,16 +419,16 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
             `new mode ${afterEntry.mode}`,
           ].join("\n")
         : makeExactPatch({
-            path: file.path,
-            basePath,
-            headPath: file.path,
+            path,
+            basePath: beforeBinary || afterBinary ? path : basePath,
+            headPath: path,
             baseRevision: input.base.revision,
             headRevision: input.head.revision,
-            before: contents.success.before,
-            after: contents.success.after,
+            before,
+            after,
           });
     const exactPatch =
-      patch !== undefined && basePath !== file.path
+      patch !== undefined && basePath !== file.path && !beforeBinary && !afterBinary
         ? [
             `diff --git a/${basePath} b/${file.path}`,
             `rename from ${basePath}`,
@@ -419,6 +437,7 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
           ].join("\n")
         : patch;
     if (
+      path.length > 512 ||
       exactPatch === undefined ||
       exactPatch.length === 0 ||
       exactPatch.length > MAX_REVIEW_PATCH_CHARS
@@ -427,13 +446,15 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
         unreviewedPaths,
         file,
         basePath,
-        exactPatch !== undefined && exactPatch.length > MAX_REVIEW_PATCH_CHARS
-          ? "patch-limit"
-          : "patch-unavailable",
+        path.length > 512
+          ? "path-limit"
+          : exactPatch !== undefined && exactPatch.length > MAX_REVIEW_PATCH_CHARS
+            ? "patch-limit"
+            : "patch-unavailable",
       );
       continue;
     }
-    changes.push(ReviewChange.make({ path: file.path, patch: exactPatch }));
+    changes.push(ReviewChange.make({ path, patch: exactPatch }));
   }
   return { changes, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions };
 });

--- a/packages/pr-review-action/src/github.ts
+++ b/packages/pr-review-action/src/github.ts
@@ -165,7 +165,7 @@ export interface TreeComparisonView {
 export interface RepositorySnapshot {
   readonly revision: string;
   readonly paths: ReadonlyArray<string>;
-  readonly readTextFile: (path: string) => Effect.Effect<string, GitHubApiFailure>;
+  readonly readTextFile: (path: string) => Effect.Effect<string, GitHubApiFailure | BinaryBlob>;
   readonly entry: (path: string) =>
     | {
         readonly sha: string;
@@ -180,6 +180,18 @@ export class GitHubApiFailure extends Schema.TaggedError<GitHubApiFailure>()("Gi
   operation: Schema.String,
   reason: Schema.String,
 }) {}
+
+/** A verified blob containing NUL bytes, not a failed GitHub read. */
+export class BinaryBlob extends Schema.TaggedError<BinaryBlob>()("BinaryBlob", {
+  sha: Revision,
+}) {}
+
+// These formats are outside the text review scope even when their bytes happen
+// to decode as UTF-8. Keep textual assets such as SVG, JSON, and XML reviewable.
+export const isBinaryAssetPath = (path: string): boolean =>
+  /\.(png|jpe?g|gif|webp|avif|heic|heif|ico|icns|bmp|tiff?|psd|woff2?|ttf|otf|eot|mp3|mp4|m4[av]|wav|ogg|flac|aac|aiff|mov|webm|avi|mkv|pdf|zip|gz|bz2|xz|7z|rar|tar|jar|wasm|exe|dll|so|dylib|class|pyc|sqlite3?|db)$/i.test(
+    path,
+  );
 
 export class StaleReviewHead extends Schema.TaggedError<StaleReviewHead>()("StaleReviewHead", {
   inspectedHead: Revision,
@@ -495,10 +507,7 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
       });
     }
     if (bytes.includes(0)) {
-      return yield* GitHubApiFailure.make({
-        operation: "decode Git blob",
-        reason: `blob ${sha} is not textual`,
-      });
+      return yield* BinaryBlob.make({ sha });
     }
     const content = yield* Effect.try({
       try: () => new TextDecoder("utf-8", { fatal: true }).decode(bytes),

--- a/packages/pr-review-action/test/action.test.ts
+++ b/packages/pr-review-action/test/action.test.ts
@@ -16,7 +16,12 @@ import {
   reviewEventFor,
   withActionInputs,
 } from "../src/action.ts";
-import { type ChangedFile, GitHubApiFailure, type RepositorySnapshot } from "../src/github.ts";
+import {
+  BinaryBlob,
+  type ChangedFile,
+  GitHubApiFailure,
+  type RepositorySnapshot,
+} from "../src/github.ts";
 import { reviewMarker } from "../src/selection.ts";
 
 const file = (path: string, patch: string | undefined): ChangedFile => ({
@@ -393,6 +398,63 @@ describe("Manual command acknowledgement", () => {
 });
 
 describe("Incremental review scope", () => {
+  it.effect("completes a binary-only PR without fetching blobs or calling a model", () =>
+    Effect.gen(function* () {
+      const published = yield* Ref.make<ReadonlyArray<typeof PublishedReviewBody.Type>>([]);
+      const client = HttpClient.make((request, url) => {
+        let response: unknown;
+        if (request.method === "POST" && url.pathname.endsWith("/reviews")) {
+          return Ref.update(published, (values) => [
+            ...values,
+            decodePublishedReview(request),
+          ]).pipe(
+            Effect.as(
+              jsonResponse(request, {
+                html_url: "https://github.test/reve-ai/example/pull/12#review",
+              }),
+            ),
+          );
+        }
+        if (url.pathname.endsWith("/pulls/12")) {
+          response = pullRequestWire("Update icons", "base", "head");
+        } else if (url.pathname.endsWith("/reviews") || url.pathname.endsWith("/files")) {
+          response = [];
+        } else if (url.pathname.includes("/compare/")) {
+          response = { merge_base_commit: { sha: "base" } };
+        } else if (url.pathname.includes("/git/commits/")) {
+          const sha = url.pathname.endsWith("/base") ? "base" : "head";
+          response = { sha, tree: { sha: `${sha}-tree` } };
+        } else if (url.pathname.includes("/git/trees/")) {
+          const sha = url.pathname.endsWith("/base-tree") ? "base-tree" : "head-tree";
+          response = {
+            sha,
+            truncated: false,
+            tree:
+              sha === "base-tree"
+                ? []
+                : [
+                    {
+                      path: "assets/icon.png",
+                      sha: "image",
+                      mode: "100644",
+                      type: "blob",
+                      size: 20_000_000,
+                    },
+                  ],
+          };
+        } else {
+          return Effect.die(`unexpected request ${request.method} ${url.href}`);
+        }
+        return Effect.succeed(jsonResponse(request, response));
+      });
+      yield* runReviewAction(client);
+      const reviews = yield* Ref.get(published);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]?.body).toContain("1 ignored");
+      expect(reviews[0]?.body).toContain(reviewMarker(true, true));
+    }),
+  );
+
   it("publishes blocking findings as a head-bound change request", () => {
     expect(reviewEventFor(1)).toBe("REQUEST_CHANGES");
     expect(reviewEventFor(0)).toBe("COMMENT");
@@ -908,6 +970,100 @@ describe("exact review delta", () => {
       expect(surface.changes[0]?.patch.length).toBeLessThan(1_000);
       expect(surface.changes[0]?.patch).not.toContain("x".repeat(1_000));
     }),
+  );
+
+  it.effect("ignores binary assets before hydration and preserves capacity for text assets", () =>
+    Effect.gen(function* () {
+      const binaries = [
+        ...Array.from({ length: 101 }, (_, index) => `assets/${index}.PNG`),
+        "assets/font.woff2",
+        "assets/video.mp4",
+        "assets/archive.zip",
+        "assets/manual.pdf",
+      ];
+      const text = { "src/main.ts": "export const value = 1;", "assets/icon.svg": "<svg/>" };
+      const base = treeSnapshot("base", {});
+      const head = treeSnapshot(
+        "head",
+        {
+          ...Object.fromEntries(binaries.map((path) => [path, "not text"])),
+          ...text,
+          "assets/unchanged.jpg": "not text",
+        },
+        new Set([...binaries, "assets/unchanged.jpg"]),
+      );
+      const surface = yield* hydrateExactChanges({
+        files: [],
+        changedPaths: [...binaries, ...Object.keys(text)],
+        base,
+        head,
+        ignore: [],
+      });
+      expect(surface.ignoredPaths).toEqual([...binaries].sort());
+      expect(surface.unreviewedPaths).toEqual([]);
+      expect(surface.changes.map(({ path }) => path)).toEqual(Object.keys(text).sort());
+      const repository = makeReviewRepository({
+        base,
+        head,
+        ignore: [],
+        unavailablePaths: surface.unavailablePaths,
+      });
+      expect((yield* repository.findFiles({ revision: "head", query: "assets/" })).paths).toEqual([
+        "assets/icon.svg",
+      ]);
+      expect(
+        yield* repository
+          .readFile({ revision: "head", path: "assets/unchanged.jpg", startLine: 1, lineCount: 1 })
+          .pipe(Effect.flip),
+      ).toMatchObject({ _tag: "ReviewContextError" });
+    }),
+  );
+
+  it.effect.each([false, true])("ignores a binary rename in either direction: %s", (reverse) =>
+    Effect.gen(function* () {
+      const previousPath = reverse ? "assets/unknown" : "assets/icon.png";
+      const path = reverse ? "assets/icon.png" : "assets/unknown";
+      const surface = yield* hydrateExactChanges({
+        files: [{ ...file(path, undefined), previousPath, status: "renamed" }],
+        changedPaths: [previousPath, path],
+        base: treeSnapshot("base", { [previousPath]: "binary" }, new Set([previousPath])),
+        head: treeSnapshot("head", { [path]: "binary" }, new Set([path])),
+        ignore: [],
+      });
+      expect(surface.ignoredPaths).toEqual([path]);
+      expect(surface.changes).toEqual([]);
+      expect([...surface.unavailablePaths].sort()).toEqual([previousPath, path].sort());
+    }),
+  );
+
+  it.effect.each([false, true])(
+    "does not let detected binary content hide a source read failure: %s",
+    (failedRead) =>
+      Effect.gen(function* () {
+        const path = "assets/unknown";
+        const surface = yield* hydrateExactChanges({
+          files: [],
+          changedPaths: [path],
+          ignore: [],
+          base: {
+            ...treeSnapshot("base", { [path]: "binary" }),
+            readTextFile: () => Effect.fail(BinaryBlob.make({ sha: "binary" })),
+          },
+          head: {
+            ...treeSnapshot("head", { [path]: "text" }),
+            readTextFile: () =>
+              failedRead
+                ? Effect.fail(
+                    GitHubApiFailure.make({ operation: "get Git blob", reason: "unavailable" }),
+                  )
+                : Effect.succeed("text"),
+          },
+        });
+        expect(surface.ignoredPaths).toEqual(failedRead ? [] : [path]);
+        expect(surface.unreviewedPaths).toEqual(failedRead ? [path] : []);
+        expect(surface.changes).toEqual([]);
+        expect(surface.unavailablePaths.has(path)).toBe(true);
+      }),
   );
 
   it.effect("keeps expected blob read failures as coverage gaps and admits other files", () =>

--- a/packages/pr-review-action/test/action.test.ts
+++ b/packages/pr-review-action/test/action.test.ts
@@ -1019,50 +1019,90 @@ describe("exact review delta", () => {
     }),
   );
 
-  it.effect.each([false, true])("ignores a binary rename in either direction: %s", (reverse) =>
+  it.effect.each([false, true])("preserves the textual side of a binary rename: %s", (reverse) =>
     Effect.gen(function* () {
-      const previousPath = reverse ? "assets/unknown" : "assets/icon.png";
-      const path = reverse ? "assets/icon.png" : "assets/unknown";
+      const previousPath = reverse ? "src/icon.ts" : "assets/icon.png";
+      const path = reverse ? "assets/icon.png" : "src/icon.ts";
+      const content = "export const icon = true;\n";
+      const base = treeSnapshot("base", { [previousPath]: content }, new Set(["assets/icon.png"]));
+      const head = treeSnapshot("head", { [path]: content }, new Set(["assets/icon.png"]));
       const surface = yield* hydrateExactChanges({
         files: [{ ...file(path, undefined), previousPath, status: "renamed" }],
         changedPaths: [previousPath, path],
-        base: treeSnapshot("base", { [previousPath]: "binary" }, new Set([previousPath])),
-        head: treeSnapshot("head", { [path]: "binary" }, new Set([path])),
+        base,
+        head,
         ignore: [],
       });
-      expect(surface.ignoredPaths).toEqual([path]);
-      expect(surface.changes).toEqual([]);
-      expect([...surface.unavailablePaths].sort()).toEqual([previousPath, path].sort());
+      expect(surface.ignoredPaths).toEqual(["assets/icon.png"]);
+      expect(surface.unreviewedPaths).toEqual([]);
+      expect(surface.changes).toHaveLength(1);
+      expect(surface.changes[0]?.path).toBe("src/icon.ts");
+      expect(surface.changes[0]?.patch).toContain(`${reverse ? "-" : "+"}${content}`);
+      expect(surface.changes[0]?.patch).not.toContain("rename from");
+      const repository = makeReviewRepository({
+        base,
+        head,
+        ignore: [],
+        unavailablePaths: surface.unavailablePaths,
+      });
+      expect(
+        (yield* repository.findFiles({ revision: reverse ? "base" : "head", query: "src/" })).paths,
+      ).toEqual(["src/icon.ts"]);
+      yield* repository.readFile({
+        revision: reverse ? "base" : "head",
+        path: "src/icon.ts",
+        startLine: 1,
+        lineCount: 1,
+      });
     }),
   );
 
-  it.effect.each([false, true])(
-    "does not let detected binary content hide a source read failure: %s",
-    (failedRead) =>
+  it.effect.each(
+    (["addition", "deletion", "binary", "failure"] as const).flatMap((mode) =>
+      [false, true].map((renamed) => ({ mode, renamed })),
+    ),
+  )(
+    "preserves text and read failures beside content-detected binaries: $mode, renamed=$renamed",
+    ({ mode, renamed }) =>
       Effect.gen(function* () {
         const path = "assets/unknown";
+        const previousPath = renamed ? "assets/old" : path;
+        const textPath = mode === "deletion" ? previousPath : path;
         const surface = yield* hydrateExactChanges({
-          files: [],
-          changedPaths: [path],
+          files: renamed ? [{ ...file(path, undefined), previousPath, status: "renamed" }] : [],
+          changedPaths: renamed ? [previousPath, path] : [path],
           ignore: [],
           base: {
-            ...treeSnapshot("base", { [path]: "binary" }),
-            readTextFile: () => Effect.fail(BinaryBlob.make({ sha: "binary" })),
+            ...treeSnapshot("base", { [previousPath]: "binary" }),
+            readTextFile: () =>
+              mode === "deletion"
+                ? Effect.succeed("text")
+                : Effect.fail(BinaryBlob.make({ sha: "binary" })),
           },
           head: {
             ...treeSnapshot("head", { [path]: "text" }),
             readTextFile: () =>
-              failedRead
+              mode === "failure"
                 ? Effect.fail(
                     GitHubApiFailure.make({ operation: "get Git blob", reason: "unavailable" }),
                   )
-                : Effect.succeed("text"),
+                : mode === "addition"
+                  ? Effect.succeed("text")
+                  : Effect.fail(BinaryBlob.make({ sha: "binary" })),
           },
         });
-        expect(surface.ignoredPaths).toEqual(failedRead ? [] : [path]);
-        expect(surface.unreviewedPaths).toEqual(failedRead ? [path] : []);
-        expect(surface.changes).toEqual([]);
-        expect(surface.unavailablePaths.has(path)).toBe(true);
+        expect(surface.ignoredPaths).toEqual(mode === "binary" ? [path] : []);
+        expect(surface.unreviewedPaths).toEqual(mode === "failure" ? [path] : []);
+        if (mode === "addition" || mode === "deletion") {
+          expect(surface.changes).toHaveLength(1);
+          expect(surface.changes[0]?.path).toBe(textPath);
+          expect(surface.changes[0]?.patch).toContain(mode === "addition" ? "+text" : "-text");
+          expect(surface.changes[0]?.patch).not.toContain("rename from");
+          expect(surface.unavailablePaths.has(textPath)).toBe(false);
+        } else {
+          expect(surface.changes).toEqual([]);
+          expect(surface.unavailablePaths.has(path)).toBe(true);
+        }
       }),
   );
 

--- a/packages/pr-review-action/test/github.test.ts
+++ b/packages/pr-review-action/test/github.test.ts
@@ -622,8 +622,52 @@ describe("GitHub tree comparison", () => {
 
       const failure = yield* comparison.head.readTextFile(path).pipe(Effect.flip);
 
-      expect(failure.reason).toContain(`returned blob ${"c".repeat(40)}`);
-      expect(failure.reason).toContain(`requested blob ${headBlob}`);
+      expect(failure).toMatchObject({
+        _tag: "GitHubApiFailure",
+        reason: expect.stringContaining(
+          `returned blob ${"c".repeat(40)} for requested blob ${headBlob}`,
+        ),
+      });
     }),
+  );
+
+  it.effect.each([
+    { bytes: new Uint8Array([65, 0, 66]), size: 3, tag: "BinaryBlob" },
+    { bytes: new Uint8Array([65, 0, 66]), size: 4, tag: "GitHubApiFailure" },
+    { bytes: new Uint8Array([255]), size: 1, tag: "GitHubApiFailure" },
+  ])(
+    "classifies verified binary bytes without swallowing malformed source: %#",
+    ({ bytes, size, tag }) =>
+      Effect.gen(function* () {
+        const path = "assets/unknown";
+        const blob = "a".repeat(40);
+        const client = HttpClient.make((request, url) => {
+          const body = url.pathname.includes("/git/commits/")
+            ? {
+                sha: url.pathname.endsWith(baseRevision) ? baseRevision : headRevision,
+                tree: { sha: headTree },
+              }
+            : url.pathname.includes("/git/trees/")
+              ? { sha: headTree, truncated: false, tree: [entry(path, blob)] }
+              : { sha: blob, size, encoding: "base64", content: Encoding.encodeBase64(bytes) };
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new globalThis.Response(JSON.stringify(body), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            ),
+          );
+        });
+        const github = yield* makeGitHubClient({
+          repository,
+          pullRequest: 12,
+          token: Redacted.make("github-token"),
+          apiUrl: "https://api.github.test",
+        }).pipe(Effect.provideService(HttpClient.HttpClient, client));
+        const comparison = yield* github.compareTrees(baseRevision, headRevision);
+        expect((yield* comparison.head.readTextFile(path).pipe(Effect.flip))._tag).toBe(tag);
+      }),
   );
 });


### PR DESCRIPTION
Ignore known binary asset formats before downloading blobs or consuming the text-review file limit. Treat verified NUL-containing blobs as ignored rather than incomplete coverage, while preserving failures for unavailable or malformed source. Text assets such as SVG remain reviewable, and binary-only PRs complete without a model call.

This belongs in the reviewer rather than requiring every consumer to maintain image ignore patterns. Both source tools and patch hydration enforce the same binary-format exclusions. The committed Action bundle is rebuilt; consumers pinned to an older Action commit need to update their pin after merge.

Preserve the textual side when a rename or content replacement crosses between binary and text. Review it as an addition or deletion; only explicit ignore rules discard both sides of a rename.

Verified with all 139 reviewer tests and `vp run ready`, including regressions for binary-only PRs, mixed text/assets, renames, read limits, and genuine source-read failures.
