### PR TITLE
feat(engine): support text output and durable current-run pruning

### DIFF
--- a/.changeset/plain-text-durable-pruning.md
+++ b/.changeset/plain-text-durable-pruning.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Support schema-validated plain-text final replies with `Output.text(schema)`. Honor prompt targets when pruning older tool results and durably replay pruning of fully settled current-run batches while preserving the newest result and incomplete work.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -36,6 +36,27 @@ It also accepts `inputPrompt`, `completion`, `runDisposition`, a description, an
 Instructions may be static prompt input or a function of decoded input. That function may return
 an `Effect`. Its errors and service requirements become part of the run type.
 
+## Choose final-output format
+
+Output Schemas use JSON final messages by default. For ordinary assistant text, wrap the complete
+Schema with `Output.text`. The Schema must encode as a string; its checks, transformations, and
+service requirements still apply.
+
+```ts twoslash
+import * as Output from "@effect-agent/engine/Output";
+import { Schema } from "effect";
+
+const Reply = Output.text(Schema.String.check(Schema.isMaxLength(20_000)));
+// Pass Reply as Agent.make(..., { output: Reply, ... }).
+```
+
+The runtime instructs the model to reply without JSON wrapping and decodes that text directly.
+Whitespace, quotes, and empty replies are preserved. Use `Schema.NonEmptyString` when silence is
+invalid. Apply `Output.text` after composing the Schema. Required completion tools still take
+precedence; optional completion tools retain their own parameter contract. Durable records store
+the string as a JSON string value and replay it through the same Schema. Metadata does not select
+an output format.
+
 ## Choose model-visible input
 
 The runtime normally sends the complete schema-encoded input as a JSON user message. Use

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -985,7 +985,7 @@ append-only history starts from the last provider-reported input and estimates a
 Preparation and transient-context hooks use a fresh estimate. Within a turn, the engine reuses
 the history view and estimate until compaction changes them. The default compactor then:
 
-1. clears old application tool results outside the protected `keepRecentTokens` tail while keeping
+1. clears old application tool results outside the preferred `keepRecentTokens` tail while keeping
    message structure and call/result pairs;
 2. if pruning is insufficient, makes one metered summary call and keeps the instruction prefix,
    summary, and recent tail.
@@ -1039,7 +1039,7 @@ Summary calls must use
 Defects and interruption retain their Effect meaning.
 
 Durable coordinators map the covered prefix to complete canonical records before committing a
-decision. Pruning and summarization cover prior-run records. Rollover can also cover settled batches
+decision. Summarization covers prior-run records. Pruning and rollover can also cover settled batches
 inside the current run, preserving its original instructions and input. A transform or decision that
 cannot map cleanly fails before the view changes. The canonical log remains append-only.
 
@@ -1178,7 +1178,9 @@ setup.
 
 - Leave output and summary room under the model window. For a 200k window, start with a
   `contextTokenLimit` between 150k and 170k.
-- `keepRecentTokens` defaults to 20k. Raise it when recent tool output must remain verbatim.
+- `keepRecentTokens` defaults to 20k. Pruning retains this preferred tail while the full prompt fits
+  its target; under pressure it clears additional older results. The newest tool result always
+  stays verbatim. If the remaining prompt cannot fit, the configured summary or overflow policy applies.
 - Use `tokenBudget` as a runaway limit. Use `costBudgetMicrousd` to bound estimated spend.
 - Delegate noisy research to bounded children so their raw tool output stays out of the parent
   context.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./AgentRuntime": "./src/AgentRuntime.ts",
+    "./Output": "./src/Output.ts",
     "./Compaction": "./src/Compaction.ts",
     "./ContextCompactor": "./src/ContextCompactor.ts",
     "./DurableStep": "./src/DurableStep.ts",

