### PR TITLE
feat(pr-review): configure the base spending allowance

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -128,13 +128,18 @@ generated-file exclusion.
 
 Review attempts default to a configurable **$2.50 maximum**. Set the Action's `max-cost-usd`
 input or local `PR_REVIEW_MAX_COST_USD` environment variable to a value from $0.01 to $100.
-The allowance is **$1 plus $1 per 100,000 characters** in admitted patches and selected prior
-feedback, capped at that maximum. For example, 10,000 characters allow $1.10, 50,000 allow
+The base defaults to **$1**. Set `base-cost-usd` or local `PR_REVIEW_BASE_COST_USD` to a value
+from $0.01 to $100. The allowance is **base plus $1 per 100,000 characters** in admitted patches
+and selected prior feedback, capped at the maximum even when the base exceeds it.
+For example, 10,000 characters allow $1.10, 50,000 allow
 $1.50, and 150,000 or more allow $2.50 with the default configuration. Ignored and excluded
 files do not increase the allowance. Empty or skipped reviews have a zero allowance.
 The footer, logs, and `cost-limit-usd` output show the actual scaled allowance, including
 both settled charges and outstanding reservations. The same policy applies to full reviews,
 incremental reviews, and eval trials; a retry gets a new allowance.
+
+With `base-cost-usd: "4.00"` and `max-cost-usd: "20.00"`, 10,000 characters allow $4.10
+and 1,600,000 or more allow $20. These are per-attempt allowances, not a cumulative PR limit.
 
 Every consumer must specify `model` (or local `PR_REVIEW_MODEL`); there is no fallback.
 Missing, blank, and unpriced models fail before paid inference. Reasoning effort defaults to

--- a/action/action.yml
+++ b/action/action.yml
@@ -44,9 +44,13 @@ inputs:
     required: false
     default: "medium"
   max-cost-usd:
-    description: "Maximum model spend per attempt in USD (0.01–100). Allowance is $1 plus $1 per 100,000 patch/feedback characters, capped at this value."
+    description: "Maximum model spend per attempt in USD (0.01–100). Allowance is base-cost-usd plus $1 per 100,000 patch/feedback characters, capped at this value."
     required: false
     default: "2.50"
+  base-cost-usd:
+    description: "Base model spend allowance per nonempty attempt in USD (0.01–100), before adding $1 per 100,000 patch/feedback characters. The total never exceeds max-cost-usd."
+    required: false
+    default: "1.00"
   priority:
     description: 'Processing priority: omit to use the OpenAI project setting, "default" to force Standard, or "fast" for Fast mode within the same spending cap.'
     required: false

