### PR TITLE
fix(cloudflare): reduce history memory and bound alarm work

### DIFF
--- a/.changeset/bounded-cloudflare-runtime.md
+++ b/.changeset/bounded-cloudflare-runtime.md
@@ -1,0 +1,8 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Stream durable history and bound Cloudflare journal read payloads while removing unused startup modules and temporary encodings. Bound alarm execution time and let durable runs yield between committed turns while preserving recovery and original run budgets.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -317,11 +317,49 @@ Alarms recover pending work after eviction without another user request.
 The host owns the Object's [single alarm](https://developers.cloudflare.com/durable-objects/api/alarms/);
 do not replace its handler or schedule unrelated alarms on that Object.
 
+Each Thread alarm reconciles recovery and advances at most one head Attempt. Accepted input can
+still join that Run through its normal turn boundaries. After ten minutes, the Attempt commits
+its completed turn and yields before preparing another turn, including context summarization.
+A later alarm resumes the same Run with its original duration deadline and cumulative usage.
+
+The whole Thread alarm has a fourteen-minute watchdog, including time waiting for another pass.
+The Schedule Owner uses the same watchdog while scanning due schedules. It continues past failed
+pages so a page of broken schedules cannot block healthy followers. Interrupted work keeps its
+durable retry obligation. These timers leave room below Cloudflare's
+[fifteen-minute alarm lifetime](https://developers.cloudflare.com/durable-objects/platform/limits/),
+but cannot preempt synchronous CPU work or an uninterruptible finalizer. Cloudflare's CPU limit
+is separate from elapsed time.
+
 `maxQueueDepthPerLane`, `maxInputBytes`, and `maxDatabaseBytes` refuse excess work with
 `AdmissionLimitExceeded` before admission. Keep Object RPC private and supply
 `operationAuthorizer` for application access rules. The default policy trusts service possession.
 
-Unconfirmed tool outcomes need authorized resolution. See [operations](../guide/operations).
+An ordinary tool interrupted before its outcome is confirmed can become Unknown during recovery;
+it is never automatically replayed. Unconfirmed outcomes need authorized resolution. See
+[operations](../guide/operations).
+
+## Runtime memory
+
+Cloudflare's 128 MB memory limit applies to an isolate, which can contain multiple Durable Objects
+and their Worker. It is not a separate allowance for every Object. See
+[memory usage metrics](https://developers.cloudflare.com/durable-objects/observability/metrics-and-analytics/#memory-usage).
+
+Use the package subpaths shown above to keep dependencies explicit. The package also declares
+unused modules removable, so Wrangler can remove unused adapters from root imports.
+
+Canonical reads and observations fetch at most 4 MiB of record JSON per internal SQL page, after
+capturing up to 1,024 sequence and size entries. Decoded objects and strings require additional
+heap. Recovery retains evidence for the addressed runs; prompt projection scans a fixed canonical
+tail and avoids retaining summarized response payloads. Metadata and scanning work still grow
+with history, and an uncompacted prompt still grows with the conversation. Configure
+[`contextTokenLimit`, compaction, tool result bounds, and concurrency](../guide/context-management)
+for the workload from the start. Admission and record-size limits do not reserve isolate memory.
+Whole-thread export still returns a complete collection; use paged reads for large histories.
+
+The [local heap benchmark](https://github.com/danieljvdm/effect-agent/tree/main/examples/cloudflare-memory#local-heap-measurements)
+measures exact Worker bundles and several concurrent Thread Objects using a synthetic model and
+tools. It requires no model key or deployment. Its local JavaScript heap snapshots help compare
+changes; profile production-like histories and tool payloads before choosing deployment capacity.
 
 ## Code execution and browsers
 

--- a/examples/cloudflare-memory/README.md
+++ b/examples/cloudflare-memory/README.md
@@ -29,3 +29,37 @@ Embedding/search are deliberately absent, so this benchmark makes no claim about
 Worker clocks advance on I/O; zero rendering intervals are not evidence of zero CPU cost.
 One first-after-inactivity sample per case cannot establish cold-start percentiles, and inactivity
 does not prove eviction. Local workerd results must not be reported as deployed latency.
+
+## Local heap measurements
+
+Run the separate heap benchmark without deploying or supplying a model key:
+
+```sh
+vp run --no-cache -F @effect-agent/example-cloudflare-memory measure:heap \
+  --out-dir /tmp/effect-agent-heap --samples 3 --objects 4
+```
+
+The command needs permission to open local HTTP and debugger ports. It saves exact Wrangler dry-run
+bundles, SHA-256 hashes, esbuild metafiles, individual samples, and a schema-encoded `report.json`.
+It compares the existing Worker's direct `ThreadObject` import with an equivalent root import and
+builds a separate synthetic runtime Worker from `wrangler.heap.jsonc`.
+
+Each Node sample uses a fresh process and evaluates the emitted bundle in a separate VM realm.
+It records the harness baseline, evaluation delta, and explicit post-GC delta. Cloudflare external
+modules are shimmed, and no handlers execute in Node. These values diagnose startup allocations;
+they do not measure workerd or a Cloudflare memory allowance.
+
+Each native sample starts fresh local workerd and reads `Runtime.getHeapUsage` through its debugger.
+It samples after startup, after initializing all Thread Objects, while every Object has live tool
+activity, and after all runs settle. Each Object uses a registered synthetic Effect AI model and
+two registered tools, a 4096-character input, and two 16384-character tool results. A tool gate fixes
+the active sampling point. The command verifies two model calls, two tool calls, and successful
+settlement per Object. `--objects` accepts 1–16 and `--samples` accepts 1–20.
+
+Native values are instantaneous JavaScript heap snapshots, not peak memory or process RSS.
+The report keeps embedder and backing-storage counters separate. It does not force workerd GC.
+Local results do not establish hosted capacity, per-Object isolation, or behavior with provider
+SDKs, long histories, more tools, or production traffic. Cloudflare's
+[memory profiler](https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/)
+explains how to inspect real workloads. Hosted latency measurement remains the explicit `measure`
+command above; neither command deploys anything.

--- a/examples/cloudflare-memory/package.json
+++ b/examples/cloudflare-memory/package.json
@@ -7,6 +7,7 @@
     "build": "wrangler deploy --dry-run",
     "check": "tsc --noEmit -p tsconfig.json",
     "measure": "node --experimental-transform-types src/measure-main.ts",
+    "measure:heap": "node --experimental-transform-types src/heap-main.ts",
     "test": "vp test --passWithNoTests"
   },
   "dependencies": {

--- a/examples/cloudflare-memory/src/heap-contracts.ts
+++ b/examples/cloudflare-memory/src/heap-contracts.ts
@@ -1,0 +1,48 @@
+import { Schema } from "effect";
+
+export class HeapProbeError extends Schema.TaggedError<HeapProbeError>()("HeapProbeError", {
+  operation: Schema.String,
+  cause: Schema.optionalKey(Schema.Defect()),
+}) {}
+
+export const HeapUsage = Schema.Struct({
+  usedSize: Schema.Number,
+  totalSize: Schema.Number,
+  embedderHeapUsedSize: Schema.optionalKey(Schema.Number),
+  backingStorageSize: Schema.optionalKey(Schema.Number),
+});
+
+export const ObjectStatus = Schema.Struct({
+  active: Schema.Boolean,
+  modelCalls: Schema.Natural,
+  toolCalls: Schema.Natural,
+});
+
+export const NodeMemory = Schema.Struct({
+  rss: Schema.Number,
+  heapTotal: Schema.Number,
+  heapUsed: Schema.Number,
+  external: Schema.Number,
+  arrayBuffers: Schema.Number,
+});
+
+export const NodeSample = Schema.Struct({
+  node: Schema.String,
+  v8: Schema.String,
+  platform: Schema.String,
+  arch: Schema.String,
+  baseline: NodeMemory,
+  evaluated: NodeMemory,
+  retained: NodeMemory,
+  evaluatedHeapDelta: Schema.Number,
+  retainedHeapDelta: Schema.Number,
+  exports: Schema.Array(Schema.String),
+});
+
+export const WorkerdSample = Schema.Struct({
+  startup: HeapUsage,
+  initialized: HeapUsage,
+  active: HeapUsage,
+  settled: HeapUsage,
+  objects: Schema.Array(ObjectStatus),
+});

--- a/examples/cloudflare-memory/src/heap-main.ts
+++ b/examples/cloudflare-memory/src/heap-main.ts
@@ -1,0 +1,18 @@
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Effect } from "effect";
+import { Command } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+import { Socket } from "effect/unstable/socket";
+
+import { command } from "./heap.ts";
+
+NodeRuntime.runMain(
+  Command.run(command, { version: "0.0.0" }).pipe(
+    Effect.scoped,
+    Effect.provide([
+      NodeServices.layer,
+      FetchHttpClient.layer,
+      Socket.layerWebSocketConstructorGlobal,
+    ]),
+  ),
+);

--- a/examples/cloudflare-memory/src/heap-node-main.ts
+++ b/examples/cloudflare-memory/src/heap-node-main.ts
@@ -1,0 +1,24 @@
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Console, Effect, Schema } from "effect";
+import { Argument, Command } from "effect/unstable/cli";
+
+import { NodeSample } from "./heap-contracts.ts";
+import { measureNode } from "./heap-node.ts";
+
+const command = Command.make(
+  "heap-node",
+  {
+    bundle: Argument.string("bundle").pipe(
+      Argument.withDescription("Exact Wrangler JavaScript bundle to evaluate."),
+    ),
+  },
+  ({ bundle }) =>
+    measureNode(bundle).pipe(
+      Effect.flatMap(Schema.encodeEffect(Schema.fromJsonString(NodeSample))),
+      Effect.flatMap(Console.log),
+    ),
+);
+
+NodeRuntime.runMain(
+  Command.run(command, { version: "0.0.0" }).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/examples/cloudflare-memory/src/heap-node.ts
+++ b/examples/cloudflare-memory/src/heap-node.ts
@@ -1,0 +1,141 @@
+// Effect has no VM-isolate or V8 heap-counter service. These Node-only APIs are
+// diagnostic adapters; the Worker bundle executes in a separate global realm.
+import * as asyncHooks from "node:async_hooks";
+import process from "node:process";
+import * as vm from "node:vm";
+
+import { Effect, FileSystem } from "effect";
+
+import { HeapProbeError, NodeSample } from "./heap-contracts.ts";
+
+const collect = Effect.try({
+  try: () => {
+    if (!globalThis.gc) throw new Error("Run with --expose-gc");
+    globalThis.gc();
+    globalThis.gc();
+  },
+  catch: (cause) => HeapProbeError.make({ operation: "Node GC", cause }),
+});
+
+const memory = Effect.sync(() => ({ ...process.memoryUsage() }));
+
+export const measureNode = Effect.fn("heap.measureNode")(function* (bundle: string) {
+  const fs = yield* FileSystem.FileSystem;
+
+  const realm = yield* Effect.try({
+    try: () => {
+      const context = vm.createContext({
+        console,
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        queueMicrotask,
+        TextEncoder,
+        TextDecoder,
+        URL,
+        URLSearchParams,
+        AbortController,
+        AbortSignal,
+        Headers,
+        Request,
+        Response,
+        ReadableStream,
+        WritableStream,
+        TransformStream,
+        crypto,
+        performance,
+        fetch,
+        atob,
+        btoa,
+        structuredClone,
+      });
+
+      const synthetic = (exports: Record<string, unknown>, identifier: string) =>
+        new vm.SyntheticModule(
+          Object.keys(exports),
+          function () {
+            for (const [key, value] of Object.entries(exports)) this.setExport(key, value);
+          },
+          { context, identifier },
+        );
+
+      const imports = new Map([
+        [
+          "cloudflare:workers",
+          synthetic(
+            {
+              RpcStub: class RpcStub {},
+              RpcTarget: class RpcTarget {},
+              WorkerEntrypoint: class WorkerEntrypoint {},
+              DurableObject: class DurableObject {},
+              WorkflowEntrypoint: class WorkflowEntrypoint {},
+              tracing: {},
+            },
+            "cloudflare:workers",
+          ),
+        ],
+        [
+          "cloudflare:workflows",
+          synthetic(
+            { NonRetryableError: class NonRetryableError extends Error {} },
+            "cloudflare:workflows",
+          ),
+        ],
+        ["node:async_hooks", synthetic(asyncHooks, "node:async_hooks")],
+      ]);
+
+      return { context, imports };
+    },
+    catch: (cause) => HeapProbeError.make({ operation: "create Node VM realm", cause }),
+  });
+
+  yield* collect;
+  const baseline = yield* memory;
+  let source: string | undefined = yield* fs.readFileString(bundle);
+
+  const module = yield* Effect.tryPromise({
+    try: async () => {
+      const module = new vm.SourceTextModule(source ?? "", {
+        context: realm.context,
+        identifier: bundle,
+      });
+
+      await module.link((specifier) => {
+        const imported = realm.imports.get(specifier);
+
+        if (!imported) throw new Error(`Unsupported external import ${specifier}`);
+
+        return imported;
+      });
+
+      return module;
+    },
+    catch: (cause) => HeapProbeError.make({ operation: "compile exact bundle", cause }),
+  });
+
+  source = undefined;
+  yield* Effect.tryPromise({
+    try: () => module.evaluate(),
+    catch: (cause) => HeapProbeError.make({ operation: "evaluate exact bundle", cause }),
+  });
+  const evaluated = yield* memory;
+
+  yield* collect;
+  const retained = yield* memory;
+
+  return yield* Effect.sync(() =>
+    NodeSample.make({
+      node: process.version,
+      v8: process.versions.v8,
+      platform: process.platform,
+      arch: process.arch,
+      baseline,
+      evaluated,
+      retained,
+      evaluatedHeapDelta: evaluated.heapUsed - baseline.heapUsed,
+      retainedHeapDelta: retained.heapUsed - baseline.heapUsed,
+      exports: Object.keys(module.namespace),
+    }),
+  );
+});

--- a/examples/cloudflare-memory/src/heap-worker.ts
+++ b/examples/cloudflare-memory/src/heap-worker.ts
@@ -1,0 +1,245 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { ThreadObjectIdentity } from "@effect-agent/platform-cloudflare/CloudflareBindings";
+import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
+import { digestDefinitions } from "@effect-agent/thread/Digest";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import { DefinitionDigestInput } from "@effect-agent/thread/Records";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import { Context, Deferred, Effect, Layer, Ref, Schema, Stream } from "effect";
+import { DurableObject } from "effect-cf";
+import {
+  LanguageModel,
+  Model,
+  Tool,
+  Toolkit,
+  type Response as AiResponse,
+} from "effect/unstable/ai";
+
+import { ObjectStatus } from "./heap-contracts.ts";
+
+class Gate extends Context.Service<
+  Gate,
+  {
+    readonly entered: Ref.Ref<boolean>;
+    readonly released: Deferred.Deferred<void>;
+    readonly modelCalls: Ref.Ref<number>;
+    readonly toolCalls: Ref.Ref<number>;
+  }
+>()("heap-benchmark/Gate") {
+  static readonly layer = Layer.effect(
+    Gate,
+    Effect.gen(function* () {
+      return Gate.of({
+        entered: yield* Ref.make(false),
+        released: yield* Deferred.make<void>(),
+        modelCalls: yield* Ref.make(0),
+        toolCalls: yield* Ref.make(0),
+      });
+    }),
+  );
+}
+
+const Lookup = Tool.make("lookup", {
+  parameters: Schema.Struct({ query: Schema.String }),
+  success: Schema.Struct({ text: Schema.String }),
+  dependencies: [Gate],
+});
+
+const Summarize = Tool.make("summarize", {
+  parameters: Schema.Struct({ query: Schema.String }),
+  success: Schema.Struct({ text: Schema.String }),
+  dependencies: [Gate],
+});
+
+const tools = Toolkit.make(Lookup, Summarize);
+
+const toolLayer = tools.toLayer({
+  lookup: () =>
+    Effect.gen(function* () {
+      const gate = yield* Gate;
+
+      yield* Ref.update(gate.toolCalls, (n) => n + 1);
+      yield* Ref.set(gate.entered, true);
+      yield* Deferred.await(gate.released);
+
+      return { text: "lookup ".padEnd(16_384, "x") };
+    }),
+  summarize: () =>
+    Effect.gen(function* () {
+      const gate = yield* Gate;
+
+      yield* Ref.update(gate.toolCalls, (n) => n + 1);
+
+      return { text: "summary ".padEnd(16_384, "y") };
+    }),
+});
+
+const usage = { inputTokens: {}, outputTokens: {} };
+
+const parts = (hasResults: boolean): ReadonlyArray<AiResponse.StreamPartEncoded> =>
+  hasResults
+    ? [
+        { type: "text-start", id: "answer" },
+        { type: "text-delta", id: "answer", delta: '{"answer":"synthetic result"}' },
+        { type: "text-end", id: "answer" },
+        { type: "finish", reason: "stop", usage },
+      ]
+    : [
+        {
+          type: "tool-call",
+          id: "lookup-1",
+          name: "lookup",
+          params: { query: "synthetic" },
+          providerExecuted: false,
+        },
+        {
+          type: "tool-call",
+          id: "summarize-1",
+          name: "summarize",
+          params: { query: "synthetic" },
+          providerExecuted: false,
+        },
+        { type: "finish", reason: "tool-calls", usage },
+      ];
+
+const model = Model.make(
+  "synthetic",
+  "heap-benchmark",
+  Layer.effect(
+    LanguageModel.LanguageModel,
+    Effect.gen(function* () {
+      const gate = yield* Gate;
+
+      return yield* LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: ({ prompt }) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              yield* Ref.update(gate.modelCalls, (n) => n + 1);
+
+              return Stream.fromIterable(parts(JSON.stringify(prompt).includes('"tool-result"')));
+            }),
+          ),
+      });
+    }),
+  ),
+);
+
+const definition = Agent.make("heap-benchmark", {
+  input: Schema.Struct({ question: Schema.String }),
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: ({ question }) => question,
+  toolkit: tools,
+  policy: AgentPolicy.make({
+    maxTurns: 3,
+    maxToolCalls: 2,
+    maxDuration: "60 seconds",
+    toolConcurrency: 2,
+  }),
+});
+
+const agent = Agent.withModel(definition, model);
+
+const definitions = DefinitionDigestInput.make({
+  agent: { id: definition.id, revision: 1 },
+  model: { provider: "synthetic", name: "heap-benchmark" },
+  tools: [
+    { name: "lookup", revision: 1 },
+    { name: "summarize", revision: 1 },
+  ],
+});
+
+const application = ThreadObject.layer([{ agent, definitions }]).pipe(
+  Layer.provide(toolLayer),
+  Layer.provideMerge(Gate.layer),
+);
+
+export class HeapThread extends ThreadObject.make(application, {
+  namespaceBinding: "HEAP_THREADS",
+  deploymentId: "heap-benchmark",
+  producerPrefix: "heap-benchmark",
+}) {
+  status() {
+    return this[DurableObject.RunSymbol](
+      Effect.gen(function* () {
+        const gate = yield* Gate;
+
+        return ObjectStatus.make({
+          active: (yield* Ref.get(gate.entered)) && !(yield* Deferred.isDone(gate.released)),
+          modelCalls: yield* Ref.get(gate.modelCalls),
+          toolCalls: yield* Ref.get(gate.toolCalls),
+        });
+      }),
+    );
+  }
+
+  release() {
+    return this[DurableObject.RunSymbol](
+      Effect.flatMap(Gate, (gate) => Deferred.succeed(gate.released, undefined)),
+    );
+  }
+
+  run() {
+    return this[DurableObject.RunSymbol](
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const { threadId } = yield* ThreadObjectIdentity;
+
+        const receipt = yield* runtime.submit(
+          agent,
+          { question: "synthetic input ".padEnd(4096, "q") },
+          {
+            threadId,
+            principal: Principal.make("heap-benchmark"),
+            idempotencyKey: IdempotencyKey.make("one-run"),
+            definitions: yield* digestDefinitions(definitions),
+          },
+        );
+
+        yield* runtime.processThreadResolved(threadId);
+
+        return (yield* runtime.awaitSettlement(receipt)).outcome;
+      }),
+    );
+  }
+}
+
+interface Env {
+  HEAP_THREADS: DurableObjectNamespace<HeapThread>;
+  BENCH_TOKEN: string;
+}
+
+export default {
+  fetch(request: Request, env: Env): Promise<Response> {
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        if (
+          !env.BENCH_TOKEN ||
+          request.headers.get("authorization") !== `Bearer ${env.BENCH_TOKEN}`
+        )
+          return new Response("Unauthorized", { status: 401 });
+        const url = new URL(request.url);
+
+        if (url.pathname === "/ready") return Response.json({ ready: true });
+
+        const id = yield* Schema.decodeUnknownEffect(
+          Schema.String.check(Schema.isPattern(/^object-[0-9]+$/)),
+        )(url.searchParams.get("id"));
+
+        const object = env.HEAP_THREADS.getByName(id);
+
+        switch (url.pathname) {
+          case "/status":
+            return Response.json(yield* Effect.promise(() => object.status()));
+          case "/release":
+            return Response.json(yield* Effect.promise(() => object.release()));
+          case "/run":
+            return Response.json(yield* Effect.promise(() => object.run()));
+          default:
+            return new Response("Not found", { status: 404 });
+        }
+      }),
+    );
+  },
+};

