### PR TITLE
feat(platform-cloudflare): add durable host publication hooks

### DIFF
--- a/.changeset/durable-host-publication.md
+++ b/.changeset/durable-host-publication.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Add scoped host publication hooks to Thread Object Layers, with durable producer generations and publication deadlines sharing the native maintenance alarm. Drain pending host publications before runtime recovery and Agent work.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -110,6 +110,56 @@ They are captured when the Object acquires the runtime, not on each worker call.
 Use `options.eventLayer` for per-event observability and resources. Use
 `options.toolFailureObserver` for [recovered tool failures](../guide/run-agents#observe-recovered-tool-failures).
 
+### Publish durable host activity
+
+Use the optional publication Layer to deliver canonical records or durable approval, abort, and
+unknown-resolution intents to a host-owned destination:
+
+```ts
+import { ThreadPublication } from "@effect-agent/platform-cloudflare/Alarm";
+import {
+  DurableObjectContext,
+  ThreadObjectIdentity,
+} from "@effect-agent/platform-cloudflare/CloudflareBindings";
+import { ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+
+// `makePublication` is an application Effect yielding ThreadPublicationService.
+// It yields the raw LOCAL ThreadStore and SubmissionLedger, native DurableObjectContext,
+// ThreadObjectIdentity, and any application services its implementation needs.
+const RuntimeLive = ThreadObject.layer(registrations, {
+  publication: Layer.effect(ThreadPublication)(makePublication),
+});
+```
+
+Setup errors and service requirements remain in the resulting Layer; its Scope owns acquired
+resources. Initialization must remain local and bounded. The raw source ports are for reading;
+publication must not mutate them or write the native alarm slot. Other consumers need no setup.
+
+The host owns schema-versioned cursors, destination idempotency, acknowledgements and retry
+policy. Implement four hooks, with failures typed as `DurableAlarmError`:
+
+- `invalidate` durably marks source-derived work pending after a source commit.
+- `prepareGeneration(generation)` invalidates a scan when the native generation changes. Repeated
+  calls for the same generation must preserve bounded scan progress.
+- `drain` performs bounded delivery and persists acknowledgements or a retry deadline. External
+  delivery is at least once; use destination idempotency. Scope per-delivery resources explicitly.
+- `pendingDeadline` returns `Option<number>` in epoch milliseconds, or `None` when caught up.
+
+All hooks except `drain` must be bounded local operations, without waiting behind network I/O.
+Hooks can overlap: the host must prevent an older drain from overwriting newer cursor or retry
+state. Do not reenter source mutations from a publication hook. A parked obligation is host-owned
+and needs a host repair operation to restore its deadline.
+
+The platform prearms a native generation before ingress mutations and publication-producing
+runtime writes. It prepares a generation only after its producers have returned, drains publication
+before recovery or potentially slow Agent work, and keeps the earliest publication/runtime alarm.
+Pending publication defers runtime work, including when its retry deadline is in the future.
+A post-commit publication failure is logged without changing the committed source result; the
+new generation repairs missed invalidation after a crash. Alarm failures propagate for Workerd
+retry, and interruption remains interruption. Custom host facts must be committed through
+`ThreadMaintenance.withMutation` to get the same prearm and post-commit hooks.
+
 ## Configure the binding
 
 ```jsonc

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -6,6 +6,7 @@ import {
 } from "@effect-agent/thread/DurableAgentRuntime";
 import { SubmissionLedger, type SubmissionSnapshot } from "@effect-agent/thread/SubmissionLedger";
 import {
+  Cause,
   Clock,
   Context,
   DateTime,
@@ -157,7 +158,7 @@ export class DurableAlarmService extends Context.Service<
 export class MaintenancePassReport extends Schema.Class<MaintenancePassReport>(
   "@effect-agent/platform-cloudflare/MaintenancePassReport",
 )({
-  /** `caught-up` is generation-only; `actionable` ran recovery and at most one head Attempt. */
+  /** `caught-up` ran no runtime work (publication may be pending); `actionable` ran recovery. */
   phase: Schema.Literals(["caught-up", "actionable"]),
   /** Recovery decisions executed (or deferred) BEFORE any new claim in this pass. */
   recovered: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
@@ -195,6 +196,53 @@ export class ThreadMaintenanceFailpoint extends Context.Service<
 >()("@effect-agent/platform-cloudflare/ThreadMaintenanceFailpoint") {
   static readonly layer = Layer.succeed(this)({ hit: () => Effect.void });
 }
+
+/**
+ * Durable host publication of canonical records and ledger approval/abort/resolution intents.
+ * The host owns schema-versioned cursors, destination idempotency and acknowledgement. Delivery
+ * is at least once. Hooks must not write the alarm slot or mutate the supplied raw source ports.
+ *
+ * `invalidate`, `prepareGeneration` and `pendingDeadline` must be bounded local operations.
+ * `prepareGeneration` durably invalidates a scan only when its generation changes; repeated
+ * calls must preserve partial scan progress. It runs with no source mutation in flight.
+ * `drain` performs bounded delivery and persists retries before returning. A pending deadline
+ * defers runtime recovery/Attempts, allowing committed host publications to drain first.
+ * Unexpected hook failures leave the prearmed generation for retry. Hooks acquire per-call
+ * resources with Effect.scoped; Layer construction owns incarnation resources (eviction need
+ * not run finalizers). Do not hold a local hook behind network I/O or call back into producers.
+ */
+export interface ThreadPublicationService {
+  readonly invalidate: Effect.Effect<void, DurableAlarmError>;
+  readonly prepareGeneration: (generation: bigint) => Effect.Effect<void, DurableAlarmError>;
+  readonly drain: Effect.Effect<void, DurableAlarmError>;
+  readonly pendingDeadline: Effect.Effect<Option.Option<number>, DurableAlarmError>;
+}
+
+/** Opt in with `ThreadObject.layer(registrations, { publication: Layer.effect(ThreadPublication)(...) })`. */
+export class ThreadPublication extends Context.Service<
+  ThreadPublication,
+  ThreadPublicationService
+>()("@effect-agent/platform-cloudflare/ThreadPublication") {
+  static readonly layer = Layer.succeed(this)({
+    invalidate: Effect.void,
+    prepareGeneration: () => Effect.void,
+    drain: Effect.void,
+    pendingDeadline: Effect.succeed(Option.none()),
+  });
+}
+
+/** @internal A committed source operation must not become a failed operation because delivery failed. */
+export const publishCommitted = Effect.gen(function* () {
+  const publication = yield* ThreadPublication;
+
+  yield* publication.invalidate.pipe(Effect.andThen(publication.drain));
+}).pipe(
+  Effect.catchCause((cause) =>
+    Cause.hasInterrupts(cause)
+      ? Effect.interrupt
+      : Effect.logError("Thread publication deferred after source commit", cause),
+  ),
+);
 
 const MaintenanceGeneration = Schema.BigIntFromString.check(
   Schema.isGreaterThanOrEqualToBigInt(0n),
@@ -271,6 +319,80 @@ const stableExternalWait = (
   }
 };
 
+/** @internal Shared prearm/acknowledgement boundary for ingress and runtime-owned producers. */
+export class ThreadMutationGate extends Context.Service<
+  ThreadMutationGate,
+  {
+    readonly withMutation: <A, E, R>(
+      body: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | DurableAlarmError, R>;
+    readonly withSnapshot: <A, E, R>(
+      body: (active: number) => Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E, R>;
+  }
+>()("@effect-agent/platform-cloudflare/internal/ThreadMutationGate") {
+  static readonly layer = Layer.effect(this)(
+    Effect.gen(function* () {
+      const { ctx } = yield* DurableObjectContext;
+      const config = yield* CloudflareDurableRuntimeConfig;
+      const failpoint = yield* ThreadMaintenanceFailpoint;
+      // A fresh incarnation has no live mutations; durable generations survive eviction.
+      const activeMutations = yield* Ref.make(0);
+      const generationGate = yield* Semaphore.make(1);
+      const minimumAlarmDelay = Math.max(1, Math.ceil(config.alarmBackoffBase / 2));
+
+      const runTransaction = <A>(operation: string, transaction: () => Promise<A>) =>
+        Effect.tryPromise({ try: transaction, catch: alarmFailure(operation) });
+
+      const beginMutation = Effect.fn("ThreadMaintenance.beginMutation")(function* () {
+        yield* failpoint.hit("maintenance:dirty:before");
+        const now = yield* Clock.currentTimeMillis;
+
+        yield* runTransaction("advance maintenance generation", () =>
+          ctx.storage.transaction(async (transaction) => {
+            const { state } = await readMaintenanceState(transaction);
+
+            const next = ThreadMaintenanceState.make({
+              ...state,
+              dirty: state.dirty + 1n,
+            });
+
+            await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(next));
+            // The earliest configured retry bounds a newly actionable mutation without relying
+            // on its best-effort immediate wake hint.
+            await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
+          }),
+        );
+        yield* failpoint.hit("maintenance:dirty:after");
+        yield* Ref.update(activeMutations, (active) => active + 1);
+      });
+
+      const endMutation = generationGate.withPermit(
+        Ref.update(activeMutations, (active) => Math.max(0, active - 1)),
+      );
+
+      const withMutation = <A, E, R>(
+        body: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, E | DurableAlarmError, R> =>
+        Effect.acquireUseRelease(
+          generationGate.withPermit(beginMutation()),
+          () =>
+            failpoint.hit("maintenance:mutation:armed").pipe(
+              Effect.andThen(body),
+              Effect.tap(() => failpoint.hit("maintenance:mutation:finished")),
+            ),
+          () => endMutation,
+        );
+
+      return ThreadMutationGate.of({
+        withMutation,
+        withSnapshot: (body) =>
+          generationGate.withPermit(Effect.flatMap(Ref.get(activeMutations), body)),
+      });
+    }),
+  );
+}
+
 export type MaintenancePassFailure =
   | DurableWorkerFailure
   | DurableBindingFailure
@@ -313,6 +435,8 @@ export class ThreadMaintenance extends Context.Service<
   static readonly layer: Layer.Layer<
     ThreadMaintenance,
     never,
+    | ThreadMutationGate
+    | ThreadPublication
     | DurableAgentRuntime
     | SubmissionLedger
     | DurableAlarmService
@@ -335,68 +459,13 @@ export class ThreadMaintenance extends Context.Service<
        * restarts at zero and merely re-arms sooner than a long-lived one would have.
        */
       const stalls = yield* Ref.make(0);
-      /**
-       * Incarnation-local mutation count guarded with the generation transactions below. It is
-       * deliberately not durable: after eviction every begun mutation has stopped, while its
-       * pre-armed dirty generation remains durable for recovery. The short gate never spans the
-       * caller's mutation or cross-Object I/O.
-       */
-      const activeMutations = yield* Ref.make(0);
-      const generationGate = yield* Semaphore.make(1);
-      // At-least-once deliveries are idempotent, but overlapping pass bodies could otherwise
-      // acknowledge state while a sibling pass is still mutating it. Port/RPC mutations do not
-      // take this permit, so cross-Object I/O cannot deadlock the maintenance serialization.
+      const mutations = yield* ThreadMutationGate;
+      const publication = yield* ThreadPublication;
       const maintenancePassGate = yield* Semaphore.make(1);
       const minimumAlarmDelay = Math.max(1, Math.ceil(config.alarmBackoffBase / 2));
 
-      const runTransaction = <A>(
-        operation: string,
-        transaction: () => Promise<A>,
-      ): Effect.Effect<A, DurableAlarmError> =>
-        Effect.tryPromise({
-          try: transaction,
-          catch: alarmFailure(operation),
-        });
-
-      const beginMutation = Effect.fn("ThreadMaintenance.beginMutation")(function* () {
-        yield* failpoint.hit("maintenance:dirty:before");
-        const now = yield* Clock.currentTimeMillis;
-
-        yield* runTransaction("advance maintenance generation", () =>
-          ctx.storage.transaction(async (transaction) => {
-            const { state } = await readMaintenanceState(transaction);
-
-            const next = ThreadMaintenanceState.make({
-              ...state,
-              dirty: state.dirty + 1n,
-            });
-
-            await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(next));
-            // The earliest configured retry bounds a newly actionable mutation without relying
-            // on its best-effort immediate wake hint.
-            await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
-          }),
-        );
-        yield* failpoint.hit("maintenance:dirty:after");
-        yield* Ref.update(activeMutations, (active) => active + 1);
-      });
-
-      const endMutation = generationGate.withPermit(
-        Ref.update(activeMutations, (active) => Math.max(0, active - 1)),
-      );
-
-      const withMutation = <A, E, R>(
-        body: Effect.Effect<A, E, R>,
-      ): Effect.Effect<A, E | DurableAlarmError, R> =>
-        Effect.acquireUseRelease(
-          generationGate.withPermit(beginMutation()),
-          () =>
-            failpoint.hit("maintenance:mutation:armed").pipe(
-              Effect.andThen(body),
-              Effect.tap(() => failpoint.hit("maintenance:mutation:finished")),
-            ),
-          () => endMutation,
-        );
+      const runTransaction = <A>(operation: string, transaction: () => Promise<A>) =>
+        Effect.tryPromise({ try: transaction, catch: alarmFailure(operation) });
 
       const ensureAlarm = Effect.fn("ThreadMaintenance.ensureAlarm")(function* () {
         yield* failpoint.hit("maintenance:ensure:before");
@@ -414,6 +483,18 @@ export class ThreadMaintenance extends Context.Service<
             }
           }),
         );
+        const deadline = yield* publication.pendingDeadline;
+
+        if (Option.isSome(deadline)) {
+          yield* runTransaction("ensure publication alarm", () =>
+            ctx.storage.transaction((transaction) =>
+              ensureTransactionAlarmBy(
+                transaction,
+                Math.max(now + minimumAlarmDelay, deadline.value),
+              ),
+            ),
+          );
+        }
         yield* failpoint.hit("maintenance:ensure:after");
       });
 
@@ -429,7 +510,8 @@ export class ThreadMaintenance extends Context.Service<
               await transaction.put(MAINTENANCE_STATE_KEY, encodeMaintenanceState(state));
             }
             if (state.processed >= state.dirty) {
-              await transaction.deleteAlarm();
+              // Prearm even a publication-only pass before invoking any host hook.
+              await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
 
               return { _tag: "CaughtUp" as const, nonterminal: state.nonterminal };
             }
@@ -437,7 +519,11 @@ export class ThreadMaintenance extends Context.Service<
             // LATER to its bounded backoff, which does not cancel the running handler.
             await ensureTransactionAlarmBy(transaction, now + minimumAlarmDelay);
 
-            return { _tag: "Actionable" as const, generation: state.dirty };
+            return {
+              _tag: "Actionable" as const,
+              generation: state.dirty,
+              nonterminal: state.nonterminal,
+            };
           }),
         );
 
@@ -474,23 +560,74 @@ export class ThreadMaintenance extends Context.Service<
             alarm: report.alarm,
           }).pipe(Effect.as(report));
 
-        const started = yield* generationGate.withPermit(
+        const started = yield* mutations.withSnapshot((activeAtStart) =>
           Effect.gen(function* () {
-            const activeAtStart = yield* Ref.get(activeMutations);
             const generation = yield* beginPass();
+
+            if (generation._tag === "Actionable" && activeAtStart === 0) {
+              // The gate excludes a producer starting between the snapshot and certification.
+              yield* publication.prepareGeneration(generation.generation);
+            }
 
             return { ...generation, activeAtStart };
           }),
         );
 
-        if (started._tag === "CaughtUp") {
+        const deadline = yield* publication.pendingDeadline;
+
+        if (
+          started._tag === "Actionable" ||
+          (Option.isSome(deadline) && deadline.value <= (yield* Clock.currentTimeMillis))
+        ) {
+          yield* publication.drain;
+        }
+        const pending = yield* publication.pendingDeadline;
+
+        if (started._tag === "CaughtUp" || Option.isSome(pending)) {
+          yield* failpoint.hit("maintenance:finish:before");
+
+          const disposition = yield* mutations.withSnapshot((active) =>
+            Effect.gen(function* () {
+              // Re-read under the producer gate: a concurrent append/host mutation cannot be
+              // cleared using a stale empty deadline. Dirty generations bound all producer races.
+              const latest = yield* publication.pendingDeadline;
+              const now = yield* Clock.currentTimeMillis;
+
+              return yield* runTransaction("finish publication pass", () =>
+                ctx.storage.transaction(async (transaction) => {
+                  const { state } = await readMaintenanceState(transaction);
+
+                  const nativeDeadline =
+                    active > 0 || state.dirty > state.processed
+                      ? now + config.wakeScanInterval
+                      : Infinity;
+
+                  const next = Option.isSome(latest)
+                    ? Math.min(nativeDeadline, latest.value)
+                    : nativeDeadline;
+
+                  if (Number.isFinite(next)) {
+                    await transaction.setAlarm(Math.max(now + minimumAlarmDelay, next));
+
+                    return "rearmed" as const;
+                  }
+                  await transaction.deleteAlarm();
+
+                  return "cleared" as const;
+                }),
+              );
+            }),
+          );
+
+          yield* failpoint.hit("maintenance:finish:after");
+
           return yield* annotate(
             MaintenancePassReport.make({
               phase: "caught-up",
               recovered: 0,
               settled: 0,
               nonterminal: started.nonterminal,
-              alarm: "cleared",
+              alarm: disposition,
             }),
           );
         }
@@ -528,9 +665,9 @@ export class ThreadMaintenance extends Context.Service<
 
         yield* failpoint.hit("maintenance:finish:before");
 
-        const alarmDisposition = yield* generationGate.withPermit(
+        const alarmDisposition = yield* mutations.withSnapshot((active) =>
           Effect.gen(function* () {
-            const active = yield* Ref.get(activeMutations);
+            const publicationDeadline = yield* publication.pendingDeadline;
 
             return yield* runTransaction("finish maintenance pass", () =>
               ctx.storage.transaction(async (transaction) => {
@@ -556,7 +693,14 @@ export class ThreadMaintenance extends Context.Service<
                   // Replace the crash-fallback slot with this pass's bounded backoff. The target
                   // is never earlier than the begin-pass fallback, so workerd does not cancel
                   // this running alarm handler before its report/span can complete.
-                  await transaction.setAlarm(now + delay);
+                  await transaction.setAlarm(
+                    Option.isSome(publicationDeadline)
+                      ? Math.max(
+                          now + minimumAlarmDelay,
+                          Math.min(now + delay, publicationDeadline.value),
+                        )
+                      : now + delay,
+                  );
 
                   return "rearmed" as const;
                 }
@@ -566,7 +710,22 @@ export class ThreadMaintenance extends Context.Service<
                   // unseen effects are never acknowledged. Do not accelerate that future alarm
                   // from inside the current handler: workerd cancels a running handler when it
                   // writes an earlier slot.
-                  await ensureTransactionAlarmBy(transaction, now + config.wakeScanInterval);
+                  await ensureTransactionAlarmBy(
+                    transaction,
+                    Option.isSome(publicationDeadline)
+                      ? Math.max(
+                          now + minimumAlarmDelay,
+                          Math.min(now + config.wakeScanInterval, publicationDeadline.value),
+                        )
+                      : now + config.wakeScanInterval,
+                  );
+
+                  return "rearmed" as const;
+                }
+                if (Option.isSome(publicationDeadline)) {
+                  await transaction.setAlarm(
+                    Math.max(now + minimumAlarmDelay, publicationDeadline.value),
+                  );
 
                   return "rearmed" as const;
                 }
@@ -615,8 +774,15 @@ export class ThreadMaintenance extends Context.Service<
               }),
           }),
         ),
-        ensureAlarm: ensureAlarm(),
-        withMutation,
+        ensureAlarm: mutations.withSnapshot(() => ensureAlarm()),
+        withMutation: (body) =>
+          mutations.withMutation(
+            body.pipe(
+              Effect.tap(() =>
+                publishCommitted.pipe(Effect.provideService(ThreadPublication, publication)),
+              ),
+            ),
+          ),
       });
     }),
   );

--- a/packages/platform-cloudflare/src/ThreadObject.ts
+++ b/packages/platform-cloudflare/src/ThreadObject.ts
@@ -103,6 +103,7 @@ import { ProgressWaitRegistry } from "./internal/progress-wait.ts";
 export {
   layer,
   layerConfig,
+  type ThreadPublicationOptions as PublicationOptions,
   type CloudflareDurableRuntimeOptions as RuntimeOptions,
   type CloudflareDurableRuntimeServices as Services,
   type CloudflareDurableRuntimeInitializationError as InitializationError,

--- a/packages/platform-cloudflare/src/internal/layers.ts
+++ b/packages/platform-cloudflare/src/internal/layers.ts
@@ -47,8 +47,8 @@ import {
   type OperationAuthorizerService,
 } from "@effect-agent/thread/OperationAuthorizer";
 import { ProducerId } from "@effect-agent/thread/Records";
-import { type SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
-import { type ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { LedgerError, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { ThreadStoreError, ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { type WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { BrowserCrypto } from "@effect/platform-browser";
@@ -58,6 +58,9 @@ import { Context, Duration, Effect, Layer, Schema } from "effect";
 
 import {
   ThreadMaintenance,
+  ThreadMutationGate,
+  ThreadPublication,
+  publishCommitted,
   ThreadMaintenanceFailpoint,
   DurableAlarmService,
   type ThreadMaintenanceFailpointHandler,
@@ -168,6 +171,7 @@ export type CloudflareDurableRuntimeServices =
   | WakeScheduler
   | DurableAlarmService
   | ThreadMaintenance
+  | ThreadPublication
   | ThreadObjectPorts
   | ProgressWaitRegistry;
 
@@ -311,15 +315,33 @@ export const layerConfig = (
     }),
   );
 
+export interface ThreadPublicationOptions<E = never, R = never> {
+  /**
+   * Optional host outbox consumer, built once per incarnation with RAW LOCAL ThreadStore and
+   * SubmissionLedger services. Yield DurableObjectContext and ThreadObjectIdentity for native
+   * bindings and identity. Initialization is local-only, inside the constructor gate; setup
+   * errors and additional requirements remain in the returned Layer. Layer.effect owns Scope.
+   * Canonical appends and durable approval, abort and unknown-resolution intents invalidate
+   * publication after commit. Custom host facts must use ThreadMaintenance.withMutation.
+   */
+  readonly publication?: Layer.Layer<ThreadPublication, E, R>;
+}
+
 /**
  * Register typed Agents and version declarations. Hashing and dependency capture happen in
  * this Layer's Scope, after application Layers have been provided. Every Agent's instruction,
  * Tool, Schema, and model requirements remain visible until satisfied by Layer composition.
  * Use Layer.unwrap for registration values that need effectful application setup.
  */
-export const layer = <const Entries extends ReadonlyArray<AgentRegistration>>(
+export const layer = <const Entries extends ReadonlyArray<AgentRegistration>, E = never, R = never>(
   registrations: Entries,
-) => Layer.unwrap(Effect.map(compileRegistrations(registrations), layerFromBindings));
+  options: ThreadPublicationOptions<E, R> = {},
+) =>
+  Layer.unwrap(
+    Effect.map(compileRegistrations(registrations), (bindings) =>
+      layerFromBindings(bindings, options),
+    ),
+  );
 
 /**
  * Assemble the durable runtime from already-resolved Agent Bindings.
@@ -327,12 +349,16 @@ export const layer = <const Entries extends ReadonlyArray<AgentRegistration>>(
  * Supply host services through `ThreadObject.make` or `ThreadObject.layerConfig` and
  * the Durable Object context and namespace Layers when composing a custom host.
  */
-export const layerFromBindings = (
+export const layerFromBindings = <E = never, R = never>(
   bindings: ReadonlyArray<ResolvedBinding>,
+  options: ThreadPublicationOptions<E, R> = {},
 ): Layer.Layer<
   CloudflareDurableRuntimeServices,
-  DoStorageInitializationError,
-  DurableObjectContext | ThreadObjectNamespace | CloudflareBootstrapServices
+  DoStorageInitializationError | E,
+  | DurableObjectContext
+  | ThreadObjectNamespace
+  | CloudflareBootstrapServices
+  | Exclude<R, ThreadStore | SubmissionLedger>
 > =>
   Layer.unwrap(
     Effect.gen(function* () {
@@ -355,9 +381,66 @@ export const layerFromBindings = (
 
       // The same local ports serve routed decorators and owner-side RPC execution.
       // The RPC executor must never receive routed ports and bounce requests between Objects.
-      const localPorts = Layer.mergeAll(threadStoreLayer, submissionLedgerLayer).pipe(
+      const rawLocalPorts = Layer.mergeAll(threadStoreLayer, submissionLedgerLayer).pipe(
         Layer.provide(infrastructure),
       );
+
+      const publication = (options.publication ?? ThreadPublication.layer).pipe(
+        Layer.provide(rawLocalPorts),
+      );
+
+      const localPorts =
+        options.publication === undefined
+          ? rawLocalPorts
+          : Layer.effectContext(
+              Effect.gen(function* () {
+                const store = yield* ThreadStore;
+                const ledger = yield* SubmissionLedger;
+                const mutations = yield* ThreadMutationGate;
+                const publish = yield* Effect.context<ThreadPublication>();
+                const afterCommit = publishCommitted.pipe(Effect.provide(publish));
+
+                // Every runtime-owned producer prearms too: a crash between commit and invalidation
+                // leaves a NEW, uncertified generation. Source errors keep their native port types.
+                const observedStore = ThreadStore.of({
+                  ...store,
+                  append: (request) =>
+                    mutations
+                      .withMutation(store.append(request).pipe(Effect.tap(() => afterCommit)))
+                      .pipe(
+                        Effect.catchTag("DurableAlarmError", (cause) =>
+                          ThreadStoreError.make({
+                            operation: "prearm publication append",
+                            message: cause.message,
+                            cause,
+                          }),
+                        ),
+                      ),
+                });
+
+                const observeIntent = <A, Failure>(body: Effect.Effect<A, Failure>) =>
+                  mutations.withMutation(body.pipe(Effect.tap(() => afterCommit))).pipe(
+                    Effect.catchTag("DurableAlarmError", (cause) =>
+                      LedgerError.make({
+                        operation: "prearm publication intent",
+                        message: "The publication generation could not be armed",
+                        cause,
+                      }),
+                    ),
+                  );
+
+                return Context.make(ThreadStore, observedStore).pipe(
+                  Context.add(SubmissionLedger, {
+                    ...ledger,
+                    recordApprovalDecision: (request) =>
+                      observeIntent(ledger.recordApprovalDecision(request)),
+                    requestAbort: (request) => observeIntent(ledger.requestAbort(request)),
+                    recordUnknownResolution: (request) =>
+                      observeIntent(ledger.recordUnknownResolution(request)),
+                  }),
+                );
+              }),
+            ).pipe(Layer.provide(rawLocalPorts));
 
       const portsEndpointLayer = Layer.effect(ThreadObjectPorts)(
         Effect.gen(function* () {
@@ -386,6 +469,6 @@ export const layerFromBindings = (
         runtimeStack,
         ThreadMaintenance.layer.pipe(Layer.provide(runtimeStack)),
         portsEndpointLayer,
-      );
+      ).pipe(Layer.provideMerge(publication), Layer.provide(ThreadMutationGate.layer));
     }),
   );

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -23,6 +23,7 @@ import { expect } from "vite-plus/test";
 
 import { decodeThreadId, supplierCountsFor, supplierValuesFor } from "./fixtures.ts";
 import type {
+  PublicationThreadObject,
   ContextCompactorThreadObject,
   DynamicBindingsThreadObject,
   DeniedThreadObject,
@@ -38,6 +39,7 @@ declare global {
   namespace Cloudflare {
     interface Env {
       THREADS: DurableObjectNamespace<TestThreadObject>;
+      PUBLICATIONS: DurableObjectNamespace<PublicationThreadObject>;
       LIMITED: DurableObjectNamespace<LimitedThreadObject>;
       TINYDB: DurableObjectNamespace<TinyDatabaseThreadObject>;
       DENIED: DurableObjectNamespace<DeniedThreadObject>;
@@ -58,6 +60,7 @@ declare global {
  */
 
 export type TestNamespace =
+  | "PUBLICATIONS"
   | "THREADS"
   | "LIMITED"
   | "TINYDB"

--- a/packages/platform-cloudflare/test/publication-fixture.ts
+++ b/packages/platform-cloudflare/test/publication-fixture.ts
@@ -1,0 +1,148 @@
+import { RecoverySnapshotRequest, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { ThreadStore, ThreadTailRequest } from "@effect-agent/thread/ThreadStore";
+import { Clock, Effect, Layer, Option, Schema, Stream } from "effect";
+
+import { ThreadPublication, DurableAlarmError } from "../src/Alarm.ts";
+import { DurableObjectContext, ThreadObjectIdentity } from "../src/CloudflareBindings.ts";
+
+export const PublicationCursor = Schema.Struct({
+  version: Schema.Literal(1),
+  generation: Schema.String,
+  source: Schema.Natural,
+  tail: Schema.Natural,
+  dirty: Schema.Boolean,
+  decisions: Schema.Array(Schema.String),
+});
+
+export const PUBLICATION_KEY = "test:publication:cursor";
+export const SOURCE_KEY = "test:publication:source";
+
+export interface PublicationControl {
+  readonly entered?: () => void;
+  readonly release?: Promise<void>;
+  readonly failure?: "failure" | "defect" | "interruption" | "timeout";
+  readonly retryAt?: number;
+}
+
+export const publicationControls = new Map<string, PublicationControl>();
+export const publicationResources = new Map<string, { acquired: number; released: number }>();
+export const publicationPreparations = new Map<string, Array<string>>();
+
+/** Persistent host cursor over the real local source ports; only the destination is controlled. */
+export const publicationLayer = Layer.effect(ThreadPublication)(
+  Effect.gen(function* () {
+    const { ctx } = yield* DurableObjectContext;
+    const { threadId } = yield* ThreadObjectIdentity;
+    const store = yield* ThreadStore;
+    const ledger = yield* SubmissionLedger;
+
+    const read = Effect.promise(() => ctx.storage.get(PUBLICATION_KEY)).pipe(
+      Effect.flatMap((value) =>
+        value === undefined
+          ? Effect.succeed({
+              version: 1 as const,
+              generation: "",
+              source: 0,
+              tail: 0,
+              dirty: true,
+              decisions: [] as Array<string>,
+            })
+          : Schema.decodeUnknownEffect(PublicationCursor)(value),
+      ),
+    );
+
+    const save = (cursor: typeof PublicationCursor.Type) =>
+      Schema.encodeEffect(PublicationCursor)(cursor).pipe(
+        Effect.flatMap((value) => Effect.promise(() => ctx.storage.put(PUBLICATION_KEY, value))),
+      );
+
+    const source = Effect.promise(() => ctx.storage.get(SOURCE_KEY)).pipe(
+      Effect.flatMap((value) => Schema.decodeUnknownEffect(Schema.Natural)(value ?? 0)),
+    );
+
+    const tail = store.inspectTail(ThreadTailRequest.make({ threadId })).pipe(
+      Effect.map((tail) => tail.tailSequence),
+      Effect.catchTag("ThreadNotMaterialized", () => Effect.succeed(0)),
+    );
+
+    const failure = (cause: unknown) =>
+      DurableAlarmError.make({
+        operation: "host publication",
+        message: "host publication failed",
+        cause,
+      });
+
+    return ThreadPublication.of({
+      invalidate: Effect.gen(function* () {
+        yield* save({ ...(yield* read), dirty: true });
+      }).pipe(Effect.mapError(failure)),
+      prepareGeneration: (generation) =>
+        Effect.gen(function* () {
+          const cursor = yield* read;
+
+          if (cursor.generation === String(generation)) return;
+          const calls = publicationPreparations.get(threadId) ?? [];
+
+          calls.push(String(generation));
+          publicationPreparations.set(threadId, calls);
+          yield* save({ ...cursor, generation: String(generation), dirty: true });
+        }).pipe(Effect.mapError(failure)),
+      drain: Effect.gen(function* () {
+        const resources = publicationResources.get(threadId) ?? { acquired: 0, released: 0 };
+
+        publicationResources.set(threadId, resources);
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            resources.acquired++;
+          }),
+          () =>
+            Effect.sync(() => {
+              resources.released++;
+            }),
+        );
+        const cursor = yield* read;
+        const currentSource = yield* source;
+        const currentTail = yield* tail;
+        const control = publicationControls.get(threadId);
+
+        if (control?.retryAt !== undefined) return;
+        if (control?.failure === "failure") return yield* failure("retryable destination failure");
+        if (control?.failure === "defect") return yield* Effect.die("destination defect");
+        if (control?.failure === "interruption") return yield* Effect.interrupt;
+        if (control?.failure === "timeout")
+          return yield* Effect.never.pipe(Effect.timeout("0 millis"));
+        control?.entered?.();
+        const release = control?.release;
+
+        if (release !== undefined) yield* Effect.promise(() => release);
+        const rows = yield* Stream.runCollect(ledger.scanNonterminal);
+        const decisions: Array<string> = [];
+
+        for (const row of rows) {
+          const snapshot = yield* ledger.loadRecoverySnapshot(
+            RecoverySnapshotRequest.make({ submissionId: row.submissionId }),
+          );
+
+          decisions.push(...snapshot.approvalDecisions.map((intent) => intent.decision));
+        }
+        yield* save({
+          ...cursor,
+          source: currentSource,
+          tail: currentTail,
+          dirty: false,
+          decisions: [...new Set([...cursor.decisions, ...decisions])],
+        });
+      }).pipe(Effect.scoped, Effect.mapError(failure)),
+      pendingDeadline: Effect.gen(function* () {
+        const cursor = yield* read;
+
+        if (!cursor.dirty && cursor.source >= (yield* source) && cursor.tail >= (yield* tail))
+          return Option.none();
+
+        return Option.some(
+          publicationControls.get(threadId)?.retryAt ?? (yield* Clock.currentTimeMillis),
+        );
+      }).pipe(Effect.mapError(failure)),
+    });
+  }),
+);

--- a/packages/platform-cloudflare/test/publication.test.ts
+++ b/packages/platform-cloudflare/test/publication.test.ts
@@ -1,0 +1,374 @@
+import { ApprovalDecisionCommand, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { Cause, Clock, Context, Effect, Exit, Layer, Schema } from "effect";
+import { DurableObject } from "effect-cf";
+import { TestClock } from "effect/testing";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+
+import type { DurableAlarmError } from "../src/Alarm.ts";
+import { ThreadMaintenance, ThreadPublication } from "../src/Alarm.ts";
+import {
+  DurableObjectContext,
+  ThreadObjectIdentity,
+  ThreadObjectNamespace,
+} from "../src/CloudflareBindings.ts";
+import { CloudflareThreadClient } from "../src/CloudflareThreadClient.ts";
+import * as ThreadObject from "../src/ThreadObject.ts";
+import {
+  approvalDefinition,
+  plannerDefinition,
+  submitOptions,
+  maintenanceClocks,
+  armMaintenancePause,
+  awaitMaintenancePause,
+  releaseMaintenancePause,
+  armStorageEviction,
+  armedEvictionsRemaining,
+  BOOK_TOOL_CALL_ID,
+  decodeThreadId,
+} from "./fixtures.ts";
+import {
+  allSettled,
+  anyInState,
+  drainAlarmsUntil,
+  laneRows,
+  readCanonical,
+  runClient,
+  scheduledAlarm,
+  stubFor,
+} from "./harness.ts";
+import {
+  PublicationCursor,
+  PUBLICATION_KEY,
+  SOURCE_KEY,
+  publicationControls,
+  publicationPreparations,
+  publicationResources,
+} from "./publication-fixture.ts";
+
+const namespace = "PUBLICATIONS";
+const stub = (thread: string) => stubFor(thread, namespace);
+
+const alarm = (thread: string) =>
+  runInDurableObject(stub(thread), (instance) => Promise.resolve(instance.alarm()));
+
+const cursor = (thread: string) =>
+  runInDurableObject(stub(thread), async (_, state) =>
+    Schema.decodeUnknownSync(PublicationCursor)(await state.storage.get(PUBLICATION_KEY)),
+  );
+
+const generation = (thread: string) =>
+  runInDurableObject(stub(thread), async (_, state) =>
+    Schema.decodeUnknownSync(
+      Schema.Struct({ dirty: Schema.BigIntFromString, processed: Schema.BigIntFromString }),
+    )(await state.storage.get("effect-agent:thread-maintenance:v1")),
+  );
+
+const submit = (
+  thread: string,
+  definition: typeof plannerDefinition | typeof approvalDefinition = plannerDefinition,
+) =>
+  runClient(
+    Effect.gen(function* () {
+      const client = yield* CloudflareThreadClient;
+
+      return yield* client.submit(
+        { definition },
+        { question: "publication", ref: thread },
+        submitOptions(thread, thread),
+      );
+    }),
+    namespace,
+  );
+
+const mutate = (thread: string, source: number) =>
+  runInDurableObject(stub(thread), (instance, state) =>
+    instance[DurableObject.RunSymbol](
+      ThreadMaintenance.use((maintenance) =>
+        maintenance.withMutation(Effect.promise(() => state.storage.put(SOURCE_KEY, source))),
+      ),
+    ),
+  );
+
+const quiesce = (thread: string) =>
+  drainAlarmsUntil(thread, async () => (await scheduledAlarm(thread, namespace)) === null, {
+    namespace,
+  });
+
+const withThread = (
+  test: (thread: string, now: number, advance: (millis: number) => Promise<void>) => Promise<void>,
+) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const thread = `publication-${crypto.randomUUID()}`;
+      const now = Date.now() + 86_400_000;
+
+      yield* TestClock.setTime(now);
+      maintenanceClocks.set(thread, yield* Clock.Clock);
+      const clock = yield* TestClock.testClockWith(Effect.succeed);
+
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          publicationControls.delete(thread);
+          publicationPreparations.delete(thread);
+          publicationResources.delete(thread);
+          maintenanceClocks.delete(thread);
+          releaseMaintenancePause(thread);
+        }),
+      );
+      yield* Effect.promise(() =>
+        test(thread, now, (millis) => Effect.runPromise(clock.adjust(millis))),
+      );
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+const latch = () => {
+  let resolve!: () => void;
+
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+
+  return { promise, resolve: () => resolve() };
+};
+
+describe("durable host publication", () => {
+  it("drains committed intent before runtime recovery and preserves the earliest retry deadline", () =>
+    withThread(async (thread, now) => {
+      const receipt = await submit(thread, approvalDefinition);
+
+      await drainAlarmsUntil(thread, anyInState(thread, "suspended", namespace), { namespace });
+      await quiesce(thread);
+      publicationControls.set(thread, { retryAt: now + 25 });
+      await runClient(
+        CloudflareThreadClient.use((client) =>
+          client.resolveApproval(
+            decodeThreadId(thread),
+            ApprovalDecisionCommand.make({
+              submissionId: receipt.submissionId,
+              toolCallId: BOOK_TOOL_CALL_ID,
+              decision: "approved",
+              resolver: "publication-test",
+              reason: "approved",
+            }),
+          ),
+        ),
+        namespace,
+      );
+      await alarm(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("input-applied");
+      expect(await scheduledAlarm(thread, namespace)).toBe(now + 25);
+      publicationControls.delete(thread);
+      const entered = latch();
+      const release = latch();
+
+      publicationControls.set(thread, { entered: entered.resolve, release: release.promise });
+      const running = alarm(thread);
+
+      try {
+        await entered.promise;
+        expect((await laneRows(thread, namespace))[0]?.state).toBe("input-applied");
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      } finally {
+        publicationControls.delete(thread);
+        release.resolve();
+        await running;
+      }
+      await quiesce(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+      expect((await cursor(thread)).decisions).toEqual(["approved"]);
+      expect((await cursor(thread)).tail).toBe(
+        (await readCanonical(thread, namespace)).at(-1)?.sequence,
+      );
+    }));
+
+  it("does not certify a generation while a producer is still in flight", () =>
+    withThread(async (thread) => {
+      await alarm(thread);
+      const before = await cursor(thread);
+
+      armMaintenancePause(thread, "maintenance:mutation:armed");
+      const mutation = mutate(thread, 1);
+
+      await awaitMaintenancePause(thread, "maintenance:mutation:armed");
+      try {
+        await alarm(thread);
+        expect((await cursor(thread)).generation).toBe(before.generation);
+        const state = await generation(thread);
+
+        expect(state.dirty).toBeGreaterThan(state.processed);
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      } finally {
+        releaseMaintenancePause(thread);
+        await mutation;
+      }
+      await quiesce(thread);
+      expect((await cursor(thread)).source).toBe(1);
+    }));
+
+  it("keeps a producer racing an empty publication drain armed", () =>
+    withThread(async (thread) => {
+      await alarm(thread);
+      const entered = latch();
+      const release = latch();
+
+      publicationControls.set(thread, { entered: entered.resolve, release: release.promise });
+      const first = mutate(thread, 1);
+
+      await entered.promise;
+      publicationControls.delete(thread);
+      try {
+        await mutate(thread, 2);
+        // The older drain now writes a stale cursor after the newer publication acknowledged.
+      } finally {
+        release.resolve();
+        await first;
+      }
+      expect((await cursor(thread)).source).toBe(1);
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      await quiesce(thread);
+      expect((await cursor(thread)).source).toBe(2);
+    }));
+
+  it("does not erase a new producer when finishing a publication-only pass", () =>
+    withThread(async (thread) => {
+      await alarm(thread);
+      armMaintenancePause(thread, "maintenance:finish:before");
+      const running = alarm(thread);
+
+      await awaitMaintenancePause(thread, "maintenance:finish:before");
+      try {
+        await mutate(thread, 1);
+      } finally {
+        releaseMaintenancePause(thread);
+        await running;
+      }
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      await quiesce(thread);
+      expect((await cursor(thread)).source).toBe(1);
+    }));
+
+  it("recertifies a runtime-owned append after eviction between source commit and invalidation", () =>
+    withThread(async (thread, _now, advance) => {
+      await submit(thread);
+      armStorageEviction(thread, "append:after");
+      await alarm(thread).catch(() => undefined);
+      expect(armedEvictionsRemaining(thread)).toBe(0);
+      // A new incarnation must see a generation newer than the scan prepared before runtime work.
+      const state = await generation(thread);
+      const before = await cursor(thread);
+
+      expect(state.dirty).toBeGreaterThan(BigInt(before.generation));
+      expect(state.dirty).toBeGreaterThan(state.processed);
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      await advance(1_000);
+      await drainAlarmsUntil(thread, allSettled(thread, namespace), { namespace });
+      await quiesce(thread);
+      expect((await cursor(thread)).tail).toBe(
+        (await readCanonical(thread, namespace)).at(-1)?.sequence,
+      );
+    }));
+
+  it("returns the committed submission when immediate publication fails and repairs it by alarm", () =>
+    withThread(async (thread) => {
+      publicationControls.set(thread, { failure: "failure" });
+      const receipt = await submit(thread);
+
+      expect((await laneRows(thread, namespace))[0]?.submission_id).toBe(receipt.submissionId);
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      publicationControls.delete(thread);
+      await quiesce(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+      expect((await cursor(thread)).tail).toBe(
+        (await readCanonical(thread, namespace)).at(-1)?.sequence,
+      );
+    }));
+
+  it.each(["failure", "defect", "interruption", "timeout"] as const)(
+    "retains a prearmed native alarm across publication %s",
+    (failure) =>
+      withThread(async (thread) => {
+        await submit(thread);
+        publicationControls.set(thread, { failure });
+        await expect(alarm(thread)).rejects.toBeDefined();
+        const resources = publicationResources.get(thread);
+
+        expect(resources?.acquired).toBeGreaterThan(0);
+        expect(resources?.released).toBe(resources?.acquired);
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+        const state = await generation(thread);
+
+        expect(state.dirty).toBeGreaterThan(state.processed);
+        publicationControls.delete(thread);
+        await runDurableObjectAlarm(stub(thread));
+        await quiesce(thread);
+        expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+      }),
+  );
+});
+
+class PublicationSetupError extends Schema.TaggedError<PublicationSetupError>()(
+  "PublicationSetupError",
+  {},
+) {}
+class Destination extends Context.Service<Destination, { readonly enabled: boolean }>()(
+  "test/PublicationDestination",
+) {}
+
+it("preserves publication setup E/R/Scope and releases resources on typed initialization failure", async () => {
+  const lifecycle: Array<string> = [];
+
+  const publication = Layer.effect(ThreadPublication)(
+    Effect.gen(function* () {
+      yield* Destination;
+      yield* ThreadStore;
+      yield* SubmissionLedger;
+      yield* ThreadObjectIdentity;
+      yield* DurableObjectContext;
+      yield* Effect.acquireRelease(
+        Effect.sync(() => lifecycle.push("acquired")),
+        () => Effect.sync(() => lifecycle.push("released")),
+      );
+
+      return yield* PublicationSetupError.make({});
+    }),
+  );
+
+  const runtime = ThreadObject.layer([], { publication }).pipe(
+    Layer.provide(
+      ThreadObject.layerConfig({ deploymentId: "publication", producerPrefix: "publication" }),
+    ),
+  );
+
+  expectTypeOf<Layer.Error<typeof runtime>>().toEqualTypeOf<
+    ThreadObject.InitializationError | PublicationSetupError
+  >();
+  expectTypeOf<Layer.Services<typeof runtime>>().toEqualTypeOf<
+    Destination | DurableObjectContext | ThreadObjectNamespace
+  >();
+  expectTypeOf<ThreadPublication["Service"]["drain"]>().toEqualTypeOf<
+    Effect.Effect<void, DurableAlarmError>
+  >();
+  await runInDurableObject(stub("publication-scope"), (_, state) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const exit = yield* Layer.build(
+          runtime.pipe(
+            Layer.provide([
+              Layer.succeed(Destination, { enabled: true }),
+              DurableObjectContext.layer(state, env),
+              ThreadObjectNamespace.layer(env.PUBLICATIONS),
+            ]),
+          ),
+        ).pipe(Effect.scoped, Effect.exit);
+
+        expect(Exit.isFailure(exit) && Cause.findErrorOption(exit.cause)).toMatchObject({
+          _tag: "Some",
+          value: { _tag: "PublicationSetupError" },
+        });
+        expect(lifecycle).toEqual(["acquired", "released"]);
+      }),
+    ),
+  );
+});

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -37,6 +37,7 @@ import {
   plannerModel,
   registrationDefinitions,
   testRuntimeLayer,
+  makeTestBindings,
   runtimeEvictionFailpoint,
   notifyScheduleAlarmCompleted,
   scheduleAuthorizer,
@@ -58,6 +59,7 @@ import {
   observabilityProbeLayer,
   telemetryProbe,
 } from "./observability-fixture.ts";
+import { publicationLayer } from "./publication-fixture.ts";
 import { makeSubagentTestBindings, transportFaultReason } from "./subagent-fixtures.ts";
 import {
   subscriptionAlarmExtensionLayer,
@@ -311,6 +313,15 @@ const maintenanceClockLayer = Layer.effect(
     return maintenanceClocks.get(identity.threadId) ?? (yield* Clock.Clock);
   }),
 );
+
+export class PublicationThreadObject extends ThreadObject.make(
+  Layer.unwrap(
+    Effect.map(makeTestBindings, (bindings) =>
+      layerFromBindings(bindings, { publication: publicationLayer }),
+    ),
+  ).pipe(Layer.provideMerge(maintenanceClockLayer)),
+  { ...baseOptions, namespaceBinding: "PUBLICATIONS" },
+) {}
 
 export class TestThreadObject extends ThreadObject.make(
   testRuntimeLayer.pipe(Layer.provideMerge(maintenanceClockLayer)),

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
               compatibilityFlags: ["nodejs_compat"],
               durableObjects: {
                 THREADS: { className: "TestThreadObject", useSQLite: true },
+                PUBLICATIONS: { className: "PublicationThreadObject", useSQLite: true },
                 MEMORIES: { className: "TestMemoryObject", useSQLite: true },
                 SCHEDULES: { className: "TestScheduleOwnerObject", useSQLite: true },
                 SUBSCRIPTIONS: { className: "TestSubscriptionPartitionObject", useSQLite: true },


### PR DESCRIPTION
Hosts publishing committed Thread activity need durable wakeups and must finish publication before resuming potentially slow Agent work. Add an optional publication Layer that shares the native maintenance alarm, preserves setup errors/requirements/Scope, and receives raw local source ports.

```ts
// makePublication yields the local ThreadStore, SubmissionLedger and host services.
ThreadObject.layer(registrations, {
  publication: Layer.effect(ThreadPublication)(makePublication),
});
```

The host owns schema-versioned cursors, acknowledgement, destination idempotency and retry policy. Hooks expose `invalidate`, `prepareGeneration`, `drain`, and `pendingDeadline`, with operational failures typed as `DurableAlarmError`. Defaults need no setup.

```mermaid
sequenceDiagram
  participant P as Source producer
  participant M as Native maintenance
  participant H as Host publication
  P->>M: Prearm a new durable generation
  P->>P: Commit canonical record or intent
  P->>H: Invalidate and drain
  M->>H: Prepare completed producer generation; drain
  H-->>M: Pending deadline or caught up
  M->>M: Rearm or run recovery/Agent work
```

Runtime-owned appends also prearm: a crash after commit but before invalidation must leave a generation newer than the last prepared scan. Event finalizers or post-commit callbacks alone cannot provide that recovery guarantee. Publication failures after commit preserve the source result; alarm failures propagate for retry. Delivery remains at least once.

Validation: focused package typecheck and lint; 22 existing Workerd alarm/registration tests; 11 new Workerd publication tests exercising eviction, concurrent mutation/drain/clear boundaries, deadline ordering, typed failures, defects, interruption, timeout and scoped cleanup. Full `vp run ready` awaits the coordinated local validation slot. Includes the public guide and changeset.
