### PR TITLE
fix(platform-cloudflare): expose shared producer gate for composition

### DIFF
--- a/.changeset/shared-publication-gate.md
+++ b/.changeset/shared-publication-gate.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Expose the native producer gate through Thread Object services so rebuilt runtime and maintenance Layers share in-flight publication activity.

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -319,7 +319,11 @@ const stableExternalWait = (
   }
 };
 
-/** @internal Shared prearm/acknowledgement boundary for ingress and runtime-owned producers. */
+/**
+ * Shared prearm/acknowledgement boundary for ingress and runtime-owned producers.
+ * `ThreadObject.layer` provides this same instance in its Services. Rebuilt runtime/maintenance
+ * Layers must reuse that instance; a second gate cannot observe the native producers' activity.
+ */
 export class ThreadMutationGate extends Context.Service<
   ThreadMutationGate,
   {

--- a/packages/platform-cloudflare/src/internal/layers.ts
+++ b/packages/platform-cloudflare/src/internal/layers.ts
@@ -171,6 +171,7 @@ export type CloudflareDurableRuntimeServices =
   | WakeScheduler
   | DurableAlarmService
   | ThreadMaintenance
+  | ThreadMutationGate
   | ThreadPublication
   | ThreadObjectPorts
   | ProgressWaitRegistry;
@@ -469,6 +470,6 @@ export const layerFromBindings = <E = never, R = never>(
         runtimeStack,
         ThreadMaintenance.layer.pipe(Layer.provide(runtimeStack)),
         portsEndpointLayer,
-      ).pipe(Layer.provideMerge(publication), Layer.provide(ThreadMutationGate.layer));
+      ).pipe(Layer.provideMerge(publication), Layer.provideMerge(ThreadMutationGate.layer));
     }),
   );