--- a/examples/cloudflare-memory/src/heap-workerd.ts
+++ b/examples/cloudflare-memory/src/heap-workerd.ts
@@ -1,0 +1,197 @@
+import { Deferred, Effect, Fiber, FileSystem, Schedule, Schema } from "effect";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { Socket } from "effect/unstable/socket";
+import { convertV4MiniflareOptions, Log, LogLevel, Miniflare } from "miniflare";
+
+import { HeapProbeError, HeapUsage, ObjectStatus, WorkerdSample } from "./heap-contracts.ts";
+
+const Message = Schema.Struct({
+  id: Schema.optionalKey(Schema.Number),
+  result: Schema.optionalKey(Schema.Unknown),
+  error: Schema.optionalKey(Schema.Struct({ message: Schema.String })),
+});
+
+const Targets = Schema.Array(
+  Schema.Struct({
+    id: Schema.String,
+    webSocketDebuggerUrl: Schema.String,
+  }),
+);
+
+const inspector = Effect.fn("heap.inspector")(function* (url: string, method: string) {
+  const response = yield* Deferred.make<unknown, HeapProbeError>();
+  const socket = yield* Socket.makeWebSocket(url);
+  const write = yield* socket.writer;
+
+  yield* socket
+    .runString(
+      (text) =>
+        Effect.gen(function* () {
+          const message = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Message))(text);
+
+          if (message.id !== 1) return;
+          if (message.error)
+            yield* Deferred.fail(
+              response,
+              HeapProbeError.make({ operation: `${method}: ${message.error.message}` }),
+            );
+          else yield* Deferred.succeed(response, message.result);
+        }).pipe(
+          Effect.catch((cause) =>
+            Deferred.fail(
+              response,
+              HeapProbeError.make({ operation: "decode inspector response", cause }),
+            ),
+          ),
+        ),
+      {
+        onOpen: write(JSON.stringify({ id: 1, method })).pipe(
+          Effect.catch((cause) =>
+            Deferred.fail(
+              response,
+              HeapProbeError.make({ operation: "write inspector request", cause }),
+            ),
+          ),
+          Effect.asVoid,
+        ),
+      },
+    )
+    .pipe(
+      Effect.catch((cause) =>
+        Deferred.fail(response, HeapProbeError.make({ operation: method, cause })),
+      ),
+      Effect.forkScoped,
+    );
+
+  return yield* Deferred.await(response).pipe(
+    Effect.timeout("10 seconds"),
+    Effect.mapError((cause) =>
+      HeapProbeError.make({ operation: `inspector command ${method}`, cause }),
+    ),
+  );
+}, Effect.scoped);
+
+const request = (runtime: Miniflare, route: string, id?: string) =>
+  Effect.tryPromise({
+    try: (signal) =>
+      runtime.dispatchFetch(`http://benchmark/${route}${id ? `?id=${id}` : ""}`, {
+        headers: { authorization: "Bearer local-heap-probe" },
+        signal,
+      }),
+    catch: (cause) => HeapProbeError.make({ operation: route, cause }),
+  }).pipe(
+    Effect.flatMap((response) =>
+      response.ok
+        ? Effect.tryPromise({
+            try: () => response.json(),
+            catch: (cause) => HeapProbeError.make({ operation: `decode ${route}`, cause }),
+          })
+        : Effect.fail(HeapProbeError.make({ operation: `${route} returned ${response.status}` })),
+    ),
+  );
+
+export const measureWorkerd = Effect.fn("heap.measureWorkerd")(
+  function* (bundle: string, count: number) {
+    const fs = yield* FileSystem.FileSystem;
+    const script = yield* fs.readFileString(bundle);
+
+    const runtime = yield* Effect.acquireRelease(
+      Effect.try({
+        try: () =>
+          new Miniflare(
+            convertV4MiniflareOptions({
+              name: "heap-benchmark",
+              modules: true,
+              script,
+              compatibilityDate: "2026-08-01",
+              compatibilityFlags: ["nodejs_compat"],
+              inspectorPort: 0,
+              log: new Log(LogLevel.ERROR),
+              bindings: { BENCH_TOKEN: "local-heap-probe" },
+              durableObjects: { HEAP_THREADS: { className: "HeapThread", useSQLite: true } },
+            }),
+          ),
+        catch: (cause) => HeapProbeError.make({ operation: "open local workerd", cause }),
+      }),
+      (runtime) => Effect.promise(() => runtime.dispose()),
+    );
+
+    yield* Effect.tryPromise({
+      try: () => runtime.ready,
+      catch: (cause) => HeapProbeError.make({ operation: "workerd ready", cause }),
+    });
+
+    const url = yield* Effect.tryPromise({
+      try: () => runtime.getInspectorURL(),
+      catch: (cause) => HeapProbeError.make({ operation: "inspector URL", cause }),
+    });
+
+    url.protocol = "http:";
+    url.pathname = "/json";
+
+    const targets = yield* HttpClient.get(url).pipe(
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(Targets)),
+    );
+
+    const target = targets.find((target) => target.id.includes("heap-benchmark"));
+
+    if (!target)
+      return yield* HeapProbeError.make({ operation: "find heap-benchmark inspector target" });
+
+    const readHeap = inspector(target.webSocketDebuggerUrl, "Runtime.getHeapUsage").pipe(
+      Effect.flatMap(Schema.decodeUnknownEffect(HeapUsage)),
+    );
+
+    yield* request(runtime, "ready");
+    const startup = yield* readHeap;
+    const ids = Array.from({ length: count }, (_, i) => `object-${i}`);
+
+    const statuses = Effect.forEach(
+      ids,
+      (id) =>
+        request(runtime, "status", id).pipe(
+          Effect.flatMap(Schema.decodeUnknownEffect(ObjectStatus)),
+        ),
+      { concurrency: count },
+    );
+
+    yield* statuses;
+    const initialized = yield* readHeap;
+
+    const running = yield* Effect.forEach(
+      ids,
+      (id) =>
+        request(runtime, "run", id).pipe(
+          Effect.flatMap(Schema.decodeUnknownEffect(Schema.Literal("completed"))),
+        ),
+      { concurrency: count },
+    ).pipe(Effect.forkScoped);
+
+    yield* statuses.pipe(
+      Effect.repeat({
+        until: (items) => items.every((item) => item.active && item.toolCalls === 2),
+        schedule: Schedule.spaced("20 millis"),
+      }),
+      Effect.timeout("30 seconds"),
+    );
+    const active = yield* readHeap;
+
+    yield* Effect.forEach(ids, (id) => request(runtime, "release", id), { concurrency: count });
+    yield* Fiber.join(running);
+    const settled = yield* readHeap;
+    const objects = yield* statuses;
+
+    if (
+      !objects.every(
+        (object) => !object.active && object.modelCalls === 2 && object.toolCalls === 2,
+      )
+    )
+      return yield* HeapProbeError.make({
+        operation: "expected two model calls and two tools per completed Object",
+      });
+
+    return WorkerdSample.make({ startup, initialized, active, settled, objects });
+  },
+  Effect.scoped,
+  Effect.timeout("60 seconds"),
+);

--- a/examples/cloudflare-memory/src/heap.ts
+++ b/examples/cloudflare-memory/src/heap.ts
@@ -1,0 +1,299 @@
+import { Console, Crypto, Effect, Encoding, FileSystem, Path, Schema, Stream } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { ChildProcess } from "effect/unstable/process";
+
+import { HeapProbeError, NodeSample, WorkerdSample } from "./heap-contracts.ts";
+import { measureWorkerd } from "./heap-workerd.ts";
+
+const ModuleContribution = Schema.Struct({ path: Schema.String, bytes: Schema.Number });
+
+const Bundle = Schema.Struct({
+  name: Schema.String,
+  file: Schema.String,
+  bytes: Schema.Number,
+  sha256: Schema.String,
+  modules: Schema.Array(ModuleContribution),
+  nodeSamples: Schema.Array(NodeSample),
+});
+
+const Report = Schema.Struct({
+  version: Schema.Literal(1),
+  revision: Schema.String,
+  dirty: Schema.Boolean,
+  wrangler: Schema.String,
+  miniflare: Schema.String,
+  effect: Schema.String,
+  objectCount: Schema.Number,
+  sampleCount: Schema.Number,
+  bundles: Schema.Array(Bundle),
+  workerdSamples: Schema.Array(WorkerdSample),
+  notes: Schema.Array(Schema.String),
+});
+
+const Metafile = Schema.Struct({
+  outputs: Schema.Record(
+    Schema.String,
+    Schema.Struct({
+      bytes: Schema.Number,
+      entryPoint: Schema.optionalKey(Schema.String),
+      inputs: Schema.Record(Schema.String, Schema.Struct({ bytesInOutput: Schema.Number })),
+    }),
+  ),
+});
+
+const run = Effect.fn("heap.run")(function* (
+  cwd: string,
+  args: ReadonlyArray<string>,
+  env?: Record<string, string>,
+) {
+  const child = yield* ChildProcess.make("vp", ["exec", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+    extendEnv: true,
+  });
+
+  const [stdout, stderr, code] = yield* Effect.all(
+    [
+      Stream.mkString(Stream.decodeText(child.stdout)),
+      Stream.mkString(Stream.decodeText(child.stderr)),
+      child.exitCode,
+    ],
+    { concurrency: 3 },
+  );
+
+  if (code !== 0)
+    return yield* HeapProbeError.make({
+      operation: `${args[0]} exited ${code}: ${stdout}${stderr}`,
+    });
+
+  return { stdout, stderr };
+}, Effect.scoped);
+
+const buildBundle = Effect.fn("heap.buildBundle")(function* (options: {
+  example: string;
+  output: string;
+  name: string;
+  config: string;
+  entry?: string;
+  samples: number;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const directory = path.join(options.output, options.name);
+
+  yield* fs.makeDirectory(directory, { recursive: true });
+
+  const built = yield* run(
+    options.example,
+    [
+      "wrangler",
+      "deploy",
+      "--dry-run",
+      ...(options.entry ? [options.entry] : []),
+      "--config",
+      options.config,
+      "--outdir",
+      directory,
+      "--metafile",
+      path.join(directory, "meta.json"),
+    ],
+    { WRANGLER_SEND_METRICS: "false", WRANGLER_LOG_PATH: path.join(directory, "wrangler.log") },
+  );
+
+  yield* fs.writeFileString(path.join(directory, "build.log"), built.stdout + built.stderr);
+
+  const meta = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Metafile))(
+    yield* fs.readFileString(path.join(directory, "meta.json")),
+  );
+
+  const output = Object.entries(meta.outputs).find(
+    ([name, value]) => name.endsWith(".js") && value.entryPoint,
+  );
+
+  if (!output)
+    return yield* HeapProbeError.make({ operation: `find emitted entry ${options.name}` });
+  const file = path.join(directory, path.basename(output[0]));
+  const bytes = yield* fs.readFile(file);
+
+  const modules = Object.entries(output[1].inputs)
+    .filter(([, value]) => value.bytesInOutput > 0)
+    .map(([path, value]) => ({ path, bytes: value.bytesInOutput }))
+    .sort((a, b) => b.bytes - a.bytes);
+
+  const nodeSamples = yield* Effect.forEach(
+    Array.from({ length: options.samples }, (_, i) => i),
+    Effect.fn(function* (i) {
+      const sample = yield* run(options.example, [
+        "node",
+        "--experimental-transform-types",
+        "--expose-gc",
+        "--experimental-vm-modules",
+        path.join(options.example, "src", "heap-node-main.ts"),
+        file,
+      ]);
+
+      yield* fs.writeFileString(path.join(directory, `node-${i + 1}.json`), sample.stdout);
+
+      return yield* Schema.decodeUnknownEffect(Schema.fromJsonString(NodeSample))(sample.stdout);
+    }),
+  );
+
+  return Bundle.make({
+    name: options.name,
+    file,
+    bytes: bytes.byteLength,
+    sha256: Encoding.encodeHex(yield* crypto.digest("SHA-256", bytes)),
+    modules,
+    nodeSamples,
+  });
+});
+
+const version = Effect.fn("heap.version")(function* (filename: string) {
+  const fs = yield* FileSystem.FileSystem;
+
+  return (yield* Schema.decodeUnknownEffect(
+    Schema.fromJsonString(Schema.Struct({ version: Schema.String })),
+  )(yield* fs.readFileString(filename))).version;
+});
+
+const git = Effect.fn("heap.git")(function* (root: string, args: ReadonlyArray<string>) {
+  const child = yield* ChildProcess.make("git", args, {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [text, code] = yield* Effect.all([
+    Stream.mkString(Stream.decodeText(child.stdout)),
+    child.exitCode,
+  ]);
+
+  if (code !== 0) return yield* HeapProbeError.make({ operation: `git ${args.join(" ")}` });
+
+  return text.trim();
+}, Effect.scoped);
+
+export const command = Command.make(
+  "measure-heap",
+  {
+    output: Flag.string("out-dir").pipe(
+      Flag.withDescription(
+        "New or existing directory for exact bundles, samples, and report.json.",
+      ),
+    ),
+    samples: Flag.integer("samples").pipe(
+      Flag.withDefault(3),
+      Flag.withSchema(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 20 }))),
+      Flag.withDescription("Fresh processes and local workerd instances per cohort, 1–20."),
+    ),
+    objects: Flag.integer("objects").pipe(
+      Flag.withDefault(4),
+      Flag.withSchema(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 16 }))),
+      Flag.withDescription("Initialized and concurrently active Thread Objects, 1–16."),
+    ),
+  },
+  Effect.fn(function* ({ output, samples, objects }) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const example = path.resolve(
+      path.dirname(yield* path.fromFileUrl(new URL(import.meta.url))),
+      "..",
+    );
+
+    const root = path.resolve(example, "../..");
+
+    output = path.resolve(output);
+    yield* fs.makeDirectory(output, { recursive: true });
+    // Remove only our result: a failed invocation must not leave an older success report.
+    yield* fs.remove(path.join(output, "report.json"), { force: true });
+    const scratch = yield* fs.makeTempDirectoryScoped({ prefix: "effect-agent-heap-root-" });
+    const source = yield* fs.readFileString(path.join(example, "src", "worker.ts"));
+
+    const directImport =
+      'import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";';
+
+    if (!source.includes(directImport))
+      return yield* HeapProbeError.make({
+        operation: "memory Worker import changed; update the equivalent root consumer",
+      });
+    yield* fs.writeFileString(
+      path.join(scratch, "worker.ts"),
+      source.replace(
+        directImport,
+        'import { ThreadObject } from "@effect-agent/platform-cloudflare";',
+      ),
+    );
+    yield* fs.copyFile(path.join(scratch, "worker.ts"), path.join(output, "root-consumer.ts"));
+    yield* fs.copyFile(
+      path.join(example, "src", "contracts.ts"),
+      path.join(scratch, "contracts.ts"),
+    );
+    yield* fs.symlink(path.join(example, "node_modules"), path.join(scratch, "node_modules"));
+    const common = { example, output, samples, config: path.join(example, "wrangler.jsonc") };
+
+    yield* Console.error("Building and measuring exact Worker bundles...");
+    const direct = yield* buildBundle({ ...common, name: "direct" });
+
+    const rootImport = yield* buildBundle({
+      ...common,
+      name: "root",
+      entry: path.join(scratch, "worker.ts"),
+    });
+
+    const runtime = yield* buildBundle({
+      ...common,
+      name: "runtime",
+      config: path.join(example, "wrangler.heap.jsonc"),
+    });
+
+    yield* Console.error(`Sampling local workerd with ${objects} active Thread Objects...`);
+
+    const workerdSamples = yield* Effect.forEach(
+      Array.from({ length: samples }, (_, i) => i),
+      Effect.fn(function* (i) {
+        const sample = yield* measureWorkerd(runtime.file, objects);
+
+        yield* fs.writeFileString(
+          path.join(output, `workerd-${i + 1}.json`),
+          yield* Schema.encodeEffect(Schema.fromJsonString(WorkerdSample))(sample),
+        );
+
+        return sample;
+      }),
+    );
+
+    const report = Report.make({
+      version: 1,
+      revision: yield* git(root, ["rev-parse", "HEAD"]),
+      dirty: (yield* git(root, ["status", "--porcelain"])).length > 0,
+      wrangler: yield* version(path.join(example, "node_modules/wrangler/package.json")),
+      miniflare: yield* version(path.join(example, "node_modules/miniflare/package.json")),
+      effect: yield* version(path.join(root, "node_modules/effect/package.json")),
+      objectCount: objects,
+      sampleCount: samples,
+      bundles: [direct, rootImport, runtime],
+      workerdSamples,
+      notes: [
+        "Node VM results measure exact-bundle module evaluation relative to a preloaded Effect harness and empty realm. Cloudflare external modules are shimmed; no handlers execute in Node.",
+        "Local workerd Runtime.getHeapUsage values are instantaneous JS heap snapshots for one Worker isolate, not peak usage, process RSS, total isolate memory, or a hosted capacity guarantee. Embedder/backing storage counters are reported separately when supported.",
+        "Startup follows a /ready request with no Objects. Initialized follows one status RPC per Object. Active requires every Object to have started both tools, with lookup blocked at an explicit gate. Settled requires completed receipts and exactly two model calls and two tool calls per Object.",
+        "Synthetic model, two registered tools, 4096-character input per Object, two 16384-character tool results per run. No provider, remote binding, network tool, or deployment is used.",
+        "Local workerd GC is not forced. Node reports both post-evaluation and explicit post-GC deltas. Neither sampled value establishes peak memory.",
+      ],
+    });
+
+    yield* fs.writeFileString(
+      path.join(output, "report.json"),
+      yield* Schema.encodeEffect(Schema.fromJsonString(Report))(report),
+    );
+    yield* Console.log(`Memory report: ${path.join(output, "report.json")}`);
+  }),
+).pipe(
+  Command.withDescription(
+    "Measure bundled startup heap and synthetic concurrent Thread Objects locally; never deploys.",
+  ),
+);

