### PR TITLE
test: keep alarm fixture waits in their owning events

### DIFF
--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -99,55 +99,98 @@ const maintenanceGeneration = (thread: string) =>
   );
 
 describe("DC alarm semantics", () => {
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/e6407479ae233527685928bead040dbfe5153a22
   it("returns after one head Attempt and leaves later FIFO work armed for another event", () =>
     Effect.runPromise(
       Effect.gen(function* () {
         const thread = lane("one-head");
-        const entered = yield* Deferred.make<void>();
-        const finished = yield* Deferred.make<void>();
-        const release = yield* Deferred.make<void>();
+
+        // Native Promise continuations keep each waiter in its own Durable Object event.
+        const makeHold = () => {
+          let resolveEntered!: () => void;
+          let resolveReleased!: () => void;
+          let resolveFinished!: () => void;
+          let didEnter = false;
+
+          const entered = new Promise<void>((resolve) => {
+            resolveEntered = resolve;
+          });
+
+          const released = new Promise<void>((resolve) => {
+            resolveReleased = resolve;
+          });
+
+          const finished = new Promise<void>((resolve) => {
+            resolveFinished = resolve;
+          });
+
+          return {
+            entered,
+            release: () => resolveReleased(),
+            finish: () => (didEnter ? finished : Promise.resolve()),
+            hold: {
+              entered: Effect.sync(() => {
+                didEnter = true;
+                resolveEntered();
+              }),
+              release: Effect.promise(() => released),
+              finished: Effect.sync(() => resolveFinished()),
+            },
+          };
+        };
+
+        const head = makeHold();
+        const follower = makeHold();
+        let passFinished = Promise.resolve();
 
         // Future virtual time keeps native automatic alarms from racing explicit deliveries.
         yield* TestClock.setTime(Date.now() + 86_400_000);
         maintenanceClocks.set(thread, yield* Clock.Clock);
         alarmAttemptHolds.set(thread, {
           location: "terminalize:after-canonical-append",
-          entered,
-          finished,
-          release,
+          ...head.hold,
         });
         yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            maintenanceClocks.delete(thread);
+          Effect.promise(async () => {
             alarmAttemptHolds.delete(thread);
+            head.release();
+            follower.release();
+            await passFinished;
+            await head.finish();
+            await follower.finish();
+            maintenanceClocks.delete(thread);
           }),
         );
         const first = yield* Effect.promise(() => submitTo(plannerDefinition, thread));
 
-        const pass = yield* Effect.promise(() =>
-          runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
-        ).pipe(Effect.forkChild);
+        const pass = yield* Effect.promise(() => {
+          const promise = runInDurableObject(stubFor(thread), (instance) =>
+            Promise.resolve(instance.alarm()),
+          );
 
-        yield* Deferred.await(entered);
+          // Observe native completion even if the waiting child fiber is interrupted.
+          passFinished = promise.then(
+            () => undefined,
+            () => undefined,
+          );
+
+          return promise;
+        }).pipe(Effect.forkChild);
+
+        yield* Effect.promise(() => head.entered);
         // The head has completed its model and join seams. This follower needs its own Attempt.
-        const nextEntered = yield* Deferred.make<void>();
-        const nextFinished = yield* Deferred.make<void>();
-        const nextRelease = yield* Deferred.make<void>();
-
         // Native alarms may redeliver immediately. Hold the follower so only a separate
         // event can own it; the first pass must return without waiting for this resource.
         alarmAttemptHolds.set(thread, {
           location: "claim:after-claim",
-          entered: nextEntered,
-          finished: nextFinished,
-          release: nextRelease,
+          ...follower.hold,
         });
 
         const second = yield* Effect.promise(() =>
           submitTo(plannerDefinition, thread, `${thread}-next`),
         );
 
-        yield* Deferred.succeed(release, undefined);
+        head.release();
         yield* Fiber.join(pass);
         const rows = yield* Effect.promise(() => laneRows(thread));
 
@@ -158,7 +201,7 @@ describe("DC alarm semantics", () => {
 
         expect(generation.dirty > generation.processed).toBe(true);
         expect(yield* Effect.promise(() => scheduledAlarm(thread))).not.toBeNull();
-        yield* Deferred.succeed(nextRelease, undefined);
+        follower.release();
         yield* Effect.promise(() =>
           runInDurableObject(stubFor(thread), (instance) => Promise.resolve(instance.alarm())),
         );
@@ -179,7 +222,11 @@ describe("DC alarm semantics", () => {
 
         yield* TestClock.setTime(Date.now() + 86_400_000);
         maintenanceClocks.set(thread, yield* Clock.Clock);
-        alarmAttemptHolds.set(thread, { location: "claim:after-claim", entered, finished });
+        alarmAttemptHolds.set(thread, {
+          location: "claim:after-claim",
+          entered: Deferred.succeed(entered, undefined).pipe(Effect.asVoid),
+          finished: Deferred.succeed(finished, undefined).pipe(Effect.asVoid),
+        });
         yield* Effect.addFinalizer(() =>
           Effect.sync(() => {
             maintenanceClocks.delete(thread);

--- a/packages/platform-cloudflare/test/fixtures.ts
+++ b/packages/platform-cloudflare/test/fixtures.ts
@@ -70,9 +70,9 @@ export const alarmAttemptHolds = new Map<
   string,
   {
     readonly location: DurableRuntimeFailpointLocation;
-    readonly entered: Deferred.Deferred<void>;
-    readonly finished: Deferred.Deferred<void>;
-    readonly release?: Deferred.Deferred<void>;
+    readonly entered: Effect.Effect<void>;
+    readonly finished: Effect.Effect<void>;
+    readonly release?: Effect.Effect<void>;
   }
 >();
 
@@ -145,9 +145,9 @@ export const runtimeEvictionFailpoint =
         alarmAttemptHolds.delete(name);
 
         return Effect.acquireUseRelease(
-          Deferred.succeed(hold.entered, undefined),
-          () => (hold.release === undefined ? Effect.never : Deferred.await(hold.release)),
-          () => Deferred.succeed(hold.finished, undefined),
+          hold.entered,
+          () => hold.release ?? Effect.never,
+          () => hold.finished,
         );
       }
       if (armedRuntimeFailures.get(name) === location) {


### PR DESCRIPTION
The one-head alarm test shares Effect Deferred values across Runner and ThreadObject events, and its failure cleanup can leave held work running. Use native Promise handshakes registered in each event, then release and await both holds before removing the test clock. This changes the existing test and fixture only; production alarm behavior and all FIFO/dirty-generation assertions remain unchanged.

[Main's Cloudflare CI](https://github.com/danieljvdm/effect-agent/actions/runs/33840974095/job/100923022316) fails this test with a cross-object I/O rejection and hangs until its 15-minute timeout. The failure was also observed during a wider local run, while the original test and alarm file passed in isolation. This is a candidate fix for that event-context failure, separate from memory accounting in #322.

`vp run ready` and [hosted CI](https://github.com/danieljvdm/effect-agent/actions/runs/33845335967) passed, including the required `ready` status. Linux Cloudflare completed normally: all 37 files, 416 tests and two existing skips, including all 15 alarm tests. The prior cross-object rejection and hung-run signatures were absent. Bundle comparison also passed. The local run logged a pool teardown warning before exiting successfully; that warning was absent from the hosted Cloudflare run.
