### PR TITLE
fix: tighten Effect contracts and runtime boundaries

### DIFF
--- a/.changeset/bounded-host-cleanup.md
+++ b/.changeset/bounded-host-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/sandbox-local": patch
+---
+
+Bound Cloudflare progress-wait cancellation and Quick Action response cleanup, and retain cancellation hints for late progress retries. Apply sandbox wall-time limits to configuration, process startup, and execution together.

--- a/.changeset/consistent-storage-recovery.md
+++ b/.changeset/consistent-storage-recovery.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Keep admission identities and applied input markers consistent across storage adapters, and reject checkpoints whose payload disagrees with stored metadata. Read SQLite recovery snapshots without acquiring a write lock.

--- a/.changeset/distinct-budget-identities.md
+++ b/.changeset/distinct-budget-identities.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/capabilities": patch
+---
+
+Keep delimiter-containing budget IDs independent and retain typed subagent result projection failures in durable delegation. Reduce UTF-8 sizing allocations and repeated JSON validation without changing encoded limits.

--- a/.changeset/preserve-schema-requirements.md
+++ b/.changeset/preserve-schema-requirements.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+---
+
+Preserve tool parameter encoder requirements in agent composition and validate policy bounds through Schema. Reduce UTF-8 sizing allocations and repeated response and prompt traversal.

--- a/.changeset/preserve-testing-failures.md
+++ b/.changeset/preserve-testing-failures.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/testing": patch
+---
+
+Reject hostile program outputs through typed errors and detach accepted JSON results and diagnostics from program-owned objects. Preserve defects and interruption when Chaos tolerates injected typed failures.

--- a/.changeset/run-scoped-thread-projections.md
+++ b/.changeset/run-scoped-thread-projections.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/thread": minor
+---
+
+Keep completed Steps and projected tool calls distinct when component IDs contain separators or are reused across runs.
+
+BEHAVIOR CHANGE: Include `schemaVersion: 2` on manually created `ThreadProjection` values and `runId` on `SubagentInvocationState`; discard and rebuild checkpoints whose projection state fails Schema decoding.

--- a/.changeset/shared-node-recovery-scans.md
+++ b/.changeset/shared-node-recovery-scans.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-node": patch
+---
+
+Share periodic recovery scans across active wake subscribers while retaining every lane in large scans. Stop scanning when the last subscriber leaves and restart on later demand.

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -30,6 +30,11 @@ applied input and terminal outcomes. Projections, checkpoints, indexes, and UI v
 
 Replay rebuilds state from records. It never executes a tool or repeats an external effect.
 
+`ThreadProjection` version 2 scopes open tool calls and subagent invocations by Run and Tool Call
+ID. Decode checkpoint state with its Schema before replaying a suffix. Earlier projection states,
+including empty views, fail decoding and must be discarded and rebuilt from canonical records.
+The canonical record and checkpoint envelope versions remain unchanged.
+
 ## Track unfinished work {#operational-obligation}
 
 The submission ledger owns admission, FIFO readiness, attempt ownership, abort intent, recovery,
@@ -53,6 +58,11 @@ If an ordinary tool may have finished before its worker disappeared, recovery re
 
 Durable Steps record one result for each deterministic Step name. Their external execution is at
 least once and may repeat. Applications still need idempotency, reconciliation, or compensation.
+
+Step identity includes the Run ID, Tool Call ID, and Step name. New Step record and batch IDs use
+a versioned JSON tuple so separator characters cannot merge distinct Steps. Recovery derives
+the same identity from each recorded payload, preserving completed Steps stored with older IDs
+without executing their bodies again.
 
 ## Reuse the same agent definition {#one-authoring-model}
 

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -27,6 +27,10 @@ administration contract applies to Node and SQLite class `DN` and Cloudflare Dur
 Cloudflare Thread Objects expose encoded administration methods through the application's
 Worker.
 
+The `explain --thread <id> --json` payload is an array of recovery explanations, including `[]`
+when the lane has no nonterminal work. `explain --submission <id> --json` returns one explanation
+object.
+
 The administrative methods above, observation, settlement waits, abort, and unknown or approval
 resolution consult `OperationAuthorizer`. Its default allows trusted service holders. Install a
 real authorizer before exposing these methods outside a trusted host. Denial fails as

--- a/docs/guide/sandbox.md
+++ b/docs/guide/sandbox.md
@@ -116,9 +116,10 @@ process cleanup.
 
 ## Limits and local adapter boundaries
 
-The local adapter enforces its wall-clock limit and combined stdout and stderr byte limit. It does
-not enforce process isolation, mount access, CPU limits, memory limits, secret-handle resolution,
-or artifact collection. Requests that ask for those features fail as
+The local adapter enforces one wall-clock limit across environment loading, process startup, and
+stream consumption. Output activity does not reset this deadline. It also enforces the combined
+stdout and stderr byte limit. It does not enforce process isolation, mount access, CPU limits,
+memory limits, secret-handle resolution, or artifact collection. Requests that ask for those features fail as
 `SandboxUnsupportedRequestError` before the process starts.
 
 `NetworkDisabled` is required by the local adapter because it rejects allowlists. It is only a

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -203,6 +203,8 @@ principal, idempotency key, and definition digests. Return its receipt after adm
 Use `client.awaitSettlement(receipt)` for completion.
 For updates, call `readPage`, then `awaitProgress`, then read after the last received sequence.
 Scope progress waits so interruption cancels them remotely.
+Cancellation is best effort and waits at most one second for the remote reply, so a lost reply
+does not prevent local shutdown. The Object retains bounded cancellation hints for late retries.
 Expose these Effects through your application's HTTP or RPC API.
 
 ## Shared memory {#shared-memory}

--- a/docs/platforms/node.md
+++ b/docs/platforms/node.md
@@ -30,6 +30,8 @@ The version declarations identify the agent, model, and tools used by accepted w
 Use a persistent database path with one live host per SQLite file. Give each replacement host
 incarnation a distinct `producerId`.
 `workerConcurrency` limits worker loops and defaults to one.
+Active workers share one periodic ledger scan.
+The scan stops when the last subscriber leaves and restarts when another subscribes.
 `NodeDurableHost.layer` checks storage, recovers pending work, and starts the worker pool when
 the Layer is acquired. Save this as `node-host.ts`, replacing `producerId` for each process start:
 

--- a/packages/capabilities/src/Approval.ts
+++ b/packages/capabilities/src/Approval.ts
@@ -1,6 +1,7 @@
 import { ThreadId, RunId, ToolCallId } from "@effect-agent/core/Identifiers";
-import { Clock, Context, DateTime, Duration, Effect, Encoding, Layer, Ref, Schema } from "effect";
+import { Clock, Context, DateTime, Duration, Effect, Layer, Ref, Schema } from "effect";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
 import { RedactedPreview, Redactor, type RedactionError } from "./Redaction.ts";
 
 const MAX_APPROVAL_TARGETS = 32;
