### PR TITLE
feat(platform-node): start managed workers with the host layer

### DIFF
--- a/.changeset/node-host-workers.md
+++ b/.changeset/node-host-workers.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-node": minor
+---
+
+Start a scoped worker pool with `NodeDurableHost.layer(registrations, options)` and supervise it with `NodeDurableHost.run`. Close admission when the pool exits and stop workers before releasing runtime resources.

--- a/docs/platforms/node.md
+++ b/docs/platforms/node.md
@@ -14,64 +14,48 @@ A bounded worker pool executes registered agents and recovers work after a resta
 bun add @effect-agent/platform-node@beta
 ```
 
-For the examples below, also install `effect@4.0.0-rc.112`, `@effect-agent/thread@beta`, and
-`@effect/platform-node@4.0.0-rc.112`.
+For the examples below, also install `effect@4.0.0-rc.112`, `@effect-agent/core@beta`,
+`@effect-agent/thread@beta`, `@effect/ai-openai@4.0.0-rc.112`, and `@effect/platform-node@4.0.0-rc.112`.
 Keep framework packages at one release and use compatible [Effect and provider packages](../guide/getting-started#installation-and-compatibility).
 
-## Configure the host
+## Create an agent
+
+Save this as `node-agent.ts`. The model's client reads `OPENAI_API_KEY` from the environment.
+The version declarations identify the agent, model, and tools used by accepted work.
+
+<<< @/snippets/travel-planner/node-agent.ts{ts twoslash}
+
+## Start the host
 
 Use a persistent database path with one live host per SQLite file. Give each replacement host
 incarnation a distinct `producerId`.
 `workerConcurrency` limits worker loops and defaults to one.
-`NodeDurableHost.layerRegistered` checks storage and runs recovery before accepting work.
+`NodeDurableHost.layer` checks storage, recovers pending work, and starts the worker pool when
+the Layer is acquired. Save this as `node-host.ts`, replacing `producerId` for each process start:
 
-Pass typed agent registrations to `NodeDurableHost.layerRegistered`. Its runtime computes definition
-digests and captures worker services in the Layer's Scope. Node supplies Crypto; provide
-model clients, tool handlers, instruction services, and schema services to the returned Layer.
-Keep the concrete registration tuple inferred so its requirements remain visible.
-Use `NodeDurableHost.layerStack` when you already have `ResolvedBinding` values from
-`compileRegistrations` and own their application Scope yourself.
+<<< @/snippets/travel-planner/node-host.ts{ts twoslash}
 
-Registrations include JSON descriptions and versions for the agent, model, and toolkit.
-Version tool implementations and other behavior JSON cannot represent.
-Submission digests must match the registered definitions. Keep matching bindings available
-until their work settles; an empty registration cannot execute work.
+TypeScript infers the registration's model, tool, instruction, and schema service requirements.
+Provide those services to the Layer, as `OpenAiLive` does here. Node supplies Crypto.
 
-Use `digestDefinitions` to compute submission digests.
-`DurableWorkerBinding.make(agent, digests)` accepts precomputed digests.
+Save this as `node-main.ts` and run it with Node's TypeScript transform support:
 
-## Run the workers
+<<< @/snippets/travel-planner/node-main.ts{ts twoslash}
 
-```ts twoslash
-import { NodeDurableHost } from "@effect-agent/platform-node/NodeDurableHost";
-import { type AgentRegistration } from "@effect-agent/thread/AgentRegistration";
-import { Effect } from "effect";
-
-export const workers = <const Entries extends ReadonlyArray<AgentRegistration>>(
-  registrations: Entries,
-) =>
-  Effect.gen(function* () {
-    const host = yield* NodeDurableHost;
-    yield* host.runResolvedWorkers;
-  }).pipe(
-    Effect.provide(
-      NodeDurableHost.layerRegistered(registrations, {
-        filename: "./agents.sqlite",
-        deploymentId: "travel-planner",
-        producerId: "worker-1",
-        workerConcurrency: 4,
-      }),
-    ),
-    Effect.scoped,
-  );
+```sh
+node --experimental-transform-types node-main.ts
 ```
 
