### PR TITLE
fix(engine): release completed turn state between requests

### DIFF
--- a/.changeset/finite-turn-lifetime.md
+++ b/.changeset/finite-turn-lifetime.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/engine": patch
+---
+
+Release completed turn state before starting the next turn to reduce memory retained during long runs.
+
+BEHAVIOR CHANGE: Resources acquired by `beforeTurn` or `context.prepare` now close with that turn. Move resources needed across turns into a surrounding run Layer or Scope.

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -50,6 +50,11 @@ contract. Compaction summaries never receive transient references. Durable
 recovery rebuilds the committed model view before applying prompt preparation; a transient loader
 receives the current Attempt's official source, Thread ID, Run ID, Turn ID, and Turn number.
 
+Each turn releases its response trace and prepared context before the next turn starts. Official
+history and detached event replay retain their own records. Resources acquired by `beforeTurn`
+or `context.prepare` also close at that turn boundary, including on failure or interruption.
+Acquire resources needed across turns in a surrounding run Layer or Scope.
+
 To add application instructions to each request:
 
 ```ts twoslash

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -213,13 +213,13 @@ export interface PreparedRunContext {
   readonly prompt: Prompt.Prompt;
 }
 
-/**
- * Dependency-neutral ordered context transformation / compaction hook.
- * Resources acquired by `prepare` belong to the current Turn and close before
- * the next Turn starts. Acquire resources shared across Turns in a surrounding
- * Run Layer or Scope instead.
- */
+/** Dependency-neutral ordered context transformation / compaction hook. */
 export interface RunContextHook<Error = never, Requirements = never> {
+  /**
+   * Resources acquired by `prepare` belong to the current Turn and close before
+   * the next Turn starts. Acquire resources shared across Turns in a surrounding
+   * Run Layer or Scope instead.
+   */
   readonly prepare: (
     request: RunContextRequest,
   ) => Effect.Effect<PreparedRunContext, Error, Requirements>;

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -213,7 +213,12 @@ export interface PreparedRunContext {
   readonly prompt: Prompt.Prompt;
 }
 
-/** Dependency-neutral ordered context transformation / compaction hook. */
+/**
+ * Dependency-neutral ordered context transformation / compaction hook.
+ * Resources acquired by `prepare` belong to the current Turn and close before
+ * the next Turn starts. Acquire resources shared across Turns in a surrounding
+ * Run Layer or Scope instead.
+ */
 export interface RunContextHook<Error = never, Requirements = never> {
   readonly prepare: (
     request: RunContextRequest,
@@ -757,6 +762,7 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
    * and compaction calls. The preceding Tool batch and history advance have finished. A resumed
    * canonical Tool batch bypasses this hook until it continues to a new Turn. This hook does not
    * reset the Run deadline or change prompt protection, and is not automatically inherited by spawned children.
+   * Resources acquired here close with the current Turn, before the next Turn starts.
    */
   readonly beforeTurn?: (() => Effect.Effect<void, HookError, HookRequirements>) | undefined;
   /** Reuse a Thread identity, including retained history, instead of allocating one. */

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -82,6 +82,7 @@ import {
   Option,
   PubSub,
   Queue,
+  Result,
   Schema,
   Scope,
   Semaphore,
@@ -4240,11 +4241,21 @@ function decodeRunDisposition<DispositionSchema extends Schema.Top>(
     : decodeRunDispositionCandidate(declaration, encoded);
 }
 
-type ContinueTurn = (
+/** Internal control output consumed by the driver before RunEvent publication. */
+interface NextTurn {
+  readonly _tag: "NextTurn";
+  readonly prompt: Prompt.Prompt;
+  readonly turn: number;
+  readonly toolCalls: number;
+}
+
+type TurnOutput = RunEvent | NextTurn;
+
+const nextTurn = (
   prompt: Prompt.Prompt,
   turn: number,
   toolCalls: number,
-) => Stream.Stream<never>;
+): Stream.Stream<TurnOutput> => Stream.succeed({ _tag: "NextTurn", prompt, turn, toolCalls });
 
 const makeTurn = <
   InputSchema extends Schema.Top,
@@ -4276,9 +4287,8 @@ const makeTurn = <
   turn: number,
   priorToolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
-  nextTurn: ContinueTurn,
 ): Stream.Stream<
-  RunEvent,
+  TurnOutput,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
   InterpreterRequirements<typeof agent, HookRequirements, InstructionRequirements>
 > =>
@@ -5038,7 +5048,7 @@ const makeTurn = <
            * Turn is final-answer constrained via `tokenExhausted`.
            */
           type TurnEvents = Stream.Stream<
-            RunEvent,
+            TurnOutput,
             AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
             InterpreterRequirements<typeof agent, HookRequirements, InstructionRequirements>
           >;
@@ -5092,8 +5102,8 @@ const makeTurn = <
                     }
 
                     const emitThen = <NextError, NextRequirements>(
-                      nextStream: Stream.Stream<RunEvent, NextError, NextRequirements>,
-                    ): Stream.Stream<RunEvent, NextError, NextRequirements> =>
+                      nextStream: Stream.Stream<TurnOutput, NextError, NextRequirements>,
+                    ): Stream.Stream<TurnOutput, NextError, NextRequirements> =>
                       pre.length === 0
                         ? nextStream
                         : Stream.fromIterable(pre).pipe(Stream.concat(nextStream));
@@ -5156,7 +5166,6 @@ const makeTurn = <
                                 turn,
                                 toolCalls,
                                 options,
-                                nextTurn,
                               ),
                             ),
                           ),
@@ -5335,7 +5344,6 @@ const makeTurn = <
                         turn,
                         toolCalls,
                         options,
-                        nextTurn,
                       ),
                     ),
                   );
@@ -5399,16 +5407,7 @@ const makeTurn = <
 
                 return toolResults.pipe(
                   Stream.concat(
-                    toolBatchContinuation(
-                      agent,
-                      context,
-                      trace,
-                      prompt,
-                      turn,
-                      toolCalls,
-                      options,
-                      nextTurn,
-                    ),
+                    toolBatchContinuation(agent, context, trace, prompt, turn, toolCalls, options),
                   ),
                 );
               }),
@@ -5474,9 +5473,8 @@ const toolBatchContinuation = <
   turn: number,
   toolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
-  nextTurn: ContinueTurn,
 ): Stream.Stream<
-  RunEvent,
+  TurnOutput,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
   InterpreterRequirements<typeof agent, HookRequirements, InstructionRequirements>
 > =>
@@ -5639,9 +5637,8 @@ const makeResumeTurn = <
   resume: RunTurnResume,
   countedToolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
-  nextTurn: ContinueTurn,
 ): Stream.Stream<
-  RunEvent,
+  TurnOutput,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
   InterpreterRequirements<typeof agent, HookRequirements, InstructionRequirements>
 > =>
@@ -5922,16 +5919,7 @@ const makeResumeTurn = <
       ).pipe(Stream.flatMap(Stream.fromIterable));
 
       const continueAfterBatch = () =>
-        toolBatchContinuation(
-          agent,
-          context,
-          trace,
-          resumedPrompt,
-          turn,
-          toolCalls,
-          options,
-          nextTurn,
-        );
+        toolBatchContinuation(agent, context, trace, resumedPrompt, turn, toolCalls, options);
 
       // RUN-018 on the resume path: a canonically declared over-budget batch
       // settles synthetically under final-answer mode — recorded settled
@@ -6380,13 +6368,6 @@ function streamWithCompletion<
                   }
                 | undefined;
 
-              const nextTurn: ContinueTurn = (prompt, turn, toolCalls) =>
-                Stream.fromEffectDrain(
-                  Effect.sync(() => {
-                    pending = { prompt, turn, toolCalls };
-                  }),
-                );
-
               if (resumed !== undefined) {
                 // A declared-batch resume re-enters mid-Turn: steering seams
                 // reopen only after the resumed batch settles, so the initial
@@ -6408,7 +6389,7 @@ function streamWithCompletion<
                 };
               }
 
-              // Each finite Turn schedules at most one successor. Sequential
+              // Each finite Turn returns at most one successor request. Sequential
               // flatMap releases its child pull and Scope before taking that
               // request, so prior traces and prepared prompts do not remain
               // reachable through recursively nested Stream.concat descriptions.
@@ -6430,7 +6411,6 @@ function streamWithCompletion<
                         request.turn,
                         request.toolCalls,
                         options,
-                        nextTurn,
                       )
                     : makeResumeTurn(
                         agent,
@@ -6439,8 +6419,18 @@ function streamWithCompletion<
                         request.resume,
                         request.toolCalls,
                         options,
-                        nextTurn,
                       ),
+                ),
+                Stream.filterMapEffect((output) =>
+                  Effect.sync(() => {
+                    if (output._tag === "NextTurn") {
+                      pending = output;
+
+                      return Result.fail(undefined);
+                    }
+
+                    return Result.succeed(output);
+                  }),
                 ),
               );
             }),

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -4240,6 +4240,12 @@ function decodeRunDisposition<DispositionSchema extends Schema.Top>(
     : decodeRunDispositionCandidate(declaration, encoded);
 }
 
+type ContinueTurn = (
+  prompt: Prompt.Prompt,
+  turn: number,
+  toolCalls: number,
+) => Stream.Stream<never>;
+
 const makeTurn = <
   InputSchema extends Schema.Top,
   OutputSchema extends Schema.Top,
@@ -4270,6 +4276,7 @@ const makeTurn = <
   turn: number,
   priorToolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
+  nextTurn: ContinueTurn,
 ): Stream.Stream<
   RunEvent,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
@@ -5149,6 +5156,7 @@ const makeTurn = <
                                 turn,
                                 toolCalls,
                                 options,
+                                nextTurn,
                               ),
                             ),
                           ),
@@ -5176,7 +5184,7 @@ const makeTurn = <
               const steering = yield* drainInputs(context, options);
               const nextPrompt = yield* appendInputs(context, history, steering, options);
 
-              return makeTurn(agent, context, nextPrompt, turn + 1, toolCalls, options);
+              return nextTurn(nextPrompt, turn + 1, toolCalls);
             });
 
           /**
@@ -5218,7 +5226,7 @@ const makeTurn = <
                 );
                 const nextPrompt = yield* appendInputs(context, history, queued, options);
 
-                return makeTurn(agent, context, nextPrompt, turn + 1, toolCalls, options);
+                return nextTurn(nextPrompt, turn + 1, toolCalls);
               }
               const output = yield* decodeFinalOutput(agent, trace.text.join(""));
               const declaration = agent.definition.runDisposition;
@@ -5327,6 +5335,7 @@ const makeTurn = <
                         turn,
                         toolCalls,
                         options,
+                        nextTurn,
                       ),
                     ),
                   );
@@ -5390,7 +5399,16 @@ const makeTurn = <
 
                 return toolResults.pipe(
                   Stream.concat(
-                    toolBatchContinuation(agent, context, trace, prompt, turn, toolCalls, options),
+                    toolBatchContinuation(
+                      agent,
+                      context,
+                      trace,
+                      prompt,
+                      turn,
+                      toolCalls,
+                      options,
+                      nextTurn,
+                    ),
                   ),
                 );
               }),
@@ -5456,6 +5474,7 @@ const toolBatchContinuation = <
   turn: number,
   toolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
+  nextTurn: ContinueTurn,
 ): Stream.Stream<
   RunEvent,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
@@ -5573,7 +5592,7 @@ const toolBatchContinuation = <
       const steering = yield* drainInputs(context, options);
       const nextPrompt = yield* appendInputs(context, history, steering, options);
 
-      return makeTurn(agent, context, nextPrompt, turn + 1, toolCalls, options);
+      return nextTurn(nextPrompt, turn + 1, toolCalls);
     }),
   );
 
@@ -5620,6 +5639,7 @@ const makeResumeTurn = <
   resume: RunTurnResume,
   countedToolCalls: number,
   options: RunOptions<HookError, HookRequirements>,
+  nextTurn: ContinueTurn,
 ): Stream.Stream<
   RunEvent,
   AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
@@ -5902,7 +5922,16 @@ const makeResumeTurn = <
       ).pipe(Stream.flatMap(Stream.fromIterable));
 
       const continueAfterBatch = () =>
-        toolBatchContinuation(agent, context, trace, resumedPrompt, turn, toolCalls, options);
+        toolBatchContinuation(
+          agent,
+          context,
+          trace,
+          resumedPrompt,
+          turn,
+          toolCalls,
+          options,
+          nextTurn,
+        );
 
       // RUN-018 on the resume path: a canonically declared over-budget batch
       // settles synthetically under final-answer mode — recorded settled
@@ -6341,29 +6370,78 @@ function streamWithCompletion<
                 context.compaction.protectedEnd = prompt.content.length;
               }
               yield* advanceHistory(context, prompt, options);
+
+              let pending:
+                | {
+                    readonly prompt: Prompt.Prompt;
+                    readonly turn: number;
+                    readonly toolCalls: number;
+                    readonly resume?: RunTurnResume;
+                  }
+                | undefined;
+
+              const nextTurn: ContinueTurn = (prompt, turn, toolCalls) =>
+                Stream.fromEffectDrain(
+                  Effect.sync(() => {
+                    pending = { prompt, turn, toolCalls };
+                  }),
+                );
+
               if (resumed !== undefined) {
                 // A declared-batch resume re-enters mid-Turn: steering seams
                 // reopen only after the resumed batch settles, so the initial
                 // drain is skipped and the continuation drains at the safe seam.
-                return makeResumeTurn(
-                  agent,
-                  context,
+                pending = {
                   prompt,
-                  resumed.batch,
-                  resumed.usage.toolCalls,
-                  options,
-                );
-              }
-              const steering = yield* drainInputs(context, options);
-              const initialPrompt = yield* appendInputs(context, prompt, steering, options);
+                  turn: resumed.batch.turn,
+                  toolCalls: resumed.usage.toolCalls,
+                  resume: resumed.batch,
+                };
+              } else {
+                const steering = yield* drainInputs(context, options);
+                const initialPrompt = yield* appendInputs(context, prompt, steering, options);
 
-              return makeTurn(
-                agent,
-                context,
-                initialPrompt,
-                (resumeUsage?.committedTurns ?? 0) + 1,
-                resumeUsage?.toolCalls ?? 0,
-                options,
+                pending = {
+                  prompt: initialPrompt,
+                  turn: (resumeUsage?.committedTurns ?? 0) + 1,
+                  toolCalls: resumeUsage?.toolCalls ?? 0,
+                };
+              }
+
+              // Each finite Turn schedules at most one successor. Sequential
+              // flatMap releases its child pull and Scope before taking that
+              // request, so prior traces and prepared prompts do not remain
+              // reachable through recursively nested Stream.concat descriptions.
+              return Stream.fromEffectRepeat(
+                Effect.suspend(() => {
+                  const current = pending;
+
+                  pending = undefined;
+
+                  return current === undefined ? Cause.done() : Effect.succeed(current);
+                }),
+              ).pipe(
+                Stream.flatMap((request) =>
+                  request.resume === undefined
+                    ? makeTurn(
+                        agent,
+                        context,
+                        request.prompt,
+                        request.turn,
+                        request.toolCalls,
+                        options,
+                        nextTurn,
+                      )
+                    : makeResumeTurn(
+                        agent,
+                        context,
+                        request.prompt,
+                        request.resume,
+                        request.toolCalls,
+                        options,
+                        nextTurn,
+                      ),
+                ),
               );
             }),
           );

--- a/packages/engine/test/turn-lifetime.test.ts
+++ b/packages/engine/test/turn-lifetime.test.ts
@@ -1,0 +1,188 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { RunId, ThreadId, TurnId } from "@effect-agent/core/Identifiers";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import type { RunEvent } from "@effect-agent/core/RunEvent";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { expect, layer } from "@effect/vitest";
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Schema, Stream } from "effect";
+import { LanguageModel, Model, type Response, Tool, Toolkit } from "effect/unstable/ai";
+
+const identifiers = Layer.succeed(IdGenerator, {
+  nextThreadId: Effect.succeed(Schema.decodeSync(ThreadId)("turn-lifetime-thread")),
+  nextRunId: Effect.succeed(Schema.decodeSync(RunId)("turn-lifetime-run")),
+  nextTurnId: Effect.succeed(Schema.decodeSync(TurnId)("turn-lifetime-turn")),
+});
+
+class PreparationFailed extends Schema.TaggedError<PreparationFailed>()("PreparationFailed", {}) {}
+
+layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("Turn lifetime", (it) => {
+  for (const ending of ["complete", "failure", "defect", "interrupt"] as const) {
+    it.effect(`releases completed Turn resources before the next Turn and handles ${ending}`, () =>
+      Effect.gen(function* () {
+        const thirdTurnEntered = yield* Deferred.make<void>();
+        const active = new Set<number>();
+        const activeBeforePreparation: Array<number> = [];
+        const finalized: Array<number> = [];
+        const historyLengths: Array<number> = [];
+        const events: Array<RunEvent> = [];
+        let modelCalls = 0;
+        let modelFinalizers = 0;
+        let toolCalls = 0;
+
+        const tools = Toolkit.make(
+          Tool.make("next", { parameters: Schema.Struct({}), success: Schema.String }),
+        );
+
+        const model = Model.make(
+          "scripted",
+          "turn-lifetime",
+          Layer.effect(
+            LanguageModel.LanguageModel,
+            Effect.gen(function* () {
+              yield* Effect.acquireRelease(Effect.void, () =>
+                Effect.sync(() => {
+                  modelFinalizers++;
+                }),
+              );
+
+              return yield* LanguageModel.make({
+                generateText: () => Effect.succeed([]),
+                streamText: () => {
+                  modelCalls++;
+                  expect(modelFinalizers).toBe(0);
+
+                  const parts: ReadonlyArray<Response.StreamPartEncoded> =
+                    modelCalls < 3
+                      ? [
+                          {
+                            type: "tool-call",
+                            id: `call-${modelCalls}`,
+                            name: "next",
+                            params: {},
+                          },
+                          {
+                            type: "finish",
+                            reason: "tool-calls",
+                            usage: { inputTokens: {}, outputTokens: {} },
+                          },
+                        ]
+                      : [
+                          { type: "text-start", id: "answer" },
+                          { type: "text-delta", id: "answer", delta: '"done"' },
+                          { type: "text-end", id: "answer" },
+                          {
+                            type: "finish",
+                            reason: "stop",
+                            usage: { inputTokens: {}, outputTokens: {} },
+                          },
+                        ];
+
+                  return Stream.fromIterable(parts);
+                },
+              });
+            }),
+          ),
+        );
+
+        const agent = Agent.withModel(
+          Agent.make("turn-lifetime", {
+            input: Schema.String,
+            output: Schema.String,
+            instructions: "Use next twice, then answer.",
+            toolkit: tools,
+            policy: AgentPolicy.make({
+              maxTurns: 3,
+              maxToolCalls: 2,
+              maxDuration: "30 seconds",
+              toolConcurrency: 1,
+            }),
+          }),
+          model,
+        );
+
+        const run = AgentRuntime.stream(agent, "begin", {
+          context: {
+            prepare: ({ source, turn }) =>
+              Effect.gen(function* () {
+                activeBeforePreparation.push(active.size);
+                historyLengths.push(source.content.length);
+                yield* Effect.acquireRelease(
+                  Effect.sync(() => active.add(turn)),
+                  () =>
+                    Effect.sync(() => {
+                      active.delete(turn);
+                      finalized.push(turn);
+                    }),
+                );
+                if (turn === 3) {
+                  if (ending === "failure") return yield* new PreparationFailed();
+                  if (ending === "defect") return yield* Effect.die("preparation defect");
+                  if (ending === "interrupt") {
+                    yield* Deferred.succeed(thirdTurnEntered, undefined);
+
+                    return yield* Effect.never;
+                  }
+                }
+
+                return { prompt: source };
+              }),
+          },
+        }).pipe(
+          Stream.tap((event) => Effect.sync(() => events.push(event))),
+          Stream.runDrain,
+          Effect.provide(
+            tools.toLayer({
+              next: () =>
+                Effect.sync(() => {
+                  toolCalls++;
+
+                  return "continue";
+                }),
+            }),
+          ),
+        );
+
+        const exit = yield* Effect.scoped(
+          ending === "interrupt"
+            ? Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(run);
+
+                yield* Deferred.await(thirdTurnEntered);
+                yield* Fiber.interrupt(fiber);
+
+                return yield* Fiber.await(fiber);
+              })
+            : Effect.exit(run),
+        );
+
+        expect(activeBeforePreparation).toEqual([0, 0, 0]);
+        expect(finalized).toEqual([1, 2, 3]);
+        expect(active.size).toBe(0);
+        expect(modelFinalizers).toBe(1);
+        expect(toolCalls).toBe(2);
+        expect(historyLengths).toEqual([2, 4, 6]);
+        expect(events.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(2);
+        if (ending === "complete") {
+          expect(Exit.isSuccess(exit)).toBe(true);
+          expect(events.at(-1)).toMatchObject({ _tag: "RunCompleted", output: "done", turns: 3 });
+        } else {
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isSuccess(exit)) throw new Error("Expected the selected failure");
+          if (ending === "failure") {
+            expect(Cause.findErrorOption(exit.cause)).toEqual(Option.some(new PreparationFailed()));
+            expect(events.at(-1)).toMatchObject({
+              _tag: "RunFailed",
+              errorTag: "PreparationFailed",
+            });
+          } else if (ending === "defect") {
+            expect(Cause.hasDies(exit.cause)).toBe(true);
+          } else {
+            expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+          }
+        }
+      }),
+    );
+  }
+});

--- a/packages/engine/test/turn-lifetime.test.ts
+++ b/packages/engine/test/turn-lifetime.test.ts
@@ -2,7 +2,7 @@ import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import { RunId, ThreadId, TurnId } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
-import type { RunEvent } from "@effect-agent/core/RunEvent";
+import { RunEvent } from "@effect-agent/core/RunEvent";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
 import { expect, layer } from "@effect/vitest";
@@ -163,6 +163,12 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("Turn lifetime"
         expect(modelFinalizers).toBe(1);
         expect(toolCalls).toBe(2);
         expect(historyLengths).toEqual([2, 4, 6]);
+
+        const eventCodec = Schema.Array(RunEvent);
+
+        expect(Schema.decodeSync(eventCodec)(Schema.encodeSync(eventCodec)(events))).toEqual(
+          events,
+        );
         expect(events.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(2);
         if (ending === "complete") {
           expect(Exit.isSuccess(exit)).toBe(true);


### PR DESCRIPTION
Long runs kept completed turn streams, response traces, and prepared prompts reachable while later turns executed. Replace recursive turn concatenation with one pending turn request and a sequential driver. Each turn commits history, returns its successor as private data, and ends before the driver starts that successor. The driver consumes the request before publishing public events. Per-turn response and tool ordering, durable commit seams, policy checks, and typed failures remain intact.

```mermaid
flowchart LR
  subgraph Before
    A[Turn 1 stream and state] -->|concat retains| B[Turn 2 stream and state]
    B -->|concat retains| C[Turn 3 stream and state]
  end
  subgraph After
    D[One pending turn request] --> E[Current turn stream]
    E --> F[Commit history and return successor request]
    F --> G[Release child pull and Scope]
    G --> D
  end
