### PR TITLE
test(cloudflare): use one clock for alarm initialization and events

### DIFF
--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -233,6 +233,16 @@ describe("DC alarm semantics", () => {
             alarmAttemptHolds.delete(thread);
           }),
         );
+
+        const initializedAlarm = yield* Effect.promise(() =>
+          runInDurableObject(stubFor(thread), async (instance, state) => {
+            await instance[DurableObject.RunSymbol](Effect.void);
+
+            return state.storage.getAlarm();
+          }),
+        );
+
+        expect(initializedAlarm).toBeGreaterThanOrEqual(yield* Clock.currentTimeMillis);
         const receipt = yield* Effect.promise(() => submitTo(plannerDefinition, thread));
 
         const pass = yield* Effect.tryPromise({

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -300,17 +300,20 @@ const progressIncarnation = (ctx: DurableObjectState): number => {
   return created;
 };
 
-export class TestThreadObject extends ThreadObject.make(testRuntimeLayer, {
-  ...baseOptions,
-  eventLayer: Layer.effect(
-    Clock.Clock,
-    Effect.gen(function* () {
-      const identity = yield* ThreadObjectIdentity;
+// Initialization arms maintenance alarms before event-only layers are available.
+const maintenanceClockLayer = Layer.effect(
+  Clock.Clock,
+  Effect.gen(function* () {
+    const identity = yield* ThreadObjectIdentity;
 
-      return maintenanceClocks.get(identity.threadId) ?? (yield* Clock.Clock);
-    }),
-  ),
-}) {
+    return maintenanceClocks.get(identity.threadId) ?? (yield* Clock.Clock);
+  }),
+);
+
+export class TestThreadObject extends ThreadObject.make(
+  testRuntimeLayer.pipe(Layer.provideMerge(maintenanceClockLayer)),
+  baseOptions,
+) {
   memoryChange(project: string, encoded: unknown) {
     return this[DurableObject.RunSymbol](
       Effect.gen(function* () {


### PR DESCRIPTION
The alarm deadline test installed its virtual clock only for Durable Object events. Initialization ran with the real clock and scheduled an alarm about a day earlier than the test clock, allowing automatic delivery to race the test's held maintenance attempt.

Provide the existing clock layer through the test application runtime so initialization and later events use the same clock. Before submission, the deadline test now initializes the object and checks that its bootstrap alarm is scheduled at or after virtual time. Production code is unchanged.

The new assertion fails on the previous setup, with the stored alarm about one day behind virtual time, and passes after the fix. The existing timeout, resource finalization, ownership release, dirty retry, and eventual settlement assertions remain intact. The complete Cloudflare package passes 419 tests with two existing browser skips.

`vp run ready` passes, including the full Cloudflare suite under repository test concurrency, recovery tests, documentation, and package builds. The first full gate exceeded the unchanged memory-soak test's absolute heap allowance by 1,044,560 bytes. That test does not import the changed Cloudflare files. Its complete testing package passed unchanged in isolation with 377 tests before the final gate; the failed measurement remains recorded rather than widening the allowance.
