### PR TITLE
fix(release): make dry-run an optional publish flag

### DIFF
--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -13,10 +13,12 @@ import {
   Schema,
   Stream,
 } from "effect";
+import { Command } from "effect/unstable/cli";
 import { Yaml } from "effect/unstable/encoding";
 import { ChildProcess } from "effect/unstable/process";
 
 import {
+  command as releaseCommand,
   PublishManifest,
   withTemporaryManifest,
   withPublishManifests,
@@ -620,6 +622,25 @@ layer(NodeServices.layer)("workspace toolchain", (it) => {
       expect(changesets?.env?.GITHUB_TOKEN).toBe("${{ steps.app-token.outputs.token }}");
       expect(changesets?.with?.publish).toBe("./node_modules/.bin/vp run release:publish");
       expect(release.jobs.release?.permissions?.["id-token"]).toBe("write");
+    }),
+  );
+
+  it.effect("publishes without flags and requires an explicit dry-run opt-in", () =>
+    Effect.gen(function* () {
+      const modes: Array<boolean> = [];
+
+      const run = Command.runWith(
+        Command.withHandler(releaseCommand, ({ dryRun }) =>
+          Effect.sync(() => {
+            modes.push(dryRun);
+          }),
+        ),
+        { version: "1.0.0", renderErrors: false },
+      );
+
+      yield* run([]);
+      yield* run(["--dry-run"]);
+      expect(modes).toEqual([false, true]);
     }),
   );
 

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -308,6 +308,7 @@ export const command = CliCommand.make(
   {
     dryRun: Flag.boolean("dry-run").pipe(
       Flag.withDescription("Build and inspect npm packages without publishing or creating tags."),
+      Flag.withDefault(false),
     ),
     otp: Flag.string("otp").pipe(
       Flag.optional,


### PR DESCRIPTION
The publish step after #303 failed with `Missing required flag: --dry-run`, before building packages or reaching npm. Effect CLI requires boolean flags unless they have an explicit default. Default `--dry-run` to `false` so the existing Changesets command publishes normally, while `--dry-run` still inspects packages without publishing.

Add a regression at the exported command boundary for both invocations. Keep the existing Changesets workflow, npm trusted publishing, beta tagging, and manifest restoration unchanged.

Failure: https://github.com/danieljvdm/effect-agent/actions/runs/33707024484

Validation: `vp run ready` passed. `vp run release:publish --dry-run` inspected all fourteen packages and restored the source manifests without publishing or creating tags. The built declarations include protected-browser APIs and `AgentRegistration.attemptLayer`.

After merging this fix, the normal workflow will refresh the pending version PR #308. Its owner can merge that PR to publish; a successful version-PR update alone does not prove npm publication. No package versions or release policy change in this repair.
