### PR TITLE
fix(pr-review): recover transient GitHub reads and incomplete reviews

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -35,6 +35,16 @@ not incomplete coverage, and are unavailable to source tools. A binary-only PR n
 model call. SVG, JSON, XML, and other text assets remain reviewable. API failures, malformed
 responses, invalid UTF-8 without NUL bytes, and source-size limits still fail coverage checks.
 Binary detection by content retains the existing file and byte read limits.
+GitHub reads retry transport errors, incomplete or invalid JSON bodies, timeouts, HTTP 408,
+5xx responses, and rate-limited 403/429 responses up to three times. Attempts have a 15-second
+timeout, exponential backoff starting at one second, and a shared 90-second read deadline.
+Retry-After and rate-limit reset delays are respected; a delay beyond the deadline stops the read
+instead of retrying early. Generated-file classification retains its tighter 10-second deadline.
+Schema-invalid responses, invalid UTF-8, identity mismatches, and ordinary permission or missing-file
+errors fail immediately. Retries use the same immutable blob SHA. GitHub writes are never retried.
+Read diagnostics include the operation, attempt, failure category, HTTP status, and GitHub request
+ID when available, without response bodies or credentials. Exhausted source reads log the affected
+path and revisions and leave coverage incomplete.
 When a rename or content replacement crosses between binary and text, the textual side
 is still reviewed as an addition or deletion. Explicit ignore rules continue to exclude
 an entire rename when either path matches.
@@ -61,7 +71,7 @@ bots' reviews are never dismissed.
 
 Incremental passes select prior reviews with an inline finding on an admitted changed path.
 They verify those specific blockers without expanding new-defect discovery beyond the delta.
-Use `@effect-agent review full` for body-only findings, fixes in other paths, or a same-head retry.
+Use `@effect-agent review full` for body-only findings, fixes in other paths, or a manual same-head retry.
 At most eight prior reviews are considered, each with its complete review body and bot comments
 within 32,000 characters. Oversized feedback stays blocking; it is never truncated for verification.
 Follow-up verification shares the same conversation and spending and execution
@@ -74,7 +84,10 @@ GitHub still accepts review comments, so it consumes the automatic allowance. Re
 review or inspect and dismiss manually.
 
 Automatic waves use the configured limit, defaulting to two; this repository allows five.