--- a/packages/platform-cloudflare/test/publication.test.ts
+++ b/packages/platform-cloudflare/test/publication.test.ts
@@ -1,3 +1,4 @@
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
 import { ApprovalDecisionCommand, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
 import { ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
@@ -6,13 +7,14 @@ import { DurableObject } from "effect-cf";
 import { TestClock } from "effect/testing";
 import { describe, expect, expectTypeOf, it } from "vite-plus/test";
 
-import type { DurableAlarmError } from "../src/Alarm.ts";
+import type { DurableAlarmError, ThreadMutationGate } from "../src/Alarm.ts";
 import { ThreadMaintenance, ThreadPublication } from "../src/Alarm.ts";
 import {
   DurableObjectContext,
   ThreadObjectIdentity,
   ThreadObjectNamespace,
 } from "../src/CloudflareBindings.ts";
+import type { CloudflarePlatformConfigError } from "../src/CloudflareConfig.ts";
 import { CloudflareThreadClient } from "../src/CloudflareThreadClient.ts";
 import * as ThreadObject from "../src/ThreadObject.ts";
 import {
@@ -207,6 +209,50 @@ describe("durable host publication", () => {
       expect((await cursor(thread)).source).toBe(1);
     }));
 
+  it("rebuilt maintenance observes an in-flight native ledger producer through the exported gate", () =>
+    withThread(async (thread) => {
+      const receipt = await submit(thread, approvalDefinition);
+
+      await drainAlarmsUntil(thread, anyInState(thread, "suspended", namespace), { namespace });
+      await quiesce(thread);
+      const before = await cursor(thread);
+
+      armMaintenancePause(thread, "maintenance:mutation:armed");
+
+      // Bypass ingress maintenance: only the source port's ORIGINAL producer gate is active.
+      const producer = runInDurableObject(stub(thread), (instance) =>
+        instance[DurableObject.RunSymbol](
+          SubmissionLedger.use((ledger) =>
+            ledger.recordApprovalDecision(
+              ApprovalDecisionCommand.make({
+                submissionId: receipt.submissionId,
+                toolCallId: BOOK_TOOL_CALL_ID,
+                decision: "approved",
+                resolver: "publication-composition-test",
+                reason: "share native producer activity",
+              }),
+            ),
+          ),
+        ),
+      );
+
+      await awaitMaintenancePause(thread, "maintenance:mutation:armed");
+      try {
+        await alarm(thread);
+        expect((await cursor(thread)).generation).toBe(before.generation);
+        const state = await generation(thread);
+
+        expect(state.dirty).toBeGreaterThan(state.processed);
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      } finally {
+        releaseMaintenancePause(thread);
+        await producer;
+      }
+      await quiesce(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+      expect((await cursor(thread)).decisions).toEqual(["approved"]);
+    }));
+
   it("keeps a producer racing an empty publication drain armed", () =>
     withThread(async (thread) => {
       await alarm(thread);
@@ -371,4 +417,21 @@ it("preserves publication setup E/R/Scope and releases resources on typed initia
       }),
     ),
   );
+});
+
+it("provides the native gate to fresh maintenance and runtime Layers without new requirements", () => {
+  const rebuilt = Layer.fresh(ThreadMaintenance.layer).pipe(
+    Layer.provideMerge(DurableAgentRuntime.layerWithBindings([])),
+    Layer.provideMerge(ThreadObject.layer([])),
+  );
+
+  expectTypeOf<
+    Extract<ThreadObject.Services, ThreadMutationGate>
+  >().toEqualTypeOf<ThreadMutationGate>();
+  expectTypeOf<Layer.Services<typeof rebuilt>>().toEqualTypeOf<
+    ThreadObject.BootstrapServices | DurableObjectContext | ThreadObjectNamespace
+  >();
+  expectTypeOf<Layer.Error<typeof rebuilt>>().toEqualTypeOf<
+    Exclude<ThreadObject.InitializationError, CloudflarePlatformConfigError>
+  >();
 });

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -17,12 +17,14 @@ import {
 } from "@effect-agent/platform-cloudflare/CloudflareScheduling";
 import { makeSubscriptionPartitionObjectClass } from "@effect-agent/platform-cloudflare/CloudflareSubscriptions";
 import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
 import { OperationDenied } from "@effect-agent/thread/OperationAuthorizer";
 import { ScheduleAuthorizer, ScheduleFailpoint } from "@effect-agent/thread/Schedule";
 import { Clock, Context, Crypto, Effect, Layer, Schema } from "effect";
 import { DurableObject, DurableObjectState, RpcTracing, WorkerEnvironment } from "effect-cf";
 import { OtlpExporter } from "effect/unstable/observability";
 
+import { ThreadMaintenance } from "../src/Alarm.ts";
 import { layerFromBindings } from "../src/internal/layers.ts";
 import {
   THREADS_BINDING,
@@ -317,9 +319,14 @@ const maintenanceClockLayer = Layer.effect(
 export class PublicationThreadObject extends ThreadObject.make(
   Layer.unwrap(
     Effect.map(makeTestBindings, (bindings) =>
-      layerFromBindings(bindings, { publication: publicationLayer }),
+      Layer.fresh(ThreadMaintenance.layer).pipe(
+        Layer.provideMerge(DurableAgentRuntime.layerWithBindings(bindings)),
+      ),
     ),
-  ).pipe(Layer.provideMerge(maintenanceClockLayer)),
+  ).pipe(
+    Layer.provideMerge(ThreadObject.layer([], { publication: publicationLayer })),
+    Layer.provideMerge(maintenanceClockLayer),
+  ),
   { ...baseOptions, namespaceBinding: "PUBLICATIONS" },
 ) {}
 


### PR DESCRIPTION
Rebuilding `DurableAgentRuntime` and `Layer.fresh(ThreadMaintenance.layer)` over `ThreadObject.layer` previously left `ThreadMutationGate` unsatisfied. Export the existing native gate through `ThreadObject.Services` and retain it with `Layer.provideMerge`, so rebuilt maintenance observes the same producer activity.

```ts
Layer.fresh(ThreadMaintenance.layer).pipe(
  Layer.provideMerge(DurableAgentRuntime.layerWithBindings(bindings)),
  Layer.provideMerge(ThreadObject.layer([], { publication })),
);
```

```mermaid
flowchart LR
  T[ThreadObject Services] --> G[Same native producer gate]
  P[Native source writers] --> G
  M[Rebuilt ThreadMaintenance] --> G
```

Creating another gate would allow maintenance to certify a generation while a native producer is still in flight. The Workerd fixture now uses this exact composition, and the new regression pauses a raw ledger writer outside ingress maintenance before checking generation/alarm retention. Type assertions verify the exported service and unchanged E/R requirements.

Validation: focused lint and package typecheck; 35 Workerd publication, alarm and registration tests pass. Includes a changeset. Exact-head full CI is the remaining handoff gate; no duplicate local full-suite run.
