### PR TITLE
fix(thread): preserve terminal tool history across rollover

### DIFF
--- a/.changeset/terminal-tool-history.md
+++ b/.changeset/terminal-tool-history.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Preserve completed Tool results before repeated-failure termination and allow later context rollover past invisible incomplete batches from canonically terminated prior Runs without rewriting or replaying their evidence.

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -1085,6 +1085,12 @@ decision. Summarization covers prior-run records. Pruning and rollover can also 
 inside the current run, preserving its original instructions and input. A transform or decision that
 cannot map cleanly fails before the view changes. The canonical log remains append-only.
 
+A completed Tool batch enters official history before the repeated-failure limit ends a Run,
+including provider-executed results. A later Run may cover an incomplete prior-Run batch already
+omitted from its prompt only when canonical records prove that prior Run ended after its final
+response. This changes coverage eligibility without settling, rewriting, or replaying the old call.
+Current-Run, nonterminal, and malformed post-terminal batches remain protected.
+
 <a id="composing-preparation-and-tool-authorization"></a>
 <a id="supplying-a-cloudflare-compactor"></a>
 

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -5983,13 +5983,21 @@ const makeTurn = <
             if (trace.applicationToolCalls.length === 0) {
               return afterValidatedResponse(
                 Effect.gen(function* () {
+                  const history = historyWithResponse();
+
+                  // Preserve a completed provider Tool batch even when its final outcome
+                  // reaches the failure limit and no following Turn starts.
+                  yield* advanceHistory(context, history, options);
                   yield* applyRepeatedFailurePolicy(
                     context,
                     trace,
                     agent.definition.policy.repeatedFailureLimit,
                   );
 
-                  return yield* continueTurn(historyWithResponse());
+                  const steering = yield* drainInputs(context, options);
+                  const nextPrompt = yield* appendInputs(context, history, steering, options);
+
+                  return nextTurn(nextPrompt, turn + 1, toolCalls);
                 }),
               );
             }
@@ -6131,11 +6139,6 @@ const toolBatchContinuation = <
         }
         orderedResults.push(result);
       }
-      yield* applyRepeatedFailurePolicy(
-        context,
-        trace,
-        agent.definition.policy.repeatedFailureLimit,
-      );
 
       const toolMessage = Prompt.makeMessage("tool", {
         content: orderedResults.map((result) =>
@@ -6154,6 +6157,15 @@ const toolBatchContinuation = <
         ...promptFromTurnParts(trace).content,
         toolMessage,
       ]);
+
+      // Publish the complete batch before enforcing a terminal policy. RunFailed commits
+      // this history through the same durable seam as a subsequent Turn or completion.
+      yield* advanceHistory(context, history, options);
+      yield* applyRepeatedFailurePolicy(
+        context,
+        trace,
+        agent.definition.policy.repeatedFailureLimit,
+      );
 
       const rolloverResult = orderedResults.length === 1 ? orderedResults[0] : undefined;
 
@@ -6198,7 +6210,6 @@ const toolBatchContinuation = <
           completionResult.encodedResult,
         );
 
-        yield* advanceHistory(context, history, options);
         const bounds = effectiveRunBounds(agent.definition.policy, options);
 
         const exhausted = context.tokenExhausted
@@ -6232,7 +6243,6 @@ const toolBatchContinuation = <
           ),
         );
       }
-      yield* advanceHistory(context, history, options);
       const steering = yield* drainInputs(context, options);
       const nextPrompt = yield* appendInputs(context, history, steering, options);
 

--- a/packages/storage-memory/test/durable-thread-head.test.ts
+++ b/packages/storage-memory/test/durable-thread-head.test.ts
@@ -1,6 +1,6 @@
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
-import { ReceiptId, ThreadId } from "@effect-agent/core/Identifiers";
+import { ReceiptId, RunId, ThreadId } from "@effect-agent/core/Identifiers";
 import { CompactionError, ContextCompactor } from "@effect-agent/engine/ContextCompactor";
 import { ModelCallContext } from "@effect-agent/engine/ContextWindow";
 import { DurableStep, ToolExecutionClass } from "@effect-agent/engine/DurableStep";
@@ -15,7 +15,19 @@ import {
 } from "@effect-agent/thread/DurableAgentRuntime";
 import { DurableRuntimeFailpointError } from "@effect-agent/thread/DurableFailpoint";
 import { OperationAuthorizer, OperationDenied } from "@effect-agent/thread/OperationAuthorizer";
