### PR TITLE
fix(platform-cloudflare): defer native subscription alarm services

### DIFF
--- a/.changeset/native-subscription-alarm-services.md
+++ b/.changeset/native-subscription-alarm-services.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Allow ancillary alarm callbacks and payload decoders to use native partition subscription services while capturing host dependencies during assembly.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -376,8 +376,20 @@ Execution remains at least once; provider failures never invent event completion
 
 Cloudflare hosts can install `SubscriptionPartitionAlarmExtension` with handlers built by
 `makeSubscriptionPartitionAlarmHandler`. Each handler owns one non-framework tag, a payload
-Schema and a bounded timeout (at most 30 seconds). The factory captures host services while each
-codec/callback invocation owns a fresh Scope. Invocation cleanup runs on success, typed failure,
+Schema and a bounded timeout (at most 30 seconds). The factory captures host services but defers
+`Subscriptions`, `SubscriptionIntake` and `SubscriptionDriver` requirements, including those in
+payload decoders, until invocation. `makeSubscriptionPartitionObjectClass` supplies these native
+services from the addressed partition after building the host Layer. Keep their lookup inside the
+callback or decoder; yielding them while building the host Layer still requires them at assembly.
+Handlers retain only their required native services in `R`; host requirements remain on the factory
+Effect. Even if native services were present at assembly, the invocation uses its own instances.
+
+An existing `handle: () => runtime.process` can therefore keep `SubscriptionIntake` in the process
+Effect's requirements. Map its expected failures to `SubscriptionAlarmExtensionError`; no extra
+handler argument or client Layer is needed. See the compiling Cloudflare example below for a
+handler that accepts an event through native intake.
+
+Each codec/callback invocation owns a fresh Scope. Invocation cleanup runs on success, typed failure,
 defect, timeout and interruption; captured host services keep their host lifetime.
 
 The native multiplexer processes at most 16 alarms per invocation and durably retries failed rows

--- a/packages/platform-cloudflare/examples/subscriptions.ts
+++ b/packages/platform-cloudflare/examples/subscriptions.ts
@@ -1,19 +1,23 @@
 import { type ThreadObjectNamespace } from "@effect-agent/platform-cloudflare/CloudflareBindings";
 import {
   CloudflareSubscriptionsClient,
+  makeSubscriptionPartitionAlarmHandler,
   makeSubscriptionPartitionObjectClass,
+  SubscriptionAlarmExtensionError,
+  SubscriptionPartitionAlarmExtension,
   type SubscriptionPartitionIdentity,
   SubscriptionPartitionNamespace,
   type SubscriptionPartitionObjectRpc,
 } from "@effect-agent/platform-cloudflare/CloudflareSubscriptions";
 import { type EventSources } from "@effect-agent/thread/EventSource";
+import { Principal } from "@effect-agent/thread/SubmissionLedger";
 import {
   type SourcePartition,
   type SubscriptionAuthorizer,
 } from "@effect-agent/thread/Subscription";
 import { type SubscriptionInputBindings } from "@effect-agent/thread/SubscriptionInput";
 import { SubscriptionIntake, Subscriptions } from "@effect-agent/thread/Subscriptions";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schema } from "effect";
 import type { DurableObjectState, WorkerEnvironment } from "effect-cf";
 
 /**
@@ -27,6 +31,32 @@ export const makeSubscriptionPartition = <E>(
     DurableObjectState.DurableObjectState | WorkerEnvironment | SubscriptionPartitionIdentity
   >,
 ) => makeSubscriptionPartitionObjectClass(host);
+
+/** Merge into the host Layer. Only trusted host code may enqueue these verified events. */
+export const verifiedEventAlarms = Layer.effect(
+  SubscriptionPartitionAlarmExtension,
+  makeSubscriptionPartitionAlarmHandler({
+    tag: "application/verified-event",
+    payload: Schema.Struct({
+      eventId: Schema.NonEmptyString.check(Schema.isMaxLength(128)),
+      topic: Schema.NonEmptyString.check(Schema.isMaxLength(128)),
+      message: Schema.String.check(Schema.isMaxLength(4_096)),
+    }),
+    timeoutMillis: 30_000,
+    handle: ({ payload }) =>
+      Effect.gen(function* () {
+        const intake = yield* SubscriptionIntake;
+
+        yield* intake.accept(
+          Principal.make("application-verifier"),
+          { name: "application-event", version: "1" },
+          payload,
+        );
+      }).pipe(
+        Effect.mapError(() => SubscriptionAlarmExtensionError.make({ code: "verified-intake" })),
+      ),
+  }).pipe(Effect.map((handler) => ({ handlers: [handler] }))),
+);
 
 /** Bind one client to one permitted source partition; every operation creates a fresh RPC stub. */
 export const subscriptionClientLayer = (

--- a/packages/platform-cloudflare/src/CloudflareSubscriptions.ts
+++ b/packages/platform-cloudflare/src/CloudflareSubscriptions.ts
@@ -65,11 +65,17 @@ export class SubscriptionAlarmExtensionError extends Schema.TaggedError<Subscrip
   { code: Schema.NonEmptyString.check(Schema.isMaxLength(128)) },
 ) {}
 
