### PR TITLE
feat(memory): bound SQL accounting work and reserve withdrawal capacity

### DIFF
--- a/.changeset/tidy-memory-accounting.md
+++ b/.changeset/tidy-memory-accounting.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/thread": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Keep SQL memory admission work bounded as retained history grows, charge replacements by their byte delta, and preserve existing exact-result receipts. Add optional withdrawal capacity reserves within hard storage limits; deploy exclusively upgraded writers before relying on reserves.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -269,8 +269,32 @@ Default owner limits are 16 distinct sources, 1 MiB encoded request, 4 MiB encod
 16 MiB revalidation input, and a 10-second deadline. `MemoryObject.make` accepts `rpcLimits` and
 `storageLimits`. Storage defaults cap encoded rows at 1,900,000 bytes, 10,000 documents, 100,000
 operation receipts, and 512 MiB of conservatively accounted row data. SQLite page/index overhead is
-not included. Tombstones and receipts count toward capacity; there is no automatic pruning. A
-replacement conservatively charges both the old and new document while admitting the write.
+not included. Tombstones and receipts count toward capacity; there is no automatic pruning.
+Replacements charge the difference between the old and new encoded document, plus the new receipt.
+Persistent counters make admission independent of retained history size. Opening an existing
+version-2 store initializes counters once, atomically, without rewriting documents or receipts.
+
+Optional `reservedWithdrawalReceipts` and `reservedWithdrawalBytes` storage limits default to zero.
+They withhold capacity from ordinary `Put` within the existing hard receipt and byte limits;
+`Withdraw` can use the remaining hard budget. Row and document limits still apply. A withdrawal
+of an existing source adds one receipt and no document identity. A missing source cannot be
+withdrawn: the host must retain suppression for work that arrives before a document exists.
+
+Reserves are finite. Budget enough receipts and encoded bytes for the cleanup commands the host
+must complete; they do not guarantee unlimited cleanup. An existing store above the ordinary
+threshold remains readable and replayable, while new ordinary writes fail typed. A full store
+needs an explicit capacity increase within supported bounds before it has cleanup headroom.
+
+Deploy exclusively upgraded writers before relying on reserves. Accounting triggers include
+already-open older writers, but those writers can consume the reserved region because they do not
+know the new admission policy. Keep the database, accounting table, triggers and metadata together
+in backups; missing established accounting fails rather than silently resetting usage.
+
+Cleanup that edits a shared profile is a `Put`. A trusted host can build a second
+`memoryStoreLayer` with `SqlMemoryLimits` over the **same owner SQL client**, omitting the reserves
+while retaining the same hard totals. Authorize that capability only for cleanup obligations.
+Limits are captured when the Layer is built; providing different limits around an existing
+writer call does not change them. Do not create a second independently locked DO SQL client.
 
 Expected failures cross RPC in Schema-defined envelopes. `MemoryRpcError` distinguishes denied,
 protocol, budget, timeout, and unavailable failures; source and write errors retain their domain tags.

--- a/packages/core/src/MemoryStore.ts
+++ b/packages/core/src/MemoryStore.ts
@@ -201,6 +201,8 @@ export class MemoryStorageError extends Schema.TaggedError<MemoryStorageError>()
 
 export const MemoryMutationPoint = Schema.Literals([
   "memory:initialize:before",
+  "memory:initialize:before-accounting",
+  "memory:initialize:after-accounting",
   "memory:initialize:after",
   "memory:change:before",
   "memory:change:after-state",
@@ -267,6 +269,9 @@ export class MemoryReader extends Context.Service<
  * durable idempotency receipts can be guaranteed. Apply authorization before calling it.
  * Reconcile an existing operation receipt before evaluating tombstones or expected revisions:
  * identical commands return the original result; changed commands fail MemoryOperationConflict.
+ * Original results include content, even for a historical Put replayed after withdrawal;
+ * replay does not change the current head. Revalidate a source before using recalled content.
+ * A failed acknowledgement can hide a committed change: retain and retry the exact command.
  * Successful withdrawal excludes checks begun afterward; already captured views may finish.
  * Receipts and original Thread history are separate retention concerns.
  */

--- a/packages/platform-cloudflare/test/memory.test.ts
+++ b/packages/platform-cloudflare/test/memory.test.ts
@@ -714,6 +714,70 @@ describe("shared Cloudflare memory owner", () => {
     );
   });
 
+  it("accounts replacements and reserved withdrawal receipts in real DO transactions", async () => {
+    const name = project();
+
+    await runInDurableObject(stub(name), (_instance, state) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const writer = yield* MemoryWriter;
+          const original = memoryPut(name, "source", "original", null, "🌱".repeat(1_000));
+
+          yield* writer.change(original);
+
+          const before = state.storage.sql
+            .exec<{ bytes: number }>("SELECT bytes FROM effect_agent_memory_usage_v1")
+            .one().bytes;
+
+          const correction = memoryPut(name, "source", "correction", "1", "é");
+
+          yield* writer.change(correction);
+
+          const after = state.storage.sql
+            .exec<{ bytes: number }>("SELECT bytes FROM effect_agent_memory_usage_v1")
+            .one().bytes;
+
+          expect(after).toBeLessThan(before);
+          expect(
+            yield* writer
+              .change(memoryPut(name, "source", "blocked", "2", "text"))
+              .pipe(Effect.flip),
+          ).toMatchObject({ reason: "invalid-input" });
+
+          const withdrawal = MemoryWrite.make({
+            _tag: "Withdraw",
+            key: original.key,
+            operationId: "cleanup",
+            expectedRevision: "2",
+            reason: "removed",
+          });
+
+          const tombstone = yield* writer.change(withdrawal);
+
+          expect(yield* writer.change(withdrawal)).toEqual(tombstone);
+          expect(
+            state.storage.sql
+              .exec("SELECT documents, receipts FROM effect_agent_memory_usage_v1")
+              .toArray(),
+          ).toEqual([{ documents: 1, receipts: 3 }]);
+        }).pipe(
+          Effect.provide(
+            doMemoryStoreLayer(
+              state.storage,
+              DoMemoryStorageLimits.make({
+                maxRowBytes: 20_000,
+                maxStorageBytes: 40_000,
+                maxDocuments: 1,
+                maxReceipts: 3,
+                reservedWithdrawalReceipts: 1,
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+
   it("finalizes owner authorization on timeout and lets a client interrupt without waiting for the owner", () =>
     Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/storage-cloudflare/src/DoMemoryStore.ts
+++ b/packages/storage-cloudflare/src/DoMemoryStore.ts
@@ -13,6 +13,8 @@ export class DoMemoryStorageLimits extends Schema.Class<DoMemoryStorageLimits>(
   maxStorageBytes: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 536_870_912 })),
   maxDocuments: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 100_000 })),
   maxReceipts: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 1_000_000 })),
