### PR TITLE
perf(thread): reduce history reads and incremental staging work

### DIFF
--- a/.changeset/incremental-retained-history.md
+++ b/.changeset/incremental-retained-history.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Reduce retained-history staging work while enforcing persistence limits on every update.

--- a/.changeset/narrow-abort-intent-reads.md
+++ b/.changeset/narrow-abort-intent-reads.md
@@ -1,0 +1,9 @@
+---
+"@effect-agent/thread": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+"@effect-agent/platform-node": patch
+---
+
+Poll durable abort intent without loading unrelated recovery state. Implement `SubmissionLedger.readAbortIntent` in custom ledger adapters.

--- a/.changeset/shorter-durable-history-reads.md
+++ b/.changeset/shorter-durable-history-reads.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Reduce durable Run startup reads while preserving context compaction and recovery behavior.

--- a/docs/guide/certify-adapters.md
+++ b/docs/guide/certify-adapters.md
@@ -25,6 +25,25 @@ Checkpoint support is optional and used only by explicit projection consumers. R
 and durable recovery do not read it. An adapter with checkpoints must also run the checkpoint
 conformance suite.
 
+Implement `SubmissionLedger.readAbortIntent` as a strongly consistent read of one submission's
+abort intent. The runtime polls this method during execution, so its work must stay independent
+of other submissions, approvals, and attached children. Unknown submissions fail with `LedgerError`.
+The read grants no ownership, and `canonicalRecordId` must come from canonical history.
+
+```ts
+import type { SubmissionId } from "@effect-agent/core/Identifiers";
+import { AbortIntentRequest, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { Effect } from "effect";
+
+const readAbort = Effect.fn(function* (submissionId: SubmissionId) {
+  const ledger = yield* SubmissionLedger;
+  return yield* ledger.readAbortIntent(AbortIntentRequest.make({ submissionId }));
+});
+```
+
+Cloudflare keeps this read local to the submission's owning Durable Object. The abort command
+still becomes canonical under the append gate before the runtime interrupts execution.
+
 ## Run the certification
 
 ```ts

--- a/packages/platform-node/src/NodeDurableAgentRuntime.ts
+++ b/packages/platform-node/src/NodeDurableAgentRuntime.ts
@@ -359,6 +359,7 @@ export const ownershipDrainLayer: Layer.Layer<SubmissionLedger, never, Submissio
         finalizeSettlement: (request) =>
           ledger.finalizeSettlement(request).pipe(Effect.tap(() => untrack(request.submissionId))),
         requestAbort: ledger.requestAbort,
+        readAbortIntent: ledger.readAbortIntent,
         claimJoining: ledger.claimJoining,
         markJoined: ledger.markJoined,
         revertJoining: ledger.revertJoining,

--- a/packages/storage-cloudflare/src/DoSubmissionLedger.ts
+++ b/packages/storage-cloudflare/src/DoSubmissionLedger.ts
@@ -12,6 +12,7 @@ import {
 import {
   AbortCommand,
   AbortIntent,
+  AbortIntentRequest,
   AdmissionAdmitted,
   AdmissionConflict,
   AdmissionNotAdmitted,
@@ -215,6 +216,15 @@ class AbortIntentRow extends Schema.Class<AbortIntentRow>("AbortIntentRow")({
 
 class MaxQueueSequenceRow extends Schema.Class<MaxQueueSequenceRow>("MaxQueueSequenceRow")({
   max_queue_sequence: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+}) {}
+
+class AbortIntentLookupRow extends Schema.Class<AbortIntentLookupRow>("AbortIntentLookupRow")({
+  submission_id: BoundedIdentifier,
+  abort_submission_id: Schema.NullOr(BoundedIdentifier),
+  author: Schema.NullOr(BoundedIdentifier),
+  reason: Schema.NullOr(BoundedStoredText),
+  requested_at: Schema.NullOr(BoundedTimestamp),
+  canonical_record_id: Schema.NullOr(BoundedIdentifier),
 }) {}
 
 class CanonicalRecordIdRow extends Schema.Class<CanonicalRecordIdRow>("CanonicalRecordIdRow")({
@@ -3012,6 +3022,77 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
     LedgerError
   >(undefined, scanPage);
 
+  const readAbortIntentForSubmission: SubmissionLedger["Service"]["readAbortIntent"] = Effect.fn(
+    "DoSubmissionLedger.readAbortIntentForSubmission",
+  )(function* (request) {
+    const operation = "ledger read abort intent";
+
+    const validated = yield* Schema.decodeUnknownEffect(Schema.toType(AbortIntentRequest))(
+      request,
+    ).pipe(Effect.mapError(internalFailure(operation)));
+
+    const recordId = submissionAbortRecordId(validated.submissionId);
+
+    const rows = yield* sql<Record<string, unknown>>`
+      SELECT
+        submission.submission_id,
+        abort.submission_id AS abort_submission_id,
+        abort.author,
+        abort.reason,
+        abort.requested_at,
+        canonical.record_id AS canonical_record_id
+      FROM effect_agent_submissions AS submission
+      LEFT JOIN effect_agent_abort_intents AS abort
+        ON abort.submission_id = submission.submission_id
+      LEFT JOIN effect_agent_canonical_records AS canonical
+        ON canonical.thread_id = submission.thread_id
+          AND canonical.record_id = ${recordId}
+      WHERE submission.submission_id = ${validated.submissionId}
+    `.pipe(Effect.mapError(sqlFailure(operation)));
+
+    const decoded = yield* decodeRows(
+      Schema.Array(AbortIntentLookupRow),
+      "effect_agent_abort_intents",
+      validated.submissionId,
+      rows,
+    ).pipe(Effect.mapError(internalFailure(operation)));
+
+    if (decoded.length === 0) {
+      return yield* LedgerError.make({
+        operation,
+        message: `Unknown submission ${validated.submissionId}.`,
+      });
+    }
+    if (decoded.length !== 1) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_abort_intents",
+        validated.submissionId,
+        "An abort intent lookup returned more than one row.",
+      );
+    }
+    const row = decoded[0];
+
+    if (row.abort_submission_id === null) return undefined;
+
+    return yield* decodeAbortIntent({
+      submissionId: row.abort_submission_id,
+      author: row.author,
+      reason: row.reason,
+      requestedAt: row.requested_at,
+      ...(row.canonical_record_id === null ? {} : { canonicalRecordId: row.canonical_record_id }),
+    }).pipe(
+      Effect.mapError((error) =>
+        corruptionFailure(
+          operation,
+          "effect_agent_abort_intents",
+          validated.submissionId,
+          error.message,
+        ),
+      ),
+    );
+  });
+
   const loadRecoverySnapshot: SubmissionLedger["Service"]["loadRecoverySnapshot"] = Effect.fn(
     "DoSubmissionLedger.loadRecoverySnapshot",
   )(function* (request: RecoverySnapshotRequest) {
@@ -3281,6 +3362,7 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
       releaseChildBudget,
       scanNonterminal,
       loadRecoverySnapshot,
+      readAbortIntent: readAbortIntentForSubmission,
     }),
   );
 });

--- a/packages/storage-cloudflare/src/PortRouting.ts
+++ b/packages/storage-cloudflare/src/PortRouting.ts
@@ -692,6 +692,15 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
     // The local scan IS the whole worklist: one Thread per Object (durability §5).
     scanNonterminal: local.scanNonterminal,
 
+    readAbortIntent: (request) =>
+      submissionTarget("ledger read abort intent", request.submissionId).pipe(
+        Effect.flatMap((target) =>
+          target._tag === "local"
+            ? local.readAbortIntent(request)
+            : Effect.fail(crossThreadLedgerError("ledger read abort intent", target.threadId)),
+        ),
+      ),
+
     loadRecoverySnapshot: (request) =>
       submissionTarget("ledger load recovery snapshot", request.submissionId).pipe(
         Effect.flatMap((target) =>

--- a/packages/storage-cloudflare/test/do-ledger.test.ts
+++ b/packages/storage-cloudflare/test/do-ledger.test.ts
@@ -15,6 +15,8 @@ import {
 import { evictionFailpointHandler } from "@effect-agent/storage-cloudflare/testing/DoStorageFailpointTesting";
 import { digestJson } from "@effect-agent/thread/Digest";
 import {
+  AbortCommand,
+  AbortIntentRequest,
   BeginChildBudgetReleaseRequest,
   ChildBudgetReservationRequest,
   ChildReservationId,
@@ -33,8 +35,9 @@ import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import { runInDurableObject } from "cloudflare:test";
 import type { Crypto } from "effect";
-import { Cause, Effect, Exit, Layer, Option, Schema, Stream } from "effect";
+import { Cause, Effect, Exit, Layer, Option, Ref, Schema, Stream } from "effect";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
+import { CurrentTransformer } from "effect/unstable/sql/Statement";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -69,6 +72,41 @@ const isDoStorageError = Schema.is(DoStorageError);
 const isDoValueBoundExceeded = Schema.is(DoValueBoundExceeded);
 
 describe("DoSubmissionLedger", () => {
+  it("reads an abort intent with one query regardless of other admitted inputs", () =>
+    withThreadStorage("wp1-ledger-abort-poll", (storage) =>
+      Effect.gen(function* () {
+        const ledger = yield* SubmissionLedger;
+        const admitted = yield* ledger.admit(yield* admission("abort-poll", "target", {}));
+        const request = AbortIntentRequest.make({ submissionId: admitted.submissionId });
+        const queries = yield* Ref.make(0);
+
+        const read = ledger
+          .readAbortIntent(request)
+          .pipe(
+            Effect.provideService(CurrentTransformer, (statement) =>
+              Ref.update(queries, (count) => count + 1).pipe(Effect.as(statement)),
+            ),
+          );
+
+        expect(yield* read).toBeUndefined();
+        for (let index = 0; index < 5; index++) {
+          yield* ledger.admit(
+            yield* admission("abort-poll", `other-${index}`, { text: "x".repeat(1024) }),
+          );
+        }
+        expect(yield* read).toBeUndefined();
+        yield* ledger.requestAbort(
+          AbortCommand.make({
+            submissionId: admitted.submissionId,
+            author: "operator",
+            reason: "stop",
+          }),
+        );
+        expect(yield* read).toMatchObject({ reason: "stop" });
+        expect(yield* Ref.get(queries)).toBe(3);
+      }).pipe(Effect.provide([ledgerLayer({ storage }), BrowserCrypto.layer])),
+    ));
+
   // The SAME adapter-neutral contract suite the Node/SQLite and in-memory adapters run —
   // all cases, including lease expiry via TestClock, producer fencing, joined input,
   // suspensions, unknown outcomes, and the S2 subagent operations — executed in-workerd

--- a/packages/storage-cloudflare/test/routing.test.ts
+++ b/packages/storage-cloudflare/test/routing.test.ts
@@ -25,6 +25,7 @@ import {
   MarkJoinedRequest,
   MarkReadyRequest,
   RecoverySnapshotRequest,
+  AbortIntentRequest,
   RenewOwnershipRequest,
   SettlementConflict,
   SettlementFinalization,
@@ -892,6 +893,9 @@ describe("cross-DO port routing", () => {
         );
         yield* expectCrossLedger(
           ledger.loadRecoverySnapshot(RecoverySnapshotRequest.make({ submissionId: foreignSid })),
+        );
+        yield* expectCrossLedger(
+          ledger.readAbortIntent(AbortIntentRequest.make({ submissionId: foreignSid })),
         );
 
         const observeFailure = yield* store

--- a/packages/storage-memory/src/MemorySubmissionLedger.ts
+++ b/packages/storage-memory/src/MemorySubmissionLedger.ts
@@ -70,6 +70,7 @@ import {
   SettlementReservationSnapshot,
   settlementFailureFromRecord,
   AbortIntent,
+  AbortIntentRequest,
   SubmissionLedger,
   SubmissionLookup,
   SubmissionLookupByKey,
@@ -2256,6 +2257,19 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
       ),
     );
 
+    const readAbortIntent: SubmissionLedger["Service"]["readAbortIntent"] = Effect.fn(
+      "MemorySubmissionLedger.readAbortIntent",
+    )(function* (unvalidated) {
+      const request = yield* validate(AbortIntentRequest, "readAbortIntent", unvalidated);
+      const stored = (yield* Ref.get(state)).submissions.get(request.submissionId);
+
+      if (stored === undefined) {
+        return yield* ledgerError("readAbortIntent", `Unknown Submission ${request.submissionId}`);
+      }
+
+      return stored.abortIntent;
+    });
+
     const loadRecoverySnapshot: SubmissionLedger["Service"]["loadRecoverySnapshot"] = Effect.fn(
       "MemorySubmissionLedger.loadRecoverySnapshot",
     )((unvalidated) =>
@@ -2402,6 +2416,7 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
       releaseChildBudget,
       scanNonterminal,
       loadRecoverySnapshot,
+      readAbortIntent,
     });
   });
 

--- a/packages/storage-memory/test/runtime-history-cost.test.ts
+++ b/packages/storage-memory/test/runtime-history-cost.test.ts
@@ -1,0 +1,176 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
+import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
+import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
+import {
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+} from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeFailpoint } from "@effect-agent/thread/DurableFailpoint";
+import {
+  BatchId,
+  CanonicalBatch,
+  CanonicalSequence,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ProducerEpoch,
+  ProducerId,
+  RecordEnvelope,
+  RecordId,
+  RepairAnnotated,
+  ThreadCreated,
+} from "@effect-agent/thread/Records";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import {
+  FencedAppendRequest,
+  ThreadMaterialization,
+  ThreadStore,
+} from "@effect-agent/thread/ThreadStore";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeCrypto } from "@effect/platform-node";
+import { expect, it } from "@effect/vitest";
+import { Array, DateTime, Effect, Layer, Schema, Stream } from "effect";
+import { LanguageModel, Model, Toolkit, type Response } from "effect/unstable/ai";
+
+const digest = Schema.decodeSync(Digest)("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+
+const definition = Agent.make("history-cost", {
+  input: Schema.String,
+  output: Schema.String,
+  instructions: "Answer as JSON.",
+  toolkit: Toolkit.empty,
+  policy: AgentPolicy.make({
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+});
+
+const response: ReadonlyArray<Response.StreamPartEncoded> = [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: '"done"' },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+];
+
+const base = Layer.mergeAll(
+  MemoryThreadStoreLive,
+  MemorySubmissionLedgerLive,
+  WakeScheduler.layerNoop,
+  ToolReconciler.uncertain,
+  DurableRuntimeFailpoint.layer,
+  RunToolAuthorization.allowAll,
+  DurableRuntimeConfig.layer({
+    deploymentId: Schema.decodeSync(DeploymentId)("history-cost"),
+    producerId: Schema.decodeSync(ProducerId)("history-cost"),
+  }),
+).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: number) {
+  const store = yield* ThreadStore;
+  const threadId = Schema.decodeSync(ThreadId)(`history-cost-${historySize}`);
+  const producerEpoch = Schema.decodeSync(ProducerEpoch)(0);
+  const createdAt = yield* DateTime.now;
+  let tailSequence = Schema.decodeSync(CanonicalSequence)(0);
+  let tailDigest = EMPTY_TAIL_DIGEST;
+
+  yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch }));
+  for (let start = 0; start < historySize; start += 256) {
+    const records = Array.makeBy(Math.min(256, historySize - start), (offset) =>
+      RecordEnvelope.make({
+        recordId: Schema.decodeSync(RecordId)(`history-seed:${start + offset}`),
+        family: "thread",
+        schemaVersion: 1,
+        deploymentId: Schema.decodeSync(DeploymentId)("history-cost"),
+        createdAt,
+        payload:
+          start + offset === 0
+            ? ThreadCreated.make({ agentId: definition.id, definitions })
+            : RepairAnnotated.make({ reason: "history-cost", details: { text: "x".repeat(128) } }),
+      }),
+    );
+
+    const appended = yield* store.append(
+      FencedAppendRequest.make({
+        threadId,
+        producerEpoch,
+        expectedTailSequence: tailSequence,
+        expectedTailDigest: tailDigest,
+        batch: CanonicalBatch.make({
+          batchId: Schema.decodeSync(BatchId)(`history-seed:${start}`),
+          producerId: Schema.decodeSync(ProducerId)("history-cost"),
+          records,
+        }),
+      }),
+    );
+
+    tailSequence = appended.lastSequence;
+    tailDigest = appended.tailDigest;
+  }
+  let returnedRecords = 0;
+  let measured = false;
+
+  const counted = ThreadStore.of({
+    ...store,
+    read: (request) =>
+      store.read(request).pipe(
+        Stream.tap(() =>
+          Effect.sync(() => {
+            if (!measured) returnedRecords++;
+          }),
+        ),
+      ),
+  });
+
+  const model = Model.make(
+    "scripted",
+    "history-cost",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: () =>
+          Stream.fromEffect(
+            Effect.sync(() => {
+              measured = true;
+            }),
+          ).pipe(Stream.flatMap(() => Stream.fromIterable(response))),
+      }),
+    ),
+  );
+
+  const agent = Agent.withModel(definition, model);
+
+  const runtime = yield* DurableAgentRuntime.pipe(
+    Effect.provide(DurableAgentRuntime.layer),
+    Effect.provideService(ThreadStore, counted),
+  );
+
+  yield* runtime.submit(agent, "measure", {
+    threadId,
+    principal: Schema.decodeSync(Principal)("history-cost"),
+    idempotencyKey: Schema.decodeSync(IdempotencyKey)("history-cost"),
+    definitions,
+  });
+  yield* runtime.processThread(agent, threadId);
+
+  return { returnedRecords, measured };
+});
+
+it.live("bounds startup history reads while retaining the complete fixed prefix", () =>
+  Effect.gen(function* () {
+    for (const historySize of [1, 11, 2051]) {
+      const measurement = yield* measure(historySize).pipe(Effect.provide(base));
+
+      expect(measurement.measured).toBe(true);
+      expect(measurement.returnedRecords).toBeLessThanOrEqual(3 * historySize + 6);
+    }
+  }),
+);

--- a/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
+++ b/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
@@ -12,6 +12,7 @@ import {
 import {
   AbortCommand,
   AbortIntent,
+  AbortIntentRequest,
   AdmissionAdmitted,
   AdmissionConflict,
   AdmissionNotAdmitted,
@@ -202,6 +203,15 @@ class AbortIntentRow extends Schema.Class<AbortIntentRow>("AbortIntentRow")({
 
 class MaxQueueSequenceRow extends Schema.Class<MaxQueueSequenceRow>("MaxQueueSequenceRow")({
   max_queue_sequence: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+}) {}
+
+class AbortIntentLookupRow extends Schema.Class<AbortIntentLookupRow>("AbortIntentLookupRow")({
+  submission_id: BoundedIdentifier,
+  abort_submission_id: Schema.NullOr(BoundedIdentifier),
+  author: Schema.NullOr(BoundedIdentifier),
+  reason: Schema.NullOr(BoundedStoredText),
+  requested_at: Schema.NullOr(BoundedTimestamp),
+  canonical_record_id: Schema.NullOr(BoundedIdentifier),
 }) {}
 
 class CanonicalRecordIdRow extends Schema.Class<CanonicalRecordIdRow>("CanonicalRecordIdRow")({
@@ -2905,6 +2915,77 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
     LedgerError
   >(undefined, scanPage);
 
+  const readAbortIntentForSubmission: SubmissionLedger["Service"]["readAbortIntent"] = Effect.fn(
+    "SqliteSubmissionLedger.readAbortIntentForSubmission",
+  )(function* (request) {
+    const operation = "ledger read abort intent";
+
+    const validated = yield* Schema.decodeUnknownEffect(Schema.toType(AbortIntentRequest))(
+      request,
+    ).pipe(Effect.mapError(internalFailure(operation)));
+
+    const recordId = submissionAbortRecordId(validated.submissionId);
+
+    const rows = yield* sql<Record<string, unknown>>`
+      SELECT
+        submission.submission_id,
+        abort.submission_id AS abort_submission_id,
+        abort.author,
+        abort.reason,
+        abort.requested_at,
+        canonical.record_id AS canonical_record_id
+      FROM effect_agent_submissions AS submission
+      LEFT JOIN effect_agent_abort_intents AS abort
+        ON abort.submission_id = submission.submission_id
+      LEFT JOIN effect_agent_canonical_records AS canonical
+        ON canonical.thread_id = submission.thread_id
+          AND canonical.record_id = ${recordId}
+      WHERE submission.submission_id = ${validated.submissionId}
+    `.pipe(Effect.mapError(sqlFailure(operation)));
+
+    const decoded = yield* decodeRows(
+      Schema.Array(AbortIntentLookupRow),
+      "effect_agent_abort_intents",
+      validated.submissionId,
+      rows,
+    ).pipe(Effect.mapError(internalFailure(operation)));
+
+    if (decoded.length === 0) {
+      return yield* LedgerError.make({
+        operation,
+        message: `Unknown submission ${validated.submissionId}.`,
+      });
+    }
+    if (decoded.length !== 1) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_abort_intents",
+        validated.submissionId,
+        "An abort intent lookup returned more than one row.",
+      );
+    }
+    const row = decoded[0];
+
+    if (row.abort_submission_id === null) return undefined;
+
+    return yield* decodeAbortIntent({
+      submissionId: row.abort_submission_id,
+      author: row.author,
+      reason: row.reason,
+      requestedAt: row.requested_at,
+      ...(row.canonical_record_id === null ? {} : { canonicalRecordId: row.canonical_record_id }),
+    }).pipe(
+      Effect.mapError((error) =>
+        corruptionFailure(
+          operation,
+          "effect_agent_abort_intents",
+          validated.submissionId,
+          error.message,
+        ),
+      ),
+    );
+  });
+
   const loadRecoverySnapshot: SubmissionLedger["Service"]["loadRecoverySnapshot"] = Effect.fn(
     "SqliteSubmissionLedger.loadRecoverySnapshot",
   )(function* (request: RecoverySnapshotRequest) {
@@ -3156,6 +3237,7 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
       releaseChildBudget,
       scanNonterminal,
       loadRecoverySnapshot,
+      readAbortIntent: readAbortIntentForSubmission,
     }),
   );
 });

--- a/packages/storage-sqlite/test/sqlite-ledger.test.ts
+++ b/packages/storage-sqlite/test/sqlite-ledger.test.ts
@@ -35,6 +35,7 @@ import {
 } from "@effect-agent/thread/Records";
 import {
   AbortCommand,
+  AbortIntentRequest,
   AdmissionRequest,
   ApprovalDecisionCommand,
   ApprovalPendingSuspension,
@@ -103,6 +104,7 @@ import {
 } from "effect";
 import { TestClock } from "effect/testing";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
+import { CurrentTransformer } from "effect/unstable/sql/Statement";
 
 type Equal<Left, Right> =
   (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
@@ -307,6 +309,45 @@ const combinedLayer = (filename: string) =>
   );
 
 describe("SqliteSubmissionLedger", () => {
+  it.effect("reads an abort intent with one query regardless of other admitted inputs", () =>
+    withTemporaryDatabase((filename) =>
+      withLedger(
+        filename,
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const admitted = yield* ledger.admit(yield* admission("abort-poll", "target", {}));
+          const request = AbortIntentRequest.make({ submissionId: admitted.submissionId });
+          const queries = yield* Ref.make(0);
+
+          const read = ledger
+            .readAbortIntent(request)
+            .pipe(
+              Effect.provideService(CurrentTransformer, (statement) =>
+                Ref.update(queries, (count) => count + 1).pipe(Effect.as(statement)),
+              ),
+            );
+
+          expect(yield* read).toBeUndefined();
+          for (let index = 0; index < 5; index++) {
+            yield* ledger.admit(
+              yield* admission("abort-poll", `other-${index}`, { text: "x".repeat(1024) }),
+            );
+          }
+          expect(yield* read).toBeUndefined();
+          yield* ledger.requestAbort(
+            AbortCommand.make({
+              submissionId: admitted.submissionId,
+              author: "operator",
+              reason: "stop",
+            }),
+          );
+          expect(yield* read).toMatchObject({ reason: "stop" });
+          expect(yield* Ref.get(queries)).toBe(3);
+        }),
+      ),
+    ),
+  );
+
   describe("shared SubmissionLedger conformance", () => {
     for (const conformanceCase of submissionLedgerConformanceCases) {
       it.effect(conformanceCase.name, () =>

--- a/packages/testing/test/persistent-threads.test.ts
+++ b/packages/testing/test/persistent-threads.test.ts
@@ -1,8 +1,8 @@
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
-import { ThreadId } from "@effect-agent/core/Identifiers";
+import { RunId, ThreadId } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
-import { type RunEvent } from "@effect-agent/core/RunEvent";
+import { RunCompleted, type RunEvent } from "@effect-agent/core/RunEvent";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import { RunContextPreparationPassthrough } from "@effect-agent/engine/RunOptions";
 import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
@@ -144,6 +144,173 @@ const withDatabase = <A, E, R>(use: (filename: string) => Effect.Effect<A, E, R>
   ).pipe(Effect.provide(Layer.merge(NodeFileSystem.layer, services)));
 
 describe("persistent threads", () => {
+  it.effect("does not reread an encoded message when later history updates append messages", () =>
+    Effect.gen(function* () {
+      const history = yield* ThreadHistory;
+
+      const opened = yield* history.open({
+        threadId,
+        runId: Schema.decodeSync(RunId)("staging-encoded-prefix"),
+      });
+
+      if (opened === undefined) return yield* Effect.die("Missing retained history staging");
+
+      let reads = 0;
+      const part = Prompt.makePart("text", { text: "retained" });
+
+      Object.defineProperty(part, "text", {
+        get: () => {
+          reads++;
+
+          return "retained";
+        },
+      });
+
+      let messages: ReadonlyArray<Prompt.Message> = [
+        Prompt.makeMessage("assistant", { content: [part] }),
+      ];
+
+      yield* opened.stageHistory(Prompt.fromMessages(messages));
+      const initialReads = reads;
+
+      expect(initialReads).toBeGreaterThan(0);
+      for (let turn = 0; turn < 10; turn++) {
+        messages = [
+          ...messages,
+          Prompt.makeMessage("assistant", {
+            content: [Prompt.makePart("text", { text: `addition-${turn}` })],
+          }),
+        ];
+        yield* opened.stageHistory(Prompt.fromMessages(messages));
+      }
+      expect(reads).toBe(initialReads);
+    }).pipe(Effect.provide(memory)),
+  );
+
+  it.effect(
+    "preserves the last valid history through replacement, shortening, and failed staging",
+    () =>
+      Effect.gen(function* () {
+        const history = yield* ThreadHistory;
+        const runId = Schema.decodeSync(RunId)("staging-replacement");
+        const opened = yield* history.open({ threadId, runId });
+
+        if (opened === undefined) return yield* Effect.die("Missing retained history staging");
+
+        const user = Prompt.makeMessage("user", {
+          content: [Prompt.makePart("text", { text: "input" })],
+        });
+
+        const removed = Prompt.makeMessage("assistant", {
+          content: [Prompt.makePart("text", { text: "removed" })],
+        });
+
+        const replacement = Prompt.makeMessage("assistant", {
+          content: [Prompt.makePart("text", { text: "replacement" })],
+        });
+
+        yield* opened.stageInput("input");
+        yield* opened.stageHistory(Prompt.fromMessages([user]));
+        yield* opened.stageHistory(Prompt.fromMessages([user, removed]));
+        yield* opened.stageHistory(Prompt.fromMessages([user, replacement]));
+        yield* opened.stageHistory(Prompt.fromMessages([user]));
+        yield* opened.stageHistory(Prompt.fromMessages([replacement]));
+        yield* opened.stageHistory(Prompt.fromMessages([replacement]));
+
+        const failure = yield* opened
+          .stageHistory(
+            Prompt.fromMessages([
+              replacement,
+              Prompt.makeMessage("assistant", {
+                content: [Prompt.makePart("text", { text: "x".repeat(1_048_576) })],
+              }),
+            ]),
+          )
+          .pipe(Effect.flip);
+
+        expect(failure).toMatchObject({ _tag: "ThreadHistoryError", reason: "limit" });
+        yield* opened.commit(
+          RunCompleted.make({
+            eventVersion: 1,
+            runId,
+            threadId,
+            agentId: definition.id,
+            sequence: 1,
+            timestamp: yield* DateTime.now,
+            output: "done",
+            turns: 1,
+            finishReason: "completed",
+          }),
+        );
+        expect((yield* history.load(threadId)).content).toEqual([replacement]);
+      }).pipe(Effect.provide(memory)),
+  );
+
+  for (const limit of ["bytes", "nodes", "collection", "depth"] as const) {
+    it.effect(`rejects ${limit} overflow at history staging before any commit`, () =>
+      Effect.gen(function* () {
+        const history = yield* ThreadHistory;
+
+        const opened = yield* history.open({
+          threadId,
+          runId: Schema.decodeSync(RunId)(`staging-${limit}`),
+        });
+
+        if (opened === undefined) return yield* Effect.die("Missing retained history staging");
+
+        const text = (value: string) =>
+          Prompt.makeMessage("user", { content: [Prompt.makePart("text", { text: value })] });
+
+        const result = (value: unknown, index: number) =>
+          Prompt.makeMessage("tool", {
+            content: [
+              Prompt.makePart("tool-result", {
+                id: `result-${index}`,
+                name: "lookup",
+                result: value,
+                isFailure: false,
+                providerExecuted: false,
+              }),
+            ],
+          });
+
+        let fitting: ReadonlyArray<Prompt.Message>;
+        let overflowing: ReadonlyArray<Prompt.Message>;
+
+        switch (limit) {
+          case "bytes":
+            fitting = [text("x".repeat(600_000))];
+            overflowing = [...fitting, text("y".repeat(600_000))];
+            break;
+          case "nodes":
+            fitting = Array.makeBy(16, (index) => result(Array.replicate(0, 4_000), index));
+            overflowing = [...fitting, result(Array.replicate(0, 4_000), 16)];
+            break;
+          case "collection":
+            fitting = Array.makeBy(4_096, () => text("x"));
+            overflowing = [...fitting, text("y")];
+            break;
+          case "depth": {
+            let deep: unknown = 0;
+
+            for (let depth = 0; depth < 64; depth++) deep = { value: deep };
+            fitting = [text("input")];
+            overflowing = [...fitting, result(deep, 0)];
+            break;
+          }
+        }
+        yield* opened.stageHistory(Prompt.fromMessages(fitting));
+
+        const failure = yield* opened
+          .stageHistory(Prompt.fromMessages(overflowing))
+          .pipe(Effect.flip);
+
+        expect(failure).toMatchObject({ _tag: "ThreadHistoryError", reason: "limit" });
+        expect((yield* exported).records).toEqual([]);
+      }).pipe(Effect.provide(memory)),
+    );
+  }
+
   it.effect("rejects competing history ownership before model execution", () =>
     Effect.gen(function* () {
       yield* AgentRuntime.run(agent([answer("retained")]), "prior", options);

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -218,6 +218,7 @@ import {
 } from "./RunJournal.ts";
 import {
   type AbortIntent,
+  AbortIntentRequest,
   type AdmissionConflict,
   type Claim,
   type JoinedToHost,
@@ -5950,11 +5951,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           while (true) {
             yield* Effect.sleep(config.abortPollInterval);
 
-            const snapshot = yield* ledger.loadRecoverySnapshot(
-              RecoverySnapshotRequest.make({ submissionId }),
-            );
-
-            const intent = snapshot.abortIntent;
+            const intent = yield* ledger.readAbortIntent(AbortIntentRequest.make({ submissionId }));
 
             if (intent === undefined) continue;
             yield* appendAbortRecord(ctx, intent);

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -2274,10 +2274,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     ctx: AttemptAppendContext,
     submission: SubmissionSnapshot,
     maxDurationMillis: number,
+    records: ReadonlyArray<CanonicalRecordEnvelope>,
   ) {
     const runId = runIdForSubmission(submission.submissionId);
     const recordId = runStartedRecordId(runId);
-    const records = yield* readControl(submission.threadId, [submission.submissionId]);
     const existing = yield* canonicalRunStartFromRecords(records, runId);
     let start: RecordEnvelope;
 
@@ -6161,7 +6161,40 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         yield* ledger.markReady(MarkReadyRequest.make({ submissionId }));
       }
       const ctx = yield* attemptContextFor(threadId, claim.producerEpoch);
-      const records = yield* readControl(threadId, [submissionId]);
+
+      let controlThrough = (yield* store.inspectTail(ThreadTailRequest.make({ threadId })))
+        .tailSequence;
+
+      let records: ReadonlyArray<CanonicalRecordEnvelope> = yield* readCanonicalRange(
+        threadId,
+        ZERO_SEQUENCE,
+        controlThrough,
+        controlRecords([submissionId]),
+      );
+
+      // The append-only prefix remains valid for this Attempt. Retain only this Run's control
+      // evidence and validate each newly visible suffix against its own captured tail.
+      const refreshControl = Effect.fn("DurableAgentRuntime.refreshAttemptControl")(function* (
+        throughSequence?: CanonicalSequence,
+      ) {
+        const through =
+          throughSequence ??
+          (yield* store.inspectTail(ThreadTailRequest.make({ threadId }))).tailSequence;
+
+        if (through > controlThrough) {
+          const suffix = yield* readCanonicalRange(
+            threadId,
+            controlThrough,
+            through,
+            controlRecords([submissionId]),
+          );
+
+          records = [...records, ...suffix];
+          controlThrough = through;
+        }
+
+        return records;
+      });
 
       const childPolicy =
         submission.parentLinkage === undefined
@@ -6225,6 +6258,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         ctx,
         submission,
         Duration.toMillis(agent.definition.policy.maxDuration),
+        yield* refreshControl(),
       );
 
       let expiredChildObligation = false;
@@ -6236,7 +6270,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
       // Recheck after duration interruption too: that Attempt may have prepared new ordinary calls.
       const ordinaryCallsResolved = Effect.gen(function* () {
-        const reconciliationRecords = yield* readControl(threadId, [submissionId]);
+        const reconciliationRecords = yield* refreshControl();
 
         const reconciliationSnapshot = yield* ledger.loadRecoverySnapshot(
           RecoverySnapshotRequest.make({ submissionId }),
@@ -6306,9 +6340,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
         const canonical = canonicalRange(threadId, tail.tailSequence);
 
-        const currentRecords = yield* Stream.runCollect(
-          canonical.pipe(Stream.filter(controlRecords([submissionId]))),
-        );
+        const currentRecords = yield* refreshControl(tail.tailSequence);
 
         const outcome = yield* runModel(
           agent,

--- a/packages/thread/src/PersistentHistory.ts
+++ b/packages/thread/src/PersistentHistory.ts
@@ -135,6 +135,10 @@ const layer = Layer.effect(
         Effect.mapError((cause) => error("encoding", cause.message, cause)),
       );
 
+      const expectedTailSequence = base.tailSequence;
+      const expectedTailDigest = base.tailDigest;
+      const initialPromptLength = prompt.content.length;
+
       const createdAt = yield* DateTime.now;
 
       const record = (id: string, payload: RecordEnvelope["payload"], timestamp = createdAt) =>
@@ -149,6 +153,8 @@ const layer = Layer.effect(
 
       let input: RecordEnvelope | undefined;
       let messages: PersistedJson | undefined;
+      let stagedSource: ReadonlyArray<Prompt.Message> = [];
+      let encodedMessages: ReadonlyArray<Prompt.MessageEncoded> = [];
 
       return {
         prompt,
@@ -163,14 +169,35 @@ const layer = Layer.effect(
           );
         }),
         stageHistory: Effect.fn("PersistentHistory.stageHistory")(function* (next: Prompt.Prompt) {
-          messages = yield* Schema.encodeEffect(Prompt.Prompt)(
-            Prompt.fromMessages(next.content.slice(prompt.content.length)),
+          const source = next.content.slice(initialPromptLength);
+          let retained = 0;
+
+          while (
+            retained < source.length &&
+            retained < stagedSource.length &&
+            source[retained] === stagedSource[retained]
+          ) {
+            retained++;
+          }
+
+          // Normal engine updates append messages. Rewritten or shortened histories retain only
+          // their unchanged prefix, so direct staging callers keep the same replacement behavior.
+          const suffix = yield* Schema.encodeEffect(Prompt.Prompt)(
+            Prompt.fromMessages(source.slice(retained)),
           ).pipe(
             Effect.mapError((cause) =>
               error("encoding", "Run history could not be encoded", cause),
             ),
-            Effect.flatMap(persisted),
           );
+
+          const nextEncoded = [...encodedMessages.slice(0, retained), ...suffix.content];
+          const nextMessages = yield* persisted({ content: nextEncoded });
+
+          // Aggregate validation stays at every history update: per-message limits would admit
+          // oversized Runs and move failures past the next model or Tool call.
+          messages = nextMessages;
+          encodedMessages = nextEncoded;
+          stagedSource = source;
         }),
         commit: Effect.fn("PersistentHistory.commit")(function* (completion: RunCompletedEvent) {
           if (input === undefined || messages === undefined) {
@@ -196,8 +223,8 @@ const layer = Layer.effect(
               FencedAppendRequest.make({
                 threadId,
                 producerEpoch: HISTORY_EPOCH,
-                expectedTailSequence: base.tailSequence,
-                expectedTailDigest: base.tailDigest,
+                expectedTailSequence,
+                expectedTailDigest,
                 batch: CanonicalBatch.make({
                   batchId: batchId(`history:${runId}`),
                   producerId: producer(`history:${runId}`),

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -16,6 +16,7 @@ import { digestJson, type DigestError } from "./Digest.ts";
 import {
   BatchId,
   CanonicalBatch,
+  type CompactionCreated,
   ModelResponseRecorded,
   PersistedJson,
   RecordEnvelope,
@@ -509,8 +510,9 @@ export interface JournalBoundary {
 
 /**
  * Reconstruct a fixed canonical prefix from a re-readable stream. The caller must keep the same
- * records visible on every traversal. Compaction metadata and the resulting live Prompt remain
- * resident; covered historical message/tool payloads do not. An uncompacted Prompt still grows
+ * records visible on both traversals. The first collects compaction and settlement metadata; the
+ * second decodes each uncovered response once while rebuilding Prompt and usage. Metadata and the
+ * live Prompt remain resident; covered historical message/tool payloads do not. An uncompacted Prompt still grows
  * with its conversation, so hosts must configure an appropriate context compaction policy.
  * @internal
  */
@@ -548,12 +550,17 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
   const settledToolCallRecordIds = new Set<string>();
   const settledById = new Map<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>();
+  const compactions: Array<{ readonly payload: CompactionCreated; readonly sequence: number }> = [];
 
   yield* Stream.runForEach(records, (envelope) =>
     Effect.sync(() => {
       const payload = envelope.record.payload;
 
-      if (payload._tag === "CompactionCreated") return;
+      if (payload._tag === "CompactionCreated") {
+        compactions.push({ payload, sequence: envelope.sequence });
+
+        return;
+      }
       if ("runId" in payload && typeof payload.runId === "string") {
         if (!firstSequenceByRun.has(payload.runId)) {
           firstSequenceByRun.set(payload.runId, envelope.sequence);
@@ -596,27 +603,22 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   let summarizeSequence = -1;
   let clearBound = 0;
 
-  yield* Stream.runForEach(records, (envelope) =>
-    Effect.sync(() => {
-      const payload = envelope.record.payload;
-
-      if (payload._tag !== "CompactionCreated") return;
-      if (!boundIsValid(payload.runId, payload.coversThrough, envelope.sequence)) return;
-      if (payload.kind === "summarize") {
-        if (payload.summary === undefined) return;
-        if (
-          payload.coversThrough > summarizeBound ||
-          (payload.coversThrough === summarizeBound && envelope.sequence > summarizeSequence)
-        ) {
-          summarizeBound = payload.coversThrough;
-          summarizeSummary = payload.summary;
-          summarizeSequence = envelope.sequence;
-        }
-      } else if (payload.coversThrough > clearBound) {
-        clearBound = payload.coversThrough;
+  for (const { payload, sequence } of compactions) {
+    if (!boundIsValid(payload.runId, payload.coversThrough, sequence)) continue;
+    if (payload.kind === "summarize") {
+      if (payload.summary === undefined) continue;
+      if (
+        payload.coversThrough > summarizeBound ||
+        (payload.coversThrough === summarizeBound && sequence > summarizeSequence)
+      ) {
+        summarizeBound = payload.coversThrough;
+        summarizeSummary = payload.summary;
+        summarizeSequence = sequence;
       }
-    }),
-  );
+    } else if (payload.coversThrough > clearBound) {
+      clearBound = payload.coversThrough;
+    }
+  }
   let summaryEmitted = false;
 
   const emitSummary = () => {
@@ -661,76 +663,56 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     finalizationUsed: false,
   };
 
-  yield* Stream.runForEach(records, (envelope) =>
-    Effect.gen(function* () {
-      const record = envelope.record;
-      const payload = envelope.record.payload;
+  const accountResponse = Effect.fn("RunJournal.accountResponse")(function* (
+    envelope: CanonicalRecordEnvelope,
+    payload: ModelResponseRecorded,
+    messages: Prompt.Prompt,
+  ) {
+    const record = envelope.record;
 
-      if (payload._tag === "RunPolicyUsageReserved" && payload.runId === ownerRunId) {
-        if (
-          payload.programmaticToolCalls < policyUsage.programmaticToolCalls ||
-          (policyUsage.finalizationUsed && !payload.finalizationUsed)
-        ) {
-          return yield* journalError("Run policy reservations must be monotonic");
-        }
-        policyUsage.programmaticToolCalls = payload.programmaticToolCalls;
-        policyUsage.finalizationUsed = payload.finalizationUsed;
-      }
-      if (payload._tag !== "ModelResponseRecorded") return;
-      if (envelope.sequence <= summarizeBound && payload.runId !== ownerRunId) return;
-      const messages = yield* decodePromptMessages(payload.messages);
+    const declared = declaredApplicationToolCallIds(messages);
+    const declaredRecordIds: Array<RecordId> = [];
 
-      const declared = declaredApplicationToolCallIds(messages);
-      const declaredRecordIds: Array<RecordId> = [];
+    for (const id of declared) {
+      const toolCallId = yield* Effect.try({
+        try: () => decodeToolCallId(id),
+        catch: (cause) => journalError("Failed to decode a declared Tool Call ID", cause),
+      });
 
-      for (const id of declared) {
-        const toolCallId = yield* Effect.try({
-          try: () => decodeToolCallId(id),
-          catch: (cause) => journalError("Failed to decode a declared Tool Call ID", cause),
-        });
+      declaredRecordIds.push(toolCallSettledRecordId(payload.runId, payload.turn, toolCallId));
+    }
+    if (declaredRecordIds.some((recordId) => !settledToolCallRecordIds.has(recordId))) {
+      incompleteToolTurns.add(envelope.record.recordId);
+      for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
+    }
+    if (payload.runId !== ownerRunId) return;
+    policyUsage.committedTurns = Math.max(policyUsage.committedTurns, payload.turn);
 
-        declaredRecordIds.push(toolCallSettledRecordId(payload.runId, payload.turn, toolCallId));
-      }
-      if (declaredRecordIds.some((recordId) => !settledToolCallRecordIds.has(recordId))) {
-        incompleteToolTurns.add(envelope.record.recordId);
-        for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
-      }
-      if (payload.runId !== ownerRunId) return;
-      policyUsage.committedTurns = Math.max(policyUsage.committedTurns, payload.turn);
+    const calls = messages.content.flatMap((message) =>
+      message.role === "assistant"
+        ? message.content.filter((part) => part.type === "tool-call")
+        : [],
+    );
 
-      const calls = messages.content.flatMap((message) =>
-        message.role === "assistant"
-          ? message.content.filter((part) => part.type === "tool-call")
-          : [],
-      );
+    policyUsage.toolCalls += calls.length;
+    if (incompleteToolTurns.has(record.recordId)) return;
+    for (const call of calls) {
+      const result = call.providerExecuted
+        ? messages.content
+            .flatMap((message) => (message.role === "assistant" ? message.content : []))
+            .find(
+              (part) => part.type === "tool-result" && part.providerExecuted && part.id === call.id,
+            )
+        : settledById.get(`tool-settled:${ownerRunId}:${payload.turn}:${call.id}`);
 
-      policyUsage.toolCalls += calls.length;
-      if (incompleteToolTurns.has(record.recordId)) return;
-      for (const call of calls) {
-        const result = call.providerExecuted
-          ? messages.content
-              .flatMap((message) => (message.role === "assistant" ? message.content : []))
-              .find(
-                (part) =>
-                  part.type === "tool-result" && part.providerExecuted && part.id === call.id,
-              )
-          : settledById.get(`tool-settled:${ownerRunId}:${payload.turn}:${call.id}`);
-
-        if (result === undefined || ("budgetRejected" in result && result.budgetRejected === true))
-          continue;
-        if (!("isFailure" in result)) continue;
-        policyUsage.consecutiveToolFailures = result.isFailure
-          ? policyUsage.consecutiveToolFailures + 1
-          : 0;
-      }
-    }),
-  );
-
-  const validatedPolicyUsage = yield* Schema.decodeUnknownEffect(RunPolicyUsage)(policyUsage).pipe(
-    Effect.mapError((cause) =>
-      journalError("Run policy accounting exceeds its Schema bounds", cause),
-    ),
-  );
+      if (result === undefined || ("budgetRejected" in result && result.budgetRejected === true))
+        continue;
+      if (!("isFailure" in result)) continue;
+      policyUsage.consecutiveToolFailures = result.isFailure
+        ? policyUsage.consecutiveToolFailures + 1
+        : 0;
+    }
+  });
 
   const flushTools = Effect.fn("RunJournal.flushTools")(function* (
     current: FoldState,
@@ -752,6 +734,16 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     Effect.gen(function* () {
       const payload = envelope.record.payload;
 
+      if (payload._tag === "RunPolicyUsageReserved" && payload.runId === ownerRunId) {
+        if (
+          payload.programmaticToolCalls < policyUsage.programmaticToolCalls ||
+          (policyUsage.finalizationUsed && !payload.finalizationUsed)
+        ) {
+          return yield* journalError("Run policy reservations must be monotonic");
+        }
+        policyUsage.programmaticToolCalls = payload.programmaticToolCalls;
+        policyUsage.finalizationUsed = payload.finalizationUsed;
+      }
       if (PROMPT_TRANSPARENT_TAGS.has(payload._tag)) return;
       // The compaction record governs the fold (pre-scan) and contributes no
       // message of its own; records at or below the summarize bound render as
@@ -762,6 +754,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
         // into the summary (the append side never covers the owner, but stay
         // fail-safe if it ever did).
         if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {
+          const messages = yield* decodePromptMessages(payload.messages);
+
+          yield* accountResponse(envelope, payload, messages);
           const responseUsage = yield* projectedResponseUsage(payload);
 
           usage.modelCalls = yield* addProjectedUsage(
@@ -846,6 +841,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
       const messages = yield* decodePromptMessages(payload.messages);
       const forRun = payload.runId === ownerRunId;
 
+      yield* accountResponse(envelope, payload, messages);
       if (forRun) {
         const responseUsage = yield* projectedResponseUsage(payload);
 
@@ -906,6 +902,12 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   );
   emitSummary();
   state = yield* flushTools(state);
+
+  const validatedPolicyUsage = yield* Schema.decodeUnknownEffect(RunPolicyUsage)(policyUsage).pipe(
+    Effect.mapError((cause) =>
+      journalError("Run policy accounting exceeds its Schema bounds", cause),
+    ),
+  );
 
   return {
     policyUsage: validatedPolicyUsage,

--- a/packages/thread/src/SubmissionLedger.ts
+++ b/packages/thread/src/SubmissionLedger.ts
@@ -409,6 +409,11 @@ export class AbortIntent extends Schema.Class<AbortIntent>("@effect-agent/thread
   canonicalRecordId: Schema.optionalKey(RecordId),
 }) {}
 
+/** Address one lane-local abort intent without loading unrelated recovery state. */
+export class AbortIntentRequest extends Schema.Class<AbortIntentRequest>(
+  "@effect-agent/thread/AbortIntentRequest",
+)({ submissionId: SubmissionId }) {}
+
 /**
  * Atomic claim of the contiguous ready prefix of strictly-later queued Submissions for joining
  * into the active host Run (plan §2.5). Fenced by the host Attempt's ownership token — no epoch
@@ -1071,6 +1076,13 @@ export class SubmissionLedger extends Context.Service<
     readonly requestAbort: (
       request: AbortCommand,
     ) => Effect.Effect<AbortIntent, SettlementConflict | JoinedToHost | LedgerError>;
+    /**
+     * Strongly consistent lane-local read. Unknown Submissions fail with LedgerError. Canonical
+     * proof has the same meaning as in RecoverySnapshot; this read grants no execution authority.
+     */
+    readonly readAbortIntent: (
+      request: AbortIntentRequest,
+    ) => Effect.Effect<AbortIntent | undefined, LedgerError>;
     readonly claimJoining: (
       request: ClaimJoiningRequest,
     ) => Effect.Effect<ReadonlyArray<JoiningClaim>, OwnershipLost | LedgerError>;

--- a/packages/thread/src/SubmissionLedgerConformance.ts
+++ b/packages/thread/src/SubmissionLedgerConformance.ts
@@ -20,6 +20,7 @@ import {
 import {
   type AdmissionResult,
   AbortCommand,
+  AbortIntentRequest,
   AdmissionConflict,
   AdmissionRequest,
   ApprovalConflict,
@@ -1153,6 +1154,13 @@ const abortIdempotency = conformanceCase(
         yield* admissionRequest(threadId, "abort-key-1", { work: "abort" }),
       );
 
+      const readRequest = AbortIntentRequest.make({ submissionId: admitted.submissionId });
+
+      yield* ensure(
+        (yield* ledger.readAbortIntent(readRequest)) === undefined,
+        "An admitted Submission without an abort intent must return undefined",
+      );
+
       const intent = yield* ledger.requestAbort(
         AbortCommand.make({
           submissionId: admitted.submissionId,
@@ -1178,11 +1186,30 @@ const abortIdempotency = conformanceCase(
         "Repeating an abort command must return the recorded intent unchanged",
       );
       const snapshot = yield* recoverySnapshot(admitted.submissionId);
+      const narrow = yield* ledger.readAbortIntent(readRequest);
 
       yield* ensure(
         snapshot.abortIntent !== undefined && snapshot.abortIntent.reason === intent.reason,
         "The recovery snapshot must expose the recorded abort intent",
       );
+      yield* ensure(
+        narrow !== undefined &&
+          narrow.submissionId === intent.submissionId &&
+          narrow.author === intent.author &&
+          narrow.reason === intent.reason &&
+          sameInstant(narrow.requestedAt, intent.requestedAt) &&
+          narrow.canonicalRecordId === snapshot.abortIntent?.canonicalRecordId,
+        "The narrow read must preserve the recorded intent and canonical proof",
+      );
+
+      const unknown = yield* expectFailure(
+        "reading an unknown Submission's abort intent",
+        ledger.readAbortIntent(
+          AbortIntentRequest.make({ submissionId: decodeSubmissionId("unknown-abort-target") }),
+        ),
+      );
+
+      yield* ensure(unknown._tag === "LedgerError", "Unknown abort targets must fail typed");
 
       const settledLane = decodeThreadId("ledger-conformance-abort-settled");
       const settledWork = yield* admitReady(settledLane, "abort-key-2", { work: "settled" });

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -918,6 +918,54 @@ describe("engine compaction records and projection (RUN-026)", () => {
   });
 
   layer(NodeCrypto.layer)((it) => {
+    it.effect("preserves an earlier Run's policy usage under a later Run's summary", () =>
+      Effect.gen(function* () {
+        const failedTurn = secondToolTurn.map((message) =>
+          message.role === "tool"
+            ? Prompt.makeMessage("tool", {
+                content: message.content.map((part) =>
+                  part.type === "tool-result" ? { ...part, isFailure: true } : part,
+                ),
+              })
+            : message,
+        );
+
+        const turn = yield* turnCanonicalBatch(
+          turnInput(failedTurn, 1, RUN_ID, {
+            inputTokens: 12,
+            outputTokens: 3,
+          }),
+        );
+
+        const envelopes = envelopesOf([turn]);
+        const uncompacted = yield* projectRunJournal(envelopes, RUN_ID);
+
+        const compacted = yield* projectRunJournal(
+          [
+            ...envelopes,
+            envelopeAt(
+              envelopes.length + 1,
+              auditRecord(
+                "later-run-summary",
+                compactionPayload({ coversThrough: envelopes.length }),
+              ),
+            ),
+          ],
+          RUN_ID,
+        );
+
+        expect(compacted.policyUsage).toEqual(uncompacted.policyUsage);
+        expect(compacted.policyUsage).toMatchObject({
+          committedTurns: 1,
+          toolCalls: 1,
+          consecutiveToolFailures: 1,
+        });
+        expect(compacted.usage).toEqual(uncompacted.usage);
+        expect(promptText(compacted.prompt)).toContain("Goal: book the Kyoto trip");
+        expect(toolResults(compacted.prompt)).toEqual([]);
+      }),
+    );
+
     it.effect("RUN-026: a summarize compaction folds covered records into the summary", () =>
       Effect.gen(function* () {
         const turnOne = yield* turnCanonicalBatch(turnInput(toolTurnAppended));
@@ -1136,7 +1184,7 @@ describe("engine compaction records and projection (RUN-026)", () => {
 
           expect(promptText(projected.prompt)).toContain("Goal: book the Kyoto trip");
           expect(toolResults(projected.prompt)).toEqual([]);
-          expect(traversals).toBeLessThanOrEqual(4);
+          expect(traversals).toBe(2);
 
           const split = envelopeAt(
             records.length + 1,


### PR DESCRIPTION
Durable attempts reuse their addressed control records and read only newly appended canonical suffixes at later control checks. Journal reconstruction uses two fixed-prefix traversals, collecting compaction and settlement metadata before decoding uncovered responses and rebuilding the prompt. This preserves covered-history handling without loading the full canonical log into an attempt cache.

The metadata pass remains necessary to validate compaction coverage before decoding historical responses that may have been superseded. A full-history cache would retain the payloads this change aims to avoid.

Abort polling uses a new `SubmissionLedger.readAbortIntent` operation. Memory reads the addressed entry directly; SQLite and Durable Object adapters issue one joined query and decode only the abort fields. The canonical abort record remains the proof required before interruption. Adapter routing and the Node runtime forward the new operation.

```ts
const ledger = yield* SubmissionLedger
const intent = yield* ledger.readAbortIntent(
  AbortIntentRequest.make({ submissionId }),
)
```

Custom SubmissionLedger implementations must add this method. Unknown submissions fail with `LedgerError`; an existing submission without an abort intent returns `undefined`.

`PersistentHistory` encodes only the appended suffix of each staged prompt. Replacing or shortening a prompt re-encodes from its first changed message. Full aggregate persistence validation still runs at each update, preserving the existing byte, depth, node and collection limits before the next model or tool call.

```mermaid
flowchart LR
  Prefix[Fixed canonical prefix] --> Metadata[Compaction and settlement metadata]
  Prefix --> Projection[Decode uncovered responses once]
  Metadata --> Projection
  Controls[Attempt control evidence] --> Suffix[Refresh appended suffix only]
  Prompt[Staged prompt] --> Encode[Encode changed suffix]
  Encode --> Validate[Validate entire staged value]
