### PR TITLE
ci: raise repository review spending allowance

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -70,5 +70,6 @@ jobs:
           guidance-file: .github/review-guidance.md
           model: gpt-6-astra
           priority: fast
-          max-cost-usd: "10.00"
+          base-cost-usd: "20.00"
+          max-cost-usd: "25.00"
           ignore: "bun.lock,action/dist/**,**/CHANGELOG.md,.agents/skills/**,.claude/skills/**"

--- a/action/README.md
+++ b/action/README.md
@@ -163,7 +163,8 @@ Set `priority: default` to force Standard processing, or `priority: fast` (local
 Fast is supported for the listed models, subject to account and regional availability.
 Fast mode costs twice the standard token rates for the supported models and uses the same
 size-scaled spending cap, so the allowance buys fewer tokens. The effect-agent repository's
-workflow opts into Fast mode with `max-cost-usd: "10.00"`; its allowance still scales with PR size.
+workflow opts into Fast mode with `base-cost-usd: "20.00"` and `max-cost-usd: "25.00"`;
+its allowance still scales with PR size.
 Requests with omitted priority reserve at Fast rates because the project setting can enable Fast.
 Explicit priorities reserve at the selected tier's rates, and settlement uses the tier reported by OpenAI,
 including standard-rate fallback from Fast mode. Both `fast` and `priority` response tags identify


### PR DESCRIPTION
Large reviews can stop well below the configured maximum: the attempt on #341 received a $3.93 allowance because the policy starts with a $1 base and adds $1 per 100,000 admitted patch/feedback characters.

Set the repository workflow's base to $20 and its per-attempt ceiling to $25, and update the matching documentation. For the same admitted input, #341 would receive about $22.93. Raising only the maximum would leave its effective allowance unchanged.

Validation: `vp fmt --check .github/workflows/pr-review.yml action/README.md` passes. Both files are identical to the isolated budget commit on #341.

This configuration must land on `main` before rerunning #341 because `pull_request_target` uses the base branch workflow. Landing this PR requires owner approval; it does not land or publish the library changes in #341.