+  reservedWithdrawalBytes: Schema.optional(Schema.Natural),
+  reservedWithdrawalReceipts: Schema.optional(Schema.Natural),
 }) {}
 
 export const defaultDoMemoryStorageLimits = DoMemoryStorageLimits.make({
@@ -26,6 +28,9 @@ export const defaultDoMemoryStorageLimits = DoMemoryStorageLimits.make({
  * Local memory only, without Thread tables. Keep one SQL client per owner and pass the
  * full storage handle: sql-only handles cannot provide atomic receipts and revisions.
  * Byte limits conservatively count encoded rows, not SQLite page/index overhead.
+ * Optional withdrawal reserves default to zero and stay within hard byte/receipt limits.
+ * Ordinary Put cannot consume them. Deploy exclusively upgraded writers before relying
+ * on reserves; the SQL accounting migration preserves older writers and their receipts.
  */
 export const doMemoryStoreLayerWithFailpoints = (
   storage: NonNullable<SqliteClient.SqliteClientConfig["storage"]>,

--- a/packages/storage-sqlite/test/sqlite-memory-store.test.ts
+++ b/packages/storage-sqlite/test/sqlite-memory-store.test.ts
@@ -168,7 +168,435 @@ const readCurrent = (filename: string) =>
 const runRaw = <A, E>(filename: string, effect: Effect.Effect<A, E, SqlClientService.SqlClient>) =>
   effect.pipe(Effect.provide(SqliteClient.layer({ filename, busyTimeout: 5_000 })));
 
+// Derive the oracle from retained rows, independently of the accounting triggers.
+const checkUsage = (filename: string) =>
+  runRaw(
+    filename,
+    Effect.gen(function* () {
+      const sql = yield* SqlClientService.SqlClient;
+
+      const documents = yield* sql<{ namespace: string; source_id: string; document_json: string }>`
+    SELECT namespace, source_id, document_json FROM effect_agent_memory_documents_v1
+  `;
+
+      const receipts = yield* sql<{
+        namespace: string;
+        source_id: string;
+        operation_id: string;
+        command_json: string;
+        result_json: string;
+      }>`
+    SELECT namespace, source_id, operation_id, command_json, result_json FROM effect_agent_memory_receipts_v1
+  `;
+
+      const bytes = [...documents, ...receipts].reduce(
+        (total, row) =>
+          total +
+          128 +
+          Object.values(row).reduce(
+            (size, value) => size + new TextEncoder().encode(value).length,
+            0,
+          ),
+        0,
+      );
+
+      const usage = yield* sql<{ documents: number; receipts: number; bytes: number }>`
+    SELECT documents, receipts, bytes FROM effect_agent_memory_usage_v1
+  `;
+
+      expect(usage).toEqual([{ documents: documents.length, receipts: receipts.length, bytes }]);
+
+      return { documents: documents.length, receipts: receipts.length, bytes };
+    }),
+  );
+
+// Reproduce the beta.47 layout without touching canonical document/receipt bytes.
+const legacyLayout = (filename: string) =>
+  runRaw(
+    filename,
+    Effect.gen(function* () {
+      const sql = yield* SqlClientService.SqlClient;
+
+      for (const table of ["documents", "receipts"]) {
+        for (const event of ["insert", "update", "delete"]) {
+          yield* sql.unsafe(`DROP TRIGGER effect_agent_memory_${table}_v1_usage_${event}`);
+        }
+      }
+      yield* sql`DROP TABLE effect_agent_memory_usage_v1`;
+      yield* sql`DELETE FROM effect_agent_memory_metadata WHERE component = 'memory-usage'`;
+    }),
+  );
+
 describe("SQLite memory store", () => {
+  it.effect("admits shrinking UTF-8 replacements by their retained byte delta", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const first = put("large", null, "🌱".repeat(1_000));
+        const replacement = put("small", "1", "é");
+        const defaults = yield* SqlMemoryLimits;
+
+        yield* Effect.flatMap(MemoryWriter, (writer) => writer.change(first)).pipe(
+          Effect.provide(storeLayer(filename)),
+        );
+        const before = yield* checkUsage(filename);
+
+        // The smaller head releases more bytes than the new small receipt consumes.
+        const bounded = storeLayer(filename).pipe(
+          Layer.provide(
+            Layer.succeed(SqlMemoryLimits, {
+              ...defaults,
+              maxStorageBytes: before.bytes,
+              maxDocuments: 1,
+            }),
+          ),
+        );
+
+        const result = yield* Effect.flatMap(MemoryWriter, (writer) =>
+          writer.change(replacement),
+        ).pipe(Effect.provide(bounded));
+
+        expect(result.generation).toBe(2);
+        const after = yield* checkUsage(filename);
+
+        expect(after.bytes).toBeLessThan(before.bytes);
+        expect(after).toMatchObject({ documents: 1, receipts: 2 });
+        yield* Effect.gen(function* () {
+          const writer = yield* MemoryWriter;
+
+          expect(yield* writer.change(replacement)).toEqual(result);
+          expect(
+            yield* writer.change(put("small", "1", "changed")).pipe(Effect.flip),
+          ).toBeInstanceOf(MemoryOperationConflict);
+        }).pipe(Effect.provide(bounded));
+        expect(yield* checkUsage(filename)).toEqual(after);
+      }),
+    ),
+  );
+
+  it.effect(
+    "reserves receipt capacity for terminal withdrawal and permits exact replay at the hard limit",
+    () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const defaults = yield* SqlMemoryLimits;
+
+          const bounded = storeLayer(filename).pipe(
+            Layer.provide(
+              Layer.succeed(SqlMemoryLimits, {
+                ...defaults,
+                maxDocuments: 1,
+                maxReceipts: 2,
+                reservedWithdrawalReceipts: 1,
+              }),
+            ),
+          );
+
+          yield* Effect.gen(function* () {
+            const writer = yield* MemoryWriter;
+
+            expect(yield* writer.change(withdraw("missing", "1")).pipe(Effect.flip)).toBeInstanceOf(
+              MemoryConflict,
+            );
+            const original = yield* writer.change(put("original", null, "retained"));
+
+            expect(
+              yield* writer.change(put("correction", "1", "new")).pipe(Effect.flip),
+            ).toMatchObject({ reason: "invalid-input" });
+            const tombstone = yield* writer.change(withdraw("withdraw", "1"));
+
+            expect(yield* writer.change(withdraw("withdraw", "1"))).toEqual(tombstone);
+            expect(yield* writer.change(put("original", null, "retained"))).toEqual(original);
+            expect(
+              yield* writer.change(put("late", "2", "resurrect")).pipe(Effect.flip),
+            ).toBeInstanceOf(MemoryWithdrawn);
+          }).pipe(Effect.provide(bounded));
+          expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 2 });
+        }),
+      ),
+  );
+
+  it.effect("uses finite byte headroom after migration above the ordinary threshold", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const defaults = yield* SqlMemoryLimits;
+
+        yield* Effect.flatMap(MemoryWriter, (writer) =>
+          writer.change(put("seed", null, "short")),
+        ).pipe(Effect.provide(storeLayer(filename)));
+        const before = yield* checkUsage(filename);
+
+        yield* legacyLayout(filename);
+
+        const limits = {
+          ...defaults,
+          maxStorageBytes: before.bytes + 5_000,
+          reservedWithdrawalBytes: 5_000,
+        };
+
+        const bounded = storeLayer(filename).pipe(
+          Layer.provide(Layer.succeed(SqlMemoryLimits, limits)),
+        );
+
+        yield* Effect.gen(function* () {
+          const writer = yield* MemoryWriter;
+
+          expect(
+            yield* writer.change(put("ordinary", "1", "short")).pipe(Effect.flip),
+          ).toMatchObject({ reason: "invalid-input" });
+          expect(
+            yield* writer
+              .change(
+                MemoryWrite.make({
+                  _tag: "Withdraw",
+                  key,
+                  operationId: "cleanup",
+                  expectedRevision: "1",
+                  reason: "€".repeat(4_096),
+                }),
+              )
+              .pipe(Effect.flip),
+          ).toMatchObject({ operation: "memory storage limit", reason: "invalid-input" });
+          expect(yield* writer.change(withdraw("cleanup", "1"))).toMatchObject({
+            _tag: "WithdrawnMemoryDocument",
+          });
+        }).pipe(Effect.provide(bounded));
+        expect((yield* checkUsage(filename)).bytes).toBeLessThanOrEqual(limits.maxStorageBytes);
+      }),
+    ),
+  );
+
+  it.effect("keeps trusted cleanup Put within the same hard limit over one SQL client", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const defaults = yield* SqlMemoryLimits;
+        const sqlLayer = SqliteClient.layer({ filename });
+
+        const ordinary = memoryStoreLayer.pipe(
+          Layer.provide(
+            Layer.succeed(SqlMemoryLimits, {
+              ...defaults,
+              maxReceipts: 2,
+              reservedWithdrawalReceipts: 1,
+            }),
+          ),
+        );
+
+        const cleanup = memoryStoreLayer.pipe(
+          Layer.provide(
+            Layer.succeed(SqlMemoryLimits, {
+              ...defaults,
+              maxReceipts: 2,
+            }),
+          ),
+        );
+
+        yield* Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const writer = yield* MemoryWriter;
+
+            yield* writer.change(put("profile", null, "source-owned and unrelated"));
+            expect(
+              yield* writer.change(put("cleanup", "1", "unrelated")).pipe(Effect.flip),
+            ).toMatchObject({ reason: "invalid-input" });
+          }).pipe(Effect.provide(ordinary));
+          yield* Effect.gen(function* () {
+            const writer = yield* MemoryWriter;
+
+            expect(yield* writer.change(put("cleanup", "1", "unrelated"))).toMatchObject({
+              generation: 2,
+            });
+            expect(
+              yield* writer.change(put("overflow", "2", "more")).pipe(Effect.flip),
+            ).toMatchObject({ reason: "invalid-input" });
+          }).pipe(Effect.provide(cleanup));
+        }).pipe(Effect.provide(sqlLayer));
+        expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 2 });
+      }),
+    ),
+  );
+
+  for (const point of [
+    "memory:initialize:before-accounting",
+    "memory:initialize:after-accounting",
+  ] as const) {
+    it.effect(`migrates legacy receipts atomically after ${point}`, () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const old = put("legacy", null, "old plaintext 🌱");
+
+          const otherKey = MemoryKey.make({
+            namespace: TestNamespace.make("tenant-b"),
+            id: key.id,
+          });
+
+          const other = putFor(otherKey, "legacy", null, "different namespace");
+
+          const results = yield* Effect.gen(function* () {
+            const writer = yield* MemoryWriter;
+            const original = yield* writer.change(old);
+
+            yield* writer.change(put("correction", "1", "corrected"));
+            const tombstone = yield* writer.change(withdraw("terminal", "2"));
+            const second = yield* writer.change(other);
+
+            return { original, tombstone, second };
+          }).pipe(Effect.provide(storeLayer(filename)));
+
+          const snapshot = () =>
+            runRaw(
+              filename,
+              Effect.gen(function* () {
+                const sql = yield* SqlClientService.SqlClient;
+
+                return yield* sql`SELECT * FROM effect_agent_memory_receipts_v1 ORDER BY namespace, operation_id`;
+              }),
+            );
+
+          const receipts = yield* snapshot();
+
+          yield* legacyLayout(filename);
+          expect(yield* readCurrent(filename)).toEqual(results.tombstone);
+
+          const failed = yield* Effect.void.pipe(
+            Effect.provide(
+              failpointLayer(filename, (current) =>
+                current === point
+                  ? Effect.fail(MemoryMutationFailure.make({ point }))
+                  : Effect.void,
+              ),
+            ),
+            Effect.flip,
+          );
+
+          expect(failed).toEqual(MemoryMutationFailure.make({ point }));
+
+          const tables = yield* runRaw(
+            filename,
+            Effect.gen(function* () {
+              const sql = yield* SqlClientService.SqlClient;
+
+              return yield* sql`SELECT name FROM sqlite_master WHERE name = 'effect_agent_memory_usage_v1'`;
+            }),
+          );
+
+          expect(tables).toEqual([]);
+          yield* TestClock.setTime(50_000);
+          yield* Effect.gen(function* () {
+            const writer = yield* MemoryWriter;
+
+            expect(yield* writer.change(old)).toEqual(results.original);
+            expect(yield* writer.change(other)).toEqual(results.second);
+            expect(yield* writer.change(withdraw("terminal", "2"))).toEqual(results.tombstone);
+            expect(
+              yield* writer.change(put("legacy", null, "changed")).pipe(Effect.flip),
+            ).toBeInstanceOf(MemoryOperationConflict);
+            expect(
+              yield* writer.change(put("late", "3", "resurrect")).pipe(Effect.flip),
+            ).toBeInstanceOf(MemoryWithdrawn);
+          }).pipe(Effect.provide(storeLayer(filename)));
+          expect(yield* snapshot()).toEqual(receipts);
+          expect(yield* checkUsage(filename)).toMatchObject({ documents: 2, receipts: 4 });
+        }),
+      ),
+    );
+  }
+
+  it.effect("serializes independent connections against the last ordinary receipt", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const defaults = yield* SqlMemoryLimits;
+
+        yield* Effect.void.pipe(Effect.provide(storeLayer(filename)));
+
+        const writes = ["a", "b"].map((id) =>
+          Effect.flatMap(MemoryWriter, (writer) =>
+            writer.change(
+              putFor(MemoryKey.make({ namespace: key.namespace, id }), id, null, "text"),
+            ),
+          ).pipe(
+            Effect.provide(
+              storeLayer(filename).pipe(
+                Layer.provide(
+                  Layer.succeed(SqlMemoryLimits, {
+                    ...defaults,
+                    maxReceipts: 2,
+                    reservedWithdrawalReceipts: 1,
+                  }),
+                ),
+              ),
+            ),
+            Effect.result,
+          ),
+        );
+
+        const results = yield* Effect.all(writes, { concurrency: 2 });
+
+        expect(results.filter(Result.isSuccess)).toHaveLength(1);
+        expect(results.filter(Result.isFailure)).toHaveLength(1);
+        expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 1 });
+      }),
+    ),
+  );
+
+  for (const damage of ["row", "marker", "trigger", "counter"] as const) {
+    it.effect(`rejects damaged established accounting: ${damage}`, () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          yield* Effect.flatMap(MemoryWriter, (writer) =>
+            writer.change(put("retained", null, "text")),
+          ).pipe(Effect.provide(storeLayer(filename)));
+          yield* runRaw(
+            filename,
+            Effect.gen(function* () {
+              const sql = yield* SqlClientService.SqlClient;
+
+              if (damage === "row") yield* sql`DELETE FROM effect_agent_memory_usage_v1`;
+              if (damage === "marker")
+                yield* sql`DELETE FROM effect_agent_memory_metadata WHERE component = 'memory-usage'`;
+              if (damage === "trigger")
+                yield* sql`DROP TRIGGER effect_agent_memory_documents_v1_usage_update`;
+              if (damage === "counter") {
+                yield* sql`PRAGMA ignore_check_constraints = ON`;
+                yield* sql`UPDATE effect_agent_memory_usage_v1 SET receipts = -1`;
+              }
+            }),
+          );
+          expect(
+            yield* Effect.void.pipe(Effect.provide(storeLayer(filename)), Effect.flip),
+          ).toMatchObject({ _tag: "MemoryStorageError", reason: "corrupt" });
+          expect(yield* readCurrent(filename)).toMatchObject({ generation: 1 });
+        }),
+      ),
+    );
+  }
+
+  it.effect("rejects invalid reserves before creating storage", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const defaults = yield* SqlMemoryLimits;
+
+        for (const reserve of [-1, 1.5, 3]) {
+          expect(
+            yield* Effect.void.pipe(
+              Effect.provide(
+                storeLayer(filename).pipe(
+                  Layer.provide(
+                    Layer.succeed(SqlMemoryLimits, {
+                      ...defaults,
+                      maxReceipts: 2,
+                      reservedWithdrawalReceipts: reserve,
+                    }),
+                  ),
+                ),
+              ),
+              Effect.flip,
+            ),
+          ).toMatchObject({ reason: "invalid-input" });
+        }
+      }),
+    ),
+  );
+
   for (const limit of ["maxDocuments", "maxReceipts", "maxStorageBytes"] as const) {
     it.effect(`enforces ${limit} independently without a row byte limit`, () =>
       withTemporaryDatabase((filename) =>
@@ -524,6 +952,7 @@ describe("SQLite memory store", () => {
           MemoryConflict.make({ key, expectedRevision: "1", actualRevision: "2" }),
         );
         expect((yield* readCurrent(filename))?.generation).toBe(2);
+        expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 2 });
       }),
     ),
   );