-Provide the remaining application services to `workers(registrations)`, then call
-`NodeRuntime.runMain` at the process entry point. Creating the host alone does not start workers.
-If the process also serves requests, share one host Layer between both effects.
-Use `NodeDurableAgentRuntime.layerRegistered` for custom lifecycle composition with executable
-registrations. Its `layerWithBindings` constructor accepts previously compiled bindings; `layer`
-constructs an unregistered runtime for admission, recovery, and the generic single-agent APIs.
+`NodeDurableHost.run` observes the existing pool; calling it again does not start more workers.
+If a worker fails, admission closes and `run` fails with the original typed error or defect.
+`NodeRuntime.runMain` then closes the host. Use `run` rather than `Layer.launch(HostLive)`,
+which does not observe background worker failures. Interrupting only an observer leaves the
+pool running; closing the host's Scope closes admission, stops and joins workers, releases
+ownership, and closes storage and application services.
+
+If the process also serves requests, race the server Effect with `NodeDurableHost.run` using
+`Effect.raceFirst`, and provide the shared `HostLive` to that combined Effect. A worker failure
+then stops the server too. Creating two separate host Layers for the same SQLite file is unsupported.
 
 ## Use an Effect Workflow engine {#workflow}
 
@@ -82,35 +66,28 @@ its Schema-decoded output. A pending Agent suspends the handler through Effect's
 fiber alive in the parent.
 
 ```ts twoslash
-import { Agent } from "@effect-agent/core";
 import { AgentWorkflow } from "@effect-agent/workflow";
 import { Schema } from "effect";
-import { Toolkit } from "effect/unstable/ai";
 import { Workflow } from "effect/unstable/workflow";
 
-const triage = Agent.make("triage", {
-  input: Schema.String,
-  output: Schema.Struct({ severity: Schema.Literals(["low", "high", "critical"]) }),
-  instructions: "Classify the severity of the bug report.",
-  toolkit: Toolkit.empty,
-});
+import { planner } from "./node-agent.ts";
 
-const Review = Workflow.make("Review", {
-  payload: { issueId: Schema.String, report: Schema.String },
-  success: triage.output,
+const PlanTrip = Workflow.make("PlanTrip", {
+  payload: { tripId: Schema.String, request: Schema.String },
+  success: planner.output,
   error: AgentWorkflow.Error,
-  idempotencyKey: ({ issueId }) => issueId,
+  idempotencyKey: ({ tripId }) => tripId,
 });
 
-export const ReviewLive = Review.toLayer(({ report }) =>
-  AgentWorkflow.execute(triage, report, { name: "triage" }),
+export const PlanTripLive = PlanTrip.toLayer(({ request }) =>
+  AgentWorkflow.execute(planner, request, { name: "plan-itinerary" }),
 );
 
-export const review = Review.execute({ issueId: "123", report: "Login is broken" });
+export const trip = PlanTrip.execute({ tripId: "kyoto", request: "Three days in Kyoto." });
 ```
 
-Register `triage` and its model in the durable runtime below. Supply the resulting host Layer
-to `ReviewLive` with `Layer.provideMerge`, then provide that Layer to `review`. Share one
+Register `planner` and its model in the durable runtime below. Supply the resulting host Layer
+to `PlanTripLive` with `Layer.provideMerge`, then provide that Layer to `trip`. Share one
 WorkflowEngine Layer between the parent and host; a mismatched engine fails before admission.
 Multi-step handlers use ordinary `Effect.gen` and bounded `Effect.all`.
 
@@ -154,12 +131,13 @@ import {
   NodeWorkflowRepairTrigger,
   SqlWorkflowDispatchStore,
 } from "@effect-agent/platform-node/NodeWorkflow";
-import { type AgentRegistration } from "@effect-agent/thread/AgentRegistration";
 import { WorkflowAgentHost } from "@effect-agent/workflow/WorkflowAgentHost";
 import { NodeCrypto } from "@effect/platform-node";
 import { SqliteClient } from "@effect/sql-sqlite-node";
 import { Layer } from "effect";
 import { ClusterWorkflowEngine, SingleRunner } from "effect/unstable/cluster";
+
+import { definitions, ModelLive, OpenAiLive, planner } from "./node-agent.ts";
 
 const workflowDatabase = SqliteClient.layer({ filename: "./workflow.sqlite" });
 const engine = ClusterWorkflowEngine.layer.pipe(
@@ -169,27 +147,25 @@ const infrastructure = Layer.mergeAll(engine, SqlWorkflowDispatchStore.layer).pi
   Layer.provide(workflowDatabase),
 );
 
