### PR TITLE
feat(sandbox): support protected browser checkout actions

### DIFF
--- a/.changeset/protected-browser-ordinary-controls.md
+++ b/.changeset/protected-browser-ordinary-controls.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/sandbox": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Add protected non-secret form filling, native choice state, billing-address metadata, and explicit host authorization for checkout submission and observation origins. Allow finite interactive browser passes up to one hour while preserving credential gates and private session cleanup.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -413,7 +413,10 @@ Native submit clicks require the host's optional `BrowserCredentialAccess.author
 When present, this hook runs before **every** ordinary navigation, fill, and click, with
 `{ caller, action, exposures }`. `action._tag` is `Navigate`, `Fill`, `Click`, or `Submit`;
 navigation includes its URL, while control actions include the current opaque ref, exact target,
-and role (implicit for Submit). Fill values are omitted. Recheck user intent, caller ownership,
+and role (implicit for Submit). Link observations and `Click` actions with role `link` also include
+the resolved HTTPS destination `url`; their `target.recipientOrigin` is the destination origin.
+The native fingerprint pins the full destination, including changes to `href` or the document base,
+and the policy checks it again after authorization. Fill values are omitted. Recheck user intent, caller ownership,
 current grants for every prior exposure, and the requested merchant/frame/recipient target.
 The policy rechecks caller and target after authorization returns. No authorization is cached.
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -388,8 +388,9 @@ Use `ExactHosts` for a fixed network allowlist. `Unrestricted` is an explicit ho
 
 The host access service owns caller authentication, vault lookup, current grants, and recipient
 trust. Derive caller identity from the authorized invocation, never model arguments or possession
-of an offer. `list` authorizes only bounded display metadata, such as a label, brand, and last four
-digits, not vault keys or credentials. `authorize` checks current ownership, purpose, field roles,
+of an offer. `list` authorizes only bounded display metadata, such as a label, brand, last four
+digits, and optional plaintext `billingAddress`, not vault keys or credentials. Include address
+metadata only when the caller may see it for the authorized checkout. `authorize` checks current ownership, purpose, field roles,
 submission permission, and exact canonical HTTPS top-level, frame, and form-recipient origins,
 including non-default ports. Card grants must match both merchant and processor/frame. `resolve`
 returns Schema-validated `Redacted` material after those checks; authorization repeats before each
@@ -400,7 +401,29 @@ The runtime protocol needs no site-specific selectors:
 1. `navigate` to a host-authorized HTTPS URL, then `observe` bounded text and native controls.
 2. Select discovered field references and request `listCredentialOffers({ kind, target })`.
 3. Propose `useCredential({ offer, fields, submit? })` with only opaque refs and field roles.
-4. Continue with `observe`, `navigate`, or `click` under the post-exposure observation grant.
+4. Continue with `observe`, `navigate`, `fill`, or `click` under the post-exposure observation grant.
+
+`fill(ProtectedBrowserFill.make({ ref, value }))` accepts up to 8,192 characters of non-secret text
+for a discovered `text` or `select` control. Empty text clears a field. Native single selects match
+a unique enabled option value first, then a unique exact trimmed label; ambiguous, disabled, or
+missing options are unsupported. Ordinary inputs and textareas need no form. Credential roles,
+including username, remain exclusive to `useCredential`; never supply secrets to ordinary fill.
+`click` also accepts native `radio` and `checkbox` controls, whose observations include `checked`.
+Native submit clicks require the host's optional `BrowserCredentialAccess.authorizeAction` hook.
+When present, this hook runs before **every** ordinary navigation, fill, and click, with
+`{ caller, action, exposures }`. `action._tag` is `Navigate`, `Fill`, `Click`, or `Submit`;
+navigation includes its URL, while control actions include the current opaque ref, exact target,
+and role (implicit for Submit). Fill values are omitted. Recheck user intent, caller ownership,
+current grants for every prior exposure, and the requested merchant/frame/recipient target.
+The policy rechecks caller and target after authorization returns. No authorization is cached.
+
+This allows a merchant `Submit` after separate processor-frame credential fills: each prior
+target appears in `exposures`, while the submit has its own merchant target. Without the hook,
+native submit clicks remain unsupported and ordinary actions retain their observation gate.
+For a submit in the same credential form, `useCredential({ offer, fields, submit })` supports both
+login and card offers through the existing `authorize` call with `submit: true`.
+Fill and click can trigger page handlers and side effects; authorize them in the host.
+They share the private pass lock, limits, and failure cleanup.
 
 References bind actual nodes, documents, frames, forms, and roles. Node replacement, changed
 form/action/role, frame navigation, rediscovery, or 60 seconds of elapsed time invalidates them.
@@ -411,18 +434,19 @@ The adapter uses an isolated browser world and native setters, not model-provide
 
 Supported controls are native username/email/password inputs, native login form submission, and
 standard `cc-*` card fields, including native selects. Credential fields must have an associated
-native form, either by containment or an explicit `form` attribute. Standalone fields are unsupported.
+native form, either by containment or an explicit `form` attribute. Standalone credential fields are unsupported.
 Inspection rejects action URLs or fingerprint attributes longer than 2,048 characters inside the
 browser before serialization; fingerprints remain in the browser. HTTPS frames may be same- or cross-origin
-when every involved origin is allowed. Opaque frames, popups, shadow/custom controls, CAPTCHA,
+when every involved origin is allowed. Blank and opaque child frames are omitted from observations
+and cannot supply references. The main document still requires a valid HTTPS origin. Popups, shadow/custom controls, CAPTCHA,
 OTP, passkeys, wallets, and 3DS have no automation fallback. Invalid native form requirements
-produce `needs-attention`. Card filling never submits a purchase. Filling can itself execute page
+produce `needs-attention`. Card filling without an explicit submit does not dispatch native form submission. Filling can itself execute page
 handlers and cause side effects, which the host must authorize.
 
 ### Protection and recipient trust
 
 Secrets enter only the private browser transport, not Tool arguments/results, normal errors,
-traces, checkpoints, or journals. The handle exposes no raw fill, JavaScript, screenshot, Live
+traces, checkpoints, or journals. The handle exposes no selectors, JavaScript, screenshot, Live
 View, DevTools, handoff, or provider identity. A fresh session is acquired with `recording=false`
 explicitly on the wire. This relies on Cloudflare's opt-in recording behavior; no independent
 recording-enabled attestation endpoint exists.
@@ -433,7 +457,23 @@ Protection does not extend to those operators or a compromised provider. Expirin
 does not make a previously exposed session private; always open a fresh pass.
 
 After any possibly dispatched secret write, every observation and non-secret action requires
-`observation` to return `trust-recipient-no-credential-echo` for current origins and prior exposures.
+`observation` to approve current origins and prior exposures. The string
+`trust-recipient-no-credential-echo` trusts all current HTTPS observation origins. To select only
+host-authorized recipients, return:
+
+```ts
+CredentialObservationGrant.make({
+  decision: "trust-recipient-no-credential-echo",
+  origins: ["https://merchant.example", "https://processor.example"],
+});
+```
+
+The current top origin must be included. Excluded frames supply neither text nor usable refs;
+expanding a later grant cannot revive discarded refs. The hook receives all current frame origins
+on every check, so the host can reconsider selection. If trust narrows during discovery, the result
+is withheld. Origin selection never widens network policy, grants credential use, or authorizes
+submission. The library never infers trust from prior card exposures.
+
 This explicitly trusts the recipient not to echo raw, encoded, transformed, or delayed credentials.
 It is not universal secrecy against hostile pages. Discovery omits input values, but DOM scrubbing
 and substring redaction cannot make arbitrary pages safe. Denial blocks observation before reading
@@ -487,8 +527,12 @@ Browser APIs use finite requests and typed expected failures:
 - `PageCrawl` fixes the start host, purposes, page/depth/byte/deadline limits, and cancellation
   lifecycle. Its stream ends only after the provider reports a terminal result or a typed failure.
 - `PageScreenshot` accepts only PNG and enforces a caller-selected byte limit.
-- An interactive policy fixes network mode, at most 1,000 actions, at most 10 minutes, and at most
+- An interactive policy fixes network mode, at most 1,000 actions, at most 60 minutes, and at most
   8 MiB from one result. Handles expire at policy limits or explicit close.
+
+The protected Cloudflare binding requests at most ten minutes of provider idle keep-alive,
+independently of the total pass deadline. A longer policy permits active work; it does not promise
+that an idle browser will remain available for the whole hour or reconnect an expired session.
 
 These caps do not authorize the destination, protect every network path, or make provider actions
 replay-safe. Keep an application allowlist for stateless capture; choose the interactive network