-export interface SubscriptionPartitionAlarmHandler {
+/** Native partition services supplied at alarm invocation, after the host Layer is built. */
+export type SubscriptionPartitionAlarmServices =
+  | Subscriptions
+  | SubscriptionIntake
+  | SubscriptionDriver;
+
+export interface SubscriptionPartitionAlarmHandler<R = SubscriptionPartitionAlarmServices> {
   readonly tag: string;
   readonly handle: (
     event: DurableObjectAlarm.DurableObjectAlarmEvent,
-  ) => Effect.Effect<void, SubscriptionAlarmProtocolError | SubscriptionAlarmExtensionError>;
+  ) => Effect.Effect<void, SubscriptionAlarmProtocolError | SubscriptionAlarmExtensionError, R>;
 }
 
 /** Host-only handlers; the framework reserves its namespace and rejects every unknown tag. */
@@ -79,7 +85,8 @@ export const SubscriptionPartitionAlarmExtension = Context.Reference<{
   defaultValue: () => ({ handlers: [] }),
 });
 
-/** Capture host services once; each invocation owns its codec/handler Scope and timeout.
+/** Capture host services once, deferring native partition services to invocation.
+ * Each invocation owns its codec/handler Scope and timeout.
  * Callback failures stay typed. Defects and interruption reach the native alarm multiplexer.
  * The host owns durable idempotency, prearming and external-effect uncertainty.
  */
@@ -95,9 +102,17 @@ export const makeSubscriptionPartitionAlarmHandler = Effect.fn(
     },
   ) => Effect.Effect<void, SubscriptionAlarmExtensionError, R>;
 }): Effect.fn.Return<
-  SubscriptionPartitionAlarmHandler,
+  SubscriptionPartitionAlarmHandler<
+    Exclude<
+      Exclude<R | Payload["DecodingServices"], Scope.Scope>,
+      Exclude<
+        Exclude<R | Payload["DecodingServices"], Scope.Scope | SubscriptionPartitionAlarmServices>,
+        SubscriptionPartitionAlarmServices
+      >
+    >
+  >,
   SubscriptionAlarmProtocolError,