--- a/packages/engine/src/ContextCompactor.ts
+++ b/packages/engine/src/ContextCompactor.ts
@@ -109,7 +109,7 @@ const defaultCompactor = (model?: CompactionModelLayer): ContextCompaction => ({
       const decisions: Array<CompactionDecision> = [];
 
       if (!forceSummarize && policy.mode !== "summarize") {
-        const through = choosePruneBound(source.content, state, keepRecentTokens);
+        const through = choosePruneBound(source.content, state, keepRecentTokens, targetTokens);
 
         if (through > state.clearedThrough) {
           state.clearedThrough = through;

--- a/packages/engine/src/Output.ts
+++ b/packages/engine/src/Output.ts
@@ -1,0 +1,2 @@
+/** Schema-owned final-output formats for Agent definitions. */
+export { textOutput as text } from "./internal/output-contract.ts";

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,5 @@
 export * as AgentRuntime from "./AgentRuntime.ts";
+export * as Output from "./Output.ts";
 export * as Compaction from "./Compaction.ts";
 export * as ContextCompactor from "./ContextCompactor.ts";
 export * as DurableStep from "./DurableStep.ts";

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -102,7 +102,7 @@ import {
 
 import { ThreadHistory, ThreadHistoryError } from "../ThreadHistory.ts";
 import { boundedValueFootprint, utf8ByteLength } from "./bounded-value.ts";
-import { insertOutputContract, outputSchemaContract } from "./output-contract.ts";
+import { insertOutputContract, isTextOutput, outputSchemaContract } from "./output-contract.ts";
 import {
   boundedCanonicalJsonSnapshot,
   boundedJsonSnapshot,
@@ -4262,15 +4262,15 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
   AgentOutputError,
   Agent.OutputSchema<AgentValue>["DecodingServices"]
 > {
-  const eventJson = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Json))(
-    text,
-  ).pipe(
-    Effect.mapError((cause) =>
-      AgentOutputError.make({
-        message: `Agent output is not valid JSON: ${cause.message}`,
-      }),
-    ),
-  );
+  const eventJson = isTextOutput(agent.definition.output)
+    ? text
+    : yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Json))(text).pipe(
+        Effect.mapError((cause) =>
+          AgentOutputError.make({
+            message: `Agent output is not valid JSON: ${cause.message}`,
+          }),
+        ),
+      );
 
   const candidateOutput: unknown = eventJson;
 

--- a/packages/engine/src/internal/compaction.ts
+++ b/packages/engine/src/internal/compaction.ts
@@ -274,17 +274,24 @@ export const buildCompactedView = (
  * Prune selection: the new `clearedThrough` bound. Walks tool messages
  * newest→oldest, always protecting the most recent tool message (the model
  * has not reacted to it yet), then protecting older ones while their
- * estimates fit inside `keepRecentTokens`. Never decreases the bound.
+ * estimates fit inside `keepRecentTokens`. If the whole view exceeds `targetTokens`,
+ * clear more older results until it fits or only the newest result remains.
+ * Replaced messages consume no retention budget. Never decreases the bound.
  */
 export const choosePruneBound = (
   source: ReadonlyArray<Prompt.Message>,
   state: ContextCompactionState,
   keepRecentTokens: number,
+  targetTokens?: number,
 ): number => {
   const toolIndices: Array<number> = [];
 
   for (let index = 0; index < source.length; index += 1) {
-    if (source[index]?.role === "tool" && !isProtected(state, source, index)) {
+    if (
+      index >= (state.replacement?.through ?? 0) &&
+      source[index]?.role === "tool" &&
+      !isProtected(state, source, index)
+    ) {
       toolIndices.push(index);
     }
   }
@@ -315,9 +322,32 @@ export const choosePruneBound = (
     break;
   }
 
-  return newestCleared === -1
-    ? state.clearedThrough
-    : Math.max(state.clearedThrough, newestCleared + 1);
+  let through =
+    newestCleared === -1 ? state.clearedThrough : Math.max(state.clearedThrough, newestCleared + 1);
+
+  if (targetTokens === undefined) return through;
+
+  let estimated = estimatePromptTokens(
+    buildCompactedView(source, { ...state, clearedThrough: through }),
+  );
+
+  for (
+    let position = 0;
+    position < toolIndices.length - 1 && estimated > targetTokens;
+    position += 1
+  ) {
+    const index = toolIndices[position];
+
+    if (index === undefined || index < through) continue;
+    const message = source[index];
+
+    if (message === undefined) continue;
+    through = index + 1;
+    estimated -=
+      estimateMessageTokens(message) - estimateMessageTokens(clearedToolMessage(message));
+  }
+
+  return through;
 };
 
 /**

--- a/packages/engine/src/internal/output-contract.ts
+++ b/packages/engine/src/internal/output-contract.ts
@@ -1,12 +1,34 @@
 import type * as Agent from "@effect-agent/core/Agent";
+import { Schema } from "effect";
 import { Prompt, Tool } from "effect/unstable/ai";
+
+const outputFormatAnnotation = "@effect-agent/engine/Output/format";
+
+/**
+ * Declare ordinary assistant text as an Agent's final-output wire format. Apply this to the
+ * complete output Schema after composing transformations. Its encoded type must be string;
+ * decoding, checks, transformations, and service requirements remain owned by that Schema.
+ * Text is preserved verbatim, including whitespace, quotes, and an empty reply when allowed.
+ * Required completion Tools still take precedence. Unmarked Schemas use JSON final output.
+ *
+ * @example
+ * ```ts
+ * output: Output.text(Schema.String.check(Schema.isMaxLength(20_000)))
+ * ```
+ */
+export const textOutput = <S extends Schema.Top & { readonly Encoded: string }>(
+  schema: S,
+): S["Rebuild"] => schema.annotate({ [outputFormatAnnotation]: "text" });
+
+export const isTextOutput = (schema: Schema.Top): boolean =>
+  Schema.resolveAnnotations(schema)?.[outputFormatAnnotation] === "text";
 
 /**
  * Model-visible final-output contract (RUN-028).
  *
  * For ordinary text completion, the interpreter's only output-conformance
  * point is `decodeFinalOutput`, which validates the final text after the
- * model has already finished. This module renders that Schema to JSON Schema
+ * model has already finished. This module renders that Schema's wire contract
  * with the same Effect AI derivation the providers use for Tool parameters
  * and states it as one framework-owned system message on every model request.
  * A required completion Tool instead gets a native-tool directive: its Tool
@@ -19,9 +41,6 @@ import { Prompt, Tool } from "effect/unstable/ai";
  * into official history, so canonical records, run events, and the committed
  * DN/DC golden are unchanged.
  *
- * Reversal: deleting this module, its single `makeTurn` call site, the
- * `RunContextRequest.outputContract` field, and its test file restores the
- * prior behavior exactly.
  */
 
 /** Rendering outcome for one definition's output Schema. */
@@ -65,6 +84,17 @@ export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputCon
     return {
       _tag: "rendered",
       message: requiredCompletionDirective(definition.completion.tool),
+    };
+  }
+  if (isTextOutput(definition.output)) {
+    return {
+      _tag: "rendered",
+      message:
+        "Final output contract: write the final reply as ordinary assistant text, without JSON wrapping. " +
+        "An empty reply is valid only when allowed by the output Schema and the task instructions." +
+        (definition.completion === undefined
+          ? ""
+          : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead; the engine projects its successful result into the Agent output.`),
     };
   }
   try {

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -1,7 +1,7 @@
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
-import { AgentRuntime } from "@effect-agent/engine";
+import { AgentRuntime, Output } from "@effect-agent/engine";
 import {
   type AgentResult,
   type AgentRuntimeFailure,
@@ -375,4 +375,45 @@ it("retains every branch's tool requirements and failures across execution views
   expectTypeOf<Effect.Services<typeof selectedRun>>().toEqualTypeOf<
     BoundServices | ThreadHistory | IdGenerator
   >();
+});
+
+it("text output preserves Schema transformations, errors and decoder requirements", () => {
+  const schema = Output.text(
+    Schema.NumberFromString.pipe(
+      Schema.decode({
+        decode: SchemaGetter.transformOrFail((value) => Effect.as(Decoder, value)),
+        encode: SchemaGetter.transformOrFail((value) => Effect.as(Encoder, value)),
+      }),
+    ),
+  );
+
+  expectTypeOf<typeof schema.Type>().toEqualTypeOf<number>();
+  expectTypeOf<typeof schema.Encoded>().toEqualTypeOf<string>();
+  expectTypeOf<typeof schema.DecodingServices>().toEqualTypeOf<Decoder>();
+  expectTypeOf<typeof schema.EncodingServices>().toEqualTypeOf<Encoder>();
+
+  const definition = Agent.make("typed-text-output", {
+    input: Schema.String,
+    output: schema,
+    instructions: "Return a number.",
+    toolkit: Toolkit.empty,
+  });
+
+  const agent = Agent.withModel(definition, model);
+  const decoded = AgentRuntime.decodeFinalOutput(agent, "42");
+
+  expectTypeOf<Effect.Services<typeof decoded>>().toEqualTypeOf<Decoder>();
+  expectTypeOf<Effect.Error<typeof decoded>>().toEqualTypeOf<
+    import("@effect-agent/core/AgentError").AgentOutputError
+  >();
+  expectTypeOf<Effect.Success<typeof decoded>["decoded"]>().toEqualTypeOf<number>();
+  const run = AgentRuntime.run(agent, "input");
+
+  expectTypeOf<Effect.Services<typeof run>>().toEqualTypeOf<
+    Decoder | Encoder | ProviderClient | ThreadHistory | IdGenerator
+  >();
+  // @ts-expect-error Text output requires a string-encoded Schema.
+  Output.text(Schema.Struct({ answer: Schema.String }));
+  // @ts-expect-error A decoded string is insufficient when its encoded form is numeric.
+  Output.text(Schema.flip(Schema.NumberFromString));
 });

--- a/packages/engine/test/compaction.test.ts
+++ b/packages/engine/test/compaction.test.ts
@@ -1091,6 +1091,79 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
     }),
   );
 
+  it.effect(
+    "pruning honors the whole prompt target even when all tool results fit the preferred tail",
+    () =>
+      Effect.gen(function* () {
+        const compactor = yield* ContextCompactor;
+
+        const source = Prompt.fromMessages([
+          Prompt.makeMessage("system", { content: "instructions ".repeat(100) }),
+          ...["oldest", "middle", "newest"].flatMap((id) => [
+            Prompt.makeMessage("assistant", {
+              content: [
+                Prompt.makePart("tool-call", {
+                  id,
+                  name: "search",
+                  params: {},
+                  providerExecuted: false,
+                }),
+              ],
+            }),
+            Prompt.makeMessage("tool", {
+              content: [
+                Prompt.makePart("tool-result", {
+                  id,
+                  name: "search",
+                  result: id.repeat(120),
+                  isFailure: false,
+                  providerExecuted: false,
+                }),
+              ],
+            }),
+          ]),
+        ]);
+
+        const request = {
+          source,
+          state: initialCompactionState(),
+          policy: CompactionPolicy.make({ keepRecentTokens: 10_000, mode: "prune" }),
+          threadId: ThreadId.make("target-pruning"),
+          runId: RunId.make("target-pruning"),
+          turn: 1,
+          trigger: "pressure" as const,
+          modelCallAllowed: false,
+          summarize: () => Effect.die("Pruning must not call a model"),
+        };
+
+        expect(
+          yield* compactor.compact({ ...request, targetTokens: undefined }).pipe(Stream.runCollect),
+        ).toEqual([]);
+        // Full prompt is ~1100 tokens. Both old results must clear to reach 800;
+        // tool results alone fit well inside the preferred tail and the 800-token target.
+        expect(
+          yield* compactor.compact({ ...request, targetTokens: 800 }).pipe(Stream.runCollect),
+        ).toEqual([{ kind: "clear-tool-results", through: 5 }]);
+        // An impossible target must still retain the newest batch.
+        expect(
+          yield* compactor.compact({ ...request, targetTokens: 1 }).pipe(Stream.runCollect),
+        ).toEqual([{ kind: "clear-tool-results", through: 5 }]);
+        // A replacement hides older results; their bytes must not trigger redundant pruning.
+        expect(
+          yield* compactor
+            .compact({
+              ...request,
+              state: {
+                ...request.state,
+                replacement: { kind: "rollover", through: 5, windowId: "window" },
+              },
+              targetTokens: 800,
+            })
+            .pipe(Stream.runCollect),
+        ).toEqual([]);
+      }),
+  );
+
   // ------------------------------------------------------------ RUN-026 prune
 
   it.effect(

--- a/packages/engine/test/output-contract.test.ts
+++ b/packages/engine/test/output-contract.test.ts
@@ -4,6 +4,7 @@ import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import { ThreadId, RunId, TurnId } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import * as Output from "@effect-agent/engine/Output";
 import { expect, layer } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Logger, Option, Ref, Schema, Stream } from "effect";
 import { LanguageModel, Model, Prompt, type Response, Tool, Toolkit } from "effect/unstable/ai";
@@ -159,6 +160,106 @@ const testLayer = Layer.mergeAll(
 );
 
 layer(testLayer)("RUN-028 model-visible output contract", (it) => {
+  it.effect("preserves plain-text final output verbatim, including empty replies", () =>
+    Effect.gen(function* () {
+      for (const text of [
+        'Hello, "world"!\nA second line.',
+        "",
+        "  ",
+        '{"answer":"literal text"}',
+      ]) {
+        const requests: Array<Prompt.Prompt> = [];
+
+        const definition = Agent.make("text-output", {
+          input: Schema.String,
+          output: Output.text(Schema.String.check(Schema.isMaxLength(100))),
+          instructions: "Reply in plain text.",
+          toolkit: Toolkit.empty,
+          policy,
+        });
+
+        const model = Model.make(
+          "test",
+          "text-output",
+          Layer.effect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: () => Effect.succeed([]),
+              streamText: (request) => {
+                requests.push(request.prompt);
+
+                return Stream.fromIterable(finalParts(text));
+              },
+            }),
+          ),
+        );
+
+        const agent = Agent.withModel(definition, model);
+        const result = yield* AgentRuntime.run(agent, "reply");
+
+        expect(result.output).toBe(text);
+        expect(yield* AgentRuntime.decodeFinalOutput(agent, text)).toEqual({
+          encoded: text,
+          decoded: text,
+        });
+        expect(contractMessages(requests[0] ?? Prompt.empty)[0]).toContain(
+          "ordinary assistant text",
+        );
+        expect(contractMessages(requests[0] ?? Prompt.empty)[0]).not.toContain("must be only JSON");
+      }
+    }),
+  );
+
+  it.effect("validates text Schemas and preserves their decoded transformations", () =>
+    Effect.gen(function* () {
+      const definition = Agent.make("validated-text", {
+        input: Schema.String,
+        output: Output.text(Schema.NumberFromString.check(Schema.isGreaterThan(0))),
+        instructions: "Return a positive number in plain text.",
+        toolkit: Toolkit.empty,
+        policy,
+      });
+
+      const agent = Agent.withModel(definition, liveShapedModel([]));
+
+      expect(yield* AgentRuntime.decodeFinalOutput(agent, "42")).toEqual({
+        encoded: "42",
+        decoded: 42,
+      });
+      for (const text of ["", "-1", "not a number"]) {
+        const exit = yield* AgentRuntime.decodeFinalOutput(agent, text).pipe(Effect.exit);
+
+        expect(failureFrom(exit)).toBeInstanceOf(AgentOutputError);
+      }
+    }),
+  );
+
+  it.effect("required completion Tools take precedence over a text output Schema", () => {
+    const Complete = Tool.make("complete_text", {
+      parameters: Schema.Struct({ answer: Schema.String }),
+      success: Schema.String,
+    });
+
+    const definition = Agent.make("required-text-completion", {
+      input: Schema.String,
+      output: Output.text(Schema.String),
+      instructions: "Complete through the Tool.",
+      toolkit: Toolkit.make(Complete),
+      policy,
+      completion: { tool: "complete_text", required: true, project: ({ result }) => result },
+    });
+
+    const contract = outputSchemaContract(definition);
+
+    expect(contract._tag).toBe("rendered");
+    if (contract._tag === "rendered") {
+      expect(contract.message).toContain('required completion Tool "complete_text"');
+      expect(contract.message).not.toContain("write the final reply as ordinary assistant text");
+    }
+
+    return Effect.void;
+  });
+
   it.effect(
     "carries the contract on every Turn's request adjacent to the last system block and never in official history",
     () => {

--- a/packages/engine/vite.config.ts
+++ b/packages/engine/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     entry: [
       "src/index.ts",
       "src/AgentRuntime.ts",
+      "src/Output.ts",
       "src/Compaction.ts",
       "src/ContextCompactor.ts",
       "src/ContextWindow.ts",

--- a/packages/testing/test/durable-output-compaction.test.ts
+++ b/packages/testing/test/durable-output-compaction.test.ts
@@ -1,0 +1,320 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { CLEARED_TOOL_RESULT, CONTEXT_ROLLOVER_PREFIX } from "@effect-agent/engine/Compaction";
+import { ContextRolloverRequest, ContextRolloverTool } from "@effect-agent/engine/ContextWindow";
+import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
+import * as Output from "@effect-agent/engine/Output";
+import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
+import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
+import {
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+} from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeFailpointError } from "@effect-agent/thread/DurableFailpoint";
+import { DefinitionDigests, DeploymentId, Digest, ProducerId } from "@effect-agent/thread/Records";
+import { projectRunJournal, runIdForSubmission } from "@effect-agent/thread/RunJournal";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import { DurableRuntimeFailpointTestControl } from "@effect-agent/thread/testing/DurableFailpointTestControl";
+import { ThreadRead, ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeCrypto } from "@effect/platform-node";
+import { expect, layer } from "@effect/vitest";
+import { Cause, Effect, Exit, Layer, Option, Schema, Stream } from "effect";
+import { LanguageModel, Model, Prompt, type Response, Tool, Toolkit } from "effect/unstable/ai";
+
+const digest = Digest.make("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+
+const testLayer = DurableAgentRuntime.layer.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      MemorySubmissionLedgerLive,
+      MemoryThreadStoreLive,
+      WakeScheduler.layerNoop,
+      ToolReconciler.uncertain,
+      RunToolAuthorization.allowAll,
+      DurableRuntimeFailpointTestControl.layer,
+      DurableRuntimeConfig.layer({
+        deploymentId: DeploymentId.make("output-compaction"),
+        producerId: ProducerId.make("output-compaction"),
+      }),
+    ).pipe(Layer.provideMerge(NodeCrypto.layer)),
+  ),
+);
+
+const submitOptions = (id: string) => ({
+  threadId: ThreadId.make(id),
+  principal: Principal.make("output-compaction"),
+  idempotencyKey: IdempotencyKey.make(id),
+  definitions,
+});
+
+const usage = { inputTokens: { total: 1_300 }, outputTokens: { total: 10 } };
+
+const finalParts = (text: string): ReadonlyArray<Response.StreamPartEncoded> => [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: text },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage },
+];
+
+const callParts = (
+  id: string,
+  name: string,
+  params: Schema.Json,
+  inputTokens = 100,
+): ReadonlyArray<Response.StreamPartEncoded> => [
+  { type: "tool-call", id, name, params, providerExecuted: false },
+  {
+    type: "finish",
+    reason: "tool-calls",
+    usage: { ...usage, inputTokens: { total: inputTokens } },
+  },
+];
+
+// Model calls and captured requests outlive rebuilt Layers across Attempts.
+const scriptedModel = (script: (call: number) => ReadonlyArray<Response.StreamPartEncoded>) => {
+  const prompts: Array<Prompt.Prompt> = [];
+
+  const model = Model.make(
+    "test",
+    "output-compaction",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: (request) => {
+          const call = prompts.length;
+
+          prompts.push(request.prompt);
+
+          return Stream.fromIterable(script(call));
+        },
+      }),
+    ),
+  );
+
+  return { model, prompts };
+};
+
+const readLog = Effect.fn("readLog")(function* (threadId: ThreadId) {
+  const store = yield* ThreadStore;
+
+  return yield* store.read(ThreadRead.make({ threadId, limit: 1_024 })).pipe(Stream.runCollect);
+});
+
+const results = (prompt: Prompt.Prompt) =>
+  prompt.content.flatMap((message) =>
+    typeof message.content === "string"
+      ? []
+      : message.content.flatMap((part) => (part.type === "tool-result" ? [part.result] : [])),
+  );
+
+const expectCrash = <A, E>(exit: Exit.Exit<A, E>) => {
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (Exit.isSuccess(exit)) throw new Error("Expected the crash failpoint");
+  const failure = Cause.findErrorOption(exit.cause);
+
+  expect(Option.isSome(failure) && Schema.is(DurableRuntimeFailpointError)(failure.value)).toBe(
+    true,
+  );
+};
+
+layer(testLayer)("durable output and current-Run pruning", (it) => {
+  for (const text of ['  Committed once.\n"Keep these quotes."  ', ""]) {
+    it.effect(
+      `replays canonical plain text without another model call (${text === "" ? "empty" : "verbatim"})`,
+      () =>
+        Effect.gen(function* () {
+          const runtime = yield* DurableAgentRuntime;
+          const control = yield* DurableRuntimeFailpointTestControl;
+          const scripted = scriptedModel(() => finalParts(text));
+
+          const agent = Agent.withModel(
+            Agent.make("durable-text", {
+              input: Schema.String,
+              output: Output.text(Schema.String.check(Schema.isMaxLength(100))),
+              instructions: "Reply in plain text.",
+              toolkit: Toolkit.empty,
+            }),
+            scripted.model,
+          );
+
+          const receipt = yield* runtime.submit(
+            agent,
+            "reply",
+            submitOptions(`text-${text.length}`),
+          );
+
+          yield* control.setHandler((location) =>
+            location === "turn:after-canonical-append"
+              ? Effect.fail(DurableRuntimeFailpointError.make({ location }))
+              : Effect.void,
+          );
+          expectCrash(
+            yield* runtime
+              .processThread(agent, receipt.threadId)
+              .pipe(Effect.exit, Effect.ensuring(control.clear)),
+          );
+          const settled = yield* runtime.processThread(agent, receipt.threadId);
+
+          expect(settled).toHaveLength(1);
+          expect(settled[0]?.outcome).toBe("completed");
+          expect(scripted.prompts).toHaveLength(1);
+          const records = yield* readLog(receipt.threadId);
+
+          expect(
+            records
+              .filter(({ record }) => record.payload._tag === "RunCompleted")
+              .map(({ record }) => record.payload),
+          ).toEqual([expect.objectContaining({ output: text })]);
+        }),
+    );
+  }
+
+  for (const rollover of [false, true]) {
+    for (const barrier of [
+      "compaction:before-canonical-append",
+      "compaction:after-canonical-append",
+    ] as const) {
+      it.effect(
+        `prunes settled current-Run results across ${barrier}, prior rollover=${rollover}`,
+        () =>
+          Effect.gen(function* () {
+            const runtime = yield* DurableAgentRuntime;
+            const control = yield* DurableRuntimeFailpointTestControl;
+
+            const toolkit = Toolkit.make(
+              Tool.make("search", {
+                parameters: Schema.Struct({}),
+                success: Schema.String,
+              }).annotate(ToolExecutionClass, "readonly"),
+              Tool.make("new_context", {
+                parameters: ContextRolloverRequest,
+                success: ContextRolloverRequest,
+              })
+                .annotate(ToolExecutionClass, "readonly")
+                .annotate(ContextRolloverTool, true),
+            );
+
+            const evidence = [
+              "OLD-EVIDENCE " + "a".repeat(4_000),
+              "NEWEST-EVIDENCE " + "b".repeat(4_000),
+            ];
+
+            let executions = 0;
+
+            const handlers = toolkit.toLayer({
+              search: () => Effect.sync(() => evidence[executions++] ?? "Unexpected replay"),
+              new_context: Effect.succeed,
+            });
+
+            const scripted = scriptedModel((call) => {
+              if (rollover && call === 0)
+                return callParts("window", "new_context", {
+                  handoff: "Continue the original objective.",
+                });
+              const search = call - (rollover ? 1 : 0);
+
+              return search < 2
+                ? callParts(`search-${search}`, "search", {}, search === 0 ? 100 : 1_800)
+                : finalParts("Finished.");
+            });
+
+            const agent = Agent.withModel(
+              Agent.make("durable-pruning", {
+                input: Schema.String,
+                output: Output.text(Schema.String),
+                instructions: "Complete the original objective.",
+                toolkit,
+                policy: {
+                  maxTurns: 6,
+                  maxToolCalls: 5,
+                  contextTokenLimit: 2_400,
+                  compaction: { mode: "prune", keepRecentTokens: 20_000 },
+                },
+              }),
+              scripted.model,
+            );
+
+            const receipt = yield* runtime.submit(
+              agent,
+              "ORIGINAL-INPUT",
+              submitOptions(`prune-${rollover}-${barrier}`),
+            );
+
+            const process = runtime
+              .processThread(agent, receipt.threadId)
+              .pipe(Effect.provide(handlers));
+
+            yield* control.setHandler((location) =>
+              location === barrier && executions === 2
+                ? Effect.fail(DurableRuntimeFailpointError.make({ location }))
+                : Effect.void,
+            );
+            const firstAttempt = yield* process.pipe(Effect.exit, Effect.ensuring(control.clear));
+
+            expectCrash(firstAttempt);
+            const before = yield* readLog(receipt.threadId);
+
+            const beforePrunes = before.filter(
+              ({ record }) =>
+                record.payload._tag === "CompactionCreated" &&
+                record.payload.kind === "clear-tool-results",
+            );
+
+            expect(beforePrunes).toHaveLength(
+              barrier === "compaction:after-canonical-append" ? 1 : 0,
+            );
+            expect(executions).toBe(2);
+            const settled = yield* process;
+
+            expect(settled[0]?.outcome).toBe("completed");
+            expect(executions).toBe(2);
+            expect(scripted.prompts).toHaveLength(rollover ? 4 : 3);
+            const finalPrompt = scripted.prompts.at(-1) ?? Prompt.empty;
+
+            expect(results(finalPrompt)).toEqual([CLEARED_TOOL_RESULT, evidence[1]]);
+            expect(JSON.stringify(finalPrompt)).toContain("ORIGINAL-INPUT");
+            expect(JSON.stringify(finalPrompt)).toContain("Complete the original objective.");
+            expect(
+              finalPrompt.content.some(
+                (message) =>
+                  message.role === "user" &&
+                  message.content.some(
+                    (part) => part.type === "text" && part.text.startsWith(CONTEXT_ROLLOVER_PREFIX),
+                  ),
+              ),
+            ).toBe(rollover);
+            const records = yield* readLog(receipt.threadId);
+
+            const prunes = records.filter(
+              ({ record }) =>
+                record.payload._tag === "CompactionCreated" &&
+                record.payload.kind === "clear-tool-results",
+            );
+
+            expect(prunes).toHaveLength(1);
+
+            const oldResult = records.find(
+              ({ record }) =>
+                record.payload._tag === "ToolCallSettled" && record.payload.result === evidence[0],
+            );
+
+            expect(prunes[0]?.record.payload).toMatchObject({ coversThrough: oldResult?.sequence });
+            expect(JSON.stringify(records)).toContain(evidence[0]);
+
+            const replay = yield* projectRunJournal(
+              records,
+              runIdForSubmission(receipt.submissionId),
+            );
+
+            expect(results(replay.prompt)).toEqual([CLEARED_TOOL_RESULT, evidence[1]]);
+            expect(replay.usage.inputTokens).toBe(rollover ? 3_300 : 3_200);
+          }),
+      );
+    }
+  }
+});

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -4141,7 +4141,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           usageSummary: yield* currentUsageSummary(),
         };
       }
-      // Summaries and pruning cover only prior Runs. A rollover separately maps fully settled
+      // Summaries cover only prior Runs. Pruning and rollover also map fully settled
       // current-Run records and preserves the canonical instruction/input block during replay.
       let ownerFirstSequence: CanonicalSequence | undefined;
 
@@ -4544,8 +4544,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             let sourceJournal = journal;
             let sourceBoundaries = boundaries;
 
-            if (commit.kind === "rollover") {
-              // Results must be canonical before a rollover can cover them. Newly committed
+            if (commit.kind !== "summarize") {
+              // Results must be canonical before pruning or rollover can cover them. Newly committed
               // compactions remain overlays on this Attempt's append-only source, so omit those
               // overlays while reconstructing the exact source-to-record mapping.
               yield* recordHalt(commitPendingTurn);
@@ -4567,11 +4567,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               );
             }
 
-            // Summaries/pruning use the initial prior-Run boundaries; rollovers also admit
+            // Summaries use the initial prior-Run boundaries; pruning and rollover also admit
             // complete current-Run boundaries from the fresh canonical source above.
             const coverable = sourceBoundaries.filter(
               (boundary) =>
-                commit.kind === "rollover" ||
+                commit.kind !== "summarize" ||
                 ownerFirstSequence === undefined ||
                 boundary.sequence < ownerFirstSequence,
             );
@@ -4581,7 +4581,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 message:
                   commit.kind === "rollover"
                     ? "Durable rollover requires complete canonical records"
-                    : "Durable compaction requires eligible prior-Run records",
+                    : "Durable compaction requires eligible canonical records",
               });
             }
 
@@ -4644,19 +4644,19 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 message:
                   commit.kind === "rollover"
                     ? "Rollover coverage cannot be mapped to complete canonical records"
-                    : "Compaction coverage cannot be mapped to complete prior-Run records",
+                    : "Compaction coverage cannot be mapped to complete canonical records",
               });
             }
             const coveredSequence = lastCovered.sequence;
 
             if (
-              commit.kind === "rollover" &&
+              commit.kind !== "summarize" &&
               sourceBoundaries.some(
                 (boundary) => boundary.incomplete === true && boundary.sequence <= coveredSequence,
               )
             ) {
               return yield* CompactionError.make({
-                message: "Rollover cannot cover an incomplete Tool batch",
+                message: "Compaction cannot cover an incomplete Tool batch",
               });
             }
             if (commit.kind === "summarize" && (commit.summary ?? "").trim().length === 0) {

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -547,7 +547,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
 
   // RUN-026 pre-scan: the widest VALID compaction bounds govern the fold. A
   // valid record covers strictly below its own sequence and never splits a response from its
-  // settled tool results. Only rollovers may cover their owner Run's records;
+  // settled tool results. Pruning and rollovers may cover complete owner-Run batches;
   // a summarize record must carry its summary. Invalid records
   // are ignored fail-safe — the full history stays authoritative. Ties on
   // coversThrough resolve to the record appended later (higher sequence),
@@ -599,9 +599,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     }),
   );
 
-  const rolloverCoverage = compactions.reduce(
+  const settledCoverage = compactions.reduce(
     (through, { payload }) =>
-      payload.kind === "rollover" ? Math.max(through, payload.coversThrough) : through,
+      payload.kind !== "summarize" ? Math.max(through, payload.coversThrough) : through,
     0,
   );
 
@@ -609,13 +609,12 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   let ownerPrefixSequence = Number.POSITIVE_INFINITY;
   let protectedContext: Prompt.Prompt | undefined;
 
-  if (rolloverCoverage > 0) {
+  if (settledCoverage > 0) {
     yield* Stream.runForEach(records, (envelope) =>
       Effect.gen(function* () {
         const payload = envelope.record.payload;
 
-        if (payload._tag !== "ModelResponseRecorded" || envelope.sequence > rolloverCoverage)
-          return;
+        if (payload._tag !== "ModelResponseRecorded" || envelope.sequence > settledCoverage) return;
         const messages = yield* decodePromptMessages(payload.messages);
         const declared = declaredApplicationToolCallIds(messages);
 
@@ -655,10 +654,10 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     if (coversThrough <= 0 || coversThrough >= ownSequence) return false;
     const ownerFirst = firstSequenceByRun.get(runId);
 
-    if (payload.kind !== "rollover" && ownerFirst !== undefined && coversThrough >= ownerFirst)
+    if (payload.kind === "summarize" && ownerFirst !== undefined && coversThrough >= ownerFirst)
       return false;
     if (
-      payload.kind === "rollover" &&
+      payload.kind !== "summarize" &&
       incompleteResponseSequences.some((sequence) => sequence <= coversThrough)
     )
       return false;

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -1098,38 +1098,84 @@ describe("engine compaction records and projection (RUN-026)", () => {
         }),
     );
 
+    for (const kind of ["rollover", "clear-tool-results"] as const)
+      it.effect(
+        `${kind} cannot cover an incomplete Tool batch even when its available results are below the cutoff`,
+        () =>
+          Effect.gen(function* () {
+            const batch = yield* turnCanonicalBatch({
+              ...turnInput(toolTurnAppended),
+              runScopedPrefixLength: 2,
+            });
+
+            const records = envelopesOf([batch]).slice(0, 2);
+
+            const rollover = envelopeAt(
+              3,
+              auditRecord(
+                "incomplete-rollover",
+                compactionPayload({
+                  kind,
+                  runId: RUN_ID,
+                  turn: 2,
+                  summary: undefined,
+                  coversThrough: 2,
+                  handoff: "Uncommitted handoff",
+                }),
+              ),
+            );
+
+            const projection = yield* projectRunJournal([...records, rollover], RUN_ID);
+
+            expect(projection.contextWindowId).toBeUndefined();
+            expect(promptText(projection.prompt)).not.toContain("Uncommitted handoff");
+            expect(projection.prompt.content.slice(0, 2)).toEqual(toolTurnAppended.slice(0, 2));
+            expect(toolResults(projection.prompt)).toEqual([{ bookingRef: "flight-42" }]);
+          }),
+      );
+
     it.effect(
-      "rollover cannot cover an incomplete Tool batch even when its available results are below the cutoff",
+      "prunes fully settled current-Run batches without losing replay usage, prefix or latest result",
       () =>
         Effect.gen(function* () {
-          const batch = yield* turnCanonicalBatch({
-            ...turnInput(toolTurnAppended),
+          const first = yield* turnCanonicalBatch({
+            ...turnInput(toolTurnAppended, 1, RUN_ID, { inputTokens: 100, outputTokens: 10 }),
             runScopedPrefixLength: 2,
           });
 
-          const records = envelopesOf([batch]).slice(0, 2);
+          const next = yield* turnCanonicalBatch(
+            turnInput(secondToolTurn, 2, RUN_ID, { inputTokens: 200, outputTokens: 20 }),
+          );
 
-          const rollover = envelopeAt(
-            3,
+          const records = envelopesOf([first, next]);
+          const baseline = yield* projectRunJournal(records, RUN_ID);
+
+          const prune = envelopeAt(
+            records.length + 1,
             auditRecord(
-              "incomplete-rollover",
+              "prune-owner",
               compactionPayload({
-                kind: "rollover",
+                kind: "clear-tool-results",
                 runId: RUN_ID,
-                turn: 2,
+                turn: 3,
                 summary: undefined,
-                coversThrough: 2,
-                handoff: "Uncommitted handoff",
+                coversThrough: first.records.length,
               }),
             ),
           );
 
-          const projection = yield* projectRunJournal([...records, rollover], RUN_ID);
+          const replay = yield* projectRunJournal([...records, prune], RUN_ID);
 
-          expect(projection.contextWindowId).toBeUndefined();
-          expect(promptText(projection.prompt)).not.toContain("Uncommitted handoff");
-          expect(projection.prompt.content.slice(0, 2)).toEqual(toolTurnAppended.slice(0, 2));
-          expect(toolResults(projection.prompt)).toEqual([{ bookingRef: "flight-42" }]);
+          expect(toolResults(replay.prompt)).toEqual([
+            "[tool result cleared by compaction]",
+            "[tool result cleared by compaction]",
+            { bookingRef: "lodging-7" },
+          ]);
+          expect(replay.prompt.content.slice(0, 2)).toEqual(baseline.prompt.content.slice(0, 2));
+          expect(replay.usage).toEqual(baseline.usage);
+          expect(replay.policyUsage).toEqual(baseline.policyUsage);
+          expect(replay.committedTurns).toBe(baseline.committedTurns);
+          expect(replay.pendingContextToolCallId).toBe(baseline.pendingContextToolCallId);
         }),
     );
 


### PR DESCRIPTION
String-output agents currently need JSON-quoted final text, and pruning can fail under prompt pressure even when older tool results are disposable. This adds an explicit text schema contract and lets durable pruning cover fully settled batches from the current run, including after rollover.

```ts
import * as Output from "@effect-agent/engine/Output";
import { Schema } from "effect";

// Agent.make(..., { output: Reply, ... })
const Reply = Output.text(Schema.String.check(Schema.isMaxLength(20_000)));
```

Text remains schema-validated and preserves whitespace, quotes, and allowed empty replies through canonical replay. Unmarked schemas retain JSON output; required completion tools retain precedence. An explicit schema helper avoids interpreting application metadata or changing existing string-schema agents.

Pruning now accounts for the whole prompt target and preserves the newest tool result. It reuses rollover's canonical mapping and existing crash barriers:

```text
settled results → canonical append → exact source-prefix match
               → CompactionCreated → live view / journal replay
```

Incomplete batches remain protected, summaries remain limited to prior runs, and original evidence stays in the append-only log. Already-replaced messages do not consume the retention budget.

Validation: full CI `ready` passed on the reviewed commit, including static checks, all workspace and adapter suites, package/docs builds, and bundle checks. All 96 focused tests passed, with type tests covering transformations, Effect requirements, and rejection of non-string wire schemas. Automated review found no actionable issues across the 18-file diff.

The integration job passed on one retry after an unchanged lost-join-acknowledgment test hit its existing 5-second deadline. That test also passed independently in 282 ms; the six new durability tests passed in the original CI run in 376 ms. No source or timeout changes were made for the retry.