-export const workflowHost = <const Entries extends ReadonlyArray<AgentRegistration>>(
-  registrations: Entries,
-) =>
-  WorkflowAgentHost.layer({
-    deploymentId: "travel-planner",
-    principal: "travel-planner-service",
-    executionConcurrency: 4,
-    repairBatchSize: 32,
-    dispatchTimeoutMillis: 10_000,
-  }).pipe(
-    Layer.provide(
-      NodeDurableAgentRuntime.layerRegistered(registrations, {
-        filename: "./agents.sqlite",
-        deploymentId: "travel-planner",
-        producerId: "workflow-worker-1",
-      }),
-    ),
-    Layer.provideMerge(infrastructure),
-    Layer.provide(NodeWorkflowRepairTrigger.layer({ interval: "1 second" })),
-    Layer.provide(NodeCrypto.layer),
-  );
+export const WorkflowLive = WorkflowAgentHost.layer({
+  deploymentId: "travel-planner",
+  principal: "travel-planner-service",
+  executionConcurrency: 4,
+  repairBatchSize: 32,
+  dispatchTimeoutMillis: 10_000,
+}).pipe(
+  Layer.provide(
+    NodeDurableAgentRuntime.layerRegistered([{ agent: planner, model: ModelLive, definitions }], {
+      filename: "./agents.sqlite",
+      deploymentId: "travel-planner",
+      producerId: "workflow-worker-1",
+    }),
+  ),
+  Layer.provideMerge(infrastructure),
+  Layer.provide(NodeWorkflowRepairTrigger.layer({ interval: "1 second" })),
+  Layer.provide(NodeCrypto.layer),
+  Layer.provide(OpenAiLive),
+);
 ```
 
 Provide the remaining model, tool, instruction, and schema services to this Layer, then share it
@@ -260,10 +236,27 @@ Each Attempt owns its resources and releases ownership and permits before native
 Closing the host Scope stops its repair trigger and closes acquired resources. The SQL assembly
 is certified for a single Node process. It makes no multi-runner or Cloudflare Workflow claim.
 
+## Custom runtime composition
+
+Use `NodeDurableAgentRuntime.layerRegistered` when you own execution, as in the Workflow
+assembly above. It captures registrations and acquires storage without starting workers.
+`layerWithBindings` accepts precompiled `ResolvedBinding` values whose application Scope you own;
+`layer` constructs an unregistered runtime for explicit admission and execution.
+
+The service class's existing `NodeDurableHost.layerRegistered`, `layerStack`, and `layer`
+constructors remain available for manually managed hosts. Import the class from
+`@effect-agent/platform-node/NodeDurableHost` when using these APIs; their workers start only
+when you run `host.runResolvedWorkers`. The module-level `NodeDurableHost.layer` shown above
+owns worker startup and is the default for an application.
+
+Registrations carry application version declarations. Update them when behavior changes,
+including tool implementations that JSON cannot represent, and keep matching bindings available
+until their work settles. `digestDefinitions` computes the digests for explicit submissions;
+`DurableWorkerBinding.make(agent, digests)` accepts precomputed digests.
+
 ## Configure runtime services
 
-Pass service layers through `NodeDurableHost.layerRegistered`, `NodeDurableHost.layerStack`,
-or `NodeDurableAgentRuntime.layer`:
+Pass service layers in the options to `NodeDurableHost.layer` or `NodeDurableAgentRuntime.layer`:
 
 | Option              | Service                 | Default                                                     |
 | ------------------- | ----------------------- | ----------------------------------------------------------- |

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -248,6 +248,11 @@ the Thread journal and submission ledger.
 
 ### `@effect-agent/platform-node`
 
+`NodeDurableHost.layer(registrations, options)` acquires storage, recovers pending work, and
+starts a bounded worker pool. `NodeDurableHost.run` observes that pool and propagates worker
+failure to the application. Provide the host Layer once around the supervised application;
+its Scope closes admission and joins workers before releasing runtime resources.
+
 Assembles SQLite storage, recovery, and workers through `NodeDurableHost`.
 Registers agent bindings before execution, recovers before admission, and releases ownership
 before closing storage. See the [Node.js guide](../platforms/node).

--- a/docs/snippets/travel-planner/node-agent.ts
+++ b/docs/snippets/travel-planner/node-agent.ts
@@ -1,0 +1,20 @@
+import { Agent } from "@effect-agent/core";
+import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
+import { Config, Layer, Schema } from "effect";
+import { Toolkit } from "effect/unstable/ai";
+import { FetchHttpClient } from "effect/unstable/http";
+
+export const planner = Agent.make("trip-planner", {
+  input: Schema.String,
+  output: Schema.Struct({ itinerary: Schema.Array(Schema.String) }),
+  instructions: "Plan a trip with one itinerary entry per day.",
+  toolkit: Toolkit.empty,
+});
+
+export const ModelLive = OpenAiLanguageModel.model("gpt-4.1-mini");
+
+export const OpenAiLive = OpenAiClient.layerConfig({
+  apiKey: Config.redacted("OPENAI_API_KEY"),
+}).pipe(Layer.provide(FetchHttpClient.layer));
+
+export const definitions = { agent: "v1", model: "gpt-4.1-mini", tools: "v1" };

--- a/docs/snippets/travel-planner/node-host.ts
+++ b/docs/snippets/travel-planner/node-host.ts
@@ -1,0 +1,11 @@
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { Layer } from "effect";
+
+import { definitions, ModelLive, OpenAiLive, planner } from "./node-agent.ts";
+
+export const HostLive = NodeDurableHost.layer([{ agent: planner, model: ModelLive, definitions }], {
+  filename: "./agents.sqlite",
+  deploymentId: "travel-planner",
+  producerId: "worker-start-001",
+  workerConcurrency: 4,
+}).pipe(Layer.provide(OpenAiLive));

--- a/docs/snippets/travel-planner/node-main.ts
+++ b/docs/snippets/travel-planner/node-main.ts
@@ -1,0 +1,7 @@
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
+
+import { HostLive } from "./node-host.ts";
+
+NodeRuntime.runMain(NodeDurableHost.run.pipe(Effect.provide(HostLive)));

--- a/packages/platform-node/src/NodeDurableHost.ts
+++ b/packages/platform-node/src/NodeDurableHost.ts
@@ -38,7 +38,7 @@ import {
   type ThreadNotMaterialized,
   type ThreadStoreError,
 } from "@effect-agent/thread/ThreadStore";
-import { type Stream, Context, type Crypto, Effect, Layer, Ref, Schema } from "effect";
+import { type Stream, Context, type Crypto, Effect, Fiber, Layer, Ref, Schema } from "effect";
 
 import {
   NodeDurableAgentRuntime,
@@ -56,7 +56,7 @@ export class AdmissionClosed extends Schema.TaggedError<AdmissionClosed>()("Admi
   message: Schema.String,
 }) {}
 
-const makeHost = Effect.gen(function* () {
+const makeHost = Effect.fn("NodeDurableHost.make")(function* (startWorkers: boolean) {
   const runtime = yield* DurableAgentRuntime;
   const config = yield* NodeDurableAgentRuntimeConfig;
 
@@ -69,10 +69,6 @@ const makeHost = Effect.gen(function* () {
   const startupRecovery = yield* runtime.runRecovery;
 
   const admission = yield* Ref.make(true);
-
-  // Shutdown step 1 (DEPLOY-005): admission closes before the ownership drain in the runtime
-  // Layer below releases claims and before the stores close in reverse acquisition order.
-  yield* Effect.addFinalizer(() => Ref.set(admission, false));
 
   const requireAdmission: Effect.Effect<void, AdmissionClosed> = Ref.get(admission).pipe(
     Effect.flatMap((open) =>
@@ -107,6 +103,19 @@ const makeHost = Effect.gen(function* () {
   // runs `workerConcurrency: 1` over exactly this loop.
   const runResolvedWorkers = runWorkers(runtime.runResolvedWorker);
 
+  const run = startWorkers
+    ? Fiber.join(
+        yield* runResolvedWorkers.pipe(
+          Effect.onExit(() => Ref.set(admission, false)),
+          Effect.forkScoped,
+        ),
+      )
+    : runResolvedWorkers;
+
+  // Register after the worker fiber: close admission, interrupt/join workers, drain
+  // runtime ownership, then close storage and captured application services.
+  yield* Effect.addFinalizer(() => Ref.set(admission, false));
+
   return NodeDurableHost.of({
     startupRecovery,
     admissionOpen: Ref.get(admission),
@@ -121,12 +130,14 @@ const makeHost = Effect.gen(function* () {
     wake: runtime.wake,
     scanObligations: runtime.scanObligations,
     runWorkers,
-    runResolvedWorkers,
+    run,
+    runResolvedWorkers: run,
   });
 });
 
 /**
- * Operational host lifecycle for the DN runtime (deployment §2/§5/§6).
+ * Operational host service. Prefer the module's `layer` and `run` for managed workers.
+ * The static constructors on this class retain explicit, manual worker ownership.
  *
  * Startup gates run during Layer construction, so the service existing implies readiness:
  * configuration was schema-decoded, the SQLite file passed the exact-version compatibility check,
@@ -150,6 +161,8 @@ export class NodeDurableHost extends Context.Service<
     readonly startupRecovery: ReadonlyArray<RecoveryReport>;
     /** Admission-role readiness (deployment §7): true until shutdown begins. */
     readonly admissionOpen: Effect.Effect<boolean>;
+    /** Observe the managed worker pool, preserving its failure. Manual hosts start their pool here. */
+    readonly run: Effect.Effect<void, DurableWorkerFailure | DurableBindingFailure>;
     /** `DurableAgentRuntime.submit` behind the host admission gate. */
     readonly submit: <InputSchema extends Schema.Top>(
       agent: DurableSubmitAgent<InputSchema>,
@@ -197,6 +210,7 @@ export class NodeDurableHost extends Context.Service<
      * Run `workerConcurrency` copies of `DurableAgentRuntime.runResolvedWorker` over the host's
      * registered Bindings (S2): every claimed head resolves its exact stored Binding before any
      * code runs (SUB-023), so one bounded pool serves parent and attached-child lanes.
+     * Hosts built with the module-level `layer` instead join their existing pool.
      */
     readonly runResolvedWorkers: Effect.Effect<void, DurableWorkerFailure | DurableBindingFailure>;
   }
@@ -235,7 +249,7 @@ export class NodeDurableHost extends Context.Service<
     NodeDurableHost,
     DurableWorkerFailure,
     DurableAgentRuntime | NodeDurableAgentRuntimeConfig
-  > = Layer.effect(NodeDurableHost)(makeHost);
+  > = Layer.effect(NodeDurableHost)(makeHost(false));
 
   /** The complete DN host: `NodeDurableAgentRuntime.layer(options)` plus the host lifecycle gates. */
   static layerStack<
@@ -265,3 +279,39 @@ export class NodeDurableHost extends Context.Service<
     );
   }
 }
+
+/**
+ * Acquire a complete Node host and start one bounded, scoped worker pool after recovery.
+ * Provide model, tool, instruction, and schema dependencies to this Layer. Reusing the Layer
+ * shares the same pool. A worker failure closes admission; observe it with `run` at the process
+ * boundary so the application exits and releases the host instead of remaining idle.
+ */
+export const layer = <
+  const Entries extends ReadonlyArray<AgentRegistration>,
+  ContextError = never,
+  ContextRequirements = never,
+  AuthorizationError = never,
+  AuthorizationRequirements = never,
+>(
+  registrations: Entries,
+  options: NodeDurableAgentRuntimeOptions<
+    ContextError,
+    ContextRequirements,
+    AuthorizationError,
+    AuthorizationRequirements
+  >,
+) =>
+  Layer.effect(NodeDurableHost)(makeHost(true)).pipe(
+    Layer.provideMerge(NodeDurableAgentRuntime.layerRegistered(registrations, options)),
+  );
+
+/**
+ * Supervise the host's existing workers without starting another pool. Use with
+ * `Effect.provide(HostLive)` and `NodeRuntime.runMain`; race it with a server Effect when
+ * the same process also serves requests. Unlike `Layer.launch`, this observes worker failures.
+ */
+export const run = Effect.gen(function* () {
+  const host = yield* NodeDurableHost;
+
+  return yield* host.run;
+});

--- a/packages/platform-node/test/layers.test.ts
+++ b/packages/platform-node/test/layers.test.ts
@@ -17,9 +17,11 @@ import {
   type NodeDurableAgentRuntimeServices,
 } from "@effect-agent/platform-node/NodeDurableAgentRuntime";
 import { NodeDurableHost } from "@effect-agent/platform-node/NodeDurableHost";
+import * as NodeHost from "@effect-agent/platform-node/NodeDurableHost";
 import { SqliteStorageCompatibilityError } from "@effect-agent/storage-sqlite/SqliteStorageError";
 import { CurrentSqliteStorageVersion } from "@effect-agent/storage-sqlite/SqliteStorageVersion";
 import { type SqliteStorageInitializationError } from "@effect-agent/storage-sqlite/SqliteThreadStore";
+import type { DurableBindingFailure } from "@effect-agent/thread/AgentRegistration";
 import { type DigestError, digestDefinitions, digestJson } from "@effect-agent/thread/Digest";
 import {
   DurableAgentRuntime,
@@ -283,8 +285,206 @@ const readLogTags = (threadId: ThreadId) =>
   });
 
 describe("NodeDurableAgentRuntime", () => {
+  it.effect.each(["failure", "defect", "timeout", "interruption"] as const)(
+    "supervises managed workers and releases their resources on %s",
+    (mode) =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const ready = yield* Deferred.make<NodeDurableHost["Service"]>();
+          const started = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          const marks: Array<string> = [];
+          const model = yield* makeScriptedModel(() => finalParts('{"answer":"unused"}'));
+
+          class Resource extends Context.Service<Resource, string>()("test/ManagedHostResource") {}
+
+          const agent = Agent.withModel(
+            Agent.make("managed-worker", {
+              input: plannerDefinition.input,
+              output: plannerDefinition.output,
+              instructions: () => Resource,
+              toolkit: Toolkit.empty,
+            }),
+            model,
+          );
+
+          const definitions = DefinitionDigestInput.make({ agent: "v1", model: "v1", tools: "v1" });
+
+          const digests = yield* digestDefinitions(definitions).pipe(
+            Effect.provide(NodeCrypto.layer),
+          );
+
+          const live = NodeHost.layer(
+            [{ agent, definitions }],
+            runtimeOptions(filename, {
+              runtimeFailpoint: (location) =>
+                location === "claim:after-claim"
+                  ? Effect.gen(function* () {
+                      yield* Deferred.succeed(started, undefined);
+                      yield* Deferred.await(release);
+                      if (mode === "failure")
+                        return yield* DurableRuntimeFailpointError.make({ location });
+                      if (mode === "defect") return yield* Effect.die("worker defect");
+
+                      return yield* Effect.never;
+                    }).pipe(
+                      Effect.ensuring(
+                        Effect.sync(() => {
+                          marks.push("worker-finalized");
+                        }),
+                      ),
+                    )
+                  : Effect.void,
+            }),
+          ).pipe(
+            Layer.provide(
+              Layer.effect(
+                Resource,
+                Effect.acquireRelease(Effect.succeed("Answer as JSON."), () =>
+                  Effect.sync(() => {
+                    marks.push("resource-finalized");
+                  }),
+                ),
+              ),
+            ),
+          );
+
+          const main = Effect.gen(function* () {
+            const host = yield* NodeDurableHost;
+
+            yield* Deferred.succeed(ready, host);
+            yield* host.submit(
+              agent,
+              { question: "wait" },
+              {
+                ...submitOptions("managed-thread", "managed-input"),
+                definitions: digests,
+              },
+            );
+            yield* NodeHost.run.pipe(
+              Effect.onError(() =>
+                mode === "failure" || mode === "defect"
+                  ? Effect.gen(function* () {
+                      expect(yield* host.admissionOpen).toBe(false);
+                      expect(
+                        yield* host
+                          .submit(
+                            agent,
+                            { question: "too late" },
+                            {
+                              ...submitOptions("late-thread", "late-input"),
+                              definitions: digests,
+                            },
+                          )
+                          .pipe(Effect.result),
+                      ).toMatchObject({
+                        _tag: "Failure",
+                        failure: { _tag: "AdmissionClosed" },
+                      });
+                    })
+                  : Effect.void,
+              ),
+            );
+          }).pipe(Effect.provide(live));
+
+          const fiber = yield* (
+            mode === "timeout" ? main.pipe(Effect.timeout("1 second")) : main
+          ).pipe(Effect.forkChild);
+
+          const host = yield* Deferred.await(ready);
+
+          yield* Deferred.await(started);
+          yield* Deferred.succeed(release, undefined);
+          if (mode === "timeout") yield* TestClock.adjust("1 second");
+          if (mode === "interruption") yield* Fiber.interrupt(fiber);
+          const exit = yield* Fiber.await(fiber);
+
+          expect(marks).toEqual(["worker-finalized", "resource-finalized"]);
+          expect(yield* host.admissionOpen).toBe(false);
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (mode === "failure")
+            expect(failureOf(exit)).toMatchObject({ _tag: "DurableRuntimeFailpointError" });
+          if (mode === "defect") expect(failureOf(exit)).toBe("worker defect");
+          if (mode === "timeout") expect(failureOf(exit)).toMatchObject({ _tag: "TimeoutError" });
+          if (mode === "interruption") expect(Exit.hasInterrupts(exit)).toBe(true);
+        }),
+      ),
+  );
+
   it.effect(
-    "compiles registrations in the host Scope and retains their services until shutdown",
+    "shares one bounded managed pool across observers and closes admission before draining it",
+    () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const started = yield* Deferred.make<void>();
+          const ready = yield* Deferred.make<NodeDurableHost["Service"]>();
+          const claimed = yield* Ref.make(0);
+          const finalized = yield* Ref.make(0);
+          const model = yield* makeScriptedModel(() => finalParts('{"answer":"unused"}'));
+          const agent = Agent.withModel(plannerDefinition, model);
+          const definitions = DefinitionDigestInput.make({ agent: "v1", model: "v1", tools: "v1" });
+
+          const digests = yield* digestDefinitions(definitions).pipe(
+            Effect.provide(NodeCrypto.layer),
+          );
+
+          const live = NodeHost.layer(
+            [{ agent, definitions }],
+            runtimeOptions(filename, {
+              workerConcurrency: 2,
+              runtimeFailpoint: (location) =>
+                location === "claim:after-claim"
+                  ? Effect.gen(function* () {
+                      const count = yield* Ref.updateAndGet(claimed, (n) => n + 1);
+
+                      if (count === 2) yield* Deferred.succeed(started, undefined);
+
+                      return yield* Effect.never;
+                    }).pipe(
+                      Effect.ensuring(
+                        Effect.gen(function* () {
+                          const host = yield* Deferred.await(ready);
+
+                          expect(yield* host.admissionOpen).toBe(false);
+                          yield* Ref.update(finalized, (n) => n + 1);
+                        }),
+                      ),
+                    )
+                  : Effect.void,
+            }),
+          );
+
+          yield* Effect.gen(function* () {
+            const host = yield* NodeDurableHost;
+
+            yield* Deferred.succeed(ready, host);
+            for (const id of ["first", "second", "third"]) {
+              yield* host.submit(
+                agent,
+                { question: id },
+                {
+                  ...submitOptions(id, id),
+                  definitions: digests,
+                },
+              );
+            }
+            yield* Deferred.await(started);
+            const first = yield* NodeHost.run.pipe(Effect.forkChild);
+            const second = yield* NodeHost.run.pipe(Effect.forkChild);
+
+            yield* Fiber.interrupt(first);
+            yield* Fiber.interrupt(second);
+            expect(yield* host.admissionOpen).toBe(true);
+            expect(yield* Ref.get(claimed)).toBe(2);
+            expect(yield* Ref.get(finalized)).toBe(0);
+          }).pipe(Effect.provide(live));
+          expect(yield* Ref.get(finalized)).toBe(2);
+        }),
+      ),
+  );
+
+  it.effect(
+    "starts registered workers with the host Layer and retains their services until shutdown",
     () =>
       withTemporaryDatabase((filename) =>
         Effect.gen(function* () {
@@ -332,7 +532,7 @@ describe("NodeDurableAgentRuntime", () => {
             tools: [],
           });
 
-          const live = NodeDurableHost.layerRegistered(
+          const live = NodeHost.layer(
             [{ agent, definitions }],
             runtimeOptions(filename, {
               storageFailpoint: (location) =>
@@ -364,6 +564,14 @@ describe("NodeDurableAgentRuntime", () => {
 
           const requirements: Assert<Equal<Layer.Services<typeof live>, Instructions>> = true;
 
+          const runRequirements: Assert<
+            Equal<Effect.Services<typeof NodeHost.run>, NodeDurableHost>
+          > = true;
+
+          const runErrors: Assert<
+            Equal<Effect.Error<typeof NodeHost.run>, DurableWorkerFailure | DurableBindingFailure>
+          > = true;
+
           const errors: Assert<
             Equal<
               Layer.Error<typeof live>,
@@ -373,6 +581,8 @@ describe("NodeDurableAgentRuntime", () => {
 
           expect(
             requirements &&
+              runRequirements &&
+              runErrors &&
               errors &&
               registeredOutput &&
               registeredRequirements &&
@@ -397,13 +607,10 @@ describe("NodeDurableAgentRuntime", () => {
               },
             );
 
-            const worker = yield* host.runResolvedWorkers.pipe(Effect.forkChild);
-
             yield* Deferred.await(settled);
             const settlement = yield* host.awaitSettlement(receipt);
 
             expect(settlement.outcome).toBe("completed");
-            yield* Fiber.interrupt(worker);
             expect(yield* Ref.get(active)).toBe(true);
 
             return host;
@@ -453,7 +660,7 @@ describe("NodeDurableAgentRuntime", () => {
             Effect.acquireRelease(Effect.succeed({}), () => Ref.set(released, true)),
           );
 
-          const live = NodeDurableHost.layerRegistered(
+          const live = NodeHost.layer(
             [
               {
                 agent,
@@ -496,7 +703,7 @@ describe("NodeDurableAgentRuntime", () => {
       toolAuthorization: configuredAuthorization,
     });
 
-    const both = NodeDurableHost.layerRegistered([], {
+    const both = NodeHost.layer([], {
       ...runtimeOptions("unused.sqlite"),
       runContext: configuredContext,
       toolAuthorization: configuredAuthorization,


### PR DESCRIPTION
The Node guide required callers to write a generic registration wrapper and manually start workers after acquiring a host. Add module-level `NodeDurableHost.layer` to start one scoped, bounded pool after startup recovery, and `NodeDurableHost.run` to observe that pool and propagate its failures.

```ts
import { NodeDurableHost } from "@effect-agent/platform-node";
import { NodeRuntime } from "@effect/platform-node";
import { Effect, Layer } from "effect";

