### PR TITLE
fix(engine): enforce prepared context and summary budgets

### DIFF
--- a/.changeset/protect-prepared-context.md
+++ b/.changeset/protect-prepared-context.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/engine": patch
+---
+
+Enforce prepared-context limits and preserve protected history while reusing per-turn context estimates. Bound default summarizer requests to 80,000 characters and reject summaries above 65,536 characters.
+
+BEHAVIOR CHANGE: Custom compaction strategies must emit summaries of at most 65,536 characters. Preparation hooks must preserve covered prefixes after compaction and retain a mappable instruction/input block for nondurable compaction.

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -78,6 +78,14 @@ For durable execution, install `MetricContextLive` when [configuring the runtime
 Transforms change the model prompt, not stored input or history. Use
 [`inputPrompt`](./agents#choose-model-visible-input) to choose which input fields the model sees.
 
+Prepared prompts receive fresh context estimates, including replacement content. For nondurable
+compaction, retain the original instruction/input messages or an unambiguous, content-equivalent
+ordering of them. The engine rejects compaction with `CompactionError` when that block cannot be
+mapped safely. Original message identities disambiguate repeated instructions or input text.
+After compaction, preparation must preserve the content and order of the covered prefix. Rebuilding
+equivalent messages is supported; replacing, inserting into, or reordering that prefix fails before
+another model request. Durable reconstruction keeps its canonical coverage checks at commit time.
+
 ## Recall application-owned sources {#recall-memory}
 
 `Memory.recall` turns readable, application-selected sources into a bounded transient model view.
@@ -967,8 +975,10 @@ always fail because another model call would add time or cost.
 
 ## Compaction
 
-With `contextTokenLimit`, the engine estimates the next prompt before every turn. It starts from
-the last provider-reported input and estimates appended content. The default compactor then:
+With `contextTokenLimit`, the engine estimates the next prompt before every turn. Ordinary
+append-only history starts from the last provider-reported input and estimates appended content.
+Preparation and transient-context hooks use a fresh estimate. Within a turn, the engine reuses
+the history view and estimate until compaction changes them. The default compactor then:
 
 1. clears old application tool results outside the protected `keepRecentTokens` tail while keeping
    message structure and call/result pairs;
@@ -981,7 +991,16 @@ the same compacted view.
 
 A summary must finish successfully and contain non-whitespace text. The interpreter charges its
 usage before validating it. A rejected summary leaves the previous summary and coverage in place;
-already committed pruning remains. Durable summaries are limited to 65,536 characters.
+already committed pruning remains. All summaries, including custom strategy decisions, are limited
+to 65,536 characters and fail with `CompactionError` above that bound. Summaries are never silently
+truncated to fit.
+
+The complete default summarizer request fits within 80,000 characters, including instructions,
+transcript delimiters, and the previous summary. It retains the oldest and newest covered messages
+and marks the omitted middle. Message and string-result previews are clipped before rendering;
+oversized structured tool results receive an explicit omission marker. An oversized previous summary
+is rejected before rendering. These limits change only the model view, leaving canonical evidence
+intact.
 
 If the provider reports context overflow, the engine may compact and retry once. Transport
 ambiguity can duplicate that model call. A second rejection, or overflow without

--- a/packages/engine/src/ContextCompactor.ts
+++ b/packages/engine/src/ContextCompactor.ts
@@ -7,20 +7,26 @@ import {
   choosePruneBound,
   chooseSummarizeCut,
   collectCoveredMessages,
-  COMPACTION_INSTRUCTION,
   estimatePromptTokens,
   renderForSummary,
+  SUMMARY_MAX_LENGTH,
+  SUMMARY_REQUEST_PREFIX,
+  SUMMARY_REQUEST_SUFFIX,
   type ContextCompactionState,
 } from "./internal/compaction.ts";
 
-/** A proposed view change. Source indices are exclusive prefix bounds, never record sequences. */
+/**
+ * A proposed view change. Source indices are exclusive prefix bounds, never record sequences.
+ * Summaries contain at most 65,536 characters; the interpreter rejects oversized decisions
+ * before committing or changing coverage.
+ */
 export const CompactionDecision = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("clear-tool-results"), through: Schema.Natural }),
   Schema.Struct({
     kind: Schema.Literal("summarize"),
     through: Schema.Natural,
     summary: Schema.NonEmptyString.check(
-      Schema.isMaxLength(8 * 1024 * 1024),
+      Schema.isMaxLength(SUMMARY_MAX_LENGTH),
       Schema.isPattern(/\S/),
     ),
   }),
