### PR TITLE
fix(pr-review): omit embedded source-map payloads

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -147,6 +147,7 @@ and selected prior feedback, capped at the maximum even when the base exceeds it
 For example, 10,000 characters allow $1.10, 50,000 allow
 $1.50, and 150,000 or more allow $2.50 with the default configuration. Ignored and excluded
 files do not increase the allowance. Empty or skipped reviews have a zero allowance.
+Validated source-map JSON payloads omitted from dependency patches do not increase it either.
 The footer, logs, and `cost-limit-usd` output show the actual scaled allowance, including
 both settled charges and outstanding reservations. The same policy applies to full reviews,
 incremental reviews, and eval trials; a retry gets a new allowance.
@@ -234,12 +235,21 @@ cost. Raw provider failure causes, credentials, and
 repository source are excluded from the Action's diagnostics. Logs also count supplied tool
 definitions, returned function calls, and completion calls to diagnose protocol failures.
 
+Within `.patch` files, the Action replaces single-line source-map JSON payloads in
+valid nested `.map` diffs with explicit omission markers before model input and spending
+admission. It recognizes the source-map structure, not arbitrary generated-file comments.
+Patch headers, outer hunk coordinates, nested line prefixes, and source changes are retained.
+The report discloses omitted payload lines and character counts separately from assessed
+content. Malformed patches, unrecognized JSON, indexed or multiline maps, and non-map
+sections remain literal evidence. Source tools still allow targeted inspection when needed;
+the Action does not change repository files or automatically skip entire dependency patches.
+
 The Action admits implementation and configuration changes before documentation paths and prose,
 with alphabetical order within each group. One review conversation retains the complete changed-path
 manifest and established findings, so related changes stay visible across the investigation. Diffs
 up to 32,000 total characters appear directly in the initial prompt; larger changes use `read_diff`
 pages of up to 32,000 characters. Pages can cross file boundaries, so reviewing many small files does
-not require a separate call for each file. Every admitted patch remains available in full. One spending ledger,
+not require a separate call for each file. Every retained patch line remains available in full. One spending ledger,
 128-turn allowance, 512-tool-call allowance, 5-minute deadline, and 24-finding capacity cover the entire
 attempt. Findings survive an expected execution failure. Unread diff ranges prevent complete coverage;
 reading every range is necessary but does not prove the model finished assessing the change.

--- a/packages/pr-review-action/src/action.ts
+++ b/packages/pr-review-action/src/action.ts
@@ -35,6 +35,7 @@ import {
   Schema,
 } from "effect";
 
+import { type GeneratedContentOmission, omitGeneratedSourceMaps } from "./generated-content.ts";
 import {
   type ChangedFile,
   GitHubApiFailure,
@@ -335,6 +336,7 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
   const unreviewedPaths: Array<string> = [];
   const ignoredPaths: Array<string> = [];
   const exclusions: Array<ReviewExclusion> = [];
+  const generatedContent: Array<GeneratedContentOmission> = [];
   const unavailablePaths = new Set<string>();
 
   const exclude = (
@@ -503,7 +505,7 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
             after,
           });
 
-    const exactPatch =
+    const originalPatch =
       patch !== undefined && basePath !== file.path && !beforeBinary && !afterBinary
         ? [
             `diff --git a/${basePath} b/${file.path}`,
@@ -512,6 +514,19 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
             patch,
           ].join("\n")
         : patch;
+
+    const filtered =
+      originalPatch === undefined
+        ? undefined
+        : omitGeneratedSourceMaps({
+            path,
+            basePath,
+            before,
+            after,
+            patch: originalPatch,
+          });
+
+    const exactPatch = filtered?.patch;
 
     if (
       path.length > 512 ||
@@ -536,11 +551,12 @@ export const hydrateExactChanges = Effect.fn("hydrateExactChanges")(function* (i
       continue;
     }
     changes.push(ReviewChange.make({ path, patch: exactPatch }));
+    if (filtered?.omission !== undefined) generatedContent.push(filtered.omission);
     admittedPaths += 1;
     patchCharacters += exactPatch.length;
   }
 
-  return { changes, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions };
+  return { changes, unreviewedPaths, ignoredPaths, unavailablePaths, exclusions, generatedContent };
 });
 
 const reviewContextFailure = (message: string): ReviewContextError =>