// Application definitions and provider setup; shown in the Node guide.
import { planner, ModelLive, OpenAiLive, definitions } from "./node-agent.ts";

const HostLive = NodeDurableHost.layer(
  [{ agent: planner, model: ModelLive, definitions }],
  {
    filename: "./agents.sqlite",
    deploymentId: "travel-planner",
    producerId: "worker-start-001", // Use a fresh identity for each process start.
    workerConcurrency: 4,
  },
).pipe(Layer.provide(OpenAiLive));

NodeRuntime.runMain(NodeDurableHost.run.pipe(Effect.provide(HostLive)));
```

Acquiring the Layer starts workers; observing `run` never starts another pool. Worker failures close admission and reach `run` with their original typed errors or defects. Scope shutdown closes admission, interrupts and joins workers, then releases runtime ownership, storage, and application services.

```mermaid
flowchart LR
  Layer[NodeDurableHost.layer] --> Recovery[Startup recovery]
  Recovery --> Pool[Scoped worker pool]
  Pool -->|exit closes admission| Run[NodeDurableHost.run]
  Run -->|failure propagates| Main[NodeRuntime.runMain]
  Main -->|scope shutdown| Cleanup[Join workers and release resources]
```

Use `run` instead of `Layer.launch`: native Layer launch does not observe background fiber failures. For an HTTP process, race the server Effect with `run` and provide their shared host Layer around the combined Effect. Existing service-class constructors remain available for manual ownership; the lower-level runtime used by Effect Workflow does not acquire an extra pool.

Replace both generic helpers in the Node guide with concrete examples, including a trip-planning agent and a complete provider setup. The lifecycle tests cover automatic execution, shared bounded workers, admission closure on failure, typed errors, defects, timeout, interruption, and resource release order. The documentation examples compile during the docs build.
