### PR TITLE
fix(engine): cache response codecs and bound tool execution

### DIFF
--- a/.changeset/owned-progress-budget.md
+++ b/.changeset/owned-progress-budget.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/engine": patch
+---
+
+Bound published Tool progress to 8 MiB of JSON per Run and retain owned snapshots for live events and detached replay. Reject invalid or oversized application progress with `ModelProtocolError`, and allow a smaller cumulative limit through `bufferLimits.maxToolProgressBytes`.

--- a/.changeset/quiet-stream-tool-bounds.md
+++ b/.changeset/quiet-stream-tool-bounds.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/engine": patch
+---
+
+Reuse response codecs across streamed chunks and bound pending Tool stream fibers by the configured concurrency. Return owned JSON snapshots from programmatic Tool calls so later handler or redactor mutations cannot exceed the admitted result limit.

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -60,6 +60,24 @@ and one terminal classification. Provider SDK chunks do not enter this stable un
 The stream uses bounded backpressure. Completion, failure, and interruption close its resources.
 Interrupting the only ephemeral consumer interrupts the run.
 
+Published `ToolProgress` results are owned JSON snapshots. Their cumulative UTF-8 JSON size is
+limited to 8 MiB per run, shared by application and provider progress. This also bounds progress
+payloads retained for detached replay. Oversized progress fails with `ModelProtocolError` without
+truncation. Application progress must contain plain JSON data; accessors, custom serialization,
+and non-finite numbers fail with the same error. Terminal tool results use `toolResultBounds`
+separately.
+
+Lower the progress allowance with `bufferLimits` on `run`, `stream`, or `start`. Larger values
+cannot raise the engine's ceiling:
+
+```ts twoslash
+import { type RunBufferLimits } from "@effect-agent/engine/RunOptions";
+
+export const progressBufferLimits: RunBufferLimits = {
+  maxToolProgressBytes: 1024 * 1024,
+};
+```
+
 ## Start and re-observe locally
 
 ```ts

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -35,9 +35,10 @@ that declaration.
 The runtime validates the complete model response before starting any handler. It resolves tool
 names, decodes parameters, checks budgets, and obtains approvals for the whole batch.
 
-It then runs scoped child fibers behind a finite Effect `Semaphore`. Live progress follows actual
-completion order. Canonical history and the next model turn use declaration order. The model never
-sees a partial batch.
+It bounds both active call streams and handler execution by the resolved concurrency, using scoped
+child fibers and a finite Effect `Semaphore`. Pending calls do not allocate waiting stream fibers.
+Live progress follows actual completion order. Canonical history and the next model turn use
+declaration order. The model never sees a partial batch.
 
 ## Keep tool failures typed {#failure-remains-failure}
 

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -742,6 +742,12 @@ export interface RunBufferLimits {
   readonly maxModelResponseBytes?: number | undefined;
   /** Maximum semantic Run events, including the reserved terminal event. */
   readonly maxRunEvents?: number | undefined;
+  /**
+   * Maximum cumulative UTF-8 JSON bytes in published ToolProgress results, including provider
+   * progress and detached replay. Defaults to 8 MiB. Invalid or oversized application progress
+   * fails with ModelProtocolError; terminal Tool results use the Agent's toolResultBounds.
+   */
+  readonly maxToolProgressBytes?: number | undefined;
   /** Maximum Subagent lifecycle payloads queued by one Tool batch. */
   readonly maxSubagentEventsPerBatch?: number | undefined;
 }

--- a/packages/engine/src/ToolBroker.ts
+++ b/packages/engine/src/ToolBroker.ts
@@ -21,7 +21,7 @@ export interface ProgrammaticToolInput {
   readonly encodedArguments: unknown;
 }
 
-/** The handler ran and settled with its encoded success value. */
+/** The handler ran and settled with an owned JSON snapshot of its encoded success value. */
 export interface ProgrammaticCallSuccess {
   readonly _tag: "ProgrammaticCallSuccess";
   /** Broker-owned zero-based index of this call within the pass (RUN-016). */
@@ -71,8 +71,9 @@ export type ProgrammaticCallOutcome =
 export interface ToolBrokerPassOptions {
   /**
    * Maximum UTF-8 byte size of one encoded success result at the sandbox
-   * boundary. The broker owns this bound (runtime spec §12.1); the executor
-   * enforces its own transport bound independently.
+   * boundary. The returned value is decoded from the exact JSON representation
+   * admitted by this bound, after redaction. Later handler or redactor mutations
+   * cannot change it. The executor enforces its own transport bound independently.
    */
   readonly maxResultBytes: number;
   /**

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -71,6 +71,7 @@ import { InputTokenUsage, ModelCallUsage, OutputTokenUsage } from "@effect-agent
 import type { Layer, Take } from "effect";
 import {
   Cause,
+  Channel,
   Clock,
   Context,
   DateTime,
@@ -721,14 +722,30 @@ const inspectModelResponsePartCapacity = (
  * parameter Schemas; the engine decodes and canonically re-encodes each call
  * against the Definition-owned Schema before it enters history or executes.
  */
-const encodedToolParameterToolkit = <Tools extends Record<string, Tool.Any>>(
-  toolkit: Toolkit.Toolkit<Tools>,
-): Toolkit.Any =>
+const encodedToolParameterToolkit = (toolkit: Toolkit.Any): Toolkit.Any =>
   Toolkit.make(
     ...Object.values(toolkit.tools).map((tool) =>
       tool.setParameters(Schema.toEncoded(tool.parametersSchema)),
     ),
   );
+
+const makeModelResponseCodec = (toolkit: Toolkit.Any) =>
+  Schema.toCodecJson(Response.StreamPart(encodedToolParameterToolkit(toolkit)));
+
+// Native Toolkits are immutable. Weak keys let discarded definitions and handler Toolkits go
+// away while each live Toolkit shares its canonical codec across response parts and Turns.
+const modelResponseCodecs = new WeakMap<Toolkit.Any, ReturnType<typeof makeModelResponseCodec>>();
+
+const modelResponseCodecFor = (toolkit: Toolkit.Any) => {
+  const cached = modelResponseCodecs.get(toolkit);
+
+  if (cached !== undefined) return cached;
+  const codec = makeModelResponseCodec(toolkit);
+
+  modelResponseCodecs.set(toolkit, codec);
+
+  return codec;
+};
 
 const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(function* <
   Tools extends Record<string, Tool.Any>,
@@ -755,7 +772,7 @@ const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(func
   } else {
     yield* inspectModelResponsePartCapacity(usage, part, limits);
   }
-  const codec = Schema.toCodecJson(Response.StreamPart(encodedToolParameterToolkit(toolkit)));
+  const codec = modelResponseCodecFor(toolkit);
 
   const encodingFailure = ModelProtocolError.make({
     message: "Model response part failed canonical encoding",
@@ -2189,8 +2206,8 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
           ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
         >
       >((stream, group) => {
-        const next = Stream.mergeAll(
-          group.map((call) =>
+        const channels = group.map(
+          (call) =>
             withSemaphorePermit(
               semaphore,
               executePreparedToolCall(
@@ -2213,9 +2230,13 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
                 Stream.provideService(ToolBroker, brokerFor(call).service),
                 Stream.ensuring(Effect.sync(() => brokerFor(call).close())),
               ),
-            ),
-          ),
-          { concurrency: "unbounded" },
+            ).channel,
+        );
+
+        // Stream.mergeAll uses sequential concatenation at concurrency one. Keep a scoped call
+        // fiber even then so early downstream close still runs terminal telemetry and observers.
+        const next = Stream.fromChannel(
+          Channel.mergeAll(Channel.fromIterable(channels), { concurrency }),
         );
 
         return stream.pipe(Stream.concat(next));
@@ -6960,11 +6981,13 @@ const measureProgrammaticToolCall = <R>(
     );
   });
 
-const brokerEncodedByteLength = (value: unknown): number | undefined => {
+const brokerSerializeJson = (
+  value: unknown,
+): { readonly text: string; readonly bytes: number } | undefined => {
   try {
-    const encoded = JSON.stringify(value);
+    const text = JSON.stringify(value);
 
-    return encoded === undefined ? undefined : utf8ByteLength(encoded);
+    return text === undefined ? undefined : { text, bytes: utf8ByteLength(text) };
   } catch {
     return undefined;
   }
@@ -7369,9 +7392,7 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
                     encodedResult: terminal.encodedResult,
                   } as const;
                 }
-                if (
-                  Option.isNone(Schema.decodeUnknownOption(Schema.Json)(terminal.encodedResult))
-                ) {
+                if (Option.isNone(brokerDecodeJson(terminal.encodedResult))) {
                   return yield* startedFailure(
                     "protocol",
                     "ModelProtocolError",
@@ -7394,17 +7415,35 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
                   }
                   encodedResult = redacted.value;
                 }
-                const bytes = brokerEncodedByteLength(encodedResult);
+                const snapshot = brokerSerializeJson(encodedResult);
 
-                if (bytes === undefined || bytes > passOptions.maxResultBytes) {
+                if (snapshot === undefined || snapshot.bytes > passOptions.maxResultBytes) {
                   return yield* startedFailure(
                     "infrastructure",
                     "ProgrammaticResultLimitError",
-                    `Tool ${input.toolName} result of ${bytes ?? "unencodable"} bytes exceeds the ${passOptions.maxResultBytes}-byte broker bound`,
+                    `Tool ${input.toolName} result of ${snapshot?.bytes ?? "unencodable"} bytes exceeds the ${passOptions.maxResultBytes}-byte broker bound`,
                   );
                 }
 
-                return { _tag: "ProgrammaticCallSuccess", index, encodedResult } as const;
+                // Retain the exact representation admitted above. Reusing the handler or redactor
+                // value would let later mutation or stateful getters escape the byte bound.
+                const owned = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Json))(
+                  snapshot.text,
+                );
+
+                if (Option.isNone(owned)) {
+                  return yield* startedFailure(
+                    "protocol",
+                    "ModelProtocolError",
+                    `Tool ${input.toolName} produced a success encoding outside JSON`,
+                  );
+                }
+
+                return {
+                  _tag: "ProgrammaticCallSuccess",
+                  index,
+                  encodedResult: owned.value,
+                } as const;
               }),
             );
 

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -442,6 +442,8 @@ interface RunContext {
   /** Finite engine-owned memory ceilings, optionally tightened per Run. */
   readonly bufferLimits: EffectiveRunBufferLimits;
   sequence: number;
+  /** Cumulative JSON bytes of published progress, retained by detached replay until Scope close. */
+  toolProgressBytes: number;
   /**
    * Run-wide count of reserved programmatic (broker) Tool invocations.
    * A committed reservation survives interruption before Handler start.
@@ -553,6 +555,7 @@ const DEFAULT_RUN_BUFFER_LIMITS = {
   maxModelResponseParts: 16_384,
   maxModelResponseBytes: 8 * 1024 * 1024,
   maxRunEvents: 65_536,
+  maxToolProgressBytes: 8 * 1024 * 1024,
   maxSubagentEventsPerBatch: 1_024,
 } as const;
 
@@ -560,6 +563,7 @@ interface EffectiveRunBufferLimits {
   readonly maxModelResponseParts: number;
   readonly maxModelResponseBytes: number;
   readonly maxRunEvents: number;
+  readonly maxToolProgressBytes: number;
   readonly maxSubagentEventsPerBatch: number;
 }
 
@@ -590,6 +594,11 @@ const effectiveRunBufferLimits = (
     configured?.maxRunEvents,
     DEFAULT_RUN_BUFFER_LIMITS.maxRunEvents,
     2,
+  ),
+  maxToolProgressBytes: tighteningBufferLimit(
+    configured?.maxToolProgressBytes,
+    DEFAULT_RUN_BUFFER_LIMITS.maxToolProgressBytes,
+    1,
   ),
   maxSubagentEventsPerBatch: tighteningBufferLimit(
     configured?.maxSubagentEventsPerBatch,
@@ -1795,12 +1804,14 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
         const toolCallId = yield* decodeToolCallId(call.id);
 
         if (result.preliminary) {
+          const owned = yield* ownApplicationToolProgress(context, result.encodedResult);
+
           const event: RunEvent = ToolProgress.make({
             ...(yield* eventBase(context)),
             turnId,
             toolCallId,
             toolName: call.name,
-            result: yield* decodeEventJson(result.encodedResult, "Tool result"),
+            result: owned,
             providerExecuted: false,
           });
 
@@ -3003,6 +3014,41 @@ const eventBase = (context: RunContext) => eventBaseFor(context, false);
 /** The ordinary event budget always reserves one slot for this typed terminal projection. */
 const terminalEventBase = (context: RunContext) => eventBaseFor(context, true);
 
+const toolProgressLimitError = (context: RunContext) =>
+  ModelProtocolError.make({
+    message: `Run exceeded the ${context.bufferLimits.maxToolProgressBytes}-byte Tool progress limit or received invalid progress JSON`,
+  });
+
+const admitToolProgress = (
+  context: RunContext,
+  snapshot: BoundedJsonSnapshot,
+): Effect.Effect<Schema.Json, ModelProtocolError> =>
+  Effect.suspend(() => {
+    if (snapshot.bytes > context.bufferLimits.maxToolProgressBytes - context.toolProgressBytes) {
+      return Effect.fail(toolProgressLimitError(context));
+    }
+    context.toolProgressBytes += snapshot.bytes;
+
+    return Effect.succeed(snapshot.value);
+  });
+
+const ownApplicationToolProgress = (
+  context: RunContext,
+  result: unknown,
+): Effect.Effect<Schema.Json, ModelProtocolError> =>
+  Effect.suspend(() => {
+    // Bound traversal before Schema validation or serialization can allocate a full copy. The
+    // owned frozen value is the only payload published to live consumers and detached replay.
+    const snapshot = boundedCanonicalJsonSnapshot(
+      result,
+      context.bufferLimits.maxToolProgressBytes - context.toolProgressBytes,
+    );
+
+    return snapshot === undefined
+      ? Effect.fail(toolProgressLimitError(context))
+      : admitToolProgress(context, snapshot);
+  });
+
 const snapshotStagedProviderEvent = (
   trace: TurnTrace,
   payload: unknown,
@@ -3115,7 +3161,18 @@ const stampProviderResultEvent = (
   turnId: TurnId,
   payload: ProviderResultEventPayload,
 ): Effect.Effect<RunEvent, ModelProtocolError> =>
-  Effect.map(eventBase(context), (base) => {
+  Effect.gen(function* () {
+    if (payload._tag === "ToolProgress") {
+      // Provider staging already owns and normalizes this value under its 1 MiB aggregate cap.
+      // Measure that bounded representation and reuse it without changing provider JSON semantics.
+      const text = yield* Schema.encodeEffect(Schema.fromJsonString(Schema.Json))(
+        payload.result,
+      ).pipe(Effect.mapError(() => toolProgressLimitError(context)));
+
+      yield* admitToolProgress(context, { value: payload.result, bytes: utf8ByteLength(text) });
+    }
+    const base = yield* eventBase(context);
+
     switch (payload._tag) {
       case "ToolProgress":
         return ToolProgress.make({ ...base, turnId, ...payload });
@@ -6239,6 +6296,7 @@ function streamWithCompletion<
             compactor,
             bufferLimits: effectiveRunBufferLimits(options.bufferLimits),
             sequence: 0,
+            toolProgressBytes: 0,
             programmaticToolCalls: resumeUsage?.programmaticToolCalls ?? 0,
             finalizationUsed: resumeUsage?.finalizationUsed ?? false,
             policyReservations: yield* Semaphore.make(1),

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -8,6 +8,7 @@ import {
   type AgentRuntimeRequirements,
   type AgentCompletionProjectionRequirements,
 } from "@effect-agent/engine/AgentRuntime";
+import { type RunBufferLimits } from "@effect-agent/engine/RunOptions";
 import { type ThreadHistory } from "@effect-agent/engine/ThreadHistory";
 import { Context, Effect, Layer, Schema, SchemaGetter, type Scope, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
@@ -84,7 +85,8 @@ const model = Model.make(
 
 it("preserves encoded input, output, failures and every unsatisfied service", () => {
   const input = { city: "Lisbon", days: "2" };
-  const run = AgentRuntime.run(planner, input);
+  const bufferLimits: RunBufferLimits = { maxToolProgressBytes: 1_024 };
+  const run = AgentRuntime.run(planner, input, { bufferLimits });
   const provided = run.pipe(Effect.provide(model));
 
   type DefinitionServices =

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -33,6 +33,7 @@ import {
   Fiber,
   Layer,
   Logger,
+  Metric,
   Option,
   Redacted,
   Ref,
@@ -3475,6 +3476,102 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
         }
         expect(promptOrder).toEqual(["lookup-1", "lookup-2", "lookup-3"]);
       }),
+  );
+
+  it.effect("bounds waiting stream fibers when a large Tool batch is blocked", () =>
+    Effect.gen(function* () {
+      const concurrency = 2;
+
+      const blockedBatch = Effect.fnUntraced(function* (batchSize: number) {
+        const entered = yield* Deferred.make<void>();
+        let starts = 0;
+        let finalized = 0;
+        let fibers = 0;
+
+        const metrics: Metric.FiberRuntimeMetricsService = {
+          recordFiberStart: () => {
+            fibers += 1;
+          },
+          recordFiberEnd: () => {
+            fibers -= 1;
+          },
+        };
+
+        const Lookup = Tool.make("lookup", {
+          parameters: Schema.Struct({ index: Schema.Int }),
+          success: Schema.String,
+        });
+
+        const toolkit = Toolkit.make(Lookup);
+
+        const handlers = toolkit.toLayer({
+          lookup: () =>
+            Effect.gen(function* () {
+              starts += 1;
+              if (starts === concurrency) yield* Deferred.succeed(entered, undefined);
+
+              return yield* Effect.never;
+            }).pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  finalized += 1;
+                }),
+              ),
+            ),
+        });
+
+        const definition = Agent.make("blocked-batch", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Run the lookups.",
+          toolkit,
+          policy: AgentPolicy.make({
+            maxTurns: 2,
+            maxToolCalls: batchSize,
+            maxDuration: "30 seconds",
+            toolConcurrency: concurrency,
+          }),
+        });
+
+        const parts: Array<Response.StreamPartEncoded> = Array.from(
+          { length: batchSize },
+          (_, index) => ({
+            type: "tool-call",
+            id: `lookup-${index}`,
+            name: "lookup",
+            params: { index },
+            providerExecuted: false,
+          }),
+        );
+
+        parts.push({ type: "finish", reason: "tool-calls", usage });
+
+        const fiber = yield* AgentRuntime.run(
+          Agent.withModel(definition, modelFromParts(parts)),
+          "go",
+        ).pipe(
+          Effect.provide(handlers),
+          Effect.provideService(Metric.FiberRuntimeMetrics, metrics),
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(entered);
+        // Advance no time, but wait for the runtime fibers to reach suspension before sampling.
+        yield* TestClock.adjust(0);
+        const waitingFibers = fibers;
+
+        expect(starts).toBe(concurrency);
+        yield* Fiber.interrupt(fiber);
+        expect(finalized).toBe(concurrency);
+
+        return waitingFibers;
+      });
+
+      const smallBatch = yield* blockedBatch(4);
+      const largeBatch = yield* blockedBatch(64);
+
+      expect(largeBatch).toBeLessThanOrEqual(smallBatch + concurrency);
+    }),
   );
 
   it.effect("preflights the complete Tool batch before starting any handler", () =>

--- a/packages/engine/test/tool-broker.test.ts
+++ b/packages/engine/test/tool-broker.test.ts
@@ -1034,6 +1034,68 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
     }),
   );
 
+  it.effect.each([false, true])(
+    "owns the admitted JSON result across later mutation, with redaction %s",
+    (redact) =>
+      Effect.gen(function* () {
+        const innerToolkit = Toolkit.make(LooseTool);
+        const maxResultBytes = 256;
+        let expanded = false;
+        const retained = { nested: { value: "small" } };
+
+        const dynamic = {
+          get value() {
+            return expanded ? "x".repeat(1_048_576) : "small";
+          },
+        };
+
+        const values = [dynamic, retained];
+        let nextResult = 0;
+
+        yield* runOrchestrated({
+          innerToolkit,
+          innerHandlers: innerToolkit.toLayer({
+            loose: () => Effect.sync(() => (redact ? null : values[nextResult++])),
+          }),
+          passOptions: {
+            maxResultBytes,
+            ...(redact ? { redactResult: () => Effect.sync(() => values[nextResult++]) } : {}),
+          },
+          program: (pass) =>
+            Effect.gen(function* () {
+              const dynamicOutcome = yield* pass.invoke({
+                toolName: "loose",
+                encodedArguments: { key: "dynamic" },
+              });
+
+              const retainedOutcome = yield* pass.invoke({
+                toolName: "loose",
+                encodedArguments: { key: "retained" },
+              });
+
+              expanded = true;
+              retained.nested.value = "x".repeat(1_048_576);
+              for (const outcome of [dynamicOutcome, retainedOutcome]) {
+                expect(outcome._tag).toBe("ProgrammaticCallSuccess");
+                if (outcome._tag !== "ProgrammaticCallSuccess") {
+                  throw new Error("Expected a JSON result within the broker limit");
+                }
+                // Every character in these fixtures is ASCII, so string length is UTF-8 bytes.
+                expect(JSON.stringify(outcome.encodedResult).length).toBeLessThanOrEqual(
+                  maxResultBytes,
+                );
+              }
+              expect(dynamicOutcome).toMatchObject({ encodedResult: { value: "small" } });
+              expect(retainedOutcome).toMatchObject({
+                encodedResult: { nested: { value: "small" } },
+              });
+
+              return null;
+            }),
+        });
+      }),
+  );
+
   it.effect("RUN-017 budget exhaustion prevents the next call mid-pass", () =>
     Effect.gen(function* () {
       const invocations = yield* Ref.make(0);

--- a/packages/engine/test/tool-progress.test.ts
+++ b/packages/engine/test/tool-progress.test.ts
@@ -1,0 +1,247 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { ThreadId, RunId, TurnId } from "@effect-agent/core/Identifiers";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import { RunContextPreparationPassthrough } from "@effect-agent/engine/RunOptions";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { expect, layer } from "@effect/vitest";
+import { Deferred, Effect, Exit, Layer, Ref, Schema, Stream } from "effect";
+import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
+
+const Progress = Tool.make("report_progress", {
+  parameters: Schema.Struct({}),
+  success: Schema.Any,
+});
+
+const Hosted = Tool.providerDefined({
+  id: "test.hosted_progress",
+  customName: "Hosted",
+  providerName: "hosted",
+  parameters: Schema.Struct({}),
+  success: Schema.Struct({ status: Schema.String }),
+})(undefined);
+
+const toolkit = Toolkit.make(Progress, Hosted);
+const usage = { inputTokens: {}, outputTokens: {} };
+
+const applicationCall: Response.StreamPartEncoded = {
+  type: "tool-call",
+  id: "application",
+  name: "report_progress",
+  params: {},
+  providerExecuted: false,
+};
+
+const makeAgent = (firstTurn: ReadonlyArray<Response.StreamPartEncoded> = [applicationCall]) =>
+  Agent.withModel(
+    Agent.make("progress-bounds", {
+      input: Schema.String,
+      output: Schema.String,
+      instructions: "Report progress, then answer.",
+      toolkit,
+      policy: AgentPolicy.make({
+        maxTurns: 2,
+        maxToolCalls: 2,
+        maxDuration: "30 seconds",
+        toolConcurrency: 1,
+      }),
+    }),
+    Model.make(
+      "scripted",
+      "progress-bounds",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        Effect.gen(function* () {
+          const turn = yield* Ref.make(0);
+
+          return yield* LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () =>
+              Stream.unwrap(
+                Ref.getAndUpdate(turn, (value) => value + 1).pipe(
+                  Effect.map((value) =>
+                    Stream.fromIterable<Response.StreamPartEncoded>(
+                      value === 0
+                        ? [...firstTurn, { type: "finish", reason: "tool-calls", usage }]
+                        : [
+                            { type: "text-start", id: "answer" },
+                            { type: "text-delta", id: "answer", delta: '"done"' },
+                            { type: "text-end", id: "answer" },
+                            { type: "finish", reason: "stop", usage },
+                          ],
+                    ),
+                  ),
+                ),
+              ),
+          });
+        }),
+      ),
+    ),
+  );
+
+const testLayer = Layer.mergeAll(
+  Layer.succeed(IdGenerator, {
+    nextThreadId: Effect.succeed(Schema.decodeSync(ThreadId)("progress-thread")),
+    nextRunId: Effect.succeed(Schema.decodeSync(RunId)("progress-run")),
+    nextTurnId: Effect.succeed(Schema.decodeSync(TurnId)("progress-turn")),
+  }),
+  ThreadHistory.layerTransient,
+  RunContextPreparationPassthrough,
+);
+
+layer(testLayer)("Tool progress ownership and byte limits", (it) => {
+  it.effect("retains owned progress in detached replay after the handler mutates its result", () =>
+    Effect.gen(function* () {
+      const release = yield* Deferred.make<void>();
+      const retained = { nested: { value: "original" } };
+
+      const detached = yield* AgentRuntime.start(makeAgent(), "go").pipe(
+        Effect.provide(
+          toolkit.toLayer({
+            report_progress: (_, context) =>
+              Effect.gen(function* () {
+                yield* context.preliminary(retained);
+                yield* Deferred.await(release);
+
+                return "terminal result";
+              }),
+          }),
+        ),
+      );
+
+      yield* detached.observe.pipe(
+        Stream.filter((event) => event._tag === "ToolProgress"),
+        Stream.take(1),
+        Stream.runDrain,
+      );
+      retained.nested.value = "changed";
+      yield* Deferred.succeed(release, undefined);
+      expect((yield* detached.await).output).toBe("done");
+      const progress = (yield* detached.events).filter((event) => event._tag === "ToolProgress");
+
+      expect(progress).toHaveLength(1);
+      expect(progress[0]?.result).toEqual({ nested: { value: "original" } });
+      expect(progress[0]?.result).not.toBe(retained);
+      expect(Object.isFrozen(progress[0]?.result)).toBe(true);
+    }),
+  );
+
+  it.effect.each([2, 3])(
+    "admits at most eight cumulative UTF-8 progress bytes for %i values",
+    (count) =>
+      Effect.gen(function* () {
+        const detached = yield* AgentRuntime.start(makeAgent(), "go", {
+          bufferLimits: { maxToolProgressBytes: 8 },
+        }).pipe(
+          Effect.provide(
+            toolkit.toLayer({
+              report_progress: (_, context) =>
+                Effect.gen(function* () {
+                  for (let index = 0; index < count; index += 1) yield* context.preliminary("é");
+
+                  return "terminal result exceeds the progress allowance";
+                }),
+            }),
+          ),
+        );
+
+        const exit = yield* Effect.exit(detached.await);
+        const events = yield* detached.events;
+        const progress = events.filter((event) => event._tag === "ToolProgress");
+
+        expect(progress.map((event) => event.result)).toEqual(["é", "é"]);
+        expect(Exit.isSuccess(exit)).toBe(count === 2);
+        expect(events.at(-1)?._tag).toBe(count === 2 ? "RunCompleted" : "RunFailed");
+        if (count === 3) expect(events.at(-1)).toMatchObject({ errorTag: "ModelProtocolError" });
+      }),
+  );
+
+  it.effect.each(["oversized", "accessor"])(
+    "rejects %s progress and finalizes its active handler",
+    (kind) =>
+      Effect.gen(function* () {
+        let finalized = false;
+
+        const payload =
+          kind === "oversized"
+            ? "x".repeat(64)
+            : {
+                get value() {
+                  return "x";
+                },
+              };
+
+        const events = yield* AgentRuntime.stream(makeAgent(), "go", {
+          bufferLimits: { maxToolProgressBytes: 8 },
+        }).pipe(
+          Stream.takeUntil((event) => event._tag === "ToolProgress" || event._tag === "RunFailed"),
+          Stream.runCollect,
+          Effect.provide(
+            toolkit.toLayer({
+              report_progress: (_, context) =>
+                context.preliminary(payload).pipe(
+                  Effect.andThen(Effect.never),
+                  Effect.ensuring(
+                    Effect.sync(() => {
+                      finalized = true;
+                    }),
+                  ),
+                ),
+            }),
+          ),
+        );
+
+        expect(events.filter((event) => event._tag === "ToolProgress")).toHaveLength(0);
+        expect(events.at(-1)).toMatchObject({ _tag: "RunFailed", errorTag: "ModelProtocolError" });
+        expect(finalized).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "shares the cumulative progress allowance between provider and application results",
+    () =>
+      Effect.gen(function* () {
+        const detached = yield* AgentRuntime.start(
+          makeAgent([
+            { type: "tool-call", id: "hosted", name: "Hosted", params: {}, providerExecuted: true },
+            {
+              type: "tool-result",
+              id: "hosted",
+              name: "Hosted",
+              result: { status: "x" },
+              isFailure: false,
+              providerExecuted: true,
+              preliminary: true,
+            },
+            {
+              type: "tool-result",
+              id: "hosted",
+              name: "Hosted",
+              result: { status: "done" },
+              isFailure: false,
+              providerExecuted: true,
+            },
+            applicationCall,
+          ]),
+          "go",
+          { bufferLimits: { maxToolProgressBytes: 14 } },
+        ).pipe(
+          Effect.provide(
+            toolkit.toLayer({
+              report_progress: (_, context) => context.preliminary("x").pipe(Effect.as("terminal")),
+            }),
+          ),
+        );
+
+        const exit = yield* Effect.exit(detached.await);
+        const events = yield* detached.events;
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(
+          events.filter((event) => event._tag === "ToolProgress").map((event) => event.result),
+        ).toEqual([{ status: "x" }]);
+        expect(events.at(-1)).toMatchObject({ _tag: "RunFailed", errorTag: "ModelProtocolError" });
+      }),
+  );
+});


### PR DESCRIPTION
Reuse each live Toolkit's response codec across streamed chunks, bound tool-batch fibers by the resolved concurrency, and return broker results from the exact JSON bytes admitted by the broker. Published tool progress now uses owned snapshots with an 8 MiB cumulative payload allowance per run, including detached replay.

The native Channel merge keeps a finite number of call fibers even at concurrency one. Using `Stream.mergeAll` directly selects its sequential fast path at one, which broke existing early-close telemetry and failure-observer tests. The explicit tool semaphore and sequential barriers remain in place.

```mermaid
sequenceDiagram
  participant Handler
  participant Broker
  participant Redactor
  participant Caller
  Handler->>Broker: encoded result
  opt redactor configured
    Broker->>Redactor: validated JSON
    Redactor-->>Broker: replacement result
  end
  Broker->>Broker: serialize once, admit bytes, decode owned snapshot
  Broker-->>Caller: ProgrammaticCallSuccess with admitted snapshot
