### PR TITLE
perf(storage-memory): read canonical pages by sequence offset

### DIFF
--- a/.changeset/quick-memory-pages.md
+++ b/.changeset/quick-memory-pages.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/storage-memory": patch
+---
+
+Read in-memory Thread pages without scanning or copying the rest of the history.

--- a/packages/storage-memory/src/MemoryThreadStore.ts
+++ b/packages/storage-memory/src/MemoryThreadStore.ts
@@ -409,11 +409,12 @@ const makeThreadStore = Effect.gen(function* () {
     (threadId: ThreadId, afterSequence: CanonicalSequence | undefined, limit: number) =>
       Ref.get(state).pipe(
         Effect.flatMap((current) => findThread(current, threadId)),
-        Effect.map((thread) =>
-          thread.records
-            .filter((record) => record.sequence > (afterSequence ?? ZERO_CANONICAL_SEQUENCE))
-            .slice(0, limit),
-        ),
+        Effect.map((thread) => {
+          // Append assigns gap-free sequences starting at 1, so the exclusive cursor is an index.
+          const start = afterSequence ?? ZERO_CANONICAL_SEQUENCE;
+
+          return thread.records.slice(start, start + limit);
+        }),
       ),
   );
 

--- a/packages/storage-memory/test/memory-storage.test.ts
+++ b/packages/storage-memory/test/memory-storage.test.ts
@@ -128,6 +128,76 @@ const append = (
   );
 
 describe("MemoryThreadStore", () => {
+  it.effect("reads bounded pages from one snapshot while another batch is appended", () =>
+    Effect.gen(function* () {
+      const store = yield* ThreadStore;
+
+      yield* store.materialize(
+        ThreadMaterialization.make({ threadId, producerEpoch: FIRST_PRODUCER_EPOCH }),
+      );
+      expect(
+        yield* store.read(ThreadRead.make({ threadId, limit: 2 })).pipe(Stream.runCollect),
+      ).toEqual([]);
+
+      const first = yield* append(
+        store,
+        batch("page-first", [inputRecord("page-1", "one"), inputRecord("page-2", "two")]),
+      );
+
+      const tail = yield* append(
+        store,
+        batch("page-second", [inputRecord("page-3", "three"), inputRecord("page-4", "four")]),
+        first,
+      );
+
+      const snapshot = yield* store.export(ThreadExportRequest.make({ threadId }));
+      const readStarted = yield* Deferred.make<void>();
+      const resumeRead = yield* Deferred.make<void>();
+
+      const reader = yield* store.read(ThreadRead.make({ threadId, limit: 10 })).pipe(
+        Stream.tap(() =>
+          Deferred.succeed(readStarted, undefined).pipe(Effect.andThen(Deferred.await(resumeRead))),
+        ),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(readStarted);
+      yield* append(store, batch("page-third", [inputRecord("page-5", "five")]), tail);
+      yield* Deferred.succeed(resumeRead, undefined);
+      expect(yield* Fiber.join(reader)).toEqual(snapshot.records);
+
+      const exported = yield* store.export(ThreadExportRequest.make({ threadId }));
+
+      const cases = [
+        { afterSequence: undefined, expected: [0, 1] },
+        { afterSequence: 0, expected: [0, 1] },
+        { afterSequence: 1, expected: [1, 2] },
+        { afterSequence: 3, expected: [3, 4] },
+        { afterSequence: 4, expected: [4] },
+        { afterSequence: 5, expected: [] },
+        { afterSequence: 6, expected: [] },
+        { afterSequence: Number.MAX_SAFE_INTEGER, expected: [] },
+      ];
+
+      for (const { afterSequence, expected } of cases) {
+        const page = yield* store
+          .read(
+            ThreadRead.make({
+              threadId,
+              ...(afterSequence === undefined
+                ? {}
+                : { afterSequence: canonicalSequence(afterSequence) }),
+              limit: 2,
+            }),
+          )
+          .pipe(Stream.runCollect);
+
+        expect(page).toEqual(expected.map((index) => exported.records[index]));
+      }
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   describe("shared ThreadStore conformance", () => {
     for (const conformanceCase of threadStoreConformanceCases) {
       it.effect(conformanceCase.name, () =>


### PR DESCRIPTION
Read in-memory Thread pages by contiguous sequence offset. A small page no longer scans the whole thread or allocates the remaining suffix. Snapshot behavior and cursor validation stay intact.

A deterministic regression covers concurrent append, page boundaries, and empty tails. The 161 memory adapter tests pass, including contract and recovery suites.

For a 1,024-record first page in a 32,768-record thread, a local diagnostic reduced visited records from 32,768 to 1,024 and allocated array slots from 33,792 to 1,024. On Node 24.20.0, five samples of 100 reads after 20 warmups measured a median of 0.288 ms before and 0.017 ms after, with ranges of 0.275–0.299 ms and 0.016–0.019 ms. The smallest-history cohort was noisy; this does not establish a universal latency improvement. Allocation counts are array slots, not heap bytes.

`vp run ready` passes. Its first Cloudflare run failed an existing alarm-deadline assertion; the isolated 419-test Cloudflare suite and the complete resumed gate passed.