--- a/packages/platform-cloudflare/src/protected-browser/binding.ts
+++ b/packages/platform-cloudflare/src/protected-browser/binding.ts
@@ -107,7 +107,8 @@ export const browserRunProtectedBindingLayer = (options: {
 
             const acquired = await puppeteer.acquire(binding, {
               recording: false,
-              keep_alive: Math.max(10_000, policy.maxElapsedMillis),
+              // Provider inactivity timeout, independent of the finite total pass deadline.
+              keep_alive: Math.min(600_000, Math.max(10_000, policy.maxElapsedMillis)),
             });
 
             sessionId = Redacted.make(

--- a/packages/platform-cloudflare/src/protected-browser/inspect-frame.ts
+++ b/packages/platform-cloudflare/src/protected-browser/inspect-frame.ts
@@ -29,7 +29,8 @@ export const inspectFrame = `(() => {
     const form = el.form ?? null;
     let formIndex = forms.indexOf(form);
     if (formIndex < 0) { formIndex = forms.length; forms.push(form); }
-    const action = form ? (el.hasAttribute('formaction') ? el.formAction : form.action || doc.URL) : doc.URL;
+    // Resolved href (including path/query/fragment and base-URL changes) is part of the fingerprint.
+    const action = el instanceof HTMLAnchorElement ? el.href : form ? (el.hasAttribute('formaction') ? el.formAction : form.action || doc.URL) : doc.URL;
     const method = form ? (el.hasAttribute('formmethod') ? el.formMethod : form.method) : '';
     const enctype = form?.enctype ?? '';
     const name = el.name ?? '';

--- a/packages/platform-cloudflare/src/protected-browser/inspect-frame.ts
+++ b/packages/platform-cloudflare/src/protected-browser/inspect-frame.ts
@@ -5,9 +5,27 @@ export const maxAttributeLength = 2048;
 export const inspectFrame = `(() => {
   const doc = document;
   const forms = [];
-  const elements = [...doc.querySelectorAll('input,select,button,a[href]')].slice(0, 65);
+  const isChoice = el => el instanceof HTMLInputElement && ['radio','checkbox'].includes(el.type);
+  const presented = el => {
+    if (el.closest('[hidden],[aria-hidden="true"],[inert]') ||
+      ['hidden','collapse'].includes(getComputedStyle(el).visibility)) return false;
+    for (let parent = el; parent; parent = parent.parentElement) {
+      if (getComputedStyle(parent).opacity === '0') return false;
+    }
+    return true;
+  };
+  const hasLayout = el => presented(el) &&
+    [...el.getClientRects()].some(rect => rect.width > 0 && rect.height > 0);
+  const available = el => el.type !== 'hidden' && !el.closest('[hidden],[aria-hidden="true"],[inert]') &&
+    (hasLayout(el) || (isChoice(el) && [...(el.labels ?? [])].some(hasLayout)));
+  const elements = [...doc.querySelectorAll('input,textarea,select,button,a[href]')].filter(available).slice(0, 65);
+  const labelText = el => {
+    const label = el.labels?.[0]?.cloneNode(true);
+    label?.querySelectorAll('input,textarea,select,script,style,noscript').forEach(child => child.remove());
+    return label?.textContent ?? el.getAttribute('aria-label');
+  };
   const describe = (el) => {
-    if (doc !== document || !el.isConnected || el.ownerDocument !== doc) return null;
+    if (doc !== document || !el.isConnected || el.ownerDocument !== doc || !available(el)) return null;
     const form = el.form ?? null;
     let formIndex = forms.indexOf(form);
     if (formIndex < 0) { formIndex = forms.length; forms.push(form); }
@@ -17,29 +35,35 @@ export const inspectFrame = `(() => {
     const name = el.name ?? '';
     const completion = el.getAttribute('autocomplete') ?? '';
     const inputType = el.type ?? '';
+    const choiceValue = isChoice(el) ? el.value : '';
     // Reject before parsing, fingerprinting or CDP transfer. Truncation could hide a target change.
-    if ([action, method, enctype, name, completion, inputType].some(value => value.length > ${maxAttributeLength})) return null;
+    if ([action, method, enctype, name, completion, inputType, choiceValue].some(value => value.length > ${maxAttributeLength})) return null;
     const type = inputType.toLowerCase();
     const autocomplete = completion.trim().toLowerCase().split(/\\s+/).at(-1);
     const cardRoles = { 'cc-name':'card-name', 'cc-number':'card-number', 'cc-exp':'card-expiry',
       'cc-exp-month':'card-expiry-month', 'cc-exp-year':'card-expiry-year', 'cc-csc':'card-security-code' };
     let role = 'unsupported';
-    const nativeField = el instanceof HTMLInputElement || el instanceof HTMLSelectElement;
-    if (nativeField && form && !['submit','button'].includes(type) && !el.disabled && !el.readOnly && el.getClientRects().length > 0) {
-      if (el instanceof HTMLInputElement && type === 'password') role = 'password';
-      else if (['text','email','tel','number','month',''].includes(type) || el instanceof HTMLSelectElement) {
-        if (cardRoles[autocomplete]) role = cardRoles[autocomplete];
-        else if (autocomplete === 'username' || autocomplete === 'email') role = 'username';
+    const nativeField = el instanceof HTMLInputElement || el instanceof HTMLSelectElement || el instanceof HTMLTextAreaElement;
+    if (nativeField && !['submit','button'].includes(type) && !el.matches(':disabled') && !el.readOnly && !(el instanceof HTMLSelectElement && el.multiple)) {
+      if (isChoice(el)) role = type;
+      else if (type === 'password' || ['current-password','new-password','one-time-code'].includes(autocomplete)) {
+        if (type === 'password' && form) role = 'password';
+      } else if (['text','email','tel','number','month','search','url','date','time','week','datetime-local','textarea',''].includes(type) || el instanceof HTMLSelectElement) {
+        if (cardRoles[autocomplete]) { if (form) role = cardRoles[autocomplete]; }
+        else if (autocomplete === 'username' || autocomplete === 'email') { if (form) role = 'username'; }
         else if (['text','email'].includes(type) && form && form.querySelector('input[type="password"]')) role = 'username';
+        else if (el instanceof HTMLSelectElement) { if (!el.multiple) role = 'select'; }
+        else role = 'text';
       }
     } else if (el instanceof HTMLButtonElement || (el instanceof HTMLInputElement && ['submit','button'].includes(type))) {
-      if (!el.disabled) role = type === 'submit' && form ? 'submit' : type === 'button' ? 'button' : 'unsupported';
+      if (!el.matches(':disabled')) role = type === 'submit' && form ? 'submit' : type === 'button' ? 'button' : 'unsupported';
     } else if (el instanceof HTMLAnchorElement) role = 'link';
-    const fingerprint = JSON.stringify([role, action, method, enctype, name, completion, type]);
-    return { role, formIndex, action, fingerprint,
-      label: (el.labels?.[0]?.textContent ?? el.getAttribute('aria-label') ?? el.textContent ?? '').slice(0,200) };
+    const fingerprint = JSON.stringify([role, action, method, enctype, name, completion, type, choiceValue]);
+    return { role, formIndex, action, fingerprint, ...(isChoice(el) ? {checked: el.checked} : {}),
+      label: (labelText(el) ?? (nativeField ? '' : el.textContent) ?? '').slice(0,200) };
   };
-  const expose = ({role, formIndex, action, label}) => ({role, formIndex, action, label});
+  const expose = ({role, formIndex, action, label, checked}) =>
+    ({role, formIndex, action, label, ...(checked === undefined ? {} : {checked})});
   const original = elements.map(describe);
   const validate = (index) => {
     const current = describe(elements[index]);
@@ -51,14 +75,32 @@ export const inspectFrame = `(() => {
     doc, elements, original: original.map(current => current && expose(current)), validate,
     text: () => {
       if (doc !== document) return null;
-      const clone = doc.body?.cloneNode(true);
-      clone?.querySelectorAll('input,textarea,select,script,style,noscript,iframe,object,embed').forEach(el => el.remove());
-      return (clone?.textContent ?? '').slice(0,65536);
+      if (!doc.body) return '';
+      const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+      const range = doc.createRange();
+      let text = '';
+      for (let node = walker.nextNode(); node && text.length < 65536; node = walker.nextNode()) {
+        const parent = node.parentElement;
+        if (!parent || parent.closest('input,textarea,select,script,style,noscript,iframe,object,embed')) continue;
+        if (!presented(parent)) continue;
+        range.selectNodeContents(node);
+        if (![...range.getClientRects()].some(rect => rect.width > 0 && rect.height > 0)) continue;
+        text += (node.textContent ?? '').replace(/\\s+/g, ' ') + ' ';
+      }
+      return text.slice(0,65536);
     },
     fill: (index, role, value) => {
       const current = validate(index);
       if (!current || current.role !== role) return false;
       const el = elements[index];
+      if (role === 'select') {
+        const options = [...el.options].filter(option => !option.matches(':disabled'));
+        const values = options.filter(option => option.value === value);
+        const matches = values.length > 0 ? values : options.filter(option => option.textContent?.trim() === value);
+        if (matches.length !== 1) return 'unsupported';
+        value = matches[0].value;
+        if ([...el.options].filter(option => option.value === value).length !== 1) return 'unsupported';
+      }
       let prototype = Object.getPrototypeOf(el);
       let setter;
       while (prototype && !setter) { setter = Object.getOwnPropertyDescriptor(prototype,'value')?.set; prototype = Object.getPrototypeOf(prototype); }
@@ -73,7 +115,7 @@ export const inspectFrame = `(() => {
     },
     click: (index) => {
       const current = validate(index);
-      if (!current || !['button','submit','link'].includes(current.role)) return false;
+      if (!current || !['button','submit','link','radio','checkbox'].includes(current.role)) return false;
       if (current.role === 'submit' && elements[index].form && !elements[index].form.matches(':valid')) return 'needs-attention';
       elements[index].click();
       return true;

--- a/packages/platform-cloudflare/src/protected-browser/native.ts
+++ b/packages/platform-cloudflare/src/protected-browser/native.ts
@@ -30,6 +30,7 @@ const Description = Schema.Struct({
   formIndex: Schema.Natural,
   action: Schema.String.check(Schema.isMaxLength(maxAttributeLength)),
   label: Schema.String.check(Schema.isMaxLength(200)),
+  checked: Schema.optionalKey(Schema.Boolean),
 });
 
 const Descriptions = Schema.Array(Schema.NullOr(Description)).check(Schema.isMaxLength(65));
@@ -97,6 +98,7 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
   let closed = false;
   let violation = false;
   let documentRef: string | undefined;
+  let observationOrigins: ReadonlySet<string> | undefined;
   const frames = new Map<Frame, FrameState>();
   const controls = new Map<string, ControlState>();
 
@@ -144,13 +146,30 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
     clear();
   };
 
-  const context = Effect.gen(function* () {
-    yield* check;
+  const observationFrames = Effect.gen(function* () {
     const list = page.frames();
 
-    if (list.length > 16) return yield* transportError("unsupported");
+    if (list.length > 32) return yield* transportError("unsupported");
+
+    // Opaque/blank child documents have no observation channel or credential targets.
+    // The main document and every retained HTTPS child still require strict origin validation.
+    return yield* Effect.filter(list, (frame) =>
+      frame === page.mainFrame()
+        ? Effect.succeed(true)
+        : Effect.try({
+            try: () => frame.url() !== "" && new URL(frame.url()).protocol === "https:",
+            catch: () => transportError("provider"),
+          }),
+    );
+  });
+
+  const context = Effect.gen(function* () {
+    yield* check;
+    const list = yield* observationFrames;
     const topOrigin = yield* origin(page.url());
-    const frameOrigins = yield* Effect.forEach(list, (frame) => origin(frame.url()));
+    const frameOrigins = [...new Set(yield* Effect.forEach(list, (frame) => origin(frame.url())))];
+
+    if (frameOrigins.length > 16) return yield* transportError("unsupported");
 
     if (documentRef === undefined) documentRef = yield* uuid;
 
@@ -175,6 +194,8 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
 
     if (
       !state ||
+      (observationOrigins !== undefined &&
+        !observationOrigins.has(state.control.target.frameOrigin)) ||
       state.expires <= (yield* clock.currentTimeMillis) ||
       !(yield* isCurrent(state.frame))
     )
@@ -232,6 +253,22 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
   );
 
   return {
+    restrictObservation: Effect.fn("ProtectedNativeTransport.restrictObservation")(
+      function* (origins) {
+        yield* check;
+        observationOrigins =
+          origins === undefined
+            ? undefined
+            : new Set(yield* decode(Schema.Array(CredentialOrigin), origins));
+        // A later grant expansion must not revive previously excluded references.
+        for (const [ref, state] of controls)
+          if (
+            observationOrigins !== undefined &&
+            !observationOrigins.has(state.control.target.frameOrigin)
+          )
+            controls.delete(ref);
+      },
+    ),
     context,
     invalidate,
     close,
@@ -252,8 +289,13 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
       const discovered: Array<ProtectedBrowserControl> = [];
       let text = "";
       let truncated = false;
+      const frameOrigins = new Set<string>();
 
-      for (const frame of page.frames()) {
+      for (const frame of yield* observationFrames) {
+        const frameOrigin = yield* origin(frame.url());
+
+        if (observationOrigins !== undefined && !observationOrigins.has(frameOrigin)) continue;
+        frameOrigins.add(frameOrigin);
         if (typeof frame.isolatedRealm !== "function") return yield* transportError("unsupported");
         const handle = yield* remote(() => frame.isolatedRealm().evaluateHandle(inspectFrame));
 
@@ -300,6 +342,7 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
             ref: yield* uuid,
             role: desc.role,
             label: desc.label,
+            ...(desc.checked === undefined ? {} : { checked: desc.checked }),
             target: CredentialTarget.make({
               topOrigin: before.topOrigin,
               frameOrigin: yield* origin(frame.url()),
@@ -338,6 +381,7 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
 
       return yield* decode(ProtectedDiscovery, {
         ...before,
+        frameOrigins: [...frameOrigins],
         text,
         controls: discovered,
         truncated,

--- a/packages/platform-cloudflare/src/protected-browser/native.ts
+++ b/packages/platform-cloudflare/src/protected-browser/native.ts
@@ -343,6 +343,7 @@ export const makeProtectedNativeTransport = Effect.fn("ProtectedNativeTransport.
             role: desc.role,
             label: desc.label,
             ...(desc.checked === undefined ? {} : { checked: desc.checked }),
+            ...(desc.role === "link" ? { url: desc.action } : {}),
             target: CredentialTarget.make({
               topOrigin: before.topOrigin,
               frameOrigin: yield* origin(frame.url()),

--- a/packages/platform-cloudflare/src/protected-browser/policy.ts
+++ b/packages/platform-cloudflare/src/protected-browser/policy.ts
@@ -303,7 +303,8 @@ export const browserRunProtectedLayer = () =>
 
             if (
               !sameTarget(current.target, action.target) ||
-              current.role !== (action._tag === "Submit" ? "submit" : action.role)
+              current.role !== (action._tag === "Submit" ? "submit" : action.role) ||
+              (action._tag === "Click" && action.role === "link" && current.url !== action.url)
             )
               return yield* fail("stale-reference");
           }
@@ -466,16 +467,28 @@ export const browserRunProtectedLayer = () =>
                   control.role !== "submit"
                 )
                   return yield* fail("unsupported");
-                yield* authorizeAction(
-                  control.role === "submit"
-                    ? { _tag: "Submit", ref: decoded.ref, target: control.target }
-                    : {
-                        _tag: "Click",
-                        ref: decoded.ref,
-                        target: control.target,
-                        role: control.role,
-                      },
-                );
+                let action: ProtectedBrowserAction;
+
+                if (control.role === "link") {
+                  if (control.url === undefined) return yield* fail("unsupported");
+                  action = {
+                    _tag: "Click",
+                    ref: decoded.ref,
+                    target: control.target,
+                    role: "link",
+                    url: control.url,
+                  };
+                } else if (control.role === "submit") {
+                  action = { _tag: "Submit", ref: decoded.ref, target: control.target };
+                } else {
+                  action = {
+                    _tag: "Click",
+                    ref: decoded.ref,
+                    target: control.target,
+                    role: control.role,
+                  };
+                }
+                yield* authorizeAction(action);
                 dispatch = "possibly-dispatched";
                 yield* remote(driver.click(decoded.ref)).pipe(
                   Effect.catch((error) => {
@@ -632,6 +645,8 @@ export const browserRunProtectedLayer = () =>
                   yield* access
                     .authorize(authorization)
                     .pipe(Effect.mapError((error) => fail(error.reason)));
+                  if (Redacted.value(yield* caller) !== Redacted.value(principal))
+                    return yield* fail("denied");
                 });
 
                 yield* authorize;

--- a/packages/platform-cloudflare/src/protected-browser/policy.ts
+++ b/packages/platform-cloudflare/src/protected-browser/policy.ts
@@ -7,6 +7,7 @@ import {
   CredentialOffer,
   CredentialOfferMetadata,
   CredentialOrigin,
+  CredentialObservationDecision,
   type CredentialTarget,
   CredentialUseResult,
   ListCredentialOffers,
@@ -14,6 +15,7 @@ import {
   ProtectedBrowser,
   ProtectedBrowserClick,
   ProtectedBrowserError,
+  ProtectedBrowserFill,
   ProtectedBrowserNavigate,
   ProtectedBrowserObservation,
   ProtectedBrowserControl,
@@ -22,6 +24,7 @@ import {
   type CredentialKind,
   type CredentialUseAuthorization,
   type ProtectedBrowserHandle,
+  type ProtectedBrowserAction,
   type ProtectedCleanup,
   type ProtectedObservationState,
 } from "@effect-agent/sandbox/ProtectedBrowser";
@@ -51,6 +54,10 @@ export class ProtectedBrowserDispatch extends Context.Service<
 
 /** Decoded adapter boundary. SDK exceptions and page diagnostics never cross this port. */
 export interface ProtectedBrowserTransport {
+  /** Select observation/target origins; undefined restores all network-permitted HTTPS frames. */
+  readonly restrictObservation: (
+    origins: ReadonlyArray<typeof CredentialOrigin.Type> | undefined,
+  ) => Effect.Effect<void, ProtectedTransportError>;
   readonly context: Effect.Effect<typeof ProtectedPageContext.Type, ProtectedTransportError>;
   readonly discover: Effect.Effect<typeof ProtectedDiscovery.Type, ProtectedTransportError>;
   readonly target: (ref: string) => Effect.Effect<ProtectedBrowserControl, ProtectedTransportError>;
@@ -58,7 +65,7 @@ export interface ProtectedBrowserTransport {
   readonly click: (ref: string) => Effect.Effect<void, ProtectedTransportError>;
   readonly fill: (
     ref: string,
-    role: typeof CredentialFieldRole.Type,
+    role: typeof CredentialFieldRole.Type | "text" | "select",
     value: Redacted.Redacted<string>,
   ) => Effect.Effect<void, ProtectedTransportError, ProtectedBrowserDispatch>;
   /** Invalidates local references synchronously before bounded exact-session cleanup. */
@@ -133,7 +140,7 @@ const secretFor = (material: BrowserCredentialMaterial, role: typeof CredentialF
 
 /**
  * Fresh private passes only. Account administrators and Browser Rendering token holders are
- * trusted operators. No viewer, handoff, raw JavaScript, screenshot or plaintext-fill API exists.
+ * trusted operators. No viewer, handoff, raw JavaScript, screenshot or plaintext credential API exists.
  * Hosts explicitly authorize post-exposure observations for recipients they trust not to echo.
  */
 export const browserRunProtectedLayer = () =>
@@ -240,23 +247,67 @@ export const browserRunProtectedLayer = () =>
 
         const permitObservation = Effect.gen(function* () {
           const context = yield* pageContext;
+          let origins: ReadonlyArray<typeof CredentialOrigin.Type> | undefined;
 
           if (exposures.length > 0) {
             observation = "protected";
+            const principal = yield* caller;
 
-            const decision = yield* access
-              .observation({ ...context, caller: yield* caller, exposures: [...exposures] })
+            const rawDecision = yield* access
+              .observation({ ...context, caller: principal, exposures: [...exposures] })
               .pipe(Effect.mapError((error) => fail(error.reason)));
 
-            if (decision !== "trust-recipient-no-credential-echo")
-              return yield* fail("observation-blocked");
+            if (Redacted.value(yield* caller) !== Redacted.value(principal))
+              return yield* fail("denied");
+
+            const decision = yield* Schema.decodeUnknownEffect(CredentialObservationDecision)(
+              rawDecision,
+            ).pipe(Effect.mapError(() => fail("observation-blocked")));
+
+            if (decision === "deny") return yield* fail("observation-blocked");
+            if (typeof decision !== "string") {
+              origins = [...decision.origins];
+              if (!origins.includes(context.topOrigin)) return yield* fail("observation-blocked");
+            }
             observation = "approved-after-exposure";
           }
+          yield* remote(driver.restrictObservation(origins));
 
-          return context;
+          return {
+            ...context,
+            frameOrigins: context.frameOrigins.filter(
+              (origin) => origins === undefined || origins.includes(origin),
+            ),
+          };
         });
 
         const target = (ref: string) => remote(driver.target(ref));
+
+        const authorizeAction = Effect.fn("ProtectedBrowser.authorizeAction")(function* (
+          action: ProtectedBrowserAction,
+        ) {
+          if (access.authorizeAction === undefined) {
+            if (action._tag === "Submit") return yield* fail("unsupported");
+
+            return;
+          }
+          const principal = yield* caller;
+
+          yield* access
+            .authorizeAction({ caller: principal, action, exposures: [...exposures] })
+            .pipe(Effect.mapError((error) => fail(error.reason)));
+          if (Redacted.value(yield* caller) !== Redacted.value(principal))
+            return yield* fail("denied");
+          if (action._tag !== "Navigate") {
+            const current = yield* target(action.ref);
+
+            if (
+              !sameTarget(current.target, action.target) ||
+              current.role !== (action._tag === "Submit" ? "submit" : action.role)
+            )
+              return yield* fail("stale-reference");
+          }
+        }, Effect.withTracerEnabled(false));
 
         const bounded = <A>(result: A) => {
           const bytes = new TextEncoder().encode(JSON.stringify(result)).byteLength;
@@ -366,6 +417,7 @@ export const browserRunProtectedLayer = () =>
                 )
                   return yield* fail("denied");
                 if (exposures.length > 0) yield* permitObservation;
+                yield* authorizeAction({ _tag: "Navigate", url: decoded.url });
                 offers.clear();
                 dispatch = "possibly-dispatched";
                 yield* remote(driver.navigate(decoded.url));
@@ -379,8 +431,14 @@ export const browserRunProtectedLayer = () =>
               const result = yield* remote(driver.discover);
               const after = yield* permitObservation;
 
-              if (before.document !== after.document || result.document !== after.document)
+              if (
+                before.document !== after.document ||
+                result.document !== after.document ||
+                result.topOrigin !== after.topOrigin
+              )
                 return yield* fail("stale-reference");
+              if (result.frameOrigins.some((origin) => !after.frameOrigins.includes(origin)))
+                return yield* fail("observation-blocked");
 
               return yield* bounded(
                 ProtectedBrowserObservation.make({
@@ -400,12 +458,66 @@ export const browserRunProtectedLayer = () =>
                 yield* permitObservation;
                 const control = yield* target(decoded.ref);
 
-                // Credential submission goes through useCredential, never a generic click.
-                if (control.role !== "link" && control.role !== "button")
+                if (
+                  control.role !== "link" &&
+                  control.role !== "button" &&
+                  control.role !== "radio" &&
+                  control.role !== "checkbox" &&
+                  control.role !== "submit"
+                )
                   return yield* fail("unsupported");
+                yield* authorizeAction(
+                  control.role === "submit"
+                    ? { _tag: "Submit", ref: decoded.ref, target: control.target }
+                    : {
+                        _tag: "Click",
+                        ref: decoded.ref,
+                        target: control.target,
+                        role: control.role,
+                      },
+                );
                 dispatch = "possibly-dispatched";
-                yield* remote(driver.click(decoded.ref));
+                yield* remote(driver.click(decoded.ref)).pipe(
+                  Effect.catch((error) => {
+                    if (error.reason === "needs-attention") dispatch = "not-dispatched";
+
+                    return Effect.fail(error);
+                  }),
+                );
                 dispatch = "dispatched";
+                if (control.role === "submit") milestone = "submission-dispatched";
+                yield* permitObservation;
+              }),
+            ),
+          fill: (request) =>
+            run(
+              Effect.gen(function* () {
+                const decoded = yield* Schema.decodeUnknownEffect(ProtectedBrowserFill)(
+                  request,
+                ).pipe(Effect.mapError(() => fail("denied")));
+
+                yield* permitObservation;
+                const control = yield* target(decoded.ref);
+
+                if (control.role !== "text" && control.role !== "select")
+                  return yield* fail("unsupported");
+                yield* authorizeAction({
+                  _tag: "Fill",
+                  ref: decoded.ref,
+                  target: control.target,
+                  role: control.role,
+                });
+                yield* remote(
+                  driver.fill(decoded.ref, control.role, Redacted.make(decoded.value)),
+                ).pipe(
+                  Effect.provideService(ProtectedBrowserDispatch, {
+                    mark: Effect.sync(() => {
+                      dispatch = "possibly-dispatched";
+                    }),
+                  }),
+                );
+                dispatch = "dispatched";
+                milestone = "filled";
                 yield* permitObservation;
               }),
             ),
@@ -475,8 +587,6 @@ export const browserRunProtectedLayer = () =>
 
                 if (Redacted.value(principal) !== Redacted.value(offer.caller))
                   return yield* fail("denied");
-                if (offer.kind === "card" && decoded.submit !== undefined)
-                  return yield* fail("unsupported");
                 if (
                   new Set(decoded.fields.map((field) => field.ref)).size !==
                     decoded.fields.length ||

--- a/packages/platform-cloudflare/test/protected-browser-native.test.ts
+++ b/packages/platform-cloudflare/test/protected-browser-native.test.ts
@@ -5,6 +5,7 @@ import {
   BrowserCredentialAccess,
   CredentialAccessError,
   CredentialOfferMetadata,
+  CredentialObservationGrant,
   ListCredentialOffers,
   LoginCredential,
   CardCredential,
@@ -25,6 +26,7 @@ import {
 import {
   BrowserRunProtectedTransport,
   browserRunProtectedLayer,
+  ProtectedBrowserDispatch,
 } from "../src/protected-browser/policy.ts";
 
 class ProbeError extends Schema.TaggedError<ProbeError>()("ProtectedNativeProbeError", {}) {}
@@ -33,7 +35,7 @@ const native = <A>(run: () => Promise<A>) =>
   Effect.tryPromise({ try: run, catch: () => new ProbeError() });
 
 const secret = "dummy-password-sentinel";
-const hosts = ["alpha.test", "beta.test", "processor.test"];
+const hosts = ["alpha.test", "beta.test", "processor.test", "incidental.test"];
 
 const policy = InteractiveBrowserPolicy.make({
   network: { _tag: "ExactHosts", allowedHosts: hosts },
@@ -80,7 +82,10 @@ it.live(
             2,
           );
         else if (url.pathname === "/pay")
-          body = '<iframe src="https://processor.test/fields"></iframe>';
+          body =
+            '<form onsubmit="event.preventDefault();document.body.append(\'Purchase submitted\')"><button>Pay now</button></form><iframe src="https://processor.test/fields"></iframe><iframe src="https://incidental.test/noise"></iframe>';
+        else if (url.pathname === "/noise")
+          body = '<main>Untrusted frame text</main><input aria-label="Untrusted frame control">';
         else if (url.pathname === "/fields")
           body =
             '<form><input autocomplete="cc-name"><input autocomplete="cc-number"><input autocomplete="cc-exp"><input autocomplete="cc-csc"><button>Pay</button></form>';
@@ -94,6 +99,7 @@ it.live(
       let resolutions = 0;
       let grants = true;
       let observationTrusted = true;
+      let selectedOrigins: ReadonlyArray<string> | undefined;
 
       const access = BrowserCredentialAccess.of({
         caller: Effect.succeed(Redacted.make("authorized-test-invocation")),
@@ -129,8 +135,25 @@ it.live(
                   securityCode: Redacted.make("123"),
                 });
           }),
+        authorizeAction: (request) =>
+          request.action._tag !== "Submit" ||
+          (grants &&
+            request.action.target.frameOrigin === "https://alpha.test" &&
+            request.action.target.recipientOrigin === "https://alpha.test" &&
+            request.exposures.some((target) => target.frameOrigin === "https://processor.test"))
+            ? Effect.void
+            : Effect.fail(new CredentialAccessError({ reason: "denied" })),
         observation: () =>
-          Effect.succeed(observationTrusted ? "trust-recipient-no-credential-echo" : "deny"),
+          Effect.succeed(
+            !observationTrusted
+              ? "deny"
+              : selectedOrigins === undefined
+                ? "trust-recipient-no-credential-echo"
+                : CredentialObservationGrant.make({
+                    decision: "trust-recipient-no-credential-echo",
+                    origins: selectedOrigins,
+                  }),
+          ),
       });
 
       // The same pinned SDK ships separate bundled and internal declarations with private brands.
@@ -356,7 +379,36 @@ it.live(
           milestone: "filled",
           authentication: "unverified",
         });
-        expect(JSON.stringify(yield* handle.observe)).not.toContain("4111111111111111");
+
+        const incidentalRef = checkout.controls.find(
+          (control) => control.label === "Untrusted frame control",
+        )!.ref;
+
+        yield* driver.restrictObservation(["https://alpha.test", "https://processor.test"]);
+        expect(yield* driver.target(incidentalRef).pipe(Effect.flip)).toMatchObject({
+          reason: "stale-reference",
+        });
+        yield* driver.restrictObservation(undefined);
+        expect(yield* driver.target(incidentalRef).pipe(Effect.flip)).toMatchObject({
+          reason: "stale-reference",
+        });
+        selectedOrigins = ["https://alpha.test", "https://processor.test"];
+        const selected = yield* handle.observe;
+
+        expect(JSON.stringify(selected)).not.toContain("4111111111111111");
+        expect(JSON.stringify(selected)).not.toContain("Untrusted frame");
+        phase = "merchant-submission";
+        const merchantSubmit = selected.controls.find((control) => control.label === "Pay now")!;
+
+        grants = false;
+        expect(
+          yield* handle
+            .click(ProtectedBrowserClick.make({ ref: merchantSubmit.ref }))
+            .pipe(Effect.flip),
+        ).toMatchObject({ reason: "denied", dispatch: "not-dispatched" });
+        grants = true;
+        yield* handle.click(ProtectedBrowserClick.make({ ref: merchantSubmit.ref }));
+        expect((yield* handle.observe).text).toContain("Purchase submitted");
         // A recipient can echo transformed material long after the fill. Only a current host
         // trust decision authorizes observing that context; substring filters cannot do this.
         observationTrusted = false;
@@ -382,5 +434,167 @@ it.live(
         Effect.provide(layer),
       );
     }).pipe(Effect.scoped, Effect.provide(BrowserCrypto.layer)),
+  { timeout: 30_000 },
+);
+
+it.live(
+  "fills native ordinary controls by held refs and rejects stale or credential targets",
+  (test) =>
+    Effect.gen(function* () {
+      const executable = yield* Config.option(Config.string("BROWSER_TEST_EXECUTABLE"));
+
+      if (Option.isNone(executable)) return test.skip();
+
+      const browser = yield* Effect.acquireRelease(
+        native(() => nativePuppeteer.launch({ executablePath: executable.value, headless: true })),
+        (browser) => Effect.promise(() => browser.close()),
+      );
+
+      const page = yield* native(() => browser.newPage());
+
+      yield* native(() => page.setRequestInterception(true));
+      page.on("request", (request) => {
+        void request
+          .respond({
+            contentType: "text/html",
+            body: `
+        <main>Checkout</main>
+        <input type="hidden" value="hidden-value">
+        <div hidden>hidden-text<input aria-label="Hidden"></div>
+        <div style="opacity:0">transparent-text<input aria-label="Transparent"></div>
+        <label>Address<input name="address"></label>
+        <label>Notes<textarea>private-default-text</textarea></label>
+        <label>Region<select><option value="">Choose</option><option value="CA">California</option><option value="NY">New York</option><option disabled value="XX">Disabled</option><optgroup disabled><option value="YY">Disabled group</option></optgroup><option value="a">Duplicate</option><option value="b">Duplicate</option><option value="same">First</option><option value="same">Second</option></select></label>
+        <label>Delivery<input type="radio" name="shipping" value="delivery" checked></label>
+        <label>Pickup<input type="radio" name="shipping" value="pickup" style="display:none"></label>
+        <label>Agree<input type="checkbox"></label>
+        <fieldset disabled><label>Disabled<input></label></fieldset>
+        <input aria-label="OTP" autocomplete="one-time-code">
+        <input aria-label="Password hint" autocomplete="new-password">
+        <form><input aria-label="Password" type="password"><input aria-label="Card" autocomplete="cc-number"></form>
+        <iframe src="about:blank"></iframe>
+        <iframe src="data:text/html,opaque-child"></iframe>
+        <script>window.events=[];document.addEventListener('input', e=>events.push(e.type));document.addEventListener('change', e=>events.push(e.type));</script>
+      `,
+          })
+          .catch(() => {});
+      });
+      yield* native(() => page.goto("https://alpha.test/checkout"));
+
+      const driver = yield* makeProtectedNativeTransport(policy).pipe(
+        Effect.provideService(ProtectedNativeSession, {
+          browser: browser as unknown as Browser,
+          page: page as unknown as Page,
+          close: native(() => browser.close()).pipe(
+            Effect.as("confirmed" as const),
+            Effect.catch(() => Effect.succeed("unconfirmed" as const)),
+          ),
+        }),
+      );
+
+      const initial = yield* driver.discover;
+
+      expect(initial.text).toContain("Checkout");
+      for (const hidden of [
+        "hidden-value",
+        "hidden-text",
+        "transparent-text",
+        "private-default-text",
+        "opaque-child",
+      ])
+        expect(JSON.stringify(initial)).not.toContain(hidden);
+      expect(
+        initial.controls.some(
+          (control) => control.label === "Hidden" || control.label === "Transparent",
+        ),
+      ).toBe(false);
+      const address = initial.controls.find((control) => control.label === "Address")!;
+      const notes = initial.controls.find((control) => control.label === "Notes")!;
+      const region = initial.controls.find((control) => control.label === "Region")!;
+
+      expect(address.role).toBe("text");
+      expect(notes.role).toBe("text");
+      expect(region.role).toBe("select");
+      for (const label of ["Disabled", "OTP", "Password hint"])
+        expect(initial.controls.find((control) => control.label === label)!.role).toBe(
+          "unsupported",
+        );
+      yield* driver.fill(address.ref, "text", Redacted.make("123 Example Street"));
+      yield* driver.fill(notes.ref, "text", Redacted.make("Leave at reception"));
+      yield* driver.fill(region.ref, "select", Redacted.make("California"));
+      expect(yield* native(() => page.evaluate("document.querySelector('select').value"))).toBe(
+        "CA",
+      );
+      yield* driver.fill(region.ref, "select", Redacted.make("NY"));
+      for (const value of ["XX", "YY", "Duplicate", "same", "Second", "Missing"])
+        expect(
+          yield* driver.fill(region.ref, "select", Redacted.make(value)).pipe(Effect.flip),
+        ).toMatchObject({ reason: "unsupported" });
+      expect(yield* native(() => page.evaluate("document.querySelector('select').value"))).toBe(
+        "NY",
+      );
+      expect(yield* native(() => page.evaluate("window.events"))).toEqual([
+        "input",
+        "change",
+        "input",
+        "change",
+        "input",
+        "change",
+        "input",
+        "change",
+      ]);
+      yield* driver.fill(address.ref, "text", Redacted.make(""));
+      expect(
+        yield* native(() => page.evaluate("document.querySelector('[name=address]').value")),
+      ).toBe("");
+      const pickup = initial.controls.find((control) => control.label === "Pickup")!;
+      const agree = initial.controls.find((control) => control.label === "Agree")!;
+
+      expect(pickup).toMatchObject({ role: "radio", checked: false });
+      yield* driver.click(pickup.ref);
+      yield* driver.click(agree.ref);
+      const current = yield* driver.discover;
+
+      expect(current.controls.find((control) => control.label === "Delivery")!.checked).toBe(false);
+      expect(current.controls.find((control) => control.label === "Pickup")!.checked).toBe(true);
+      expect(current.controls.find((control) => control.label === "Agree")!.checked).toBe(true);
+      expect(
+        yield* driver.fill(address.ref, "text", Redacted.make("old")).pipe(Effect.flip),
+      ).toMatchObject({ reason: "stale-reference" });
+      const currentAddress = current.controls.find((control) => control.label === "Address")!;
+
+      yield* native(() =>
+        page.evaluate(
+          "document.querySelector('[name=address]').setAttribute('autocomplete','cc-number')",
+        ),
+      );
+      expect(
+        yield* driver.fill(currentAddress.ref, "text", Redacted.make("ordinary")).pipe(Effect.flip),
+      ).toMatchObject({ reason: "stale-reference" });
+      const currentNotes = current.controls.find((control) => control.label === "Notes")!;
+
+      yield* native(() =>
+        page.evaluate(
+          "document.querySelector('textarea').replaceWith(document.querySelector('textarea').cloneNode(true))",
+        ),
+      );
+      expect(
+        yield* driver.fill(currentNotes.ref, "text", Redacted.make("replaced")).pipe(Effect.flip),
+      ).toMatchObject({ reason: "stale-reference" });
+      for (const label of ["Password", "Card"])
+        expect(
+          yield* driver
+            .fill(
+              current.controls.find((control) => control.label === label)!.ref,
+              "text",
+              Redacted.make("ordinary"),
+            )
+            .pipe(Effect.flip),
+        ).toMatchObject({ reason: "stale-reference" });
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(BrowserCrypto.layer),
+      Effect.provideService(ProtectedBrowserDispatch, { mark: Effect.void }),
+    ),
   { timeout: 30_000 },
 );

--- a/packages/platform-cloudflare/test/protected-browser-native.test.ts
+++ b/packages/platform-cloudflare/test/protected-browser-native.test.ts
@@ -77,6 +77,9 @@ it.live(
             ? '<main>Private dashboard</main><a href="/next">Continue</a>'
             : "Not authenticated";
         } else if (url.pathname === "/next") body = "Useful next page";
+        else if (url.pathname === "/links")
+          body =
+            '<a id="allowed" href="/allowed">Allowed</a><a href="https://beta.test/private">Denied</a><a href="javascript:void(0)">Script</a><a href="https://u:p@alpha.test/private">Credential URL</a>';
         else if (url.pathname === "/standalone")
           body = '<section><input autocomplete="username"><input type="password"></section>'.repeat(
             2,
@@ -100,6 +103,7 @@ it.live(
       let grants = true;
       let observationTrusted = true;
       let selectedOrigins: ReadonlyArray<string> | undefined;
+      let actionOverride: BrowserCredentialAccess["Service"]["authorizeAction"] | undefined;
 
       const access = BrowserCredentialAccess.of({
         caller: Effect.succeed(Redacted.make("authorized-test-invocation")),
@@ -136,13 +140,14 @@ it.live(
                 });
           }),
         authorizeAction: (request) =>
-          request.action._tag !== "Submit" ||
+          actionOverride?.(request) ??
+          (request.action._tag !== "Submit" ||
           (grants &&
             request.action.target.frameOrigin === "https://alpha.test" &&
             request.action.target.recipientOrigin === "https://alpha.test" &&
             request.exposures.some((target) => target.frameOrigin === "https://processor.test"))
             ? Effect.void
-            : Effect.fail(new CredentialAccessError({ reason: "denied" })),
+            : Effect.fail(new CredentialAccessError({ reason: "denied" }))),
         observation: () =>
           Effect.succeed(
             !observationTrusted
@@ -223,6 +228,34 @@ it.live(
             page.evaluate("[...document.querySelectorAll('input')].map(el => el.value)"),
           ),
         ).toEqual(["", "", "", ""]);
+        phase = "link-destination-authorization";
+        yield* handle.navigate(ProtectedBrowserNavigate.make({ url: "https://alpha.test/links" }));
+        const links = (yield* handle.observe).controls;
+
+        expect(links.map((control) => control.label)).toEqual(["Allowed", "Denied"]);
+        expect(links[1]!.target.recipientOrigin).toBe("https://beta.test");
+        actionOverride = (request) =>
+          Effect.gen(function* () {
+            if (
+              request.action._tag !== "Click" ||
+              request.action.role !== "link" ||
+              request.action.url !== "https://alpha.test/allowed"
+            )
+              return yield* new CredentialAccessError({ reason: "denied" });
+            yield* native(() =>
+              page.evaluate(
+                "document.querySelector('#allowed').href='/changed-during-authorization'",
+              ),
+            ).pipe(Effect.mapError(() => new CredentialAccessError({ reason: "resolver" })));
+          });
+        expect(
+          yield* handle.click(ProtectedBrowserClick.make({ ref: links[1]!.ref })).pipe(Effect.flip),
+        ).toMatchObject({ reason: "denied", dispatch: "not-dispatched" });
+        expect(
+          yield* handle.click(ProtectedBrowserClick.make({ ref: links[0]!.ref })).pipe(Effect.flip),
+        ).toMatchObject({ reason: "stale-reference", dispatch: "not-dispatched" });
+        expect(page.url()).toBe("https://alpha.test/links");
+        actionOverride = undefined;
         for (const attribute of ["name", "autocomplete", "action"]) {
           phase = `oversized-${attribute}`;
           yield* handle.navigate(

--- a/packages/platform-cloudflare/test/protected-browser.test.ts
+++ b/packages/platform-cloudflare/test/protected-browser.test.ts
@@ -66,6 +66,7 @@ const fixture = (kind: "login" | "card" = "login", actionAuthority = true) => {
   let cleanup: "confirmed" | "unconfirmed" = "confirmed";
   let listOverride: BrowserCredentialAccess["Service"]["list"] | undefined;
   let resolveOverride: BrowserCredentialAccess["Service"]["resolve"] | undefined;
+  let authorizeOverride: BrowserCredentialAccess["Service"]["authorize"] | undefined;
   let fillOverride: ProtectedBrowserTransport["fill"] | undefined;
   let navigateOverride: ProtectedBrowserTransport["navigate"] | undefined;
   let clickOverride: ProtectedBrowserTransport["click"] | undefined;
@@ -182,7 +183,7 @@ const fixture = (kind: "login" | "card" = "login", actionAuthority = true) => {
         request.target.topOrigin === "https://shop.test" &&
         request.target.frameOrigin === target.frameOrigin &&
         request.target.recipientOrigin === target.recipientOrigin
-          ? Effect.void
+          ? (authorizeOverride?.(request) ?? Effect.void)
           : Effect.fail(new CredentialAccessError({ reason: "denied" })),
       ),
     resolve: (request) =>
@@ -273,6 +274,9 @@ const fixture = (kind: "login" | "card" = "login", actionAuthority = true) => {
     },
     setResolve: (value: typeof resolveOverride) => {
       resolveOverride = value;
+    },
+    setAuthorize: (value: typeof authorizeOverride) => {
+      authorizeOverride = value;
     },
     setList: (value: typeof listOverride) => {
       listOverride = value;
@@ -444,6 +448,7 @@ it.effect.each([
     ...f.controls[0]!,
     ref: crypto.randomUUID(),
     role: "link",
+    url: "https://shop.test/next",
   });
 
   f.controls.push(link);
@@ -1423,6 +1428,97 @@ it.effect("refuses native submission without explicit host action authority", ()
       reason: "unsupported",
       dispatch: "not-dispatched",
     });
+    expect(clicks).toBe(0);
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect.each(["allowed", "denied", "changed"] as const)(
+  "authorizes the exact link destination: %s",
+  (mode) => {
+    const f = fixture();
+
+    const link = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role: "link",
+      url: mode === "denied" ? "https://shop.test/private" : "https://shop.test/allowed",
+    });
+
+    f.controls.push(link);
+    let clicks = 0;
+
+    f.setClick(() =>
+      Effect.sync(() => {
+        clicks++;
+      }),
+    );
+    f.setAuthorizeAction((request) =>
+      Effect.gen(function* () {
+        if (
+          request.action._tag !== "Click" ||
+          request.action.role !== "link" ||
+          request.action.url !== "https://shop.test/allowed"
+        )
+          return yield* new CredentialAccessError({ reason: "denied" });
+        if (mode === "changed")
+          f.controls[f.controls.length - 1] = ProtectedBrowserControl.make({
+            ...link,
+            url: "https://shop.test/private",
+          });
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+      const execute = handle.click(ProtectedBrowserClick.make({ ref: link.ref }));
+
+      if (mode === "allowed") yield* execute;
+      else
+        expect(yield* execute.pipe(Effect.flip)).toMatchObject({
+          reason: mode === "denied" ? "denied" : "stale-reference",
+          dispatch: "not-dispatched",
+        });
+      expect(clicks).toBe(mode === "allowed" ? 1 : 0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect("rechecks caller after the final asynchronous card-submit authorization", () => {
+  const f = fixture("card");
+  let clicks = 0;
+
+  f.setClick(() =>
+    Effect.sync(() => {
+      clicks++;
+    }),
+  );
+
+  return Effect.gen(function* () {
+    const entered = yield* Deferred.make<void>();
+    const resume = yield* Deferred.make<void>();
+
+    f.setAuthorize(() =>
+      f.filled.length === f.fields.length
+        ? Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(resume)))
+        : Effect.void,
+    );
+    const handle = yield* f.open;
+    const request = yield* proposal(f, handle);
+
+    const fiber = yield* Effect.forkChild(
+      handle.useCredential(UseCredential.make({ ...request, submit: f.controls.at(-1)!.ref })),
+    );
+
+    yield* Deferred.await(entered);
+    f.setPrincipal("mallory");
+    yield* Deferred.succeed(resume, undefined);
+    expect(yield* Fiber.join(fiber).pipe(Effect.flip)).toMatchObject({
+      reason: "denied",
+      dispatch: "dispatched",
+      milestone: "filled",
+      cleanup: "confirmed",
+    });
+    expect(f.filled).toHaveLength(f.fields.length);
     expect(clicks).toBe(0);
   }).pipe(Effect.scoped, Effect.provide(f.layer));
 });

--- a/packages/platform-cloudflare/test/protected-browser.test.ts
+++ b/packages/platform-cloudflare/test/protected-browser.test.ts
@@ -5,12 +5,14 @@ import {
   CardCredential,
   CredentialAccessError,
   CredentialOfferMetadata,
+  CredentialObservationGrant,
   CredentialTarget,
   ListCredentialOffers,
   LoginCredential,
   ProtectedBrowser,
   ProtectedBrowserClick,
   ProtectedBrowserControl,
+  ProtectedBrowserFill,
   ProtectedBrowserNavigate,
   ProtectedBrowserSession,
   UseCredential,
@@ -49,7 +51,7 @@ const material = LoginCredential.make({
   password: Redacted.make(password),
 });
 
-const fixture = (kind: "login" | "card" = "login") => {
+const fixture = (kind: "login" | "card" = "login", actionAuthority = true) => {
   let principal = "alice";
   let granted = true;
   let observes = true;
@@ -67,6 +69,13 @@ const fixture = (kind: "login" | "card" = "login") => {
   let fillOverride: ProtectedBrowserTransport["fill"] | undefined;
   let navigateOverride: ProtectedBrowserTransport["navigate"] | undefined;
   let clickOverride: ProtectedBrowserTransport["click"] | undefined;
+
+  let authorizeActionOverride:
+    | NonNullable<BrowserCredentialAccess["Service"]["authorizeAction"]>
+    | undefined;
+
+  let observationOverride: BrowserCredentialAccess["Service"]["observation"] | undefined;
+  let selectedOrigins: ReadonlyArray<string> | undefined;
 
   const target = CredentialTarget.make({
     topOrigin: "https://shop.test",
@@ -90,7 +99,10 @@ const fixture = (kind: "login" | "card" = "login") => {
     Effect.suspend(() => {
       const found = controls.find((control) => control.ref === ref);
 
-      return stale || disposed || !found
+      return stale ||
+        disposed ||
+        !found ||
+        (selectedOrigins !== undefined && !selectedOrigins.includes(found.target.frameOrigin))
         ? Effect.fail(new ProtectedTransportError({ reason: "stale-reference" }))
         : Effect.succeed(found);
     });
@@ -102,11 +114,26 @@ const fixture = (kind: "login" | "card" = "login") => {
   };
 
   const driver: ProtectedBrowserTransport = {
+    restrictObservation: (origins) =>
+      Effect.sync(() => {
+        selectedOrigins = origins;
+      }),
     context: Effect.succeed(context),
     discover: Effect.sync(() => {
       reads++;
 
-      return { ...context, text: "account dashboard", controls, truncated: false };
+      return {
+        ...context,
+        frameOrigins: context.frameOrigins.filter(
+          (origin) => selectedOrigins === undefined || selectedOrigins.includes(origin),
+        ),
+        text: "account dashboard",
+        controls: controls.filter(
+          (control) =>
+            selectedOrigins === undefined || selectedOrigins.includes(control.target.frameOrigin),
+        ),
+        truncated: false,
+      };
     }),
     target: getTarget,
     navigate: (url) => Effect.suspend(() => navigateOverride?.(url) ?? Effect.void),
@@ -118,7 +145,7 @@ const fixture = (kind: "login" | "card" = "login") => {
       ),
     fill: Effect.fn(function* (
       ref: string,
-      role: typeof CredentialFieldRole.Type,
+      role: Parameters<ProtectedBrowserTransport["fill"]>[1],
       value: Redacted.Redacted<string>,
     ) {
       yield* getTarget(ref);
@@ -177,7 +204,21 @@ const fixture = (kind: "login" | "card" = "login") => {
                   }),
             );
       }),
-    observation: () =>
+    ...(actionAuthority
+      ? {
+          authorizeAction: (
+            request: Parameters<
+              NonNullable<BrowserCredentialAccess["Service"]["authorizeAction"]>
+            >[0],
+          ) =>
+            authorizeActionOverride?.(request) ??
+            (request.action._tag === "Submit"
+              ? Effect.fail(new CredentialAccessError({ reason: "denied" }))
+              : Effect.void),
+        }
+      : {}),
+    observation: (request) =>
+      observationOverride?.(request) ??
       Effect.sync(() => (observes ? "trust-recipient-no-credential-echo" : "deny")),
   });
 
@@ -245,6 +286,13 @@ const fixture = (kind: "login" | "card" = "login") => {
     setClick: (value: typeof clickOverride) => {
       clickOverride = value;
     },
+    setAuthorizeAction: (value: typeof authorizeActionOverride) => {
+      authorizeActionOverride = value;
+    },
+    setObservation: (value: typeof observationOverride) => {
+      observationOverride = value;
+    },
+    context,
     needAttention: () => {
       attention = true;
     },
@@ -314,7 +362,9 @@ it.effect(
       };
 
       const error = yield* Effect.gen(function* () {
-        return yield* (yield* BrowserRunProtectedTransport).open(policy);
+        return yield* (yield* BrowserRunProtectedTransport).open(
+          InteractiveBrowserPolicy.make({ ...policy, maxElapsedMillis: 3_600_000 }),
+        );
       }).pipe(
         Effect.scoped,
         Effect.provide(
@@ -334,6 +384,7 @@ it.effect(
       );
 
       expect(new URL(requests[0]!.url).searchParams.get("recording")).toBe("false");
+      expect(new URL(requests[0]!.url).searchParams.get("keep_alive")).toBe("600000");
       expect(closed).toEqual([sessionId]);
       expect(error).toMatchObject({
         reason: "provider",
@@ -628,29 +679,33 @@ it.effect("reports filled but not submitted when native requirements need attent
   }).pipe(Effect.scoped, Effect.provide(f.layer));
 });
 
-it.effect("denies metadata listing and card submission without resolving credentials", () => {
-  const f = fixture("card");
+it.effect(
+  "denies metadata listing and card submission after grant revocation without resolving credentials",
+  () => {
+    const f = fixture("card");
 
-  return Effect.gen(function* () {
-    const handle = yield* f.open;
-    const request = yield* proposal(f, handle);
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+      const request = yield* proposal(f, handle);
 
-    expect(
-      yield* handle
-        .useCredential(UseCredential.make({ ...request, submit: f.controls.at(-1)!.ref }))
-        .pipe(Effect.flip),
-    ).toMatchObject({ reason: "unsupported", dispatch: "not-dispatched" });
-    f.revoke();
-    expect(
-      yield* handle
-        .listCredentialOffers(
-          ListCredentialOffers.make({ kind: "card", target: f.controls[0]!.ref }),
-        )
-        .pipe(Effect.flip),
-    ).toMatchObject({ reason: "denied" });
-    expect(f.stats().resolved).toBe(0);
-  }).pipe(Effect.scoped, Effect.provide(f.layer));
-});
+      f.revoke();
+
+      expect(
+        yield* handle
+          .useCredential(UseCredential.make({ ...request, submit: f.controls.at(-1)!.ref }))
+          .pipe(Effect.flip),
+      ).toMatchObject({ reason: "denied", dispatch: "not-dispatched" });
+      expect(
+        yield* handle
+          .listCredentialOffers(
+            ListCredentialOffers.make({ kind: "card", target: f.controls[0]!.ref }),
+          )
+          .pipe(Effect.flip),
+      ).toMatchObject({ reason: "denied" });
+      expect(f.stats().resolved).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
 
 it.effect.each(["failure", "defect", "partial", "cleanup"] as const)(
   "sanitizes %s and preserves independent dispatch/cleanup evidence",
@@ -788,4 +843,586 @@ it.effect("one scoped session is shared by successive Tools and invalidated at S
     expect(f.stats().opens).toBe(1);
     expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({ reason: "closed" });
   }).pipe(Effect.provide(f.layer));
+});
+
+it.effect.each(["text", "select"] as const)(
+  "fills ordinary %s without vault resolution",
+  (role) => {
+    const f = fixture();
+
+    const control = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role,
+    });
+
+    f.controls.push(control);
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+
+      yield* handle.fill(
+        ProtectedBrowserFill.make({ ref: control.ref, value: "123 Example Street" }),
+      );
+      yield* handle.fill(ProtectedBrowserFill.make({ ref: control.ref, value: "" }));
+      expect(f.filled).toEqual(["123 Example Street", ""]);
+      expect(f.stats().resolved).toBe(0);
+      expect((yield* handle.observe).observation).toBe("before-exposure");
+      f.expire();
+      expect(
+        yield* handle
+          .fill(ProtectedBrowserFill.make({ ref: control.ref, value: "stale" }))
+          .pipe(Effect.flip),
+      ).toMatchObject({ reason: "stale-reference", dispatch: "not-dispatched" });
+      expect(f.filled).toHaveLength(2);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect.each(["login", "card"] as const)(
+  "refuses generic fill and submit for %s credentials",
+  (kind) => {
+    const f = fixture(kind);
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+
+      for (const field of f.controls) {
+        expect(
+          yield* handle
+            .fill(ProtectedBrowserFill.make({ ref: field.ref, value: "ordinary" }))
+            .pipe(Effect.flip),
+        ).toMatchObject({ reason: "unsupported", dispatch: "not-dispatched" });
+      }
+      expect(
+        yield* handle
+          .click(ProtectedBrowserClick.make({ ref: f.controls.at(-1)!.ref }))
+          .pipe(Effect.flip),
+      ).toMatchObject({ reason: "denied", dispatch: "not-dispatched" });
+      expect(f.stats().resolved).toBe(0);
+      expect(f.filled).toEqual([]);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect.each(["radio", "checkbox"] as const)(
+  "clicks an observed %s and reports checked state",
+  (role) => {
+    const f = fixture();
+
+    const control = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role,
+      checked: false,
+    });
+
+    f.controls.push(control);
+    f.setClick((ref) =>
+      Effect.sync(() => {
+        expect(ref).toBe(control.ref);
+        f.controls[f.controls.length - 1] = ProtectedBrowserControl.make({
+          ...control,
+          checked: true,
+        });
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+
+      expect((yield* handle.observe).controls.at(-1)!.checked).toBe(false);
+      yield* handle.click(ProtectedBrowserClick.make({ ref: control.ref }));
+      expect((yield* handle.observe).controls.at(-1)!.checked).toBe(true);
+      expect(f.stats().resolved).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect("discloses billing metadata only through an authorized bounded offer", () => {
+  const f = fixture("card");
+
+  const metadata = CredentialOfferMetadata.make({
+    label: "Card",
+    billingAddress: { line1: "123 Example Street", country: "US" },
+  });
+
+  f.setList(() => Effect.succeed([{ key: Redacted.make("private-key"), metadata }]));
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+    const request = ListCredentialOffers.make({ kind: "card", target: f.controls[0]!.ref });
+    const offers = yield* handle.listCredentialOffers(request);
+
+    expect(offers[0]!.metadata).toEqual(metadata);
+    expect(JSON.stringify(offers)).not.toContain("private-key");
+    expect(f.stats().resolved).toBe(0);
+    f.revoke();
+    expect(yield* handle.listCredentialOffers(request).pipe(Effect.flip)).toMatchObject({
+      reason: "denied",
+    });
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect.each(["before", "after"] as const)(
+  "requires the post-exposure grant %s ordinary fill",
+  (when) => {
+    const f = fixture();
+
+    const control = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role: "text",
+    });
+
+    f.controls.push(control);
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+
+      yield* handle.useCredential(yield* proposal(f, handle));
+      let writes = 0;
+
+      f.setFill(() =>
+        Effect.gen(function* () {
+          yield* (yield* ProtectedBrowserDispatch).mark;
+          writes++;
+          f.blockObservations();
+        }),
+      );
+      if (when === "before") f.blockObservations();
+      expect(
+        yield* handle
+          .fill(ProtectedBrowserFill.make({ ref: control.ref, value: "address" }))
+          .pipe(Effect.flip),
+      ).toMatchObject({
+        reason: "observation-blocked",
+        dispatch: when === "before" ? "not-dispatched" : "dispatched",
+      });
+      expect(writes).toBe(when === "before" ? 0 : 1);
+      expect(f.stats().closed).toBe(when === "before" ? 0 : 1);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect.each(["failure", "defect", "timeout", "interrupt"] as const)(
+  "sanitizes ordinary fill %s and closes once without replay",
+  (mode) => {
+    const f = fixture();
+
+    const control = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role: "text",
+    });
+
+    f.controls.push(control);
+
+    return Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      let writes = 0;
+
+      f.setFill(() =>
+        Effect.gen(function* () {
+          yield* (yield* ProtectedBrowserDispatch).mark;
+          writes++;
+          yield* Deferred.succeed(entered, undefined);
+          if (mode === "failure") return yield* new ProtectedTransportError({ reason: "provider" });
+          if (mode === "defect") return yield* Effect.die(new Error("private-fill-diagnostic"));
+
+          return yield* Effect.never;
+        }),
+      );
+      const handle = yield* f.open;
+
+      const request = ProtectedBrowserFill.make({
+        ref: control.ref,
+        value: "private-fill-diagnostic",
+      });
+
+      const fiber = yield* Effect.forkChild(handle.fill(request));
+
+      yield* Deferred.await(entered);
+      if (mode === "interrupt") yield* Fiber.interrupt(fiber);
+      else {
+        if (mode === "timeout") {
+          expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({ reason: "busy" });
+          yield* TestClock.adjust("121 seconds");
+        }
+        const error = yield* Fiber.join(fiber).pipe(Effect.flip);
+
+        expect(error).toMatchObject({
+          reason: mode === "timeout" ? "timeout" : "outcome-unknown",
+          dispatch: "possibly-dispatched",
+          cleanup: "confirmed",
+        });
+        expect(JSON.stringify(error)).not.toContain("private-fill-diagnostic");
+      }
+      expect(yield* handle.fill(request).pipe(Effect.flip)).toMatchObject({ reason: "closed" });
+      expect(writes).toBe(1);
+      expect(f.stats().closed).toBe(1);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect("enforces action and elapsed budgets during an hour-long pass", () => {
+  const f = fixture();
+
+  return Effect.gen(function* () {
+    const handle = yield* (yield* ProtectedBrowser).open(
+      InteractiveBrowserPolicy.make({ ...policy, maxElapsedMillis: 3_600_000, maxActions: 2 }),
+    );
+
+    yield* TestClock.adjust("11 minutes");
+    yield* handle.observe;
+    yield* handle.observe;
+    expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({ reason: "limit" });
+
+    const timed = yield* (yield* ProtectedBrowser).open(
+      InteractiveBrowserPolicy.make({ ...policy, maxElapsedMillis: 3_600_000 }),
+    );
+
+    yield* TestClock.adjust("60 minutes");
+    expect(yield* timed.observe.pipe(Effect.flip)).toMatchObject({
+      reason: "timeout",
+      cleanup: "confirmed",
+    });
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect("allows card submission only through current credential authorization", () => {
+  const f = fixture("card");
+  let clicks = 0;
+
+  f.setClick(() =>
+    Effect.sync(() => {
+      clicks++;
+    }),
+  );
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+    const request = yield* proposal(f, handle);
+
+    expect(
+      yield* handle.useCredential(
+        UseCredential.make({ ...request, submit: f.controls.at(-1)!.ref }),
+      ),
+    ).toMatchObject({
+      dispatch: "dispatched",
+      milestone: "submission-dispatched",
+      authentication: "unverified",
+    });
+    expect(clicks).toBe(1);
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect.each([
+  "success",
+  "revoked",
+  "caller-changed",
+  "target-changed",
+  "reply-lost",
+  "needs-attention",
+] as const)("authorizes a merchant submit after separate card-frame fills: %s", (mode) => {
+  const f = fixture("card");
+  let clicks = 0;
+
+  f.setClick(() =>
+    Effect.gen(function* () {
+      clicks++;
+      if (mode === "reply-lost") return yield* new ProtectedTransportError({ reason: "provider" });
+    }),
+  );
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+
+    yield* handle.useCredential(yield* proposal(f, handle));
+
+    const separate = CredentialTarget.make({
+      ...f.controls[0]!.target,
+      frame: crypto.randomUUID(),
+      form: crypto.randomUUID(),
+      document: crypto.randomUUID(),
+    });
+
+    for (let index = 0; index < f.controls.length; index++)
+      f.controls[index] = ProtectedBrowserControl.make({ ...f.controls[index]!, target: separate });
+    yield* handle.useCredential(yield* proposal(f, handle));
+
+    const submit = ProtectedBrowserControl.make({
+      ref: crypto.randomUUID(),
+      role: "submit",
+      label: "Pay",
+      target: CredentialTarget.make({
+        ...separate,
+        frameOrigin: "https://shop.test",
+        recipientOrigin: "https://shop.test",
+        frame: crypto.randomUUID(),
+        form: crypto.randomUUID(),
+      }),
+    });
+
+    f.controls.push(submit);
+    f.setAuthorizeAction((request) =>
+      Effect.gen(function* () {
+        expect(Redacted.value(request.caller)).toBe("alice");
+        expect(request.action).toEqual({ _tag: "Submit", ref: submit.ref, target: submit.target });
+        expect(request.exposures).toHaveLength(2);
+        expect(request.exposures.every((target) => target.frameOrigin === "https://pay.test")).toBe(
+          true,
+        );
+        if (mode === "revoked") return yield* new CredentialAccessError({ reason: "denied" });
+        if (mode === "caller-changed") f.setPrincipal("mallory");
+        if (mode === "target-changed")
+          f.controls[f.controls.length - 1] = ProtectedBrowserControl.make({
+            ...submit,
+            target: CredentialTarget.make({
+              ...submit.target,
+              recipientOrigin: "https://evil.test",
+            }),
+          });
+      }),
+    );
+    if (mode === "needs-attention") f.needAttention();
+    const execute = handle.click(ProtectedBrowserClick.make({ ref: submit.ref }));
+
+    if (mode === "success") {
+      yield* execute;
+      f.setAuthorizeAction(() => Effect.fail(new CredentialAccessError({ reason: "denied" })));
+      expect(yield* execute.pipe(Effect.flip)).toMatchObject({
+        reason: "denied",
+        dispatch: "not-dispatched",
+      });
+    } else {
+      expect(yield* execute.pipe(Effect.flip)).toMatchObject({
+        reason:
+          mode === "reply-lost"
+            ? "outcome-unknown"
+            : mode === "target-changed"
+              ? "stale-reference"
+              : mode === "needs-attention"
+                ? "needs-attention"
+                : "denied",
+        dispatch: mode === "reply-lost" ? "possibly-dispatched" : "not-dispatched",
+      });
+    }
+    expect(clicks).toBe(mode === "success" || mode === "reply-lost" ? 1 : 0);
+    if (mode === "reply-lost") {
+      expect(f.stats().closed).toBe(1);
+      expect(yield* execute.pipe(Effect.flip)).toMatchObject({ reason: "closed" });
+    }
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect.each(["navigate", "fill", "click"] as const)(
+  "checks current continuation authority before ordinary %s",
+  (action) => {
+    const f = fixture();
+
+    const field = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role: "text",
+    });
+
+    const button = ProtectedBrowserControl.make({
+      ...f.controls[0]!,
+      ref: crypto.randomUUID(),
+      role: "button",
+    });
+
+    f.controls.push(field, button);
+
+    return Effect.gen(function* () {
+      const handle = yield* f.open;
+
+      yield* handle.useCredential(yield* proposal(f, handle));
+      let writes = 0;
+
+      f.setFill(() =>
+        Effect.sync(() => {
+          writes++;
+        }),
+      );
+      f.setClick(() =>
+        Effect.sync(() => {
+          writes++;
+        }),
+      );
+      f.setNavigate(() =>
+        Effect.sync(() => {
+          writes++;
+        }),
+      );
+      f.setAuthorizeAction((request) =>
+        Effect.gen(function* () {
+          expect(request.exposures).toHaveLength(1);
+
+          return yield* new CredentialAccessError({ reason: "denied" });
+        }),
+      );
+
+      const operation =
+        action === "navigate"
+          ? handle.navigate(ProtectedBrowserNavigate.make({ url: "https://shop.test/next" }))
+          : action === "fill"
+            ? handle.fill(ProtectedBrowserFill.make({ ref: field.ref, value: "ordinary" }))
+            : handle.click(ProtectedBrowserClick.make({ ref: button.ref }));
+
+      expect(yield* operation.pipe(Effect.flip)).toMatchObject({
+        reason: "denied",
+        dispatch: "not-dispatched",
+      });
+      expect(writes).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect("uses explicit recipient selection and rejects a grant narrowed during discovery", () => {
+  const f = fixture("card");
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+
+    yield* handle.useCredential(yield* proposal(f, handle));
+    f.context.frameOrigins.push("https://untrusted.test");
+    let calls = 0;
+
+    f.setObservation((request) =>
+      Effect.sync(() => {
+        expect(request.frameOrigins).toContain("https://untrusted.test");
+        calls++;
+
+        return CredentialObservationGrant.make({
+          decision: "trust-recipient-no-credential-echo",
+          origins: calls >= 4 ? ["https://shop.test"] : ["https://shop.test", "https://pay.test"],
+        });
+      }),
+    );
+    expect((yield* handle.observe).controls).toHaveLength(f.controls.length);
+    expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({
+      reason: "observation-blocked",
+      dispatch: "not-dispatched",
+    });
+    expect(
+      yield* handle
+        .listCredentialOffers(
+          ListCredentialOffers.make({ kind: "card", target: f.controls[0]!.ref }),
+        )
+        .pipe(Effect.flip),
+    ).toMatchObject({ reason: "stale-reference" });
+    f.setObservation(() =>
+      Effect.succeed(
+        CredentialObservationGrant.make({
+          decision: "trust-recipient-no-credential-echo",
+          origins: ["https://pay.test"],
+        }),
+      ),
+    );
+    const reads = f.stats().reads;
+
+    expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({
+      reason: "observation-blocked",
+    });
+    expect(f.stats().reads).toBe(reads);
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect.each(["timeout", "interrupt"] as const)(
+  "closes an uncertain authorized submit on %s without replay",
+  (mode) => {
+    const f = fixture("card");
+
+    f.setAuthorizeAction(() => Effect.void);
+
+    return Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      let clicks = 0;
+
+      f.setClick(() =>
+        Effect.gen(function* () {
+          clicks++;
+          yield* Deferred.succeed(entered, undefined);
+
+          return yield* Effect.never;
+        }),
+      );
+      const handle = yield* f.open;
+
+      yield* handle.useCredential(yield* proposal(f, handle));
+      const execute = handle.click(ProtectedBrowserClick.make({ ref: f.controls.at(-1)!.ref }));
+      const fiber = yield* Effect.forkChild(execute);
+
+      yield* Deferred.await(entered);
+      expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({ reason: "busy" });
+      if (mode === "interrupt") yield* Fiber.interrupt(fiber);
+      else {
+        yield* TestClock.adjust("121 seconds");
+        expect(yield* Fiber.join(fiber).pipe(Effect.flip)).toMatchObject({
+          reason: "timeout",
+          dispatch: "possibly-dispatched",
+          cleanup: "confirmed",
+        });
+      }
+      expect(f.stats().closed).toBe(1);
+      expect(yield* execute.pipe(Effect.flip)).toMatchObject({ reason: "closed" });
+      expect(clicks).toBe(1);
+    }).pipe(Effect.scoped, Effect.provide(f.layer));
+  },
+);
+
+it.effect("rejects a caller change while obtaining an observation grant before reading", () => {
+  const f = fixture();
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+
+    yield* handle.useCredential(yield* proposal(f, handle));
+    const reads = f.stats().reads;
+
+    f.setObservation(() =>
+      Effect.sync(() => {
+        f.setPrincipal("mallory");
+
+        return CredentialObservationGrant.make({
+          decision: "trust-recipient-no-credential-echo",
+          origins: ["https://shop.test"],
+        });
+      }),
+    );
+    expect(yield* handle.observe.pipe(Effect.flip)).toMatchObject({
+      reason: "denied",
+      dispatch: "not-dispatched",
+    });
+    expect(f.stats().reads).toBe(reads);
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
+});
+
+it.effect("refuses native submission without explicit host action authority", () => {
+  const f = fixture("card", false);
+  let clicks = 0;
+
+  f.setClick(() =>
+    Effect.sync(() => {
+      clicks++;
+    }),
+  );
+
+  return Effect.gen(function* () {
+    const handle = yield* f.open;
+    const execute = handle.click(ProtectedBrowserClick.make({ ref: f.controls.at(-1)!.ref }));
+
+    expect(yield* execute.pipe(Effect.flip)).toMatchObject({
+      reason: "unsupported",
+      dispatch: "not-dispatched",
+    });
+    yield* handle.useCredential(yield* proposal(f, handle));
+    expect(yield* execute.pipe(Effect.flip)).toMatchObject({
+      reason: "unsupported",
+      dispatch: "not-dispatched",
+    });
+    expect(clicks).toBe(0);
+  }).pipe(Effect.scoped, Effect.provide(f.layer));
 });

--- a/packages/sandbox/src/InteractiveBrowser.ts
+++ b/packages/sandbox/src/InteractiveBrowser.ts
@@ -79,13 +79,14 @@ export const InteractiveBrowserNetworkPolicy = Schema.Union([
 
 export type InteractiveBrowserNetworkPolicy = typeof InteractiveBrowserNetworkPolicy.Type;
 
+/** Finite per-pass budgets. The elapsed ceiling is one hour; provider idle limits may be shorter. */
 export class InteractiveBrowserPolicy extends Schema.Class<InteractiveBrowserPolicy>(
   "InteractiveBrowserPolicy",
 )(
   Schema.Struct({
     network: InteractiveBrowserNetworkPolicy,
     maxActions: PositiveInt.check(Schema.isLessThanOrEqualTo(1_000)),
-    maxElapsedMillis: PositiveInt.check(Schema.isLessThanOrEqualTo(10 * 60_000)),
+    maxElapsedMillis: PositiveInt.check(Schema.isLessThanOrEqualTo(60 * 60_000)),
     maxReturnedBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(8 * 1024 * 1024)),
   }).pipe(Schema.annotate({ parseOptions: { onExcessProperty: "error" } })),
 ) {}

--- a/packages/sandbox/src/ProtectedBrowser.ts
+++ b/packages/sandbox/src/ProtectedBrowser.ts
@@ -1,6 +1,10 @@
 import { Context, Effect, Layer, Schema, Scope, type Redacted } from "effect";
 
-import { InteractiveBrowserHost, type InteractiveBrowserPolicy } from "./InteractiveBrowser.ts";
+import {
+  InteractiveBrowserHost,
+  InteractiveBrowserTargetUrl,
+  type InteractiveBrowserPolicy,
+} from "./InteractiveBrowser.ts";
 
 /** Canonical HTTPS origin, including a non-default port. Host grants match exactly. */
 export const CredentialOrigin = Schema.String.check(
@@ -24,6 +28,7 @@ export const CredentialFieldRole = Schema.Literals([
 ]);
 
 const Label = Schema.String.check(Schema.isMaxLength(200));
+const LinkUrl = InteractiveBrowserTargetUrl.check(Schema.isStartsWith("https://"));
 
 export class CredentialTarget extends Schema.Class<CredentialTarget>("CredentialTarget")({
   topOrigin: CredentialOrigin,
@@ -55,6 +60,8 @@ export class ProtectedBrowserControl extends Schema.Class<ProtectedBrowserContro
   label: Label,
   /** Current native radio/checkbox state; field values are never included. */
   checked: Schema.optionalKey(Schema.Boolean),
+  /** Resolved HTTPS destination for a native link; target.recipientOrigin is its origin. */
+  url: Schema.optionalKey(LinkUrl),
 }) {}
 
 export class ProtectedBrowserObservation extends Schema.Class<ProtectedBrowserObservation>(
@@ -246,7 +253,13 @@ export const ProtectedBrowserAction = Schema.Union([
   Schema.TaggedStruct("Click", {
     ref: BrowserReference,
     target: CredentialTarget,
-    role: Schema.Literals(["link", "button", "radio", "checkbox"]),
+    role: Schema.Literals(["button", "radio", "checkbox"]),
+  }),
+  Schema.TaggedStruct("Click", {
+    ref: BrowserReference,
+    target: CredentialTarget,
+    role: Schema.Literal("link"),
+    url: LinkUrl,
   }),
   Schema.TaggedStruct("Submit", { ref: BrowserReference, target: CredentialTarget }),
 ]);

--- a/packages/sandbox/src/ProtectedBrowser.ts
+++ b/packages/sandbox/src/ProtectedBrowser.ts
@@ -41,9 +41,20 @@ export class ProtectedBrowserControl extends Schema.Class<ProtectedBrowserContro
   target: CredentialTarget,
   role: Schema.Union([
     CredentialFieldRole,
-    Schema.Literals(["submit", "link", "button", "unsupported"]),
+    Schema.Literals([
+      "text",
+      "select",
+      "radio",
+      "checkbox",
+      "submit",
+      "link",
+      "button",
+      "unsupported",
+    ]),
   ]),
   label: Label,
+  /** Current native radio/checkbox state; field values are never included. */
+  checked: Schema.optionalKey(Schema.Boolean),
 }) {}
 
 export class ProtectedBrowserObservation extends Schema.Class<ProtectedBrowserObservation>(
@@ -63,6 +74,18 @@ export class CredentialOfferMetadata extends Schema.Class<CredentialOfferMetadat
   label: Label,
   brand: Schema.optionalKey(Label),
   lastFour: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^\d{4}$/))),
+  /** Plaintext metadata disclosed only when the host authorizes listing this offer. */
+  billingAddress: Schema.optionalKey(
+    Schema.Struct({
+      name: Schema.optionalKey(Label),
+      line1: Schema.optionalKey(Label),
+      line2: Schema.optionalKey(Label),
+      city: Schema.optionalKey(Label),
+      region: Schema.optionalKey(Label),
+      postalCode: Schema.optionalKey(Label),
+      country: Schema.optionalKey(Label),
+    }),
+  ),
 }) {}
 
 export class CredentialOffer extends Schema.Class<CredentialOffer>("CredentialOffer")({
@@ -98,6 +121,20 @@ export class ProtectedBrowserClick extends Schema.Class<ProtectedBrowserClick>(
 )({
   ref: BrowserReference,
 }) {}
+
+/**
+ * Non-secret text for an ordinary text control or native single select in the current observation.
+ * Never pass credential material. Credential roles, including username, require useCredential.
+ * Selects match a unique enabled option value, then a unique exact trimmed label. Empty text clears.
+ */
+export class ProtectedBrowserFill extends Schema.Class<ProtectedBrowserFill>(
+  "ProtectedBrowserFill",
+)(
+  Schema.Struct({
+    ref: BrowserReference,
+    value: Schema.String.check(Schema.isMaxLength(8192)),
+  }).pipe(Schema.annotate({ parseOptions: { onExcessProperty: "error" } })),
+) {}
 
 export const CredentialDispatch = Schema.Literals([
   "not-dispatched",
@@ -198,6 +235,44 @@ export interface CredentialUseAuthorization extends CredentialAccessRequest {
   readonly submit: boolean;
 }
 
+/** Exact current action proposed to host authority; no ordinary fill value or secret is included. */
+export const ProtectedBrowserAction = Schema.Union([
+  Schema.TaggedStruct("Navigate", { url: ProtectedBrowserNavigate.fields.url }),
+  Schema.TaggedStruct("Fill", {
+    ref: BrowserReference,
+    target: CredentialTarget,
+    role: Schema.Literals(["text", "select"]),
+  }),
+  Schema.TaggedStruct("Click", {
+    ref: BrowserReference,
+    target: CredentialTarget,
+    role: Schema.Literals(["link", "button", "radio", "checkbox"]),
+  }),
+  Schema.TaggedStruct("Submit", { ref: BrowserReference, target: CredentialTarget }),
+]);
+
+export type ProtectedBrowserAction = typeof ProtectedBrowserAction.Type;
+
+/**
+ * Trust only these current observation origins. The top origin must be included. Other frames
+ * supply neither text nor usable refs. This does not expand network policy or credential grants.
+ */
+export class CredentialObservationGrant extends Schema.Class<CredentialObservationGrant>(
+  "CredentialObservationGrant",
+)({
+  decision: Schema.Literal("trust-recipient-no-credential-echo"),
+  origins: Schema.Array(CredentialOrigin).check(
+    Schema.isMinLength(1),
+    Schema.isMaxLength(16),
+    Schema.isUnique(),
+  ),
+}) {}
+
+export const CredentialObservationDecision = Schema.Union([
+  Schema.Literals(["trust-recipient-no-credential-echo", "deny"]),
+  CredentialObservationGrant,
+]);
+
 /**
  * Host-only vault and grant port. Derive caller from the authorized invocation, never Tool input.
  * Recheck account ownership, current grants, merchant/frame/recipient pairing, and any side
@@ -222,26 +297,43 @@ export class BrowserCredentialAccess extends Context.Service<
       request: CredentialUseAuthorization,
     ) => Effect.Effect<BrowserCredentialMaterial, CredentialAccessError>;
     /**
+     * Optional host authority for every ordinary navigate/fill/click, mandatory for Submit.
+     * Recheck caller ownership, user intent, current submission/continuation grants for ALL prior
+     * exposures, and this exact target. Exposures may come from separate credential frames/forms.
+     * Without this hook, ordinary actions retain their observation gate and Submit is unsupported.
+     * Observation trust alone never authorizes a new native submit. Called again on each action;
+     * approvals are not cached. The pass revalidates caller and target after this hook returns.
+     */
+    readonly authorizeAction?: (request: {
+      readonly caller: Redacted.Redacted<string>;
+      readonly action: ProtectedBrowserAction;
+      readonly exposures: ReadonlyArray<CredentialTarget>;
+    }) => Effect.Effect<void, CredentialAccessError>;
+    /**
      * Explicitly trust all observed destinations not to echo credentials, including transformed
      * or delayed echoes. Called for every observation and non-secret action after exposure.
-     * This is a recipient trust decision, not a universal secrecy guarantee or login verifier.
+     * The string grant trusts all current observed origins. Return CredentialObservationGrant
+     * to select an explicit subset instead. This is recipient trust, not submission authority,
+     * a universal secrecy guarantee, or a login verifier.
      */
     readonly observation: (request: {
       readonly caller: Redacted.Redacted<string>;
       readonly topOrigin: typeof CredentialOrigin.Type;
       readonly frameOrigins: ReadonlyArray<typeof CredentialOrigin.Type>;
       readonly exposures: ReadonlyArray<CredentialTarget>;
-    }) => Effect.Effect<"trust-recipient-no-credential-echo" | "deny", CredentialAccessError>;
+    }) => Effect.Effect<typeof CredentialObservationDecision.Type, CredentialAccessError>;
   }
 >()("@effect-agent/sandbox/BrowserCredentialAccess") {}
 
-/** A private ephemeral pass. No raw fill, JavaScript, screenshots, viewer, or provider identity. */
+/** A private ephemeral pass. No selectors, JavaScript, screenshots, viewer, or provider identity. */
 export interface ProtectedBrowserHandle {
   readonly navigate: (
     request: ProtectedBrowserNavigate,
   ) => Effect.Effect<void, ProtectedBrowserError>;
   readonly observe: Effect.Effect<ProtectedBrowserObservation, ProtectedBrowserError>;
   readonly click: (request: ProtectedBrowserClick) => Effect.Effect<void, ProtectedBrowserError>;
+  /** Uses the same lock, budgets, current-target checks and post-exposure grant as other actions. */
+  readonly fill: (request: ProtectedBrowserFill) => Effect.Effect<void, ProtectedBrowserError>;
   readonly listCredentialOffers: (
     request: ListCredentialOffers,
   ) => Effect.Effect<ReadonlyArray<CredentialOffer>, ProtectedBrowserError>;

--- a/packages/sandbox/test/interactive-browser.test.ts
+++ b/packages/sandbox/test/interactive-browser.test.ts
@@ -33,6 +33,8 @@ import {
   type BrowserCredentialAccess,
   CredentialOrigin,
   CardCredential,
+  CredentialOfferMetadata,
+  ProtectedBrowserFill,
 } from "@effect-agent/sandbox/ProtectedBrowser";
 import { SandboxImplementation } from "@effect-agent/sandbox/Sandbox";
 import { Schema, type Effect, type Scope } from "effect";
@@ -45,6 +47,51 @@ type OpenResult =
   ReturnType<Open> extends Effect.Effect<infer A, infer E, infer R> ? [A, E, R] : never;
 
 describe("InteractiveBrowser schemas", () => {
+  it("bounds non-secret fill, authorized address metadata, and hour-long policies", () => {
+    const ref = "12345678-1234-4234-9234-123456789abc";
+
+    expect(Schema.decodeUnknownSync(ProtectedBrowserFill)({ ref, value: "" }).value).toBe("");
+    for (const request of [
+      { ref: "#address", value: "text" },
+      { ref, value: "x".repeat(8193) },
+      { ref, value: "text", selector: "input" },
+      { ref, value: "text", script: "document.body" },
+    ])
+      expect(Schema.decodeUnknownExit(ProtectedBrowserFill)(request)._tag).toBe("Failure");
+
+    const metadata = CredentialOfferMetadata.make({
+      label: "Personal card",
+      billingAddress: { line1: "123 Example Street", postalCode: "12345" },
+    });
+
+    expect(
+      Schema.decodeSync(CredentialOfferMetadata)(
+        Schema.encodeSync(CredentialOfferMetadata)(metadata),
+      ),
+    ).toEqual(metadata);
+    expect(
+      Schema.decodeUnknownExit(CredentialOfferMetadata)({
+        label: "Card",
+        billingAddress: { line1: "x".repeat(201) },
+      })._tag,
+    ).toBe("Failure");
+    for (const maxElapsedMillis of [600_001, 3_600_000])
+      expect(
+        Schema.decodeUnknownExit(InteractiveBrowserPolicy)({
+          network: { _tag: "ExactHosts", allowedHosts: ["example.com"] },
+          maxActions: 10,
+          maxElapsedMillis,
+          maxReturnedBytes: 1024,
+        })._tag,
+      ).toBe("Success");
+
+    const fill: Equal<
+      ReturnType<ProtectedBrowserHandle["fill"]>,
+      Effect.Effect<void, ProtectedBrowserError>
+    > = true;
+
+    expect(fill).toBe(true);
+  });
   it("keeps protected material and authority outside the model contract", () => {
     const open: Equal<
       ReturnType<ProtectedBrowser["Service"]["open"]>,
@@ -56,10 +103,7 @@ describe("InteractiveBrowser schemas", () => {
     > = true;
 
     const channels: Equal<
-      Extract<
-        keyof ProtectedBrowserHandle,
-        "fill" | "screenshot" | "sessionId" | "getLiveView" | "handoff"
-      >,
+      Extract<keyof ProtectedBrowserHandle, "screenshot" | "sessionId" | "getLiveView" | "handoff">,
       never
     > = true;
 
@@ -210,7 +254,9 @@ describe("InteractiveBrowser schemas", () => {
       { ...valid, maxActions: 0 },
       { ...valid, maxActions: 1_001 },
       { ...valid, maxElapsedMillis: 0 },
-      { ...valid, maxElapsedMillis: 600_001 },
+      { ...valid, maxElapsedMillis: 3_600_001 },
+      { ...valid, maxElapsedMillis: Number.POSITIVE_INFINITY },
+      { ...valid, maxElapsedMillis: Number.NaN },
       { ...valid, maxReturnedBytes: 0 },
       { ...valid, maxReturnedBytes: 8 * 1024 * 1024 + 1 },
     ])


### PR DESCRIPTION
Protected passes can now complete ordinary form fields and host-authorized checkout without exposing selectors or credential material. Add bounded `ProtectedBrowserFill`, native text/textarea/select support, radio/checkbox state, and authorized billing-address offer metadata. Raise the finite policy ceiling to one hour, with an independent bounded idle keep-alive.

```ts
// field is a text/select control from the current private observation.
yield* browser.fill(ProtectedBrowserFill.make({ ref: field.ref, value: "123 Example Street" }));
```

`BrowserCredentialAccess.authorizeAction({ caller, action, exposures })` runs before ordinary actions when supplied and is required for native `Submit`. Hosts can recheck all previous credential exposures before submitting a merchant form after separate processor-frame fills. Link actions include their resolved HTTPS destination, which is pinned into the native fingerprint. Caller and exact target are revalidated after authorization; `useCredential` also permits card submission through its existing `submit: true` grant.

```mermaid
sequenceDiagram
  participant Pass as Protected pass
  participant Host as BrowserCredentialAccess
  participant Native as Private native transport
  Pass->>Native: Validate current opaque ref
  Pass->>Host: authorizeAction(caller, action, exposures)
  Host-->>Pass: Current host grant or typed denial
  Pass->>Native: Revalidate caller/target, dispatch
  Pass->>Host: Recheck observation trust
```

Hosts may return `CredentialObservationGrant.make({ decision: "trust-recipient-no-credential-echo", origins: [...] })` to select observation recipients. The top origin must be included; excluded frames supply no text or usable refs, and narrowing during discovery withholds the result. The existing string grant keeps its all-current-origin meaning.

Credential roles (including username) still require `useCredential`; no submit is admitted without explicit authority. Ordinary fill, continuation, and submission retain finite budgets, current node/form/origin checks, sanitized uncertainty and exact-session cleanup. Automatic trust based on card exposure and plaintext credential fallbacks were rejected because they bypass host authority.

Validation: all 67 focused browser tests (65 policy, 2 native Chrome), uncached checks for both affected package types, and the exact-head aggregate `ready`/component CI pass. Automated and independent reviews are clean after the link-destination and asynchronous caller-authorization fixes. Includes a changeset. No deployment or live credential evidence is claimed.