-Zero disables automatic reviews.
+Zero disables automatic reviews. Rerunning the workflow can retry an incomplete review on the same
+head while automatic attempts remain. Each published attempt consumes that allowance; incomplete
+attempts never become incremental baselines. Once the allowance is exhausted, an incomplete head
+continues to fail until a manual review completes. Completed heads are still skipped.
 Only trusted bot-authored terminal markers count. Failed attempts count but cannot become diff
 baselines. An owner, member, or collaborator can request `@effect-agent review` for incremental
 review or `@effect-agent review full` for the whole admitted diff. Manual waves do not consume the

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -437,6 +437,17 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
     ).pipe(Effect.result);
 
     if (Result.isFailure(contents)) {
+      yield* Effect.logWarning("Review source read failed", {
+        path: file.path,
+        basePath,
+        baseRevision: input.base.revision,
+        headRevision: input.head.revision,
+        operation: contents.failure.operation,
+        reason: contents.failure.reason,
+        attempts: contents.failure.attempts,
+        status: contents.failure.status,
+        requestId: contents.failure.requestId,
+      });
       hydratedSourceBytes += estimatedSourceBytes;
       exclude(unreviewedPaths, file, basePath, "source-read-failed");
       continue;

--- a/packages/pr-review-action/src/github.ts
+++ b/packages/pr-review-action/src/github.ts
@@ -1,7 +1,7 @@
 import { ReviewFollowUp } from "@effect-agent/pr-review/Review";
 import { createTwoFilesPatch } from "diff";
 import type { Redacted } from "effect";
-import { Effect, Encoding, Schema } from "effect";
+import { Clock, DateTime, Effect, Encoding, Option, Result, Schema } from "effect";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import { unresolvedChangeRequests, type ReviewHistoryItem } from "./selection.ts";
@@ -209,6 +209,9 @@ export interface RepositorySnapshot {
 export class GitHubApiFailure extends Schema.TaggedError<GitHubApiFailure>()("GitHubApiFailure", {
   operation: Schema.String,
   reason: Schema.String,
+  attempts: Schema.optionalKey(Schema.Natural),
+  status: Schema.optionalKey(Schema.Natural),
+  requestId: Schema.optionalKey(Schema.String),
 }) {}
 
 /** A verified blob containing NUL bytes, not a failed GitHub read. */
@@ -299,8 +302,117 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
         Effect.mapError((cause) => failure(operation, cause)),
       );
 
-  const getPullRequest = execute("get pull request", HttpClientRequest.get(pullUrl)).pipe(
-    Effect.flatMap(decode(PullRequestWire, "get pull request")),
+  // Only explicitly read-only operations enter this retry boundary. Include body
+  // consumption in each attempt: retrying headers alone cannot repair a cut-off body.
+  const readJson = Effect.fn("GitHubClient.readJson")(function* <S extends Schema.Top>(
+    operation: string,
+    value: HttpClientRequest.HttpClientRequest,
+    schema: S,
+  ) {
+    const deadline = (yield* Clock.currentTimeMillis) + 90_000;
+
+    for (let attempt = 1; ; attempt += 1) {
+      const remaining = deadline - (yield* Clock.currentTimeMillis);
+
+      if (remaining <= 0) {
+        return yield* GitHubApiFailure.make({
+          operation,
+          reason: "GitHub read deadline exceeded",
+          attempts: attempt - 1,
+        });
+      }
+
+      const result = yield* client.execute(request(value)).pipe(
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+        Effect.flatMap((response) => response.json),
+        Effect.timeout(Math.min(15_000, remaining)),
+        Effect.result,
+      );
+
+      if (Result.isSuccess(result)) {
+        return yield* Schema.decodeUnknownEffect(schema)(result.success).pipe(
+          Effect.mapError(() =>
+            GitHubApiFailure.make({
+              operation,
+              reason: "Response does not match the GitHub schema",
+              attempts: attempt,
+            }),
+          ),
+        );
+      }
+
+      const error = result.failure;
+      const response = error._tag === "HttpClientError" ? error.response : undefined;
+      const status = response?.status;
+      const category = error._tag === "TimeoutError" ? "TimeoutError" : error.reason._tag;
+      const headers = response?.headers;
+      const now = yield* Clock.currentTimeMillis;
+      const retryAfter = headers?.["retry-after"];
+
+      const retryDate =
+        retryAfter === undefined ? undefined : Option.getOrUndefined(DateTime.make(retryAfter));
+
+      const retryAfterMs =
+        retryAfter === undefined
+          ? undefined
+          : Number.isFinite(Number(retryAfter))
+            ? Math.max(0, Number(retryAfter) * 1_000)
+            : retryDate === undefined
+              ? undefined
+              : Math.max(0, DateTime.toEpochMillis(retryDate) - now);
+
+      const rateLimited =
+        status === 429 ||
+        (status === 403 &&
+          (retryAfterMs !== undefined || headers?.["x-ratelimit-remaining"] === "0"));
+
+      const reset = Number(headers?.["x-ratelimit-reset"]);
+
+      const rateDelay =
+        retryAfterMs ??
+        (rateLimited ? Math.max(60_000, Number.isFinite(reset) ? reset * 1_000 - now : 0) : 0);
+
+      const delay = Math.max(1_000 * 2 ** (attempt - 1), rateDelay);
+
+      const retryable =
+        category === "TimeoutError" ||
+        category === "TransportError" ||
+        category === "DecodeError" ||
+        status === 408 ||
+        rateLimited ||
+        (status !== undefined && status >= 500 && status <= 599);
+
+      const retry = retryable && attempt < 4 && now + delay < deadline;
+      const requestId = headers?.["x-github-request-id"]?.slice(0, 256);
+
+      const diagnostic = {
+        operation,
+        attempt,
+        category,
+        status,
+        requestId,
+        ...(retry ? { retryInMs: delay } : {}),
+      };
+
+      yield* Effect.logWarning(retry ? "Retrying GitHub read" : "GitHub read failed", diagnostic);
+      if (!retry) {
+        return yield* GitHubApiFailure.make({
+          operation,
+          reason: `${category}${status === undefined ? "" : ` (HTTP ${String(status)})`} after ${String(attempt)} attempt(s)`,
+          attempts: attempt,
+          ...(status === undefined ? {} : { status }),
+          ...(requestId === undefined ? {} : { requestId }),
+        });
+      }
+      yield* Effect.sleep(delay);
+    }
+  });
+
+  const getPullRequest = readJson(
+    "get pull request",
+    HttpClientRequest.get(pullUrl),
+    PullRequestWire,
+  ).pipe(
     Effect.map((wire): PullRequestView => ({
       number: wire.number,
       title: wire.title,
@@ -316,16 +428,10 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
     const all: Array<ChangedFile> = [];
 
     for (let page = 1; page <= 30; page += 1) {
-      const wires = yield* execute(
+      const wires = yield* readJson(
         "list pull request files",
         HttpClientRequest.get(`${pullUrl}/files?per_page=100&page=${String(page)}`),
-      ).pipe(
-        Effect.flatMap(
-          decode(
-            Schema.Array(ChangedFileWire).check(Schema.isMaxLength(100)),
-            "list pull request files",
-          ),
-        ),
+        Schema.Array(ChangedFileWire).check(Schema.isMaxLength(100)),
       );
 
       all.push(...wires.map(changedFileFromWire));
@@ -342,16 +448,10 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
     const all: Array<ReviewHistoryItem> = [];
 
     for (let page = 1; page <= 10; page += 1) {
-      const wires = yield* execute(
+      const wires = yield* readJson(
         "list pull request reviews",
         HttpClientRequest.get(`${pullUrl}/reviews?per_page=100&page=${String(page)}`),
-      ).pipe(
-        Effect.flatMap(
-          decode(
-            Schema.Array(ReviewWire).check(Schema.isMaxLength(100)),
-            "list pull request reviews",
-          ),
-        ),
+        Schema.Array(ReviewWire).check(Schema.isMaxLength(100)),
       );
 
       all.push(...wires.map(reviewFromWire));
@@ -384,18 +484,12 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
           });
         }
 
-        const batch = yield* execute(
+        const batch = yield* readJson(
           "list review comments",
           HttpClientRequest.get(
             `${pullUrl}/reviews/${String(review.id)}/comments?per_page=100&page=${String(page)}`,
           ),
-        ).pipe(
-          Effect.flatMap(
-            decode(
-              Schema.Array(ReviewCommentWire).check(Schema.isMaxLength(100)),
-              "list review comments",
-            ),
-          ),
+          Schema.Array(ReviewCommentWire).check(Schema.isMaxLength(100)),
         );
 
         if (batch.some((comment) => comment.pull_request_review_id !== review.id)) {
@@ -461,13 +555,11 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
     }
     const reviewUrl = `${pullUrl}/reviews/${String(input.review.id)}`;
 
-    const currentReview = yield* execute(
+    const currentReview = yield* readJson(
       "get review before dismissal",
       HttpClientRequest.get(reviewUrl),
-    ).pipe(
-      Effect.flatMap(decode(ReviewWire, "get review before dismissal")),
-      Effect.map(reviewFromWire),
-    );
+      ReviewWire,
+    ).pipe(Effect.map(reviewFromWire));
 
     if (
       currentReview.id !== input.review.id ||
@@ -539,12 +631,13 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
 
     if (cached !== undefined) return cached;
 
-    const blob = yield* execute(
+    const blob = yield* readJson(
       "get Git blob",
       HttpClientRequest.get(
         `${apiUrl}/repos/${options.repository}/git/blobs/${encodeURIComponent(sha)}`,
       ),
-    ).pipe(Effect.flatMap(decode(GitBlobWire, "get Git blob")));
+      GitBlobWire,
+    );
 
     if (blob.sha !== sha) {
       return yield* GitHubApiFailure.make({
@@ -593,12 +686,13 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
   const readTreeSnapshot = Effect.fn("GitHubClient.readTreeSnapshot")(function* (
     revision: string,
   ): Effect.fn.Return<RepositorySnapshot, GitHubApiFailure> {
-    const commit = yield* execute(
+    const commit = yield* readJson(
       "get Git commit",
       HttpClientRequest.get(
         `${apiUrl}/repos/${options.repository}/git/commits/${encodeURIComponent(revision)}`,
       ),
-    ).pipe(Effect.flatMap(decode(GitCommitWire, "get Git commit")));
+      GitCommitWire,
+    );
 
     if (commit.sha !== revision) {
       return yield* GitHubApiFailure.make({
@@ -607,12 +701,13 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
       });
     }
 
-    const tree = yield* execute(
+    const tree = yield* readJson(
       "get recursive Git tree",
       HttpClientRequest.get(
         `${apiUrl}/repos/${options.repository}/git/trees/${encodeURIComponent(commit.tree.sha)}?recursive=1`,
       ),
-    ).pipe(Effect.flatMap(decode(GitTreeWire, "get recursive Git tree")));
+      GitTreeWire,
+    );
 
     if (tree.sha !== commit.tree.sha) {
       return yield* GitHubApiFailure.make({
@@ -667,12 +762,13 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
     base: string,
     head: string,
   ) {
-    const comparison = yield* execute(
+    const comparison = yield* readJson(
       "get pull request merge base",
       HttpClientRequest.get(
         `${apiUrl}/repos/${options.repository}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
       ),
-    ).pipe(Effect.flatMap(decode(CompareWire, "get pull request merge base")));
+      CompareWire,
+    );
 
     return comparison.merge_base_commit.sha;
   });
@@ -729,8 +825,7 @@ export const makeGitHubClient = Effect.fn("makeGitHubClient")(function* (options
       Effect.mapError((cause) => failure("encode generated file query", cause)),
     );
 
-    const result = yield* execute("classify generated file", query).pipe(
-      Effect.flatMap(decode(GeneratedFileWire, "classify generated file")),
+    const result = yield* readJson("classify generated file", query, GeneratedFileWire).pipe(
       Effect.timeout("10 seconds"),
       Effect.catchTag("TimeoutError", () =>
         Effect.fail(

--- a/packages/pr-review-action/src/selection.ts
+++ b/packages/pr-review-action/src/selection.ts
@@ -159,7 +159,11 @@ export const selectReview = (input: {
   if (currentHeadAttempts.some(({ marker }) => marker.version === 3 && marker.completed)) {
     return { _tag: "skip", reason: "head-already-reviewed" };
   }
-  if (input.mode === "auto" && currentHeadAttempts.length > 0) {
+  if (
+    input.mode === "auto" &&
+    currentHeadAttempts.length > 0 &&
+    automaticAttempts >= input.automaticReviewLimit
+  ) {
     return { _tag: "skip", reason: "head-review-incomplete" };
   }
 

--- a/packages/pr-review-action/test/action.test.ts
+++ b/packages/pr-review-action/test/action.test.ts
@@ -10,6 +10,7 @@ import {
   Exit,
   Fiber,
   Layer,
+  Logger,
   Option,
   Ref,
   Schema,
@@ -776,68 +777,73 @@ describe("Incremental review scope", () => {
       }),
   );
 
-  it.effect("completes a binary-only PR without fetching blobs or calling a model", () =>
-    Effect.gen(function* () {
-      const published = yield* Ref.make<ReadonlyArray<typeof PublishedReviewBody.Type>>([]);
+  it.effect.each([false, true])(
+    "completes a binary-only PR, including an incomplete same-head retry: %s",
+    (retry) =>
+      Effect.gen(function* () {
+        const published = yield* Ref.make<ReadonlyArray<typeof PublishedReviewBody.Type>>([]);
 
-      const client = HttpClient.make((request, url) => {
-        let response: unknown;
+        const client = HttpClient.make((request, url) => {
+          let response: unknown;
 
-        if (request.method === "POST" && url.pathname.endsWith("/reviews")) {
-          return Ref.update(published, (values) => [
-            ...values,
-            decodePublishedReview(request),
-          ]).pipe(
-            Effect.as(
-              jsonResponse(request, {
-                html_url: "https://github.test/reve-ai/example/pull/12#review",
-              }),
-            ),
-          );
-        }
-        if (url.pathname.endsWith("/pulls/12")) {
-          response = pullRequestWire("Update icons", "base", "head");
-        } else if (url.pathname.endsWith("/reviews") || url.pathname.endsWith("/files")) {
-          response = [];
-        } else if (url.pathname.includes("/compare/")) {
-          response = { merge_base_commit: { sha: "base" } };
-        } else if (url.pathname.includes("/git/commits/")) {
-          const sha = url.pathname.endsWith("/base") ? "base" : "head";
+          if (request.method === "POST" && url.pathname.endsWith("/reviews")) {
+            return Ref.update(published, (values) => [
+              ...values,
+              decodePublishedReview(request),
+            ]).pipe(
+              Effect.as(
+                jsonResponse(request, {
+                  html_url: "https://github.test/reve-ai/example/pull/12#review",
+                }),
+              ),
+            );
+          }
+          if (url.pathname.endsWith("/pulls/12")) {
+            response = pullRequestWire("Update icons", "base", "head");
+          } else if (url.pathname.endsWith("/reviews") || url.pathname.endsWith("/files")) {
+            response =
+              retry && url.pathname.endsWith("/reviews")
+                ? [reviewHistoryWire(1, reviewMarker(true, false), "head", "2026-08-25T00:00:00Z")]
+                : [];
+          } else if (url.pathname.includes("/compare/")) {
+            response = { merge_base_commit: { sha: "base" } };
+          } else if (url.pathname.includes("/git/commits/")) {
+            const sha = url.pathname.endsWith("/base") ? "base" : "head";
 
-          response = { sha, tree: { sha: `${sha}-tree` } };
-        } else if (url.pathname.includes("/git/trees/")) {
-          const sha = url.pathname.endsWith("/base-tree") ? "base-tree" : "head-tree";
+            response = { sha, tree: { sha: `${sha}-tree` } };
+          } else if (url.pathname.includes("/git/trees/")) {
+            const sha = url.pathname.endsWith("/base-tree") ? "base-tree" : "head-tree";
 
-          response = {
-            sha,
-            truncated: false,
-            tree:
-              sha === "base-tree"
-                ? []
-                : [
-                    {
-                      path: "assets/icon.png",
-                      sha: "image",
-                      mode: "100644",
-                      type: "blob",
-                      size: 20_000_000,
-                    },
-                  ],
-          };
-        } else {
-          return Effect.die(`unexpected request ${request.method} ${url.href}`);
-        }
+            response = {
+              sha,
+              truncated: false,
+              tree:
+                sha === "base-tree"
+                  ? []
+                  : [
+                      {
+                        path: "assets/icon.png",
+                        sha: "image",
+                        mode: "100644",
+                        type: "blob",
+                        size: 20_000_000,
+                      },
+                    ],
+            };
+          } else {
+            return Effect.die(`unexpected request ${request.method} ${url.href}`);
+          }
 
-        return Effect.succeed(jsonResponse(request, response));
-      });
+          return Effect.succeed(jsonResponse(request, response));
+        });
 
-      yield* runReviewAction(client);
-      const reviews = yield* Ref.get(published);
+        yield* runReviewAction(client);
+        const reviews = yield* Ref.get(published);
 
-      expect(reviews).toHaveLength(1);
-      expect(reviews[0]?.body).toContain("1 ignored");
-      expect(reviews[0]?.body).toContain(reviewMarker(true, true));
-    }),
+        expect(reviews).toHaveLength(1);
+        expect(reviews[0]?.body).toContain("1 ignored");
+        expect(reviews[0]?.body).toContain(reviewMarker(true, true));
+      }),
   );
 
   it("publishes blocking findings as a head-bound change request", () => {
@@ -878,7 +884,7 @@ describe("Incremental review scope", () => {
   });
 
   it.effect(
-    "keeps failed and incomplete same-head automatic attempts failing at the action seam",
+    "keeps incomplete same-head attempts failing when the automatic allowance is exhausted",
     () =>
       Effect.gen(function* () {
         for (const body of [
@@ -901,7 +907,9 @@ describe("Incremental review scope", () => {
             return recordJsonResponse(requests, request, url, response);
           });
 
-          const exit = yield* runReviewAction(client).pipe(Effect.exit);
+          const exit = yield* runReviewAction(client, { PR_REVIEW_AUTOMATIC_LIMIT: "1" }).pipe(
+            Effect.exit,
+          );
 
           expect(Exit.isFailure(exit)).toBe(true);
           expect(yield* Ref.get(requests)).toEqual([
@@ -1689,6 +1697,7 @@ layer(noGeneratedFiles)("exact review delta", (it) => {
 
   it.effect("keeps expected blob read failures as coverage gaps and admits other files", () =>
     Effect.gen(function* () {
+      const logs: Array<unknown> = [];
       const paths = ["src/a.ts", "src/b.ts"];
       const head = treeSnapshot("head", { "src/a.ts": "a", "src/b.ts": "b" });
 
@@ -1706,8 +1715,22 @@ layer(noGeneratedFiles)("exact review delta", (it) => {
               : head.readTextFile(path),
         },
         ignore: [],
-      });
+      }).pipe(
+        Effect.provide(
+          Logger.layer([Logger.make<unknown, void>(({ message }) => logs.push(message))]),
+        ),
+      );
 
+      expect(logs).toContainEqual([
+        "Review source read failed",
+        expect.objectContaining({
+          path: "src/a.ts",
+          baseRevision: "base",
+          headRevision: "head",
+          operation: "readTextFile",
+          reason: "blob unavailable",
+        }),
+      ]);
       expect(surface.unreviewedPaths).toEqual(["src/a.ts"]);
       expect(surface.exclusions).toEqual([{ path: "src/a.ts", reason: "source-read-failed" }]);
       expect([...surface.unavailablePaths]).toEqual(["src/a.ts"]);

--- a/packages/pr-review-action/test/github.test.ts
+++ b/packages/pr-review-action/test/github.test.ts
@@ -1,8 +1,8 @@
 import { ReviewFinding, ReviewFollowUp, ReviewReport } from "@effect-agent/pr-review/Review";
 import { describe, expect, it } from "@effect/vitest";
-import { Deferred, Effect, Encoding, Exit, Fiber, Redacted, Ref, Schema } from "effect";
+import { Deferred, Effect, Encoding, Exit, Fiber, Logger, Redacted, Ref, Schema } from "effect";
 import { TestClock } from "effect/testing";
-import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { HttpClient, HttpClientError, HttpClientResponse } from "effect/unstable/http";
 
 import { makeGitHubClient, type RepositorySnapshot } from "../src/github.ts";
 import { renderFindingBody, renderReviewBody } from "../src/presentation.ts";
@@ -317,6 +317,232 @@ const entry = (
   mode: "100644" | "100755" | "120000" | "040000" | "160000" = "100644",
   type: "blob" | "tree" | "commit" = "blob",
 ) => ({ path, sha, mode, type, ...(type === "blob" ? { size: 1 } : {}) });
+
+describe("GitHub read recovery", () => {
+  it.effect.each([
+    { failure: "server", attempts: 3, success: true },
+    { failure: "transport", attempts: 3, success: true },
+    { failure: "body", attempts: 3, success: true },
+    { failure: "timeout", attempts: 3, success: true },
+    { failure: "rate-limit", attempts: 3, success: true },
+    { failure: "rate-date", attempts: 3, success: true },
+    { failure: "rate-reset", attempts: 2, success: true },
+    { failure: "long-rate-limit", attempts: 1, success: false },
+    { failure: "exhausted", attempts: 4, success: false },
+    { failure: "deadline", attempts: 2, success: false },
+    { failure: "forbidden", attempts: 1, success: false },
+    { failure: "missing", attempts: 1, success: false },
+    { failure: "schema", attempts: 1, success: false },
+    { failure: "utf8", attempts: 1, success: false },
+  ])("recovers bounded blob reads: $failure", ({ failure, attempts, success }) =>
+    Effect.gen(function* () {
+      let reads = 0;
+      let finalized = 0;
+      const logs: Array<unknown> = [];
+      const blob = "a".repeat(40);
+      const path = "src/example.ts";
+
+      const client = HttpClient.make((request, url) => {
+        let body: unknown;
+        let status = 200;
+        let headers: Record<string, string> = {};
+
+        if (url.pathname.includes("/git/commits/")) {
+          body = { sha: headRevision, tree: { sha: headTree } };
+        } else if (url.pathname.includes("/git/trees/")) {
+          body = { sha: headTree, truncated: false, tree: [entry(path, blob)] };
+        } else {
+          expect(url.pathname).toBe(`/repos/${repository}/git/blobs/${blob}`);
+          reads += 1;
+          body = { sha: blob, size: 4, encoding: "base64", content: Encoding.encodeBase64("text") };
+          if (failure === "utf8") {
+            body = {
+              sha: blob,
+              size: 1,
+              encoding: "base64",
+              content: Encoding.encodeBase64(new Uint8Array([255])),
+            };
+          } else if (failure === "schema") {
+            body = { secret: "private-source-sentinel" };
+          } else if (failure === "forbidden" || failure === "missing") {
+            status = failure === "forbidden" ? 403 : 404;
+          } else if (failure === "long-rate-limit" || failure === "deadline") {
+            status = 429;
+            headers = { "retry-after": failure === "deadline" ? "60" : "120" };
+          } else if (reads <= (failure === "rate-reset" ? 1 : 2) || failure === "exhausted") {
+            if (failure === "transport") {
+              return Effect.fail(
+                new HttpClientError.HttpClientError({
+                  reason: new HttpClientError.TransportError({
+                    request,
+                    cause: new Error("private-source-sentinel"),
+                  }),
+                }),
+              );
+            }
+            if (failure === "timeout") {
+              return Effect.never.pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    finalized += 1;
+                  }),
+                ),
+              );
+            }
+            if (failure === "body") {
+              return Effect.succeed(
+                HttpClientResponse.fromWeb(
+                  request,
+                  new globalThis.Response('{"private-source-sentinel":'),
+                ),
+              );
+            }
+            status =
+              failure === "rate-limit" || failure === "rate-date" || failure === "rate-reset"
+                ? 403
+                : 503;
+            headers =
+              failure === "rate-limit"
+                ? { "retry-after": "5" }
+                : failure === "rate-date"
+                  ? { "retry-after": "Thu, 01 Jan 1970 00:00:10 GMT" }
+                  : failure === "rate-reset"
+                    ? { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "60" }
+                    : {};
+          }
+        }
+
+        return Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new globalThis.Response(JSON.stringify(body), {
+              status,
+              headers: { ...headers, "x-github-request-id": "request-123" },
+            }),
+          ),
+        );
+      });
+
+      const github = yield* makeGitHubClient({
+        repository,
+        pullRequest: 12,
+        token: Redacted.make("credential-sentinel"),
+      }).pipe(Effect.provideService(HttpClient.HttpClient, client));
+
+      const snapshot = yield* github.readTreeSnapshot(headRevision);
+
+      const fiber = yield* snapshot
+        .readTextFile(path)
+        .pipe(
+          Effect.provide(
+            Logger.layer([Logger.make<unknown, void>(({ message }) => logs.push(message))]),
+          ),
+          Effect.result,
+          Effect.forkChild,
+        );
+
+      yield* TestClock.adjust("90 seconds");
+      const result = yield* Fiber.join(fiber);
+
+      expect(result._tag).toBe(success ? "Success" : "Failure");
+      expect(reads).toBe(attempts);
+      if (result._tag === "Success") {
+        expect(result.success).toBe("text");
+        expect(yield* snapshot.readTextFile(path)).toBe("text");
+        expect(reads).toBe(attempts);
+      } else if (failure === "exhausted") {
+        expect(result.failure).toMatchObject({
+          operation: "get Git blob",
+          attempts: 4,
+          status: 503,
+          requestId: "request-123",
+        });
+        expect(logs).toContainEqual([
+          "GitHub read failed",
+          expect.objectContaining({ category: "StatusCodeError", status: 503, attempt: 4 }),
+        ]);
+      }
+      expect(finalized).toBe(failure === "timeout" ? 2 : 0);
+      expect(JSON.stringify(logs)).not.toContain("credential-sentinel");
+      expect(JSON.stringify(logs)).not.toContain("private-source-sentinel");
+    }),
+  );
+
+  it.effect.each(["active", "backoff", "defect"] as const)(
+    "preserves cancellation and defects: %s",
+    (phase) =>
+      Effect.gen(function* () {
+        let reads = 0;
+        let finalized = false;
+        const entered = yield* Deferred.make<void>();
+
+        const client = HttpClient.make((request) =>
+          Effect.gen(function* () {
+            reads += 1;
+            yield* Deferred.succeed(entered, undefined);
+            if (phase === "defect") return yield* Effect.die("broken adapter");
+            if (phase === "backoff")
+              return HttpClientResponse.fromWeb(
+                request,
+                new globalThis.Response("", { status: 503 }),
+              );
+
+            return yield* Effect.never.pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  finalized = true;
+                }),
+              ),
+            );
+          }),
+        );
+
+        const github = yield* makeGitHubClient({
+          repository,
+          pullRequest: 12,
+          token: Redacted.make("token"),
+        }).pipe(Effect.provideService(HttpClient.HttpClient, client));
+
+        const fiber = yield* github.getPullRequest.pipe(Effect.forkChild);
+
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(0);
+        if (phase !== "defect") yield* Fiber.interrupt(fiber);
+        const exit = yield* Fiber.await(fiber);
+
+        yield* TestClock.adjust("90 seconds");
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(reads).toBe(1);
+        expect(finalized).toBe(phase === "active");
+      }),
+  );
+
+  it.effect("does not replay an uncertain GitHub write", () =>
+    Effect.gen(function* () {
+      let writes = 0;
+
+      const client = HttpClient.make((request) => {
+        writes += 1;
+        expect(request.method).toBe("POST");
+
+        return Effect.succeed(
+          HttpClientResponse.fromWeb(request, new globalThis.Response("", { status: 503 })),
+        );
+      });
+
+      const github = yield* makeGitHubClient({
+        repository,
+        pullRequest: 12,
+        token: Redacted.make("token"),
+      }).pipe(Effect.provideService(HttpClient.HttpClient, client));
+
+      const failure = yield* github.acknowledgeComment(123).pipe(Effect.flip);
+
+      expect(failure._tag).toBe("GitHubApiFailure");
+      expect(writes).toBe(1);
+    }),
+  );
+});
 
 it.effect("PRR-009 publishes twenty-four blocking findings at the review field bounds", () =>
   Effect.gen(function* () {

--- a/packages/pr-review-action/test/selection.test.ts
+++ b/packages/pr-review-action/test/selection.test.ts
@@ -181,7 +181,7 @@ describe("GitHub review selection", () => {
     ).toEqual({ _tag: "skip", reason: "head-already-reviewed" });
   });
 
-  it("PRR-006 keeps a failed or incomplete same-head attempt failing without retrying it", () => {
+  it("PRR-006 retries incomplete same-head attempts within the automatic allowance", () => {
     for (const body of [
       `Review execution failed.\n\n${reviewMarker(true, false)}`,
       `Review coverage is incomplete.\n\n${reviewMarker(true, false)}`,
@@ -194,8 +194,39 @@ describe("GitHub review selection", () => {
           automaticReviewLimit: 2,
           history: [item(1, "head-1", true, false, { body })],
         }),
-      ).toEqual({ _tag: "skip", reason: "head-review-incomplete" });
+      ).toMatchObject({
+        _tag: "review",
+        scope: "full",
+        automatic: true,
+        automaticReviewsRemaining: 0,
+      });
     }
+  });
+
+  it("keeps an incomplete head failing after its automatic allowance is exhausted", () => {
+    expect(
+      selectReview({
+        mode: "auto",
+        currentHead: "head-1",
+        reviewAuthor: "effect-agent[bot]",
+        automaticReviewLimit: 2,
+        history: [item(1, "head-1", true, false), item(2, "head-1", true, false)],
+      }),
+    ).toEqual({ _tag: "skip", reason: "head-review-incomplete" });
+    expect(
+      selectReview({
+        mode: "auto",
+        currentHead: "head-2",
+        reviewAuthor: "effect-agent[bot]",
+        automaticReviewLimit: 3,
+        history: [item(1, "head-1", true, true), item(2, "head-2", true, false)],
+      }),
+    ).toMatchObject({
+      _tag: "review",
+      scope: "incremental",
+      baseRevision: "head-1",
+      automaticReviewsRemaining: 0,
+    });
   });
 
   it("PRR-006 counts failed automatic attempts but does not use them as baselines", () => {


### PR DESCRIPTION
Transient GitHub failures could exclude a readable file from review after one attempt, and rerunning the workflow refused to retry the resulting incomplete review on the same commit.

Retry read-only GitHub requests, including response-body reads, with bounded backoff, timeouts, and rate-limit delays. Retain the failure category, HTTP status, request ID, and affected source revisions when recovery fails. Allow same-head workflow retries within the existing automatic-review allowance; exhausted incomplete heads still fail. GitHub writes remain single-attempt to avoid duplicating uncertain side effects.

Validation: `vp run ready`, including 243 reviewer tests and the Action bundle build. Regression coverage includes transient recovery, retry exhaustion, rate limits, timeouts, cancellation, diagnostics, and same-head retry limits.