-import { DefinitionDigests, DeploymentId, Digest, ProducerId } from "@effect-agent/thread/Records";
+import {
+  CanonicalBatch,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ProducerId,
+  RecordEnvelope,
+} from "@effect-agent/thread/Records";
+import {
+  projectRunJournal,
+  turnIdForRun,
+  turnResponseBatch,
+} from "@effect-agent/thread/RunJournal";
 import {
   AbortCommand,
   IdempotencyKey,
@@ -31,6 +43,8 @@ import {
 import { DurableRuntimeFailpointTestControl } from "@effect-agent/thread/testing/DurableFailpointTestControl";
 import {
   ThreadExportRequest,
+  FencedAppendRequest,
+  ThreadTailRequest,
   ThreadRead,
   ThreadStore,
   ThreadStoreError,
@@ -40,6 +54,7 @@ import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { NodeCrypto } from "@effect/platform-node";
 import { expect, layer } from "@effect/vitest";
 import {
+  DateTime,
   Deferred,
   Duration,
   Effect,
@@ -52,14 +67,7 @@ import {
   Stream,
 } from "effect";
 import { TestClock } from "effect/testing";
-import {
-  type Prompt,
-  LanguageModel,
-  Model,
-  Tool,
-  Toolkit,
-  type Response,
-} from "effect/unstable/ai";
+import { Prompt, LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 const digest = Schema.decodeSync(Digest)("a".repeat(64));
 const digests = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
@@ -145,6 +153,358 @@ const snapshot = Effect.fn(function* (receipt: Receipt) {
 });
 
 layer(baseLayer)("bounded durable Thread processing", (it) => {
+  it.effect.each(["new-failure", "provider-failure", "retained-incomplete"] as const)(
+    "rolls over after terminal Tool failure without rewriting evidence: %s",
+    (scenario) =>
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+        const failpoints = yield* DurableRuntimeFailpointTestControl;
+        const requests: Array<Prompt.Prompt> = [];
+        let failTool = scenario !== "retained-incomplete";
+        const providerFailure = scenario === "provider-failure";
+        let handlerCalls = 0;
+
+        const tools = Toolkit.make(
+          Tool.make("failing_action", {
+            parameters: Tool.EmptyParams,
+            success: Schema.String,
+            failure: Schema.Struct({ message: Schema.String }),
+            failureMode: "return",
+          }),
+          Tool.providerDefined({
+            id: "test.hosted_failure",
+            customName: "HostedFailure",
+            providerName: "hosted_failure",
+            parameters: Tool.EmptyParams,
+            success: Schema.Struct({ message: Schema.String }),
+          })(undefined),
+        );
+
+        const model = Model.make(
+          "scripted",
+          "terminal-history",
+          Layer.effect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: () => Effect.succeed([]),
+              streamText: (request) => {
+                requests.push(request.prompt);
+
+                return Stream.fromIterable<Response.StreamPartEncoded>(
+                  failTool
+                    ? [
+                        {
+                          type: "tool-call",
+                          id: "failed-call",
+                          name: providerFailure ? "HostedFailure" : "failing_action",
+                          params: {},
+                          providerExecuted: providerFailure,
+                        },
+                        ...(providerFailure
+                          ? [
+                              {
+                                type: "tool-result" as const,
+                                id: "failed-call",
+                                name: "HostedFailure",
+                                result: { message: "Provider action failed conclusively" },
+                                isFailure: true,
+                                providerExecuted: true,
+                              },
+                            ]
+                          : []),
+                        {
+                          type: "finish",
+                          reason: "tool-calls",
+                          usage: { inputTokens: { total: 100 }, outputTokens: { total: 10 } },
+                        },
+                      ]
+                    : finalParts,
+                );
+              },
+            }),
+          ),
+        );
+
+        const agent = Agent.withModel(
+          Agent.make("terminal-history", {
+            input: Schema.String,
+            output: Schema.String,
+            instructions: "Preserve current input.",
+            toolkit: tools,
+            policy: AgentPolicy.make({
+              ...policy,
+              repeatedFailureLimit: 1,
+              contextTokenLimit: 20_000,
+            }),
+          }),
+          model,
+        );
+
+        const freshRuntime = Effect.gen(function* () {
+          const binding = yield* DurableWorkerBinding.make(agent, digests).pipe(
+            Effect.provide(
+              tools.toLayer({
+                failing_action: () =>
+                  Effect.suspend(() => {
+                    handlerCalls += 1;
+
+                    return Effect.fail({ message: "Action failed conclusively" });
+                  }),
+              }),
+            ),
+          );
+
+          return yield* makeRuntime([binding]).pipe(
+            Effect.provideService(
+              RunContextPreparation,
+              RunContextPreparation.of({
+                hook: {
+                  prepare: (request) =>
+                    Effect.succeed({
+                      prompt: request.source,
+                      ...(request.turn === 1 && !failTool ? { rollover: {} } : {}),
+                    }),
+                },
+              }),
+            ),
+            Effect.provide(ContextCompactor.layerRollover),
+          );
+        });
+
+        const runtime = yield* freshRuntime;
+        const thread = `terminal-history-${scenario}`;
+
+        if (scenario !== "retained-incomplete") {
+          const first = yield* runtime.submit(agent, "OLD REQUEST", options(thread, "first"));
+
+          yield* runtime.processThreadHead(first.threadId);
+
+          const original = yield* store.export(
+            ThreadExportRequest.make({ threadId: first.threadId }),
+          );
+
+          const terminal = original.records.find(
+            (entry) => entry.record.payload._tag === "SubmissionSettled",
+          );
+
+          expect(terminal?.record.payload).toMatchObject({
+            outcome: "failed",
+            policyLimit: "repeated-failures",
+          });
+
+          const projection = yield* projectRunJournal(
+            original.records,
+            Schema.decodeSync(RunId)(`run:${first.submissionId}`),
+          );
+
+          if (providerFailure) {
+            const assistant = projection.prompt.content.find(
+              (message) => message.role === "assistant",
+            );
+
+            expect(assistant?.content).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  type: "tool-result",
+                  id: "failed-call",
+                  name: "HostedFailure",
+                  isFailure: true,
+                  providerExecuted: true,
+                  result: { message: "Provider action failed conclusively" },
+                }),
+              ]),
+            );
+            expect(
+              original.records.some(
+                (entry) =>
+                  entry.record.payload._tag === "ToolCallPrepared" ||
+                  entry.record.payload._tag === "ToolCallSettled",
+              ),
+            ).toBe(false);
+
+            const response = original.records.find(
+              (entry) => entry.record.payload._tag === "ModelResponseRecorded",
+            );
+
+            expect(response!.sequence).toBeLessThan(terminal!.sequence);
+          } else {
+            const result = original.records.find(
+              (entry) => entry.record.payload._tag === "ToolCallSettled",
+            );
+
+            expect(result?.record.payload).toMatchObject({
+              toolName: "failing_action",
+              isFailure: true,
+            });
+            expect(result!.sequence).toBeLessThan(terminal!.sequence);
+          }
+          expect(projection.policyUsage.consecutiveToolFailures).toBe(1);
+          expect(projection.usage.inputTokens).toBe(100);
+          expect(projection.usage.outputTokens).toBe(10);
+          expect(handlerCalls).toBe(providerFailure ? 0 : 1);
+          expect(requests).toHaveLength(1);
+          failTool = false;
+        }
+        const current = yield* runtime.submit(agent, "CURRENT REQUEST", options(thread, "current"));
+
+        if (scenario === "retained-incomplete") {
+          const tail = yield* store.inspectTail(
+            ThreadTailRequest.make({ threadId: current.threadId }),
+          );
+
+          const record = (id: string, payload: (typeof RecordEnvelope.Encoded)["payload"]) =>
+            Schema.decodeSync(RecordEnvelope)({
+              recordId: id,
+              family: "thread",
+              schemaVersion: 1,
+              createdAt: "2026-09-01T00:00:00.000Z",
+              deploymentId: "head-test",
+              payload,
+            });
+
+          const oldRunId = Schema.decodeSync(RunId)("run:old-submission");
+
+          const response = yield* turnResponseBatch({
+            runId: oldRunId,
+            turn: 1,
+            turnId: turnIdForRun(oldRunId, 1),
+            producerId: Schema.decodeSync(ProducerId)("head-test"),
+            deploymentId: Schema.decodeSync(DeploymentId)("head-test"),
+            createdAt: DateTime.toUtc(DateTime.makeUnsafe(1_000)),
+            appended: Prompt.make([
+              { role: "user", content: "OLD RETAINED EVIDENCE" },
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool-call",
+                    id: "uncertain-call",
+                    name: "failing_action",
+                    params: {},
+                    providerExecuted: false,
+                  },
+                ],
+              },
+            ]).content,
+            usage: { inputTokens: 100, outputTokens: 10 },
+          });
+
+          yield* store.append(
+            FencedAppendRequest.make({
+              threadId: current.threadId,
+              expectedTailSequence: tail.tailSequence,
+              expectedTailDigest: tail.tailDigest,
+              producerEpoch: tail.producerEpoch,
+              batch: CanonicalBatch.make({
+                batchId: Schema.decodeSync(CanonicalBatch.fields.batchId)("retained-history"),
+                producerId: Schema.decodeSync(ProducerId)("head-test"),
+                records: [
+                  ...response.records,
+                  record("prepared-old", {
+                    _tag: "ToolCallPrepared",
+                    runId: "run:old-submission",
+                    turn: 1,
+                    turnId: "turn:run:old-submission:1",
+                    toolCallId: "uncertain-call",
+                    toolName: "failing_action",
+                    parameters: {},
+                    parametersDigest: digest,
+                    executionKind: "ordinary",
+                  }),
+                  record("settled-old", {
+                    _tag: "SubmissionSettled",
+                    submissionId: "old-submission",
+                    settlementId: "settled-old",
+                    receiptId: "receipt-old",
+                    runId: "run:old-submission",
+                    outcome: "failed",
+                    result: { errorTag: "AgentPolicyError", message: "Repeated failure limit" },
+                  }),
+                ],
+              }),
+            }),
+          );
+        }
+
+        const before = yield* store.export(
+          ThreadExportRequest.make({ threadId: current.threadId }),
+        );
+
+        const priorResponse = before.records.find(
+          (entry) => entry.record.payload._tag === "ModelResponseRecorded",
+        )?.record.payload;
+
+        if (priorResponse?._tag !== "ModelResponseRecorded") {
+          throw new Error("Expected the prior Run's canonical response");
+        }
+        const priorJournal = yield* projectRunJournal(before.records, priorResponse.runId);
+
+        const callsBefore = requests.length;
+
+        yield* failpoints.setHandler((location) =>
+          location === "compaction:after-canonical-append"
+            ? DurableRuntimeFailpointError.make({ location })
+            : Effect.void,
+        );
+        const attempt = yield* Effect.exit(runtime.processThreadHead(current.threadId));
+
+        expect(requests).toHaveLength(callsBefore);
+
+        const interrupted = yield* store.export(
+          ThreadExportRequest.make({ threadId: current.threadId }),
+        );
+
+        expect(Exit.isFailure(attempt)).toBe(true);
+        expect(
+          interrupted.records.filter((entry) => entry.record.payload._tag === "CompactionCreated"),
+        ).toHaveLength(1);
+        yield* failpoints.clear;
+        const resumed = yield* freshRuntime;
+
+        yield* resumed.processThreadHead(current.threadId);
+        expect(requests).toHaveLength(callsBefore + 1);
+        expect(JSON.stringify(requests.at(-1))).toContain("CURRENT REQUEST");
+        expect(JSON.stringify(requests.at(-1))).not.toContain("OLD");
+        const after = yield* store.export(ThreadExportRequest.make({ threadId: current.threadId }));
+
+        expect(after.records.slice(0, before.records.length)).toEqual(before.records);
+        expect(
+          after.records.filter((entry) => entry.record.payload._tag === "CompactionCreated"),
+        ).toHaveLength(1);
+        expect(
+          after.records.find(
+            (entry) =>
+              entry.record.payload._tag === "SubmissionSettled" &&
+              entry.record.payload.submissionId === current.submissionId,
+          )?.record.payload,
+        ).toMatchObject({ outcome: "completed" });
+        const retainedJournal = yield* projectRunJournal(after.records, priorResponse.runId);
+
+        expect(retainedJournal.usage).toEqual(priorJournal.usage);
+        expect(retainedJournal.usage).toMatchObject({ inputTokens: 100, outputTokens: 10 });
+        expect(retainedJournal.policyUsage).toEqual(priorJournal.policyUsage);
+        expect(handlerCalls).toBe(scenario === "new-failure" ? 1 : 0);
+        if (providerFailure) {
+          expect(
+            after.records.some(
+              (entry) =>
+                entry.record.payload._tag === "ToolCallPrepared" ||
+                entry.record.payload._tag === "ToolCallSettled",
+            ),
+          ).toBe(false);
+        }
+        if (scenario === "retained-incomplete") {
+          expect(
+            after.records.some(
+              (entry) =>
+                entry.record.payload._tag === "ToolCallSettled" &&
+                entry.record.payload.toolCallId === "uncertain-call",
+            ),
+          ).toBe(false);
+        }
+      }),
+  );
+
   // Regression seam: https://linear.app/reve/issue/KOM-125
   it.effect("resets completed Run context below capacity and recovers the canonical reset", () =>
     Effect.gen(function* () {

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -3238,12 +3238,29 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
           expect(scripted.prompts).toHaveLength(providerFirst ? 1 : 3);
           expect(yield* Ref.get(starts)).toBe(providerFirst ? 1 : 2);
 
+          const completed = yield* readLog(receipt.threadId);
+
+          const settled = completed.flatMap(({ record }) =>
+            record.payload._tag === "ToolCallSettled" ? [record.payload] : [],
+          );
+
+          expect(
+            settled.map(({ toolCallId, isFailure, result }) => ({ toolCallId, isFailure, result })),
+          ).toEqual(
+            (providerFirst ? ["app-1"] : ["app-1", "app-2"]).map((toolCallId) => ({
+              toolCallId,
+              isFailure: true,
+              result: "failed",
+            })),
+          );
+
           const journal = yield* projectRunJournal(
-            yield* readLog(receipt.threadId),
+            completed,
             runIdForSubmission(receipt.submissionId),
           );
 
-          expect(journal.policyUsage.consecutiveToolFailures).toBe(providerFirst ? 0 : 1);
+          // A completed mixed batch retains both failures even when they end the Run.
+          expect(journal.policyUsage.consecutiveToolFailures).toBe(providerFirst ? 2 : 1);
         }
       }),
   );

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -4719,7 +4719,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             if (
               commit.kind !== "summarize" &&
               sourceBoundaries.some(
-                (boundary) => boundary.incomplete === true && boundary.sequence <= coveredSequence,
+                (boundary) =>
+                  boundary.incomplete === true &&
+                  boundary.terminalPriorRun !== true &&
+                  boundary.sequence <= coveredSequence,
               )
             ) {
               return yield* CompactionError.make({

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -526,8 +526,10 @@ export interface JournalBoundary {
   readonly sequence: CanonicalSequence;
   readonly tag: "ModelResponseRecorded" | "ToolCallSettled";
   readonly promptLength: number;
-  /** A canonical declaration without all of its settled results cannot be covered by rollover. */
+  /** A declaration without all settled results requires terminal-prior-Run proof for coverage. */
   readonly incomplete?: true | undefined;
+  /** The Run terminated after its last response and differs from the projection's owner. */
+  readonly terminalPriorRun?: true | undefined;
 }
 
 /**
@@ -569,6 +571,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   // over-invalidating is the fail-safe direction.
   const firstSequenceByRun = new Map<string, number>();
   const lastResponseSequenceByRun = new Map<string, number>();
+  const terminalSequenceByRun = new Map<string, number>();
   const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
   const settledToolCallRecordIds = new Set<string>();
   const settledById = new Map<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>();
@@ -578,6 +581,15 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     Effect.sync(() => {
       const payload = envelope.record.payload;
 
+      if (
+        (payload._tag === "RunCompleted" ||
+          payload._tag === "RunFailed" ||
+          payload._tag === "SubmissionSettled") &&
+        payload.runId !== undefined &&
+        !terminalSequenceByRun.has(payload.runId)
+      ) {
+        terminalSequenceByRun.set(payload.runId, envelope.sequence);
+      }
       if (payload._tag === "CompactionCreated") {
         compactions.push({ payload, sequence: envelope.sequence });
 
@@ -614,7 +626,26 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     0,
   );
 
-  const incompleteResponseSequences: Array<number> = [];
+  // Terminality changes only prompt coverage; it never settles or resolves the Tool Call.
+  // Compare against the compaction's Run and sequence, independent of the replay's owner.
+  const isTerminalPriorRun = (
+    candidateRunId: RunId,
+    compactionRunId: RunId | undefined,
+    beforeSequence: number,
+  ): boolean => {
+    const terminal = terminalSequenceByRun.get(candidateRunId);
+
+    return (
+      candidateRunId !== compactionRunId &&
+      terminal !== undefined &&
+      terminal < beforeSequence &&
+      terminal > (lastResponseSequenceByRun.get(candidateRunId) ?? 0)
+    );
+  };
+
+  const incompleteResponseSequences: Array<{ readonly sequence: number; readonly runId: RunId }> =
+    [];
+
   let ownerPrefixSequence = Number.POSITIVE_INFINITY;
   let protectedContext: Prompt.Prompt | undefined;
 
@@ -639,7 +670,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
               toolCallSettledRecordId(payload.runId, payload.turn, callId),
             )
           ) {
-            incompleteResponseSequences.push(envelope.sequence);
+            incompleteResponseSequences.push({ sequence: envelope.sequence, runId: payload.runId });
             break;
           }
         }
@@ -667,7 +698,11 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
       return false;
     if (
       payload.kind !== "summarize" &&
-      incompleteResponseSequences.some((sequence) => sequence <= coversThrough)
+      incompleteResponseSequences.some(
+        (response) =>
+          response.sequence <= coversThrough &&
+          !isTerminalPriorRun(response.runId, runId, ownSequence),
+      )
     )
       return false;
     for (const span of settledSpans) {
@@ -926,6 +961,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
             sequence: envelope.sequence,
             tag: payload._tag,
             promptLength: replacementLength,
+            ...(isTerminalPriorRun(payload.runId, ownerRunId, Number.POSITIVE_INFINITY)
+              ? { terminalPriorRun: true }
+              : {}),
             ...(incompleteToolTurns.has(envelope.record.recordId) ||
             incompleteToolCalls.has(envelope.record.recordId)
               ? { incomplete: true }
@@ -943,6 +981,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
             tag: payload._tag,
             promptLength: state.all.length + (state.pendingTools.length === 0 ? 0 : 1),
             incomplete: true,
+            ...(isTerminalPriorRun(payload.runId, ownerRunId, Number.POSITIVE_INFINITY)
+              ? { terminalPriorRun: true }
+              : {}),
           });
 
           return;
@@ -962,6 +1003,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
           sequence: envelope.sequence,
           tag: payload._tag,
           promptLength: state.all.length + 1,
+          ...(isTerminalPriorRun(payload.runId, ownerRunId, Number.POSITIVE_INFINITY)
+            ? { terminalPriorRun: true }
+            : {}),
           ...(incompleteToolCalls.has(envelope.record.recordId) ? { incomplete: true } : {}),
         });
 
@@ -1008,6 +1052,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
         sequence: envelope.sequence,
         tag: payload._tag,
         promptLength: state.all.length,
+        ...(isTerminalPriorRun(payload.runId, ownerRunId, Number.POSITIVE_INFINITY)
+          ? { terminalPriorRun: true }
+          : {}),
         ...(incompleteToolTurns.has(envelope.record.recordId) ? { incomplete: true } : {}),
       });
     }),

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -1134,6 +1134,130 @@ describe("engine compaction records and projection (RUN-026)", () => {
           }),
       );
 
+    it.effect.each(["before", "after", "absent", "current", "response-after-terminal"] as const)(
+      "compacts invisible incomplete prior batches only after their canonical termination: %s",
+      (position) =>
+        Effect.gen(function* () {
+          const batch = yield* turnCanonicalBatch(
+            turnInput(toolTurnAppended, 1, RUN_ID, { inputTokens: 100, outputTokens: 10 }),
+          );
+
+          const incomplete = envelopesOf([batch]).slice(0, 2);
+
+          const next = yield* turnCanonicalBatch(
+            turnInput(secondToolTurn, 1, LATER_RUN_ID, { inputTokens: 200, outputTokens: 20 }),
+          );
+
+          const postTerminalResponse = yield* turnResponseBatch(
+            turnInput(secondToolTurn, 2, RUN_ID, { inputTokens: 300, outputTokens: 30 }),
+          );
+
+          for (const kind of ["rollover", "clear-tool-results"] as const) {
+            for (const terminal of ["RunFailed", "RunCompleted", "SubmissionSettled"] as const) {
+              const records = [...incomplete];
+              const owner = position === "current" ? RUN_ID : LATER_RUN_ID;
+
+              const terminalRecord = auditRecord(
+                `terminal-${terminal}`,
+                terminal === "RunFailed"
+                  ? { _tag: terminal, runId: RUN_ID, failure: { message: "failed" } }
+                  : terminal === "RunCompleted"
+                    ? { _tag: terminal, runId: RUN_ID, output: "done" }
+                    : {
+                        _tag: terminal,
+                        submissionId: SUBMISSION_ID,
+                        settlementId: "terminal",
+                        receiptId: "receipt",
+                        runId: RUN_ID,
+                        outcome: "aborted",
+                      },
+              );
+
+              if (
+                position === "before" ||
+                position === "current" ||
+                position === "response-after-terminal"
+              )
+                records.push(envelopeAt(records.length + 1, terminalRecord));
+              if (position === "response-after-terminal") {
+                for (const record of postTerminalResponse.records)
+                  records.push(envelopeAt(records.length + 1, record));
+              }
+              for (const record of next.records)
+                records.push(envelopeAt(records.length + 1, record));
+              const baseline = yield* projectRunJournal(records, owner);
+
+              expect(baseline.usage).toMatchObject(
+                position === "current"
+                  ? { inputTokens: 100, outputTokens: 10 }
+                  : { inputTokens: 200, outputTokens: 20 },
+              );
+              const through = records.length;
+
+              records.push(
+                envelopeAt(
+                  records.length + 1,
+                  auditRecord(
+                    "terminal-prefix-compaction",
+                    compactionPayload({
+                      kind,
+                      runId: owner,
+                      turn: 2,
+                      summary: undefined,
+                      coversThrough: through,
+                      handoff: "Retained handoff",
+                    }),
+                  ),
+                ),
+              );
+              if (position === "after")
+                records.push(envelopeAt(records.length + 1, terminalRecord));
+              const replay = yield* projectRunJournal(records, owner);
+
+              if (position === "before") {
+                if (kind === "rollover") {
+                  expect(replay.contextWindowId).toBe(contextWindowId(owner, 2));
+                  expect(replay.prompt.content).toEqual([
+                    contextWindowMessage(contextWindowId(owner, 2), "Retained handoff"),
+                  ]);
+                  for (const projectionOwner of [RUN_ID, undefined]) {
+                    const otherBaseline = yield* projectRunJournalStream(
+                      Stream.fromIterable(records.slice(0, through)),
+                      projectionOwner,
+                    );
+
+                    const otherView = yield* projectRunJournalStream(
+                      Stream.fromIterable(records),
+                      projectionOwner,
+                    );
+
+                    expect(otherView.contextWindowId).toBe(contextWindowId(owner, 2));
+                    expect(otherView.usage).toEqual(otherBaseline.usage);
+                    expect(otherView.policyUsage).toEqual(otherBaseline.policyUsage);
+                    if (projectionOwner === RUN_ID) {
+                      expect(otherBaseline.usage).toMatchObject({
+                        inputTokens: 100,
+                        outputTokens: 10,
+                      });
+                    }
+                  }
+                } else {
+                  expect(toolResults(replay.prompt)).toEqual([
+                    "[tool result cleared by compaction]",
+                  ]);
+                }
+              } else {
+                expect(replay.prompt).toEqual(baseline.prompt);
+                expect(replay.contextWindowId).toBeUndefined();
+              }
+              expect(replay.usage).toEqual(baseline.usage);
+              expect(replay.policyUsage).toEqual(baseline.policyUsage);
+              expect(records.slice(0, incomplete.length)).toEqual(incomplete);
+            }
+          }
+        }),
+    );
+
     it.effect(
       "prunes fully settled current-Run batches without losing replay usage, prefix or latest result",
       () =>


### PR DESCRIPTION
When a Tool batch reached the repeated-failure limit, the Run could end before its complete results entered official history. A later context rollover could also be blocked by an incomplete batch retained from an already terminated Run.

Record complete application and provider-executed results before applying the terminal failure policy:

```text
complete Tool batch
  → advanceHistory
  → repeated-failure policy
  → durable RunFailed commit includes the complete history
```

Allow rollover and pruning to cover an incomplete prior-Run batch already omitted from the prompt only when canonical evidence proves that a different Run terminated after its final response and before the compaction. Replay checks that evidence against the compaction's Run, independently of the projection owner. Current-Run, nonterminal, and malformed post-terminal batches remain protected.

This changes coverage eligibility without settling unresolved calls, rewriting canonical evidence, or replaying uncertain side effects. Preserve usage and recovery behavior through the same journal and durable-runtime boundaries. Include engine/thread patch changesets; no stored-format migration or consumer API change is required.