--- a/examples/cloudflare-memory/wrangler.heap.jsonc
+++ b/examples/cloudflare-memory/wrangler.heap.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "effect-agent-heap-benchmark",
+  "main": "src/heap-worker.ts",
+  "compatibility_date": "2026-08-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [{ "name": "HEAP_THREADS", "class_name": "HeapThread" }],
+  },
+  "exports": { "HeapThread": { "type": "durable-object", "storage": "sqlite" } },
+}

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -752,6 +752,13 @@ export interface RunBufferLimits {
  * through the generic parameters.
  */
 export interface RunOptions<HookError = never, HookRequirements = never> {
+  /**
+   * Host preparation boundary before each new model Turn, including its context preparation
+   * and compaction calls. The preceding Tool batch and history advance have finished. A resumed
+   * canonical Tool batch bypasses this hook until it continues to a new Turn. This hook does not
+   * reset the Run deadline or change prompt protection, and is not automatically inherited by spawned children.
+   */
+  readonly beforeTurn?: (() => Effect.Effect<void, HookError, HookRequirements>) | undefined;
   /** Reuse a Thread identity, including retained history, instead of allocating one. */
   readonly threadId?: ThreadId | undefined;
   /**

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -4279,6 +4279,8 @@ const makeTurn = <
     Effect.gen(function* () {
       const policy = agent.definition.policy;
       const bounds = effectiveRunBounds(policy, options);
+
+      if (options.beforeTurn !== undefined) yield* options.beforeTurn();
       const now = yield* Clock.currentTimeMillis;
 
       if (now >= context.durationDeadlineMillis) {

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -22,6 +22,8 @@ class Encoder extends Context.Service<Encoder, string>()("api-types/Encoder") {}
 class Catalog extends Context.Service<Catalog, string>()("api-types/Catalog") {}
 class InstructionError extends Schema.TaggedError<InstructionError>()("InstructionError", {}) {}
 class ToolError extends Schema.TaggedError<ToolError>()("ToolError", {}) {}
+class TurnHost extends Context.Service<TurnHost, string>()("api-types/TurnHost") {}
+class TurnHostError extends Schema.TaggedError<TurnHostError>()("TurnHostError", {}) {}
 
 const Lookup = Tool.make("lookup", {
   parameters: Schema.Struct({ city: Schema.String }),
@@ -108,6 +110,17 @@ it("preserves encoded input, output, failures and every unsatisfied service", ()
   expectTypeOf<Effect.Error<typeof run>>().toEqualTypeOf<AgentRuntimeFailure<typeof planner>>();
 
   const stream = AgentRuntime.stream(planner, input);
+
+  const gated = AgentRuntime.stream(planner, input, {
+    beforeTurn: () => TurnHost.pipe(Effect.andThen(Effect.fail(new TurnHostError()))),
+  });
+
+  expectTypeOf<Stream.Services<typeof gated>>().toEqualTypeOf<
+    Stream.Services<typeof stream> | TurnHost
+  >();
+  expectTypeOf<Stream.Error<typeof gated>>().toEqualTypeOf<
+    Stream.Error<typeof stream> | TurnHostError
+  >();
 
   expectTypeOf<Stream.Services<typeof stream>>().toEqualTypeOf<
     DefinitionServices | NativeServices | IdGenerator

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -13,6 +13,7 @@
     "src"
   ],
   "type": "module",
+  "sideEffects": [],
   "exports": {
     ".": "./src/index.ts",
     "./Alarm": "./src/Alarm.ts",

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -8,6 +8,7 @@ import { SubmissionLedger, type SubmissionSnapshot } from "@effect-agent/thread/
 import {
   Clock,
   Context,
+  DateTime,
   Effect,
   Layer,
   Option,
@@ -156,11 +157,11 @@ export class DurableAlarmService extends Context.Service<
 export class MaintenancePassReport extends Schema.Class<MaintenancePassReport>(
   "@effect-agent/platform-cloudflare/MaintenancePassReport",
 )({
-  /** `caught-up` is generation-only; `actionable` ran recovery and one bounded drain. */
+  /** `caught-up` is generation-only; `actionable` ran recovery and at most one head Attempt. */
   phase: Schema.Literals(["caught-up", "actionable"]),
   /** Recovery decisions executed (or deferred) BEFORE any new claim in this pass. */
   recovered: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
-  /** Settlements the drain pass finalized. */
+  /** Whether the head Attempt settled. Joined input may settle with that head. */
   settled: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   /** Submissions still nonterminal after the pass (suspended/unknown lanes stay honest). */
   nonterminal: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
@@ -278,11 +279,12 @@ export type MaintenancePassFailure =
 /**
  * Incremental, quiescent maintenance over a durable dirty/processed generation (issue #93).
  *
- * `pass` = generation snapshot/pre-arm → recovery → bounded drain → generation acknowledgement:
+ * `pass` = generation snapshot/pre-arm → recovery → one head Attempt → generation acknowledgement:
  *
  * 1. One storage transaction reads dirty/processed and re-arms before work. A caught-up forced
  *    alarm takes an O(1) path without recovery, ledger scans, or canonical-history reads.
- * 2. Recovery still strictly precedes a new claim, and one bounded drain advances the lane.
+ * 2. Recovery strictly precedes a new claim. One head Attempt advances the lane and requests
+ *    a safe yield after ten minutes. The whole event has a fourteen-minute cooperative timeout.
  * 3. The final transaction acknowledges only the generation observed at pass start. A racing
  *    mutation therefore remains `dirty > processed` and retains its atomically-established alarm.
  * 4. Stable external waits acknowledge and clear. Autonomous retry, indeterminate, and lease
@@ -460,10 +462,9 @@ export class ThreadMaintenance extends Context.Service<
         return Math.min(jittered, config.wakeScanInterval);
       });
 
-      const pass = Effect.fn("ThreadMaintenance.pass")(function* (): Effect.fn.Return<
-        MaintenancePassReport,
-        MaintenancePassFailure
-      > {
+      const pass = Effect.fn("ThreadMaintenance.pass")(function* (
+        yieldAfter: DateTime.Utc,
+      ): Effect.fn.Return<MaintenancePassReport, MaintenancePassFailure> {
         const annotate = (report: MaintenancePassReport) =>
           Effect.annotateCurrentSpan({
             phase: report.phase,
@@ -495,8 +496,9 @@ export class ThreadMaintenance extends Context.Service<
         }
         // Step 2 — reconciliation strictly precedes new work in this pass (exit gate).
         const recovered: ReadonlyArray<RecoveryReport> = yield* runtime.runRecovery;
-        // Step 3 — one bounded drain pass over this Object's own lane.
-        const settlements = yield* runtime.processThreadResolved(identity.threadId);
+        // One head Attempt per event. The runtime yields after a committed turn when the
+        // soft deadline is reached; queued followers belong to a subsequent alarm.
+        const settlement = yield* runtime.processThreadHead(identity.threadId, { yieldAfter });
         // Observe residual state before acknowledging this exact pass-start generation.
         const remaining = yield* Stream.runCollect(ledger.scanNonterminal);
         const reports = new Map(recovered.map((report) => [report.submissionId, report]));
@@ -518,7 +520,8 @@ export class ThreadMaintenance extends Context.Service<
         });
 
         const progressed =
-          settlements.length > 0 || recovered.some((report) => report.disposition === "repaired");
+          Option.isSome(settlement) ||
+          recovered.some((report) => report.disposition === "repaired");
 
         const delay = autonomous ? yield* rearmDelay(progressed) : 0;
         const now = yield* Clock.currentTimeMillis;
@@ -584,7 +587,7 @@ export class ThreadMaintenance extends Context.Service<
           MaintenancePassReport.make({
             phase: "actionable",
             recovered: recovered.length,
-            settled: settlements.length,
+            settled: Option.isSome(settlement) ? 1 : 0,
             nonterminal: remaining.length,
             alarm: alarmDisposition,
           }),
@@ -593,7 +596,25 @@ export class ThreadMaintenance extends Context.Service<
 
       return ThreadMaintenance.of({
         // A mid-pass immediate hint is droppable; durable dirty state decides the final alarm.
-        pass: alarm.withWakesDeferred(maintenancePassGate.withPermit(pass())),
+        pass: Effect.gen(function* () {
+          const yieldAfter = DateTime.makeUnsafe((yield* Clock.currentTimeMillis) + 10 * 60_000);
+
+          return yield* alarm.withWakesDeferred(maintenancePassGate.withPermit(pass(yieldAfter)));
+        }).pipe(
+          // Include permit waiting, recovery and acknowledgement in the event deadline.
+          // Interruption releases Attempt ownership, leaving the prearmed dirty generation
+          // for recovery. It never changes the logical Run duration or settles a policy failure.
+          // This cooperative timer cannot preempt synchronous CPU work or stuck finalizers.
+          Effect.timeoutOrElse({
+            duration: "14 minutes",
+            orElse: () =>
+              DurableAlarmError.make({
+                operation: "maintenance pass deadline",
+                message:
+                  "The maintenance event exceeded its 14 minute deadline; durable recovery remains pending",
+              }),
+          }),
+        ),
         ensureAlarm: ensureAlarm(),
         withMutation,
       });

--- a/packages/platform-cloudflare/src/CloudflareScheduling.ts
+++ b/packages/platform-cloudflare/src/CloudflareScheduling.ts
@@ -552,7 +552,8 @@ const handleScheduleRequest = Effect.fn("ScheduleOwner.handleRequest")(function*
   return yield* encodeScheduleOwnerResponse(response).pipe(Effect.orDie);
 });
 
-const scheduleAlarmHandler = (limits: SchedulingLimits) =>
+/** @internal The complete native alarm operation, including its event deadline. */
+export const scheduleAlarmHandler = (limits: SchedulingLimits) =>
   DurableObjectAlarm.processDue(
     (event) =>
       Effect.gen(function* () {
@@ -583,7 +584,12 @@ const scheduleAlarmHandler = (limits: SchedulingLimits) =>
         }
       }),
     { mode: "ordered" },
-  ).pipe(Effect.asVoid);
+  ).pipe(
+    // Bound due acquisition and acknowledgement as well as admission. Prepared occurrences
+    // and their replacement alarm survive interruption and retain their idempotency keys.
+    Effect.timeout("14 minutes"),
+    Effect.asVoid,
+  );
 
 export interface ScheduleOwnerObjectInstance extends InstanceType<
   EffectCfDurableObject.DurableObjectClass<Record<never, never>, ScheduleRuntimeServices>

--- a/packages/platform-cloudflare/src/ThreadObject.ts
+++ b/packages/platform-cloudflare/src/ThreadObject.ts
@@ -113,7 +113,7 @@ export {
  * D-P6-1): a factory returning a class that applications export from their Worker entry.
  * One SQLite-backed Object per Thread is the serialized owner (durability §6); the
  * Object never runs `runResolvedWorker`'s infinite loop — each ingress event or alarm runs
- * ONE bounded `runRecovery` + `processThreadResolved` pass, and the persisted alarm
+ * ONE bounded `runRecovery` + `processThreadHead` pass, and the persisted alarm
  * (the single multiplexed slot, D-P6-2) finishes accepted work across evictions WITHOUT any
  * incoming request.
  *

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -4,9 +4,13 @@ import {
   ApprovalDecisionCommand,
   ResolutionNeverHappened,
   UnknownResolutionCommand,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
 } from "@effect-agent/thread/SubmissionLedger";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