```

The native sequential `Stream.flatMap` owns the active turn's pull and Scope. Clearing trace fields alone would leave earlier prompt arrays and nested stream descriptions reachable, so the change removes the cross-turn nesting instead.

Resources acquired inside `beforeTurn` or `context.prepare` now close with that turn, before the next turn starts. Run-scoped model and context Layers retain their existing lifetime. Acquire a resource needed across turns in a surrounding Layer or Scope. For example, with application-defined `acquireReader`, `releaseReader`, and `reader.prepare`:

```ts
const result = Effect.scoped(
  Effect.gen(function* () {
    const reader = yield* Effect.acquireRelease(acquireReader, releaseReader);
    return yield* AgentRuntime.run(agent, "Explain the current project", {
      context: { prepare: ({ source }) => reader.prepare(source) },
    });
  }),
);
// The reader stays available for every turn and closes when this Effect ends.
// Reader acquisition and preparation errors remain in the Effect's error type.
```

Measured on Node 24.20.0 ARM64 with Effect 4.0.0-rc.112, comparing `484b0413` with final commit `2daf41a6`. The unchanged public API workload runs 128 tool turns followed by one final answer. Each tool turn emits 32 text chunks of 1 KiB, returns a 16 KiB tool result, and adds a 4 KiB marker only to prepared context. Streaming drains events; detached execution retains its normal replay history. Each measurement process warms up with two turns. There are three measured runs per mode and revision, with forced GC after a host event-loop boundary at each pause.

The primary metric is sampled post-GC heap growth above the pre-run heap while paused after completed turns. Values below are decimal MB, shown as median with the full range:

| Completed turns | Streaming before | Streaming after |
| ---: | ---: | ---: |
| 1 | 0.479 [0.361, 0.479] | 0.295 [0.286, 0.393] |
| 8 | 3.063 [1.322, 3.063] | 0.717 [0.685, 2.425] |
| 32 | 7.691 [4.449, 7.691] | 1.991 [1.959, 5.738] |
| 64 | 11.999 [8.697, 11.999] | 3.684 [3.675, 7.570] |
| 128 | 17.662 [17.385, 17.662] | 7.183 [6.916, 7.986] |

At 128 completed turns, the streaming median retained delta falls from 17,661,632 to 7,183,288 bytes, a **59.33% reduction** against the 10% target. Total process heap at that pause falls from a median 72,444,704 to 62,976,424 bytes, a separate **13.07% reduction**. Detached retained delta falls from a median 20.672 MB to 14.217 MB, or 31.22%; its before range is 20.101 to 20.810 MB and after range is 14.126 to 14.552 MB.

Across all sampled entry and response-end pauses, the streaming median retained peak falls from 17.662 MB to 7.227 MB, with candidate range 6.991 to 8.049 MB. The detached median sampled peak falls from 20.672 MB to 14.272 MB, with candidate range 14.154 to 14.623 MB. These are post-GC samples, not allocation high-water marks.

Heap snapshots identify 5,801,984 bytes exclusively retained through obsolete traces and source/prepared arrays before the change. The candidate has no completed traces retaining response parts or old source/prepared arrays. WeakRefs to all 128 obsolete source arrays, prepared arrays, and markers clear in every candidate repetition while the current 258-message canonical history remains available. All runs produce the same 4,872 events, 128 tool calls, and 129 model finalizers.

This reduces retained memory during long runs. Neither revision demonstrated an after-scope leak; prompt probes clear after scope closure. A held detached handle intentionally retains replay events; those clear after the handle is dropped. Hosted latency and CPU were not measured.

The new public lifecycle regression failed all four cases before the change, with earlier turn resources still open at subsequent preparation calls. All four now pass and cover completion, typed failure, defect, and interruption, while proving the model Layer stays open across turns. The same cases round-trip every public event through its Schema so private successor requests cannot escape. All 306 engine tests, engine type checks, changed-file static checks, and full `vp run ready` pass at the measured final commit `2daf41a6`. The first full gate hit the unchanged alarm timing test; the complete Cloudflare package then passed 419 tests with two skipped, followed by the passing full gate. A separate [test clock fix](https://github.com/danieljvdm/effect-agent/pull/330) covers that race with a deterministic regression.