```

Callers can tighten the progress allowance:

```ts
AgentRuntime.start(agent, input, {
  bufferLimits: { maxToolProgressBytes: 1024 * 1024 },
})
```

Exceeding that cumulative progress allowance fails with `ModelProtocolError`; progress is not truncated. Application progress must be plain JSON; accessors and custom serialization are rejected. Terminal tool results retain their separate `toolResultBounds` policy. This PR bounds published payloads. The native Toolkit producer queue needs the separate [upstream backpressure fix](https://github.com/Effect-TS/effect/pull/8065), which is not yet part of the pinned Effect release.

A local Node 24.20.0 ARM64 benchmark measured complete `AgentRuntime.run` calls, each streaming 1,005 parts for a 16,000-character ASCII string answer without invoking tools. One warm-up preceded five measured samples per case in separate baseline and candidate processes:

| Declared tools | Baseline median ms | Baseline range ms | Candidate median ms | Candidate range ms |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 144.07 | 143.55 to 147.93 | 131.98 | 128.06 to 137.83 |
| 10 | 1249.26 | 1123.58 to 1270.81 | 154.95 | 126.90 to 233.50 |
| 50 | 5277.70 | 5195.32 to 5429.43 | 133.93 | 130.50 to 136.29 |

These are local full-run measurements. Hosted CPU and provider latency were not measured. A separate blocked-handler diagnostic at concurrency two measured 11 suspended fibers for both 4-call and 64-call batches after the fix, versus 11 and 71 before.

Validation passed with 311 engine tests, engine type checks, and `vp run ready`. Regressions cover mutable/getter-backed broker results, detached progress ownership and byte limits, provider progress accounting, declaration order, and cleanup at concurrency one and two. The new progress cohort failed five cases before the fix and passed all six afterward.

The first full gate hit an intermittent existing Cloudflare alarm assertion at `alarm.test.ts:274`. An isolated Cloudflare rerun passed 419 tests with two skips, then the full gate passed at the unchanged commit. Independent source review found no further correctness issues.