@@ -111,11 +117,17 @@ const defaultCompactor = (model?: CompactionModelLayer): ContextCompaction => ({
               if (covered.length === 0) return Stream.empty;
               const transcript = renderForSummary(covered, state.summary);
 
+              if (transcript === undefined) {
+                return yield* CompactionError.make({
+                  message: `Previous compaction summary exceeds ${SUMMARY_MAX_LENGTH} characters`,
+                });
+              }
+
               const prompt = Prompt.fromMessages([
                 Prompt.userMessage({
                   content: [
                     Prompt.textPart({
-                      text: `${COMPACTION_INSTRUCTION}\n\n<transcript>\n${transcript}\n</transcript>`,
+                      text: `${SUMMARY_REQUEST_PREFIX}${transcript}${SUMMARY_REQUEST_SUFFIX}`,
                     }),
                   ],
                 }),

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -213,7 +213,11 @@ export interface PreparedRunContext {
   readonly prompt: Prompt.Prompt;
 }
 
-/** Dependency-neutral ordered context transformation / compaction hook. */
+/**
+ * Model-only prompt transformation. Compaction requires a safely mapped original
+ * instruction/input block and content-equivalent covered prefixes across Turns.
+ * Incompatible changes fail with CompactionError before compaction or model I/O.
+ */
 export interface RunContextHook<Error = never, Requirements = never> {
   readonly prepare: (
     request: RunContextRequest,

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -76,6 +76,7 @@ import {
   DateTime,
   Duration,
   Effect,
+  Equal,
   Exit,
   Fiber,
   Metric,
@@ -431,6 +432,14 @@ interface RunContext {
   exhaustedDimension: "tokens" | "tool-calls" | "turns" | undefined;
   /** Model-visible view state for engine-native compaction (RUN-026). */
   readonly compaction: ContextCompactionState;
+  /** Owned content snapshots bind disposable compaction indices to prepared history. */
+  preparedCompactionSource:
+    | {
+        readonly protectedReferences: ReadonlyArray<Prompt.Message>;
+        readonly protectedMessages: ReadonlyArray<Schema.Json>;
+        prefix: ReadonlyArray<Schema.Json>;
+      }
+    | undefined;
   readonly compactor: ContextCompactor["Service"];
   /** One allowance shared by threshold compaction and the same Turn's overflow retry. */
   readonly compactionTurn: {
@@ -3145,6 +3154,21 @@ const nextContextEstimate = Effect.fn("AgentRuntime.nextContextEstimate")(functi
   return yield* estimateContextTokens(context, view);
 });
 
+const snapshotCompactionMessages = Effect.fnUntraced(function* (
+  messages: ReadonlyArray<Prompt.Message>,
+) {
+  return yield* Effect.try({
+    try: () =>
+      messages.map((message) =>
+        Schema.decodeUnknownSync(Schema.Json)(
+          JSON.parse(JSON.stringify(Schema.encodeSync(Prompt.Message)(message))),
+        ),
+      ),
+    catch: (cause) =>
+      CompactionError.make({ message: "Could not snapshot prepared compaction history", cause }),
+  });
+});
+
 /** Text a provider overflow classification matches against (message + reason). */
 const overflowText = (error: AiError.AiError): string => `${error.message} ${error.reason.message}`;
 
@@ -3177,6 +3201,85 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
     const events: Array<RunEvent> = [];
     const messages = source.content;
     const allowance = context.compactionTurn;
+    const preparedSource = context.preparedCompactionSource;
+
+    const preparedSnapshot =
+      preparedSource === undefined ? undefined : yield* snapshotCompactionMessages(messages);
+
+    if (preparedSource !== undefined && preparedSnapshot !== undefined) {
+      let start = -1;
+      let end = 0;
+      let mapped = true;
+      const positions: Array<number> = [];
+
+      const originalPositions = preparedSource.protectedReferences.map((message) =>
+        messages.indexOf(message),
+      );
+
+      const originalMapping = preparedSource.protectedReferences.every((message, position) => {
+        const index = originalPositions[position];
+
+        return (
+          index !== undefined &&
+          index >= 0 &&
+          index > (originalPositions[position - 1] ?? -1) &&
+          messages.lastIndexOf(message) === index &&
+          Equal.equals(preparedSnapshot[index], preparedSource.protectedMessages[position])
+        );
+      });
+
+      for (
+        let position = 0;
+        !originalMapping && position < preparedSource.protectedMessages.length;
+        position += 1
+      ) {
+        const protectedMessage = preparedSource.protectedMessages[position];
+
+        const index = preparedSnapshot.findIndex(
+          (message, index) => index >= end && Equal.equals(message, protectedMessage),
+        );
+
+        if (index < 0) {
+          mapped = false;
+          break;
+        }
+        if (start < 0) start = index;
+        end = index + 1;
+        positions.push(index);
+      }
+      let reverseEnd = preparedSnapshot.length;
+
+      for (
+        let position = preparedSource.protectedMessages.length - 1;
+        !originalMapping && mapped && position >= 0;
+        position -= 1
+      ) {
+        const protectedMessage = preparedSource.protectedMessages[position];
+
+        const index = preparedSnapshot.findLastIndex(
+          (message, index) => index < reverseEnd && Equal.equals(message, protectedMessage),
+        );
+
+        if (index !== positions[position]) mapped = false;
+        reverseEnd = index;
+      }
+      if (originalMapping) {
+        mapped = true;
+        start = originalPositions[0] ?? -1;
+        end = (originalPositions.at(-1) ?? -1) + 1;
+      }
+      if (!mapped && options.durability === undefined) {
+        return yield* CompactionError.make({
+          message:
+            "Prepared context cannot map the protected instructions and input for compaction",
+        });
+      }
+      // Durable reconstruction can replace this Attempt's evaluated block. Its
+      // commit hook remains responsible for rejecting coverage of the owner Run.
+      state.protectedStart = mapped ? start : -1;
+      state.protectedEnd = mapped ? end : -1;
+      state.protectSystemMessages = true;
+    }
 
     if (allowance.turn !== turn) {
       allowance.turn = turn;
@@ -3401,6 +3504,12 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
             if (options.durability !== undefined)
               yield* options.durability.commitCompaction(commit);
             Object.assign(state, next);
+            if (preparedSource !== undefined && preparedSnapshot !== undefined) {
+              preparedSource.prefix = preparedSnapshot.slice(
+                0,
+                Math.max(next.clearedThrough, next.summarizedThrough),
+              );
+            }
             applied.add(decision.kind);
             events.push(
               CompactionPerformed.make({
@@ -4339,6 +4448,20 @@ const makeTurn = <
       const modelContext =
         options.context === undefined ? { prompt } : yield* options.context.prepare(contextRequest);
 
+      const priorCompactionPrefix = context.preparedCompactionSource?.prefix;
+
+      if (priorCompactionPrefix !== undefined && priorCompactionPrefix.length > 0) {
+        const preparedPrefix = yield* snapshotCompactionMessages(
+          modelContext.prompt.content.slice(0, priorCompactionPrefix.length),
+        );
+
+        if (!Equal.equals(preparedPrefix, priorCompactionPrefix)) {
+          return yield* CompactionError.make({
+            message: "Prepared context changed a prefix already covered by compaction",
+          });
+        }
+      }
+
       const trace: TurnTrace = {
         responsePartCount: 0,
         responsePartBytes: 0,
@@ -4426,37 +4549,57 @@ const makeTurn = <
       // The output contract (RUN-028) rides every outgoing request after
       // compaction, so the view must fit the limit with the contract the
       // engine will append.
+      const admissionRequired =
+        policy.contextTokenLimit !== undefined ||
+        (!context.finalizing && !finalAnswerOnly && policy.tokenBudget !== undefined);
+
       const outputContractTokens =
-        outputContractMessage === undefined
+        !admissionRequired || outputContractMessage === undefined
           ? 0
           : yield* estimateContextTokens(context, [
               Prompt.makeMessage("system", { content: outputContractMessage }),
             ]);
 
-      const canonicalDecoration = yield* outgoingModelPrompt(
-        policy,
-        context,
-        Prompt.empty,
-        turn,
-        priorToolCalls,
-      );
+      const canonicalDecoration = !admissionRequired
+        ? Prompt.empty
+        : yield* outgoingModelPrompt(policy, context, Prompt.empty, turn, priorToolCalls);
 
-      const canonicalDecorationTokens =
-        outputContractTokens + (yield* estimateContextTokens(context, canonicalDecoration.content));
+      const canonicalDecorationTokens = !admissionRequired
+        ? 0
+        : outputContractTokens +
+          (yield* estimateContextTokens(context, canonicalDecoration.content));
 
-      // Provider-reported input usage includes the previous Turn's transient
-      // context, whose size can change independently of canonical history.
-      // A fresh full estimate avoids carrying that stale amount into this
-      // Turn's admission. Runs without transient context retain the anchored
-      // estimate used by existing context economics.
+      // Preparation may replace an existing prefix, and transient context may
+      // change independently of history. Only ordinary append-only history can
+      // reuse the last provider-reported input as an estimation anchor.
       const estimateSourceContext = (view: ReadonlyArray<Prompt.Message>) =>
-        options.transientContext === undefined
+        options.context === undefined && options.transientContext === undefined
           ? nextContextEstimate(context, view)
           : estimateContextTokens(context, view);
 
+      let prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
+      let sourceTokens: number | undefined;
+
+      const preparedSourceTokens = Effect.suspend(() =>
+        sourceTokens === undefined
+          ? estimateSourceContext(prepared).pipe(
+              Effect.tap((tokens) =>
+                Effect.sync(() => {
+                  sourceTokens = tokens;
+                }),
+              ),
+            )
+          : Effect.succeed(sourceTokens),
+      );
+
+      const refreshPrepared = () => {
+        prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
+        sourceTokens = undefined;
+      };
+
       let preEvents: ReadonlyArray<RunEvent> = [];
 
-      if (!context.finalizing) {
+      if (!context.finalizing && admissionRequired) {
         const consumedTokens = context.inputTokens + context.outputTokens;
 
         const tokenCallTarget =
@@ -4478,8 +4621,7 @@ const makeTurn = <
             ? undefined
             : Math.max(0, fullTarget - canonicalDecorationTokens);
 
-        const view = buildCompactedView(modelContext.prompt.content, context.compaction);
-        const estimate = (yield* estimateSourceContext(view)) + canonicalDecorationTokens;
+        const estimate = (yield* preparedSourceTokens) + canonicalDecorationTokens;
         const contextPressure = contextCallTarget !== undefined && estimate > contextCallTarget;
         const tokenPressure = tokenCallTarget !== undefined && estimate > tokenCallTarget;
 
@@ -4506,11 +4648,11 @@ const makeTurn = <
           );
 
           preEvents = outcome.events;
+          if (outcome.events.some((event) => event._tag === "CompactionPerformed"))
+            refreshPrepared();
         }
-        const prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
 
-        const preparedEstimate =
-          (yield* estimateSourceContext(prepared)) + canonicalDecorationTokens;
+        const preparedEstimate = (yield* preparedSourceTokens) + canonicalDecorationTokens;
 
         // A summarizing compaction is itself a priced model call. Recompute
         // admission from its reported usage instead of carrying the stale
@@ -4564,12 +4706,13 @@ const makeTurn = <
           ? canonicalDecoration
           : yield* outgoingModelPrompt(policy, context, transientContext, turn, priorToolCalls);
 
-      const derivedPromptTokens =
-        options.transientContext === undefined
+      const derivedPromptTokens = !admissionRequired
+        ? 0
+        : options.transientContext === undefined
           ? canonicalDecorationTokens
           : outputContractTokens + (yield* estimateContextTokens(context, derivedPrompt.content));
 
-      if (!context.finalizing && options.transientContext !== undefined) {
+      if (!context.finalizing && admissionRequired && options.transientContext !== undefined) {
         const contextTokenLimit = policy.contextTokenLimit;
 
         const tokenCallTarget =
@@ -4592,8 +4735,7 @@ const makeTurn = <
         const sourceTarget =
           fullTarget === undefined ? undefined : Math.max(0, fullTarget - derivedPromptTokens);
 
-        let prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
-        let preparedEstimate = (yield* estimateSourceContext(prepared)) + derivedPromptTokens;
+        let preparedEstimate = (yield* preparedSourceTokens) + derivedPromptTokens;
 
         const contextPressure =
           contextTokenLimit !== undefined && preparedEstimate > contextTokenLimit;
@@ -4631,8 +4773,9 @@ const makeTurn = <
           );
 
           preEvents = [...preEvents, ...outcome.events];
-          prepared = buildCompactedView(modelContext.prompt.content, context.compaction);
-          preparedEstimate = (yield* estimateSourceContext(prepared)) + derivedPromptTokens;
+          if (outcome.events.some((event) => event._tag === "CompactionPerformed"))
+            refreshPrepared();
+          preparedEstimate = (yield* preparedSourceTokens) + derivedPromptTokens;
         }
         if (context.tokenExhausted) {
           finalAnswerOnly = true;
@@ -4686,11 +4829,9 @@ const makeTurn = <
 
       /** The model-visible view of the Turn basis under current compaction state. */
       const compactedOutgoing = (): Prompt.Prompt => {
-        const view = buildCompactedView(modelContext.prompt.content, context.compaction);
+        context.compaction.lastViewLength = prepared.length;
 
-        context.compaction.lastViewLength = view.length;
-
-        return Prompt.fromMessages([...view]);
+        return Prompt.fromMessages(prepared);
       };
 
       const attempt = (basis: Prompt.Prompt) =>
@@ -4714,22 +4855,23 @@ const makeTurn = <
                   ? outgoing
                   : insertOutputContract(outgoing, outputContractMessage);
 
-              // Transient context can change independently at every Turn. A
+              // Prepared and transient context can change at every Turn. A
               // final full-prompt check closes the per-call boundary for grace
               // finalization and any future path that bypasses research
-              // compaction admission. Runs without this hook keep their
+              // compaction admission. Runs without either hook keep their
               // provider-reported incremental estimate.
               const contextTokenLimit = policy.contextTokenLimit;
 
               const admission =
-                options.transientContext === undefined || contextTokenLimit === undefined
+                (options.context === undefined && options.transientContext === undefined) ||
+                contextTokenLimit === undefined
                   ? Effect.void
                   : estimateContextTokens(context, providerPrompt.content).pipe(
                       Effect.flatMap((estimatedTokens) =>
                         estimatedTokens <= contextTokenLimit
                           ? Effect.void
                           : ContextBudgetError.make({
-                              message: `Transient context could not fit the next model prompt inside the ${contextTokenLimit} token context target`,
+                              message: `Prepared context could not fit the next model prompt inside the ${contextTokenLimit} token context target`,
                               estimatedTokens,
                               targetTokens: contextTokenLimit,
                               completionReserveTokens: policy.completionReserveTokens,
@@ -4854,13 +4996,10 @@ const makeTurn = <
                   ),
                 );
 
-                const retryView = buildCompactedView(
-                  modelContext.prompt.content,
-                  context.compaction,
-                );
+                if (outcome.events.some((event) => event._tag === "CompactionPerformed"))
+                  refreshPrepared();
 
-                const retryEstimate =
-                  (yield* estimateSourceContext(retryView)) + derivedPromptTokens;
+                const retryEstimate = (yield* preparedSourceTokens) + derivedPromptTokens;
 
                 if (retryEstimate > contextTokenLimit) {
                   return yield* ContextBudgetError.make({
@@ -6214,6 +6353,7 @@ function streamWithCompletion<
             tokenExhausted: false,
             exhaustedDimension: undefined,
             compaction: initialCompactionState(),
+            preparedCompactionSource: undefined,
             compactionTurn: { turn: 0, summaryCalls: 0, applied: new Set() },
             compactor,
             bufferLimits: effectiveRunBufferLimits(options.bufferLimits),
@@ -6332,13 +6472,22 @@ function streamWithCompletion<
               const priorHistoryLength = context.history.content.length;
               const prompt = yield* makeInitialPrompt(instructions, inputPrompt, context.history);
 
-              // RUN-022: the instruction/input block is protected from compaction
-              // by source index. A hook-prepared prompt (durable resume) replaces
-              // the source, so index protection is unavailable there and the view
-              // falls back to protecting system-role messages.
+              // Ordinary history keeps stable indices. Prepared history must map
+              // an owned copy of this block before applying compaction coverage.
               if (options.context === undefined) {
                 context.compaction.protectedStart = priorHistoryLength;
                 context.compaction.protectedEnd = prompt.content.length;
+              } else if (
+                agent.definition.policy.contextTokenLimit !== undefined ||
+                agent.definition.policy.tokenBudget !== undefined
+              ) {
+                context.preparedCompactionSource = {
+                  protectedReferences: prompt.content.slice(priorHistoryLength),
+                  protectedMessages: yield* snapshotCompactionMessages(
+                    prompt.content.slice(priorHistoryLength),
+                  ),
+                  prefix: [],
+                };
               }
               yield* advanceHistory(context, prompt, options);
               if (resumed !== undefined) {

--- a/packages/engine/src/internal/compaction.ts
+++ b/packages/engine/src/internal/compaction.ts
@@ -1,5 +1,7 @@
 import { Prompt } from "effect/unstable/ai";
 
+import { boundedCanonicalJsonSnapshot } from "./provider-result-staging.ts";
+
 /**
  * Pure helpers for engine-native context compaction (RUN-026/RUN-027). Everything here is deterministic and side-effect free:
  * the engine's turn loop owns the state transitions, the durable coordinator
@@ -92,18 +94,20 @@ export const estimatePromptTokens = (messages: ReadonlyArray<Prompt.Message>): n
 /**
  * Mutable per-Run compaction state held on the engine's RunContext. Indices
  * are positions in the SOURCE prompt (the official-history basis handed to
- * each Turn), which grows append-only within an Attempt, so recorded indices
- * stay valid across Turns.
+ * each Turn). Ordinary history grows append-only. Prepared history must retain
+ * content-equivalent covered prefixes or the engine rejects the next Turn.
  */
 export interface ContextCompactionState {
   /**
    * Source-index bounds `[start, end)` of the protected instruction/input
-   * block. `-1` when the source is hook-prepared (durable resume): the block
-   * cannot be located by index there, so protection falls back to
-   * system-role messages.
+   * block, mapped to prepared indices when necessary. `-1` when durable
+   * reconstruction cannot locate it: its commit hook protects owner-Run
+   * records, and the view retains system-role messages.
    */
   protectedStart: number;
   protectedEnd: number;
+  /** Prepared prompts also retain application-added system instructions. */
+  protectSystemMessages?: boolean;
   /** Tool messages at source index below this bound render as cleared. */
   clearedThrough: number;
   /**
@@ -141,6 +145,7 @@ const isProtected = (
   source: ReadonlyArray<Prompt.Message>,
   index: number,
 ): boolean => {
+  if (state.protectSystemMessages && source[index]?.role === "system") return true;
   if (state.protectedStart >= 0) {
     return index >= state.protectedStart && index < state.protectedEnd;
   }
@@ -198,7 +203,19 @@ export const buildCompactedView = (
   const view: Array<Prompt.Message> = [];
 
   if (state.summary !== undefined && state.summarizedThrough > 0) {
-    for (let index = 0; index < state.summarizedThrough && index < source.length; index += 1) {
+    const protectedStart =
+      state.protectedStart >= 0 && !state.protectSystemMessages ? state.protectedStart : 0;
+
+    const protectedEnd =
+      state.protectedStart >= 0 && !state.protectSystemMessages
+        ? state.protectedEnd
+        : state.summarizedThrough;
+
+    for (
+      let index = protectedStart;
+      index < Math.min(protectedEnd, state.summarizedThrough, source.length);
+      index += 1
+    ) {
       const message = source[index];
 
       if (message !== undefined && isProtected(state, source, index)) {
@@ -341,6 +358,15 @@ export const collectCoveredMessages = (
 
 const SUMMARY_TOOL_RESULT_CLIP = 2_000;
 
+const jsonPreview = (value: unknown, limit: number): string => {
+  if (typeof value === "string") return JSON.stringify(value.slice(0, limit)).slice(0, limit);
+  const snapshot = boundedCanonicalJsonSnapshot(value, limit);
+
+  return snapshot === undefined
+    ? "[omitted oversized or unsupported JSON]"
+    : JSON.stringify(snapshot.value);
+};
+
 const partText = (part: Prompt.Message["content"][number] | string): string => {
   if (typeof part === "string") return part;
   switch (part.type) {
@@ -351,26 +377,10 @@ const partText = (part: Prompt.Message["content"][number] | string): string => {
       return "";
     }
     case "tool-call": {
-      let params: string;
-
-      try {
-        params = JSON.stringify(part.params) ?? "";
-      } catch {
-        params = "";
-      }
-
-      return `[tool call ${part.name} ${params.slice(0, 500)}]`;
+      return `[tool call ${part.name.slice(0, 500)} ${jsonPreview(part.params, 500)}]`;
     }
     case "tool-result": {
-      let result: string;
-
-      try {
-        result = JSON.stringify(part.result) ?? "";
-      } catch {
-        result = "";
-      }
-
-      return `[tool result ${part.name}: ${result.slice(0, SUMMARY_TOOL_RESULT_CLIP)}]`;
+      return `[tool result ${part.name.slice(0, 500)}: ${jsonPreview(part.result, SUMMARY_TOOL_RESULT_CLIP)}]`;
     }
     default: {
       return `[${part.type}]`;
@@ -379,15 +389,36 @@ const partText = (part: Prompt.Message["content"][number] | string): string => {
 };
 
 /**
- * Total character budget for one summarizer request, the fixed instruction
- * and previous summary counted first. Deterministic and provider-agnostic:
- * ~80k chars is ~20k tokens, far inside every supported window, so the
- * overflow-recovery summarization can never itself overflow.
+ * Character budget for the complete default summarizer request, including
+ * its instruction, transcript delimiters, previous summary, and elision marker.
  */
 export const SUMMARY_INPUT_BUDGET = 80_000;
+export const SUMMARY_MAX_LENGTH = 65_536;
+export const SUMMARY_REQUEST_PREFIX = `${COMPACTION_INSTRUCTION}\n\n<transcript>\n`;
+export const SUMMARY_REQUEST_SUFFIX = "\n</transcript>";
 
 const SUMMARY_MESSAGE_CLIP = 2_000;
 const SUMMARY_ELISION_RESERVE = 128;
+
+const summaryBlock = (message: Prompt.Message): string => {
+  let text = "";
+
+  if (typeof message.content === "string") {
+    text = message.content.slice(0, SUMMARY_MESSAGE_CLIP + 1);
+  } else {
+    for (const part of message.content) {
+      const piece = partText(part);
+
+      if (piece.length === 0) continue;
+      if (text.length > 0) text += "\n";
+      text += piece.slice(0, SUMMARY_MESSAGE_CLIP + 1 - text.length);
+      if (text.length > SUMMARY_MESSAGE_CLIP) break;
+    }
+  }
+  if (text.length === 0) return "";
+
+  return `[${message.role}]\n${text.length > SUMMARY_MESSAGE_CLIP ? `${text.slice(0, SUMMARY_MESSAGE_CLIP)}…` : text}`;
+};
 
 /**
  * Render the covered span as plain text for the summarizer call, bounded
@@ -396,89 +427,73 @@ const SUMMARY_ELISION_RESERVE = 128;
  * `SUMMARY_INPUT_BUDGET` with middle-out retention — oldest and newest
  * blocks survive, the middle collapses into one deterministic elision
  * marker. A previous summary is folded in first so nothing silently drops
- * out of coverage across repeated compactions.
+ * out of coverage across repeated compactions. An oversized previous summary
+ * returns undefined before rendering: callers must reject it, never truncate it.
  */
 export const renderForSummary = (
   covered: ReadonlyArray<Prompt.Message>,
   previousSummary: string | undefined,
-): string => {
+): string | undefined => {
+  if (previousSummary !== undefined && previousSummary.length > SUMMARY_MAX_LENGTH)
+    return undefined;
   const joiner = "\n\n";
-  const blocks: Array<string> = [];
-
-  for (const message of covered) {
-    const text =
-      typeof message.content === "string"
-        ? message.content
-        : message.content
-            .map((part) => partText(part))
-            .filter((piece) => piece.length > 0)
-            .join("\n");
-
-    if (text.length === 0) continue;
-
-    const clipped =
-      text.length > SUMMARY_MESSAGE_CLIP ? `${text.slice(0, SUMMARY_MESSAGE_CLIP)}…` : text;
-
-    blocks.push(`[${message.role}]\n${clipped}`);
-  }
 
   const previousBlock =
     previousSummary === undefined ? undefined : `[Previous summary]\n${previousSummary}`;
 
   const fixed =
     (previousBlock === undefined ? 0 : previousBlock.length + joiner.length) +
-    COMPACTION_INSTRUCTION.length;
+    SUMMARY_REQUEST_PREFIX.length +
+    SUMMARY_REQUEST_SUFFIX.length;
 
   const budget = SUMMARY_INPUT_BUDGET - fixed - SUMMARY_ELISION_RESERVE;
-  let selected: ReadonlyArray<string> = blocks;
-  let total = 0;
+  const head: Array<string> = [];
+  const tail: Array<string> = [];
+  let length = 0;
+  let start = 0;
+  let end = covered.length - 1;
+  let boundaryBlock: string | undefined;
 
-  for (const block of blocks) {
-    total += block.length + joiner.length;
-  }
-  if (total > budget) {
-    const head: Array<string> = [];
-    const tail: Array<string> = [];
-    let headLength = 0;
-    let tailLength = 0;
-    let start = 0;
-    let end = blocks.length - 1;
-    const half = Math.floor(budget / 2);
+  while (start <= end) {
+    const message = covered[start];
+    const block = message === undefined ? "" : summaryBlock(message);
 
-    while (start <= end) {
-      const candidate = blocks[start];
-
-      if (candidate === undefined || headLength + candidate.length + joiner.length > half) break;
-      head.push(candidate);
-      headLength += candidate.length + joiner.length;
-      start += 1;
+    if (block.length > 0 && length + block.length + joiner.length > Math.floor(budget / 2)) {
+      boundaryBlock = block;
+      break;
     }
-    while (end >= start) {
-      const candidate = blocks[end];
-
-      if (
-        candidate === undefined ||
-        headLength + tailLength + candidate.length + joiner.length > budget
-      ) {
-        break;
-      }
-      tail.unshift(candidate);
-      tailLength += candidate.length + joiner.length;
-      end -= 1;
+    if (block.length > 0) {
+      head.push(block);
+      length += block.length + joiner.length;
     }
-    const omitted = end - start + 1;
-
-    selected =
-      omitted > 0
-        ? [...head, `[… ${omitted} messages omitted from summary input …]`, ...tail]
-        : [...head, ...tail];
+    start += 1;
   }
+  while (end >= start) {
+    const message = covered[end];
+
+    const block =
+      end === start && boundaryBlock !== undefined
+        ? boundaryBlock
+        : message === undefined
+          ? ""
+          : summaryBlock(message);
+
+    if (block.length > 0 && length + block.length + joiner.length > budget) break;
+    if (block.length > 0) {
+      tail.push(block);
+      length += block.length + joiner.length;
+    }
+    end -= 1;
+  }
+  const omitted = end - start + 1;
   const lines: Array<string> = [];
 
   if (previousBlock !== undefined) {
     lines.push(previousBlock);
   }
-  lines.push(...selected);
+  lines.push(...head);
+  if (omitted > 0) lines.push(`[… ${omitted} messages omitted from summary input …]`);
+  lines.push(...tail.reverse());
 
   return lines.join(joiner);
 };

--- a/packages/engine/test/compaction.test.ts
+++ b/packages/engine/test/compaction.test.ts
@@ -1,5 +1,6 @@
 import * as Agent from "@effect-agent/core/Agent";
 import {
+  AgentPolicyError,
   ContextBudgetError,
   ContextOverflowError,
   ModelProtocolError,
@@ -18,6 +19,7 @@ import {
 import {
   type RunUsageDelta,
   type RunCompactionCommit,
+  type RunContextHook,
   type RunDurabilityHook,
   type RunTransientContextHook,
   type RunTurnUsage,
@@ -199,6 +201,8 @@ interface RunSetup {
   readonly noteTurnUsage?: (usage: RunTurnUsage) => Effect.Effect<void>;
   readonly consume?: (delta: RunUsageDelta) => Effect.Effect<void>;
   readonly transientContext?: RunTransientContextHook | undefined;
+  readonly context?: RunContextHook | undefined;
+  readonly history?: Prompt.Prompt | undefined;
 }
 
 const basePolicy = {
@@ -232,6 +236,7 @@ const driveRunWith = <Output extends Schema.Top>(output: Output, setup: RunSetup
     });
 
     const events = yield* Ref.make<ReadonlyArray<RunEvent>>([]);
+    const histories: Array<Prompt.Prompt> = [];
 
     const durability: RunDurabilityHook | undefined =
       commitCompaction === undefined
@@ -251,6 +256,9 @@ const driveRunWith = <Output extends Schema.Top>(output: Output, setup: RunSetup
       Agent.withModel(definition, model),
       { question: "compact?" },
       {
+        context: setup.context,
+        history: setup.history,
+        onHistory: (history) => Effect.sync(() => void histories.push(history)),
         ...(durability === undefined ? {} : { durability }),
         ...(setup.transientContext === undefined
           ? {}
@@ -266,7 +274,7 @@ const driveRunWith = <Output extends Schema.Top>(output: Output, setup: RunSetup
       Effect.exit,
     );
 
-    return { exit, requests, events: yield* Ref.get(events) };
+    return { exit, requests, histories, events: yield* Ref.get(events) };
   });
 
 /** Drive one scripted run and capture requests, events, and the exit. */
@@ -294,6 +302,318 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
     ],
     results: ["a".repeat(4_000), "b".repeat(4_000)],
   };
+
+  for (const limit of ["context", "reserve", "grace"] as const) {
+    it.effect(`admits replaced prepared content against the ${limit} limit`, () =>
+      Effect.gen(function* () {
+        const result = yield* driveRun({
+          policy: AgentPolicy.make({
+            ...basePolicy,
+            ...(limit === "reserve"
+              ? { tokenBudget: 3_000, completionReserveTokens: 1_000 }
+              : { contextTokenLimit: 2_000 }),
+            ...(limit === "grace"
+              ? { maxTurns: 1, onExhaustion: "final-answer" }
+              : { onExhaustion: "fail" }),
+            compaction: CompactionPolicy.make({ mode: "prune" }),
+          }),
+          context: {
+            prepare: ({ source, turn }) =>
+              Effect.succeed({
+                prompt: Prompt.fromMessages([
+                  Prompt.systemMessage({ content: turn === 1 ? "brief" : "GROWTH ".repeat(5_000) }),
+                  ...source.content,
+                ]),
+              }),
+          },
+          script: [
+            toolCallParts("s1", "search", {}, usageOf(100, 5)),
+            finalParts('{"answer":"unreachable"}'),
+          ],
+          results: ["small"],
+        });
+
+        expect(failureFrom(result.exit)).toBeInstanceOf(
+          limit === "reserve" ? AgentPolicyError : ContextBudgetError,
+        );
+        expect(result.requests).toHaveLength(1);
+        expect(JSON.stringify(result.histories)).not.toContain("GROWTH");
+      }),
+    );
+  }
+
+  for (const change of ["equivalent", "insert", "replace", "reorder"] as const) {
+    it.effect(`preserves protected prepared history across compaction: ${change}`, () =>
+      Effect.gen(function* () {
+        const result = yield* driveRun({
+          ...replacementSetup,
+          policy: AgentPolicy.make({
+            ...basePolicy,
+            contextTokenLimit: 2_000,
+            compaction: CompactionPolicy.make({ mode: "summarize", keepRecentTokens: 300 }),
+          }),
+          context: {
+            prepare: ({ source, turn }) => {
+              const messages = [...source.content];
+
+              if (turn === 4) {
+                if (change === "insert") {
+                  messages.splice(
+                    1,
+                    0,
+                    Prompt.userMessage({ content: [Prompt.textPart({ text: "UNRELATED" })] }),
+                  );
+                } else if (change === "replace") {
+                  messages[2] = Prompt.assistantMessage({
+                    content: [Prompt.textPart({ text: "UNRELATED" })],
+                  });
+                } else if (change === "reorder") {
+                  messages.splice(
+                    2,
+                    4,
+                    ...source.content.slice(4, 6),
+                    ...source.content.slice(2, 4),
+                  );
+                }
+              }
+
+              return Effect.succeed({
+                prompt: Schema.decodeUnknownSync(Prompt.Prompt)(
+                  JSON.parse(JSON.stringify({ content: messages })),
+                ),
+              });
+            },
+          },
+          script: [
+            toolCallParts("s1", "search", {}, usageOf(100, 5)),
+            toolCallParts("s2", "search", {}, usageOf(1_300, 5)),
+            toolCallParts("s3", "search", {}, usageOf(50, 5)),
+            finalParts('{"answer":"done"}'),
+          ],
+          results: ["a".repeat(4_000), "b".repeat(4_000), "small"],
+        }).pipe(
+          Effect.provideService(ContextCompactor, {
+            estimate: estimatePromptTokens,
+            compact: () =>
+              Stream.succeed({ kind: "summarize", through: 4, summary: "First result covered" }),
+          }),
+        );
+
+        expect(promptText(result.requests[2]?.prompt ?? Prompt.empty)).toContain("compact?");
+        if (change === "equivalent") {
+          if (Exit.isFailure(result.exit)) return yield* Effect.failCause(result.exit.cause);
+          expect(result.requests).toHaveLength(4);
+          expect(toolResultValues(result.requests[3]?.prompt ?? Prompt.empty)).toEqual([
+            "b".repeat(4_000),
+            "small",
+          ]);
+        } else {
+          expect(failureFrom(result.exit)).toBeInstanceOf(CompactionError);
+          expect(result.requests).toHaveLength(3);
+        }
+        expect(JSON.stringify(result.histories)).toContain("a".repeat(4_000));
+        expect(JSON.stringify(result.histories)).not.toContain("UNRELATED");
+      }),
+    );
+  }
+
+  it.effect("rejects compaction when preparation cannot map the protected input", () =>
+    Effect.gen(function* () {
+      const result = yield* driveRun({
+        ...replacementSetup,
+        context: {
+          prepare: ({ source }) =>
+            Effect.succeed({
+              prompt: Prompt.fromMessages(
+                source.content.map((message, index) =>
+                  index === 1
+                    ? Prompt.userMessage({
+                        content: [Prompt.textPart({ text: "replacement input" })],
+                      })
+                    : message,
+                ),
+              ),
+            }),
+        },
+      }).pipe(
+        Effect.provideService(ContextCompactor, {
+          estimate: estimatePromptTokens,
+          compact: () =>
+            Stream.succeed({ kind: "summarize", through: 4, summary: "unsafe replacement" }),
+        }),
+      );
+
+      expect(failureFrom(result.exit)).toBeInstanceOf(CompactionError);
+      expect(compactionEvents(result.events)).toEqual([]);
+      expect(JSON.stringify(result.histories)).toContain("compact?");
+    }),
+  );
+
+  it.effect("maps identity preparation to the current input when prior history repeats it", () =>
+    Effect.gen(function* () {
+      const result = yield* driveRun({
+        ...replacementSetup,
+        policy: AgentPolicy.make({
+          ...basePolicy,
+          contextTokenLimit: 2_000,
+          compaction: CompactionPolicy.make({ mode: "summarize", keepRecentTokens: 300 }),
+        }),
+        history: Prompt.fromMessages([
+          Prompt.systemMessage({
+            content: "Research the question with the search tool, then answer.",
+          }),
+          ...Prompt.make(JSON.stringify({ question: "compact?" })).content,
+        ]),
+        context: { prepare: ({ source }) => Effect.succeed({ prompt: source }) },
+      }).pipe(
+        Effect.provideService(ContextCompactor, {
+          estimate: estimatePromptTokens,
+          compact: () =>
+            Stream.succeed({
+              kind: "summarize",
+              through: 6,
+              summary: "Prior input and first search covered",
+            }),
+        }),
+      );
+
+      if (Exit.isFailure(result.exit)) return yield* Effect.failCause(result.exit.cause);
+      expect(result.requests).toHaveLength(3);
+      const outgoing = result.requests[2]?.prompt ?? Prompt.empty;
+
+      expect(
+        outgoing.content.filter(
+          (message) => messageText(message) === JSON.stringify({ question: "compact?" }),
+        ),
+      ).toHaveLength(1);
+      expect(toolResultValues(outgoing)).toEqual(["b".repeat(4_000)]);
+      expect(JSON.stringify(result.histories)).toContain("a".repeat(4_000));
+    }),
+  );
+
+  it.effect(
+    "omits oversized structured tool previews without changing summary source evidence",
+    () =>
+      Effect.gen(function* () {
+        const compactor = yield* ContextCompactor;
+        const result = { evidence: "large evidence ".repeat(10_000) };
+
+        const source = Prompt.fromMessages([
+          Prompt.assistantMessage({
+            content: [
+              Prompt.toolCallPart({
+                id: "large",
+                name: "search",
+                params: {},
+                providerExecuted: false,
+              }),
+            ],
+          }),
+          Prompt.toolMessage({
+            content: [
+              Prompt.toolResultPart({
+                id: "large",
+                name: "search",
+                result,
+                isFailure: false,
+                providerExecuted: false,
+              }),
+            ],
+          }),
+          ...Array.from({ length: 100 }, (_, index) =>
+            Prompt.userMessage({
+              content: [Prompt.textPart({ text: `entry-${index} ${"x".repeat(2_000)}` })],
+            }),
+          ),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "recent tail" })] }),
+        ]);
+
+        const prompts: Array<Prompt.Prompt> = [];
+
+        yield* compactor
+          .compact({
+            source,
+            state: initialCompactionState(),
+            policy: CompactionPolicy.make({ keepRecentTokens: 1, mode: "summarize" }),
+            targetTokens: 10,
+            forceSummarize: false,
+            allowSummarize: true,
+            summarize: (prompt) =>
+              Effect.sync(() => {
+                prompts.push(prompt);
+
+                return "summary";
+              }),
+          })
+          .pipe(Stream.runCollect);
+
+        expect(prompts).toHaveLength(1);
+        const transcript = promptText(prompts[0] ?? Prompt.empty);
+
+        expect(transcript.length).toBeLessThanOrEqual(SUMMARY_INPUT_BUDGET);
+        expect(transcript).toContain(
+          "[tool result search: [omitted oversized or unsupported JSON]]",
+        );
+        expect(transcript).toContain("messages omitted from summary input");
+        expect(transcript).toContain("entry-0 ");
+        expect(transcript).toContain("entry-99 ");
+        expect(toolResultValues(source)).toEqual([result]);
+      }),
+  );
+
+  it.effect(
+    "bounds the complete default summary request and rejects an oversized prior summary",
+    () =>
+      Effect.gen(function* () {
+        const compactor = yield* ContextCompactor;
+
+        const source = Prompt.fromMessages([
+          ...Array.from({ length: 100 }, (_, index) =>
+            Prompt.userMessage({
+              content: [Prompt.textPart({ text: `entry-${index} ${"x".repeat(2_000)}` })],
+            }),
+          ),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "recent tail" })] }),
+        ]);
+
+        for (const length of [65_536, 65_537, 100_000]) {
+          const prompts: Array<Prompt.Prompt> = [];
+          const state = { ...initialCompactionState(), summary: "s".repeat(length) };
+
+          const exit = yield* compactor
+            .compact({
+              source,
+              state,
+              policy: CompactionPolicy.make({ keepRecentTokens: 1, mode: "summarize" }),
+              targetTokens: 10,
+              forceSummarize: false,
+              allowSummarize: true,
+              summarize: (prompt) =>
+                Effect.sync(() => {
+                  prompts.push(prompt);
+
+                  return "summary";
+                }),
+            })
+            .pipe(Stream.runCollect, Effect.exit);
+
+          if (length === 65_536) {
+            expect(Exit.isSuccess(exit)).toBe(true);
+            expect(promptText(prompts[0] ?? Prompt.empty).length).toBeLessThanOrEqual(
+              SUMMARY_INPUT_BUDGET,
+            );
+            expect(promptText(prompts[0] ?? Prompt.empty)).toContain(state.summary);
+            expect(promptText(prompts[0] ?? Prompt.empty)).toContain("entry-0 ");
+            expect(promptText(prompts[0] ?? Prompt.empty)).toContain("entry-99 ");
+          } else {
+            expect(failureFrom(exit)).toBeInstanceOf(CompactionError);
+            expect(prompts).toEqual([]);
+            expect(renderForSummary([], state.summary)).toBeUndefined();
+          }
+          expect(state.summary.length).toBe(length);
+        }
+      }),
+  );
 
   it.effect(
     "decorates the injected strategy and estimator while retaining summary Model metering and history",
@@ -540,6 +860,11 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
             estimate: estimatePromptTokens,
             compact: () => Stream.succeed({ kind: "summarize", through: 4, summary: " \n\t " }),
           }),
+          ContextCompactor.of({
+            estimate: estimatePromptTokens,
+            compact: () =>
+              Stream.succeed({ kind: "summarize", through: 4, summary: "s".repeat(65_537) }),
+          }),
         ]) {
           const commits: Array<RunCompactionCommit> = [];
 
@@ -720,6 +1045,7 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
       // Per-message clip applies to plain text, not only tool results.
       const oversized = renderForSummary([userMessage(`start${"x".repeat(10_000)}end`)], undefined);
 
+      if (oversized === undefined) throw new Error("Expected bounded summary rendering");
       expect(oversized.length).toBeLessThan(3_000);
 
       // Total budget: many clipped messages exceed it; middle-out retention
@@ -730,6 +1056,7 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
 
       const rendered = renderForSummary(many, "previous summary text");
 
+      if (rendered === undefined) throw new Error("Expected bounded summary rendering");
       expect(rendered.length + COMPACTION_INSTRUCTION.length).toBeLessThanOrEqual(
         SUMMARY_INPUT_BUDGET,
       );
@@ -873,6 +1200,7 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
     readonly name: string;
     readonly parts: ReadonlyArray<Response.StreamPartEncoded>;
   }> = [
+    { name: "oversized", parts: finalParts("s".repeat(65_537), usageOf(50, 20)) },
     { name: "finish-only", parts: [{ type: "finish", reason: "stop", usage: usageOf(50, 20) }] },
     { name: "whitespace-only", parts: finalParts(" \n\t ", usageOf(50, 20)) },
     {
@@ -929,7 +1257,9 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
               }),
           });
 
-          expect(failureFrom(exit)).toBeInstanceOf(ModelProtocolError);
+          expect(failureFrom(exit)).toBeInstanceOf(
+            invalid.name === "oversized" ? CompactionError : ModelProtocolError,
+          );
           expect(requests).toHaveLength(5);
           expect(compactionEvents(events).map((event) => event.kind)).toEqual(["summarize"]);
           expect(commits.map((commit) => commit.summary)).toEqual(["Goal: preserved summary"]);
@@ -1336,7 +1666,7 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
     Effect.gen(function* () {
       const policy = AgentPolicy.make({
         ...basePolicy,
-        contextTokenLimit: 20_000,
+        contextTokenLimit: 5_000,
         compaction: CompactionPolicy.make({ keepRecentTokens: 300, mode: "summarize" }),
       });
 
@@ -1346,7 +1676,7 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
           toolCallParts("s1", "search", {}, usageOf(100, 5)),
           toolCallParts("s2", "search", {}, usageOf(200, 5)),
           { fail: "maximum context length exceeded" },
-          finalParts(`Goal: ${"summary".repeat(20_000)}`, usageOf(20, 10)),
+          finalParts(`Goal: ${"summary".repeat(8_000)}`, usageOf(20, 10)),
         ],
         results: ["a".repeat(4_000), "b".repeat(4_000)],
       });


### PR DESCRIPTION
Prepared context could replace an existing prefix while admission reused provider usage for the old content. A later compaction could also reuse source indices against different prepared history. Estimate transformed prompts afresh, preserve the original instruction/input block through identity or unambiguous content mapping, and reject changes to covered prefixes before another model request. Durable coverage still passes through the existing commit contract.

Reuse the compacted view and source estimate within each turn, skip admission estimates when no limit applies, and render only the selected summary head/tail. Complete default summary requests now fit within 80,000 characters; selected oversized structured results receive an omission marker. Every summary is capped at 65,536 characters and oversized prior summaries fail without truncation. The guide and changeset describe the custom-strategy and preparation-hook behavior changes.

```mermaid
flowchart LR
  Prepare[Prepared prompt] --> Guard[Validate covered prefix]
  Guard --> View[Reuse current context view]
  View --> Admit[Check context and reserve]
  Admit -->|Over limit| Compact[Compact within turn allowance]
  Compact --> View
  Admit --> Decorate[Add current request instructions]
  Decorate --> Final[Check final prepared prompt]
  Final --> Provider[Model request]
```

Validation passed with 314 engine tests and `vp run ready`, including adapter, crash, build, and documentation checks. The initial eight public regressions failed on the baseline; the final suite also covers grace admission, oversized custom/provider summaries, duplicate input under identity preparation, and bounded structured-result previews.

An unchanged Cloudflare alarm assertion failed intermittently during parallel gates. The full Cloudflare package passed in isolation with 419 tests and two existing skips, then the final full gate passed with that unchanged validated task cached.

Local Node 24.20 ARM64 complete-run measurements use two immediate scripted model turns, 1,000 prior messages, three warmups and twelve uninstrumented samples per case in each of two reversed-order replicates. Times below show pooled 24-sample medians followed by the minimum to maximum range in milliseconds. Estimator counts come from a separate instrumented run.

| Case | Baseline ms | Candidate ms | Estimator calls | Messages estimated |
| --- | ---: | ---: | ---: | ---: |
| No limits | 8.28, 7.61 to 10.84 | 3.07, 2.75 to 5.49 | 8 → 0 | 2,010 → 0 |
| Context limit | 7.92, 7.61 to 10.17 | 5.91, 5.14 to 8.79 | 8 → 6 | 2,010 → 1,006 |
| Prepared, no limits | 7.74, 7.38 to 10.85 | 2.89, 2.70 to 5.30 | 8 → 0 | 2,010 → 0 |
| Prepared, context limit | 7.81, 7.53 to 9.59 | 13.81, 12.46 to 16.20 | 8 → 8 | 2,010 → 4,016 |
| Transient, no limits | 17.41, 17.08 to 18.94 | 3.23, 2.72 to 6.72 | 12 → 0 | 6,022 → 0 |
| Transient, context limit | 22.95, 21.97 to 25.12 | 13.93, 12.92 to 45.55 | 14 → 10 | 8,032 → 4,020 |
| Compaction | 7.16, 6.69 to 9.15 | 7.34, 6.68 to 10.16 | 10 → 9 | 2,020 → 2,018 |

Prepared limited runs cost more because transformed history and the final provider prompt now receive full admission checks. The compaction case includes initial compaction before the first provider request and reuse of the compacted view on the second turn; it shows no speedup. Runs with 16 prior messages show no consistent improvement. These measurements cover local engine overhead. Live provider latency was not measured. All samples, including the 45.55 ms transient outlier, remain included.

A separate 2,000-message rendering diagnostic with three large structured payloads reduced content reads from 4,000 to 86 and payload property reads from 60,003 to 18 in both replicates. These instrumented counts demonstrate bounded rendering work; their elapsed times are not used as a speedup claim.

Reusing the provider anchor for prepared histories was rejected because arbitrary replacements invalidate it. Resetting compaction over a changed covered prefix was rejected because retaining the old summary would misrepresent evidence; the documented failure is explicit and fail-closed.