@@ -12,7 +13,7 @@ const ApprovalTargets = Schema.Array(Schema.String.check(Schema.isMaxLength(2 * 
   .pipe(
     Schema.refine(
       (targets): targets is ReadonlyArray<string> =>
-        targets.reduce((total, target) => total + Encoding.encodeHex(target).length / 2, 0) <=
+        targets.reduce((total, target) => total + utf8ByteLength(target), 0) <=
         MAX_APPROVAL_TARGET_BYTES,
       { expected: `approval targets totaling at most ${MAX_APPROVAL_TARGET_BYTES} UTF-8 bytes` },
     ),

--- a/packages/capabilities/src/Budget.ts
+++ b/packages/capabilities/src/Budget.ts
@@ -221,6 +221,11 @@ const sameLimits = (a: UsageBudgetLimits, b: UsageBudgetLimits): boolean =>
   a.maxCostMicrousd === b.maxCostMicrousd &&
   a.maxDurationMillis === b.maxDurationMillis;
 
+// JSON escapes lone surrogates before URI encoding; every valid string stays distinct,
+// and an ID can never introduce the path separator used by retirement.
+const nodeKeyComponent = (config: UsageBudgetNodeConfig): string =>
+  `${config.level}:${encodeURIComponent(JSON.stringify(config.id))}`;
+
 const durationExceeded = (node: LedgerNode, now: number): BudgetExceeded => {
   const limitValue = node.config.limits.maxDurationMillis ?? 0;
 
@@ -356,7 +361,7 @@ const makeNode = (
     });
 
   const child = Effect.fn("UsageBudgetNode.child")(function* (childConfig: UsageBudgetNodeConfig) {
-    const childKey = `${key}/${childConfig.level}:${childConfig.id}`;
+    const childKey = `${key}/${nodeKeyComponent(childConfig)}`;
     const childHandleId = Symbol(`usage-budget:${childConfig.level}:${childConfig.id}`);
     const now = yield* Clock.currentTimeMillis;
 
@@ -500,7 +505,7 @@ export const makeUsageBudgetRoot = Effect.fn("makeUsageBudgetRoot")(function* (
   config: UsageBudgetNodeConfig,
 ) {
   const startedAt = yield* Clock.currentTimeMillis;
-  const key = `${config.level}:${config.id}`;
+  const key = nodeKeyComponent(config);
   const handleId = Symbol(`usage-budget:${config.level}:${config.id}`);
 
   const ledger = yield* Ref.make<BudgetLedger>({

--- a/packages/capabilities/src/CodeMode.ts
+++ b/packages/capabilities/src/CodeMode.ts
@@ -22,6 +22,8 @@ import { NetworkDisabled } from "@effect-agent/sandbox/Sandbox";
 import { type Layer, Context, Duration, Effect, Option, Schema, type Scope } from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
+
 /**
  * Code Mode (D-035, ADR-0017; capability spec §9.1): one native Effect AI
  * Tool whose input is bounded JavaScript source, executed in one isolated
@@ -39,18 +41,6 @@ const BoundedErrorTag = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 const BoundedLogLine = Schema.String.check(Schema.isMaxLength(16 * 1024));
 const BoundedLogs = Schema.Array(BoundedLogLine).check(Schema.isMaxLength(4_096));
 const BoundedCode = Schema.NonEmptyString.check(Schema.isMaxLength(512 * 1024));
-
-const utf8ByteLength = (value: string): number => {
-  let total = 0;
-
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-
-    total += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
-  }
-
-  return total;
-};
 
 const encodedJsonByteLength = (value: unknown): number | undefined => {
   try {

--- a/packages/capabilities/src/EphemeralThreads.ts
+++ b/packages/capabilities/src/EphemeralThreads.ts
@@ -1,6 +1,8 @@
 import { ThreadId, RunId } from "@effect-agent/core/Identifiers";
-import { Clock, Context, DateTime, Effect, Encoding, Layer, Schema, SynchronizedRef } from "effect";
+import { Clock, Context, DateTime, Effect, Layer, Schema, SynchronizedRef } from "effect";
 import { Prompt } from "effect/unstable/ai";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 /** Bound applied to one text projection before it can enter a model context. */
 export const ThreadText = Schema.String.check(Schema.isMaxLength(64 * 1024));
@@ -120,8 +122,6 @@ export class EphemeralThreads extends Context.Service<
   }
 >()("@effect-agent/capabilities/EphemeralThreads") {}
 
-const utf8Bytes = (value: string): number => Encoding.encodeHex(value).length / 2;
-
 const encodeMessage = (
   threadId: ThreadId,
   message: Prompt.Message,
@@ -172,7 +172,7 @@ const appendEncoded = Effect.fn("EphemeralThreads.appendEncoded")(function* (
       observedValue: current.messages.length + 1,
     });
   }
-  const messageBytes = utf8Bytes(encoded);
+  const messageBytes = utf8ByteLength(encoded);
   const contentBytes = current.contentBytes + messageBytes;
 
   if (contentBytes > MAX_THREAD_CONTENT_BYTES) {

--- a/packages/capabilities/src/Mcp.ts
+++ b/packages/capabilities/src/Mcp.ts
@@ -1,4 +1,5 @@
 import {
+  Array,
   type JsonSchema,
   Context,
   Crypto,
@@ -14,12 +15,12 @@ import {
 import { Tool, type Toolkit } from "effect/unstable/ai";
 import * as McpSchema from "effect/unstable/ai/McpSchema";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
+
 const MAX_MCP_TOOLS = 128;
 const MAX_MCP_DISCOVERY_BYTES = 1024 * 1024;
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0));
 const Sha256Digest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/));
-const JsonArray = Schema.Array(Schema.Json);
-const isJsonArray = Schema.is(JsonArray);
 
 /** Server identity copied directly from Effect AI's native MCP initialization schema. */
 export class McpServerIdentity extends Schema.Class<McpServerIdentity>(
@@ -134,8 +135,6 @@ export class McpConnector extends Context.Service<
   }
 >()("@effect-agent/capabilities/McpConnector") {}
 
-const encodedBytes = (value: string): number => Encoding.encodeHex(value).length / 2;
-
 /**
  * `Tool.getJsonSchema`/`Tool.getJsonSchemaFromSchema` hoist a named, refined
  * type into `$defs` with a top-level `$ref`, but a real MCP server can only
@@ -167,7 +166,7 @@ const canonicalJson = (value: Schema.Json): Schema.Json => {
   ) {
     return value;
   }
-  if (isJsonArray(value)) return value.map(canonicalJson);
+  if (Array.isArray<Schema.Json>(value)) return value.map(canonicalJson);
   const output: Record<string, Schema.Json> = {};
 
   // Keys sort by UTF-16 code units (RFC 8785 style): locale-aware collation varies
@@ -264,7 +263,7 @@ export const validateMcpDiscovery = Effect.fn("validateMcpDiscovery")(function* 
     });
   }
   for (const tool of server.tools) {
-    const descriptionBytes = encodedBytes(tool.description ?? "");
+    const descriptionBytes = utf8ByteLength(tool.description ?? "");
 
     if (descriptionBytes > request.maxToolDescriptionBytes) {
       return yield* McpDiscoveryLimitExceeded.make({
@@ -378,7 +377,7 @@ export const validateMcpDiscovery = Effect.fn("validateMcpDiscovery")(function* 
     ),
   );
 
-  const discoveryBytes = encodedBytes(discoveryText);
+  const discoveryBytes = utf8ByteLength(discoveryText);
 
   if (discoveryBytes > request.maxDiscoveryBytes) {
     return yield* McpDiscoveryLimitExceeded.make({

--- a/packages/capabilities/src/McpClient.ts
+++ b/packages/capabilities/src/McpClient.ts
@@ -3,7 +3,6 @@ import {
   Cause,
   Context,
   Effect,
-  Encoding,
   Layer,
   Option,
   Predicate,
@@ -24,6 +23,7 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { RpcClient, RpcClientError, type RpcMessage, RpcSerialization } from "effect/unstable/rpc";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
 import {
   McpConnectionError,
   McpConnector,
@@ -212,8 +212,6 @@ const routeMessage = (
   return options.writeResponse(options.clientId, message as RpcMessage.FromServerEncoded);
 };
 
-const byteLength = (text: string): number => Encoding.encodeHex(text).length / 2;
-
 /** Reads a response body as text while refusing bodies above `maxBytes`. */
 const readBoundedText = Effect.fn("McpHttpTransport.readBoundedText")(function* (
   response: HttpClientResponse.HttpClientResponse,
@@ -232,7 +230,7 @@ const readBoundedText = Effect.fn("McpHttpTransport.readBoundedText")(function* 
   yield* response.stream.pipe(
     Stream.decodeText(),
     Stream.runForEach((chunk) => {
-      received += byteLength(chunk);
+      received += utf8ByteLength(chunk);
       if (received > maxBytes) {
         return Effect.fail(
           protocolDefect(`MCP response exceeds the ${maxBytes} byte message bound`),
@@ -292,7 +290,7 @@ const consumeEventStream = Effect.fn("McpHttpTransport.consumeEventStream")(func
         blocks.push(buffer);
         buffer = "";
       }
-      pendingBytes = byteLength(buffer);
+      pendingBytes = utf8ByteLength(buffer);
 
       return Effect.forEach(blocks, dispatchEvent, { discard: true });
     });
@@ -301,7 +299,7 @@ const consumeEventStream = Effect.fn("McpHttpTransport.consumeEventStream")(func
     Stream.decodeText(),
     Stream.runForEach((chunk) => {
       buffer += chunk;
-      pendingBytes += byteLength(chunk);
+      pendingBytes += utf8ByteLength(chunk);
       if (pendingBytes > maxBytes) {
         return Effect.fail(protocolDefect(`MCP event stream buffered more than ${maxBytes} bytes`));
       }

--- a/packages/capabilities/src/MemoryNotes.ts
+++ b/packages/capabilities/src/MemoryNotes.ts
@@ -17,12 +17,14 @@ import {
   DurableStepError,
   ToolExecutionClass,
 } from "@effect-agent/engine/DurableStep";
-import { Clock, Effect, Encoding, Schema } from "effect";
+import { Clock, Effect, Schema } from "effect";
 import { IdGenerator, Tool, Toolkit } from "effect/unstable/ai";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const NotesText = Schema.String.check(
   Schema.isMaxLength(20_000),
-  Schema.makeFilter((text) => Encoding.encodeHex(JSON.stringify(text)).length / 2 <= 32_768, {
+  Schema.makeFilter((text) => utf8ByteLength(JSON.stringify(text)) <= 32_768, {
     expected: "notes totaling at most 32768 JSON-encoded UTF-8 bytes",
   }),
 );

--- a/packages/capabilities/src/ModelContext.ts
+++ b/packages/capabilities/src/ModelContext.ts
@@ -3,6 +3,7 @@ import { Crypto, Effect, Encoding, Schema } from "effect";
 import type { Prompt } from "effect/unstable/ai";
 
 import { ThreadMessage, ThreadSnapshot, ThreadText } from "./EphemeralThreads.ts";
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const MAX_CONTEXT_MESSAGES = 1_024;
 const MAX_CONTEXT_MESSAGE_BYTES = 4 * 1024 * 1024;
@@ -32,14 +33,12 @@ export class RetainedFact extends Schema.Class<RetainedFact>(
   sourceSequences: SourceSequences,
 }) {}
 
-const encodedBytes = (value: string): number => Encoding.encodeHex(value).length / 2;
-
 const ModelContextMessages = Schema.Array(ModelContextMessage)
   .check(Schema.isMaxLength(MAX_CONTEXT_MESSAGES))
   .pipe(
     Schema.refine(
       (messages): messages is ReadonlyArray<ModelContextMessage> =>
-        messages.reduce((total, message) => total + encodedBytes(message.content), 0) <=
+        messages.reduce((total, message) => total + utf8ByteLength(message.content), 0) <=
         MAX_CONTEXT_MESSAGE_BYTES,
       { expected: `model context totaling at most ${MAX_CONTEXT_MESSAGE_BYTES} UTF-8 bytes` },
     ),
@@ -50,7 +49,7 @@ const RetainedFacts = Schema.Array(RetainedFact)
   .pipe(
     Schema.refine(
       (facts): facts is ReadonlyArray<RetainedFact> =>
-        facts.reduce((total, retained) => total + encodedBytes(retained.fact), 0) <=
+        facts.reduce((total, retained) => total + utf8ByteLength(retained.fact), 0) <=
         MAX_RETAINED_FACT_BYTES,
       { expected: `retained facts totaling at most ${MAX_RETAINED_FACT_BYTES} UTF-8 bytes` },
     ),
@@ -159,7 +158,7 @@ const validateModelView = (
       }),
     );
   }
-  const bytes = messages.reduce((total, message) => total + encodedBytes(message.content), 0);
+  const bytes = messages.reduce((total, message) => total + utf8ByteLength(message.content), 0);
 
   return bytes > MAX_CONTEXT_MESSAGE_BYTES
     ? Effect.fail(

--- a/packages/capabilities/src/Redaction.ts
+++ b/packages/capabilities/src/Redaction.ts
@@ -1,25 +1,15 @@
 import { RunEvent } from "@effect-agent/core/RunEvent";
 import { Context, Effect, Layer, Schema } from "effect";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
+
 const MAX_REDACTED_PREVIEW_BYTES = 8 * 1024;
 const MAX_REDACTION_NODES = 4_096;
 const MAX_REDACTION_DEPTH = 16;
 
-const utf8Bytes = (value: string): number => {
-  let total = 0;
-
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-
-    total += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
-  }
-
-  return total;
-};
-
 /** Branded evidence that a preview passed through the configured structural Redactor. */
 export const RedactedPreview = Schema.String.pipe(
-  Schema.refine((value): value is string => utf8Bytes(value) <= MAX_REDACTED_PREVIEW_BYTES, {
+  Schema.refine((value): value is string => utf8ByteLength(value) <= MAX_REDACTED_PREVIEW_BYTES, {
     expected: `redacted preview of at most ${MAX_REDACTED_PREVIEW_BYTES} UTF-8 bytes`,
   }),
   Schema.brand("@effect-agent/capabilities/RedactedPreview"),
@@ -85,16 +75,16 @@ const redactValue = (value: unknown, depth: number, counter: RedactionCounter): 
 };
 
 const truncateUtf8 = (value: string, maxBytes: number): string => {
-  if (utf8Bytes(value) <= maxBytes) {
+  if (utf8ByteLength(value) <= maxBytes) {
     return value;
   }
   const suffix = "…";
-  const suffixBytes = utf8Bytes(suffix);
+  const suffixBytes = utf8ByteLength(suffix);
   let output = "";
   let bytes = 0;
 
   for (const character of value) {
-    const characterBytes = utf8Bytes(character);
+    const characterBytes = utf8ByteLength(character);
 
     if (bytes + characterBytes + suffixBytes > maxBytes) {
       break;

--- a/packages/capabilities/src/Remembering.ts
+++ b/packages/capabilities/src/Remembering.ts
@@ -11,6 +11,8 @@ import {
 import * as Protocol from "@effect-agent/core/RememberingStore";
 import { Effect, Encoding, Schema } from "effect";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
+
 export class Limits extends Schema.Class<Limits>("@effect-agent/remembering/Limits")({
   maxSourceBytes: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 4_194_304 })),
   maxProposalBytes: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 1_048_576 })),
@@ -64,7 +66,6 @@ const sameKey = (left: MemoryKey, right: MemoryKey): boolean =>
   left.id === right.id && left.namespace.address === right.namespace.address;
 
 const encodeIntent = Schema.encodeSync(Protocol.Intent.Wire);
-const byteLength = (text: string): number => Encoding.encodeHex(text).length / 2;
 
 const validateSource = Effect.fn("Remembering.validateSource")(function* (
   intent: Protocol.Intent,
@@ -80,7 +81,7 @@ const validateSource = Effect.fn("Remembering.validateSource")(function* (
 
   if (!equal(actual, expected))
     return yield* Protocol.ProcessingError.make({ reason: "source-changed" });
-  if (byteLength(source.text) > limits.maxSourceBytes)
+  if (utf8ByteLength(source.text) > limits.maxSourceBytes)
     return yield* Protocol.ProcessingError.make({ reason: "budget" });
 
   return source;
@@ -319,7 +320,7 @@ export const make = <
       if (
         progress._tag === "Proposed" &&
         suppression === null &&
-        byteLength(JSON.stringify(progress.proposal)) > limits.maxProposalBytes
+        utf8ByteLength(JSON.stringify(progress.proposal)) > limits.maxProposalBytes
       )
         return yield* Protocol.ProcessingError.make({ reason: "budget" });
       const failpoint = yield* Protocol.MutationFailpoint;
@@ -397,7 +398,7 @@ export const make = <
           evidence: extracted.evidence,
         });
 
-        if (byteLength(JSON.stringify(proposal)) > limits.maxProposalBytes)
+        if (utf8ByteLength(JSON.stringify(proposal)) > limits.maxProposalBytes)
           return yield* Protocol.ProcessingError.make({ reason: "budget" });
         yield* validateEvidence(source, proposal);
 

--- a/packages/capabilities/src/SemanticMemory.ts
+++ b/packages/capabilities/src/SemanticMemory.ts
@@ -24,6 +24,8 @@ import {
 import { Clock, Crypto, Effect, Encoding, Schema } from "effect";
 import { EmbeddingModel } from "effect/unstable/ai";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
+
 const Timestamp = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0));
 const InputTokens = Schema.NullOr(Schema.Natural);
 
@@ -99,8 +101,6 @@ const utf8 = (text: string): Uint8Array => {
     Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16),
   );
 };
-
-const byteLength = (text: string): number => Encoding.encodeHex(text).length / 2;
 
 const invalid = (operation: string) =>
   SemanticMemoryError.make({ operation, reason: "invalid-input" });
@@ -187,7 +187,7 @@ const chunkText = Effect.fn("semanticMemory.chunkText")(function* (
   profile: SemanticMemoryProfile,
   limits: SemanticIndexLimits,
 ) {
-  if (byteLength(text) > limits.maxSourceBytes) {
+  if (utf8ByteLength(text) > limits.maxSourceBytes) {
     return yield* SemanticMemoryError.make({ operation: "chunk source", reason: "budget" });
   }
 
@@ -203,7 +203,7 @@ const chunkText = Effect.fn("semanticMemory.chunkText")(function* (
   let currentBytes = 0;
 
   for (const codepoint of text) {
-    const size = byteLength(codepoint);
+    const size = utf8ByteLength(codepoint);
 
     if (currentBytes + size > profile.maxChunkBytes) {
       chunks.push({
@@ -334,7 +334,7 @@ export const indexMemorySource = Effect.fn("indexMemorySource")(function* <
       key: checkedKey,
       status: "Indexed",
       embeddedChunks: chunks.length,
-      embeddedBytes: byteLength(document.content.text),
+      embeddedBytes: utf8ByteLength(document.content.text),
       inputTokens: response.usage.inputTokens ?? null,
       startedAt,
       finishedAt: yield* Clock.currentTimeMillis,
@@ -381,7 +381,7 @@ export const querySemanticMemory = Effect.fn("querySemanticMemory")(function* (
     Effect.mapError(() => invalid("query limits")),
   );
 
-  const queryBytes = byteLength(checkedQuery);
+  const queryBytes = utf8ByteLength(checkedQuery);
 
   if (queryBytes > checkedLimits.maxQueryBytes)
     return yield* SemanticMemoryError.make({ operation: "query bytes", reason: "budget" });

--- a/packages/capabilities/src/Subagent.ts
+++ b/packages/capabilities/src/Subagent.ts
@@ -49,6 +49,7 @@ import type { Layer } from "effect";
 import { Clock, Duration, Effect, Option, Ref, Schema } from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
 import {
   type BudgetReservationId,
   makeBudgetReservationId,
@@ -1216,18 +1217,6 @@ const encodeExecutionFailure = Schema.encodeEffect(SubagentExecutionFailure);
 const encodeGrant = Schema.encodeEffect(SubagentGrant);
 const encodeAllocationAmounts = Schema.encodeEffect(SubagentReservationAmounts);
 
-const utf8ByteLength = (value: string): number => {
-  let total = 0;
-
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-
-    total += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
-  }
-
-  return total;
-};
-
 const toNatural = (value: number): number =>
   Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 
@@ -1540,7 +1529,11 @@ const layer = <
   const encodeChildInput = Schema.encodeEffect(delegation.target.input);
   const encodeSuccess = Schema.encodeEffect(delegation.success);
   const decodeChildOutput = Schema.decodeUnknownEffect(delegation.target.output);
-  const encodeDeclaredFailure = Schema.encodeEffect(delegation.failure);
+
+  const encodeResultProjectionFailure = Schema.encodeEffect(
+    Schema.Union([delegation.failure, SubagentProjectionFailure]),
+  );
+
   const childToolNames = Object.keys(delegation.target.toolkit.tools);
 
   const childToolCallAllowance = (
@@ -2154,7 +2147,7 @@ const layer = <
             )
             .pipe(
               Effect.catch((declared) =>
-                encodeDeclaredFailure(declared).pipe(
+                encodeResultProjectionFailure(declared).pipe(
                   Effect.orDie,
                   Effect.flatMap((encodedFailure) => settleFailure(declared, encodedFailure)),
                 ),

--- a/packages/capabilities/src/internal/utf8.ts
+++ b/packages/capabilities/src/internal/utf8.ts
@@ -1,0 +1,12 @@
+/** Count UTF-8 bytes without allocating an encoded copy, including replacement bytes for lone surrogates. */
+export const utf8ByteLength = (value: string): number => {
+  let total = 0;
+
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+
+    total += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+  }
+
+  return total;
+};

--- a/packages/capabilities/test/capabilities.test.ts
+++ b/packages/capabilities/test/capabilities.test.ts
@@ -378,6 +378,36 @@ describe("capability contracts", () => {
   );
 
   it.effect(
+    "accounts exact encoded UTF-8 bytes for Unicode and lone-surrogate thread content",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+
+        yield* threads.create(threadId);
+        let expectedBytes = 0;
+
+        for (const content of [
+          "plain",
+          "\u007f\u0080\u07ff\u0800",
+          "🌊",
+          "\ud800",
+          "\udc00",
+          '"\\\n',
+        ]) {
+          const message = textMessage("user", content);
+          const encoded = yield* Schema.encodeEffect(Prompt.Message)(message);
+          const messageBytes = new TextEncoder().encode(JSON.stringify(encoded)).byteLength;
+
+          expectedBytes += messageBytes;
+          const snapshot = yield* threads.append(threadId, ThreadAppend.make({ message }));
+
+          expect(snapshot.messages.at(-1)?.encodedBytes).toBe(messageBytes);
+          expect(snapshot.contentBytes).toBe(expectedBytes);
+        }
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
     "structurally redacts decoded approval input and audits both timeout request and decision",
     () =>
       Effect.gen(function* () {
@@ -839,6 +869,68 @@ describe("capability contracts", () => {
         expect(decoded.scopeId).toBe("run-1");
       }
     }),
+  );
+
+  it.effect(
+    "keeps delimiter-bearing and Unicode budget identities independent through retirement",
+    () =>
+      Effect.gen(function* () {
+        const delta = UsageDelta.make({
+          modelCalls: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          toolCalls: 1,
+          costMicrousd: 0,
+        });
+
+        for (const id of ["t", "t/tenant:q", 't%2F"x', "🌊", "\ud800", "\udc00"]) {
+          const config = (level: "global" | "tenant" | "run", value: string) =>
+            UsageBudgetNodeConfig.make({ level, id: value, limits: UsageBudgetLimits.make({}) });
+
+          const root = yield* makeUsageBudgetRoot(config("global", id));
+          const tenantConfig = config("tenant", id);
+          const runConfig = config("run", "r");
+          const otherConfig = config("tenant", `${id}/run:r`);
+          const other = yield* root.child(otherConfig);
+          const tenant = yield* root.child(tenantConfig);
+          const run = yield* tenant.child(runConfig);
+          const sameOther = yield* root.child(otherConfig);
+          const sameRun = yield* tenant.child(runConfig);
+
+          yield* other.consume(delta);
+          yield* sameOther.consume(delta);
+          yield* run.consume(delta);
+          expect((yield* sameOther.snapshot).toolCalls).toBe(2);
+          expect((yield* sameRun.snapshot).toolCalls).toBe(1);
+          expect((yield* tenant.snapshot).toolCalls).toBe(1);
+          expect((yield* root.snapshot).toolCalls).toBe(3);
+
+          yield* other.retire;
+          yield* sameOther.retire;
+          const freshOther = yield* root.child(otherConfig);
+
+          expect((yield* freshOther.snapshot).toolCalls).toBe(0);
+          yield* sameRun.consume(delta);
+          expect((yield* run.snapshot).toolCalls).toBe(2);
+          expect((yield* tenant.snapshot).toolCalls).toBe(2);
+
+          yield* run.retire;
+          yield* sameRun.retire;
+          yield* tenant.retire;
+          const freshTenant = yield* root.child(tenantConfig);
+          const freshRun = yield* freshTenant.child(runConfig);
+
+          expect((yield* freshTenant.snapshot).toolCalls).toBe(0);
+          expect((yield* freshRun.snapshot).toolCalls).toBe(0);
+          expect((yield* root.snapshot).toolCalls).toBe(4);
+          yield* freshRun.retire;
+          yield* freshTenant.retire;
+          yield* freshOther.retire;
+          yield* root.retire;
+        }
+      }),
   );
 
   it.effect(

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -1797,6 +1797,116 @@ layer(TestServices)("SubagentRuntime S2 durable delegation", (it) => {
     }),
   );
 
+  it.effect("joins default and explicit projection failures in both durable failure modes", () =>
+    Effect.gen(function* () {
+      for (const contained of [false, true]) {
+        for (const explicit of [false, true]) {
+          const joins = yield* Ref.make<ReadonlyArray<RunSubagentJoinRequest>>([]);
+          const child = durableChildIdentity(`projection-${contained}-${explicit}`);
+
+          const configuration = {
+            target: childDefinition,
+            success: Schema.String,
+            ...(explicit
+              ? {
+                  projectResult: () =>
+                    Effect.fail(
+                      SubagentProjectionFailure.make({
+                        delegationId: researchDelegation.delegationId,
+                        stage: "result",
+                        message: "The result projection was refused",
+                      }),
+                    ),
+                }
+              : {}),
+          };
+
+          const errorDelegation = Subagent.define("delegate_research", configuration);
+
+          const returnDelegation = Subagent.define("delegate_research", {
+            ...configuration,
+            failureMode: "return",
+          });
+
+          const childModel = answeringModel("unused-projection-child", '{"answer":"unused"}');
+          const options = { durable: { targetDigests: durableDigests } };
+
+          const handlers = contained
+            ? SubagentRuntime.layer(returnDelegation, childModel, options)
+            : SubagentRuntime.layer(errorDelegation, childModel, options);
+
+          const parent = Agent.make("projection-parent", {
+            input: Schema.String,
+            output: Schema.String,
+            instructions: "Delegate, then answer.",
+            toolkit: Toolkit.make(contained ? returnDelegation.tool : errorDelegation.tool),
+            policy: parentPolicy,
+          });
+
+          const handle = yield* AgentRuntime.start(parent, "start", {
+            subagent: scriptedDurableHook({
+              establish: () => ({
+                _tag: "settled",
+                ...child,
+                outcome: "completed",
+                encodedResult: { answer: "private-child-output" },
+              }),
+              joins,
+            }),
+          }).pipe(
+            Effect.provide([
+              handlers,
+              delegatingModel(
+                "projection-parent",
+                "delegate_research",
+                [{ id: "projection", params: { question: "research" } }],
+                '"done"',
+              ),
+            ]),
+          );
+
+          const exit = yield* Effect.exit(handle.await);
+
+          if (contained) {
+            expect(Exit.isSuccess(exit)).toBe(true);
+            expect(findEvent(yield* handle.events, "ToolCallSucceeded")).toMatchObject({
+              result: { _tag: "SubagentProjectionFailure", stage: "result" },
+            });
+          } else {
+            expect(failureFrom(exit)).toBeInstanceOf(SubagentProjectionFailure);
+          }
+          const recorded = yield* Ref.get(joins);
+
+          expect(recorded).toHaveLength(1);
+          expect(recorded[0]).toMatchObject({
+            toolCallId: "projection",
+            isFailure: !contained,
+            encodedResult: {
+              _tag: "SubagentProjectionFailure",
+              stage: "result",
+              message: explicit
+                ? "The result projection was refused"
+                : "Child output did not satisfy the delegation success Schema",
+            },
+          });
+          expect(JSON.stringify(recorded)).not.toContain("private-child-output");
+
+          const proofs: [
+            Assert<
+              Equal<
+                Effect.Error<ReturnType<typeof errorDelegation.projectResult>>,
+                SubagentProjectionFailure
+              >
+            >,
+            Assert<Equal<Effect.Services<ReturnType<typeof errorDelegation.projectResult>>, never>>,
+          ] = [true, true];
+
+          expect(proofs).toEqual([true, true]);
+        }
+      }
+    }),
+  );
+
   it.effect("a failed child joins as the bounded framework failure (no raw cause)", () =>
     Effect.gen(function* () {
       const invocations = yield* Ref.make(0);

--- a/packages/core/src/Agent.ts
+++ b/packages/core/src/Agent.ts
@@ -240,6 +240,8 @@ export type DefinitionRequirements<DefinitionValue extends AnyDefinition> =
         | EffectServices<InputPromptEffect<DefinitionValue["inputPrompt"], Input<DefinitionValue>>>
         | Tool.HandlersFor<Tools<DefinitionValue>>
         | Tool.HandlerServices<ToolUnion<DefinitionValue>>
+        // The interpreter canonically re-encodes decoded Tool parameters before recording them.
+        | Tool.ParametersSchema<ToolUnion<DefinitionValue>>["EncodingServices"]
         | Tool.SuccessSchema<ToolUnion<DefinitionValue>>["DecodingServices"]
         | DefinitionValue["input"]["DecodingServices"]
         | DefinitionValue["input"]["EncodingServices"]

--- a/packages/core/src/AgentPolicy.ts
+++ b/packages/core/src/AgentPolicy.ts
@@ -66,7 +66,16 @@ const AgentPolicyFields = Schema.Struct({
   toolResultBounds: ToolResultBounds,
   runStatus: Schema.Literals(["appended", "off"]),
   compaction: CompactionPolicy,
-});
+}).check(
+  Schema.makeFilter((policy) =>
+    policy.tokenBudget !== undefined && policy.completionReserveTokens > policy.tokenBudget
+      ? {
+          path: ["completionReserveTokens"],
+          issue: "completionReserveTokens cannot exceed tokenBudget",
+        }
+      : undefined,
+  ),
+);
 
 type AgentPolicyFields = typeof AgentPolicyFields.Type;
 
@@ -129,10 +138,6 @@ export class AgentPolicy extends Schema.Class<AgentPolicy>("AgentPolicy")(AgentP
       (input.tokenBudget === undefined
         ? 4_096
         : Math.min(4_096, Math.floor(input.tokenBudget / 5)));
-
-    if (input.tokenBudget !== undefined && completionReserveTokens > input.tokenBudget) {
-      throw new Error("completionReserveTokens cannot exceed tokenBudget");
-    }
 
     return super.make({
       ...input,

--- a/packages/core/src/Memory.ts
+++ b/packages/core/src/Memory.ts
@@ -1,5 +1,6 @@
-import { Effect, Encoding, Predicate, Schema, type Scope } from "effect";
+import { Effect, Predicate, Schema, type Scope } from "effect";
 
+import { utf8ByteLength as bytes } from "./internal/utf8.ts";
 import {
   MemoryLookup,
   MemoryPassage,
@@ -36,8 +37,6 @@ export class RecalledMemory extends Schema.Class<RecalledMemory>(
   bytes: Schema.Natural,
   estimatedTokens: Schema.Natural,
 }) {}
-
-const bytes = (text: string): number => Encoding.encodeHex(text).length / 2;
 
 const canonicalJson = (value: object): string =>
   JSON.stringify(value, (_key, item: unknown) =>

--- a/packages/core/src/MemoryNamespace.ts
+++ b/packages/core/src/MemoryNamespace.ts
@@ -1,4 +1,6 @@
-import { Effect, Encoding, Schema } from "effect";
+import { Effect, Schema } from "effect";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const Name = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 
@@ -59,7 +61,7 @@ export class MemoryNamespaceError extends Schema.TaggedError<MemoryNamespaceErro
 /** Portable address used by storage, receipts, indexes, and owner routing. */
 const BoundedAddress = Schema.String.check(
   Schema.isMaxLength(4_096),
-  Schema.makeFilter((address) => Encoding.encodeHex(address).length / 2 <= 4_096, {
+  Schema.makeFilter((address) => utf8ByteLength(address) <= 4_096, {
     expected: "at most 4096 UTF-8 bytes",
   }),
 );

--- a/packages/core/src/MemoryReference.ts
+++ b/packages/core/src/MemoryReference.ts
@@ -1,4 +1,6 @@
-import { Encoding, Schema } from "effect";
+import { Schema } from "effect";
+
+import { utf8ByteLength } from "./internal/utf8.ts";
 
 const Identity = Schema.NonEmptyString.check(Schema.isMaxLength(1_024));
 const Locator = Schema.NonEmptyString.check(Schema.isMaxLength(8_192));
@@ -11,8 +13,7 @@ export const MemoryMetadata = Schema.Record(
 ).check(
   Schema.makeFilter(
     (metadata) =>
-      Object.keys(metadata).length <= 64 &&
-      Encoding.encodeHex(JSON.stringify(metadata)).length / 2 <= 8_192,
+      Object.keys(metadata).length <= 64 && utf8ByteLength(JSON.stringify(metadata)) <= 8_192,
     { expected: "at most 64 metadata keys and 8192 UTF-8 bytes" },
   ),
 );

--- a/packages/core/src/MemoryRevalidation.ts
+++ b/packages/core/src/MemoryRevalidation.ts
@@ -1,5 +1,6 @@
-import { Effect, Encoding, Schema } from "effect";
+import { Effect, Schema } from "effect";
 
+import { utf8ByteLength } from "./internal/utf8.ts";
 import type * as MemoryNamespace from "./MemoryNamespace.ts";
 import {
   MemoryLookup,
@@ -132,7 +133,7 @@ export const revalidateMemoryLookup = Effect.fn("revalidateMemoryLookup")(functi
     )
       continue;
     if (decodedLimits.maxSourceBytes !== undefined) {
-      sourceBytes += Encoding.encodeHex(JSON.stringify(document)).length / 2;
+      sourceBytes += utf8ByteLength(JSON.stringify(document));
       if (sourceBytes > decodedLimits.maxSourceBytes)
         return yield* MemoryRecallError.make({
           reason: "budget",
@@ -159,8 +160,7 @@ export const revalidateMemoryLookup = Effect.fn("revalidateMemoryLookup")(functi
       const encoded = JSON.stringify(passage);
       const remaining = maxInputBytes - inputBytes;
 
-      const encodedBytes =
-        encoded.length <= remaining ? Encoding.encodeHex(encoded).length / 2 : undefined;
+      const encodedBytes = encoded.length <= remaining ? utf8ByteLength(encoded) : undefined;
 
       if (encodedBytes === undefined || encodedBytes > remaining) {
         return yield* MemoryRecallError.make({

--- a/packages/core/src/SemanticMemoryRevalidation.ts
+++ b/packages/core/src/SemanticMemoryRevalidation.ts
@@ -1,5 +1,6 @@
 import { Effect, Encoding, Schema } from "effect";
 
+import { utf8ByteLength as byteLength } from "./internal/utf8.ts";
 import { MemoryLookup, MemoryPassage } from "./MemoryReference.ts";
 import { MemoryAccess } from "./MemoryRevalidation.ts";
 import type { MemoryKey } from "./MemoryStore.ts";
@@ -49,8 +50,6 @@ export class SemanticCandidateResult extends Schema.Class<SemanticCandidateResul
   staleExcluded: Schema.Natural,
   unauthorizedExcluded: Schema.Natural,
 }) {}
-
-const byteLength = (text: string): number => Encoding.encodeHex(text).length / 2;
 
 const readDocument = Effect.fn("semanticCandidates.readDocument")(function* (key: MemoryKey) {
   const reader = yield* MemoryReader;

--- a/packages/core/src/ToolResult.ts
+++ b/packages/core/src/ToolResult.ts
@@ -1,5 +1,7 @@
 import * as Schema from "effect/Schema";
 
+import { codePointUtf8Length, utf8ByteLength } from "./internal/utf8.ts";
+
 /**
  * The minimal `TruncatedToolResult` envelope (empty head/tail, a 16-digit
  * `originalBytes`) encodes to at most 81 UTF-8 bytes; 256 guarantees every
@@ -81,28 +83,6 @@ export const unserializableToolResult = (
   }
 
   return sentinel;
-};
-
-const codePointUtf8Length = (codePoint: number): number => {
-  if (codePoint < 0x80) return 1;
-  if (codePoint < 0x800) return 2;
-  if (codePoint < 0x10000) return 3;
-
-  return 4;
-};
-
-const utf8ByteLength = (value: string): number => {
-  let bytes = 0;
-  let index = 0;
-
-  while (index < value.length) {
-    const codePoint = value.codePointAt(index) ?? 0;
-
-    bytes += codePointUtf8Length(codePoint);
-    index += codePoint > 0xffff ? 2 : 1;
-  }
-
-  return bytes;
 };
 
 const takePrefixWithinBytes = (value: string, maxBytes: number): string => {

--- a/packages/core/src/internal/utf8.ts
+++ b/packages/core/src/internal/utf8.ts
@@ -1,0 +1,23 @@
+/** UTF-8 width, including the replacement encoding used for lone UTF-16 surrogates. */
+export const codePointUtf8Length = (codePoint: number): number => {
+  if (codePoint < 0x80) return 1;
+  if (codePoint < 0x800) return 2;
+  if (codePoint < 0x10000) return 3;
+
+  return 4;
+};
+
+/** Count encoded bytes without allocating an encoded copy of the text. */
+export const utf8ByteLength = (value: string): number => {
+  let bytes = 0;
+  let index = 0;
+
+  while (index < value.length) {
+    const codePoint = value.codePointAt(index) ?? 0;
+
+    bytes += codePointUtf8Length(codePoint);
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+
+  return bytes;
+};

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -590,6 +590,36 @@ describe("core schemas", () => {
 });
 
 describe("context-economics policy", () => {
+  it("enforces completion reserve bounds through constructors and Schema codecs", () => {
+    const policy = AgentPolicy.make({
+      maxTurns: 2,
+      maxToolCalls: 1,
+      maxDuration: "30 seconds",
+      toolConcurrency: 1,
+      tokenBudget: 100,
+      completionReserveTokens: 100,
+    });
+
+    const invalid = { ...policy, completionReserveTokens: 101 };
+    const jsonCodec = Schema.toCodecJson(AgentPolicy);
+
+    const encoded = Schema.decodeUnknownSync(Schema.Record(Schema.String, Schema.Json))(
+      Schema.encodeSync(jsonCodec)(policy),
+    );
+
+    expect(Schema.decodeSync(jsonCodec)(encoded)).toEqual(policy);
+    expect(() => AgentPolicy.make(invalid)).toThrow("Schema validation failed");
+    expect(() => new AgentPolicy(invalid)).toThrow("Schema validation failed");
+    expect(Schema.decodeUnknownExit(AgentPolicy)(invalid)._tag).toBe("Failure");
+    expect(
+      Schema.decodeUnknownExit(jsonCodec)({ ...encoded, completionReserveTokens: 101 })._tag,
+    ).toBe("Failure");
+
+    Reflect.set(policy, "completionReserveTokens", 101);
+    expect(Schema.encodeExit(AgentPolicy)(policy)._tag).toBe("Failure");
+    expect(Schema.encodeExit(jsonCodec)(policy)._tag).toBe("Failure");
+  });
+
   it("fills context-economics defaults and accepts explicit overrides", () => {
     const policy = AgentPolicy.make({
       maxTurns: 2,
@@ -689,6 +719,19 @@ describe("tool result bounds", () => {
       for (const unit of [slice.charCodeAt(0), slice.charCodeAt(slice.length - 1)]) {
         expect(unit >= 0xdc00 && unit <= 0xdfff && slice.length === 1).toBe(false);
       }
+    }
+  });
+
+  it("RUN-022: counts lone surrogate replacement bytes while bounding raw JSON text", () => {
+    for (const surrogate of ["\ud800", "\udc00"]) {
+      const encoded = `"${surrogate.repeat(200)}"`;
+      const output = applyToolResultBounds(encoded, ToolResultBounds.make({ maxBytes: 256 }));
+      const envelope = Schema.decodeUnknownSync(TruncatedToolResult)(JSON.parse(output));
+
+      expect(envelope.originalBytes).toBe(602);
+      expect(utf8Bytes(output)).toBeLessThanOrEqual(256);
+      expect(encoded.startsWith(envelope.head)).toBe(true);
+      expect(encoded.endsWith(envelope.tail)).toBe(true);
     }
   });
 

--- a/packages/core/test/memory-namespace.test.ts
+++ b/packages/core/test/memory-namespace.test.ts
@@ -127,6 +127,17 @@ describe("memory namespace addresses", () => {
 
     expect(bounded.make("x".repeat(4084)).address.length).toBe(4096);
     for (const identity of [
+      "海".repeat(1361) + "a",
+      "🌊".repeat(1021),
+      "\ud800".repeat(680) + "aaaa",
+      "\udc00".repeat(680) + "aaaa",
+    ]) {
+      expect(Schema.is(MemoryNamespaceAddress)(bounded.make(identity).address)).toBe(true);
+      expect(
+        await Effect.runPromise(bounded.decode(identity + "a").pipe(Effect.flip)),
+      ).toMatchObject({ reason: "invalid-identity" });
+    }
+    for (const identity of [
       "x".repeat(4085),
       "海".repeat(1400),
       Array.from({ length: 129 }, () => 1),

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -376,10 +376,11 @@ export type AgentCompletionProjectionRequirements<
 /**
  * Inferred agent services plus the runtime's identity and Thread history authorities.
  * Engine-provided Tool handler services are excluded because the interpreter
- * supplies them itself, bound to the current Run's identity. Output decoding
- * and completion-projection Schema services stay listed unexcluded:
- * `run`/`start` re-decode terminal output and durable recovery re-decodes
- * canonical completion Tool parameters/results outside the handler boundary.
+ * supplies them itself, bound to the current Run's identity. Tool parameter
+ * encoding, output decoding, and completion-projection Schema services stay
+ * listed unexcluded: the interpreter records canonical parameters before the
+ * handler boundary, `run`/`start` re-decode terminal output, and durable recovery
+ * re-decodes canonical completion Tool parameters/results.
  */
 export type AgentRuntimeRequirements<
   AgentValue extends Agent.AnyDefinition | Agent.Any,
@@ -387,6 +388,7 @@ export type AgentRuntimeRequirements<
   InstructionRequirements = never,
 > =
   | Exclude<Agent.Requirements<AgentValue>, EngineProvidedToolServices>
+  | Tool.ParametersSchema<Agent.ToolUnion<AgentValue>>["EncodingServices"]
   | AgentCompletionProjectionRequirements<AgentValue>
   | Agent.OutputSchema<AgentValue>["DecodingServices"]
   | IdGenerator
@@ -724,14 +726,6 @@ const inspectModelResponsePartCapacity = (
   knownSafePrototypes: ReadonlySet<object> = knownSafeModelResponsePrototypes,
 ): Effect.Effect<number, ModelProtocolError> =>
   Effect.suspend(() => {
-    if (usage.responsePartCount >= limits.maxModelResponseParts) {
-      return Effect.fail(
-        ModelProtocolError.make({
-          message: `Model response exceeded the ${limits.maxModelResponseParts}-part response limit`,
-        }),
-      );
-    }
-
     const bytes = boundedValueFootprint(
       part,
       limits.maxModelResponseBytes - usage.responsePartBytes,
@@ -786,6 +780,12 @@ const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(func
   usage: ModelResponseBufferUsage,
   limits: EffectiveRunBufferLimits,
 ) {
+  if (usage.responsePartCount >= limits.maxModelResponseParts) {
+    return yield* ModelProtocolError.make({
+      message: `Model response exceeded the ${limits.maxModelResponseParts}-part response limit`,
+    });
+  }
+
   // Reject an oversized provider graph before schema encoding, structured cloning, or decoding
   // can allocate additional full copies. A decoded application Schema class is the sole exception:
   // preflight its enclosing response fields, then measure its complete canonical plain encoding
@@ -800,8 +800,6 @@ const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(func
     const preflight = schemaClassToolPartPreflight(part, toolkit);
 
     yield* inspectModelResponsePartCapacity(usage, preflight ?? part, limits);
-  } else {
-    yield* inspectModelResponsePartCapacity(usage, part, limits);
   }
   const codec = modelResponseCodecFor(toolkit);
 
@@ -878,7 +876,6 @@ interface PreparedToolCall<Tools extends Record<string, Tool.Any>> {
   readonly name: keyof Tools & string;
   readonly toolCallId: ToolCallId;
   readonly decodedParams: Tool.Parameters<ToolUnion<Tools>>;
-  readonly nativeHandlerParams: Tool.Parameters<ToolUnion<Tools>>;
   readonly tool: ToolUnion<Tools>;
   readonly declarationIndex: number;
 }
@@ -964,10 +961,18 @@ const encodeToolCallParameters = <Tools extends Record<string, Tool.Any>>(
   tool: ToolUnion<Tools>,
   toolName: string,
   decodedParams: Tool.Parameters<ToolUnion<Tools>>,
-): Effect.Effect<unknown, ModelProtocolError, Tool.HandlerServices<ToolUnion<Tools>>> => {
+): Effect.Effect<
+  unknown,
+  ModelProtocolError,
+  Tool.ParametersSchema<ToolUnion<Tools>>["EncodingServices"]
+> => {
   const encodeParameters = Schema.encodeUnknownEffect(tool.parametersSchema) as (
     input: Tool.Parameters<ToolUnion<Tools>>,
-  ) => Effect.Effect<unknown, Schema.SchemaError, Tool.HandlerServices<ToolUnion<Tools>>>;
+  ) => Effect.Effect<
+    unknown,
+    Schema.SchemaError,
+    Tool.ParametersSchema<ToolUnion<Tools>>["EncodingServices"]
+  >;
 
   return encodeParameters(decodedParams).pipe(
     Effect.mapError((cause) =>
@@ -1011,9 +1016,8 @@ const decodeToolCallParameters = <Tools extends Record<string, Tool.Any>>(
 };
 
 /**
- * The pinned `Toolkit.handle` implementation decodes internally despite its
- * decoded-parameter signature, so the native handler boundary receives the
- * canonical encoded parameters retained by the Turn trace.
+ * Decode canonical parameters for approval while retaining their encoded
+ * form for the native `Toolkit.handle` boundary.
  */
 const prepareToolCall = <Tools extends Record<string, Tool.Any>>(
   toolkit: Toolkit.WithHandler<Tools>,
@@ -1041,7 +1045,6 @@ const prepareToolCall = <Tools extends Record<string, Tool.Any>>(
           name,
           toolCallId,
           decodedParams,
-          nativeHandlerParams: call.params as Tool.Parameters<ToolUnion<Tools>>,
           tool,
           declarationIndex,
         })),
@@ -1807,13 +1810,21 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
     }).pipe(Effect.withLogSpan("AgentRuntime.tool")),
   );
 
+  // Dynamic Tool lookup erases the name/ParametersEncoded correlation. The native handler
+  // decodes these already-preflighted canonical parameters; only its input signature is widened.
+  const handle = toolkit.handle as (
+    name: keyof Tools & string,
+    params: unknown,
+    toolCallId: string,
+  ) => ReturnType<typeof toolkit.handle>;
+
   const results: Stream.Stream<
     RunEvent,
     ToolExecutionError,
     ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
   > = Stream.unwrap(
     Effect.flatMap(ToolSpanTelemetry, ({ isolateToolkitHandle }) =>
-      isolateToolkitHandle(toolkit.handle(prepared.name, prepared.nativeHandlerParams, call.id)),
+      isolateToolkitHandle(handle.call(toolkit, prepared.name, call.params, call.id)),
     ),
   ).pipe(
     Stream.mapEffect((result): Effect.Effect<RunEvent | undefined, ModelProtocolError> =>
@@ -3941,7 +3952,8 @@ const eventsForPart = Effect.fnUntraced(function* <Tools extends Record<string, 
 ): Effect.fn.Return<
   ReadonlyArray<RunEvent>,
   ModelProtocolError,
-  Tool.HandlerServices<ToolUnion<Tools>>
+  | Tool.HandlerServices<ToolUnion<Tools>>
+  | Tool.ParametersSchema<ToolUnion<Tools>>["EncodingServices"]
 > {
   yield* consumeModelResponsePart(trace, retainedBytes, context.bufferLimits);
   if (trace.finished) {
@@ -5081,25 +5093,19 @@ const makeTurn = <
               // provider-reported incremental estimate.
               const contextTokenLimit = policy.contextTokenLimit;
 
-              const admission =
-                (options.context === undefined && options.transientContext === undefined) ||
-                contextTokenLimit === undefined
-                  ? Effect.void
-                  : estimateContextTokens(providerPrompt.content).pipe(
-                      Effect.flatMap((estimatedTokens) =>
-                        estimatedTokens <= contextTokenLimit
-                          ? Effect.void
-                          : ContextBudgetError.make({
-                              message: `Prepared context could not fit the next model prompt inside the ${contextTokenLimit} token context target`,
-                              estimatedTokens,
-                              targetTokens: contextTokenLimit,
-                              completionReserveTokens: policy.completionReserveTokens,
-                            }),
-                      ),
-                    );
-
-              return admission.pipe(
-                Effect.andThen(estimateContextTokens(providerPrompt.content)),
+              return estimateContextTokens(providerPrompt.content).pipe(
+                Effect.tap((estimatedTokens) =>
+                  contextTokenLimit !== undefined &&
+                  (options.context !== undefined || options.transientContext !== undefined) &&
+                  estimatedTokens > contextTokenLimit
+                    ? ContextBudgetError.make({
+                        message: `Prepared context could not fit the next model prompt inside the ${contextTokenLimit} token context target`,
+                        estimatedTokens,
+                        targetTokens: contextTokenLimit,
+                        completionReserveTokens: policy.completionReserveTokens,
+                      })
+                    : Effect.void,
+                ),
                 Effect.tap((tokens) =>
                   Effect.sync(() => {
                     context.windowTokens = tokens;

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -294,6 +294,85 @@ it("preserves disjoint tool schemas and callbacks with different input types", (
   >();
 });
 
+it("retains transformed tool parameter services and handler failures across execution views", () => {
+  class ParametersDecoder extends Context.Service<ParametersDecoder, string>()(
+    "transformed-tool/ParametersDecoder",
+  ) {}
+  class ParametersEncoder extends Context.Service<ParametersEncoder, string>()(
+    "transformed-tool/ParametersEncoder",
+  ) {}
+
+  const Increment = Tool.make("increment", {
+    parameters: Schema.Struct({
+      value: Schema.FiniteFromString.pipe(
+        Schema.decode({
+          decode: SchemaGetter.transformOrFail((value) => Effect.as(ParametersDecoder, value)),
+          encode: SchemaGetter.transformOrFail((value) => Effect.as(ParametersEncoder, value)),
+        }),
+      ),
+    }),
+    success: Schema.Finite,
+    failure: ToolError,
+    failureMode: "error",
+    dependencies: [Catalog],
+  });
+
+  const tools = Toolkit.make(Increment);
+
+  const handlers = tools.toLayer({
+    increment: ({ value }) =>
+      Effect.gen(function* () {
+        expectTypeOf(value).toEqualTypeOf<number>();
+        const catalog = yield* Catalog;
+
+        if (catalog === "") return yield* ToolError.make({});
+
+        return value + 1;
+      }),
+  });
+
+  const definition = Agent.make("transformed-tool", {
+    input: Schema.String,
+    output: Schema.Finite,
+    instructions: "Increment the encoded number.",
+    toolkit: tools,
+    policy: planner.policy,
+  });
+
+  const binding = Agent.withModel(definition, model);
+  const run = AgentRuntime.run(binding, "Increment 41.");
+  const stream = AgentRuntime.stream(binding, "Increment 41.");
+  const start = AgentRuntime.start(binding, "Increment 41.");
+  const provided = run.pipe(Effect.provide(handlers));
+
+  type DefinitionServices =
+    | ParametersDecoder
+    | ParametersEncoder
+    | Catalog
+    | Tool.HandlersFor<typeof tools.tools>;
+  type RequiredServices =
+    | ParametersDecoder
+    | ParametersEncoder
+    | Catalog
+    | ProviderClient
+    | ThreadHistory
+    | IdGenerator;
+  type UnprovidedServices = RequiredServices | Tool.HandlersFor<typeof tools.tools>;
+  expectTypeOf<
+    Agent.DefinitionRequirements<typeof definition>
+  >().toEqualTypeOf<DefinitionServices>();
+  expectTypeOf<Effect.Services<typeof run>>().toEqualTypeOf<UnprovidedServices>();
+  expectTypeOf<Stream.Services<typeof stream>>().toEqualTypeOf<UnprovidedServices>();
+  expectTypeOf<Effect.Services<typeof start>>().toEqualTypeOf<UnprovidedServices | Scope.Scope>();
+  expectTypeOf<Effect.Services<typeof provided>>().toEqualTypeOf<RequiredServices>();
+  expectTypeOf<Extract<Effect.Error<typeof provided>, ToolError>>().toEqualTypeOf<ToolError>();
+  expectTypeOf<Effect.Error<typeof run>>().toEqualTypeOf<AgentRuntimeFailure<typeof binding>>();
+  expectTypeOf<Stream.Error<typeof stream>>().toEqualTypeOf<Effect.Error<typeof run>>();
+  expectTypeOf<Effect.Error<Effect.Success<typeof start>["await"]>>().toEqualTypeOf<
+    Effect.Error<typeof run>
+  >();
+});
+
 it("retains every branch's tool requirements and failures across execution views", () => {
   const withoutTools = Agent.make("without-tools", {
     input: Input,

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -39,6 +39,7 @@ import {
   Ref,
   References,
   Schema,
+  SchemaGetter,
   Scope,
   Stream,
   Tracer,
@@ -3642,13 +3643,33 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
     }),
   );
 
-  it.effect("preserves transformed parameters across the native Toolkit handler boundary", () => {
+  it.effect("preserves serviceful parameter transforms across the native Toolkit boundary", () => {
+    class ParametersDecoder extends Context.Service<ParametersDecoder, (value: number) => number>()(
+      "transformed-tool-runtime/ParametersDecoder",
+    ) {}
+    class ParametersEncoder extends Context.Service<ParametersEncoder, (value: number) => number>()(
+      "transformed-tool-runtime/ParametersEncoder",
+    ) {}
+
+    const decodedValues: Array<number> = [];
+    const encodedValues: Array<number> = [];
     let handlerParameter: unknown;
     let authorizationCall: RunToolAuthorizationRequest["call"] | undefined;
     let promptResult: unknown;
 
     const Increment = Tool.make("increment", {
-      parameters: Schema.Struct({ value: Schema.FiniteFromString }),
+      parameters: Schema.Struct({
+        value: Schema.FiniteFromString.pipe(
+          Schema.decode({
+            decode: SchemaGetter.transformOrFail((value) =>
+              Effect.map(ParametersDecoder, (decode) => decode(value)),
+            ),
+            encode: SchemaGetter.transformOrFail((value) =>
+              Effect.map(ParametersEncoder, (encode) => encode(value)),
+            ),
+          }),
+        ),
+      }),
       success: Schema.Struct({ value: Schema.Finite }),
     });
 
@@ -3736,12 +3757,24 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
           },
         }),
       ),
+      Effect.provideService(ParametersDecoder, (value) => {
+        decodedValues.push(value);
+
+        return value;
+      }),
+      Effect.provideService(ParametersEncoder, (value) => {
+        encodedValues.push(value);
+
+        return value;
+      }),
       Effect.scoped,
       Effect.tap(() =>
         Effect.sync(() => {
           expect(authorizationCall?.parameters).toEqual({ value: "41" });
           expect(handlerParameter).toBe(41);
           expect(promptResult).toEqual({ value: 42 });
+          expect(decodedValues).toContain(41);
+          expect(encodedValues).toContain(41);
         }),
       ),
     );

--- a/packages/platform-cloudflare/src/CloudflareThreadClient.ts
+++ b/packages/platform-cloudflare/src/CloudflareThreadClient.ts
@@ -61,6 +61,7 @@ import { cloudflareFailureSignals, safeCauseMessage } from "./internal/boundary.
 
 /** Ceiling for host protocol diagnostic strings. */
 const MAX_HOST_DIAGNOSTIC_LENGTH = 4_096;
+const PROGRESS_CANCELLATION_TIMEOUT = "1 second";
 
 const BoundedDiagnostic = Schema.String.check(Schema.isMaxLength(MAX_HOST_DIAGNOSTIC_LENGTH));
 
@@ -379,6 +380,7 @@ export class CloudflareThreadClient extends Context.Service<
     /**
      * Wait without polling until progress after `afterSequence` is already durable or hinted.
      * The result is deliberately void: canonical records remain authoritative and must be read.
+     * Interruption waits at most one second for best-effort remote cancellation.
      */
     readonly awaitProgress: (
       threadId: ThreadId,
@@ -556,6 +558,10 @@ export class CloudflareThreadClient extends Context.Service<
         encodeCancelProgressRequest(CancelProgressRequest.make({ waiterId })).pipe(
           Effect.mapError(() => undefined),
           Effect.flatMap((encoded) => call(threadId, "cancelProgress", encoded)),
+          // Finalizers are uninterruptible; only the foreign RPC branch must remain
+          // interruptible so a lost cancellation reply cannot prevent local shutdown.
+          Effect.interruptible,
+          Effect.timeout(PROGRESS_CANCELLATION_TIMEOUT),
           Effect.asVoid,
           Effect.ignore,
         );

--- a/packages/platform-cloudflare/src/internal/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/internal/browser-quick-action.ts
@@ -271,14 +271,21 @@ const navigationError = (message: string, cause?: unknown): PageCaptureNavigatio
 const privateResponseCause = (bodyText: string): Error | undefined =>
   bodyText.length === 0 ? undefined : new Error(boundedDiagnostic(bodyText));
 
+/** Foreign cancellation must not keep a response Scope open indefinitely. */
+const cancelResponse = (cancel: () => Promise<void>, warning: string): Effect.Effect<void> =>
+  Effect.tryPromise({ try: cancel, catch: () => undefined }).pipe(
+    Effect.interruptible,
+    Effect.timeoutOrElse({
+      duration: "1 second",
+      orElse: () => Effect.fail(undefined),
+    }),
+    Effect.catch(() => Effect.logWarning(warning)),
+  );
+
 const releaseResponseReader = (
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): Effect.Effect<void> =>
-  Effect.tryPromise({
-    try: () => reader.cancel(),
-    catch: (cause) => protocolError("Canceling the Quick Action response failed", cause),
-  }).pipe(
-    Effect.catch((error) => Effect.logWarning(error.message)),
+  cancelResponse(() => reader.cancel(), "Canceling the Quick Action response failed").pipe(
     Effect.ensuring(
       Effect.try({
         try: () => reader.releaseLock(),
@@ -655,16 +662,12 @@ const screenshotOptions = (request: PageScreenshotRequest): BrowserRunScreenshot
 };
 
 const cancelBody = (body: ReadableStream<Uint8Array>): Effect.Effect<void> =>
-  Effect.tryPromise({
-    try: () => body.cancel(),
-    catch: () => undefined,
-  }).pipe(Effect.catch(() => Effect.void));
+  cancelResponse(() => body.cancel(), "Canceling the screenshot response failed");
 
 const releaseScreenshotReader = (
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): Effect.Effect<void> =>
-  Effect.tryPromise({ try: () => reader.cancel(), catch: () => undefined }).pipe(
-    Effect.catch(() => Effect.logWarning("Canceling the screenshot response failed")),
+  cancelResponse(() => reader.cancel(), "Canceling the screenshot response failed").pipe(
     Effect.ensuring(
       Effect.try({
         try: () => reader.releaseLock(),

--- a/packages/platform-cloudflare/src/internal/progress-wait.ts
+++ b/packages/platform-cloudflare/src/internal/progress-wait.ts
@@ -19,7 +19,7 @@ export class ProgressWaitRegistry extends Context.Service<
     readonly subscribe: (
       waiterId: string,
     ) => Effect.Effect<Effect.Effect<void>, never, Scope.Scope>;
-    /** Cancel a registered waiter, or remember a bounded early cancellation. */
+    /** Cancel every attempt and retain a bounded tombstone for later transport attempts. */
     readonly cancel: (waiterId: string) => Effect.Effect<void>;
   }
 >()("@effect-agent/platform-cloudflare/ProgressWaitRegistry") {
@@ -78,12 +78,20 @@ export class ProgressWaitRegistry extends Context.Service<
           ),
       );
 
+      // Updating the registry and completing captured signals form one nonblocking operation;
+      // interruption between them must not strand attempts removed from the active registry.
       const cancel = Effect.fn("ProgressWaitRegistry.cancel")(function* (waiterId: string) {
-        const waiters = yield* Ref.modify(registrations, (current) => {
-          const existing = current.get(waiterId);
-          const next = new Map(current);
+        const waiters = yield* Ref.modify(
+          registrations,
+          (current): readonly [ReadonlyArray<Deferred.Deferred<void>>, Registrations] => {
+            const existing = current.get(waiterId);
 
-          if (existing === undefined) {
+            if (existing === "cancelled") return [[], current] as const;
+            const next = new Map(current);
+
+            // A retry may arrive after an active attempt was cancelled. Retain the same
+            // tombstone used for early cancellation, ordered by cancellation time.
+            next.delete(waiterId);
             next.set(waiterId, "cancelled");
             let tombstones = 0;
 
@@ -98,18 +106,14 @@ export class ProgressWaitRegistry extends Context.Service<
               }
             }
 
-            return [[], next] as const;
-          }
-          if (existing === "cancelled") return [[], current] as const;
-          next.delete(waiterId);
-
-          return [[...existing], next] as const;
-        });
+            return [existing === undefined ? [] : [...existing], next] as const;
+          },
+        );
 
         yield* Effect.forEach(waiters, (waiter) => Deferred.succeed(waiter, undefined), {
           discard: true,
         });
-      });
+      }, Effect.uninterruptible);
 
       return ProgressWaitRegistry.of({ subscribe, cancel });
     }),

--- a/packages/platform-cloudflare/test/browser-response-cleanup.test.ts
+++ b/packages/platform-cloudflare/test/browser-response-cleanup.test.ts
@@ -1,0 +1,140 @@
+import {
+  BrowserQuickActionBrowserBinding,
+  browserQuickActionCaptureLayer,
+  browserQuickActionScreenshotLayer,
+  type BrowserQuickActionClient,
+} from "@effect-agent/platform-cloudflare/CloudflareBrowser";
+import {
+  CapturePageMarkdown,
+  PageCapture,
+  PageCaptureRequest,
+  PageUrlTarget,
+  type PageCaptureError,
+} from "@effect-agent/sandbox/PageCapture";
+import {
+  PageScreenshot,
+  PageScreenshotRequest,
+  type PageScreenshotError,
+} from "@effect-agent/sandbox/PageScreenshot";
+import { expect, it } from "@effect/vitest";
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Logger } from "effect";
+import { TestClock } from "effect/testing";
+
+const capture = (
+  kind: "capture" | "screenshot",
+  response: Response,
+): Effect.Effect<unknown, PageCaptureError | PageScreenshotError> => {
+  const client: BrowserQuickActionClient = {
+    content: () => Effect.succeed(response),
+    markdown: () => Effect.succeed(response),
+    links: () => Effect.succeed(response),
+    scrape: () => Effect.succeed(response),
+    json: () => Effect.succeed(response),
+    screenshot: () => Effect.succeed(response),
+  };
+
+  const binding = Layer.succeed(BrowserQuickActionBrowserBinding)(client);
+
+  const common = {
+    target: PageUrlTarget.make({ url: "https://example.com" }),
+    engine: "chromium" as const,
+    limits: { maxOutputBytes: 8 },
+  };
+
+  return kind === "capture"
+    ? Effect.gen(function* () {
+        return yield* (yield* PageCapture).capture(
+          PageCaptureRequest.make({ ...common, action: CapturePageMarkdown.make({}) }),
+        );
+      }).pipe(Effect.provide(browserQuickActionCaptureLayer().pipe(Layer.provide(binding))))
+    : Effect.gen(function* () {
+        return yield* (yield* PageScreenshot).capture(
+          PageScreenshotRequest.make({ ...common, fullPage: false }),
+        );
+      }).pipe(Effect.provide(browserQuickActionScreenshotLayer().pipe(Layer.provide(binding))));
+};
+
+it.effect.each([
+  { kind: "capture", failure: "overflow" },
+  { kind: "capture", failure: "interruption" },
+  { kind: "screenshot", failure: "overflow" },
+  { kind: "screenshot", failure: "interruption" },
+  { kind: "screenshot", failure: "content-type" },
+] as const)("bounds stalled $kind response cancellation after $failure", ({ kind, failure }) =>
+  Effect.gen(function* () {
+    const reading = yield* Deferred.make<void>();
+    const canceling = yield* Deferred.make<void>();
+    const runSync = Effect.runSyncWith(yield* Effect.context<never>());
+    const warnings: Array<unknown> = [];
+    let cancelCalls = 0;
+
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          runSync(Deferred.succeed(reading, undefined));
+          if (failure === "overflow") controller.enqueue(new Uint8Array(16));
+        },
+        cancel() {
+          cancelCalls++;
+          runSync(Deferred.succeed(canceling, undefined));
+
+          return new Promise<void>(() => {});
+        },
+      },
+      { highWaterMark: 0 },
+    );
+
+    const response = new Response(body, {
+      headers: {
+        "content-type":
+          kind === "screenshot" && failure !== "content-type" ? "image/png" : "application/json",
+      },
+    });
+
+    const fiber = yield* capture(kind, response).pipe(
+      Effect.provide(
+        Logger.layer([
+          Logger.make((event) => {
+            warnings.push(event.message);
+          }),
+        ]),
+      ),
+      Effect.forkChild,
+    );
+
+    if (failure === "interruption") {
+      yield* Deferred.await(reading);
+      yield* Fiber.interrupt(fiber).pipe(Effect.forkChild);
+    }
+    yield* Deferred.await(canceling);
+    yield* TestClock.adjust("1 second");
+    const exit = yield* Fiber.await(fiber);
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      if (failure === "interruption") {
+        expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+        expect(Cause.hasFails(exit.cause)).toBe(false);
+      } else {
+        expect(Cause.squash(exit.cause)).toMatchObject({
+          _tag:
+            failure === "content-type"
+              ? "PageCaptureProtocolError"
+              : kind === "capture"
+                ? "PageCaptureOutputLimitError"
+                : "PageScreenshotOutputLimitError",
+        });
+      }
+      expect(Cause.hasDies(exit.cause)).toBe(false);
+    }
+    expect(cancelCalls).toBe(1);
+    expect(body.locked).toBe(false);
+    expect(warnings).toEqual([
+      [
+        kind === "capture"
+          ? "Canceling the Quick Action response failed"
+          : "Canceling the screenshot response failed",
+      ],
+    ]);
+  }),
+);

--- a/packages/platform-cloudflare/test/client-tracing.test.ts
+++ b/packages/platform-cloudflare/test/client-tracing.test.ts
@@ -394,6 +394,69 @@ describe("DEPLOY-016 opt-in native Thread RPC tracing", () => {
     );
   });
 
+  it.effect.each(["rejected", "stalled"] as const)(
+    "preserves caller interruption and finishes cleanup when remote cancellation is %s",
+    (mode) => {
+      const started = Deferred.makeUnsafe<void>();
+      const cancelling = Deferred.makeUnsafe<void>();
+      const response = Deferred.makeUnsafe<unknown>();
+      const cancelled = Deferred.makeUnsafe<unknown>();
+      let finalized = 0;
+
+      const fixture = clientFixture(
+        (method) => {
+          if (method === "awaitProgressEncoded") {
+            Deferred.doneUnsafe(started, Effect.void);
+
+            return Effect.runPromise(Deferred.await(response));
+          }
+          Deferred.doneUnsafe(cancelling, Effect.void);
+
+          return mode === "rejected"
+            ? Promise.reject(new Error("cancellation reply lost"))
+            : Effect.runPromise(Deferred.await(cancelled));
+        },
+        { rpcTracing: true },
+      );
+
+      return Effect.gen(function* () {
+        const client = yield* CloudflareThreadClient;
+
+        const waiting = yield* client.awaitProgress(threadId, zeroSequence).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              finalized++;
+            }),
+          ),
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(started);
+        const interrupting = yield* Fiber.interrupt(waiting).pipe(Effect.forkChild);
+
+        yield* Deferred.await(cancelling);
+        if (mode === "stalled") {
+          expect(finalized).toBe(0);
+          yield* TestClock.adjust("1 second");
+        }
+        yield* Fiber.join(interrupting);
+        const exit = yield* Fiber.await(waiting);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+        expect(finalized).toBe(1);
+        expect(fixture.calls.map((call) => call.method)).toEqual([
+          "awaitProgressEncoded",
+          "cancelProgressEncoded",
+        ]);
+      }).pipe(
+        Effect.provide(fixture.layer),
+        Effect.ensuring(Deferred.succeed(response, { _tag: "ProgressObserved" })),
+        Effect.ensuring(Deferred.succeed(cancelled, { _tag: "ProgressCancelled" })),
+      );
+    },
+  );
+
   it.effect("creates a fresh native context for a reset retry without changing its request", () => {
     const started = Deferred.makeUnsafe<void>();
     let attempts = 0;

--- a/packages/platform-cloudflare/test/progress-wait.test.ts
+++ b/packages/platform-cloudflare/test/progress-wait.test.ts
@@ -124,6 +124,9 @@ describe("#94 Cloudflare durable progress wait", () => {
 
           yield* registry.cancel("duplicate-attempt");
           yield* Effect.all([first, second], { concurrency: "unbounded" });
+          const retriedAfterCancel = yield* registry.subscribe("duplicate-attempt");
+
+          yield* retriedAfterCancel;
 
           yield* registry.cancel("late-attempt");
           const lateFirst = yield* registry.subscribe("late-attempt");
@@ -138,6 +141,63 @@ describe("#94 Cloudflare durable progress wait", () => {
 
     expect(completed).toBe(true);
   });
+
+  it("keeps cancellation tombstones after old attempt scopes close and removes only their waiters", () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const registry = yield* ProgressWaitRegistry;
+          const closed = yield* Effect.scoped(registry.subscribe("reused-id"));
+          const live = yield* registry.subscribe("reused-id");
+
+          yield* registry.cancel("reused-id");
+          yield* live;
+          const detached = yield* Effect.forkChild(closed, { startImmediately: true });
+
+          expect(detached.pollUnsafe()).toBeUndefined();
+          yield* Fiber.interrupt(detached);
+
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const active = yield* registry.subscribe("cancelled-before-close");
+
+              yield* registry.cancel("cancelled-before-close");
+              yield* active;
+            }),
+          );
+          yield* yield* registry.subscribe("cancelled-before-close");
+        }),
+      ).pipe(Effect.provide(ProgressWaitRegistry.layer)),
+    ));
+
+  it("bounds cancellation history by evicting oldest tombstones without removing active waiters", () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const registry = yield* ProgressWaitRegistry;
+          const active = yield* registry.subscribe("active-during-eviction");
+
+          for (let index = 0; index <= 1_024; index++) {
+            const id = `cancel-${index}`;
+            const cancelled = index % 2 === 0 ? yield* registry.subscribe(id) : Effect.void;
+
+            yield* registry.cancel(id);
+            yield* cancelled;
+          }
+          for (let index = 1; index <= 1_024; index++) {
+            yield* yield* registry.subscribe(`cancel-${index}`);
+          }
+          const evicted = yield* registry.subscribe("cancel-0");
+          const waiting = yield* Effect.forkChild(evicted, { startImmediately: true });
+
+          expect(waiting.pollUnsafe()).toBeUndefined();
+          yield* registry.cancel("active-during-eviction");
+          yield* active;
+          yield* registry.cancel("cancel-0");
+          yield* Fiber.join(waiting);
+        }),
+      ).pipe(Effect.provide(ProgressWaitRegistry.layer)),
+    ));
 
   it("returns for committed history and wakes promptly after a canonical append", async () => {
     const thread = lane("append");

--- a/packages/platform-node/src/NodeWakeScheduler.ts
+++ b/packages/platform-node/src/NodeWakeScheduler.ts
@@ -59,11 +59,13 @@ const makeWakeScheduler = Effect.gen(function* () {
 
   /**
    * Deployment §3: correctness must not depend on in-memory notifications, so every `wakes` run
-   * merges its PubSub subscription with a Clock-driven ledger-scan loop. Both live entirely in
-   * the consuming run's Scope; no fiber outlives its subscriber.
+   * merges its PubSub subscription with shared Clock-driven ledger scans. Share whole snapshots:
+   * sliding individual lanes would strand the beginning of scans larger than the hint buffer.
+   * The scan starts with the first subscriber and stops when the last subscriber leaves.
    */
-  const fallbackScans: Stream.Stream<ThreadId> = Stream.fromIterableEffectRepeat(
-    Effect.sleep(config.scanInterval).pipe(Effect.andThen(scanOnce)),
+  const fallbackScans = yield* Stream.share(
+    Stream.fromEffectRepeat(Effect.sleep(config.scanInterval).pipe(Effect.andThen(scanOnce))),
+    { capacity: 1, strategy: "sliding" },
   );
 
   return WakeScheduler.of({
@@ -72,13 +74,16 @@ const makeWakeScheduler = Effect.gen(function* () {
         .notify(threadId)
         .pipe(Effect.andThen(PubSub.publish(hints, threadId)), Effect.asVoid),
     subscribe: progress.subscribe,
-    wakes: Stream.merge(Stream.fromPubSub(hints), fallbackScans),
+    wakes: Stream.merge(
+      Stream.fromPubSub(hints),
+      fallbackScans.pipe(Stream.flatMap(Stream.fromIterable)),
+    ),
   });
 });
 
 /**
  * In-process Node `WakeScheduler`: `notify` publishes to a bounded sliding PubSub for prompt
- * same-process wakeups, and every `wakes` subscription additionally runs a periodic
+ * same-process wakeups, and active `wakes` subscriptions share one periodic
  * `SubmissionLedger.scanNonterminal` fallback so a dropped, coalesced, or never-sent notification
  * can never strand accepted work (persistence §14). Delivery may duplicate; consumers already
  * treat wakes as pure liveness hints.

--- a/packages/platform-node/test/layers.test.ts
+++ b/packages/platform-node/test/layers.test.ts
@@ -56,6 +56,7 @@ import { describe, expect, it } from "@effect/vitest";
 import type { PlatformError } from "effect";
 import {
   Cause,
+  Clock,
   Context,
   Crypto,
   Deferred,
@@ -1554,48 +1555,60 @@ describe("NodeDurableAgentRuntime", () => {
 
   it.effect("wake-scan fallback claims ready work without any notify", () =>
     withTemporaryDatabase((filename) =>
-      withHost(
-        runtimeOptions(filename, { wakeScanInterval: 1_000 }),
-        Effect.gen(function* () {
-          const ledger = yield* SubmissionLedger;
-          const wake = yield* WakeScheduler;
-          const runtime = yield* DurableAgentRuntime;
-          const thread = decodeThreadId("thread-wake");
+      Effect.gen(function* () {
+        const clock = yield* Clock.Clock;
+        const sleeping = yield* Deferred.make<void>();
 
-          // Seed accepted work through the ledger alone: no `notify` is ever sent, exactly like
-          // an admission from another process that this worker never heard about.
-          const input: PersistedJson = { question: "wake?" };
-          const inputDigest = yield* digestJson(input).pipe(Effect.provide(NodeCrypto.layer));
+        return yield* withHost(
+          runtimeOptions(filename, { wakeScanInterval: 1_000 }),
+          Effect.gen(function* () {
+            const ledger = yield* SubmissionLedger;
+            const wake = yield* WakeScheduler;
+            const runtime = yield* DurableAgentRuntime;
+            const thread = decodeThreadId("thread-wake");
 
-          const admitted = yield* ledger.admit(
-            AdmissionRequest.make({
-              threadId: thread,
-              principal: PRINCIPAL,
-              idempotencyKey: decodeIdempotencyKey("wake-1"),
-              agentId: decodeAgentId("platform-node-planner"),
-              agentDigests: DIGESTS,
-              deploymentId: decodeDeploymentId("deployment-platform-node"),
-              inputPayload: input,
-              inputDigest,
-            }),
-          );
+            // Seed accepted work through the ledger alone: no `notify` is ever sent, exactly like
+            // an admission from another process that this worker never heard about.
+            const input: PersistedJson = { question: "wake?" };
+            const inputDigest = yield* digestJson(input).pipe(Effect.provide(NodeCrypto.layer));
 
-          yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+            const admitted = yield* ledger.admit(
+              AdmissionRequest.make({
+                threadId: thread,
+                principal: PRINCIPAL,
+                idempotencyKey: decodeIdempotencyKey("wake-1"),
+                agentId: decodeAgentId("platform-node-planner"),
+                agentDigests: DIGESTS,
+                deploymentId: decodeDeploymentId("deployment-platform-node"),
+                inputPayload: input,
+                inputDigest,
+              }),
+            );
 
-          const woken = yield* Effect.forkChild(Stream.runCollect(Stream.take(wake.wakes, 1)));
+            yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
 
-          yield* TestClock.adjust(Duration.millis(1_000));
-          expect(yield* Fiber.join(woken)).toEqual([thread]);
+            const woken = yield* Effect.forkChild(Stream.runCollect(Stream.take(wake.wakes, 1)));
 
-          const model = yield* makeScriptedModel(() => finalParts('{"answer":"woken"}'));
-          const agent = Agent.withModel(plannerDefinition, model);
-          const settlements = yield* runtime.processThread(agent, thread);
+            yield* Deferred.await(sleeping);
+            yield* TestClock.adjust(Duration.millis(1_000));
+            expect(yield* Fiber.join(woken)).toEqual([thread]);
 
-          expect(settlements).toHaveLength(1);
-          expect(settlements[0]?.outcome).toBe("completed");
-          expect(yield* lookupState(admitted.submissionId)).toBe("settled");
-        }),
-      ),
+            const model = yield* makeScriptedModel(() => finalParts('{"answer":"woken"}'));
+            const agent = Agent.withModel(plannerDefinition, model);
+            const settlements = yield* runtime.processThread(agent, thread);
+
+            expect(settlements).toHaveLength(1);
+            expect(settlements[0]?.outcome).toBe("completed");
+            expect(yield* lookupState(admitted.submissionId)).toBe("settled");
+          }),
+        ).pipe(
+          Effect.provideService(Clock.Clock, {
+            ...clock,
+            sleep: (duration) =>
+              Deferred.succeed(sleeping, undefined).pipe(Effect.andThen(clock.sleep(duration))),
+          }),
+        );
+      }),
     ),
   );
 

--- a/packages/platform-node/test/wake-scheduler.test.ts
+++ b/packages/platform-node/test/wake-scheduler.test.ts
@@ -1,0 +1,265 @@
+import { ledgerLayer } from "@effect-agent/storage-sqlite/SqliteSubmissionLedger";
+import {
+  LedgerError,
+  SubmissionLedger,
+  SubmissionSnapshot,
+} from "@effect-agent/thread/SubmissionLedger";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeFileSystem } from "@effect/platform-node";
+import { expect, it } from "@effect/vitest";
+import {
+  Cause,
+  Clock,
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Queue,
+  Schema,
+  Stream,
+} from "effect";
+import { TestClock } from "effect/testing";
+
+import { NodeWakeSchedulerConfig, nodeWakeSchedulerLayer } from "../src/NodeWakeScheduler.ts";
+
+const snapshot = (index: number) =>
+  Schema.decodeSync(SubmissionSnapshot)({
+    submissionId: `submission-${index}`,
+    threadId: `thread-${index}`,
+    queueSequence: index + 1,
+    principal: "scheduler-test",
+    idempotencyKey: `key-${index}`,
+    agentId: "scheduler-agent",
+    agentDigests: { agent: "a".repeat(64), model: "a".repeat(64), tools: "a".repeat(64) },
+    deploymentId: "scheduler-deployment",
+    inputPayload: null,
+    inputDigest: "a".repeat(64),
+    receiptId: `receipt-${index}`,
+    state: "ready",
+    createdAt: "2026-09-01T00:00:00.000Z",
+  });
+
+// Retain the complete SQLite port; only its scan is controlled for scheduler lifecycle evidence.
+const schedulerLayer = (scan: SubmissionLedger["Service"]["scanNonterminal"]) =>
+  nodeWakeSchedulerLayer.pipe(
+    Layer.provide(
+      Layer.effect(
+        SubmissionLedger,
+        Effect.map(SubmissionLedger, (ledger) => ({ ...ledger, scanNonterminal: scan })),
+      ).pipe(
+        Layer.provide(
+          Layer.unwrap(
+            Effect.gen(function* () {
+              const fs = yield* FileSystem.FileSystem;
+              const directory = yield* fs.makeTempDirectoryScoped({ prefix: "wake-scheduler-" });
+
+              return ledgerLayer({ filename: `${directory}/ledger.sqlite` });
+            }),
+          ).pipe(Layer.provide(NodeFileSystem.layer)),
+        ),
+      ),
+    ),
+    Layer.provide(NodeWakeSchedulerConfig.layer({ scanInterval: Duration.seconds(1) })),
+  );
+
+const withScheduler = <A, E, R>(
+  scan: SubmissionLedger["Service"]["scanNonterminal"],
+  body: (nextSleep: Effect.Effect<void>) => Effect.Effect<A, E, R | WakeScheduler>,
+) =>
+  Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const sleeps = yield* Queue.unbounded<void>();
+
+    const observedClock: Clock.Clock = {
+      ...clock,
+      sleep: (duration) =>
+        Queue.offer(sleeps, undefined).pipe(Effect.andThen(clock.sleep(duration))),
+    };
+
+    return yield* body(Queue.take(sleeps)).pipe(
+      Effect.provide(
+        schedulerLayer(scan).pipe(Layer.provide(Layer.succeed(Clock.Clock, observedClock))),
+      ),
+    );
+  }).pipe(Effect.scoped);
+
+it.effect("shares one complete ledger scan per cadence across four subscribers", () => {
+  let scans = 0;
+  const row = snapshot(0);
+
+  const scan = Stream.suspend(() => {
+    scans++;
+
+    return Stream.make(row, row);
+  });
+
+  return withScheduler(scan, (nextSleep) =>
+    Effect.gen(function* () {
+      const wake = yield* WakeScheduler;
+
+      const consumers = yield* Effect.forEach([0, 1, 2, 3], () =>
+        Stream.runCollect(Stream.take(wake.wakes, 2)).pipe(Effect.forkChild),
+      );
+
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(scans).toBe(1);
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(scans).toBe(2);
+      for (const consumer of consumers) {
+        expect(yield* Fiber.join(consumer)).toEqual([row.threadId, row.threadId]);
+      }
+    }),
+  );
+});
+
+it.effect("retains every lane in a large scan without blocking faster subscribers", () => {
+  const rows = Array.from({ length: 1_050 }, (_, index) => snapshot(index));
+  let scans = 0;
+
+  const scan = Stream.suspend(() => {
+    scans++;
+
+    return Stream.fromIterable(rows);
+  });
+
+  return withScheduler(scan, (nextSleep) =>
+    Effect.gen(function* () {
+      const wake = yield* WakeScheduler;
+      const parked = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      let first = true;
+
+      const slow = yield* wake.wakes.pipe(
+        Stream.tap(() => {
+          if (!first) return Effect.void;
+          first = false;
+
+          return Deferred.succeed(parked, undefined).pipe(Effect.andThen(Deferred.await(release)));
+        }),
+        Stream.take(rows.length * 2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const fast = yield* Stream.runCollect(Stream.take(wake.wakes, rows.length * 4)).pipe(
+        Effect.forkChild,
+      );
+
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      yield* Deferred.await(parked);
+      for (let i = 0; i < 3; i++) {
+        yield* nextSleep;
+        yield* TestClock.adjust("1 second");
+      }
+      expect(scans).toBe(4);
+      const expected = rows.map((row) => row.threadId);
+
+      expect(yield* Fiber.join(fast)).toEqual(Array.from({ length: 4 }, () => expected).flat());
+      yield* Deferred.succeed(release, undefined);
+      expect(yield* Fiber.join(slow)).toEqual([...expected, ...expected]);
+    }),
+  );
+});
+
+it.effect("starts lazily, stops after the last subscriber, and restarts on later demand", () => {
+  let scans = 0;
+  let finalized = 0;
+
+  const scan = Stream.fromEffect(
+    Effect.gen(function* () {
+      scans++;
+
+      return yield* Effect.never.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            finalized++;
+          }),
+        ),
+      );
+    }),
+  );
+
+  return withScheduler(scan, (nextSleep) =>
+    Effect.gen(function* () {
+      const wake = yield* WakeScheduler;
+
+      yield* TestClock.adjust("2 seconds");
+      expect(scans).toBe(0);
+      const first = yield* Stream.runDrain(wake.wakes).pipe(Effect.forkChild);
+      const second = yield* Stream.runDrain(wake.wakes).pipe(Effect.forkChild);
+
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(scans).toBe(1);
+      yield* Fiber.interrupt(first);
+      expect(finalized).toBe(0);
+      yield* Fiber.interrupt(second);
+      expect(finalized).toBe(1);
+      yield* TestClock.adjust("2 seconds");
+      expect(scans).toBe(1);
+      const restarted = yield* Stream.runDrain(wake.wakes).pipe(Effect.forkChild);
+
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(scans).toBe(2);
+      yield* Fiber.interrupt(restarted);
+      expect(finalized).toBe(2);
+    }),
+  );
+});
+
+it.effect("retries typed scan failures and propagates scan defects to every subscriber", () => {
+  let scans = 0;
+  const defect = new Error("fallback scan defect");
+  const row = snapshot(0);
+
+  const scan = Stream.suspend(() => {
+    scans++;
+    if (scans === 1) return Stream.fail(LedgerError.make({ operation: "scan", message: "retry" }));
+    if (scans === 2) return Stream.succeed(row);
+
+    return Stream.die(defect);
+  });
+
+  return withScheduler(scan, (nextSleep) =>
+    Effect.gen(function* () {
+      const wake = yield* WakeScheduler;
+      const observed: Array<string> = [];
+
+      const consumers = yield* Effect.forEach([0, 1], () =>
+        wake.wakes.pipe(
+          Stream.tap((threadId) =>
+            Effect.sync(() => {
+              observed.push(threadId);
+            }),
+          ),
+          Stream.runDrain,
+          Effect.exit,
+          Effect.forkChild,
+        ),
+      );
+
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(observed).toEqual([]);
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      expect(observed).toEqual([row.threadId, row.threadId]);
+      yield* nextSleep;
+      yield* TestClock.adjust("1 second");
+      for (const consumer of consumers) {
+        const exit = yield* Fiber.join(consumer);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) expect(Cause.hasDies(exit.cause)).toBe(true);
+      }
+      expect(scans).toBe(3);
+    }),
+  );
+});

--- a/packages/sandbox-local/src/LocalSandbox.ts
+++ b/packages/sandbox-local/src/LocalSandbox.ts
@@ -269,7 +269,7 @@ const makeExecute =
           }),
         );
 
-        const execution = Stream.concat(
+        return Stream.concat(
           Stream.succeed<SandboxEvent>(
             SandboxStarted.make({
               eventVersion: 1,
@@ -285,23 +285,20 @@ const makeExecute =
             terminal,
           ),
         );
-
-        return execution.pipe(
-          Stream.interruptWhen(
-            Effect.sleep(request.limits.maxWallTime).pipe(
-              Effect.andThen(
-                Effect.fail(
-                  SandboxTimeoutError.make({
-                    implementation: unisolatedImplementation,
-                    maxWallTime: request.limits.maxWallTime,
-                  }),
-                ),
-              ),
-            ),
-          ),
-        );
       }),
-    ).pipe(Stream.withSpan("LocalSandbox.execute"));
+    ).pipe(
+      Stream.interruptWhen(
+        Effect.gen(function* () {
+          yield* Effect.sleep(request.limits.maxWallTime);
+
+          return yield* SandboxTimeoutError.make({
+            implementation: unisolatedImplementation,
+            maxWallTime: request.limits.maxWallTime,
+          });
+        }),
+      ),
+      Stream.withSpan("LocalSandbox.execute"),
+    );
 
 /**
  * Development-only local process adapter with its `ChildProcessSpawner` requirement kept visible

--- a/packages/sandbox-local/test/local-sandbox.test.ts
+++ b/packages/sandbox-local/test/local-sandbox.test.ts
@@ -27,6 +27,7 @@ import {
   type Scope,
 } from "effect";
 import { PlatformError, SystemError } from "effect/PlatformError";
+import { TestClock } from "effect/testing";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 const AllowedEnvironmentResult = Schema.Struct({
@@ -439,6 +440,168 @@ const scriptedSpawner = (
   spawnerWithStdout(Stream.fromArray(stdoutChunks));
 
 describe("unisolated local Sandbox with an injected spawner double", () => {
+  it.effect.each(["configuration", "spawn"] as const)(
+    "times out pending %s setup without emitting process events",
+    (phase) =>
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>();
+        const events: Array<SandboxEvent> = [];
+        let interrupted = false;
+        let spawned = 0;
+        let finalized = 0;
+
+        const pending = Deferred.succeed(entered, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted = true;
+            }),
+          ),
+        );
+
+        const spawner = ChildProcessSpawner.make((command) =>
+          Effect.gen(function* () {
+            spawned++;
+            yield* Effect.acquireRelease(Effect.void, () =>
+              Effect.sync(() => {
+                finalized++;
+              }),
+            );
+            if (phase === "spawn") return yield* pending;
+
+            return yield* scriptedSpawner([]).spawn(command);
+          }),
+        );
+
+        const provider =
+          phase === "configuration"
+            ? ConfigProvider.make(() => pending)
+            : ConfigProvider.fromEnvRecord({ EFFECT_AGENT_ALLOWED: "visible" });
+
+        const fiber = yield* Effect.gen(function* () {
+          const sandbox = yield* Sandbox;
+
+          yield* sandbox
+            .execute(
+              request([], {
+                environment: { allow: ["EFFECT_AGENT_ALLOWED"] },
+                limits: { maxOutputBytes: 1_024, maxWallTime: Duration.seconds(1) },
+              }),
+            )
+            .pipe(
+              Stream.runForEach((event) =>
+                Effect.sync(() => {
+                  events.push(event);
+                }),
+              ),
+            );
+        }).pipe(
+          Effect.provide(sandboxLayer),
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Effect.provide(ConfigProvider.layer(provider)),
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust("1 second");
+        const exit = yield* Fiber.await(fiber);
+
+        expect(failureFrom(exit)).toMatchObject({ _tag: "SandboxTimeoutError" });
+        expect(events).toEqual([]);
+        expect(interrupted).toBe(true);
+        expect(spawned).toBe(phase === "spawn" ? 1 : 0);
+        expect(finalized).toBe(phase === "spawn" ? 1 : 0);
+      }),
+  );
+
+  it.effect("shares the setup deadline with active output and finalizes the child once", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const spawning = yield* Deferred.make<void>();
+      const started = yield* Deferred.make<void>();
+      const output = yield* Deferred.make<void>();
+      const events: Array<SandboxEvent> = [];
+      const values = ConfigProvider.fromEnvRecord({ EFFECT_AGENT_ALLOWED: "visible" });
+      let finalized = 0;
+
+      const provider = ConfigProvider.make((path) =>
+        Deferred.succeed(entered, undefined).pipe(
+          Effect.andThen(Effect.sleep("200 millis")),
+          Effect.andThen(values.load(path)),
+        ),
+      );
+
+      const stdout = Stream.fromEffectRepeat(
+        Effect.sleep("100 millis").pipe(Effect.as(new TextEncoder().encode("output"))),
+      );
+
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(spawning, undefined);
+          yield* Effect.sleep("300 millis");
+
+          return yield* Effect.acquireRelease(spawnerWithStdout(stdout).spawn(command), () =>
+            Effect.sync(() => {
+              finalized++;
+            }),
+          );
+        }),
+      );
+
+      const fiber = yield* Effect.gen(function* () {
+        const sandbox = yield* Sandbox;
+
+        yield* sandbox
+          .execute(
+            request([], {
+              environment: { allow: ["EFFECT_AGENT_ALLOWED"] },
+              limits: { maxOutputBytes: 1_024, maxWallTime: Duration.seconds(1) },
+            }),
+          )
+          .pipe(
+            Stream.runForEach((event) =>
+              Effect.sync(() => {
+                events.push(event);
+              }).pipe(
+                Effect.andThen(
+                  event._tag === "SandboxStarted"
+                    ? Deferred.succeed(started, undefined)
+                    : event._tag === "SandboxOutput"
+                      ? Deferred.succeed(output, undefined)
+                      : Effect.void,
+                ),
+              ),
+            ),
+          );
+      }).pipe(
+        Effect.provide(sandboxLayer),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provide(ConfigProvider.layer(provider)),
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(entered);
+      yield* TestClock.adjust("200 millis");
+      yield* Deferred.await(spawning);
+      yield* TestClock.adjust("300 millis");
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("100 millis");
+      yield* Deferred.await(output);
+      yield* TestClock.adjust("300 millis");
+
+      expect(events[0]?._tag).toBe("SandboxStarted");
+      expect(events.some((event) => event._tag === "SandboxOutput")).toBe(true);
+      expect(finalized).toBe(0);
+
+      yield* TestClock.adjust("100 millis");
+      const exit = yield* Fiber.await(fiber);
+
+      expect(failureFrom(exit)).toMatchObject({ _tag: "SandboxTimeoutError" });
+      expect(events.some((event) => event._tag === "SandboxExited")).toBe(false);
+      expect(finalized).toBe(1);
+    }),
+  );
+
   it.effect("decodes UTF-8 sequences split across chunk boundaries and flushes the tail", () =>
     Effect.gen(function* () {
       const sandbox = yield* Sandbox;

--- a/packages/storage-cloudflare/src/DoThreadStore.ts
+++ b/packages/storage-cloudflare/src/DoThreadStore.ts
@@ -810,7 +810,20 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
           message: `Expected at most one checkpoint row but found ${rows.length}.`,
         });
       }
-      const checkpoint = yield* decodeCheckpoint(rows[0].checkpoint_json);
+      const row = rows[0];
+      const checkpoint = yield* decodeCheckpoint(row.checkpoint_json);
+
+      if (
+        row.thread_id !== validated.threadId ||
+        checkpoint.threadId !== row.thread_id ||
+        checkpoint.throughSequence !== row.through_sequence ||
+        checkpoint.tailDigest !== row.tail_digest
+      ) {
+        return yield* ThreadStoreError.make({
+          operation: "load checkpoint",
+          message: "Stored checkpoint metadata does not match its canonical row.",
+        });
+      }
 
       const canonicalDigest = yield* tailDigestAt(
         journal,

--- a/packages/storage-cloudflare/test/do-storage.test.ts
+++ b/packages/storage-cloudflare/test/do-storage.test.ts
@@ -19,12 +19,15 @@ import {
   threadCheckpointConformanceCases,
 } from "@effect-agent/thread/testing/ThreadStoreConformance";
 import {
+  ThreadCheckpoint,
   ThreadMaterialization,
   ThreadObservation,
   ThreadRead,
   ThreadStore,
   ThreadStoreError,
   FencedAppendRequest,
+  LoadCheckpointRequest,
+  SaveCheckpointRequest,
 } from "@effect-agent/thread/ThreadStore";
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
@@ -93,6 +96,84 @@ const batch = (
   });
 
 describe("DoThreadStore", () => {
+  for (const corruption of ["thread", "sequence", "digest"] as const) {
+    it(`rejects checkpoint ${corruption} metadata that disagrees with its row`, () =>
+      withThreadStorage(`checkpoint-metadata:${corruption}`, (storage) =>
+        Effect.gen(function* () {
+          const store = yield* ThreadStore;
+          const threadId = thread("checkpoint-metadata");
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const appended = yield* store.append(
+            FencedAppendRequest.make({
+              threadId,
+              batch: batch("checkpoint-metadata", [
+                inputRecord("checkpoint-metadata-input", "Kyoto"),
+              ]),
+              expectedTailSequence: sequence(0),
+              expectedTailDigest: EMPTY_TAIL_DIGEST,
+              producerEpoch: epoch(1),
+            }),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "checkpoint-metadata-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          yield* store.checkpoints!.save(SaveCheckpointRequest.make({ checkpoint }));
+
+          const corrupted = ThreadCheckpoint.make({
+            ...checkpoint,
+            ...(corruption === "thread" ? { threadId: thread("other-checkpoint-thread") } : {}),
+            ...(corruption === "sequence"
+              ? { throughSequence: appended.lastSequence, tailDigest: appended.tailDigest }
+              : {}),
+          });
+
+          const corruptedJson = JSON.stringify(
+            yield* Schema.encodeEffect(ThreadCheckpoint)(corrupted),
+          );
+
+          const rowDigest = corruption === "digest" ? appended.tailDigest : EMPTY_TAIL_DIGEST;
+
+          yield* Effect.sync(() =>
+            storage.sql.exec(
+              "UPDATE effect_agent_checkpoints SET checkpoint_json = ?, tail_digest = ? WHERE thread_id = ? AND through_sequence = 0",
+              corruptedJson,
+              rowDigest,
+              threadId,
+            ),
+          );
+
+          const loaded = yield* store
+            .checkpoints!.load(
+              LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: sequence(0) }),
+            )
+            .pipe(Effect.exit);
+
+          expect(Exit.isFailure(loaded)).toBe(true);
+          if (Exit.isFailure(loaded)) {
+            const error = Cause.squash(loaded.cause);
+
+            expect(error).toBeInstanceOf(ThreadStoreError);
+            if (isThreadStoreError(error)) expect(error.operation).toBe("load checkpoint");
+          }
+        }).pipe(Effect.provide(layer({ storage }))),
+      ));
+  }
+
   // The SAME adapter-neutral contract suite the Node/SQLite and in-memory adapters run,
   // executed in-workerd against a real SQLite-backed Durable Object's storage. One Durable
   // Object per case: the 0.21.x pool shares storage across tests within a run.

--- a/packages/storage-memory/src/MemorySubmissionLedger.ts
+++ b/packages/storage-memory/src/MemorySubmissionLedger.ts
@@ -271,7 +271,7 @@ const admissionKey = (
   threadId: ThreadId,
   principal: Principal,
   idempotencyKey: IdempotencyKey,
-): string => `${threadId}\u001f${principal}\u001f${idempotencyKey}`;
+): string => JSON.stringify([threadId, principal, idempotencyKey]);
 
 const toSnapshot = (row: SubmissionRow): SubmissionSnapshot =>
   SubmissionSnapshot.make({
@@ -865,6 +865,25 @@ const makeSubmissionLedger = (options: MemorySubmissionLedgerOptions = {}) =>
             }
             if (!ownsLane(stored, request.ownershipToken)) {
               return [failure(ownershipLost(current, stored)), current];
+            }
+
+            if (stored.inputApplied !== undefined) {
+              if (
+                stored.inputApplied.recordId === request.recordId &&
+                stored.inputApplied.sequence === request.sequence
+              ) {
+                return [success(undefined), current];
+              }
+
+              return [
+                failure(
+                  ledgerError(
+                    "markInputApplied",
+                    `A different canonical input marker is already recorded for Submission ${request.submissionId}`,
+                  ),
+                ),
+                current,
+              ];
             }
 
             const marker = InputAppliedMarker.make({

--- a/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
+++ b/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
@@ -3053,8 +3053,8 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
       request,
     ).pipe(Effect.mapError(internalFailure(operation)));
 
-    return yield* sql
-      .withTransaction(
+    return yield* journal
+      .withReadTransaction(operation)(
         Effect.gen(function* () {
           const submissionRow = yield* requireSubmission(operation, validated.submissionId);
           const submission = yield* decodeSubmissionSnapshot(operation, submissionRow);
@@ -3263,7 +3263,11 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
           });
         }),
       )
-      .pipe(Effect.catchTag("SqlError", (error) => Effect.fail(sqlFailure(operation)(error))));
+      .pipe(
+        Effect.catchTag("SqliteStorageError", (error) =>
+          Effect.fail(internalFailure(operation)(error)),
+        ),
+      );
   });
 
   return Context.make(

--- a/packages/storage-sqlite/src/SqliteThreadStore.ts
+++ b/packages/storage-sqlite/src/SqliteThreadStore.ts
@@ -799,7 +799,20 @@ const makeServices = Effect.fn("SqliteThreadStore.makeServices")(function* () {
           message: `Expected at most one checkpoint row but found ${rows.length}.`,
         });
       }
-      const checkpoint = yield* decodeCheckpoint(rows[0].checkpoint_json);
+      const row = rows[0];
+      const checkpoint = yield* decodeCheckpoint(row.checkpoint_json);
+
+      if (
+        row.thread_id !== validated.threadId ||
+        checkpoint.threadId !== row.thread_id ||
+        checkpoint.throughSequence !== row.through_sequence ||
+        checkpoint.tailDigest !== row.tail_digest
+      ) {
+        return yield* ThreadStoreError.make({
+          operation: "load checkpoint",
+          message: "Stored checkpoint metadata does not match its canonical row.",
+        });
+      }
 
       const canonicalDigest = yield* tailDigestAt(
         journal,

--- a/packages/storage-sqlite/src/internal/sqlite-journal.ts
+++ b/packages/storage-sqlite/src/internal/sqlite-journal.ts
@@ -1164,6 +1164,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     saveCheckpoint,
     scanStoredPayloads,
     withWriteTransaction,
+    withReadTransaction,
   } as const;
 });
 

--- a/packages/storage-sqlite/test/sqlite-ledger.test.ts
+++ b/packages/storage-sqlite/test/sqlite-ledger.test.ts
@@ -95,9 +95,11 @@ import type { Crypto, PlatformError } from "effect";
 import {
   Cause,
   DateTime,
+  Deferred,
   Effect,
   Exit,
   FileSystem,
+  Fiber,
   Layer,
   Option,
   Ref,
@@ -770,6 +772,110 @@ describe("SqliteSubmissionLedger", () => {
         expect(tail.tailDigest).toBe(EMPTY_TAIL_DIGEST);
       }).pipe(Effect.provide(combinedLayer(filename))),
     ),
+  );
+
+  it.effect("reads committed recovery state while a separate connection holds the write lock", () =>
+    withTemporaryDatabase((filename) =>
+      withLedger(
+        filename,
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const admitted = yield* ledger.admit(yield* admission("recovery-reader", "input", {}));
+          const request = RecoverySnapshotRequest.make({ submissionId: admitted.submissionId });
+
+          yield* withSql(
+            filename,
+            Effect.scoped(
+              Effect.gen(function* () {
+                const sql = yield* SqlClientService.SqlClient;
+
+                // Explicit SQL keeps the writer's transaction out of Effect's ambient
+                // transaction context: the ledger must reserve its own reader connection.
+                yield* Effect.acquireRelease(sql`BEGIN IMMEDIATE`, () =>
+                  sql`ROLLBACK`.pipe(Effect.orDie),
+                );
+                yield* sql`
+                  UPDATE effect_agent_submissions
+                  SET state = 'ready', ready_at = '1970-01-01T00:00:00.001Z'
+                  WHERE submission_id = ${admitted.submissionId}
+                `;
+
+                const snapshot = yield* ledger.loadRecoverySnapshot(request);
+
+                expect(snapshot.submission.state).toBe("admitted");
+                expect(snapshot.submission.readyAt).toBeUndefined();
+              }),
+            ),
+          );
+
+          // The completed read must release its transaction and connection reservation.
+          yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+          expect((yield* ledger.loadRecoverySnapshot(request)).submission.state).toBe("ready");
+        }),
+      ),
+    ),
+  );
+
+  it.effect(
+    "releases recovery read transactions after typed failure, defect, and interruption",
+    () =>
+      withTemporaryDatabase((filename) =>
+        withLedger(
+          filename,
+          Effect.gen(function* () {
+            const ledger = yield* SubmissionLedger;
+            const admitted = yield* ledger.admit(yield* admission("recovery-cleanup", "input", {}));
+            const request = RecoverySnapshotRequest.make({ submissionId: admitted.submissionId });
+
+            const missing = yield* ledger
+              .loadRecoverySnapshot(
+                RecoverySnapshotRequest.make({
+                  submissionId: id(
+                    RecoverySnapshotRequest.fields.submissionId,
+                    "missing-submission",
+                  ),
+                }),
+              )
+              .pipe(Effect.exit);
+
+            expect(Exit.isFailure(missing)).toBe(true);
+            if (Exit.isFailure(missing))
+              expect(Cause.squash(missing.cause)).toBeInstanceOf(LedgerError);
+            expect((yield* ledger.loadRecoverySnapshot(request)).submission.state).toBe("admitted");
+
+            const defect = yield* ledger.loadRecoverySnapshot(request).pipe(
+              Effect.provideService(CurrentTransformer, () => Effect.die("recovery-read-defect")),
+              Effect.exit,
+            );
+
+            expect(Exit.isFailure(defect)).toBe(true);
+            if (Exit.isFailure(defect))
+              expect(Cause.squash(defect.cause)).toBe("recovery-read-defect");
+            expect((yield* ledger.loadRecoverySnapshot(request)).submission.state).toBe("admitted");
+
+            const paused = yield* Deferred.make<void>();
+            const queries = yield* Ref.make(0);
+
+            const reader = yield* ledger.loadRecoverySnapshot(request).pipe(
+              Effect.provideService(CurrentTransformer, (statement) =>
+                Ref.updateAndGet(queries, (count) => count + 1).pipe(
+                  Effect.flatMap((count) =>
+                    count === 2
+                      ? Deferred.succeed(paused, undefined).pipe(Effect.andThen(Effect.never))
+                      : Effect.succeed(statement),
+                  ),
+                ),
+              ),
+              Effect.forkChild,
+            );
+
+            yield* Deferred.await(paused);
+            yield* Fiber.interrupt(reader);
+            yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+            expect((yield* ledger.loadRecoverySnapshot(request)).submission.state).toBe("ready");
+          }),
+        ),
+      ),
   );
 
   it.effect("classifies cross-connection write contention as retryable typed contention", () =>

--- a/packages/storage-sqlite/test/sqlite-storage.test.ts
+++ b/packages/storage-sqlite/test/sqlite-storage.test.ts
@@ -201,6 +201,75 @@ const withTemporaryDatabase = <A, E>(
   ).pipe(Effect.provide(NodeFileSystem.layer));
 
 describe("SqliteThreadStore", () => {
+  for (const corruption of ["thread", "sequence", "digest"] as const) {
+    it.effect(`rejects checkpoint ${corruption} metadata that disagrees with its row`, () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const store = yield* ThreadStore;
+          const sql = yield* SqlClientService.SqlClient;
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const appended = yield* append(
+            store,
+            batch("checkpoint-metadata", [inputRecord("checkpoint-metadata-input", "Kyoto")]),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "checkpoint-metadata-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          yield* store.checkpoints!.save(SaveCheckpointRequest.make({ checkpoint }));
+
+          const corrupted = ThreadCheckpoint.make({
+            ...checkpoint,
+            ...(corruption === "thread" ? { threadId: secondThreadId } : {}),
+            ...(corruption === "sequence"
+              ? { throughSequence: appended.lastSequence, tailDigest: appended.tailDigest }
+              : {}),
+          });
+
+          const corruptedJson = JSON.stringify(
+            yield* Schema.encodeEffect(ThreadCheckpoint)(corrupted),
+          );
+
+          const rowDigest = corruption === "digest" ? appended.tailDigest : EMPTY_TAIL_DIGEST;
+
+          yield* sql`
+            UPDATE effect_agent_checkpoints
+            SET checkpoint_json = ${corruptedJson}, tail_digest = ${rowDigest}
+            WHERE thread_id = ${threadId} AND through_sequence = 0
+          `;
+
+          const loaded = yield* store
+            .checkpoints!.load(
+              LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: sequence(0) }),
+            )
+            .pipe(Effect.exit);
+
+          expect(Exit.isFailure(loaded)).toBe(true);
+          if (Exit.isFailure(loaded)) {
+            const error = Cause.squash(loaded.cause);
+
+            expect(error).toBeInstanceOf(ThreadStoreError);
+            if (isThreadStoreError(error)) expect(error.operation).toBe("load checkpoint");
+          }
+        }).pipe(Effect.provide(explicitTestStorageLayer(filename))),
+      ),
+    );
+  }
+
   describe("shared ThreadStore conformance", () => {
     for (const conformanceCase of [
       ...threadStoreConformanceCases,

--- a/packages/testing/src/Chaos.ts
+++ b/packages/testing/src/Chaos.ts
@@ -588,7 +588,7 @@ export interface ChaosRunOptions {
   readonly betweenRounds?: Effect.Effect<void> | undefined;
 }
 
-/** Success → Some; typed failure → None (chaos tolerates it); defect → rethrown loudly. */
+/** Tolerate typed failures while preserving every defect and interruption reason. */
 const tolerateTyped = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<Option.Option<A>, never, R> =>
@@ -596,11 +596,11 @@ const tolerateTyped = <A, E, R>(
     Effect.exit,
     Effect.flatMap((exit) => {
       if (Exit.isSuccess(exit)) return Effect.succeed(Option.some(exit.value));
-      if (Option.isSome(Cause.findErrorOption(exit.cause))) {
-        return Effect.succeed(Option.none<A>());
-      }
+      const unexpected = exit.cause.reasons.filter((reason) => reason._tag !== "Fail");
 
-      return Effect.die(new Error(`chaos step died: ${Cause.pretty(exit.cause)}`));
+      return unexpected.length === 0
+        ? Effect.succeed(Option.none<A>())
+        : Effect.failCause(Cause.fromReasons<never>(unexpected));
     }),
   );
 

--- a/packages/testing/src/CodeExecutorSubstitute.ts
+++ b/packages/testing/src/CodeExecutorSubstitute.ts
@@ -166,6 +166,20 @@ const safeDecodeJson = (value: unknown): Option.Option<Schema.Json> => {
   }
 };
 
+const decodeJsonText = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Json));
+
+/** Own serialized result text before bounding and decoding its detached JSON snapshot. */
+const serializeJson = (value: unknown): Option.Option<string> => {
+  const decoded = safeDecodeJson(value);
+
+  if (Option.isNone(decoded)) return Option.none();
+  try {
+    return Option.fromUndefinedOr(JSON.stringify(decoded.value));
+  } catch {
+    return Option.none();
+  }
+};
+
 const boundedThrown = (value: unknown): Schema.Json => {
   const decoded = safeDecodeJson(value);
 
@@ -174,7 +188,9 @@ const boundedThrown = (value: unknown): Schema.Json => {
       const encoded = JSON.stringify(decoded.value);
 
       if (encoded !== undefined && encoded.length <= MAX_THROWN_CHARACTERS) {
-        return decoded.value;
+        const snapshot = decodeJsonText(encoded);
+
+        if (Option.isSome(snapshot)) return snapshot.value;
       }
     } catch {
       // fall through to the bounded string form
@@ -327,28 +343,36 @@ const classifyProgramFailure = (
   limits: CodeExecutionLimits,
   capture: LogCapture,
 ): CodeOutputLimitError | CodeSourceError | CodeProgramFailedError => {
-  const inner = thrown instanceof EvaluationThrew ? thrown.inner : thrown;
+  let inner = thrown;
+  let reason: "threw" | "rejected" = "rejected";
 
-  if (inner instanceof LogLimitSignal) {
-    return CodeOutputLimitError.make({
-      implementation: inProcessCodeExecutorImplementation,
-      surface: "logs",
-      limit: limits.maxLogBytes,
-      observed: inner.observed,
-      logs: [...capture.lines],
-    });
+  try {
+    const evaluationThrew = thrown instanceof EvaluationThrew;
+
+    inner = evaluationThrew ? thrown.inner : thrown;
+    if (inner instanceof LogLimitSignal) {
+      return CodeOutputLimitError.make({
+        implementation: inProcessCodeExecutorImplementation,
+        surface: "logs",
+        limit: limits.maxLogBytes,
+        observed: inner.observed,
+        logs: [...capture.lines],
+      });
+    }
+    if (inner instanceof NotAFunction) {
+      return CodeSourceError.make({
+        implementation: inProcessCodeExecutorImplementation,
+        reason: "not-a-function",
+        message: `The source expression evaluated to ${inner.actual}; it must evaluate to one async function`,
+      });
+    }
+    // Async body throws become rejections: exception-like values read as `threw`,
+    // while plain values such as uncaught host failure envelopes read as `rejected`.
+    reason = evaluationThrew || inner instanceof Error ? "threw" : "rejected";
+  } catch {
+    // A program-owned Proxy can throw from instanceof's prototype lookup. Keep
+    // that failure inside the same guarded diagnostic boundary as its value.
   }
-  if (inner instanceof NotAFunction) {
-    return CodeSourceError.make({
-      implementation: inProcessCodeExecutorImplementation,
-      reason: "not-a-function",
-      message: `The source expression evaluated to ${inner.actual}; it must evaluate to one async function`,
-    });
-  }
-  // An async function converts a body-level `throw` into a rejection, so the
-  // split is by value shape: exception-like values read as `threw`, plain
-  // rejection values (an uncaught host failure envelope) read as `rejected`.
-  const reason = thrown instanceof EvaluationThrew || inner instanceof Error ? "threw" : "rejected";
 
   return CodeProgramFailedError.make({
     implementation: inProcessCodeExecutorImplementation,
@@ -475,33 +499,36 @@ const executeInProcess: CodeExecutorExecute = Effect.fn("InProcessCodeExecutor.e
       });
     }
 
-    const value = yield* Schema.decodeUnknownEffect(Schema.Json)(returned).pipe(
-      Effect.mapError(() =>
-        CodeProgramFailedError.make({
-          implementation: inProcessCodeExecutorImplementation,
-          reason: "non-json-result",
-          thrown: null,
-          message: "The program must return a JSON value",
-          logs: [...capture.lines],
-        }),
-      ),
-    );
+    const nonJsonResult = () =>
+      CodeProgramFailedError.make({
+        implementation: inProcessCodeExecutorImplementation,
+        reason: "non-json-result",
+        thrown: null,
+        message: "The program must return a JSON value",
+        logs: [...capture.lines],
+      });
 
-    const resultBytes = encodedJsonByteLength(value);
+    const encoded = serializeJson(returned);
 
-    if (resultBytes === undefined || resultBytes > request.limits.maxResultBytes) {
+    if (Option.isNone(encoded)) return yield* nonJsonResult();
+    const resultBytes = utf8ByteLength(encoded.value);
+
+    if (resultBytes > request.limits.maxResultBytes) {
       return yield* CodeOutputLimitError.make({
         implementation: inProcessCodeExecutorImplementation,
         surface: "result",
         limit: request.limits.maxResultBytes,
-        observed: resultBytes ?? 0,
+        observed: resultBytes,
         logs: [...capture.lines],
       });
     }
+    const decoded = decodeJsonText(encoded.value);
+
+    if (Option.isNone(decoded)) return yield* nonJsonResult();
 
     return CodeExecutionResult.make({
       implementation: inProcessCodeExecutorImplementation,
-      value,
+      value: decoded.value,
       logs: [...capture.lines],
       resourceUse: CodeExecutionResourceUse.make({
         wallTime: Duration.millis(Math.max(0, finishedAt - startedAt)),

--- a/packages/testing/test/chaos-memory.test.ts
+++ b/packages/testing/test/chaos-memory.test.ts
@@ -2,6 +2,7 @@ import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemoryS
 import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
 import {
   ChaosPlan,
+  ChaosSubmissionSpec,
   DEFAULT_CHAOS_SEED,
   chaosSeedFromEnv,
   generateChaosPlans,
@@ -12,12 +13,13 @@ import {
   DurableRuntimeConfig,
 } from "@effect-agent/thread/DurableAgentRuntime";
 import { DeploymentId, ProducerId } from "@effect-agent/thread/Records";
+import { LedgerError, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
 import { DurableRuntimeFailpointTestControl } from "@effect-agent/thread/testing/DurableFailpointTestControl";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Duration, Effect, Exit, Layer, Schema } from "effect";
+import { Cause, Duration, Effect, Exit, Layer, Schema, Stream } from "effect";
 
 /**
  * P7 WP4 memory chaos lane (plan §5): ~200 seeded plans over the in-memory adapter pair,
@@ -58,7 +60,91 @@ const replayHint = (planIndex: number, plan: ChaosPlan): string =>
   `submissions [${plan.submissions.map((spec) => `${spec.lane}:${spec.kind}`).join(", ")}], ` +
   `arms [${[...plan.failpointArms, ...plan.adapterArms].join(", ")}])`;
 
+const runWithScanFailure = Effect.fn("test.runChaosWithScanFailure")(
+  function* (failure: Effect.Effect<never, LedgerError>) {
+    const ledger = yield* SubmissionLedger;
+    let injected = false;
+
+    const decorated = SubmissionLedger.of({
+      ...ledger,
+      scanNonterminal: Stream.unwrap(
+        Effect.sync(() => {
+          if (injected) return ledger.scanNonterminal;
+          injected = true;
+
+          return Stream.fromEffect(failure);
+        }),
+      ),
+    });
+
+    const plan = ChaosPlan.make({
+      seed: 1,
+      lanes: 1,
+      submissions: [ChaosSubmissionSpec.make({ lane: 0, kind: "plain" })],
+      failpointArms: [],
+      adapterArms: [],
+      abortInjections: [],
+      resolutionInjections: [],
+      approvalDecisions: [],
+    });
+
+    const exit = yield* runChaosPlan(plan).pipe(
+      Effect.provideService(SubmissionLedger, decorated),
+      Effect.exit,
+    );
+
+    expect(injected).toBe(true);
+
+    return exit;
+  },
+  Effect.provide(freshLayer()),
+  Effect.scoped,
+);
+
+const scanUnavailable = LedgerError.make({
+  operation: "scanNonterminal",
+  message: "one-shot scan unavailable",
+});
+
 describe("DUR-002/DUR-004/DUR-017 P7 chaos (memory adapters)", () => {
+  it.effect("tolerates a one-shot typed ledger failure and still verifies convergence", () =>
+    Effect.gen(function* () {
+      const exit = yield* runWithScanFailure(Effect.fail(scanUnavailable));
+
+      expect(Exit.isSuccess(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value.openObligations).toBe(0);
+        expect(exit.value.lanes.map((lane) => lane.verified)).toEqual([true]);
+      }
+    }),
+  );
+
+  it.effect("preserves a cleanup defect accompanying a tolerated ledger failure", () =>
+    Effect.gen(function* () {
+      const defect = new Error("scan cleanup defect");
+
+      const exit = yield* runWithScanFailure(
+        Effect.fail(scanUnavailable).pipe(Effect.ensuring(Effect.die(defect))),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.reasons.filter(Cause.isDieReason)).toHaveLength(1);
+        expect(exit.cause.reasons.find(Cause.isDieReason)?.defect).toBe(defect);
+        expect(Cause.hasFails(exit.cause)).toBe(false);
+      }
+    }),
+  );
+
+  it.effect("preserves ledger interruption without converting it to a defect", () =>
+    Effect.gen(function* () {
+      const exit = yield* runWithScanFailure(Effect.interrupt);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    }),
+  );
+
   it("accepts only schema-valid safe-integer CHAOS_SEED values", () => {
     expect(chaosSeedFromEnv({ CHAOS_SEED: "-42" })).toBe(-42);
     expect(chaosSeedFromEnv({ CHAOS_SEED: "12x" })).toBe(DEFAULT_CHAOS_SEED);

--- a/packages/testing/test/code-executor-substitute.test.ts
+++ b/packages/testing/test/code-executor-substitute.test.ts
@@ -1,6 +1,7 @@
 import {
   CodeExecutionHost,
   CodeExecutionLimits,
+  CodeExecutionNamespace,
   CodeExecutionRequest,
   CodeExecutor,
 } from "@effect-agent/sandbox/CodeExecutor";
@@ -11,7 +12,7 @@ import {
   inProcessCodeExecutorLayer,
 } from "@effect-agent/testing/CodeExecutorSubstitute";
 import { expect, layer } from "@effect/vitest";
-import { Duration, Effect } from "effect";
+import { Cause, Duration, Effect, Exit } from "effect";
 
 const limits = CodeExecutionLimits.make({
   maxSourceBytes: 64 * 1024,
@@ -56,6 +57,114 @@ layer(inProcessCodeExecutorLayer, { excludeTestServices: true })(
     })) {
       it.effect(conformanceCase.name, () => conformanceCase.run);
     }
+
+    for (const { name, source, reason } of [
+      {
+        name: "a returned object with a throwing getter",
+        source:
+          "async () => { console.log('before failure'); return { get value() { throw new Error('result getter'); } }; }",
+        reason: "non-json-result",
+      },
+      {
+        name: "a returned Proxy with a throwing prototype trap",
+        source:
+          "async () => { console.log('before failure'); return new Proxy({}, { getPrototypeOf() { throw new Error('result prototype'); } }); }",
+        reason: "non-json-result",
+      },
+      {
+        name: "a rejected Proxy with throwing prototype and property traps",
+        source:
+          "async () => { console.log('before failure'); throw new Proxy({}, { getPrototypeOf() { throw new Error('rejection prototype'); }, get() { throw new Error('rejection property'); } }); }",
+        reason: "rejected",
+      },
+    ]) {
+      it.effect(`reports ${name} as a typed program failure`, () =>
+        Effect.gen(function* () {
+          const error = yield* execute(request(source)).pipe(Effect.flip);
+
+          expect(error._tag).toBe("CodeProgramFailedError");
+          if (error._tag !== "CodeProgramFailedError") return;
+          expect(error.reason).toBe(reason);
+          expect(error.logs).toEqual(["before failure"]);
+          expect(error.message.length).toBeLessThanOrEqual(4_000);
+          expect(JSON.stringify(error.thrown).length).toBeLessThanOrEqual(4_002);
+        }),
+      );
+    }
+
+    for (const disposition of ["return", "throw"]) {
+      it.effect(
+        `snapshots a ${disposition} value before its getter can change during construction`,
+        () =>
+          Effect.gen(function* () {
+            const exit = yield* execute(
+              request(
+                `async () => { let reads = 0; ${disposition} new Proxy({ value: 1 }, { get(target, key) { if (key === 'value' && ++reads > 2) throw new Error('later read'); return Reflect.get(target, key); } }); }`,
+              ),
+            ).pipe(Effect.exit);
+
+            if (disposition === "return") {
+              expect(Exit.isSuccess(exit)).toBe(true);
+              if (Exit.isSuccess(exit)) {
+                expect(exit.value.value).toEqual({ value: 1 });
+                expect(exit.value.resourceUse.resultBytes).toBe(11);
+              }
+            } else {
+              expect(Exit.isFailure(exit)).toBe(true);
+              if (Exit.isFailure(exit)) {
+                expect(Cause.hasDies(exit.cause)).toBe(false);
+                const reason = exit.cause.reasons.find(Cause.isFailReason);
+
+                expect(reason?.error._tag).toBe("CodeProgramFailedError");
+                if (reason?.error._tag === "CodeProgramFailedError") {
+                  expect(reason.error.thrown).toEqual({ value: 1 });
+                }
+              }
+            }
+          }),
+      );
+    }
+
+    it.effect("preserves a host defect and finalizes its in-flight call", () =>
+      Effect.gen(function* () {
+        const defect = new Error("host defect");
+        let finalized = false;
+        const executor = yield* CodeExecutor;
+
+        const exit = yield* executor
+          .execute(
+            CodeExecutionRequest.make({
+              ...request("async () => warehouse.query({})"),
+              namespaces: [CodeExecutionNamespace.make({ name: "warehouse", methods: ["query"] })],
+            }),
+          )
+          .pipe(
+            Effect.provideService(
+              CodeExecutionHost,
+              CodeExecutionHost.of({
+                call: () =>
+                  Effect.die(defect).pipe(
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        finalized = true;
+                      }),
+                    ),
+                  ),
+              }),
+            ),
+            Effect.scoped,
+            Effect.exit,
+          );
+
+        expect(finalized).toBe(true);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(exit.cause.reasons.filter(Cause.isDieReason)).toHaveLength(1);
+          expect(exit.cause.reasons.find(Cause.isDieReason)?.defect).toBe(defect);
+          expect(Cause.hasFails(exit.cause)).toBe(false);
+        }
+      }),
+    );
 
     it.effect("rejects a CPU limit it cannot enforce with a typed unsupported error", () =>
       Effect.gen(function* () {

--- a/packages/testing/test/durable-tools.test.ts
+++ b/packages/testing/test/durable-tools.test.ts
@@ -18,6 +18,7 @@ import {
 import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
 import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
 import { compileRegistrations } from "@effect-agent/thread/AgentRegistration";
+import { digestJson } from "@effect-agent/thread/Digest";
 import {
   DurableAgentRuntime,
   DurableRuntimeConfig,
@@ -28,6 +29,7 @@ import {
   type DurableRuntimeFailpointLocation,
 } from "@effect-agent/thread/DurableFailpoint";
 import {
+  CanonicalBatch,
   type CanonicalRecordEnvelope,
   DefinitionDigestInput,
   DefinitionDigests,
@@ -57,7 +59,12 @@ import {
   type UnknownResolutionConflict,
 } from "@effect-agent/thread/SubmissionLedger";
 import { DurableRuntimeFailpointTestControl } from "@effect-agent/thread/testing/DurableFailpointTestControl";
-import { ThreadRead, ThreadStore } from "@effect-agent/thread/ThreadStore";
+import {
+  FencedAppendRequest,
+  ThreadRead,
+  ThreadStore,
+  ThreadTailRequest,
+} from "@effect-agent/thread/ThreadStore";
 import {
   ReconciliationCompleted,
   ReconciliationSafeToRetry,
@@ -2113,6 +2120,185 @@ layer(testLayer)("DUR P5 durable Tools (prepared/settled, reconciliation, unknow
         expect(settled.result).toEqual({ state: "flight-trip+lodging-trip" });
       }
     }),
+  );
+
+  it.effect(
+    "records distinct Steps when legal Tool Call IDs and Step names contain separators",
+    () =>
+      Effect.gen(function* () {
+        yield* resetReconciler;
+        const runtime = yield* DurableAgentRuntime;
+        const executed = yield* Ref.make<ReadonlyArray<string>>([]);
+
+        const toolLayer = itineraryTools.toLayer({
+          itinerary: ({ ref }) =>
+            Effect.gen(function* () {
+              const step = yield* DurableStep;
+
+              const state = yield* step.do(
+                ref,
+                Schema.String,
+                Ref.update(executed, (names) => [...names, ref]).pipe(Effect.as(ref)),
+              );
+
+              return { state };
+            }),
+        });
+
+        const definition = Agent.make("durable-step-identities", {
+          input: itineraryDefinition.input,
+          output: itineraryDefinition.output,
+          instructions: itineraryDefinition.instructions,
+          toolkit: itineraryTools,
+          policy: { ...policy, toolConcurrency: 1 },
+        });
+
+        const scripted = yield* makeScriptedModel((call) =>
+          call === 0
+            ? toolTurn(
+                toolCall("a:b", "itinerary", { ref: "c" }),
+                toolCall("a", "itinerary", { ref: "b:c" }),
+              )
+            : finalParts('{"answer":"reserved"}'),
+        );
+
+        const agent = Agent.withModel(definition, scripted.model);
+        const thread = "thread-durable-step-identities";
+
+        yield* runtime.submit(
+          agent,
+          { question: "reserve both" },
+          submitOptions(thread, "step-identities-1"),
+        );
+
+        const settlements = yield* runtime
+          .processThread(agent, decodeThreadId(thread))
+          .pipe(Effect.provide(toolLayer));
+
+        expect(settlements[0]?.outcome).toBe("completed");
+        expect(yield* Ref.get(executed)).toEqual(["c", "b:c"]);
+
+        const records = yield* readLog(thread);
+
+        const steps = records.filter(
+          (envelope) => envelope.record.payload._tag === "ToolStepSettled",
+        );
+
+        expect(steps.map((envelope) => envelope.record.payload)).toMatchObject([
+          { toolCallId: "a:b", stepName: "c", output: "c" },
+          { toolCallId: "a", stepName: "b:c", output: "b:c" },
+        ]);
+        expect(new Set(steps.map((envelope) => envelope.record.recordId)).size).toBe(2);
+        expect(new Set(steps.map((envelope) => envelope.batchId)).size).toBe(2);
+        expect(
+          records.flatMap((envelope) =>
+            envelope.record.payload._tag === "ToolCallSettled"
+              ? [envelope.record.payload.result]
+              : [],
+          ),
+        ).toEqual([{ state: "c" }, { state: "b:c" }]);
+      }),
+  );
+
+  it.effect(
+    "replays legacy Step records from their payload without executing the recorded body",
+    () =>
+      Effect.gen(function* () {
+        yield* resetReconciler;
+        const runtime = yield* DurableAgentRuntime;
+        const control = yield* ReconcilerTestControl;
+        const store = yield* ThreadStore;
+        const desk = yield* makeItineraryDesk;
+
+        const scripted = yield* makeScriptedModel((call) =>
+          call === 0
+            ? toolTurn(toolCall("itinerary-1", "itinerary", { ref: "trip" }))
+            : finalParts('{"answer":"reserved"}'),
+        );
+
+        const agent = Agent.withModel(itineraryDefinition, scripted.model);
+        const thread = "thread-legacy-durable-step";
+        const threadId = decodeThreadId(thread);
+
+        const receipt = yield* runtime.submit(
+          agent,
+          { question: "reserve it" },
+          submitOptions(thread, "legacy-step-1"),
+        );
+
+        yield* armFailpoint("tools:after-prepared-append");
+
+        const killed = yield* Effect.exit(
+          runtime.processThread(agent, threadId).pipe(Effect.provide(desk.toolLayer)),
+        );
+
+        expect(failureTag(killed)).toBe("DurableRuntimeFailpointError");
+        yield* clearFailpoint;
+        expect(yield* desk.entries).toBe(0);
+
+        const runId = runIdForSubmission(receipt.submissionId);
+        // Deliberately spell the historical identity instead of using the current formatter.
+        const legacyId = `step:${runId}:itinerary-1:reserve-flight`;
+        const outputDigest = yield* digestJson("flight-legacy");
+
+        const batch = Schema.decodeSync(CanonicalBatch)({
+          batchId: legacyId,
+          producerId: "producer-legacy",
+          records: [
+            {
+              recordId: legacyId,
+              family: "thread",
+              schemaVersion: 1,
+              createdAt: "2026-08-12T12:00:00.000Z",
+              deploymentId: "deployment-legacy",
+              payload: {
+                _tag: "ToolStepSettled",
+                runId,
+                toolCallId: "itinerary-1",
+                stepName: "reserve-flight",
+                output: "flight-legacy",
+                outputDigest,
+              },
+            },
+          ],
+        });
+
+        const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+
+        yield* store.append(
+          FencedAppendRequest.make({
+            threadId,
+            batch,
+            expectedTailSequence: tail.tailSequence,
+            expectedTailDigest: tail.tailDigest,
+            producerEpoch: tail.producerEpoch,
+          }),
+        );
+        yield* control.set(() => ReconciliationSafeToRetry.make());
+
+        const settlements = yield* runtime
+          .processThread(agent, threadId)
+          .pipe(Effect.provide(desk.toolLayer));
+
+        expect(settlements[0]?.outcome).toBe("completed");
+        expect(yield* desk.entries).toBe(1);
+        expect(yield* desk.flightRuns).toBe(0);
+        expect(yield* desk.lodgingRuns).toBe(1);
+
+        const records = yield* readLog(thread);
+
+        expect(records.filter((envelope) => envelope.record.recordId === legacyId)).toHaveLength(1);
+        expect(records.map((envelope) => envelope.record.recordId)).not.toContain(
+          toolStepSettledRecordId(runId, decodeToolCallId("itinerary-1"), "reserve-flight"),
+        );
+        expect(
+          records.flatMap((envelope) =>
+            envelope.record.payload._tag === "ToolCallSettled"
+              ? [envelope.record.payload.result]
+              : [],
+          ),
+        ).toEqual([{ state: "flight-legacy+lodging-trip" }]);
+      }),
   );
 
   it.effect("keeps failure and requirement channels typed (E/R proofs)", () =>

--- a/packages/thread/src/Digest.ts
+++ b/packages/thread/src/Digest.ts
@@ -1,5 +1,5 @@
 import type { PlatformError } from "effect";
-import { Crypto, Effect, Encoding, Schema } from "effect";
+import { Array, Crypto, Effect, Encoding, Schema } from "effect";
 
 import type { DefinitionDigestInput } from "./Records.ts";
 import { CanonicalBatch, DefinitionDigests, Digest } from "./Records.ts";
@@ -9,8 +9,6 @@ export class DigestError extends Schema.TaggedError<DigestError>()("DigestError"
   cause: Schema.optionalKey(Schema.Defect()),
 }) {}
 
-const JsonArray = Schema.Array(Schema.Json);
-const isJsonArray = Schema.is(JsonArray);
 const utf8 = new TextEncoder();
 
 const canonicalJson = (value: Schema.Json): string => {
@@ -22,7 +20,7 @@ const canonicalJson = (value: Schema.Json): string => {
   ) {
     return JSON.stringify(value);
   }
-  if (isJsonArray(value)) {
+  if (Array.isArray<Schema.Json>(value)) {
     return `[${value.map(canonicalJson).join(",")}]`;
   }
 

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -3723,6 +3723,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const knownIds = knownRecordIdsOf(records);
       const stepOutputs = new Map<string, PersistedJson>();
 
+      // Derive replay identity from the recorded tuple, never from its historical ID format.
+      // This preserves committed Step outputs when reading legacy colon-separated record IDs.
       for (const envelope of records) {
         const payload = envelope.record.payload;
 

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -172,19 +172,21 @@ export const toolCallResolvedRecordId = (
  * Deterministic identity of one accepted Durable Step result. The one-record batch reuses the
  * SAME string, so batch idempotency plus the epoch fence realize the durability §11
  * racing-writers rule: only the fenced winner's record commits; the loser replays it.
+ * A versioned JSON tuple keeps separator characters in each identity component distinct.
+ * Replay derives this key from the structured payload, including records with legacy IDs.
  */
 export const toolStepSettledRecordId = (
   runId: RunId,
   toolCallId: ToolCallId,
   stepName: string,
-): RecordId => decodeRecordId(`step:${runId}:${toolCallId}:${stepName}`);
+): RecordId => decodeRecordId(JSON.stringify(["step@2", runId, toolCallId, stepName]));
 
 /** Deterministic batch identity of one Durable Step commit (same string as its record id). */
 export const toolStepSettledBatchId = (
   runId: RunId,
   toolCallId: ToolCallId,
   stepName: string,
-): BatchId => decodeBatchId(`step:${runId}:${toolCallId}:${stepName}`);
+): BatchId => decodeBatchId(toolStepSettledRecordId(runId, toolCallId, stepName));
 
 /** Deterministic batch identity of one Turn's canonical approval-request append (plan §2.6). */
 export const turnApprovalsBatchId = (runId: RunId, turn: number): BatchId =>

--- a/packages/thread/src/SubmissionLedgerConformance.ts
+++ b/packages/thread/src/SubmissionLedgerConformance.ts
@@ -616,6 +616,64 @@ const crossPrincipalAdmissionScoping = conformanceCase(
     }),
 );
 
+const admissionTupleBoundaries = conformanceCase(
+  "preserves admission tuple boundaries when principal and key contain separators",
+  ({ ensure, expectSome }) =>
+    Effect.gen(function* () {
+      const threadId = decodeThreadId("ledger-conformance-admission-separators");
+      const ledger = yield* SubmissionLedger;
+      const base = yield* admissionRequest(threadId, "r", { work: "separators" });
+
+      const firstRequest = AdmissionRequest.make({
+        ...base,
+        principal: Schema.decodeSync(Principal)("p\u001fq"),
+      });
+
+      const secondRequest = AdmissionRequest.make({
+        ...base,
+        principal: Schema.decodeSync(Principal)("p"),
+        idempotencyKey: decodeIdempotencyKey("q\u001fr"),
+      });
+
+      const first = yield* ledger.admit(firstRequest);
+      const second = yield* ledger.admit(secondRequest);
+
+      yield* ensure(
+        !second.replayed &&
+          second.submissionId !== first.submissionId &&
+          second.receiptId !== first.receiptId &&
+          second.queueSequence === first.queueSequence + 1,
+        "Distinct admission tuples must allocate distinct identities and consecutive queue positions",
+      );
+
+      for (const [request, admitted] of [
+        [firstRequest, first],
+        [secondRequest, second],
+      ] as const) {
+        const key = SubmissionLookupByKey.make({
+          threadId,
+          principal: request.principal,
+          idempotencyKey: request.idempotencyKey,
+        });
+
+        const found = yield* expectSome("the exact admission tuple", yield* ledger.lookup(key));
+        const resolved = yield* ledger.resolveAdmission(key);
+        const replay = yield* ledger.admit(request);
+
+        yield* ensure(
+          found.submissionId === admitted.submissionId &&
+            resolved._tag === "Admitted" &&
+            resolved.submission.submissionId === admitted.submissionId &&
+            replay.replayed &&
+            replay.submissionId === admitted.submissionId &&
+            replay.receiptId === admitted.receiptId &&
+            replay.queueSequence === admitted.queueSequence,
+          "Lookup, authoritative resolution, and replay must preserve the exact admission tuple",
+        );
+      }
+    }),
+);
+
 const concurrentAdmissionFifo = conformanceCase(
   "allocates distinct FIFO queue sequences under concurrent admission and claims in order",
   ({ ensure, expectSome }) =>
@@ -971,7 +1029,7 @@ const releaseMakesHeadClaimable = conformanceCase(
 
 const inputAppliedIdempotency = conformanceCase(
   "marks canonical input applied idempotently under the owning token",
-  ({ ensure, expectSome }) =>
+  ({ ensure, expectFailure, expectSome }) =>
     Effect.gen(function* () {
       const threadId = decodeThreadId("ledger-conformance-input");
       const ledger = yield* SubmissionLedger;
@@ -1002,6 +1060,20 @@ const inputAppliedIdempotency = conformanceCase(
       );
 
       yield* ledger.markInputApplied(marker);
+      for (const conflicting of [
+        MarkInputAppliedRequest.make({
+          ...marker,
+          recordId: submissionInputRecordId(decodeSubmissionId("different-input-marker")),
+        }),
+        MarkInputAppliedRequest.make({ ...marker, sequence: decodeSequence(3) }),
+      ]) {
+        const error = yield* expectFailure(
+          "a conflicting input-applied marker",
+          ledger.markInputApplied(conflicting),
+        );
+
+        yield* ensure(isLedgerError(error), "Conflicting input markers must fail as LedgerError");
+      }
       const snapshot = yield* recoverySnapshot(admitted.submissionId);
 
       yield* ensure(
@@ -1009,7 +1081,7 @@ const inputAppliedIdempotency = conformanceCase(
           snapshot.inputApplied.recordId === marker.recordId &&
           snapshot.inputApplied.sequence === marker.sequence &&
           snapshot.submission.state === "input-applied",
-        "Repeating the identical input-applied marker must be a no-op with the marker retained",
+        "Identical replays and rejected conflicts must retain the original input-applied marker",
       );
     }),
 );
@@ -3988,6 +4060,7 @@ export const submissionLedgerConformanceCases: ReadonlyArray<SubmissionLedgerCon
   admissionGroupRace,
   admissionGroupSettlement,
   crossPrincipalAdmissionScoping,
+  admissionTupleBoundaries,
   concurrentAdmissionFifo,
   fifoHeadClaim,
   leaseExpiryReclaim,

--- a/packages/thread/src/ThreadProjection.ts
+++ b/packages/thread/src/ThreadProjection.ts
@@ -34,7 +34,7 @@ export const ApprovalRecord = Schema.Union([ToolApprovalRequested, ToolApprovalD
 export type ApprovalRecord = typeof ApprovalRecord.Type;
 
 /**
- * Parent-side view of one Subagent Invocation, keyed by the parent Tool Call: the canonical
+ * Parent-side view of one Subagent Invocation, keyed by the parent Run and Tool Call: the canonical
  * `SubagentRequested`/`SubagentStarted`/`SubagentJoined` payloads as they become canonical
  * in history. A disposable derived view — the canonical records and the child's
  * own Settlement remain the recovery truth (DUR-015).
@@ -42,6 +42,7 @@ export type ApprovalRecord = typeof ApprovalRecord.Type;
 export class SubagentInvocationState extends Schema.Class<SubagentInvocationState>(
   "@effect-agent/thread/SubagentInvocationState",
 )({
+  runId: RunId,
   toolCallId: ToolCallId,
   requested: Schema.optionalKey(SubagentRequested),
   started: Schema.optionalKey(SubagentStarted),
@@ -56,14 +57,17 @@ export class SubagentInvocationState extends Schema.Class<SubagentInvocationStat
  * prepared-minus-settled/resolved fold), `unknownToolCalls`, and `approvals`; S2 adds
  * `subagentInvocations` (the parent-side requested/started/joined fold) and `parentLink` (the
  * child-side immutable lineage). A checkpoint whose persisted state lacks these fields fails to
- * decode against this schema; the checkpoint is rejected and the projection is rebuilt from
+ * decode against this schema; callers must reject the checkpoint and rebuild the projection from
  * canonical records (documented disposable-checkpoint behavior, STORE-007/STORE-008).
+ * Version 2 scopes Tool identities by Run. Earlier projections must rebuild, including empty
+ * invocation views that may have already lost an earlier Run's unresolved Tool evidence.
  * `ModelResponseRecorded` advances `throughSequence` without dedicated projection state: Prompt
  * reconstruction reads canonical records directly.
  */
 export class ThreadProjection extends Schema.Class<ThreadProjection>(
   "@effect-agent/thread/ThreadProjection",
 )({
+  schemaVersion: Schema.Literal(2),
   threadId: ThreadId,
   throughSequence: CanonicalSequence,
   tailDigest: Digest,
@@ -82,6 +86,7 @@ export class ThreadProjection extends Schema.Class<ThreadProjection>(
 
 export const initialThreadProjection = (threadId: ThreadId): ThreadProjection =>
   ThreadProjection.make({
+    schemaVersion: 2,
     threadId,
     throughSequence: Schema.decodeSync(CanonicalSequence)(0),
     tailDigest: EMPTY_TAIL_DIGEST,
@@ -98,7 +103,7 @@ export const initialThreadProjection = (threadId: ThreadId): ThreadProjection =>
   });
 
 /**
- * Idempotent per-Tool-Call upsert of the parent-side Subagent fold. Deterministic record
+ * Idempotent per-Run-and-Tool-Call upsert of the parent-side Subagent fold. Deterministic record
  * identities make duplicates impossible in one canonical stream; the first canonical payload of
  * each stage wins so a replayed reduce is a no-op.
  */
@@ -106,7 +111,10 @@ const upsertSubagentInvocation = (
   invocations: ReadonlyArray<SubagentInvocationState>,
   payload: SubagentRequested | SubagentStarted | SubagentJoined,
 ): ReadonlyArray<SubagentInvocationState> => {
-  const existing = invocations.find((invocation) => invocation.toolCallId === payload.toolCallId);
+  const existing = invocations.find(
+    (invocation) =>
+      invocation.runId === payload.runId && invocation.toolCallId === payload.toolCallId,
+  );
 
   const requested =
     existing?.requested ?? (payload._tag === "SubagentRequested" ? payload : undefined);
@@ -115,6 +123,7 @@ const upsertSubagentInvocation = (
   const joined = existing?.joined ?? (payload._tag === "SubagentJoined" ? payload : undefined);
 
   const next = SubagentInvocationState.make({
+    runId: payload.runId,
     toolCallId: payload.toolCallId,
     ...(requested === undefined ? {} : { requested }),
     ...(started === undefined ? {} : { started }),
@@ -124,7 +133,9 @@ const upsertSubagentInvocation = (
   return existing === undefined
     ? [...invocations, next]
     : invocations.map((invocation) =>
-        invocation.toolCallId === payload.toolCallId ? next : invocation,
+        invocation.runId === payload.runId && invocation.toolCallId === payload.toolCallId
+          ? next
+          : invocation,
       );
 };
 
@@ -171,7 +182,9 @@ export const reduceThreadRecord = (
   // open until an authorized resolution or a recovered result arrives.
   const openToolCalls =
     payload._tag === "ToolCallPrepared"
-      ? projection.openToolCalls.some((call) => call.toolCallId === payload.toolCallId)
+      ? projection.openToolCalls.some(
+          (call) => call.runId === payload.runId && call.toolCallId === payload.toolCallId,
+        )
         ? projection.openToolCalls
         : [
             ...projection.openToolCalls,
@@ -183,7 +196,9 @@ export const reduceThreadRecord = (
             }),
           ]
       : payload._tag === "ToolCallSettled" || payload._tag === "ToolCallResolved"
-        ? projection.openToolCalls.filter((call) => call.toolCallId !== payload.toolCallId)
+        ? projection.openToolCalls.filter(
+            (call) => call.runId !== payload.runId || call.toolCallId !== payload.toolCallId,
+          )
         : projection.openToolCalls;
 
   const unknownToolCalls =
@@ -208,6 +223,7 @@ export const reduceThreadRecord = (
     projection.parentLink ?? (payload._tag === "SubagentLineageRecorded" ? payload : undefined);
 
   return ThreadProjection.make({
+    schemaVersion: 2,
     threadId: projection.threadId,
     throughSequence: envelope.sequence,
     tailDigest,
@@ -236,6 +252,7 @@ export const replayThread = (
 /**
  * Pure checkpoint replay. A validated checkpoint projection and its canonical tail produce the
  * same reducer path as full replay for every later record.
+ * Decode persisted state with `ThreadProjection` first; an incompatible state requires full replay.
  */
 export const replayThreadFromCheckpoint = (
   checkpoint: ThreadProjection,

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -227,6 +227,13 @@ describe("thread canonical contracts", () => {
         expect(yield* digestJson({ z: "\ud800", value: "😀é" })).toBe(
           "a2ae949a2f22f7fc31138231e3db19f57f017e0d8a09f7b2b049398f9346f57c",
         );
+        expect(
+          yield* digestJson([
+            [{ z: "last", a: [false, null, 2.5] }],
+            [],
+            { nested: [[1], { b: 2, a: 3 }] },
+          ]),
+        ).toBe("8f7312be37bd42bc167b496ac42e8e8289a845c133097cf7ab5c8e5f7e38f5ab");
       }),
     );
   });
@@ -1317,6 +1324,79 @@ describe("phase 5 durable canonical payloads", () => {
     );
   });
 
+  it("keeps an aborted Run's unknown call open when a later Run reuses its call ID", () => {
+    const threadId = Schema.decodeSync(ThreadId)("travel-thread");
+    const prepared = decodeEnvelope(1, decodeRecord("run-1-prepared", encodedToolCallPrepared));
+    const unknown = decodeEnvelope(2, decodeRecord("run-1-unknown", encodedToolCallUnknown));
+
+    const aborted = decodeEnvelope(
+      3,
+      decodeRecord("run-1-aborted", {
+        _tag: "SubmissionSettled",
+        submissionId: "submission-1",
+        settlementId: "settlement:submission-1",
+        receiptId: "receipt-1",
+        runId: "run-1",
+        outcome: "aborted",
+      }),
+    );
+
+    const preparedAgain = decodeEnvelope(
+      4,
+      decodeRecord("run-2-prepared", {
+        ...encodedToolCallPrepared,
+        runId: "run-2",
+        turnId: "turn-2",
+      }),
+    );
+
+    const prefix = [prepared, unknown, aborted, preparedAgain];
+
+    const checkpoint = Schema.decodeSync(ThreadProjection)(
+      Schema.encodeSync(ThreadProjection)(replayThread(threadId, prefix)),
+    );
+
+    expect(checkpoint.openToolCalls.map((call) => [call.runId, call.toolCallId])).toEqual([
+      ["run-1", "call-1"],
+      ["run-2", "call-1"],
+    ]);
+
+    for (const terminal of [
+      decodeRecord("run-2-settled", {
+        _tag: "ToolCallSettled",
+        runId: "run-2",
+        toolCallId: "call-1",
+        toolName: "book_flight",
+        result: { bookingRef: "booking-43" },
+        isFailure: false,
+      }),
+      decodeRecord("run-2-resolved", { ...encodedToolCallResolved, runId: "run-2" }),
+    ]) {
+      const suffix = [decodeEnvelope(5, terminal)];
+      const full = replayThread(threadId, [...prefix, ...suffix]);
+
+      expect(full.openToolCalls.map((call) => [call.runId, call.toolCallId])).toEqual([
+        ["run-1", "call-1"],
+      ]);
+      expect(full.unknownToolCalls).toEqual([unknown.record.payload]);
+      expect(replayThreadFromCheckpoint(checkpoint, suffix)).toEqual(full);
+    }
+  });
+
+  it("rejects old projection versions even when their invocation and call views are empty", () => {
+    const empty = replayThread(Schema.decodeSync(ThreadId)("travel-thread"), []);
+    const { schemaVersion, ...legacy } = Schema.encodeSync(ThreadProjection)(empty);
+
+    expect(schemaVersion).toBe(2);
+    expect(legacy.openToolCalls).toEqual([]);
+    expect(legacy.subagentInvocations).toEqual([]);
+    expect(Schema.decodeUnknownExit(ThreadProjection)(legacy)._tag).toBe("Failure");
+    expect(Schema.decodeUnknownExit(ThreadProjection)({ ...legacy, schemaVersion: 1 })._tag).toBe(
+      "Failure",
+    );
+    expect(Schema.decodeSync(ThreadProjection)({ ...legacy, schemaVersion: 2 })).toEqual(empty);
+  });
+
   it("rejects a Phase 4 checkpoint projection state so callers rebuild from canonical records", () => {
     const phase4State = {
       threadId: "travel-thread",
@@ -1493,6 +1573,85 @@ describe("S2 durable subagent canonical payloads", () => {
 
     expect(child.parentLink).toEqual(lineage.record.payload);
     expect(child.subagentInvocations).toEqual([]);
+  });
+
+  it("keeps subagent invocations separate when sequential Runs reuse a Tool Call ID", () => {
+    const threadId = Schema.decodeSync(ThreadId)("travel-thread");
+    const requested = decodeEnvelope(1, decodeRecord("first-requested", encodedSubagentRequested));
+    const started = decodeEnvelope(2, decodeRecord("first-started", encodedSubagentStarted));
+    const joined = decodeEnvelope(3, decodeRecord("first-joined", encodedSubagentJoined));
+
+    const completed = decodeEnvelope(
+      4,
+      decodeRecord("first-completed", {
+        _tag: "RunCompleted",
+        runId: encodedSubagentRequested.runId,
+        output: { answer: "Kyoto" },
+      }),
+    );
+
+    const requestedAgain = decodeEnvelope(
+      5,
+      decodeRecord("second-requested", {
+        ...encodedSubagentRequested,
+        runId: "run:submission-second",
+        turnId: "turn:run:submission-second:1",
+        childInput: { destination: "Osaka", month: "November" },
+        childThreadId: "subagent:submission-second:call-delegate-1",
+        childIdempotencyKey: "subagent:run:submission-second:call-delegate-1",
+        reservationId: "run%3Asubmission-second:call-delegate-1",
+      }),
+    );
+
+    const startedAgain = decodeEnvelope(
+      6,
+      decodeRecord("second-started", {
+        ...encodedSubagentStarted,
+        runId: "run:submission-second",
+        childThreadId: "subagent:submission-second:call-delegate-1",
+        childSubmissionId: "submission-child-2",
+        childReceiptId: "receipt-child-2",
+        childRunId: "run:submission-child-2",
+      }),
+    );
+
+    const joinedAgain = decodeEnvelope(
+      7,
+      decodeRecord("second-joined", {
+        ...encodedSubagentJoined,
+        runId: "run:submission-second",
+        childSubmissionId: "submission-child-2",
+        childSettlementId: "settlement:submission-child-2",
+        reservationId: "run%3Asubmission-second:call-delegate-1",
+      }),
+    );
+
+    const prefix = [requested, started, joined, completed, requestedAgain];
+
+    const checkpoint = Schema.decodeSync(ThreadProjection)(
+      Schema.encodeSync(ThreadProjection)(replayThread(threadId, prefix)),
+    );
+
+    const suffix = [startedAgain, joinedAgain];
+    const full = replayThread(threadId, [...prefix, ...suffix]);
+
+    expect(full.subagentInvocations).toEqual([
+      {
+        runId: encodedSubagentRequested.runId,
+        toolCallId: encodedSubagentRequested.toolCallId,
+        requested: requested.record.payload,
+        started: started.record.payload,
+        joined: joined.record.payload,
+      },
+      {
+        runId: "run:submission-second",
+        toolCallId: encodedSubagentRequested.toolCallId,
+        requested: requestedAgain.record.payload,
+        started: startedAgain.record.payload,
+        joined: joinedAgain.record.payload,
+      },
+    ]);
+    expect(replayThreadFromCheckpoint(checkpoint, suffix)).toEqual(full);
   });
 
   it("rejects a Phase 5 checkpoint projection state so callers rebuild from canonical records", () => {
@@ -1695,7 +1854,7 @@ describe("phase 5 ledger port schemas", () => {
       "tool-resolved:run:submission-1:2:call-1",
     );
     expect(toolStepSettledRecordId(runId, toolCallId, "reserve-flight")).toBe(
-      "step:run:submission-1:call-1:reserve-flight",
+      '["step@2","run:submission-1","call-1","reserve-flight"]',
     );
     expect(toolStepSettledBatchId(runId, toolCallId, "reserve-flight")).toBe(
       toolStepSettledRecordId(runId, toolCallId, "reserve-flight"),

--- a/scripts/durable-admin.ts
+++ b/scripts/durable-admin.ts
@@ -125,13 +125,20 @@ const explainCommand = CliCommand.make(
           const threadId = yield* decodeThreadId(thread.value);
           const explanations = yield* runtime.explainThread(threadId);
 
+          if (asJson) {
+            const encoded = yield* Schema.encodeEffect(Schema.Array(RecoveryExplanation))(
+              explanations,
+            );
+
+            return yield* Console.log(JSON.stringify(encoded, null, 2));
+          }
           if (explanations.length === 0) {
             return yield* Console.log(`No nonterminal Submissions on thread ${threadId}.`);
           }
 
           return yield* Effect.forEach(
             explanations,
-            (explanation) => printExplanation(explanation, asJson),
+            (explanation) => printExplanation(explanation, false),
             { discard: true },
           );
         }


### PR DESCRIPTION
Repeated traversal, ambiguous composite IDs, and incomplete cleanup boundaries could waste work or change runtime behavior under recovery, malformed output, or interruption. This pass fixes those cases across the library using native Effect Schema validation, scoped stream sharing, typed requirements, and Cause-preserving failure handling.

The changes include regression coverage, seven changesets, and updates to the existing durability, operations, sandbox, Node, and Cloudflare guides.

**Before and after**

| Area | Before | After |
| --- | --- | --- |
| Byte sizing | Several byte-count-only paths allocate a UTF-8 buffer and hexadecimal string. | Private UTF-8 counters preserve byte limits, including lone surrogates, without either allocation. |
| Engine work | Successful response preflight repeats a graph walk; prepared prompt admission can repeat token estimation. | Reuse the successful footprint and estimate the final provider prompt once. |
| Schema and Effect contracts | The completion-reserve/token-budget invariant is checked only by `AgentPolicy.make`; parameter encoder services can disappear from inferred requirements. | The reserve/budget invariant applies at Schema construction/decode/encode boundaries; parameter encoding services remain visible in `R`. Preserve encoded parameters at the native `Toolkit.handle` boundary without a misleading decoded-value assertion. |
| Identity and recovery | Delimiter-containing budget, admission, and Step IDs can collide; reused Tool Call IDs can erase another Run's unresolved projection evidence. | Encode composite identities unambiguously and scope projected Tool/Subagent identities by Run. Completed legacy Step records still replay from structured payloads. |
| Durable subagents | `SubagentProjectionFailure` from the default or explicit result projector can defect during durable failure encoding. | Encode the full declared failure union and retain one bounded canonical join result. |
| Storage adapters | Memory accepts conflicting applied-input markers; checkpoint payloads can disagree with their selected rows; SQLite recovery reads request a write lock. | Reject conflicts consistently, verify checkpoint metadata before tail lookup, and use a scoped deferred read transaction for recovery snapshots. |
| Node wakes | Four subscribers create four periodic ledger scans. | Four subscribers share one scan per cadence; scanning stops with the last subscriber and restarts on demand. |
| Host lifetime | Sandbox setup falls outside the active timeout; stalled browser or progress cancellation can block teardown. | One sandbox deadline covers configuration, spawn, and execution; cancellation cleanup is bounded to one second while preserving the original failure/interruption. Late progress retries retain bounded cancellation hints. |
| Test substitutes | Tolerating a typed Chaos failure can also hide an accompanying defect; accepted program objects retain mutable ownership. | Preserve defect/interruption Causes and return bounded, owned JSON snapshots of results and diagnostics. |
| Admin JSON | Thread explanations produce prose for zero submissions, an object for one, and concatenated objects for several. | The thread explanation payload is always one JSON array; submission explanations remain objects. |

The Node scheduler shares complete scan snapshots before flattening them per subscriber. Sharing individual hints through a sliding buffer was rejected because scans larger than the buffer could repeatedly lose early lanes; coverage includes 1,050 lanes and slow/fast subscribers.

```mermaid
flowchart LR
  L[SubmissionLedger] --> S[One scoped periodic scan]
  S --> H[Stream.share: complete snapshot]
  H --> A[Subscriber A: flatten lanes]
  H --> B[Subscriber B: flatten lanes]
  H --> C[Subscriber C: flatten lanes]
```

**Measured byte-count latency**

| UTF-8 input size | Before median, ms/op | After median, ms/op | Median reduction |
| --- | ---: | ---: | ---: |
| ASCII, 64 KiB | 0.2702 | 0.1014 | 62.5% |
| Mixed Unicode, 64 KiB | 0.2856 | 0.0572 | 80.0% |
| ASCII, 1 MiB | 11.5545 | 1.8946 | 83.6% |
| Mixed Unicode, 1 MiB | 12.1370 | 0.9124 | 92.5% |

Compared `Encoding.encodeHex(text).length / 2` with the new private core counter on Node 24.20.0, macOS arm64, Apple M4 Max, Effect 4.0.0-rc.112. Seven warmed, same-process samples per method alternated execution order; each sample performed 25 operations at 64 KiB or three at 1 MiB. Inputs were repeated ASCII `a` and mixed Unicode `a海🌊`, with matching byte counts verified. These measurements cover elapsed byte-count latency, not end-to-end agent performance or CPU time.

**Projection compatibility**

Manually constructed `ThreadProjection` values now require `schemaVersion: 2`; `SubagentInvocationState` requires the parent `runId`. Schematic field changes:

```diff
 ThreadProjection.make({
+  schemaVersion: 2,
   // existing projection fields
 });
 SubagentInvocationState.make({
+  runId,
   toolCallId,
   // existing invocation fields
 });
```

Callers must decode persisted projection state with `ThreadProjection` and discard/rebuild incompatible checkpoint projections from canonical records. Rebuilding is the caller's responsibility; an empty old projection also requires rebuilding because it may already have lost unresolved evidence. The checkpoint envelope and canonical record schema versions do not change.

**Validation**

- `vp run ready` passed on the rebased branch: **2,667 tests passed, 7 skipped, 211 test files passed**, plus static checks, export/purity checks, all builds, docs, and Cloudflare dry-run builds.
- Deterministic coverage includes Schema `E`/`R` inference, transformed tool parameters, delimiter collisions, adapter conformance, corrupted checkpoints, concurrent SQLite writer/read recovery, cancellation/finalizer behavior, and large shared wake scans.
- Existing real-process crash/recovery, failpoint, certification, chaos, and memory-soak suites are included in repository validation. The admin entry point was also exercised with zero, one, and two submissions and a single-submission explanation.
- The build still emits the existing `TS4082` diagnostics from `oxlint/plugin-exports.ts` while exiting successfully; these diagnostics were also present before the rebase and are unchanged by this patch.
- `git diff --check` passed. The branch was rebased cleanly onto `7aef6bbc`; the audited patch remained unchanged.

MCP framing, safe caching of encoded ephemeral history, and consolidation of the browser capture response protocol remain follow-up work. No performance improvement is claimed for those candidates.