```

A local Node 24.20.0 ARM64 memory-store diagnostic counted work between `processThread` entry and the first model stream call after submission. History fixtures contained a `ThreadCreated` record followed by repair annotations with 128-byte text. Each size used five samples in separate baseline and candidate processes:

| History records | Page reads before / after | Returned rows before / after | Returned JSON bytes before / after |
| ---: | ---: | ---: | ---: |
| 1 | 8 / 5 | 21 / 9 | 9,978 / 4,215 |
| 11 | 8 / 5 | 101 / 39 | 47,585 / 18,321 |
| 2,051 | 24 / 11 | 16,421 / 6,159 | 7,958,219 / 2,984,820 |

Byte counts sum the UTF-8 JSON size of each returned envelope, including repeated reads. A separate clock-only cohort removed the complete counting wrapper and measured startup over three warmups plus ten samples per case:

| History records | Baseline median ms | Baseline range ms | Candidate median ms | Candidate range ms |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1.795 | 1.520 to 2.710 | 1.694 | 1.387 to 2.341 |
| 11 | 1.672 | 1.426 to 3.458 | 1.508 | 1.348 to 1.719 |
| 2,051 | 17.774 | 16.837 to 18.159 | 11.941 | 11.533 to 13.096 |

At 2,051 records the uninstrumented local startup median fell 32.8%; the small-case ranges overlap. Timing ends on the first model-stream pull, before response parts, and excludes seeding, submission, and result-file writing. All warmups and samples were retained. Hosted database latency and wire traffic were not measured.

An independent encoding diagnostic counted 55 to 10 payload visits over 10 append-only turns, 1,275 to 50 over 50 turns, and 5,050 to 100 over 100 turns. Both 128-byte and 8 KiB additions showed the same counts. Aggregate validation still visits the staged value on every update. Forced-GC timing and staging-heap samples were noisy, so no total-latency or heap improvement is claimed for this change.

The commit closure now retains scalar tail fences instead of the exported history object. A SQLite fixture with eighty 32 KiB discarded annotations retained 8,031,040 bytes before and 8,028,768 bytes after the change, effectively unchanged. Heap snapshots showed statement-cache fibers retaining completed tracing results containing exported records, outside this closure. No speculative retention helper was added.

Validation passed with 52 focused history, journal, and startup tests, the adapter contracts, and `vp run ready`. The public startup-work guard and unchanged-message encoding regression fail before their fixes. Coverage includes covered-owner policy accounting, compaction boundaries, canonical abort proof, unknown submissions, single-query SQL reads, replacement/shortening, and rollback after an oversized staged update. Independent source review found no further correctness issues.

Parallel full gates intermittently failed an unchanged Cloudflare alarm test, once observing an already settled submission and once a cleared alarm. The complete Cloudflare package then passed in isolation with 419 tests and two existing skips. The final full gate passed with that unchanged validated task cached. A separate [test clock fix](https://github.com/danieljvdm/effect-agent/pull/330) now covers the mismatch between initialization and event clocks with a deterministic regression.