@@ -580,6 +1009,7 @@ describe("SQLite memory store", () => {
 
           expect(failed).toEqual(MemoryMutationFailure.make({ point }));
           expect(yield* readCurrent(filename)).toBeNull();
+          expect(yield* checkUsage(filename)).toEqual({ documents: 0, receipts: 0, bytes: 0 });
 
           const recovered = yield* Effect.gen(function* () {
             const writer = yield* MemoryWriter;
@@ -622,6 +1052,7 @@ describe("SQLite memory store", () => {
 
           expect(failed).toEqual(MemoryMutationFailure.make({ point }));
           expect(yield* readCurrent(filename)).toEqual(active);
+          expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 1 });
 
           const recovered = yield* Effect.gen(function* () {
             const writer = yield* MemoryWriter;
@@ -660,6 +1091,9 @@ describe("SQLite memory store", () => {
 
         expect(failure).toEqual(MemoryMutationFailure.make({ point: "memory:change:after" }));
         const committed = yield* readCurrent(filename);
+
+        // Upgrade the persisted beta.47 layout while the caller still lacks its acknowledgement.
+        yield* legacyLayout(filename);
 
         yield* TestClock.setTime(20_000);
 
@@ -726,7 +1160,12 @@ describe("SQLite memory store", () => {
     ),
   );
 
-  for (const point of ["memory:initialize:before", "memory:initialize:after"] as const) {
+  for (const point of [
+    "memory:initialize:before",
+    "memory:initialize:before-accounting",
+    "memory:initialize:after-accounting",
+    "memory:initialize:after",
+  ] as const) {
     it.effect(`recovers initialization at ${point} without canonical storage tables`, () =>
       withTemporaryDatabase((filename) =>
         Effect.gen(function* () {
@@ -762,7 +1201,63 @@ describe("SQLite memory store", () => {
             "effect_agent_memory_documents_v1",
             "effect_agent_memory_metadata",
             "effect_agent_memory_receipts_v1",
+            "effect_agent_memory_usage_v1",
           ]);
+        }),
+      ),
+    );
+  }
+
+  for (const mode of ["defect", "timeout", "interruption"] as const) {
+    it.effect(`rolls back accounting migration on ${mode}`, () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          yield* Effect.flatMap(MemoryWriter, (writer) =>
+            writer.change(put("retained", null, "text")),
+          ).pipe(Effect.provide(storeLayer(filename)));
+          yield* legacyLayout(filename);
+          const reached = yield* Deferred.make<void>();
+
+          const opening = Effect.void.pipe(
+            Effect.provide(
+              failpointLayer(filename, (point) =>
+                point === "memory:initialize:after-accounting"
+                  ? mode === "defect"
+                    ? Effect.die("injected")
+                    : Deferred.succeed(reached, undefined).pipe(Effect.andThen(Effect.never))
+                  : Effect.void,
+              ),
+            ),
+          );
+
+          if (mode === "defect") {
+            const result = yield* Effect.exit(opening);
+
+            expect(Exit.isFailure(result) && Cause.hasDies(result.cause)).toBe(true);
+          } else {
+            const fiber = yield* (
+              mode === "timeout" ? opening.pipe(Effect.timeout("1 second")) : opening
+            ).pipe(Effect.forkChild);
+
+            yield* Deferred.await(reached);
+            if (mode === "timeout") yield* TestClock.adjust("1 second");
+            else yield* Fiber.interrupt(fiber);
+            expect(Exit.isFailure(yield* Fiber.await(fiber))).toBe(true);
+          }
+
+          const partial = yield* runRaw(
+            filename,
+            Effect.gen(function* () {
+              const sql = yield* SqlClientService.SqlClient;
+
+              return yield* sql`SELECT name FROM sqlite_master WHERE name = 'effect_agent_memory_usage_v1'`;
+            }),
+          );
+
+          expect(partial).toEqual([]);
+          yield* Effect.void.pipe(Effect.provide(storeLayer(filename)));
+          expect(yield* checkUsage(filename)).toMatchObject({ documents: 1, receipts: 1 });
+          expect(yield* readCurrent(filename)).toMatchObject({ generation: 1 });
         }),
       ),
     );
@@ -786,6 +1281,7 @@ describe("SQLite memory store", () => {
 
         expect(Exit.isFailure(defectExit) && Cause.hasDies(defectExit.cause)).toBe(true);
         expect(yield* readCurrent(filename)).toBeNull();
+        expect(yield* checkUsage(filename)).toEqual({ documents: 0, receipts: 0, bytes: 0 });
 
         const timeoutFile = `${filename}-timeout`;
         const timeoutReached = yield* Deferred.make<void>();
@@ -810,6 +1306,7 @@ describe("SQLite memory store", () => {
         yield* TestClock.adjust("1 second");
         expect(Exit.isFailure(yield* Fiber.await(timeoutFiber))).toBe(true);
         expect(yield* readCurrent(timeoutFile)).toBeNull();
+        expect(yield* checkUsage(timeoutFile)).toEqual({ documents: 0, receipts: 0, bytes: 0 });
 
         const interruptedFile = `${filename}-interrupted`;
         const interruptionReached = yield* Deferred.make<void>();
@@ -839,6 +1336,7 @@ describe("SQLite memory store", () => {
           true,
         );
         expect(yield* readCurrent(interruptedFile)).toBeNull();
+        expect(yield* checkUsage(interruptedFile)).toEqual({ documents: 0, receipts: 0, bytes: 0 });
       }),
     ),
   );

--- a/packages/thread/src/SqlMemoryStore.ts
+++ b/packages/thread/src/SqlMemoryStore.ts
@@ -291,9 +291,8 @@ const validateReceiptResult = Effect.fn("SqliteMemoryStore.validateReceiptResult
   }
 });
 
-const readUsage = Effect.fn("SqliteMemoryStore.readUsage")(function* (
-  sql: SqlClientService.SqlClient,
-) {
+const readUsage = Effect.fn("SqliteMemoryStore.readUsage")(function* () {
+  const sql = yield* SqlClientService.SqlClient;
   const operation = "read memory usage";
 
   const rows = yield* query(
@@ -359,7 +358,7 @@ const initializeMemoryUsage = Effect.fn("SqliteMemoryStore.initializeUsage")(fun
       return yield* storageError(operation, "corrupt");
     }
   }
-  yield* readUsage(sql);
+  yield* readUsage();
 });
 
 const initializeMemorySchema = Effect.fn("SqliteMemoryStore.initialize")(function* () {
@@ -513,6 +512,7 @@ const makeMemoryReader = Effect.fn("SqliteMemoryStore.makeReader")(function* () 
 
 const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
   const sql = yield* SqlClientService.SqlClient;
+  const usage = readUsage().pipe(Effect.provideService(SqlClientService.SqlClient, sql));
   const failpoint = yield* MemoryMutationFailpoint;
   const limits = yield* decodeInput(Limits, yield* SqlMemoryLimits, "memory storage limits");
 
@@ -629,7 +629,7 @@ const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
             return yield* storageError("memory row byte limit", "invalid-input");
           }
 
-          const used = yield* readUsage(sql);
+          const used = yield* usage;
 
           if (used.bytes < (currentRow?.bytes ?? 0) || (current !== null && used.documents === 0)) {
             return yield* storageError("read memory usage", "corrupt");

--- a/packages/thread/src/SqlMemoryStore.ts
+++ b/packages/thread/src/SqlMemoryStore.ts
@@ -21,6 +21,8 @@ const STORAGE_VERSION = 2 as const;
 const METADATA_COMPONENT = "memory";
 const DOCUMENT_TABLE = "effect_agent_memory_documents_v1";
 const RECEIPT_TABLE = "effect_agent_memory_receipts_v1";
+const USAGE_COMPONENT = "memory-usage";
+const USAGE_TABLE = "effect_agent_memory_usage_v1";
 const MAX_STORED_JSON_CODE_UNITS = 16 * 1024 * 1024;
 const StoredJson = Schema.String.check(Schema.isMaxLength(MAX_STORED_JSON_CODE_UNITS));
 
@@ -35,9 +37,20 @@ const equivalentScopes = Schema.toEquivalence(MemoryWrite.Wire.members[0].fields
 
 /**
  * Independent adapter limits. Counts and encoded bytes include durable operation receipts.
- * Accounting is skipped only when all limits retain their unbounded defaults.
+ * Bytes count UTF-8 row payloads plus 128 bytes per row, excluding SQLite pages/indexes.
+ * Replacements charge their byte delta; receipts and tombstones are never pruned.
+ * Optional reserves (default zero) withhold capacity from Put, within the hard totals.
+ * They require exclusive upgraded writer ownership: older writers count toward usage
+ * but do not honor reserves. Limits are captured when the writer Layer is built.
  */
-export const SqlMemoryLimits = Context.Reference("@effect-agent/thread/SqlMemoryLimits", {
+export const SqlMemoryLimits = Context.Reference<{
+  readonly maxRowBytes: number;
+  readonly maxStorageBytes: number;
+  readonly maxDocuments: number;
+  readonly maxReceipts: number;
+  readonly reservedWithdrawalBytes?: number;
+  readonly reservedWithdrawalReceipts?: number;
+}>("@effect-agent/thread/SqlMemoryLimits", {
   defaultValue: () => ({
     maxRowBytes: Number.MAX_SAFE_INTEGER,
     maxStorageBytes: Number.MAX_SAFE_INTEGER,
@@ -46,11 +59,53 @@ export const SqlMemoryLimits = Context.Reference("@effect-agent/thread/SqlMemory
   }),
 });
 
+const Limits = Schema.Struct({
+  maxRowBytes: Schema.Natural,
+  maxStorageBytes: Schema.Natural,
+  maxDocuments: Schema.Natural,
+  maxReceipts: Schema.Natural,
+  reservedWithdrawalBytes: Schema.optional(Schema.Natural),
+  reservedWithdrawalReceipts: Schema.optional(Schema.Natural),
+}).check(
+  Schema.makeFilter(
+    (limits) =>
+      (limits.reservedWithdrawalBytes ?? 0) <= limits.maxStorageBytes &&
+      (limits.reservedWithdrawalReceipts ?? 0) <= limits.maxReceipts,
+    { expected: "withdrawal reserves within hard storage limits" },
+  ),
+);
+
 const UsageRow = Schema.Struct({
   documents: Schema.Natural,
   receipts: Schema.Natural,
   bytes: Schema.Natural,
 });
+
+// These expressions deliberately match the legacy aggregate's logical byte accounting.
+const documentBytesSql = (row: string) =>
+  `length(CAST(${row}.namespace AS BLOB)) + length(CAST(${row}.source_id AS BLOB)) + length(CAST(${row}.document_json AS BLOB)) + 128`;
+
+const receiptBytesSql = (row: string) =>
+  `length(CAST(${row}.namespace AS BLOB)) + length(CAST(${row}.source_id AS BLOB)) + length(CAST(${row}.operation_id AS BLOB)) + length(CAST(${row}.command_json AS BLOB)) + length(CAST(${row}.result_json AS BLOB)) + 128`;
+
+// Triggers keep already-open version-2 writers accounted for. Their admission policy
+// is still the old policy; deployment must drain them before relying on reserves.
+const usageTriggers = [
+  { table: DOCUMENT_TABLE, count: "documents", bytes: documentBytesSql },
+  { table: RECEIPT_TABLE, count: "receipts", bytes: receiptBytesSql },
+].flatMap(({ table, count, bytes }) =>
+  ["INSERT", "UPDATE", "DELETE"].map((event) => ({
+    name: `${table}_usage_${event.toLowerCase()}`,
+    sql: `CREATE TRIGGER ${table}_usage_${event.toLowerCase()} AFTER ${event} ON ${table}
+      BEGIN
+        UPDATE ${USAGE_TABLE} SET
+          ${count} = ${count} + ${event === "INSERT" ? 1 : event === "DELETE" ? -1 : 0},
+          bytes = bytes + (${event === "DELETE" ? "0" : bytes("NEW")}) - (${event === "INSERT" ? "0" : bytes("OLD")})
+        WHERE singleton = 1;
+        SELECT CASE WHEN changes() <> 1 THEN RAISE(ABORT, 'missing memory usage') END;
+      END`,
+  })),
+);
 
 class MemoryMetadataRow extends Schema.Class<MemoryMetadataRow>(
   "@effect-agent/storage-sqlite/MemoryMetadataRow",
@@ -73,6 +128,7 @@ class MemoryDocumentRow extends Schema.Class<MemoryDocumentRow>(
   generation: Schema.Int,
   revision: Schema.NonEmptyString,
   document_json: StoredJson,
+  stored_bytes: Schema.Natural,
 }) {}
 
 class MemoryReceiptRow extends Schema.Class<MemoryReceiptRow>(
@@ -235,6 +291,77 @@ const validateReceiptResult = Effect.fn("SqliteMemoryStore.validateReceiptResult
   }
 });
 
+const readUsage = Effect.fn("SqliteMemoryStore.readUsage")(function* (
+  sql: SqlClientService.SqlClient,
+) {
+  const operation = "read memory usage";
+
+  const rows = yield* query(
+    sql<Record<string, unknown>>`
+      SELECT documents, receipts, bytes FROM effect_agent_memory_usage_v1 WHERE singleton = 1
+    `,
+    operation,
+  ).pipe(Effect.flatMap((rows) => decodeRows(UsageRow, rows, operation)));
+
+  if (rows.length !== 1) return yield* storageError(operation, "corrupt");
+
+  return rows[0];
+});
+
+// Called inside schema initialization's transaction. The separate marker distinguishes
+// a legacy store from damaged established accounting; reopening never rebuilds counters.
+const initializeMemoryUsage = Effect.fn("SqliteMemoryStore.initializeUsage")(function* () {
+  const sql = yield* SqlClientService.SqlClient;
+  const failpoint = yield* MemoryMutationFailpoint;
+  const operation = "initialize memory usage";
+
+  const metadata = yield* sql<Record<string, unknown>>`
+    SELECT version FROM effect_agent_memory_metadata WHERE component = ${USAGE_COMPONENT}
+  `.pipe(Effect.flatMap((rows) => decodeRows(MemoryMetadataRow, rows, operation)));
+
+  const objects = yield* sql<Record<string, unknown>>`
+    SELECT name FROM sqlite_master
+    WHERE name = ${USAGE_TABLE} OR name IN ${sql.in(usageTriggers.map((trigger) => trigger.name))}
+  `.pipe(Effect.flatMap((rows) => decodeRows(MemoryTableRow, rows, operation)));
+
+  if (metadata.length === 0) {
+    if (objects.length !== 0) return yield* storageError(operation, "corrupt");
+    yield* failpoint.hit("memory:initialize:before-accounting");
+    yield* sql`
+      CREATE TABLE effect_agent_memory_usage_v1 (
+        singleton INTEGER PRIMARY KEY NOT NULL CHECK (singleton = 1),
+        documents INTEGER NOT NULL CHECK (typeof(documents) = 'integer' AND documents BETWEEN 0 AND 9007199254740991),
+        receipts INTEGER NOT NULL CHECK (typeof(receipts) = 'integer' AND receipts BETWEEN 0 AND 9007199254740991),
+        bytes INTEGER NOT NULL CHECK (typeof(bytes) = 'integer' AND bytes BETWEEN 0 AND 9007199254740991)
+      )
+    `;
+    yield* sql`
+      INSERT INTO effect_agent_memory_usage_v1 (singleton, documents, receipts, bytes)
+      SELECT 1,
+        (SELECT COUNT(*) FROM effect_agent_memory_documents_v1),
+        (SELECT COUNT(*) FROM effect_agent_memory_receipts_v1),
+        COALESCE((SELECT SUM(length(CAST(namespace AS BLOB)) + length(CAST(source_id AS BLOB)) +
+          length(CAST(document_json AS BLOB)) + 128) FROM effect_agent_memory_documents_v1), 0) +
+        COALESCE((SELECT SUM(length(CAST(namespace AS BLOB)) + length(CAST(source_id AS BLOB)) +
+          length(CAST(operation_id AS BLOB)) + length(CAST(command_json AS BLOB)) +
+          length(CAST(result_json AS BLOB)) + 128) FROM effect_agent_memory_receipts_v1), 0)
+    `;
+    for (const trigger of usageTriggers) yield* sql.unsafe(trigger.sql);
+    yield* sql`
+      INSERT INTO effect_agent_memory_metadata (component, version) VALUES (${USAGE_COMPONENT}, 1)
+    `;
+    yield* failpoint.hit("memory:initialize:after-accounting");
+  } else {
+    if (metadata.length !== 1 || metadata[0].version !== 1) {
+      return yield* storageError(operation, "incompatible");
+    }
+    if (objects.length !== usageTriggers.length + 1) {
+      return yield* storageError(operation, "corrupt");
+    }
+  }
+  yield* readUsage(sql);
+});
+
 const initializeMemorySchema = Effect.fn("SqliteMemoryStore.initialize")(function* () {
   const sql = yield* SqlClientService.SqlClient;
   const failpoint = yield* MemoryMutationFailpoint;
@@ -322,6 +449,7 @@ const initializeMemorySchema = Effect.fn("SqliteMemoryStore.initialize")(functio
           FROM effect_agent_memory_receipts_v1
           LIMIT 0
         `;
+        yield* initializeMemoryUsage();
       }),
     )
     .pipe(Effect.catchTag("SqlError", () => Effect.fail(storageError("initialize memory schema"))));
@@ -334,10 +462,15 @@ const makeMemoryReader = Effect.fn("SqliteMemoryStore.makeReader")(function* () 
   const readDocument = Effect.fn("SqliteMemoryStore.readDocument")(function* (
     key: MemoryKey,
     operation: string,
-  ): Effect.fn.Return<MemoryDocument | null, MemoryStorageError> {
+  ): Effect.fn.Return<
+    { readonly document: MemoryDocument; readonly bytes: number } | null,
+    MemoryStorageError
+  > {
     const rawRows = yield* query(
       sql<Record<string, unknown>>`
-        SELECT namespace, source_id, format_version, generation, revision, document_json
+        SELECT namespace, source_id, format_version, generation, revision, document_json,
+          length(CAST(namespace AS BLOB)) + length(CAST(source_id AS BLOB)) +
+          length(CAST(document_json AS BLOB)) + 128 AS stored_bytes
         FROM effect_agent_memory_documents_v1
         WHERE namespace = ${key.namespace.address} AND source_id = ${key.id}
       `,
@@ -366,13 +499,13 @@ const makeMemoryReader = Effect.fn("SqliteMemoryStore.makeReader")(function* () 
       return yield* storageError(operation, "corrupt");
     }
 
-    return document;
+    return { document, bytes: row.stored_bytes };
   });
 
   const get = Effect.fn("SqliteMemoryStore.get")(function* (key: MemoryKey) {
     const decodedKey = yield* decodeInput(MemoryKey.Wire, key, "get memory document");
 
-    return yield* readDocument(decodedKey, "get memory document");
+    return (yield* readDocument(decodedKey, "get memory document"))?.document ?? null;
   });
 
   return { get, readDocument };
@@ -381,7 +514,7 @@ const makeMemoryReader = Effect.fn("SqliteMemoryStore.makeReader")(function* () 
 const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
   const sql = yield* SqlClientService.SqlClient;
   const failpoint = yield* MemoryMutationFailpoint;
-  const limits = yield* SqlMemoryLimits;
+  const limits = yield* decodeInput(Limits, yield* SqlMemoryLimits, "memory storage limits");
 
   yield* initializeMemorySchema();
   const { get, readDocument } = yield* makeMemoryReader();
@@ -466,7 +599,8 @@ const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
             return { document: receipt.result, changed: false } as const;
           }
 
-          const current = yield* readDocument(decodedWrite.key, operation);
+          const currentRow = yield* readDocument(decodedWrite.key, operation);
+          const current = currentRow?.document ?? null;
           const modifiedAt = yield* Clock.currentTimeMillis;
           const next = yield* applyMemoryWrite(current, decodedWrite, modifiedAt);
 
@@ -480,50 +614,43 @@ const makeMemoryServices = Effect.fn("SqliteMemoryStore.make")(function* () {
 
           yield* validateEncodedChange({ commandJson, documentJson, resultJson }, operation);
 
+          const bytes = utf8ByteLength;
+          const identityBytes = bytes(next.key.namespace.address) + bytes(next.key.id);
+          const documentBytes = identityBytes + bytes(documentJson) + 128;
+
+          const receiptBytes =
+            identityBytes +
+            bytes(decodedWrite.operationId) +
+            bytes(commandJson) +
+            bytes(resultJson) +
+            128;
+
+          if (Math.max(documentBytes, receiptBytes) > limits.maxRowBytes) {
+            return yield* storageError("memory row byte limit", "invalid-input");
+          }
+
+          const used = yield* readUsage(sql);
+
+          if (used.bytes < (currentRow?.bytes ?? 0) || (current !== null && used.documents === 0)) {
+            return yield* storageError("read memory usage", "corrupt");
+          }
+
+          const maxReceipts =
+            limits.maxReceipts -
+            (decodedWrite._tag === "Put" ? (limits.reservedWithdrawalReceipts ?? 0) : 0);
+
+          const maxStorageBytes =
+            limits.maxStorageBytes -
+            (decodedWrite._tag === "Put" ? (limits.reservedWithdrawalBytes ?? 0) : 0);
+
+          // Subtract the persisted old row before adding its replacement. Subtraction
+          // comparisons avoid overflowing safe integer budgets near unbounded defaults.
           if (
-            limits.maxRowBytes !== Number.MAX_SAFE_INTEGER ||
-            limits.maxStorageBytes !== Number.MAX_SAFE_INTEGER ||
-            limits.maxDocuments !== Number.MAX_SAFE_INTEGER ||
-            limits.maxReceipts !== Number.MAX_SAFE_INTEGER
+            used.documents > limits.maxDocuments - (current === null ? 1 : 0) ||
+            used.receipts >= maxReceipts ||
+            used.bytes - (currentRow?.bytes ?? 0) > maxStorageBytes - documentBytes - receiptBytes
           ) {
-            const bytes = utf8ByteLength;
-            const identityBytes = bytes(next.key.namespace.address) + bytes(next.key.id);
-            const documentBytes = identityBytes + bytes(documentJson) + 128;
-
-            const receiptBytes =
-              identityBytes +
-              bytes(decodedWrite.operationId) +
-              bytes(commandJson) +
-              bytes(resultJson) +
-              128;
-
-            if (Math.max(documentBytes, receiptBytes) > limits.maxRowBytes) {
-              return yield* storageError("memory row byte limit", "invalid-input");
-            }
-
-            const usage = yield* sql<Record<string, unknown>>`
-              SELECT
-                (SELECT COUNT(*) FROM effect_agent_memory_documents_v1) AS documents,
-                (SELECT COUNT(*) FROM effect_agent_memory_receipts_v1) AS receipts,
-                COALESCE((SELECT SUM(length(CAST(namespace AS BLOB)) + length(CAST(source_id AS BLOB)) +
-                  length(CAST(document_json AS BLOB)) + 128) FROM effect_agent_memory_documents_v1), 0) +
-                COALESCE((SELECT SUM(length(CAST(namespace AS BLOB)) + length(CAST(source_id AS BLOB)) +
-                  length(CAST(operation_id AS BLOB)) + length(CAST(command_json AS BLOB)) +
-                  length(CAST(result_json AS BLOB)) + 128) FROM effect_agent_memory_receipts_v1), 0) AS bytes
-            `.pipe(Effect.flatMap((rows) => decodeRows(UsageRow, rows, operation)));
-
-            const used = usage[0];
-
-            if (usage.length !== 1 || used === undefined)
-              return yield* storageError(operation, "corrupt");
-            // Conservatively charge the replacement document as well. Receipts are never pruned.
-            if (
-              used.documents + (current === null ? 1 : 0) > limits.maxDocuments ||
-              used.receipts + 1 > limits.maxReceipts ||
-              used.bytes + documentBytes + receiptBytes > limits.maxStorageBytes
-            ) {
-              return yield* storageError("memory storage limit", "invalid-input");
-            }
+            return yield* storageError("memory storage limit", "invalid-input");
           }
 
           if (current === null) {


### PR DESCRIPTION
SQL memory writes currently scan retained history for capacity checks and charge both the old and replacement document. Maintain transactional usage counters and charge the replacement byte delta, preserving every existing version-2 document and receipt byte, exact-result replay, operation conflicts and terminal withdrawals. Existing stores initialize accounting atomically once; reads and uncertain-write recovery keep their original contract.

Optional withdrawal reserves stay within the existing hard totals and default to zero:

```ts
import {
  defaultDoMemoryStorageLimits,
  DoMemoryStorageLimits,
} from "@effect-agent/storage-cloudflare/DoMemoryStore";

const storageLimits = DoMemoryStorageLimits.make({
  ...defaultDoMemoryStorageLimits,
  maxReceipts: 102,
  reservedWithdrawalReceipts: 2,
  reservedWithdrawalBytes: 8_192,
});
```

Here ordinary Put admission stops at 100 total receipts; Withdraw can use the hard total of 102. Byte and row limits still apply, and capacity failures remain typed. Exact receipt replay works at capacity. Reserves are finite: **deploy exclusively upgraded writers before relying on them**. Triggers account for already-open beta.47 writers, but those writers can consume the reserved region. Authorized profile-cleanup Put can use a separate writer Layer over the same SQL client with unchanged hard totals.

Local `vp run ready` passed on head `3845a784`, including 39 SQLite memory regressions, migration failure/defect/timeout/interruption, independent connections, lost acknowledgements, workerd owner eviction and complete restart suites. `readUsage` now acquires `SqlClient` through Effect; the writer Layer binds that helper to its existing client once, preserving the public writer requirements and transaction connection.

The CI fixture fix in [#323](https://github.com/danieljvdm/effect-agent/pull/323) is merged, and this PR now targets main. The final local run passed all 419 Cloudflare tests with two existing skips, including 22 memory tests and all 15 alarm tests. An earlier full run failed the unchanged overlong-alarm test at `alarm.test.ts:255`; that case passed in isolation and the full rerun passed without alarm changes. The pool still logs a teardown warning while closing pending module resolution. [Linux CI](https://github.com/danieljvdm/effect-agent/actions/runs/33897988990) passed on `3845a784`, including the required `ready` status. [Bundle comparison](https://github.com/danieljvdm/effect-agent/actions/runs/33897989099) also passed.

Local Node 24.20 comparison of main `e6407479` against accounting implementation `dd761efe`, before the service-dependency follow-up: with identical 16,384-receipt snapshots and 256-byte text, correction median changed from 6.457 ms to 0.450 ms. Both use the allocation-free UTF-8 counter. The observed ranges were 6.148 to 7.278 ms and 0.403 to 1.787 ms, respectively, across 30 samples each after five warmups, with no failures. Candidate opening plus one-time migration took 8.195 ms, outside the write interval. These are sequential warm local diagnostics; the follow-up was not benchmarked, and hosted latency and billing remain unmeasured.

Includes a changeset; package publication and consumer adoption remain separate owner-authorized steps. `ready` exits successfully, although the unchanged lint-plugin declaration build prints nonfatal TS4082 diagnostics.