-import { Effect, Schema } from "effect";
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, Schema } from "effect";
+import { DurableObject } from "effect-cf";
+import { TestClock } from "effect/testing";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -25,6 +29,8 @@ import {
   supplierCountsFor,
   releaseMaintenancePause,
   submitOptions,
+  alarmAttemptHolds,
+  maintenanceClocks,
 } from "./fixtures.ts";
 import {
   allSettled,
@@ -93,6 +99,142 @@ const maintenanceGeneration = (thread: string) =>
   );
 
 describe("DC alarm semantics", () => {
+  it("returns after one head Attempt and leaves later FIFO work armed for another event", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const thread = lane("one-head");
+        const entered = yield* Deferred.make<void>();
+        const finished = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+
+        // Future virtual time keeps native automatic alarms from racing explicit deliveries.
+        yield* TestClock.setTime(Date.now() + 86_400_000);
+        maintenanceClocks.set(thread, yield* Clock.Clock);
+        alarmAttemptHolds.set(thread, {
+          location: "terminalize:after-canonical-append",
+          entered,
+          finished,
+          release,
+        });
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            maintenanceClocks.delete(thread);
+            alarmAttemptHolds.delete(thread);
+          }),
+        );
+        const first = yield* Effect.promise(() => submitTo(plannerDefinition, thread));
+
+        const pass = yield* Effect.promise(() =>
+          runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
+        ).pipe(Effect.forkChild);
+
+        yield* Deferred.await(entered);
+        // The head has completed its model and join seams. This follower needs its own Attempt.
+        const nextEntered = yield* Deferred.make<void>();
+        const nextFinished = yield* Deferred.make<void>();
+        const nextRelease = yield* Deferred.make<void>();
+
+        // Native alarms may redeliver immediately. Hold the follower so only a separate
+        // event can own it; the first pass must return without waiting for this resource.
+        alarmAttemptHolds.set(thread, {
+          location: "claim:after-claim",
+          entered: nextEntered,
+          finished: nextFinished,
+          release: nextRelease,
+        });
+
+        const second = yield* Effect.promise(() =>
+          submitTo(plannerDefinition, thread, `${thread}-next`),
+        );
+
+        yield* Deferred.succeed(release, undefined);
+        yield* Fiber.join(pass);
+        const rows = yield* Effect.promise(() => laneRows(thread));
+
+        expect(rows[0]).toMatchObject({ submission_id: first.submissionId, state: "settled" });
+        expect(rows[1]?.submission_id).toBe(second.submissionId);
+        expect(rows[1]?.state).not.toBe("settled");
+        const generation = yield* Effect.promise(() => maintenanceGeneration(thread));
+
+        expect(generation.dirty > generation.processed).toBe(true);
+        expect(yield* Effect.promise(() => scheduledAlarm(thread))).not.toBeNull();
+        yield* Deferred.succeed(nextRelease, undefined);
+        yield* Effect.promise(() =>
+          runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
+        );
+        expect((yield* Effect.promise(() => laneRows(thread))).map((row) => row.state)).toEqual([
+          "settled",
+          "settled",
+        ]);
+        yield* Effect.promise(() => assertConvergence(thread));
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+    ));
+
+  it("interrupts an overlong alarm, closes scoped work and preserves its dirty retry obligation", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const thread = lane("event-deadline");
+        const entered = yield* Deferred.make<void>();
+        const finished = yield* Deferred.make<void>();
+
+        yield* TestClock.setTime(Date.now() + 86_400_000);
+        maintenanceClocks.set(thread, yield* Clock.Clock);
+        alarmAttemptHolds.set(thread, { location: "claim:after-claim", entered, finished });
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            maintenanceClocks.delete(thread);
+            alarmAttemptHolds.delete(thread);
+          }),
+        );
+        const receipt = yield* Effect.promise(() => submitTo(plannerDefinition, thread));
+
+        const pass = yield* Effect.tryPromise({
+          try: () =>
+            runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
+          catch: (cause) => String(cause),
+        }).pipe(Effect.exit, Effect.forkChild);
+
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust("14 minutes");
+        const exit = yield* Fiber.join(pass);
+
+        expect(Exit.isFailure(exit) ? Cause.pretty(exit.cause) : "success").toContain(
+          "14 minute deadline",
+        );
+        expect(yield* Deferred.isDone(finished)).toBe(true);
+        const generation = yield* Effect.promise(() => maintenanceGeneration(thread));
+
+        expect(generation.dirty > generation.processed).toBe(true);
+        expect(yield* Effect.promise(() => scheduledAlarm(thread))).not.toBeNull();
+
+        const snapshot = yield* Effect.promise(() =>
+          runInDurableObject(stubFor(thread), (instance) =>
+            instance[DurableObject.RunSymbol](
+              Effect.gen(function* () {
+                const ledger = yield* SubmissionLedger;
+
+                return yield* ledger.loadRecoverySnapshot(
+                  RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+                );
+              }),
+            ),
+          ),
+        );
+
+        expect(snapshot.ownership).toBeUndefined();
+        const before = yield* Effect.promise(() => readCanonical(thread));
+
+        expect(before.some(({ record }) => record.payload._tag === "SubmissionSettled")).toBe(
+          false,
+        );
+        // The same live incarnation can claim again; no lease wait or policy failure is needed.
+        yield* Effect.promise(() =>
+          runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
+        );
+        yield* Effect.promise(() => assertConvergence(thread));
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+    ));
+
   it("issue #93: a stable approval wait quiesces and a forced caught-up alarm performs no SQL work", async () => {
     const thread = lane("issue-93-quiescent-approval");
     const receipt = await submitTo(approvalDefinition, thread);

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -38,7 +38,7 @@ import {
   ReconciliationUncertain,
   ToolReconciler,
 } from "@effect-agent/thread/ToolReconciler";
-import { Duration, Effect, Layer, Schema, Stream } from "effect";
+import { type Clock, Deferred, Duration, Effect, Layer, Schema, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 import { layerFromBindings } from "../src/internal/layers.ts";
@@ -62,6 +62,19 @@ const armedRuntimeEvictions = new Map<string, Array<DurableRuntimeFailpointLocat
 
 /** Typed (thrown, NOT abort) pass failures for the workerd alarm-retry row. */
 export const armedRuntimeFailures = new Map<string, DurableRuntimeFailpointLocation>();
+
+/** Virtual event clocks and a scoped post-claim hold for native alarm deadline evidence. */
+export const maintenanceClocks = new Map<string, Clock.Clock>();
+
+export const alarmAttemptHolds = new Map<
+  string,
+  {
+    readonly location: DurableRuntimeFailpointLocation;
+    readonly entered: Deferred.Deferred<void>;
+    readonly finished: Deferred.Deferred<void>;
+    readonly release?: Deferred.Deferred<void>;
+  }
+>();
 
 /**
  * Arm an ORDERED queue of eviction locations for one Thread. Chained rows (a location
@@ -126,6 +139,17 @@ export const runtimeEvictionFailpoint =
       const name = ctx.id.name;
 
       if (name === undefined) return Effect.void;
+      const hold = alarmAttemptHolds.get(name);
+
+      if (hold !== undefined && location === hold.location) {
+        alarmAttemptHolds.delete(name);
+
+        return Effect.acquireUseRelease(
+          Deferred.succeed(hold.entered, undefined),
+          () => (hold.release === undefined ? Effect.never : Deferred.await(hold.release)),
+          () => Deferred.succeed(hold.finished, undefined),
+        );
+      }
       if (armedRuntimeFailures.get(name) === location) {
         armedRuntimeFailures.delete(name);
 
@@ -499,6 +523,14 @@ const schedulePolicyResources = new Map<
   }
 >();
 
+export const schedulePrepareHolds = new Map<
+  string,
+  {
+    readonly entered: Deferred.Deferred<void>;
+    readonly finished: Deferred.Deferred<void>;
+  }
+>();
+
 export const observeSchedulePolicyResources = (owner: ScheduleOwner) => {
   const probe = { acquired: 0, released: 0, fail: false };
 
@@ -539,6 +571,17 @@ export const scheduleAuthorizer = (owner: ScheduleOwner) => {
     prepare: () =>
       Effect.suspend(() => {
         const key = scheduleOwnerKey(owner);
+        const deadlineHold = schedulePrepareHolds.get(key);
+
+        if (deadlineHold !== undefined) {
+          schedulePrepareHolds.delete(key);
+
+          return Effect.acquireUseRelease(
+            Deferred.succeed(deadlineHold.entered, undefined),
+            () => Effect.never,
+            () => Deferred.succeed(deadlineHold.finished, undefined),
+          );
+        }
         const hold = scheduleAuthorizationFailureHolds.get(key);
 
         if (hold?.held === true) {

--- a/packages/platform-cloudflare/test/scheduling.test.ts
+++ b/packages/platform-cloudflare/test/scheduling.test.ts
@@ -6,15 +6,19 @@ import {
 import { DoScheduleAlarmControl } from "@effect-agent/storage-cloudflare/DoScheduleStore";
 import {
   ScheduleId,
+  defaultSchedulingLimits,
   type ScheduleAuthorizer,
   type ScheduleOwner,
 } from "@effect-agent/thread/Schedule";
+import { scheduleOwnerKey } from "@effect-agent/thread/ScheduleTransition";
 import { Scheduling } from "@effect-agent/thread/Scheduling";
 import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
-import { Effect, type Layer, Schema } from "effect";
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, type Layer, Schema } from "effect";
 import { DurableObject, type DurableObjectState, type WorkerEnvironment } from "effect-cf";
+import { TestClock } from "effect/testing";
 import { describe, expect, it } from "vite-plus/test";
 
+import { scheduleAlarmHandler } from "../src/CloudflareScheduling.ts";
 import {
   TEST_DIGESTS,
   TEST_PRINCIPAL,
@@ -28,6 +32,7 @@ import {
   observeScheduleIdle,
   observeSchedulePolicyResources,
   plannerDefinition,
+  schedulePrepareHolds,
 } from "./fixtures.ts";
 import { laneRows, runScheduleClient, scheduleStubFor } from "./harness.ts";
 
@@ -144,6 +149,128 @@ const manage = (
   );
 
 describe("Cloudflare Schedule Owner", () => {
+  it("reaches healthy work after a full corrupt due page and retains its recovery alarm", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const healthy = fixture("healthy-after-page");
+
+        const broken = Array.from({ length: 16 }, () => ({
+          ...fixture("broken-first-page"),
+          owner: healthy.owner,
+          scope: healthy.scope,
+        }));
+
+        for (const entry of [...broken, healthy]) {
+          yield* Effect.promise(() =>
+            manage(entry, Date.now() + 86_400_000, "progress past failed work"),
+          );
+        }
+        yield* Effect.promise(() =>
+          runInDurableObject(scheduleStubFor(healthy.owner), (_instance, state) => {
+            state.storage.sql.exec(
+              "UPDATE effect_agent_schedules SET deadline_at_millis = 0, record_json = json_set(record_json, '$.nextAtMillis', 0)",
+            );
+            state.storage.sql.exec("UPDATE effect_cf_scheduled_alarms SET run_at = 0");
+            for (const entry of broken) {
+              state.storage.sql.exec(
+                "UPDATE effect_agent_schedules SET record_json = ? WHERE schedule_id = ?",
+                "{invalid-json",
+                entry.scheduleId,
+              );
+            }
+          }),
+        );
+        yield* TestClock.setTime(Date.now() + 3_600_000);
+        const clock = yield* Clock.Clock;
+        const before = yield* Effect.promise(() => storeProbe(healthy.owner));
+
+        const runPass = () =>
+          Effect.promise(() =>
+            runInDurableObject(scheduleStubFor(healthy.owner), (instance) =>
+              instance[DurableObject.RunSymbol](
+                scheduleAlarmHandler(defaultSchedulingLimits).pipe(
+                  Effect.provideService(Clock.Clock, clock),
+                ),
+              ),
+            ),
+          );
+
+        yield* runPass();
+
+        expect((yield* Effect.promise(() => snapshotFor(healthy))).lastReceipt).not.toBeNull();
+        expect(yield* Effect.promise(() => laneRows(healthy.thread))).toHaveLength(1);
+        const after = yield* Effect.promise(() => storeProbe(healthy.owner));
+
+        expect(after?.alarm_generation).toBeGreaterThan(before?.alarm_generation ?? 0);
+        const alarms = yield* Effect.promise(() => alarmRows(healthy.owner));
+
+        expect(alarms).toHaveLength(1);
+        expect(alarms[0]?.run_at).toBeGreaterThan(yield* Clock.currentTimeMillis);
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+    ));
+
+  it("interrupts an overlong schedule alarm and preserves its replacement wake and scoped cleanup", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const data = fixture("alarm-deadline");
+        const entered = yield* Deferred.make<void>();
+        const finished = yield* Deferred.make<void>();
+
+        yield* Effect.promise(() => manage(data, Date.now() + 86_400_000, "deadline recovery"));
+        yield* Effect.promise(() =>
+          runInDurableObject(scheduleStubFor(data.owner), (_instance, state) => {
+            state.storage.sql.exec(
+              "UPDATE effect_agent_schedules SET deadline_at_millis = 0, record_json = json_set(record_json, '$.nextAtMillis', 0)",
+            );
+            state.storage.sql.exec("UPDATE effect_cf_scheduled_alarms SET run_at = 0");
+          }),
+        );
+        yield* TestClock.setTime(Date.now() + 3_600_000);
+        const clock = yield* Clock.Clock;
+        const key = scheduleOwnerKey(data.owner);
+
+        schedulePrepareHolds.set(key, { entered, finished });
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            schedulePrepareHolds.delete(key);
+          }),
+        );
+        const before = yield* Effect.promise(() => storeProbe(data.owner));
+
+        const runPass = () =>
+          Effect.tryPromise({
+            try: () =>
+              runInDurableObject(scheduleStubFor(data.owner), (instance) =>
+                instance[DurableObject.RunSymbol](
+                  scheduleAlarmHandler(defaultSchedulingLimits).pipe(
+                    Effect.provideService(Clock.Clock, clock),
+                  ),
+                ),
+              ),
+            catch: (cause) => String(cause),
+          });
+
+        const pending = yield* runPass().pipe(Effect.exit, Effect.forkChild);
+
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust("14 minutes");
+        const exit = yield* Fiber.join(pending);
+
+        expect(Exit.isFailure(exit) ? Cause.pretty(exit.cause) : "success").toContain(
+          "TimeoutError",
+        );
+        expect(yield* Deferred.isDone(finished)).toBe(true);
+        expect(
+          (yield* Effect.promise(() => storeProbe(data.owner)))?.alarm_generation,
+        ).toBeGreaterThan(before?.alarm_generation ?? 0);
+        expect(yield* Effect.promise(() => alarmRows(data.owner))).toHaveLength(1);
+        expect((yield* Effect.promise(() => snapshotFor(data))).lastReceipt).toBeNull();
+        yield* runPass();
+        expect((yield* Effect.promise(() => snapshotFor(data))).lastReceipt).not.toBeNull();
+        expect(yield* Effect.promise(() => laneRows(data.thread))).toHaveLength(1);
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+    ));
+
   it("requires host policy and routing Layers with all application dependencies provided", () => {
     type Host = Parameters<typeof makeScheduleOwnerObjectClass>[0];
     type Ports = ScheduleAuthorizer | ThreadObjectNamespace;

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -19,7 +19,7 @@ import { makeSubscriptionPartitionObjectClass } from "@effect-agent/platform-clo
 import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
 import { OperationDenied } from "@effect-agent/thread/OperationAuthorizer";
 import { ScheduleAuthorizer, ScheduleFailpoint } from "@effect-agent/thread/Schedule";
-import { Context, Crypto, Effect, Layer, Schema } from "effect";
+import { Clock, Context, Crypto, Effect, Layer, Schema } from "effect";
 import { DurableObject, DurableObjectState, RpcTracing, WorkerEnvironment } from "effect-cf";
 import { OtlpExporter } from "effect/unstable/observability";
 
@@ -30,6 +30,7 @@ import {
   PRODUCER_PREFIX,
   fixtureReconcilerLayer,
   maintenanceRaceFailpoint,
+  maintenanceClocks,
   makeContextCompactorRunContextLayer,
   makeContextAuthorizationLayer,
   plannerDefinition,
@@ -299,7 +300,17 @@ const progressIncarnation = (ctx: DurableObjectState): number => {
   return created;
 };
 
-export class TestThreadObject extends ThreadObject.make(testRuntimeLayer, baseOptions) {
+export class TestThreadObject extends ThreadObject.make(testRuntimeLayer, {
+  ...baseOptions,
+  eventLayer: Layer.effect(
+    Clock.Clock,
+    Effect.gen(function* () {
+      const identity = yield* ThreadObjectIdentity;
+
+      return maintenanceClocks.get(identity.threadId) ?? (yield* Clock.Clock);
+    }),
+  ),
+}) {
   memoryChange(project: string, encoded: unknown) {
     return this[DurableObject.RunSymbol](
       Effect.gen(function* () {

--- a/packages/storage-cloudflare/src/DoThreadStore.ts
+++ b/packages/storage-cloudflare/src/DoThreadStore.ts
@@ -616,11 +616,17 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
   });
 
   const loadRecords = Effect.fn("DoThreadStore.loadRecords")(function* (request: RawReadRequest) {
-    const rows = yield* journal
+    const result = yield* journal
       .read(request)
       .pipe(Effect.mapError((error) => storeError("read canonical records", error)));
 
-    return yield* Effect.forEach(rows, decodeEnvelope);
+    return {
+      count: result.count,
+      records: result.records.pipe(
+        Stream.mapError((error) => storeError("read canonical records", error)),
+        Stream.mapEffect(decodeEnvelope),
+      ),
+    };
   });
 
   const readEffect = Effect.fn("DoThreadStore.read")(function* (request: ThreadRead) {
@@ -630,7 +636,7 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
 
     yield* requireThread(journal, validated.threadId);
 
-    const records = yield* loadRecords(
+    const result = yield* loadRecords(
       RawReadRequest.make({
         threadId: validated.threadId,
         fromSequenceExclusive: validated.afterSequence ?? ZERO_CANONICAL_SEQUENCE,
@@ -638,7 +644,7 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
       }),
     );
 
-    return Stream.fromIterable(records);
+    return result.records;
   });
 
   const read: ThreadStore["Service"]["read"] = (request) => Stream.unwrap(readEffect(request));
@@ -655,7 +661,7 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
     const poll = Effect.fn("DoThreadStore.observePoll")(function* () {
       const fromSequenceExclusive = yield* Ref.get(cursor);
 
-      const records = yield* loadRecords(
+      const result = yield* loadRecords(
         RawReadRequest.make({
           threadId: validated.threadId,
           fromSequenceExclusive,
@@ -663,17 +669,16 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
         }),
       );
 
-      if (records.length === 0) {
+      if (result.count === 0) {
         yield* Effect.sleep(config.observationPollInterval);
 
-        return [];
+        return Stream.empty;
       }
-      yield* Ref.set(cursor, records[records.length - 1].sequence);
 
-      return records;
+      return result.records.pipe(Stream.tap((record) => Ref.set(cursor, record.sequence)));
     });
 
-    return Stream.fromIterableEffectRepeat(poll());
+    return Stream.fromEffectRepeat(poll()).pipe(Stream.flatten);
   });
 
   const observe: ThreadStore["Service"]["observe"] = (request) =>

--- a/packages/storage-cloudflare/src/MemoryProtocol.ts
+++ b/packages/storage-cloudflare/src/MemoryProtocol.ts
@@ -28,7 +28,7 @@ import {
   revalidateSemanticMemoryCandidates,
 } from "@effect-agent/core/SemanticMemoryRevalidation";
 import { Principal } from "@effect-agent/thread/SubmissionLedger";
-import { Clock, Context, Effect, Encoding, Schema } from "effect";
+import { Clock, Context, Effect, Schema } from "effect";
 
 export class MemoryRpcError extends Schema.TaggedError<MemoryRpcError>()("MemoryRpcError", {
   reason: Schema.Literals(["denied", "protocol", "budget", "timeout", "unavailable"]),
@@ -127,7 +127,7 @@ export class MemoryOwnerIdentity extends Context.Service<
   }
 >()("@effect-agent/storage-cloudflare/MemoryOwnerIdentity") {}
 
-export const memoryWireBytes = (text: string): number => Encoding.encodeHex(text).length / 2;
+export const memoryWireBytes = (text: string): number => new TextEncoder().encode(text).byteLength;
 
 export const decodeMemoryWire = Effect.fn("decodeMemoryWire")(function* <A, I>(
   schema: Schema.Codec<A, I, never>,

--- a/packages/storage-cloudflare/src/internal/do-journal.ts
+++ b/packages/storage-cloudflare/src/internal/do-journal.ts
@@ -1,6 +1,6 @@
 import { CanonicalSequence, ProducerEpoch } from "@effect-agent/thread/Records";
 import { SqliteMigrator } from "@effect/sql-sqlite-do";
-import { Effect, Schema } from "effect";
+import { Effect, Schema, Stream } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlError } from "effect/unstable/sql/SqlError";
 
@@ -27,6 +27,7 @@ const BoundedStoredText = Schema.String.check(Schema.isMaxLength(2_000_000));
 const BoundedIdentifier = Schema.NonEmptyString.check(Schema.isMaxLength(1024));
 const MAX_RECORDS_PER_THREAD = 65_536;
 const MAX_IDENTIFIER_LENGTH = 1_024;
+const MAX_READ_PAGE_JSON_BYTES = 4 * 1024 * 1024;
 /** Durable Object SQL storage allows at most 100 bound parameters per statement. */
 const MAX_BOUND_PARAMETERS = 100;
 const isSqlError = Schema.is(SqlError);
@@ -76,6 +77,13 @@ class RecordRow extends Schema.Class<RecordRow>("RecordRow")({
   record_json: BoundedStoredText,
   sequence: CanonicalSequence,
 }) {}
+
+const ReadPlanRow = Schema.Struct({
+  sequence: CanonicalSequence,
+  record_json_bytes: Schema.Natural.check(Schema.isLessThanOrEqualTo(MAX_READ_PAGE_JSON_BYTES)),
+});
+
+type ReadPage = [typeof ReadPlanRow.Type, ...Array<typeof ReadPlanRow.Type>];
 
 class CheckpointRow extends Schema.Class<CheckpointRow>("CheckpointRow")({
   checkpoint_json: BoundedStoredText,
@@ -134,8 +142,6 @@ export class RawCheckpoint extends Schema.Class<RawCheckpoint>(
 export class RawThreadExport extends Schema.Class<RawThreadExport>(
   "@effect-agent/storage-cloudflare/RawThreadExport",
 )({
-  batches: Schema.Array(BatchRow),
-  checkpoints: Schema.Array(CheckpointRow),
   thread: ThreadRow,
   records: Schema.Array(RecordRow),
 }) {}
@@ -737,13 +743,12 @@ const makeJournal = (
   });
 
   const read = Effect.fn("DoJournal.read")(function* (request: RawReadRequest) {
-    const rows = yield* sql<Record<string, unknown>>`
+    // Capture membership without retaining payloads. Append-only sequences keep each later
+    // payload query inside this snapshot, even when new records arrive during consumption.
+    const planRows = yield* sql<Record<string, unknown>>`
       SELECT
-        thread_id,
         sequence,
-        record_id,
-        batch_id,
-        record_json
+        length(CAST(record_json AS BLOB)) AS record_json_bytes
       FROM effect_agent_canonical_records
       WHERE thread_id = ${request.threadId}
         AND sequence > ${request.fromSequenceExclusive}
@@ -751,12 +756,78 @@ const makeJournal = (
       LIMIT ${request.limit}
     `.pipe(Effect.mapError(storageError("read canonical records")));
 
-    return yield* decodeRows(
-      Schema.Array(RecordRow),
+    const plan = yield* decodeRows(
+      Schema.Array(ReadPlanRow),
       "effect_agent_canonical_records",
       `${request.threadId}>${request.fromSequenceExclusive}`,
-      rows,
+      planRows,
     );
+
+    const mismatch = () =>
+      DoStorageCorruptionError.make({
+        table: "effect_agent_canonical_records",
+        rowKey: `${request.threadId}>${request.fromSequenceExclusive}`,
+        message: "Canonical read membership, sequence, or payload size changed from its read plan.",
+      });
+
+    if (plan.length > request.limit) return yield* mismatch();
+
+    const pages: Array<ReadPage> = [];
+    let page: ReadPage | undefined;
+    let pageBytes = 0;
+    let previousSequence = request.fromSequenceExclusive;
+
+    for (const row of plan) {
+      if (row.sequence !== previousSequence + 1) return yield* mismatch();
+      previousSequence = row.sequence;
+      if (page === undefined || pageBytes + row.record_json_bytes > MAX_READ_PAGE_JSON_BYTES) {
+        page = [row];
+        pages.push(page);
+        pageBytes = row.record_json_bytes;
+      } else {
+        page.push(row);
+        pageBytes += row.record_json_bytes;
+      }
+    }
+
+    const readPage = Effect.fn("DoJournal.readPage")(function* (page: ReadPage) {
+      const rows = yield* sql<Record<string, unknown>>`
+        SELECT thread_id, sequence, record_id, batch_id, record_json
+        FROM effect_agent_canonical_records
+        WHERE thread_id = ${request.threadId}
+          AND sequence >= ${page[0].sequence}
+          AND sequence <= ${page[page.length - 1].sequence}
+        ORDER BY sequence
+      `.pipe(Effect.mapError(storageError("read canonical records")));
+
+      const decoded = yield* decodeRows(
+        Schema.Array(RecordRow),
+        "effect_agent_canonical_records",
+        `${request.threadId}/${page[0].sequence}`,
+        rows,
+      );
+
+      if (
+        decoded.length !== page.length ||
+        decoded.some(
+          (row, index) =>
+            row.thread_id !== request.threadId ||
+            row.sequence !== page[index].sequence ||
+            storedTextBytes(row.record_json) !== page[index].record_json_bytes,
+        )
+      ) {
+        return yield* mismatch();
+      }
+
+      return decoded;
+    });
+
+    return {
+      count: plan.length,
+      records: Stream.fromIterable(pages).pipe(
+        Stream.flatMap((page) => Stream.fromIterableEffect(readPage(page))),
+      ),
+    };
   });
 
   const exportThread = Effect.fn("DoJournal.exportThread")(function* (threadId: string) {
@@ -783,20 +854,6 @@ const makeJournal = (
 
           yield* failpoint("export:after-thread-read");
 
-          const batchRows = yield* sql<Record<string, unknown>>`
-            SELECT
-              thread_id,
-              batch_id,
-              first_sequence,
-              last_sequence,
-              batch_digest,
-              tail_digest,
-              batch_json
-            FROM effect_agent_canonical_batches
-            WHERE thread_id = ${threadId}
-            ORDER BY first_sequence
-          `.pipe(Effect.mapError(storageError("export canonical batches")));
-
           const recordRows = yield* sql<Record<string, unknown>>`
             SELECT
               thread_id,
@@ -809,36 +866,13 @@ const makeJournal = (
             ORDER BY sequence
           `.pipe(Effect.mapError(storageError("export canonical records")));
 
-          const checkpointRows = yield* sql<Record<string, unknown>>`
-            SELECT
-              thread_id,
-              through_sequence,
-              tail_digest,
-              checkpoint_json
-            FROM effect_agent_checkpoints
-            WHERE thread_id = ${threadId}
-            ORDER BY through_sequence
-          `.pipe(Effect.mapError(storageError("export checkpoints")));
-
           return RawThreadExport.make({
             thread,
-            batches: yield* decodeRows(
-              Schema.Array(BatchRow),
-              "effect_agent_canonical_batches",
-              threadId,
-              batchRows,
-            ),
             records: yield* decodeRows(
               Schema.Array(RecordRow),
               "effect_agent_canonical_records",
               threadId,
               recordRows,
-            ),
-            checkpoints: yield* decodeRows(
-              Schema.Array(CheckpointRow),
-              "effect_agent_checkpoints",
-              threadId,
-              checkpointRows,
             ),
           });
         }),

--- a/packages/storage-cloudflare/test/do-storage.test.ts
+++ b/packages/storage-cloudflare/test/do-storage.test.ts
@@ -20,6 +20,8 @@ import {
 } from "@effect-agent/thread/testing/ThreadStoreConformance";
 import {
   ThreadMaterialization,
+  ThreadObservation,
+  ThreadRead,
   ThreadStore,
   ThreadStoreError,
   FencedAppendRequest,
@@ -27,7 +29,7 @@ import {
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import type { Crypto } from "effect";
-import { Cause, Effect, Exit, Layer, Option, Schema, Tracer } from "effect";
+import { Cause, Effect, Exit, Layer, Option, Schema, Stream, Tracer } from "effect";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -147,6 +149,94 @@ describe("DoThreadStore", () => {
     expect(requirementsProof).toBe(true);
     expect(errorProof).toBe(true);
   });
+
+  it("streams large reads from their captured membership and resumes observation through later appends", () =>
+    withThreadStorage("wp1-store-large-read-snapshot", (storage) =>
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+        const threadId = thread("thread-large-read-snapshot");
+        let tail = { lastSequence: sequence(0), tailDigest: EMPTY_TAIL_DIGEST };
+
+        yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }));
+
+        const appendInput = Effect.fn("DoThreadStoreTest.appendLargeInput")(function* (
+          name: string,
+          input: string,
+        ) {
+          tail = yield* store.append(
+            FencedAppendRequest.make({
+              threadId,
+              batch: batch(`large-batch-${name}`, [inputRecord(`large-record-${name}`, input)]),
+              expectedTailSequence: tail.lastSequence,
+              expectedTailDigest: tail.tailDigest,
+              producerEpoch: epoch(1),
+            }),
+          );
+        });
+
+        const input = "x".repeat(900_000);
+
+        for (let index = 1; index <= 9; index++) yield* appendInput(String(index), input);
+
+        const records = yield* store.read(ThreadRead.make({ threadId, limit: 1_024 })).pipe(
+          Stream.mapEffect(
+            Effect.fn(function* (record) {
+              if (record.sequence === 1) yield* appendInput("during-read", "later");
+
+              return { sequence: record.sequence, offset: record.offset };
+            }),
+          ),
+          Stream.runCollect,
+        );
+
+        expect(records.map((record) => record.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        const limited = yield* store
+          .read(ThreadRead.make({ threadId, afterSequence: sequence(2), limit: 5 }))
+          .pipe(
+            Stream.map((record) => record.sequence),
+            Stream.runCollect,
+          );
+
+        expect(limited).toEqual([3, 4, 5, 6, 7]);
+
+        const observed = yield* store
+          .observe(ThreadObservation.make({ threadId, afterOffset: records[3].offset }))
+          .pipe(
+            Stream.mapEffect(
+              Effect.fn(function* (record) {
+                if (record.sequence === 5) yield* appendInput("during-observe", "later again");
+
+                return record.sequence;
+              }),
+            ),
+            Stream.take(7),
+            Stream.runCollect,
+          );
+
+        expect(observed).toEqual([5, 6, 7, 8, 9, 10, 11]);
+
+        const changed = yield* store.read(ThreadRead.make({ threadId, limit: 9 })).pipe(
+          Stream.tap((record) =>
+            Effect.sync(() => {
+              if (record.sequence === 1) {
+                storage.sql.exec(
+                  "DELETE FROM effect_agent_canonical_records WHERE thread_id = ? AND sequence = 9",
+                  threadId,
+                );
+              }
+            }),
+          ),
+          Stream.runDrain,
+          Effect.flip,
+        );
+
+        expect(changed).toMatchObject({
+          _tag: "ThreadStoreError",
+          cause: { _tag: "DoStorageCorruptionError" },
+        });
+      }).pipe(Effect.provide(layer({ storage }))),
+    ));
 
   it("validates convenience-layer configuration before initializing storage", () =>
     withThreadStorage("wp1-store-invalid-config", (storage) =>

--- a/packages/storage-cloudflare/test/memory-protocol.test.ts
+++ b/packages/storage-cloudflare/test/memory-protocol.test.ts
@@ -1,0 +1,29 @@
+import {
+  decodeMemoryWire,
+  encodeMemoryWire,
+} from "@effect-agent/storage-cloudflare/MemoryProtocol";
+import { Effect, Schema } from "effect";
+import { describe, expect, it } from "vite-plus/test";
+
+describe("MemoryProtocol", () => {
+  it("enforces the UTF-8 wire budget at the exact multibyte boundary", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const text = "é€😀";
+        const encoded = '"é€😀"';
+
+        expect(yield* encodeMemoryWire(Schema.String, text, 11)).toBe(encoded);
+        expect(yield* decodeMemoryWire(Schema.String, encoded, 11)).toBe(text);
+        expect(yield* encodeMemoryWire(Schema.String, text, 10).pipe(Effect.flip)).toMatchObject({
+          _tag: "MemoryRpcError",
+          reason: "budget",
+        });
+        expect(yield* decodeMemoryWire(Schema.String, encoded, 10).pipe(Effect.flip)).toMatchObject(
+          {
+            _tag: "MemoryRpcError",
+            reason: "budget",
+          },
+        );
+      }),
+    ));
+});

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -9,6 +9,7 @@ import { RunContextPreparation, RunToolAuthorization } from "@effect-agent/engin
 import { ToolBroker } from "@effect-agent/engine/ToolBroker";
 import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
 import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
+import { DurableWorkerBinding } from "@effect-agent/thread/AgentRegistration";
 import {
   DurableAgentRuntime,
   DurableRuntimeConfig,
@@ -4318,51 +4319,236 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
 });
 
 layer(testLayer)("RUN-030 canonical duration", (it) => {
-  it.effect("refuses executed history whose original start evidence is missing", () =>
-    Effect.gen(function* () {
-      const runtime = yield* DurableAgentRuntime;
-      const store = yield* ThreadStore;
-      const scripted = yield* makeScriptedModel(() => toolCallParts);
-      const agent = Agent.withModel(searchDefinition, scripted.model);
+  it.effect(
+    "an already-expired host deadline yields before initial context preparation or provider I/O",
+    () =>
+      Effect.gen(function* () {
+        const prepared = yield* Ref.make(0);
+        const scripted = yield* makeScriptedModel(() => finalParts('{"answer":"later"}'));
+        const agent = Agent.withModel(plannerDefinition, scripted.model);
+        const binding = yield* DurableWorkerBinding.make(agent, DIGESTS);
 
-      const receipt = yield* runtime.submit(
-        agent,
-        { question: "missing clock" },
-        submitOptions("missing-run-start", "start"),
-      );
+        yield* Effect.gen(function* () {
+          const runtime = yield* DurableAgentRuntime;
 
-      yield* armFailpoint("turn:after-response-append");
-      expect(
-        failureTag(
-          yield* Effect.exit(
-            runtime.processThread(agent, receipt.threadId).pipe(Effect.provide(searchToolLayer)),
-          ),
-        ),
-      ).toBe("DurableRuntimeFailpointError");
-      yield* clearFailpoint;
+          const receipt = yield* runtime.submit(
+            agent,
+            { question: "initial yield" },
+            submitOptions("host-yield-initial", "one"),
+          );
 
-      const withoutStart = ThreadStore.of({
-        ...store,
-        read: (request) =>
-          store
-            .read(request)
-            .pipe(Stream.filter(({ record }) => record.payload._tag !== "RunStarted")),
-      });
+          const yieldAfter = yield* DateTime.now;
 
-      const recovered = yield* Effect.exit(
-        Effect.flatMap(DurableAgentRuntime, (fresh) =>
-          fresh.processThread(agent, receipt.threadId),
-        ).pipe(
-          Effect.provide(Layer.fresh(DurableAgentRuntime.layer)),
-          Effect.provideService(ThreadStore, withoutStart),
-          Effect.provide(searchToolLayer),
-        ),
-      );
+          expect(
+            Option.isNone(yield* runtime.processThreadHead(receipt.threadId, { yieldAfter })),
+          ).toBe(true);
+          expect(yield* Ref.get(prepared)).toBe(0);
+          expect(scripted.prompts).toHaveLength(0);
+          expect(
+            (yield* readLog("host-yield-initial")).some(
+              ({ record }) => record.payload._tag === "SubmissionSettled",
+            ),
+          ).toBe(false);
+          const completed = yield* runtime.processThreadHead(receipt.threadId);
 
-      expect(failureTag(recovered)).toBe("RunJournalError");
-      expect(scripted.prompts).toHaveLength(1);
-    }),
+          expect(Option.isSome(completed) && completed.value.outcome).toBe("completed");
+          expect(scripted.prompts).toHaveLength(1);
+        }).pipe(
+          Effect.provide(DurableAgentRuntime.layerWithBindings([binding])),
+          Effect.provideService(RunContextPreparation, {
+            hook: {
+              prepare: ({ source }) =>
+                Ref.update(prepared, (count) => count + 1).pipe(Effect.as({ prompt: source })),
+            },
+          }),
+        );
+      }),
   );
+
+  for (const expired of [false, true])
+    it.effect(
+      `yields before the next provider call, releases resources, and ${expired ? "preserves the original deadline" : "resumes the same Run"}`,
+      () =>
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const acquired = yield* Ref.make(0);
+          const released = yield* Ref.make(0);
+          const toolCalls = yield* Ref.make(0);
+          const preparations = yield* Ref.make(0);
+          const thread = `host-yield-${expired}`;
+
+          const scripted = yield* makeScriptedModel((call) =>
+            call === 0 ? toolCallParts : finalParts('{"answer":"resumed"}'),
+          );
+
+          const model = Layer.merge(
+            scripted.model,
+            Layer.effectDiscard(
+              Effect.acquireRelease(
+                Ref.update(acquired, (count) => count + 1),
+                () => Ref.update(released, (count) => count + 1),
+              ),
+            ),
+          );
+
+          const yieldingTools = Toolkit.make(Search.annotate(ToolExecutionClass, "ordinary"));
+
+          const definition = Agent.make("host-yield-search", {
+            input: searchDefinition.input,
+            output: searchDefinition.output,
+            instructions: "Search before answering.",
+            toolkit: yieldingTools,
+            policy: searchDefinition.policy,
+          });
+
+          const agent = Agent.withModel(definition, model);
+
+          const binding = yield* DurableWorkerBinding.make(agent, DIGESTS).pipe(
+            Effect.provide(
+              yieldingTools.toLayer({
+                search: () =>
+                  Ref.update(toolCalls, (count) => count + 1).pipe(
+                    Effect.andThen(TestClock.adjust(Duration.seconds(1))),
+                    Effect.as({ available: true }),
+                  ),
+              }),
+            ),
+          );
+
+          yield* Effect.gen(function* () {
+            const runtime = yield* DurableAgentRuntime;
+
+            const receipt = yield* runtime.submit(
+              agent,
+              { question: "yield" },
+              submitOptions(thread, "one"),
+            );
+
+            const now = yield* DateTime.now;
+            const yieldAfter = DateTime.toUtc(DateTime.makeUnsafe(DateTime.toEpochMillis(now) + 1));
+            const first = yield* runtime.processThreadHead(receipt.threadId, { yieldAfter });
+
+            expect(Option.isNone(first)).toBe(true);
+            expect(scripted.prompts).toHaveLength(1);
+            expect(yield* Ref.get(preparations)).toBe(1);
+            expect(yield* Ref.get(acquired)).toBe(1);
+            expect(yield* Ref.get(released)).toBe(1);
+
+            const pending = yield* ledger.loadRecoverySnapshot(
+              RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+            );
+
+            expect(pending.ownership).toBeUndefined();
+            expect(pending.submission.state).not.toBe("settled");
+            const before = yield* readLog(thread);
+
+            expect(
+              before.filter(({ record }) => record.payload._tag === "ToolCallSettled"),
+            ).toHaveLength(1);
+            const start = before.find(({ record }) => record.payload._tag === "RunStarted");
+
+            if (expired) yield* TestClock.adjust(Duration.seconds(30));
+            const second = yield* runtime.processThreadHead(receipt.threadId);
+
+            expect(Option.isSome(second) && second.value.outcome).toBe(
+              expired ? "failed" : "completed",
+            );
+            expect(scripted.prompts).toHaveLength(expired ? 1 : 2);
+            expect(yield* Ref.get(acquired)).toBe(2);
+            expect(yield* Ref.get(released)).toBe(2);
+            expect(yield* Ref.get(toolCalls)).toBe(1);
+            const after = yield* readLog(thread);
+
+            expect(after.filter(({ record }) => record.payload._tag === "RunStarted")).toEqual([
+              start,
+            ]);
+            expect(
+              after.filter(({ record }) => record.payload._tag === "ToolCallPrepared"),
+            ).toHaveLength(1);
+            expect(
+              after.filter(({ record }) => record.payload._tag === "ToolCallSettled"),
+            ).toHaveLength(1);
+          }).pipe(
+            Effect.provide(DurableAgentRuntime.layerWithBindings([binding])),
+            Effect.provideService(RunContextPreparation, {
+              hook: {
+                prepare: ({ source }) =>
+                  Ref.update(preparations, (count) => count + 1).pipe(
+                    Effect.as({ prompt: source }),
+                  ),
+              },
+            }),
+          );
+        }),
+    );
+
+  for (const corruption of ["missing", "wrong-run"] as const)
+    it.effect(`refuses executed history whose original start evidence is ${corruption}`, () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const store = yield* ThreadStore;
+        const scripted = yield* makeScriptedModel(() => toolCallParts);
+        const agent = Agent.withModel(searchDefinition, scripted.model);
+
+        const receipt = yield* runtime.submit(
+          agent,
+          { question: "missing clock" },
+          submitOptions(`invalid-run-start-${corruption}`, "start"),
+        );
+
+        yield* armFailpoint("turn:after-response-append");
+        expect(
+          failureTag(
+            yield* Effect.exit(
+              runtime.processThread(agent, receipt.threadId).pipe(Effect.provide(searchToolLayer)),
+            ),
+          ),
+        ).toBe("DurableRuntimeFailpointError");
+        yield* clearFailpoint;
+
+        const withoutStart = ThreadStore.of({
+          ...store,
+          read: (request) =>
+            store.read(request).pipe(
+              Stream.filter(
+                ({ record }) => corruption !== "missing" || record.payload._tag !== "RunStarted",
+              ),
+              Stream.map((envelope) => {
+                const payload = envelope.record.payload;
+
+                if (corruption !== "wrong-run" || payload._tag !== "RunStarted") return envelope;
+
+                return CanonicalRecordEnvelope.make({
+                  ...envelope,
+                  record: RecordEnvelope.make({
+                    ...envelope.record,
+                    payload: {
+                      ...payload,
+                      runId: runIdForSubmission(Schema.decodeSync(SubmissionId)("wrong-run-start")),
+                    },
+                  }),
+                });
+              }),
+            ),
+        });
+
+        const recovered = yield* Effect.exit(
+          Effect.flatMap(DurableAgentRuntime, (fresh) =>
+            fresh.processThread(agent, receipt.threadId),
+          ).pipe(
+            Effect.provide(Layer.fresh(DurableAgentRuntime.layer)),
+            Effect.provideService(ThreadStore, withoutStart),
+            Effect.provide(searchToolLayer),
+          ),
+        );
+
+        // A missing record leaves a sequence gap, rejected before Run-specific clock validation.
+        expect(failureTag(recovered)).toBe(
+          corruption === "missing" ? "ThreadStoreError" : "RunJournalError",
+        );
+        expect(scripted.prompts).toHaveLength(1);
+      }),
+    );
 
   it.effect("starts the clock once across both Run-start append failpoints", () =>
     Effect.gen(function* () {

--- a/packages/testing/test/durable-subagents.test.ts
+++ b/packages/testing/test/durable-subagents.test.ts
@@ -1313,7 +1313,7 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         const rejected = yield* Effect.exit(hostileRuntime.processThreadResolved(parent.threadId));
 
         expect(failureTag(rejected)).toBe(
-          corrupt === "missing" ? "RunJournalError" : "LedgerError",
+          corrupt === "missing" ? "ThreadStoreError" : "LedgerError",
         );
         expect(payloadsOf(yield* readLog(parent.threadId), "SubagentJoined")).toHaveLength(0);
         expect((yield* parentReservations(parent.submissionId)).map((row) => row.status)).toEqual([

--- a/packages/thread/src/Digest.ts
+++ b/packages/thread/src/Digest.ts
@@ -11,6 +11,7 @@ export class DigestError extends Schema.TaggedError<DigestError>()("DigestError"
 
 const JsonArray = Schema.Array(Schema.Json);
 const isJsonArray = Schema.is(JsonArray);
+const utf8 = new TextEncoder();
 
 const canonicalJson = (value: Schema.Json): string => {
   if (
@@ -40,9 +41,7 @@ export const digestJson = Effect.fn("Thread.digestJson")(function* (
 ): Effect.fn.Return<Digest, DigestError, Crypto.Crypto> {
   const crypto = yield* Crypto.Crypto;
 
-  const bytes = yield* Effect.fromResult(
-    Encoding.decodeHex(Encoding.encodeHex(canonicalJson(value))),
-  ).pipe(Effect.mapError(() => DigestError.make({ message: "Canonical JSON encoding failed" })));
+  const bytes = utf8.encode(canonicalJson(value));
 
   const digest = yield* crypto
     .digest("SHA-256", bytes)

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -69,6 +69,7 @@ import {
   Context,
   Crypto,
   DateTime,
+  Deferred,
   Duration,
   Effect,
   Equal,
@@ -184,7 +185,8 @@ import {
   modelResponseInterruptedBatchId,
   modelResponseInterruptedRecordId,
   modelResponseRecordId,
-  projectRunJournal,
+  projectRunJournalStream,
+  type JournalBoundary,
   runCompletedRecordId,
   runIdForSubmission,
   runStartedBatchId,
@@ -717,6 +719,7 @@ type AttemptOutcome =
  */
 type RunPhaseOutcome =
   | AttemptOutcome
+  | { readonly _tag: "yielded" }
   | { readonly _tag: "suspended"; readonly toolCallId: ToolCallId }
   | { readonly _tag: "suspendedChild"; readonly children: AgentChildPending["children"] };
 
@@ -1037,36 +1040,118 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     });
   };
 
-  const readAll = Effect.fn("DurableAgentRuntime.readAll")(function* (
+  /** Re-readable, contiguous canonical prefix. Each traversal retains only the adapter's chunk. */
+  const canonicalRange = (
     threadId: ThreadId,
-  ): Effect.fn.Return<Array<CanonicalRecordEnvelope>, ThreadStoreError | ThreadNotMaterialized> {
-    const collected: Array<CanonicalRecordEnvelope> = [];
-    let after: CanonicalSequence | undefined = undefined;
+    throughSequence: CanonicalSequence,
+    afterSequence: CanonicalSequence = ZERO_SEQUENCE,
+  ): Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized> =>
+    Stream.suspend(() => {
+      let expected = afterSequence + 1;
+      let after = afterSequence;
 
-    while (true) {
-      const request: ThreadRead =
-        after === undefined
-          ? ThreadRead.make({ threadId, limit: READ_PAGE })
-          : ThreadRead.make({ threadId, limit: READ_PAGE, afterSequence: after });
+      const next = (): Stream.Stream<
+        CanonicalRecordEnvelope,
+        ThreadStoreError | ThreadNotMaterialized
+      > =>
+        Stream.suspend(() => {
+          if (expected > throughSequence) return Stream.empty;
+          const start = expected;
+          const limit = Math.min(READ_PAGE, throughSequence - start + 1);
 
-      const page: Array<CanonicalRecordEnvelope> = yield* Stream.runCollect(store.read(request));
+          const page = store
+            .read(
+              ThreadRead.make({
+                threadId,
+                limit,
+                ...(after === 0 ? {} : { afterSequence: after }),
+              }),
+            )
+            .pipe(
+              Stream.mapEffect((envelope) => {
+                if (envelope.sequence !== expected || expected >= start + limit) {
+                  return Effect.fail(
+                    ThreadStoreError.make({
+                      operation: "read recovery history",
+                      message: `Canonical history for ${threadId} is not contiguous: expected sequence ${expected}, received ${envelope.sequence}`,
+                    }),
+                  );
+                }
+                expected += 1;
+                after = envelope.sequence;
 
-      collected.push(...page);
-      const last = page.at(-1);
+                return Effect.succeed(envelope);
+              }),
+            );
 
-      if (page.length < READ_PAGE || last === undefined) return collected;
-      after = last.sequence;
-    }
+          return Stream.concat(
+            page,
+            Stream.suspend(() =>
+              expected === start + limit
+                ? next()
+                : Stream.fail(
+                    ThreadStoreError.make({
+                      operation: "read recovery history",
+                      message: `Canonical history for ${threadId} ended at ${after}; expected ${limit} records through sequence ${throughSequence}, received ${expected - start}`,
+                    }),
+                  ),
+            ),
+          );
+        });
+
+      return next();
+    });
+
+  /**
+   * Retain addressed runs and their deterministic identities independently of payload claims.
+   * Marker matching deliberately errs toward retaining malformed/conflicting identity evidence.
+   */
+  const controlRecords = (submissionIds: ReadonlyArray<SubmissionId>) => {
+    const runIds = new Set(submissionIds.map(runIdForSubmission));
+    const runMarkers = [...runIds].map((runId) => `:${runId}:`);
+
+    const recordIds = new Set(
+      submissionIds.flatMap((id) => [
+        submissionInputRecordId(id),
+        submissionAbortRecordId(id),
+        submissionSettlementRecordId(id),
+        runStartedRecordId(runIdForSubmission(id)),
+        runCompletedRecordId(runIdForSubmission(id)),
+      ]),
+    );
+
+    return ({ record }: CanonicalRecordEnvelope): boolean =>
+      recordIds.has(record.recordId) ||
+      runMarkers.some((marker) => record.recordId.includes(marker)) ||
+      record.recordId.startsWith("subagent-lineage:") ||
+      record.payload._tag === "SubagentLineageRecorded" ||
+      ("runId" in record.payload &&
+        record.payload.runId !== undefined &&
+        runIds.has(record.payload.runId));
+  };
+
+  const readControl = Effect.fn("DurableAgentRuntime.readControl")(function* (
+    threadId: ThreadId,
+    submissionIds: ReadonlyArray<SubmissionId>,
+  ) {
+    const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+
+    return yield* Stream.runCollect(
+      canonicalRange(threadId, tail.tailSequence).pipe(
+        Stream.filter(controlRecords(submissionIds)),
+      ),
+    );
   });
 
   const readAllTolerant = Effect.fn("DurableAgentRuntime.readAllTolerant")(
     (
       threadId: ThreadId,
+      submissionIds: ReadonlyArray<SubmissionId>,
     ): Effect.Effect<
       { readonly records: ReadonlyArray<CanonicalRecordEnvelope>; readonly materialized: boolean },
       ThreadStoreError
     > =>
-      readAll(threadId).pipe(
+      readControl(threadId, submissionIds).pipe(
         Effect.map((records) => ({ records, materialized: true })),
         Effect.catchTag("ThreadNotMaterialized", () =>
           Effect.succeed({ records: [], materialized: false }),
@@ -1077,6 +1162,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
   interface RecoveryHistorySnapshot {
     readonly records: ReadonlyArray<CanonicalRecordEnvelope>;
     readonly materialized: boolean;
+    readonly throughSequence: CanonicalSequence;
+    readonly submissionIds: ReadonlyArray<SubmissionId>;
   }
 
   /**
@@ -1089,64 +1176,36 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     threadId: ThreadId,
     afterSequence: CanonicalSequence,
     throughSequence: CanonicalSequence,
+    retain: (record: CanonicalRecordEnvelope) => boolean,
   ): Effect.fn.Return<Array<CanonicalRecordEnvelope>, ThreadStoreError | ThreadNotMaterialized> {
-    const collected: Array<CanonicalRecordEnvelope> = [];
-    let after = afterSequence;
-    let expected = afterSequence + 1;
-
-    while (expected <= throughSequence) {
-      const limit = Math.min(READ_PAGE, throughSequence - expected + 1);
-
-      const request = ThreadRead.make({
-        threadId,
-        limit,
-        ...(after === 0 ? {} : { afterSequence: after }),
-      });
-
-      const page: Array<CanonicalRecordEnvelope> = yield* Stream.runCollect(store.read(request));
-
-      if (page.length !== limit) {
-        return yield* ThreadStoreError.make({
-          operation: "read recovery history",
-          message: `Canonical history for ${threadId} ended at ${after}; expected ${limit} records through sequence ${throughSequence}, received ${page.length}`,
-        });
-      }
-      for (const envelope of page) {
-        if (envelope.sequence !== expected) {
-          return yield* ThreadStoreError.make({
-            operation: "read recovery history",
-            message: `Canonical history for ${threadId} is not contiguous: expected sequence ${expected}, received ${envelope.sequence}`,
-          });
-        }
-        expected += 1;
-        after = envelope.sequence;
-        collected.push(envelope);
-      }
-    }
-
-    return collected;
+    return yield* Stream.runCollect(
+      canonicalRange(threadId, throughSequence, afterSequence).pipe(Stream.filter(retain)),
+    );
   });
 
   /**
    * Capture one strongly-consistent pass-start tail and read exactly that prefix. This snapshot
    * is disposable: `runRecovery` retains it only while processing the scan's contiguous group
-   * for this Thread, so resident canonical history is bounded to one Thread prefix
+   * for this Thread, retaining only the addressed runs' control evidence
    * and never survives the pass or an interruption/restart.
    */
   const readRecoveryHistory = Effect.fn("DurableAgentRuntime.readRecoveryHistory")(function* (
     threadId: ThreadId,
+    submissionIds: ReadonlyArray<SubmissionId>,
   ): Effect.fn.Return<RecoveryHistorySnapshot, ThreadStoreError> {
     const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId })).pipe(
       Effect.map(Option.some),
       Effect.catchTag("ThreadNotMaterialized", () => Effect.succeed(Option.none())),
     );
 
-    if (Option.isNone(tail)) return { records: [], materialized: false };
+    if (Option.isNone(tail))
+      return { records: [], materialized: false, throughSequence: ZERO_SEQUENCE, submissionIds };
 
     const records = yield* readCanonicalRange(
       threadId,
       ZERO_SEQUENCE,
       tail.value.tailSequence,
+      controlRecords(submissionIds),
     ).pipe(
       Effect.catchTag("ThreadNotMaterialized", (error) =>
         ThreadStoreError.make({
@@ -1157,7 +1216,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       ),
     );
 
-    return { records, materialized: true };
+    return { records, materialized: true, throughSequence: tail.value.tailSequence, submissionIds };
   });
 
   /**
@@ -1168,13 +1227,19 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
   const refreshRecoveryHistory = Effect.fn("DurableAgentRuntime.refreshRecoveryHistory")(function* (
     threadId: ThreadId,
     records: ReadonlyArray<CanonicalRecordEnvelope>,
+    after: CanonicalSequence,
+    submissionIds: ReadonlyArray<SubmissionId>,
   ): Effect.fn.Return<ReadonlyArray<CanonicalRecordEnvelope>, DurableWorkerFailure> {
-    const after = records.at(-1)?.sequence ?? ZERO_SEQUENCE;
     const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
 
     if (tail.tailSequence <= after) return records;
 
-    const suffix = yield* readCanonicalRange(threadId, after, tail.tailSequence).pipe(
+    const suffix = yield* readCanonicalRange(
+      threadId,
+      after,
+      tail.tailSequence,
+      controlRecords(submissionIds),
+    ).pipe(
       Effect.catchTag("ThreadNotMaterialized", (error) =>
         ThreadStoreError.make({
           operation: "read recovery history",
@@ -1595,20 +1660,22 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
    * history through the engine's batch-resume continuation.
    */
   const withoutPendingBatch = (
-    records: ReadonlyArray<CanonicalRecordEnvelope>,
+    records: Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized>,
     pending: PendingToolBatch,
     runId: ReturnType<typeof runIdForSubmission>,
-  ): ReadonlyArray<CanonicalRecordEnvelope> =>
-    records.filter((envelope) => {
-      if (envelope.record.recordId === pending.responseRecordId) return false;
-      const payload = envelope.record.payload;
+  ): Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized> =>
+    records.pipe(
+      Stream.filter((envelope) => {
+        if (envelope.record.recordId === pending.responseRecordId) return false;
+        const payload = envelope.record.payload;
 
-      return !(
-        payload._tag === "ToolCallSettled" &&
-        payload.runId === runId &&
-        pending.declaredIds.has(payload.toolCallId)
-      );
-    });
+        return !(
+          payload._tag === "ToolCallSettled" &&
+          payload.runId === runId &&
+          pending.declaredIds.has(payload.toolCallId)
+        );
+      }),
+    );
 
   /** Materialize without regressing a fence someone else already advanced. */
   const materializeAtLeast = (
@@ -2210,7 +2277,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
   ) {
     const runId = runIdForSubmission(submission.submissionId);
     const recordId = runStartedRecordId(runId);
-    const records = yield* readAll(submission.threadId);
+    const records = yield* readControl(submission.threadId, [submission.submissionId]);
     const existing = yield* canonicalRunStartFromRecords(records, runId);
     let start: RecordEnvelope;
 
@@ -2682,7 +2749,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             ? // A racing establishment pass (or the child's own claimed worker) advanced the
               // log; the deterministic identity means the record either exists or the next
               // pass re-proves it — verify instead of trusting the race blindly.
-              readAll(request.childThreadId).pipe(
+              readControl(request.childThreadId, []).pipe(
                 Effect.flatMap((current) =>
                   current.some((candidate) => candidate.record.recordId === recordId)
                     ? Effect.void
@@ -2805,7 +2872,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         request.targetAgentId,
         request.targetDigests,
       );
-      const childRead = yield* readAllTolerant(request.childThreadId);
+      const childRead = yield* readAllTolerant(request.childThreadId, []);
 
       yield* ensureChildLineage(parent, request, childRead.records);
       yield* ledger.markReady(MarkReadyRequest.make({ submissionId: childSubmissionId }));
@@ -2920,7 +2987,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     ) {
       return mismatch("The child admission linkage does not name this parent Tool Call");
     }
-    const childRecords = yield* readAll(request.childThreadId);
+    const childRecords = yield* readControl(request.childThreadId, [child.submissionId]);
 
     const lineageEnvelope = childRecords.find(
       (envelope) => envelope.record.recordId === subagentLineageRecordId(request.childThreadId),
@@ -3166,7 +3233,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     );
 
     if (snapshot.childReservations.length === 0) return false;
-    const records = yield* readAll(submission.threadId);
+    const records = yield* readControl(submission.threadId, [submission.submissionId]);
     const subagent = subagentRecordsOf(records, runIdForSubmission(submission.submissionId));
     let open = false;
 
@@ -3199,7 +3266,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         RecoverySnapshotRequest.make({ submissionId: parent.submissionId }),
       );
 
-      const records = yield* readAll(parent.threadId);
+      const records = yield* readControl(parent.threadId, [parent.submissionId]);
       const runId = runIdForSubmission(parent.submissionId);
       const pending = yield* pendingToolBatchFor(records, runId);
       const knownIds = knownRecordIdsOf(records);
@@ -3362,7 +3429,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       );
 
       if (snapshot.childReservations.length === 0) return "clear";
-      const records = yield* readAll(parent.threadId);
+      const records = yield* readControl(parent.threadId, [parent.submissionId]);
 
       for (const envelope of records) knownIds.add(envelope.record.recordId);
       const subagent = subagentRecordsOf(records, runId);
@@ -3589,14 +3656,20 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     submission: SubmissionSnapshot,
     tokenRef: Ref.Ref<OwnershipToken>,
     records: ReadonlyArray<CanonicalRecordEnvelope>,
+    canonical: Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized>,
     lineage: AttemptLineage,
     approvalDecisions: ReadonlyArray<ApprovalDecisionIntent>,
     runTiming: { readonly startedAt: DateTime.Utc; readonly deadline: DateTime.Utc },
+    yieldAfter?: DateTime.Utc,
   ) =>
     Effect.gen(function* () {
       const submissionId = submission.submissionId;
       const runId = runIdForSubmission(submissionId);
-      const journal = yield* projectRunJournal(records, runId);
+      const boundaries: Array<JournalBoundary> = [];
+
+      const journal = yield* projectRunJournalStream(canonical, runId, (boundary) =>
+        boundaries.push(boundary),
+      );
 
       const childLineage = records.find(
         ({ record }) => record.recordId === subagentLineageRecordId(submission.threadId),
@@ -3619,7 +3692,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const resumeProjection =
         pending === undefined
           ? journal
-          : yield* projectRunJournal(withoutPendingBatch(records, pending, runId), runId);
+          : yield* projectRunJournalStream(withoutPendingBatch(canonical, pending, runId), runId);
 
       const tools: Record<string, Tool.Any> = agent.definition.toolkit.tools;
 
@@ -4148,6 +4221,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       // handler channel; this side channel preserves the original failure so the Attempt aborts
       // (obligation still owed) instead of settling the Run `failed` on an infrastructure fault.
       const haltRef = yield* Ref.make<DurableWorkerFailure | undefined>(undefined);
+      const yieldSignal = yield* Deferred.make<void>();
 
       const recordHalt = <A, R>(
         effect: Effect.Effect<A, DurableWorkerFailure, R>,
@@ -4463,40 +4537,58 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 message: "Compaction is already committed for this Turn and kind",
               });
             }
+
             // Coverage selection walks the attempt-start snapshot: records
             // appended by THIS Attempt are all owner-Run and excluded by the
             // prior-Runs-only rule regardless.
-            const coverable: Array<CanonicalRecordEnvelope> = [];
+            const coverable = boundaries.filter(
+              (boundary) =>
+                ownerFirstSequence === undefined || boundary.sequence < ownerFirstSequence,
+            );
 
-            for (const envelope of records) {
-              if (ownerFirstSequence !== undefined && envelope.sequence >= ownerFirstSequence) {
-                break;
-              }
-              const tag = envelope.record.payload._tag;
-
-              if (tag === "ModelResponseRecorded" || tag === "ToolCallSettled") {
-                coverable.push(envelope);
-              }
-            }
             if (coverable.length === 0) {
               return yield* CompactionError.make({
                 message: "Durable compaction requires eligible prior-Run records",
               });
             }
 
-            // Map only a prefix the strategy actually covered. Reprojection retains prior
-            // compaction records, so indices remain correct after earlier summaries. A host
-            // prompt transform that breaks this correspondence cannot authorize deletion.
-            const encodedSource = yield* Schema.encodeEffect(Prompt.Prompt)(commit.source).pipe(
-              Effect.mapError((cause) =>
-                CompactionError.make({
-                  message: "Could not encode the compaction source",
-                  cause,
-                }),
-              ),
-            );
+            // Compare each visible message once. A transformed source can authorize only its
+            // exact canonical prefix; no per-candidate rereads or full encoded Prompt copies.
+            let matchingPrefix = 0;
+            let requiredThrough = 0;
+            const comparisonLimit = Math.min(journal.prompt.content.length, commit.through);
 
-            let lastCovered: CanonicalRecordEnvelope | undefined;
+            for (let index = 0; index < commit.through; index += 1) {
+              const message = commit.source.content[index];
+
+              if (
+                message !== undefined &&
+                (commit.kind === "summarize" ? message.role !== "system" : message.role === "tool")
+              )
+                requiredThrough = index + 1;
+              if (index >= comparisonLimit || index !== matchingPrefix || message === undefined)
+                continue;
+              const canonicalMessage = journal.prompt.content[index];
+
+              if (canonicalMessage === undefined) continue;
+
+              const encode = (entry: Prompt.Message) =>
+                Schema.encodeEffect(Prompt.Message)(entry).pipe(
+                  Effect.mapError((cause) =>
+                    CompactionError.make({
+                      message: "Could not encode the canonical compaction prefix",
+                      cause,
+                    }),
+                  ),
+                );
+
+              const left = yield* encode(canonicalMessage);
+              const right = yield* encode(message);
+
+              if (JSON.stringify(left) === JSON.stringify(right)) matchingPrefix += 1;
+            }
+
+            let lastCovered: JournalBoundary | undefined;
 
             for (let index = 0; index < coverable.length; index += 1) {
               const candidate = coverable[index];
@@ -4504,53 +4596,12 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               if (candidate === undefined) continue;
               const following = coverable[index + 1];
 
-              if (
-                following !== undefined &&
-                following.record.payload._tag !== "ModelResponseRecorded"
-              )
-                continue;
+              if (following !== undefined && following.tag !== "ModelResponseRecorded") continue;
 
-              const prefix = yield* recordHalt(
-                projectRunJournal(
-                  records.filter(
-                    (entry) =>
-                      entry.sequence <= candidate.sequence ||
-                      entry.record.payload._tag === "CompactionCreated",
-                  ),
-                  runId,
-                ),
-              );
-
-              const length = prefix.prompt.content.length;
+              const length = candidate.promptLength;
 
               if (length === 0 || length > commit.through) continue;
-              // A shorter canonical prefix is sufficient only if the remaining source
-              // messages would not change. Never acknowledge partial persistence.
-              if (
-                commit.source.content
-                  .slice(length, commit.through)
-                  .some((message) =>
-                    commit.kind === "summarize"
-                      ? message.role !== "system"
-                      : message.role === "tool",
-                  )
-              )
-                continue;
-
-              const encodedPrefix = yield* Schema.encodeEffect(Prompt.Prompt)(prefix.prompt).pipe(
-                Effect.mapError((cause) =>
-                  CompactionError.make({
-                    message: "Could not encode the canonical compaction prefix",
-                    cause,
-                  }),
-                ),
-              );
-
-              if (
-                JSON.stringify(encodedPrefix.content) !==
-                JSON.stringify(encodedSource.content.slice(0, length))
-              )
-                continue;
+              if (length < requiredThrough || length > matchingPrefix) continue;
               lastCovered = candidate;
             }
             if (lastCovered === undefined) {
@@ -5518,6 +5569,23 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               },
             }),
         ...(preparedContext === undefined ? {} : { context: preparedContext }),
+        ...(yieldAfter === undefined
+          ? {}
+          : {
+              beforeTurn: () =>
+                Effect.gen(function* () {
+                  // The engine chooses the next Turn only after completing Tools and advancing
+                  // history. Stop before context preparation can invoke a compaction Model.
+                  if ((yield* Clock.currentTimeMillis) >= DateTime.toEpochMillis(yieldAfter)) {
+                    yield* recordHalt(commitPendingTurn);
+                    yield* Deferred.succeed(yieldSignal, undefined);
+
+                    // The successful signal wins the outer race and closes the stream Scope;
+                    // no synthetic engine RunFailed event or terminal Settlement is produced.
+                    return yield* Effect.never;
+                  }
+                }),
+            }),
         ...(runContextPreparation.transientContext === undefined
           ? {}
           : { transientContext: runContextPreparation.transientContext }),
@@ -5913,9 +5981,16 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         ).pipe(Effect.andThen(Effect.never)),
       );
 
-      const raced = Effect.raceFirst(consume, Effect.raceFirst(abortWatcher, renewal)).pipe(
-        Effect.provideService(IdGenerator, idGenerator),
-      );
+      const execution = Effect.raceFirst(consume, Effect.raceFirst(abortWatcher, renewal));
+
+      const raced = (
+        yieldAfter === undefined
+          ? execution
+          : Effect.raceFirst(
+              execution,
+              Deferred.await(yieldSignal).pipe(Effect.as({ _tag: "yielded" as const })),
+            )
+      ).pipe(Effect.provideService(IdGenerator, idGenerator));
 
       const result = yield* raced.pipe(
         Effect.catch(
@@ -5978,6 +6053,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         ),
       );
 
+      if (result._tag === "yielded") return result;
       if (result._tag === "suspendedRun") return approvalSuspension(result.toolCallId);
       if (result._tag === "suspendedChildRun") return childSuspension(result.children);
       if (result._tag === "aborted") {
@@ -6057,6 +6133,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     threadId: ThreadId,
     claim: Claim,
     tokenRef: Ref.Ref<OwnershipToken>,
+    yieldAfter?: DateTime.Utc,
   ) =>
     Effect.gen(function* () {
       const submissionId = claim.submissionId;
@@ -6084,7 +6161,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         yield* ledger.markReady(MarkReadyRequest.make({ submissionId }));
       }
       const ctx = yield* attemptContextFor(threadId, claim.producerEpoch);
-      const records = yield* readAll(threadId);
+      const records = yield* readControl(threadId, [submissionId]);
 
       const childPolicy =
         submission.parentLinkage === undefined
@@ -6159,7 +6236,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
       // Recheck after duration interruption too: that Attempt may have prepared new ordinary calls.
       const ordinaryCallsResolved = Effect.gen(function* () {
-        const reconciliationRecords = yield* readAll(threadId);
+        const reconciliationRecords = yield* readControl(threadId, [submissionId]);
 
         const reconciliationSnapshot = yield* ledger.loadRecoverySnapshot(
           RecoverySnapshotRequest.make({ submissionId }),
@@ -6226,7 +6303,12 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       let approvalDecisionIntents = snapshot.approvalDecisions;
 
       while (true) {
-        const currentRecords = yield* readAll(threadId);
+        const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+        const canonical = canonicalRange(threadId, tail.tailSequence);
+
+        const currentRecords = yield* Stream.runCollect(
+          canonical.pipe(Stream.filter(controlRecords([submissionId]))),
+        );
 
         const outcome = yield* runModel(
           agent,
@@ -6234,11 +6316,14 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           submission,
           tokenRef,
           currentRecords,
+          canonical,
           lineage,
           approvalDecisionIntents,
           runTiming,
+          yieldAfter,
         );
 
+        if (outcome._tag === "yielded") return Option.none();
         if (outcome._tag === "suspendedChild") {
           // Durable waitingForChild suspension (spec §12 step 10, SUB-030): the sibling
           // late-settles are already canonical; the ledger transition ends the ownership
@@ -6387,7 +6472,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       yield* ensureThreadCreated(submission.threadId, submission.agentId, submission.agentDigests);
       const ctx = yield* attemptContextFor(submission.threadId, claim.producerEpoch);
       const tokenRef = yield* Ref.make(claim.ownershipToken);
-      const records = yield* readAll(submission.threadId);
+      const records = yield* readControl(submission.threadId, [submission.submissionId]);
 
       const recorded = records.some(
         (envelope) =>
@@ -6458,6 +6543,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       submission: SubmissionSnapshot,
     ) => Effect.Effect<CapturedWorkerBinding, DurableBindingFailure>,
     threadId: ThreadId,
+    options?: { readonly yieldAfter?: DateTime.Utc },
   ): Effect.Effect<Option.Option<Settlement>, DurableWorkerFailure | DurableBindingFailure> =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -6495,7 +6581,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         // readiness, SUB-016).
         // Release the claim, nudge the parent lane, and leave the child to establishment.
         if (submission.parentLinkage !== undefined && submission.state === "admitted") {
-          const read = yield* readAllTolerant(threadId);
+          const read = yield* readAllTolerant(threadId, []);
 
           const lineageRecorded = read.records.some(
             (envelope) => envelope.record.payload._tag === "SubagentLineageRecorded",
@@ -6548,7 +6634,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
         return yield* resolution.binding.attempt(
           (agent, attemptThreadId, attemptClaim) =>
-            runAttempt(agent, attemptThreadId, attemptClaim, tokenRef),
+            runAttempt(agent, attemptThreadId, attemptClaim, tokenRef, options?.yieldAfter),
           threadId,
           claim,
         );
@@ -6639,11 +6725,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
   const processThreadHeadImpl = (
     threadId: ThreadId,
+    options?: { readonly yieldAfter?: DateTime.Utc },
   ): Effect.Effect<Option.Option<Settlement>, DurableWorkerFailure | DurableBindingFailure> =>
     processThreadHead(
       (submission) =>
         resolveWorkerBinding(registeredBindings, submission.agentId, submission.agentDigests),
       threadId,
+      options,
     );
 
   const claimFor = Effect.fn("DurableAgentRuntime.claimFor")(function* (
@@ -7061,6 +7149,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       evidence: RecoveryEvidence,
       decision: RecoveryDecision,
       records: ReadonlyArray<CanonicalRecordEnvelope>,
+      history: RecoveryHistorySnapshot,
     ): Effect.fn.Return<
       "repaired" | "deferred" | "none" | "unknown",
       DurableWorkerFailure,
@@ -7269,7 +7358,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           );
           const ctx = yield* attemptContextFor(submission.threadId, claim.producerEpoch);
           const tokenRef = yield* Ref.make(claim.ownershipToken);
-          const currentRecords = yield* refreshRecoveryHistory(submission.threadId, records);
+
+          const currentRecords = yield* refreshRecoveryHistory(
+            submission.threadId,
+            records,
+            history.throughSequence,
+            history.submissionIds,
+          );
 
           yield* applyCanonicalInput(
             ctx,
@@ -7640,6 +7735,29 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       RecoverySnapshotRequest.make({ submissionId: submission.submissionId }),
     );
 
+    // A racing steering link can name a host outside the pass's nonterminal group. Read that
+    // host from the same verified prefix, without changing this snapshot's visibility.
+    if (
+      snapshot.hostSubmissionId !== undefined &&
+      !history.submissionIds.includes(snapshot.hostSubmissionId)
+    ) {
+      const hostRecords = yield* readCanonicalRange(
+        submission.threadId,
+        ZERO_SEQUENCE,
+        history.throughSequence,
+        controlRecords([snapshot.hostSubmissionId]),
+      );
+
+      const merged = new Map(history.records.map((entry) => [entry.sequence, entry]));
+
+      for (const entry of hostRecords) merged.set(entry.sequence, entry);
+      history = {
+        ...history,
+        records: [...merged.values()].sort((left, right) => left.sequence - right.sequence),
+        submissionIds: [...history.submissionIds, snapshot.hostSubmissionId],
+      };
+    }
+
     const evidence = yield* evidenceFor(
       history.records,
       submission.submissionId,
@@ -7650,7 +7768,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     const decision = classifyRecovery(snapshot, evidence);
 
     const disposition = yield* Effect.scoped(
-      executeRecoveryDecision(snapshot, evidence, decision, history.records),
+      executeRecoveryDecision(snapshot, evidence, decision, history.records, history),
     );
 
     if (disposition === "repaired") {
@@ -7677,7 +7795,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       });
     }
 
-    return yield* recoverSnapshot(found.value, yield* readRecoveryHistory(found.value.threadId));
+    return yield* recoverSnapshot(
+      found.value,
+      yield* readRecoveryHistory(found.value.threadId, [submissionId]),
+    );
   });
 
   const runRecoveryImpl = Effect.fn("DurableAgentRuntime.runRecovery")(
@@ -7695,7 +7816,15 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         const first = nonterminal[index];
 
         if (first === undefined) break;
-        const history = yield* readRecoveryHistory(first.threadId);
+        const submissionIds: Array<SubmissionId> = [];
+
+        for (let offset = index; offset < nonterminal.length; offset += 1) {
+          const entry = nonterminal[offset];
+
+          if (entry === undefined || entry.threadId !== first.threadId) break;
+          submissionIds.push(entry.submissionId);
+        }
+        const history = yield* readRecoveryHistory(first.threadId, submissionIds);
 
         while (index < nonterminal.length) {
           const submission = nonterminal[index];
@@ -8115,7 +8244,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       RecoverySnapshotRequest.make({ submissionId: submission.submissionId }),
     );
 
-    const read = yield* readAllTolerant(submission.threadId);
+    const read = yield* readRecoveryHistory(submission.threadId, [
+      submission.submissionId,
+      ...(snapshot.hostSubmissionId === undefined ? [] : [snapshot.hostSubmissionId]),
+    ]);
 
     const evidence = yield* evidenceFor(
       read.records,
@@ -8330,7 +8462,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       RecoverySnapshotRequest.make({ submissionId: command.submissionId }),
     );
 
-    const read = yield* readAllTolerant(submission.threadId);
+    const read = yield* readRecoveryHistory(submission.threadId, [
+      submission.submissionId,
+      ...(snapshot.hostSubmissionId === undefined ? [] : [snapshot.hostSubmissionId]),
+    ]);
 
     const evidence = yield* evidenceFor(
       read.records,
@@ -8378,7 +8513,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     );
 
     const disposition = yield* Effect.scoped(
-      executeRecoveryDecision(snapshot, evidence, decision, read.records),
+      executeRecoveryDecision(snapshot, evidence, decision, read.records, read),
     );
 
     if (disposition === "repaired") {
@@ -8419,7 +8554,6 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     const nonterminal = yield* Stream.runCollect(ledger.scanNonterminal);
     const nowMillis = yield* Clock.currentTimeMillis;
     const generatedAt = yield* nowUtc;
-    const recordsCache = new Map<ThreadId, ReadonlyArray<CanonicalRecordEnvelope>>();
     const entries: Array<ObligationEntry> = [];
 
     for (const submission of nonterminal) {
@@ -8433,12 +8567,9 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       switch (submission.state) {
         case "unknown": {
           blockedOn = "unknown";
-          let records = recordsCache.get(submission.threadId);
 
-          if (records === undefined) {
-            records = (yield* readAllTolerant(submission.threadId)).records;
-            recordsCache.set(submission.threadId, records);
-          }
+          const records = (yield* readAllTolerant(submission.threadId, [submission.submissionId]))
+            .records;
 
           const resolvedIds = new Set(
             snapshot.unknownResolutions.map((intent) => intent.toolCallId),
@@ -8800,9 +8931,13 @@ export class DurableAgentRuntime extends Context.Service<
      * owned, unknown, or suspended head returns None and leaves accepted work pending.
      * Ready input may join this Run through the existing Turn seams and settle with its head.
      * Interruption ends only this Attempt; ownership cleanup uses its latest renewed token.
+     * A trusted host may supply `yieldAfter` to return None before the next Turn's context
+     * preparation, committing any completed Turn first. This releases ownership without settling or resetting the durable
+     * Run deadline. It is a cooperative scheduling deadline, not a hard interruption timeout.
      */
     readonly processThreadHead: (
       threadId: ThreadId,
+      options?: { readonly yieldAfter?: DateTime.Utc },
     ) => Effect.Effect<Option.Option<Settlement>, DurableWorkerFailure | DurableBindingFailure>;
     readonly runWorker: <
       InputSchema extends Schema.Top,

--- a/packages/thread/src/Records.ts
+++ b/packages/thread/src/Records.ts
@@ -20,8 +20,10 @@ import {
   ToolExecutionKind,
 } from "@effect-agent/core/SubagentContract";
 import { ModelCallUsage, RunUsageSummary } from "@effect-agent/core/Usage";
-import { Encoding, Schema } from "effect";
+import { Schema } from "effect";
 import { Prompt } from "effect/unstable/ai";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const identifier = <const Name extends string>(name: Name) =>
   Schema.NonEmptyString.pipe(Schema.brand(`@effect-agent/thread/${name}`));
@@ -157,9 +159,7 @@ const isPersistedJson = (input: unknown): input is Schema.Json => {
     if (!isJson(input)) return false;
     const encoded = JSON.stringify(input);
 
-    return (
-      encoded !== undefined && Encoding.encodeHex(encoded).length / 2 <= MAX_PERSISTED_JSON_BYTES
-    );
+    return encoded !== undefined && utf8ByteLength(encoded) <= MAX_PERSISTED_JSON_BYTES;
   } catch {
     return false;
   }

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -9,7 +9,7 @@ import { type ExhaustedLimit } from "@effect-agent/core/RunEvent";
 import { RunPolicyUsage } from "@effect-agent/core/RunPolicyUsage";
 import { ModelCallUsage, summarizeModelUsage } from "@effect-agent/core/Usage";
 import { CLEARED_TOOL_RESULT, COMPACTION_SUMMARY_PREFIX } from "@effect-agent/engine/Compaction";
-import { type Crypto, Effect, Schema, type DateTime } from "effect";
+import { type Crypto, Effect, Schema, Stream, type DateTime } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
 import { digestJson, type DigestError } from "./Digest.ts";
@@ -23,6 +23,7 @@ import {
   RunCompleted,
   ToolCallSettled,
   type CanonicalRecordEnvelope,
+  type CanonicalSequence,
   type DeploymentId,
   type ProducerId,
 } from "./Records.ts";
@@ -499,10 +500,28 @@ const PROMPT_TRANSPARENT_TAGS: ReadonlySet<string> = new Set([
  * later Run: the orphan assistant Tool declaration and any partial Tool results from that Turn
  * are excluded, while preceding instruction/user messages in the response record remain history.
  */
-const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwner")(function* (
-  records: ReadonlyArray<CanonicalRecordEnvelope>,
+/** @internal Lightweight canonical boundaries collected without retaining record payloads. */
+export interface JournalBoundary {
+  readonly sequence: CanonicalSequence;
+  readonly tag: "ModelResponseRecorded" | "ToolCallSettled";
+  readonly promptLength: number;
+}
+
+/**
+ * Reconstruct a fixed canonical prefix from a re-readable stream. The caller must keep the same
+ * records visible on every traversal. Compaction metadata and the resulting live Prompt remain
+ * resident; covered historical message/tool payloads do not. An uncompacted Prompt still grows
+ * with its conversation, so hosts must configure an appropriate context compaction policy.
+ * @internal
+ */
+export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalStream")(function* <
+  E,
+  R,
+>(
+  records: Stream.Stream<CanonicalRecordEnvelope, E, R>,
   ownerRunId: RunId | undefined,
-): Effect.fn.Return<RunJournalProjection, RunJournalError> {
+  onBoundary?: (boundary: JournalBoundary) => void,
+): Effect.fn.Return<RunJournalProjection, RunJournalError | E, R> {
   let state: FoldState = {
     all: [],
     before: [],
@@ -527,26 +546,38 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
   const firstSequenceByRun = new Map<string, number>();
   const lastResponseSequenceByRun = new Map<string, number>();
   const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
+  const settledToolCallRecordIds = new Set<string>();
+  const settledById = new Map<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>();
 
-  for (const envelope of records) {
-    const payload = envelope.record.payload;
+  yield* Stream.runForEach(records, (envelope) =>
+    Effect.sync(() => {
+      const payload = envelope.record.payload;
 
-    if (payload._tag === "CompactionCreated") continue;
-    if ("runId" in payload && typeof payload.runId === "string") {
-      if (!firstSequenceByRun.has(payload.runId)) {
-        firstSequenceByRun.set(payload.runId, envelope.sequence);
+      if (payload._tag === "CompactionCreated") return;
+      if ("runId" in payload && typeof payload.runId === "string") {
+        if (!firstSequenceByRun.has(payload.runId)) {
+          firstSequenceByRun.set(payload.runId, envelope.sequence);
+        }
       }
-    }
-    if (payload._tag === "ModelResponseRecorded") {
-      lastResponseSequenceByRun.set(payload.runId, envelope.sequence);
-    } else if (payload._tag === "ToolCallSettled") {
-      const from = lastResponseSequenceByRun.get(payload.runId);
+      if (payload._tag === "ModelResponseRecorded") {
+        lastResponseSequenceByRun.set(payload.runId, envelope.sequence);
+      } else if (payload._tag === "ToolCallSettled") {
+        settledToolCallRecordIds.add(envelope.record.recordId);
+        if (payload.runId === ownerRunId)
+          settledById.set(envelope.record.recordId, {
+            isFailure: payload.isFailure,
+            ...(payload.budgetRejected === undefined
+              ? {}
+              : { budgetRejected: payload.budgetRejected }),
+          });
+        const from = lastResponseSequenceByRun.get(payload.runId);
 
-      if (from !== undefined && from < envelope.sequence) {
-        settledSpans.push({ from, to: envelope.sequence });
+        if (from !== undefined && from < envelope.sequence) {
+          settledSpans.push({ from, to: envelope.sequence });
+        }
       }
-    }
-  }
+    }),
+  );
 
   const boundIsValid = (runId: string, coversThrough: number, ownSequence: number): boolean => {
     if (coversThrough >= ownSequence) return false;
@@ -565,25 +596,27 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
   let summarizeSequence = -1;
   let clearBound = 0;
 
-  for (const envelope of records) {
-    const payload = envelope.record.payload;
+  yield* Stream.runForEach(records, (envelope) =>
+    Effect.sync(() => {
+      const payload = envelope.record.payload;
 
-    if (payload._tag !== "CompactionCreated") continue;
-    if (!boundIsValid(payload.runId, payload.coversThrough, envelope.sequence)) continue;
-    if (payload.kind === "summarize") {
-      if (payload.summary === undefined) continue;
-      if (
-        payload.coversThrough > summarizeBound ||
-        (payload.coversThrough === summarizeBound && envelope.sequence > summarizeSequence)
-      ) {
-        summarizeBound = payload.coversThrough;
-        summarizeSummary = payload.summary;
-        summarizeSequence = envelope.sequence;
+      if (payload._tag !== "CompactionCreated") return;
+      if (!boundIsValid(payload.runId, payload.coversThrough, envelope.sequence)) return;
+      if (payload.kind === "summarize") {
+        if (payload.summary === undefined) return;
+        if (
+          payload.coversThrough > summarizeBound ||
+          (payload.coversThrough === summarizeBound && envelope.sequence > summarizeSequence)
+        ) {
+          summarizeBound = payload.coversThrough;
+          summarizeSummary = payload.summary;
+          summarizeSequence = envelope.sequence;
+        }
+      } else if (payload.coversThrough > clearBound) {
+        clearBound = payload.coversThrough;
       }
-    } else if (payload.coversThrough > clearBound) {
-      clearBound = payload.coversThrough;
-    }
-  }
+    }),
+  );
   let summaryEmitted = false;
 
   const emitSummary = () => {
@@ -599,7 +632,8 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     // Covered records always precede the owner Run's records (the append
     // side never covers the appending Run), so the summary belongs to both
     // the full projection and the prior-Run history.
-    state = { ...state, all: [...state.all, message], before: [...state.before, message] };
+    state.all.push(message);
+    state.before.push(message);
   };
 
   const modelUsage: Array<ModelCallUsage> = [];
@@ -616,42 +650,8 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
 
   let usageTurn = 0;
 
-  const settledToolCallRecordIds = new Set<string>();
-
-  for (const envelope of records) {
-    const payload = envelope.record.payload;
-
-    if (payload._tag !== "ToolCallSettled") continue;
-    settledToolCallRecordIds.add(envelope.record.recordId);
-  }
-
-  const decodedResponses = new Map<string, Prompt.Prompt>();
   const incompleteToolTurns = new Set<string>();
   const incompleteToolCalls = new Set<string>();
-
-  for (const envelope of records) {
-    const payload = envelope.record.payload;
-
-    if (payload._tag !== "ModelResponseRecorded") continue;
-    const messages = yield* decodePromptMessages(payload.messages);
-
-    decodedResponses.set(envelope.record.recordId, messages);
-    const declared = declaredApplicationToolCallIds(messages);
-    const declaredRecordIds: Array<RecordId> = [];
-
-    for (const id of declared) {
-      const toolCallId = yield* Effect.try({
-        try: () => decodeToolCallId(id),
-        catch: (cause) => journalError("Failed to decode a declared Tool Call ID", cause),
-      });
-
-      declaredRecordIds.push(toolCallSettledRecordId(payload.runId, payload.turn, toolCallId));
-    }
-    if (declaredRecordIds.some((recordId) => !settledToolCallRecordIds.has(recordId))) {
-      incompleteToolTurns.add(envelope.record.recordId);
-      for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
-    }
-  }
 
   const policyUsage = {
     committedTurns: 0,
@@ -661,56 +661,70 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     finalizationUsed: false,
   };
 
-  const settledById = new Map<string, ToolCallSettled>();
+  yield* Stream.runForEach(records, (envelope) =>
+    Effect.gen(function* () {
+      const record = envelope.record;
+      const payload = envelope.record.payload;
 
-  for (const { record } of records) {
-    if (record.payload._tag === "ToolCallSettled") settledById.set(record.recordId, record.payload);
-  }
-  for (const { record } of records) {
-    const payload = record.payload;
-
-    if (!("runId" in payload) || payload.runId !== ownerRunId) continue;
-    if (payload._tag === "RunPolicyUsageReserved") {
-      if (
-        payload.programmaticToolCalls < policyUsage.programmaticToolCalls ||
-        (policyUsage.finalizationUsed && !payload.finalizationUsed)
-      ) {
-        return yield* journalError("Run policy reservations must be monotonic");
+      if (payload._tag === "RunPolicyUsageReserved" && payload.runId === ownerRunId) {
+        if (
+          payload.programmaticToolCalls < policyUsage.programmaticToolCalls ||
+          (policyUsage.finalizationUsed && !payload.finalizationUsed)
+        ) {
+          return yield* journalError("Run policy reservations must be monotonic");
+        }
+        policyUsage.programmaticToolCalls = payload.programmaticToolCalls;
+        policyUsage.finalizationUsed = payload.finalizationUsed;
       }
-      policyUsage.programmaticToolCalls = payload.programmaticToolCalls;
-      policyUsage.finalizationUsed = payload.finalizationUsed;
-    }
-    if (payload._tag !== "ModelResponseRecorded") continue;
-    const messages = decodedResponses.get(record.recordId);
+      if (payload._tag !== "ModelResponseRecorded") return;
+      if (envelope.sequence <= summarizeBound && payload.runId !== ownerRunId) return;
+      const messages = yield* decodePromptMessages(payload.messages);
 
-    if (messages === undefined) return yield* journalError("Missing decoded policy response");
-    policyUsage.committedTurns = Math.max(policyUsage.committedTurns, payload.turn);
+      const declared = declaredApplicationToolCallIds(messages);
+      const declaredRecordIds: Array<RecordId> = [];
 
-    const calls = messages.content.flatMap((message) =>
-      message.role === "assistant"
-        ? message.content.filter((part) => part.type === "tool-call")
-        : [],
-    );
+      for (const id of declared) {
+        const toolCallId = yield* Effect.try({
+          try: () => decodeToolCallId(id),
+          catch: (cause) => journalError("Failed to decode a declared Tool Call ID", cause),
+        });
 
-    policyUsage.toolCalls += calls.length;
-    if (incompleteToolTurns.has(record.recordId)) continue;
-    for (const call of calls) {
-      const result = call.providerExecuted
-        ? messages.content
-            .flatMap((message) => (message.role === "assistant" ? message.content : []))
-            .find(
-              (part) => part.type === "tool-result" && part.providerExecuted && part.id === call.id,
-            )
-        : settledById.get(`tool-settled:${ownerRunId}:${payload.turn}:${call.id}`);
+        declaredRecordIds.push(toolCallSettledRecordId(payload.runId, payload.turn, toolCallId));
+      }
+      if (declaredRecordIds.some((recordId) => !settledToolCallRecordIds.has(recordId))) {
+        incompleteToolTurns.add(envelope.record.recordId);
+        for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
+      }
+      if (payload.runId !== ownerRunId) return;
+      policyUsage.committedTurns = Math.max(policyUsage.committedTurns, payload.turn);
 
-      if (result === undefined || ("budgetRejected" in result && result.budgetRejected === true))
-        continue;
-      if (!("isFailure" in result)) continue;
-      policyUsage.consecutiveToolFailures = result.isFailure
-        ? policyUsage.consecutiveToolFailures + 1
-        : 0;
-    }
-  }
+      const calls = messages.content.flatMap((message) =>
+        message.role === "assistant"
+          ? message.content.filter((part) => part.type === "tool-call")
+          : [],
+      );
+
+      policyUsage.toolCalls += calls.length;
+      if (incompleteToolTurns.has(record.recordId)) return;
+      for (const call of calls) {
+        const result = call.providerExecuted
+          ? messages.content
+              .flatMap((message) => (message.role === "assistant" ? message.content : []))
+              .find(
+                (part) =>
+                  part.type === "tool-result" && part.providerExecuted && part.id === call.id,
+              )
+          : settledById.get(`tool-settled:${ownerRunId}:${payload.turn}:${call.id}`);
+
+        if (result === undefined || ("budgetRejected" in result && result.budgetRejected === true))
+          continue;
+        if (!("isFailure" in result)) continue;
+        policyUsage.consecutiveToolFailures = result.isFailure
+          ? policyUsage.consecutiveToolFailures + 1
+          : 0;
+      }
+    }),
+  );
 
   const validatedPolicyUsage = yield* Schema.decodeUnknownEffect(RunPolicyUsage)(policyUsage).pipe(
     Effect.mapError((cause) =>
@@ -724,28 +738,115 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
     if (current.pendingTools.length === 0) return current;
     const toolMessage = yield* toolMessageFromSettled(current.pendingTools);
 
+    current.all.push(toolMessage);
+    if (!current.pendingToolsForRun) current.before.push(toolMessage);
+
     return {
       ...current,
-      all: [...current.all, toolMessage],
-      before: current.pendingToolsForRun ? current.before : [...current.before, toolMessage],
       pendingTools: [],
       pendingToolsForRun: false,
     };
   });
 
-  for (const envelope of records) {
-    const payload = envelope.record.payload;
+  yield* Stream.runForEach(records, (envelope) =>
+    Effect.gen(function* () {
+      const payload = envelope.record.payload;
 
-    if (PROMPT_TRANSPARENT_TAGS.has(payload._tag)) continue;
-    // The compaction record governs the fold (pre-scan) and contributes no
-    // message of its own; records at or below the summarize bound render as
-    // the one summary message emitted at the covered/kept transition.
-    if (payload._tag === "CompactionCreated") continue;
-    if (envelope.sequence <= summarizeBound) {
-      // Owner-Run usage still counts even when the message content is folded
-      // into the summary (the append side never covers the owner, but stay
-      // fail-safe if it ever did).
-      if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {
+      if (PROMPT_TRANSPARENT_TAGS.has(payload._tag)) return;
+      // The compaction record governs the fold (pre-scan) and contributes no
+      // message of its own; records at or below the summarize bound render as
+      // the one summary message emitted at the covered/kept transition.
+      if (payload._tag === "CompactionCreated") return;
+      if (envelope.sequence <= summarizeBound) {
+        // Owner-Run usage still counts even when the message content is folded
+        // into the summary (the append side never covers the owner, but stay
+        // fail-safe if it ever did).
+        if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {
+          const responseUsage = yield* projectedResponseUsage(payload);
+
+          usage.modelCalls = yield* addProjectedUsage(
+            "modelCalls",
+            usage.modelCalls,
+            responseUsage.modelCalls,
+          );
+          usage.inputTokens = yield* addProjectedUsage(
+            "inputTokens",
+            usage.inputTokens,
+            responseUsage.inputTokens,
+          );
+          usage.outputTokens = yield* addProjectedUsage(
+            "outputTokens",
+            usage.outputTokens,
+            responseUsage.outputTokens,
+          );
+          usage.costMicrousd = yield* addProjectedUsage(
+            "costMicrousd",
+            usage.costMicrousd,
+            responseUsage.costMicrousd,
+          );
+          usage.modelUsage.push(...responseUsage.modelUsage);
+          if (payload.turn > usageTurn) {
+            usageTurn = payload.turn;
+            usage.lastInputTokens = responseUsage.inputTokens;
+            usage.lastOutputTokens = responseUsage.outputTokens;
+          }
+        }
+        if (payload._tag === "ModelResponseRecorded" || payload._tag === "ToolCallSettled") {
+          onBoundary?.({
+            sequence: envelope.sequence,
+            tag: payload._tag,
+            promptLength: summarizeSummary === undefined ? 0 : 1,
+          });
+        }
+
+        return;
+      }
+      emitSummary();
+      if (payload._tag === "ToolCallSettled") {
+        if (payload.runId !== ownerRunId && incompleteToolCalls.has(envelope.record.recordId)) {
+          onBoundary?.({
+            sequence: envelope.sequence,
+            tag: payload._tag,
+            promptLength: state.all.length + (state.pendingTools.length === 0 ? 0 : 1),
+          });
+
+          return;
+        }
+        if (
+          state.pendingTools.length > 0 &&
+          state.pendingToolsForRun !== (payload.runId === ownerRunId)
+        ) {
+          state = yield* flushTools(state);
+        }
+        state.pendingTools.push({ record: payload, cleared: envelope.sequence <= clearBound });
+        state = {
+          ...state,
+          pendingToolsForRun: payload.runId === ownerRunId,
+        };
+        onBoundary?.({
+          sequence: envelope.sequence,
+          tag: payload._tag,
+          promptLength: state.all.length + 1,
+        });
+
+        return;
+      }
+      state = yield* flushTools(state);
+      if (payload._tag === "ModelCompleted" && payload.messages !== undefined) {
+        const messages = yield* decodePromptMessages(payload.messages);
+
+        for (const message of messages.content) {
+          state.all.push(message);
+          if (payload.runId !== ownerRunId) state.before.push(message);
+        }
+
+        return;
+      }
+      if (payload._tag !== "ModelResponseRecorded") return;
+      const messages = yield* decodePromptMessages(payload.messages);
+      const forRun = payload.runId === ownerRunId;
+
+      if (forRun) {
         const responseUsage = yield* projectedResponseUsage(payload);
 
         usage.modelCalls = yield* addProjectedUsage(
@@ -775,97 +876,34 @@ const projectRunJournalForOwner = Effect.fn("RunJournal.projectRunJournalForOwne
           usage.lastOutputTokens = responseUsage.outputTokens;
         }
       }
-      continue;
-    }
-    emitSummary();
-    if (payload._tag === "ToolCallSettled") {
-      if (payload.runId !== ownerRunId && incompleteToolCalls.has(envelope.record.recordId)) {
-        continue;
-      }
-      if (
-        state.pendingTools.length > 0 &&
-        state.pendingToolsForRun !== (payload.runId === ownerRunId)
-      ) {
-        state = yield* flushTools(state);
+
+      const modelVisible =
+        !forRun && payload.runScopedPrefixLength !== undefined
+          ? Prompt.fromMessages(messages.content.slice(payload.runScopedPrefixLength))
+          : messages;
+
+      const visibleMessages =
+        !forRun && incompleteToolTurns.has(envelope.record.recordId)
+          ? withoutApplicationToolCallMessages(modelVisible)
+          : modelVisible.content;
+
+      for (const message of visibleMessages) {
+        state.all.push(message);
+        if (!forRun) state.before.push(message);
       }
       state = {
         ...state,
-        pendingTools: [
-          ...state.pendingTools,
-          { record: payload, cleared: envelope.sequence <= clearBound },
-        ],
-        pendingToolsForRun: payload.runId === ownerRunId,
+        committedTurns: forRun
+          ? Math.max(state.committedTurns, payload.turn)
+          : state.committedTurns,
       };
-      continue;
-    }
-    state = yield* flushTools(state);
-    if (payload._tag === "ModelCompleted" && payload.messages !== undefined) {
-      const messages = yield* decodePromptMessages(payload.messages);
-
-      state = {
-        ...state,
-        all: [...state.all, ...messages.content],
-        before:
-          payload.runId === ownerRunId ? state.before : [...state.before, ...messages.content],
-      };
-      continue;
-    }
-    if (payload._tag !== "ModelResponseRecorded") continue;
-    const messages = decodedResponses.get(envelope.record.recordId);
-
-    if (messages === undefined) {
-      return yield* journalError("A canonical ModelResponseRecorded was not decoded");
-    }
-    const forRun = payload.runId === ownerRunId;
-
-    if (forRun) {
-      const responseUsage = yield* projectedResponseUsage(payload);
-
-      usage.modelCalls = yield* addProjectedUsage(
-        "modelCalls",
-        usage.modelCalls,
-        responseUsage.modelCalls,
-      );
-      usage.inputTokens = yield* addProjectedUsage(
-        "inputTokens",
-        usage.inputTokens,
-        responseUsage.inputTokens,
-      );
-      usage.outputTokens = yield* addProjectedUsage(
-        "outputTokens",
-        usage.outputTokens,
-        responseUsage.outputTokens,
-      );
-      usage.costMicrousd = yield* addProjectedUsage(
-        "costMicrousd",
-        usage.costMicrousd,
-        responseUsage.costMicrousd,
-      );
-      usage.modelUsage.push(...responseUsage.modelUsage);
-      if (payload.turn > usageTurn) {
-        usageTurn = payload.turn;
-        usage.lastInputTokens = responseUsage.inputTokens;
-        usage.lastOutputTokens = responseUsage.outputTokens;
-      }
-    }
-
-    const modelVisible =
-      !forRun && payload.runScopedPrefixLength !== undefined
-        ? Prompt.fromMessages(messages.content.slice(payload.runScopedPrefixLength))
-        : messages;
-
-    const visibleMessages =
-      !forRun && incompleteToolTurns.has(envelope.record.recordId)
-        ? withoutApplicationToolCallMessages(modelVisible)
-        : modelVisible.content;
-
-    state = {
-      ...state,
-      all: [...state.all, ...visibleMessages],
-      before: forRun ? state.before : [...state.before, ...visibleMessages],
-      committedTurns: forRun ? Math.max(state.committedTurns, payload.turn) : state.committedTurns,
-    };
-  }
+      onBoundary?.({
+        sequence: envelope.sequence,
+        tag: payload._tag,
+        promptLength: state.all.length,
+      });
+    }),
+  );
   emitSummary();
   state = yield* flushTools(state);
 
@@ -884,7 +922,7 @@ export const projectRunJournal = Effect.fn("RunJournal.projectRunJournal")(
     records: ReadonlyArray<CanonicalRecordEnvelope>,
     runId: RunId,
   ): Effect.Effect<RunJournalProjection, RunJournalError> =>
-    projectRunJournalForOwner(records, runId),
+    projectRunJournalStream(Stream.fromIterable(records), runId),
 );
 
 /**
@@ -896,7 +934,7 @@ export const promptFromCanonicalRecords = Effect.fn("RunJournal.promptFromCanoni
   (
     records: ReadonlyArray<CanonicalRecordEnvelope>,
   ): Effect.Effect<Prompt.Prompt, RunJournalError> =>
-    projectRunJournalForOwner(records, undefined).pipe(
+    projectRunJournalStream(Stream.fromIterable(records), undefined).pipe(
       Effect.map((projection) => projection.prompt),
     ),
 );

--- a/packages/thread/src/Scheduling.ts
+++ b/packages/thread/src/Scheduling.ts
@@ -5,7 +5,6 @@ import {
   Crypto,
   DateTime,
   Effect,
-  Encoding,
   Layer,
   Option,
   Result,
@@ -22,6 +21,7 @@ import {
   scheduleNextAfter,
   scheduleResumeCursor,
 } from "./internal/schedule-time.ts";
+import { utf8ByteLength } from "./internal/utf8.ts";
 import { admitPreparedInput } from "./PreparedInputAdmission.ts";
 import { DefinitionDigests, type Digest, PersistedJson } from "./Records.ts";
 import {
@@ -134,8 +134,7 @@ const asSnapshot = (record: ScheduleRecord, observedAtMillis: number): ScheduleS
   };
 };
 
-const inputByteLength = (input: PersistedJson): number =>
-  Encoding.encodeHex(JSON.stringify(input)).length / 2;
+const inputByteLength = (input: PersistedJson): number => utf8ByteLength(JSON.stringify(input));
 
 const currentMillis = DateTime.now.pipe(Effect.map(DateTime.toEpochMillis));
 

--- a/packages/thread/src/SqlMemoryStore.ts
+++ b/packages/thread/src/SqlMemoryStore.ts
@@ -11,9 +11,11 @@ import {
   MemoryWrite,
   MemoryWriter,
 } from "@effect-agent/core/MemoryStore";
-import { Clock, Context, Effect, Encoding, Layer, Schema } from "effect";
+import { Clock, Context, Effect, Layer, Schema } from "effect";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
 import type { SqlError } from "effect/unstable/sql/SqlError";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const STORAGE_VERSION = 2 as const;
 const METADATA_COMPONENT = "memory";
@@ -484,7 +486,7 @@ const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
             limits.maxDocuments !== Number.MAX_SAFE_INTEGER ||
             limits.maxReceipts !== Number.MAX_SAFE_INTEGER
           ) {
-            const bytes = (value: string) => Encoding.encodeHex(value).length / 2;
+            const bytes = utf8ByteLength;
             const identityBytes = bytes(next.key.namespace.address) + bytes(next.key.id);
             const documentBytes = identityBytes + bytes(documentJson) + 128;
 

--- a/packages/thread/src/Subscriptions.ts
+++ b/packages/thread/src/Subscriptions.ts
@@ -1,19 +1,9 @@
 import { ThreadId } from "@effect-agent/core/Identifiers";
-import {
-  Cause,
-  Context,
-  Crypto,
-  DateTime,
-  Effect,
-  Encoding,
-  Layer,
-  Option,
-  Schema,
-  Semaphore,
-} from "effect";
+import { Cause, Context, Crypto, DateTime, Effect, Layer, Option, Schema, Semaphore } from "effect";
 
 import { digestJson } from "./Digest.ts";
 import { EventSources, type NormalizedEvent } from "./EventSource.ts";
+import { utf8ByteLength } from "./internal/utf8.ts";
 import { admitPreparedInput, PreparedInputAdmission } from "./PreparedInputAdmission.ts";
 import { DefinitionDigests, type PersistedJson } from "./Records.ts";
 import { type ScheduleRetryReason } from "./Schedule.ts";
@@ -48,7 +38,7 @@ const now = DateTime.now.pipe(Effect.map(DateTime.toEpochMillis));
 const failure = (reason: SubscriptionError["reason"], code: string) =>
   SubscriptionError.make({ reason, code });
 
-const bytes = (value: PersistedJson) => Encoding.encodeHex(JSON.stringify(value)).length / 2;
+const bytes = (value: PersistedJson) => utf8ByteLength(JSON.stringify(value));
 
 const sameSource = (a: EventSourceVersion, b: EventSourceVersion) =>
   a.name === b.name && a.version === b.version;

--- a/packages/thread/src/internal/utf8.ts
+++ b/packages/thread/src/internal/utf8.ts
@@ -1,0 +1,14 @@
+/** Count UTF-8 bytes without allocating an encoded copy of the string. */
+export const utf8ByteLength = (value: string): number => {
+  let bytes = 0;
+  let index = 0;
+
+  while (index < value.length) {
+    const codePoint = value.codePointAt(index) ?? 0;
+
+    bytes += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+
+  return bytes;
+};

--- a/packages/thread/test/durable-runtime-types.test.ts
+++ b/packages/thread/test/durable-runtime-types.test.ts
@@ -9,7 +9,7 @@ import {
 import { type Settlement } from "@effect-agent/thread/SubmissionLedger";
 import { type SubmissionStatus } from "@effect-agent/thread/SubmissionStatus";
 import { expectTypeOf, it } from "@effect/vitest";
-import type { Effect, Option } from "effect";
+import type { DateTime, Effect, Option } from "effect";
 
 type Runtime = DurableAgentRuntime["Service"];
 type Head = ReturnType<Runtime["processThreadHead"]>;
@@ -18,7 +18,9 @@ type Inspection = ReturnType<Runtime["inspectSubmissionStatus"]>;
 type Recovery = ReturnType<Runtime["recoverSubmission"]>;
 
 it("keeps bounded worker operations and status reads typed without hidden requirements", () => {
-  expectTypeOf<Parameters<Runtime["processThreadHead"]>>().toEqualTypeOf<[threadId: ThreadId]>();
+  expectTypeOf<Parameters<Runtime["processThreadHead"]>>().toEqualTypeOf<
+    [threadId: ThreadId, options?: { readonly yieldAfter?: DateTime.Utc }]
+  >();
   expectTypeOf<Parameters<Runtime["processThreadResolved"]>>().toEqualTypeOf<
     [threadId: ThreadId]
   >();

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -16,6 +16,7 @@ import {
   modelResponseRecordId,
   promptFromCanonicalRecords,
   projectRunJournal,
+  projectRunJournalStream,
   runCompletedRecordId,
   runIdForSubmission,
   subagentJoinBatchId,
@@ -37,7 +38,7 @@ import {
 } from "@effect-agent/thread/RunJournal";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it, layer } from "@effect/vitest";
-import { DateTime, Effect, Schema } from "effect";
+import { DateTime, Effect, Schema, Stream } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
 const SUBMISSION_ID = Schema.decodeSync(SubmissionId)("submission-journal");
@@ -1095,6 +1096,59 @@ describe("engine compaction records and projection (RUN-026)", () => {
             { bookingRef: "flight-42" },
             { bookingRef: "lodging-7" },
           ]);
+        }),
+    );
+
+    it.effect(
+      "streams a validated summary without decoding covered responses, but rejects split coverage",
+      () =>
+        Effect.gen(function* () {
+          const turn = yield* turnCanonicalBatch(turnInput(toolTurnAppended));
+
+          const records = envelopesOf([turn]).map((envelope) => {
+            const payload = envelope.record.payload;
+
+            return payload._tag !== "ModelResponseRecorded"
+              ? envelope
+              : CanonicalRecordEnvelope.make({
+                  ...envelope,
+                  record: RecordEnvelope.make({
+                    ...envelope.record,
+                    payload: { ...payload, messages: { archived: true } },
+                  }),
+                });
+          });
+
+          const summarize = envelopeAt(
+            records.length + 1,
+            auditRecord("stream-summary", compactionPayload({ coversThrough: 3 })),
+          );
+
+          let traversals = 0;
+
+          const source = Stream.suspend(() => {
+            traversals += 1;
+
+            return Stream.fromIterable([...records, summarize]);
+          });
+
+          const projected = yield* projectRunJournalStream(source, LATER_RUN_ID);
+
+          expect(promptText(projected.prompt)).toContain("Goal: book the Kyoto trip");
+          expect(toolResults(projected.prompt)).toEqual([]);
+          expect(traversals).toBeLessThanOrEqual(4);
+
+          const split = envelopeAt(
+            records.length + 1,
+            auditRecord("stream-split", compactionPayload({ coversThrough: 1 })),
+          );
+
+          const failure = yield* projectRunJournalStream(
+            Stream.fromIterable([...records, split]),
+            LATER_RUN_ID,
+          ).pipe(Effect.flip);
+
+          expect(failure._tag).toBe("RunJournalError");
         }),
     );
 

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -224,6 +224,9 @@ describe("thread canonical contracts", () => {
         const umlautLast = yield* digestJson({ z: 2, "\u00e4": 1 });
 
         expect(umlautLast).toBe(umlautFirst);
+        expect(yield* digestJson({ z: "\ud800", value: "😀é" })).toBe(
+          "a2ae949a2f22f7fc31138231e3db19f57f017e0d8a09f7b2b049398f9346f57c",
+        );
       }),
     );
   });
@@ -260,6 +263,11 @@ describe("thread canonical contracts", () => {
     expect(
       Schema.decodeUnknownExit(PersistedJson)("x".repeat(MAX_PERSISTED_JSON_BYTES + 1))._tag,
     ).toBe("Failure");
+    // JSON quotes consume two bytes; astral code points consume four rather than UTF-16's two.
+    const utf8Boundary = "😀".repeat(Math.floor((MAX_PERSISTED_JSON_BYTES - 2) / 4));
+
+    expect(Schema.decodeUnknownExit(PersistedJson)(utf8Boundary)._tag).toBe("Success");
+    expect(Schema.decodeUnknownExit(PersistedJson)(`${utf8Boundary}😀`)._tag).toBe("Failure");
 
     const cyclic: Record<string, unknown> = {};
 


### PR DESCRIPTION
Long histories retained unnecessary record payloads, root imports kept unused Cloudflare adapters, and alarms could outlive the platform's event lifetime. Stream history, remove avoidable allocations, and let durable runs yield between committed turns while preserving their original deadlines and usage budgets.

| Area | Before | After |
| --- | --- | --- |
| History reads and recovery | The SQL stream buffered up to 128 payload rows; recovery and prompt projection collected history payloads. | SQL payload pages contain at most 4 MiB of record JSON, planned from up to 1,024 sequence/size entries. Recovery streams a fixed canonical tail and retains relevant evidence; projection avoids retaining summarized response payloads. |
| Startup modules | Root imports retained unused adapters. | Package side-effect metadata lets Wrangler remove 20 unused modules, with the existing exports preserved. |
| Temporary allocations | Export queried unused batch/checkpoint data; byte counts and hashing created temporary hex encodings. | Export reads only the data it returns; UTF-8 sizing and digest encoding avoid those temporary strings. Digest values remain compatible. |
| Alarm execution | A Thread alarm drained multiple heads without an event deadline. | One head Attempt per alarm, cooperative yield after 10 minutes, and a 14-minute watchdog around the entire Thread or Schedule Owner event. Schedule scanning continues past failed pages so later schedules remain reachable. |
| Measurement | No repeatable local heap benchmark for bundle startup and concurrent Thread Objects. | An opt-in benchmark saves exact bundles, hashes, metafiles, fresh-process Node samples, and native workerd snapshots with a synthetic model and tools. |

Measured before/after: the following comparison isolates the new package side-effect metadata on otherwise identical final source, using Wrangler dry-run bundles. Node values are median heap deltas across three fresh processes per case, with Cloudflare modules shimmed and no handlers running.

| Measurement | Before | After |
| --- | ---: | ---: |
| Root-import bundle | 2,690,388 bytes | 2,428,841 bytes (**9.72% smaller**) |
| Root-import gzip | 488.30 KiB | 444.96 KiB |
| Root-import contributing modules | 255 | 235 |
| Root-import Node evaluation heap delta | 33.134 MiB | 27.785 MiB |
| Root-import Node post-GC heap delta | 16.363 MiB | 15.132 MiB |
| Direct-import bundle control | 2,427,736 bytes | 2,427,736 bytes, byte-identical |

Node measurements diagnose startup allocations; they do not measure Cloudflare isolate capacity. Separately, three fresh native workerd samples of the final implementation, each with four concurrently active Durable Objects, measured 29.660–29.677 MiB of active JavaScript heap and completed all four runs with eight model calls and eight tool calls per sample. These are instantaneous snapshots, not peak memory, and have no native before/after baseline.

The new typed `RunOptions.beforeTurn` hook places the host's yield boundary before context preparation, including model-backed compaction:

```mermaid
sequenceDiagram
    participant Alarm as ThreadMaintenance
    participant Durable as DurableAgentRuntime
    participant Engine as AgentRuntime
    Alarm->>Durable: processThreadHead(threadId, { yieldAfter })
    Durable->>Engine: Consume run stream
    Engine->>Durable: beforeTurn(), before context preparation
    alt Host deadline reached
        Durable->>Durable: Commit completed turn and signal yield
        Durable->>Durable: Close Attempt scope and release ownership
        Durable-->>Alarm: None; retain durable retry
    else Time remains
        Durable-->>Engine: Continue context preparation and model turn
    end
```

Caller example, inside an Effect program with `runtime` and `threadId` already resolved:

```ts
import { Clock, DateTime } from "effect";

const yieldAfter = DateTime.makeUnsafe(
  (yield* Clock.currentTimeMillis) + 10 * 60_000,
);
const result = yield* runtime.processThreadHead(threadId, { yieldAfter });
// Some(Settlement) on settlement; None on yield or no runnable head.
// Failures remain DurableWorkerFailure | DurableBindingFailure.
```

Yielding preserves the same Run and its accumulated budgets. Watchdogs are cooperative and cannot preempt synchronous CPU work or uninterruptible finalizers. An ordinary tool with an unconfirmed outcome retains Unknown recovery semantics and is never automatically replayed. History metadata and scanning remain proportional to history; uncompacted prompts and explicit whole-thread exports still grow with the conversation.

`vp run ready` passed on the committed source, including adapter, recovery/fault, native alarm, type, build, and documentation checks. Regression coverage includes yield before compaction, ownership cleanup, original Run budgets, bounded payload pages, and a healthy schedule following a full page of broken schedules.

Reproduce the local heap measurements without deploying or using a model key:

```sh
vp run --no-cache -F @effect-agent/example-cloudflare-memory measure:heap \
  --out-dir /tmp/effect-agent-heap --samples 3 --objects 4
```