--- a/examples/pr-review-eval/src/openai-variant.ts
+++ b/examples/pr-review-eval/src/openai-variant.ts
@@ -1,6 +1,7 @@
 import {
   makeReviewOpenAi,
   reviewCostLimitMicrousd,
+  reviewBaseCostUsd,
   reviewMaxCostUsd,
   reviewModel,
   reviewReasoningEffort,
@@ -59,6 +60,7 @@ export interface CurrentOpenAiVariantOptions {
 export const makeCurrentOpenAiVariant = Effect.fn("PrReviewEval.makeCurrentOpenAiVariant")(
   function* (options: CurrentOpenAiVariantOptions) {
     const maxCostUsd = yield* reviewMaxCostUsd;
+    const baseCostUsd = yield* reviewBaseCostUsd;
     const model = yield* reviewModel;
     const reasoningEffort = yield* reviewReasoningEffort;
 
@@ -117,7 +119,7 @@ export const makeCurrentOpenAiVariant = Effect.fn("PrReviewEval.makeCurrentOpenA
         const provider = yield* makeReviewOpenAi({
           model: configuration.model,
           cacheKey: `pr-review:${request.headRevision}`,
-          costLimitMicrousd: reviewCostLimitMicrousd(request, maxCostUsd),
+          costLimitMicrousd: reviewCostLimitMicrousd(request, maxCostUsd, baseCostUsd),
         }).pipe(Effect.mapError((error) => reviewerFailure(error)));
 
         const reviewer = makeReviewer({

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -56,6 +56,7 @@ import {
 } from "./presentation.ts";
 import {
   makeReviewOpenAi,
+  reviewBaseCostUsd,
   reviewCostLimitMicrousd,
   reviewPriority,
   reviewMaxCostUsd,
@@ -87,6 +88,7 @@ const ACTION_INPUT_BY_CONFIG: Readonly<Record<string, string>> = {
   PR_REVIEW_EFFORT: "INPUT_EFFORT",
   PR_REVIEW_PRIORITY: "INPUT_PRIORITY",
   PR_REVIEW_MAX_COST_USD: "INPUT_MAX-COST-USD",
+  PR_REVIEW_BASE_COST_USD: "INPUT_BASE-COST-USD",
   PR_REVIEW_GUIDANCE_FILE: "INPUT_GUIDANCE-FILE",
   PR_REVIEW_IGNORE: "INPUT_IGNORE",
 };
@@ -754,6 +756,7 @@ export const reviewActionProgram = Effect.gen(function* () {
   const priority = yield* reviewPriority;
 
   const maxCostUsd = yield* reviewMaxCostUsd;
+  const baseCostUsd = yield* reviewBaseCostUsd;
 
   const guidanceFile = yield* Config.string("PR_REVIEW_GUIDANCE_FILE").pipe(Config.withDefault(""));
 
@@ -946,7 +949,7 @@ export const reviewActionProgram = Effect.gen(function* () {
       followUps,
     });
 
-    const costLimitMicrousd = reviewCostLimitMicrousd(request, maxCostUsd);
+    const costLimitMicrousd = reviewCostLimitMicrousd(request, maxCostUsd, baseCostUsd);
 
     const provider = yield* makeReviewOpenAi({
       model: modelName,

--- a/packages/pr-review-action/src/review-openai.ts
+++ b/packages/pr-review-action/src/review-openai.ts
@@ -21,10 +21,14 @@ export const reviewPriority = Config.literals(["", "default", "fast"], "PR_REVIE
   Config.withDefault(""),
 );
 
-/** Maximum per attempt; the actual allowance scales with the admitted review input. */
-const ReviewMaxCostUsd = Schema.Number.check(Schema.isBetween({ minimum: 0.01, maximum: 100 }));
+const ReviewCostUsd = Schema.Number.check(Schema.isBetween({ minimum: 0.01, maximum: 100 }));
 
-export const reviewMaxCostUsd = Config.schema(ReviewMaxCostUsd, "PR_REVIEW_MAX_COST_USD").pipe(
+export const reviewBaseCostUsd = Config.schema(ReviewCostUsd, "PR_REVIEW_BASE_COST_USD").pipe(
+  Config.withDefault(1),
+);
+
+/** Maximum per attempt; the actual allowance scales with the admitted review input. */
+export const reviewMaxCostUsd = Config.schema(ReviewCostUsd, "PR_REVIEW_MAX_COST_USD").pipe(
   Config.withDefault(2.5),
 );
 
@@ -32,10 +36,11 @@ const ReviewCostLimitMicrousd = Schema.Int.check(
   Schema.isBetween({ minimum: 1, maximum: 100_000_000 }),
 );
 
-/** $1 for investigation, plus $1 per 100,000 patch/feedback characters, up to the configured cap. */
+/** Configured base plus $1 per 100,000 patch/feedback characters, up to the configured cap. */
 export const reviewCostLimitMicrousd = (
   request: Pick<ReviewRequest, "changes" | "followUps">,
   maxCostUsd: number,
+  baseCostUsd = 1,
 ): number => {
   const characters =
     request.changes.reduce((total, change) => total + change.patch.length, 0) +
@@ -43,7 +48,10 @@ export const reviewCostLimitMicrousd = (
 
   return characters === 0
     ? 0
-    : Math.min(Math.floor(maxCostUsd * 1_000_000), 1_000_000 + characters * 10);
+    : Math.min(
+        Math.floor(maxCostUsd * 1_000_000),
+        Math.floor(baseCostUsd * 1_000_000) + characters * 10,
+      );
 };
 
 const MAX_INPUT_TOKENS = 128_000;


### PR DESCRIPTION
Raising `max-cost-usd` alone leaves small reviews near the hardcoded $1 base, so Fast-mode consumers cannot increase their investigation allowance. Add `base-cost-usd` / `PR_REVIEW_BASE_COST_USD`, defaulting to $1, and apply it to both the Action and evals.

The allowance remains base + $1 per 100,000 admitted patch/feedback characters, bounded by `max-cost-usd`. A $4 base and $20 maximum allow $4.10 for 10,000 characters. Empty reviews still cost zero, and a base above the cap cannot raise the cap.

Validation: all 223 existing review-action tests passed. A direct smoke check passed for defaults, Action input mapping, environment precedence, invalid values, scaling, zero input, and cap enforcement. Main CI passed all static checks, tests, and builds and published the updated `action-v1`: https://github.com/danieljvdm/effect-agent/actions/runs/34062899288. Local `vp run ready` hit one unrelated Cloudflare compactor-test timeout; all five tests in that file passed on an isolated rerun.