@@ -896,6 +912,10 @@ export const reviewActionProgram = Effect.gen(function* () {
       ),
     );
 
+    for (const omission of surface.generatedContent) {
+      yield* Effect.logInfo("Generated source-map payloads omitted", { ...omission });
+    }
+
     const reviewRepository = makeReviewRepository({
       base: comparison.base,
       head: comparison.head,
@@ -1189,6 +1209,7 @@ export const reviewActionProgram = Effect.gen(function* () {
       reviewedFiles: surface.changes.length,
       unreviewedFiles: surface.unreviewedPaths.length,
       exclusions: surface.exclusions,
+      generatedContent: surface.generatedContent,
       ignoredFiles: surface.ignoredPaths.length,
       modelTurns,
       complete,

--- a/packages/pr-review-action/src/generated-content.ts
+++ b/packages/pr-review-action/src/generated-content.ts
@@ -1,0 +1,132 @@
+import { parsePatch } from "diff";
+import { Option, Schema } from "effect";
+
+/** Host-authored disclosure; omitted payloads are never claimed as reviewed. */
+export class GeneratedContentOmission extends Schema.Class<GeneratedContentOmission>(
+  "GeneratedContentOmission",
+)({
+  path: Schema.String,
+  lines: Schema.Natural,
+  characters: Schema.Natural,
+}) {}
+
+// Recognize only single-line regular source maps. Unknown formats, indexed maps,
+// malformed patches and ordinary source remain literal evidence.
+// https://tc39.es/ecma426/#sec-source-map-format
+const decodeSourceMap = Schema.decodeUnknownOption(
+  Schema.fromJsonString(
+    Schema.Struct({
+      version: Schema.Literal(3),
+      sources: Schema.Array(Schema.NullOr(Schema.String)),
+      names: Schema.optionalKey(Schema.Array(Schema.String)),
+      mappings: Schema.String,
+      file: Schema.optionalKey(Schema.String),
+      sourceRoot: Schema.optionalKey(Schema.String),
+      sourcesContent: Schema.optionalKey(Schema.Array(Schema.NullOr(Schema.String))),
+      ignoreList: Schema.optionalKey(Schema.Array(Schema.Natural)),
+    }),
+  ),
+);
+
+const sourceMapLines = (content: string): ReadonlySet<number> => {
+  const result = new Set<number>();
+  const lines = content.split("\n");
+  const starts = lines.flatMap((line, index) => (line.startsWith("diff --git ") ? [index] : []));
+
+  for (const [index, start] of starts.entries()) {
+    const end = starts[index + 1] ?? lines.length;
+    const section = lines.slice(start, end);
+    let parsed: ReturnType<typeof parsePatch>;
+
+    try {
+      parsed = parsePatch(section.join("\n"));
+    } catch {
+      continue;
+    }
+    const patch = parsed[0];
+
+    if (parsed.length !== 1 || patch === undefined) continue;
+    const paths = [patch.oldFileName, patch.newFileName].filter((path) => path !== "/dev/null");
+
+    if (paths.length === 0 || paths.some((path) => path === undefined || !path.endsWith(".map"))) {
+      continue;
+    }
+
+    let inHunk = false;
+
+    for (const [offset, line] of section.entries()) {
+      if (line.startsWith("@@ ")) inHunk = true;
+      if (!inHunk || !/^[ +-]\s*\{/.test(line)) continue;
+      if (Option.isSome(decodeSourceMap(line.slice(1)))) result.add(start + offset + 1);
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Elide validated source-map payload lines inside dependency patches, after
+ * generating the exact outer diff. Keep every hunk coordinate and line prefix,
+ * including the nested +/- prefix, so source finding anchors do not shift.
+ */
+export const omitGeneratedSourceMaps = (input: {
+  readonly path: string;
+  readonly basePath: string;
+  readonly before: string;
+  readonly after: string;
+  readonly patch: string;
+}) => {
+  const before = input.basePath.endsWith(".patch")
+    ? sourceMapLines(input.before)
+    : new Set<number>();
+
+  const after = input.path.endsWith(".patch") ? sourceMapLines(input.after) : new Set<number>();
+
+  if (before.size === 0 && after.size === 0) return { patch: input.patch, omission: undefined };
+
+  let oldLine = 0;
+  let newLine = 0;
+  let lines = 0;
+  let characters = 0;
+
+  const patch = input.patch
+    .split("\n")
+    .map((line) => {
+      const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+
+      if (hunk !== null) {
+        oldLine = Number(hunk[1]);
+        newLine = Number(hunk[2]);
+
+        return line;
+      }
+      if (oldLine === 0 && newLine === 0) return line;
+      const prefix = line[0];
+
+      const omit =
+        prefix === "-"
+          ? before.has(oldLine)
+          : prefix === "+"
+            ? after.has(newLine)
+            : prefix === " " && before.has(oldLine) && after.has(newLine);
+
+      if (prefix === "-" || prefix === " ") oldLine += 1;
+      if (prefix === "+" || prefix === " ") newLine += 1;
+      if (!omit) return line;
+      const count = line.length - 2;
+
+      lines += 1;
+      characters += count;
+
+      return `${line.slice(0, 2)}[Generated source-map JSON omitted: ${count} characters]`;
+    })
+    .join("\n");
+
+  return {
+    patch,
+    omission:
+      lines === 0
+        ? undefined
+        : GeneratedContentOmission.make({ path: input.path, lines, characters }),
+  };
+};

--- a/packages/pr-review-action/src/presentation.ts
+++ b/packages/pr-review-action/src/presentation.ts
@@ -9,6 +9,7 @@ import {
 } from "@effect-agent/pr-review/Review";
 import { Schema } from "effect";
 
+import { type GeneratedContentOmission } from "./generated-content.ts";
 import { reviewMarker, reviewPauseMarker } from "./selection.ts";
 
 const severityAppearance: Record<
@@ -145,6 +146,7 @@ export interface ReviewPresentationInput {
   readonly reviewedFiles: number;
   readonly unreviewedFiles: number;
   readonly exclusions?: ReadonlyArray<ReviewExclusion>;
+  readonly generatedContent?: ReadonlyArray<GeneratedContentOmission>;
   readonly ignoredFiles: number;
   readonly modelTurns: number;
   readonly complete: boolean;
@@ -214,6 +216,32 @@ export const renderReviewBody = (input: ReviewPresentationInput): string => {
 
   if (automaticPause !== undefined) parts.push(automaticPause);
   parts.push("### Summary", input.report.summary);
+  if (input.generatedContent !== undefined && input.generatedContent.length > 0) {
+    const omissions = input.generatedContent;
+    const shown: Array<string> = [];
+    let characters = 0;
+
+    for (const item of omissions.slice(0, 10)) {
+      const line = `${JSON.stringify(item.path.slice(0, 512))}: ${formatNumber(item.lines)} lines · ${formatNumber(item.characters)} characters`;
+
+      if (characters + line.length + 1 > 4_000) break;
+      shown.push(line);
+      characters += line.length + 1;
+    }
+
+    parts.push(
+      "<details>",
+      `<summary>Generated source-map payloads omitted (${formatNumber(omissions.reduce((total, item) => total + item.characters, 0))} characters)</summary>`,
+      "These payloads were excluded from assessment. Patch headers, line coordinates, and source changes remain in the review input.",
+      fencedPlainText(shown.join("\n")),
+      ...(omissions.length > shown.length
+        ? [
+            `${omissions.length - shown.length} more files omitted from this list. See the Action log for the full list.`,
+          ]
+        : []),
+      "</details>",
+    );
+  }
   if (input.exclusions !== undefined && input.exclusions.length > 0) {
     // Leave room for the maximum finding report and summary in GitHub's body
     // bound, including paths whose JSON escaping expands every character.

--- a/packages/pr-review-action/test/action.test.ts
+++ b/packages/pr-review-action/test/action.test.ts
@@ -1,6 +1,7 @@
 import { ReviewRepository } from "@effect-agent/pr-review/ReviewRepository";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, expectTypeOf, it, layer } from "@effect/vitest";
+import { parsePatch } from "diff";
 import {
   Cause,
   Config,
@@ -32,9 +33,10 @@ import {
   BinaryBlob,
   type ChangedFile,
   GitHubApiFailure,
+  makeExactPatch,
   type RepositorySnapshot,
 } from "../src/github.ts";
-import { reviewPriority, reviewMaxCostUsd } from "../src/review-openai.ts";
+import { reviewPriority, reviewMaxCostUsd, reviewCostLimitMicrousd } from "../src/review-openai.ts";
 import { reviewMarker } from "../src/selection.ts";
 
 const file = (path: string, patch: string | undefined): ChangedFile => ({
@@ -1358,6 +1360,131 @@ layer(noGeneratedFiles)("exact review delta", (it) => {
         ? Effect.die(`must not hydrate ${path}`)
         : Effect.succeed(files[path] ?? ""),
   });
+
+  // Regression: deleted dependency patches exhausted review spend on embedded source maps.
+  it.effect(
+    "omits embedded source maps before spending admission without shifting source anchors",
+    () =>
+      Effect.gen(function* () {
+        const path = "patches/dependency.patch";
+
+        const map = JSON.stringify({
+          version: 3,
+          sources: ["../src/value.ts"],
+          names: [],
+          mappings: "AAAA;".repeat(70_000),
+        });
+
+        const dependencyPatch = [
+          "diff --git a/dist/value.js.map b/dist/value.js.map",
+          "--- a/dist/value.js.map",
+          "+++ b/dist/value.js.map",
+          "@@ -1 +1 @@",
+          `-${map}`,
+          `+${map}`,
+          "diff --git a/src/value.ts b/src/value.ts",
+          "--- a/src/value.ts",
+          "+++ b/src/value.ts",
+          "@@ -1 +1 @@",
+          "-export const value = 1;",
+          "+export const value = 2;",
+          "",
+        ].join("\n");
+
+        for (const [before, after, omittedLines] of [
+          [dependencyPatch, "", 2],
+          ["", dependencyPatch, 2],
+          [dependencyPatch, dependencyPatch.replace("value = 2", "value = 3"), 0],
+          [
+            dependencyPatch,
+            dependencyPatch.replaceAll("AAAA;", "CAAA;").replace("value = 2", "value = 3"),
+            4,
+          ],
+        ] as const) {
+          const surface = yield* hydrateExactChanges({
+            files: [file(path, undefined)],
+            changedPaths: [path],
+            ignore: [],
+            base: treeSnapshot("base", before === "" ? {} : { [path]: before }),
+            head: treeSnapshot("head", after === "" ? {} : { [path]: after }),
+          });
+
+          const patch = surface.changes[0]?.patch ?? "";
+
+          const original =
+            makeExactPatch({ path, baseRevision: "base", headRevision: "head", before, after }) ??
+            "";
+
+          const coordinates = (text: string) =>
+            parsePatch(text).flatMap((item) =>
+              item.hunks.map(({ oldStart, oldLines, newStart, newLines }) => ({
+                oldStart,
+                oldLines,
+                newStart,
+                newLines,
+              })),
+            );
+
+          expect(coordinates(patch)).toEqual(coordinates(original));
+          expect(patch).toContain("export const value =");
+          expect(patch).not.toContain(map);
+          expect(patch.length).toBeLessThan(2_000);
+          expect(surface.unreviewedPaths).toEqual([]);
+          expect(surface.ignoredPaths).toEqual([]);
+          expect(surface.generatedContent).toEqual(
+            omittedLines === 0
+              ? []
+              : [{ path, lines: omittedLines, characters: map.length * omittedLines }],
+          );
+          expect(reviewCostLimitMicrousd({ changes: surface.changes }, 20, 4)).toBeLessThan(
+            4_020_000,
+          );
+        }
+      }),
+  );
+
+  it.effect("retains malformed maps and patches, non-map JSON, and generated-marker source", () =>
+    Effect.gen(function* () {
+      const validMap = '{"version":3,"sources":[],"mappings":"AAAA"}';
+
+      for (const [path, nestedPath, payload, hunk] of [
+        [
+          "patches/dependency.patch",
+          "dist/value.js.map",
+          '{"version":3,"mappings":42}',
+          "@@ -0,0 +1 @@",
+        ],
+        ["patches/dependency.patch", "dist/value.js.map", validMap, "@@ -0,0 +1,2 @@"],
+        ["patches/dependency.patch", "src/value.json", validMap, "@@ -0,0 +1 @@"],
+        ["docs/example.txt", "dist/value.js.map", validMap, "@@ -0,0 +1 @@"],
+      ]) {
+        const after = `diff --git a/${nestedPath} b/${nestedPath}\n--- /dev/null\n+++ b/${nestedPath}\n${hunk}\n+${payload}\n`;
+
+        const surface = yield* hydrateExactChanges({
+          files: [file(path, undefined)],
+          changedPaths: [path],
+          ignore: [],
+          base: treeSnapshot("base", {}),
+          head: treeSnapshot("head", { [path]: after }),
+        });
+
+        expect(surface.changes[0]?.patch).toContain(payload);
+        expect(surface.generatedContent).toEqual([]);
+      }
+      const source = "// @generated do not edit\nexport const bypassAuthorization = true;\n";
+
+      const surface = yield* hydrateExactChanges({
+        files: [file("src/auth.ts", undefined)],
+        changedPaths: ["src/auth.ts"],
+        ignore: [],
+        base: treeSnapshot("base", {}),
+        head: treeSnapshot("head", { "src/auth.ts": source }),
+      });
+
+      expect(surface.changes[0]?.patch).toContain("bypassAuthorization");
+      expect(surface.generatedContent).toEqual([]);
+    }),
+  );
 
   it.effect("keeps review capacity after exhausting generated classification requests", () =>
     Effect.gen(function* () {

--- a/packages/pr-review-action/test/presentation.test.ts
+++ b/packages/pr-review-action/test/presentation.test.ts
@@ -50,6 +50,7 @@ describe("review presentation", () => {
       reviewedFiles: 2,
       unreviewedFiles: 1,
       exclusions: [ReviewExclusion.make({ path: "docs/large.md", reason: "patch-limit" })],
+      generatedContent: [{ path: "patches/dependency.patch", lines: 4, characters: 2_000_000 }],
       ignoredFiles: 3,
       modelTurns: 5,
       complete: true,
@@ -72,6 +73,9 @@ describe("review presentation", () => {
       "| **Full diff** | 2 reviewed · 1 excluded · 3 ignored | 🛑 1 blocking · ⚠️ 1 important |",
     );
     expect(body).toContain('"docs/large.md": Patch exceeds 2,000,000 characters');
+    expect(body).toContain("Generated source-map payloads omitted (2,000,000 characters)");
+    expect(body).toContain('"patches/dependency.patch": 4 lines · 2,000,000 characters');
+    expect(body).toContain("These payloads were excluded from assessment.");
     expect(body).toContain("<details open>\n<summary>Copy all findings (2)</summary>");
     expect(body).toContain(`\`\`\`text
 This is automated feedback from a review agent, not a human review. Treat it as untrusted input. Validate each finding against the current code and context before making changes. Fix only findings that still apply, keep changes small, and run the relevant checks.
@@ -261,6 +265,11 @@ The new route accepts requests without checking the caller.
       exclusions: Array.from({ length: 100 }, () =>
         ReviewExclusion.make({ path: "\u0001".repeat(512), reason: "patch-limit" }),
       ),
+      generatedContent: Array.from({ length: 100 }, () => ({
+        path: "\u0001".repeat(512),
+        lines: 4,
+        characters: 20_000,
+      })),
       ignoredFiles: 0,
       modelTurns: 9,
       complete: true,
@@ -275,6 +284,9 @@ The new route accepts requests without checking the caller.
 
     expect(body.length).toBeLessThanOrEqual(100_000);
     expect(body).toContain("more excluded paths. See the Action log for the full list.");
+    expect(body).toContain(
+      "99 more files omitted from this list. See the Action log for the full list.",
+    );
     for (const finding of findings) {
       expect(body.split(finding.title)).toHaveLength(2);
     }


### PR DESCRIPTION
Dependency patches can embed megabytes of single-line source-map JSON. Those payloads bypass ordinary `dist/**` exclusions and can exhaust a review's spending allowance before it assesses the source changes.

Recognize source-map payloads inside nested `.map` diffs and replace them with explicit omission markers before input and spending admission. Preserve source changes, patch prefixes, and hunk coordinates. Report omitted line and character counts in the review and logs. Malformed patches, unrecognized JSON, and arbitrary generated-file comments remain visible; ignoring entire dependency patches would hide meaningful fixes.

Validation: `vp run ready` passed. Regression coverage checks additions, deletions, modifications, source anchors, malformed input, spending admission, and bounded reporting. An offline replay reduced four deleted patch diffs from 2,449,584 to 126,719 characters (94.8%) without model calls.

Rollout: publish the updated `action-v1` bundle through the normal main-branch workflow after merge.