-  Exclude<R | Payload["DecodingServices"], Scope.Scope>
+  Exclude<R | Payload["DecodingServices"], Scope.Scope | SubscriptionPartitionAlarmServices>
 > {
   if (
     options.tag.length === 0 ||
@@ -110,7 +125,11 @@ export const makeSubscriptionPartitionAlarmHandler = Effect.fn(
     return yield* SubscriptionAlarmProtocolError.make({
       message: "Invalid ancillary alarm tag or timeout",
     });
-  const services = yield* Effect.context<Exclude<R | Payload["DecodingServices"], Scope.Scope>>();
+
+  // Context capture includes unrequested services too; never retain a host override of native work.
+  const services = (yield* Effect.context<
+    Exclude<R | Payload["DecodingServices"], Scope.Scope | SubscriptionPartitionAlarmServices>
+  >()).pipe(Context.omit(Subscriptions, SubscriptionIntake, SubscriptionDriver));
 
   return {
     tag: options.tag,

--- a/packages/platform-cloudflare/test/subscription-alarm-handlers.test.ts
+++ b/packages/platform-cloudflare/test/subscription-alarm-handlers.test.ts
@@ -3,6 +3,7 @@ import {
   makeSubscriptionPartitionAlarmHandler,
   SubscriptionAlarmExtensionError,
 } from "@effect-agent/platform-cloudflare/CloudflareSubscriptions";
+import { SubscriptionDriver } from "@effect-agent/thread/Subscriptions";
 import { Context, DateTime, Deferred, Effect, Exit, Fiber, Schema, SchemaGetter } from "effect";
 import { DurableObjectAlarm } from "effect-cf";
 import { TestClock } from "effect/testing";
@@ -10,6 +11,16 @@ import { expect, expectTypeOf, it } from "vite-plus/test";
 
 class Host extends Context.Service<Host, string>()("test/AlarmHost") {}
 class Decoder extends Context.Service<Decoder, string>()("test/AlarmDecoder") {}
+
+const nativeDriver = SubscriptionDriver.of({
+  runDue: Effect.succeed({ processed: 1, failed: 0 }),
+  processDelivery: () => Effect.void,
+});
+
+const hostDriver = SubscriptionDriver.of({
+  runDue: Effect.die("The host driver must not replace the invocation's native driver"),
+  processDelivery: () => Effect.void,
+});
 
 const event = DurableObjectAlarm.DurableObjectAlarmEvent.make({
   _tag: "AlarmDue",
@@ -40,6 +51,7 @@ for (const outcome of ["success", "failure", "defect", "timeout", "interruption"
                 decode: SchemaGetter.transformOrFail((value) =>
                   Effect.gen(function* () {
                     expect(yield* Decoder).toBe("decoder");
+                    expect(yield* SubscriptionDriver).toBe(nativeDriver);
                     yield* Effect.addFinalizer(() =>
                       Effect.sync(() => {
                         finalized++;
@@ -60,6 +72,7 @@ for (const outcome of ["success", "failure", "defect", "timeout", "interruption"
               handle: () =>
                 Effect.gen(function* () {
                   expect(yield* Host).toBe("host");
+                  expect(yield* SubscriptionDriver).toBe(nativeDriver);
                   yield* Effect.addFinalizer(() =>
                     Effect.sync(() => {
                       finalized++;
@@ -84,15 +97,27 @@ for (const outcome of ["success", "failure", "defect", "timeout", "interruption"
             expectTypeOf<
               Effect.Error<typeof made>
             >().toEqualTypeOf<SubscriptionAlarmProtocolError>();
-            const handler = yield* made;
+            const handler = yield* made.pipe(Effect.provideService(SubscriptionDriver, hostDriver));
 
             expectTypeOf<
               Effect.Services<ReturnType<typeof handler.handle>>
-            >().toEqualTypeOf<never>();
+            >().toEqualTypeOf<SubscriptionDriver>();
             expectTypeOf<Effect.Error<ReturnType<typeof handler.handle>>>().toEqualTypeOf<
               SubscriptionAlarmExtensionError | SubscriptionAlarmProtocolError
             >();
-            const fiber = yield* Effect.forkChild(handler.handle(event));
+
+            const fiber = yield* Effect.forkChild(
+              handler
+                .handle(event)
+                .pipe(
+                  Effect.provideService(SubscriptionDriver, nativeDriver),
+                  Effect.provideService(Host, "invocation host must not replace captured host"),
+                  Effect.provideService(
+                    Decoder,
+                    "invocation decoder must not replace captured decoder",
+                  ),
+                ),
+            );
 
             yield* Deferred.await(started);
             if (outcome === "timeout") yield* TestClock.adjust(100);
@@ -128,6 +153,7 @@ it("rejects reserved ownership, wrong tags and malformed payloads", () =>
       );
       const handler = yield* makeSubscriptionPartitionAlarmHandler({ ...options, tag: event.tag });
 
+      expectTypeOf<Effect.Services<ReturnType<typeof handler.handle>>>().toEqualTypeOf<never>();
       expect((yield* handler.handle({ ...event, tag: "other/task" }).pipe(Effect.flip))._tag).toBe(
         "SubscriptionAlarmProtocolError",
       );

--- a/packages/platform-cloudflare/test/subscription-fixtures.ts
+++ b/packages/platform-cloudflare/test/subscription-fixtures.ts
@@ -3,6 +3,7 @@ import {
   makeSubscriptionPartitionAlarmHandler,
   SubscriptionPartitionAlarmExtension,
   SubscriptionAlarmExtensionError,
+  SubscriptionPartitionIdentity,
 } from "@effect-agent/platform-cloudflare/CloudflareSubscriptions";
 import { EventSources, makeEventSource } from "@effect-agent/thread/EventSource";
 import { Principal } from "@effect-agent/thread/SubmissionLedger";
@@ -15,6 +16,11 @@ import {
   makeSubscriptionInputBinding,
   SubscriptionInputBindings,
 } from "@effect-agent/thread/SubscriptionInput";
+import {
+  SubscriptionDriver,
+  SubscriptionIntake,
+  Subscriptions,
+} from "@effect-agent/thread/Subscriptions";
 import { DateTime, Effect, Layer, Schema } from "effect";
 import { DurableObjectAlarm, DurableObjectState } from "effect-cf";
 
@@ -144,6 +150,38 @@ export const subscriptionAlarmExtensionLayer = Layer.effect(
           .pipe(Effect.mapError(() => SubscriptionAlarmExtensionError.make({ code: "storage" }))),
     });
 
-    return { handlers: [failing, replacement] };
+    const intake = yield* makeSubscriptionPartitionAlarmHandler({
+      tag: "test/intake",
+      payload: Schema.Struct({
+        eventId: Schema.String,
+        topic: Schema.String,
+        message: Schema.String,
+      }),
+      timeoutMillis: 5_000,
+      handle: (event) =>
+        Effect.gen(function* () {
+          const state = yield* DurableObjectState.DurableObjectState;
+          const { partition } = yield* SubscriptionPartitionIdentity;
+          const subscriptions = yield* Subscriptions;
+          const intake = yield* SubscriptionIntake;
+          const driver = yield* SubscriptionDriver;
+
+          const page = yield* subscriptions.listSubscriptions({
+            partition,
+            ownerId: event.id,
+            principal: subscriptionPrincipal,
+          });
+
+          if (state.raw.id.name === undefined || page.items.length !== 1)
+            return yield* SubscriptionAlarmExtensionError.make({ code: "missing-registration" });
+
+          yield* intake.accept(subscriptionPrincipal, SubscriptionTestSourceVersion, event.payload);
+          yield* driver.runDue;
+        }).pipe(
+          Effect.mapError(() => SubscriptionAlarmExtensionError.make({ code: "native-intake" })),
+        ),
+    });
+
+    return { handlers: [failing, replacement, intake] };
   }),
 ).pipe(Layer.provide(DurableObjectAlarm.DurableObjectAlarm.layer));

--- a/packages/platform-cloudflare/test/subscriptions.test.ts
+++ b/packages/platform-cloudflare/test/subscriptions.test.ts
@@ -2,16 +2,18 @@ import {
   CloudflareSubscriptionsClient,
   sourcePartitionName,
   SubscriptionPartitionNamespace,
+  type SubscriptionPartitionIdentity,
   validateCloudflareSubscriptionLimits,
 } from "@effect-agent/platform-cloudflare/CloudflareSubscriptions";
 import { defaultSubscriptionLimits } from "@effect-agent/thread/Subscription";
 import { SubscriptionIntake, Subscriptions } from "@effect-agent/thread/Subscriptions";
 import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { DateTime, Effect, Layer } from "effect";
-import { DurableObject, DurableObjectAlarm } from "effect-cf";
-import { expect, it } from "vite-plus/test";
+import { DurableObject, DurableObjectAlarm, type DurableObjectState } from "effect-cf";
+import { expect, expectTypeOf, it } from "vite-plus/test";
 
 import { laneRows } from "./harness.ts";
+import type { subscriptionAlarmExtensionLayer } from "./subscription-fixtures.ts";
 import {
   armSubscriptionEviction,
   subscriptionAgentId,
@@ -43,6 +45,89 @@ const runClient = <A, E>(effect: Effect.Effect<A, E, Subscriptions | Subscriptio
   Effect.runPromise(effect.pipe(Effect.provide(clientLayer)));
 
 const sleep = (millis: number) => new Promise((resolve) => setTimeout(resolve, millis));
+
+it("composes host alarm handlers with native subscription services through the public object factory", async () => {
+  expectTypeOf<Layer.Services<typeof subscriptionAlarmExtensionLayer>>().toEqualTypeOf<
+    DurableObjectState.DurableObjectState | SubscriptionPartitionIdentity
+  >();
+
+  const partition = { tenantId: "alarm-native-intake", address: "events" };
+  const scope = { partition, ownerId: "owner", principal: subscriptionPrincipal };
+  const threadId = subscriptionThreadId("alarm-native-intake");
+  const stub = env.SUBSCRIPTIONS.get(env.SUBSCRIPTIONS.idFromName(sourcePartitionName(partition)));
+
+  const client = CloudflareSubscriptionsClient.layer(partition).pipe(
+    Layer.provide(Layer.succeed(SubscriptionPartitionNamespace)({ namespace: env.SUBSCRIPTIONS })),
+  );
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const subscriptions = yield* Subscriptions;
+
+      yield* subscriptions.subscribe(scope, {
+        subscriptionId: "native-intake",
+        source: SubscriptionTestSourceVersion,
+        parameters: { topic: "verified" },
+        context: { instruction: "process verified event" },
+        mode: "once",
+        expiresAtMillis: null,
+        destination: { _tag: "ExistingThread", threadId },
+        deliveryPrincipal: subscriptionPrincipal,
+        agentId: subscriptionAgentId,
+        definitions: subscriptionDefinitions,
+      });
+    }).pipe(Effect.provide(client)),
+  );
+
+  await runInDurableObject(stub, (instance, state) =>
+    state.blockConcurrencyWhile(async () => {
+      await instance[DurableObject.RunSymbol](
+        Effect.gen(function* () {
+          const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+          yield* alarms.scheduleAlarm({
+            tag: "test/intake",
+            id: scope.ownerId,
+            payload: { eventId: "verified-event", topic: "verified", message: "verified input" },
+            runAt: DateTime.makeUnsafe(Date.now() - 1),
+          });
+        }),
+      );
+      await state.storage.deleteAlarm();
+      await instance.alarm();
+      expect(
+        state.storage.sql
+          .exec("SELECT tag FROM effect_cf_scheduled_alarms WHERE tag = 'test/intake'")
+          .toArray(),
+      ).toEqual([]);
+    }),
+  );
+
+  const { status, deliveries } = await Effect.runPromise(
+    Effect.gen(function* () {
+      const intake = yield* SubscriptionIntake;
+      const subscriptions = yield* Subscriptions;
+
+      const status = yield* intake.status(
+        subscriptionPrincipal,
+        SubscriptionTestSourceVersion,
+        "verified-event",
+      );
+
+      const deliveries = yield* subscriptions.listDeliveries(scope, {
+        partition,
+        ownerId: scope.ownerId,
+        subscriptionId: "native-intake",
+      });
+
+      return { status, deliveries };
+    }).pipe(Effect.provide(client)),
+  );
+
+  expect(status.eventId).toBe("verified-event");
+  expect(status.routingFailure).toBeNull();
+  expect(deliveries.items).toHaveLength(1);
+});
 
 it("rejects subscription limits that can outlive one safe alarm invocation", async () => {
   const failure = await Effect.runPromise(


### PR DESCRIPTION
In beta.51, an ancillary alarm callback requiring `SubscriptionIntake` made its host Layer impossible to pass to `makeSubscriptionPartitionObjectClass`: the factory creates native services only after building that host. Defer `Subscriptions`, `SubscriptionIntake`, and `SubscriptionDriver` requirements to callback/decoder invocation while capturing ordinary host dependencies. The returned handler preserves its required native services in `R`; captured native overrides cannot replace the addressed partition's instances.

Existing factory calls stay the same. For example, this callback can remain inside `makeSubscriptionPartitionAlarmHandler` in the host Layer (`verification` is an application Effect requiring `SubscriptionIntake`):

```ts
makeSubscriptionPartitionAlarmHandler({
  tag: "application/verify",
  payload: Schema.Struct({ version: Schema.Literal(1) }),
  timeoutMillis: 30_000,
  handle: () => verification.pipe(
    Effect.mapError(() =>
      SubscriptionAlarmExtensionError.make({ code: "verification" }),
    ),
  ),
})
```

Invocation-time provision preserves one native transaction/alarm owner without adding a second handler-Layer factory, duplicate driver, or self-RPC. Payload validation, bounded timeouts, invocation Scope, typed errors, interruption, retry isolation, and private alarm generations retain their existing behavior. Includes a changeset, guide update, and compiling example.

Validation: `vp run ready` passed, including static/type/export/purity checks, adapter certification and crash/fault suites, package/example builds, documentation rendering/link validation, and the Action build. The 15 focused Workerd regressions also pass, covering public object-factory composition, native intake and selection, exact E/R types, service precedence, lifecycle cleanup, retry isolation, and replacement alarms. Existing opt-in provider/browser tests remain skipped without credentials or an external browser.

Release gate: review only. Owner-authorized landing and the normal Changesets release must precede a consumer upgrade; verify the actual published package versions rather than predicting a beta number.
