### PR TITLE
feat(thread): authorize independent worker run budgets

### DIFF
--- a/.changeset/independent-worker-run-budgets.md
+++ b/.changeset/independent-worker-run-budgets.md
@@ -1,0 +1,8 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+"@effect-agent/capabilities": patch
+"@effect-agent/thread": patch
+---
+
+Add host-authorized independent allowances for background worker Runs while preserving delegation lineage and bounded attached descendants. Keep joined inputs and replacement Attempts on the same durable allowance.

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -128,6 +128,16 @@ Durable admission checks the recorded pool before reserving another child. Recov
 the child's resolved policy and existing reservation. Unknown usage remains charged
 conservatively, and admission fails closed on inconsistent caps or exhausted concurrency.
 
+### Independently funded workers
+
+A root may request `budgetScope: "worker-run"` for a background worker only when the native
+`WorkerBudgetAuthorizer` permits its exact source, target, and allocation. Immutable delegation
+lineage still controls Tool grants and depth; accounting belongs to the worker's logical Run.
+New Runs reuse the configured allowance, while joined input and every recovery Attempt share the
+existing Run's usage. No cumulative token or cost cap is invented when that dimension is omitted.
+Attached descendants remain bounded by the immediate worker Run's reserved subtree. See the
+[subagent guide](../guide/subagents#independently-fund-background-runs) for host configuration.
+
 ### Request a larger child budget {#containment-and-the-extension-flow}
 
 `failureMode: "return"` converts expected child failures into model-visible result data. Engine

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -182,6 +182,42 @@ require the platform Crypto service. Projection services are supplied to the han
 Custom `prepareInput` receives `context.source` as `"tool"` or `"programmatic"`. Only the tool
 variant contains `context.toolCallId` and `context.parent.runId`.
 
+## Independently fund background Runs
+
+Background workers normally reserve against their source's subtree. A host may separately
+fund a root's reusable worker by supplying `WorkerBudgetAuthorizer` from
+`@effect-agent/thread/WorkerHost` and allowing the exact source, destination, and allowance.
+The default denies this permission. Request it from author-owned code:
+
+```ts
+const start = Subagent.start(Research, request, {
+  idempotencyKey,
+  budgetScope: "worker-run",
+});
+const tools = Subagent.background(Research, { start: true, budgetScope: "worker-run" });
+```
+
+The model cannot select the funding scope. The host checks it before every native input admission.
+This mode resolves the worker's own Definition policy without inheriting its source's execution
+ceiling. Declared delegation allocations bound the worker's own work and its descendants. Tokens
+and cost have no cumulative ceiling unless explicitly configured. Keep finite turn, tool-call,
+duration, concurrency, and result bounds, and authorize the exact allocation at the host.
+
+The first admission freezes the scope with the worker's immutable source, grant, and depth.
+A later native logical Run receives the same configured allowance. Input joining an active Run
+shares that Run's usage and deadline; a Receipt does not create budget credit. Retried delivery,
+replacement Attempts, owner eviction, and compaction retain the same Run journal. Changing history
+or application task identifiers never resets an active allowance.
+
+Independent funding is available only to root-created workers. Root, worker, and attached scout
+still have depths zero, one, and two. Set the worker grant's `childLifetimes` to `["attached"]`
+and `maxDepth` to `2` to allow scouts without another background generation. Reserve enough
+`descendantInvocations` and allocation beyond the worker's own full ceiling for those scouts.
+Scouts share the immediate worker Run's remaining allocation. Host worker-count, pending-input,
+input-retention, concurrency, and lifetime limits still apply across the source Thread.
+Set `WorkerHostConfig.maxActiveWorkersPerSource` to bound concurrent background workers separately
+from the root's Tool execution concurrency; omission retains the prior concurrency ceiling.
+
 ## Bound child work
 
 Children inherit omitted policy fields from their parent's resolved policy. Explicit child fields

--- a/packages/capabilities/src/Subagent.ts
+++ b/packages/capabilities/src/Subagent.ts
@@ -1397,7 +1397,12 @@ const layer = <
       const caps =
         spawner.budget === undefined
           ? resolved.caps
-          : residualSubagentCaps(resolved.caps, spawner.policy, spawner.budget);
+          : residualSubagentCaps(
+              resolved.caps,
+              spawner.policy,
+              spawner.budget,
+              spawner.budgetScope === "worker-run",
+            );
 
       const sink = yield* RunEventSink;
       const reservations = yield* SubagentReservations;

--- a/packages/capabilities/src/internal/subagent-background.ts
+++ b/packages/capabilities/src/internal/subagent-background.ts
@@ -9,6 +9,7 @@ import {
 } from "@effect-agent/core/SubagentContract";
 import {
   WorkerContext,
+  type WorkerBudgetScope,
   WorkerError,
   WorkerOperationTool,
   WorkerPage,
@@ -218,7 +219,7 @@ const operations = <
 
   const start = Effect.fn("Subagent.start")(function* (
     parameters: Parameters["Type"],
-    options: { readonly idempotencyKey: IdempotencyKey },
+    options: { readonly idempotencyKey: IdempotencyKey; readonly budgetScope?: WorkerBudgetScope },
   ) {
     const service = yield* host;
     const caller = yield* context;
@@ -242,7 +243,14 @@ const operations = <
         message: "The inherited grant does not permit background children",
       });
     }
-    const resolved = resolveSubagentPolicy(declaration, caller.policy);
+
+    const resolved = resolveSubagentPolicy(
+      declaration,
+      options.budgetScope === "worker-run" ? declaration.target.policy : caller.policy,
+      undefined,
+      options.budgetScope === "worker-run" ? "root-attached" : "conserved",
+    );
+
     const prepared = yield* prepare(parameters, caller);
 
     const encodedGrant = yield* Schema.encodeEffect(SubagentGrant)(grant).pipe(
@@ -254,6 +262,7 @@ const operations = <
       delegationId: declaration.delegationId,
       target: declaration.target,
       idempotencyKey: key,
+      ...(options.budgetScope === undefined ? {} : { budgetScope: options.budgetScope }),
       encodedGrant,
       policy: resolved.childPolicy,
       budget: SubagentBudgetReservation.make({
@@ -474,7 +483,7 @@ export const start = <
 >(
   declaration: Declaration<Name, Input, Output, Parameters, Success, Failure, Prepare, Project>,
   parameters: Parameters["Type"],
-  options: { readonly idempotencyKey: IdempotencyKey },
+  options: { readonly idempotencyKey: IdempotencyKey; readonly budgetScope?: WorkerBudgetScope },
 ) => operations(declaration).start(parameters, options);
 
 /** Admit typed follow-up parameters to the same worker Thread. */
@@ -662,9 +671,11 @@ export interface BackgroundOptions {
   readonly summary?: true;
   readonly list?: true;
   readonly cancel?: true;
+  /** Author-owned funding request for starts; every native admission separately authorizes it. */
+  readonly budgetScope?: WorkerBudgetScope;
 }
 
-type Operation = keyof BackgroundOptions;
+type Operation = Exclude<keyof BackgroundOptions, "budgetScope">;
 type Suffix = {
   start: "start";
   followUp: "follow_up";
@@ -957,7 +968,10 @@ export const background = <
           const idempotencyKey = yield* modelKey("start");
 
           return yield* ops
-            .start(parameters, { idempotencyKey })
+            .start(parameters, {
+              idempotencyKey,
+              ...(selected.budgetScope === undefined ? {} : { budgetScope: selected.budgetScope }),
+            })
             .pipe(Effect.provideService(SubagentHost, service), Effect.provide(captured));
         }),
       [followUpTool.name]: (parameters: {

--- a/packages/capabilities/src/internal/subagent-policy.ts
+++ b/packages/capabilities/src/internal/subagent-policy.ts
@@ -160,6 +160,7 @@ export const residualSubagentCaps = (
   declared: SubagentDelegationCaps,
   parent: AgentPolicy,
   inherited: SubagentBudgetReservation,
+  independentRun = false,
 ): SubagentDelegationCaps => {
   const allocation = inherited.allocation;
 
@@ -183,21 +184,48 @@ export const residualSubagentCaps = (
       Math.ceil(Duration.toMillis(parent.maxDuration)),
       declared.maxDurationMillis,
     ),
-    maxInputTokens: remaining(
-      allocation.inputTokens,
-      parent.tokenBudget ?? allocation.inputTokens,
-      declared.maxInputTokens,
-    ),
-    maxOutputTokens: remaining(
-      allocation.outputTokens,
-      parent.tokenBudget ?? allocation.outputTokens,
-      declared.maxOutputTokens,
-    ),
-    maxCostMicrousd: remaining(
-      allocation.costMicrousd,
-      parent.costBudgetMicrousd ?? allocation.costMicrousd,
-      declared.maxCostMicrousd,
-    ),
+    ...(independentRun &&
+    inherited.caps.maxInputTokens === undefined &&
+    allocation.inputTokens === 0 &&
+    parent.tokenBudget === undefined
+      ? declared.maxInputTokens === undefined
+        ? {}
+        : { maxInputTokens: declared.maxInputTokens }
+      : {
+          maxInputTokens: remaining(
+            allocation.inputTokens,
+            parent.tokenBudget ?? allocation.inputTokens,
+            declared.maxInputTokens,
+          ),
+        }),
+    ...(independentRun &&
+    inherited.caps.maxOutputTokens === undefined &&
+    allocation.outputTokens === 0 &&
+    parent.tokenBudget === undefined
+      ? declared.maxOutputTokens === undefined
+        ? {}
+        : { maxOutputTokens: declared.maxOutputTokens }
+      : {
+          maxOutputTokens: remaining(
+            allocation.outputTokens,
+            parent.tokenBudget ?? allocation.outputTokens,
+            declared.maxOutputTokens,
+          ),
+        }),
+    ...(independentRun &&
+    inherited.caps.maxCostMicrousd === undefined &&
+    allocation.costMicrousd === 0 &&
+    parent.costBudgetMicrousd === undefined
+      ? declared.maxCostMicrousd === undefined
+        ? {}
+        : { maxCostMicrousd: declared.maxCostMicrousd }
+      : {
+          maxCostMicrousd: remaining(
+            allocation.costMicrousd,
+            parent.costBudgetMicrousd ?? allocation.costMicrousd,
+            declared.maxCostMicrousd,
+          ),
+        }),
     maxResultBytes: remaining(
       allocation.resultBytes,
       parent.toolResultBounds.maxBytes,

--- a/packages/core/src/Worker.ts
+++ b/packages/core/src/Worker.ts
@@ -23,6 +23,10 @@ export const WorkerStarted = Schema.Struct({
 
 export type WorkerStarted = typeof WorkerStarted.Type;
 
+/** A host-authorized Run allowance is independent of the immutable delegation lineage. */
+export const WorkerBudgetScope = Schema.Literals(["source-subtree", "worker-run"]);
+export type WorkerBudgetScope = typeof WorkerBudgetScope.Type;
+
 /** Host-bound caller metadata. Programmatic calls never fabricate Run or Tool Call identities. */
 export const WorkerSource = Schema.Union([
   Schema.Struct({

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -21,6 +21,7 @@ import {
   type ToolExecutionKind,
 } from "@effect-agent/core/SubagentContract";
 import { type ModelCallUsage } from "@effect-agent/core/Usage";
+import type { WorkerBudgetScope } from "@effect-agent/core/Worker";
 import { type Cause, Effect, Context, type DateTime, Layer, Schema } from "effect";
 import type { LanguageModel, Model, Prompt, Response } from "effect/unstable/ai";
 
@@ -847,6 +848,8 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
   readonly subagentGrant?: SubagentGrant | undefined;
   /** Reserved subtree frame; descendants may spend only the residual after this Run's own ceiling. */
   readonly subagentBudget?: SubagentBudgetReservation | undefined;
+  /** Native host funding provenance; never inferred from absent allocation amounts. */
+  readonly subagentBudgetScope?: WorkerBudgetScope | undefined;
   /**
    * Explicit initial Prompt data, not a retention policy. With ThreadHistory.layerTransient,
    * the engine preserves this exact prefix, then appends this Run's evaluated instructions and

--- a/packages/engine/src/SubagentHost.ts
+++ b/packages/engine/src/SubagentHost.ts
@@ -7,6 +7,7 @@ import {
   WorkerError,
   type WorkerHistoryEntry,
   type WorkerContext,
+  type WorkerBudgetScope,
   type WorkerSource,
   type WorkerPage,
   type WorkerRef,
@@ -27,6 +28,8 @@ export interface StartWorkerRequest {
   readonly budget: SubagentBudgetReservation;
   readonly encodedGrant: unknown;
   readonly toolCallAllowance?: number;
+  /** Author-owned request; the durable host must separately authorize worker-run funding. */
+  readonly budgetScope?: WorkerBudgetScope;
 }
 
 export interface FollowUpWorkerRequest {

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -71,6 +71,7 @@ import {
   type ToolResultBounds,
 } from "@effect-agent/core/ToolResult";
 import { InputTokenUsage, ModelCallUsage, OutputTokenUsage } from "@effect-agent/core/Usage";
+import type { WorkerBudgetScope } from "@effect-agent/core/Worker";
 import type { Take } from "effect";
 import {
   Cause,
@@ -7135,6 +7136,7 @@ function streamWithCompletion<
               agent.definition.policy,
               options.subagentGrant,
               options.subagentBudget,
+              options.subagentBudgetScope,
             ),
           ).pipe(
             Context.add(ContextWindow, {
@@ -8783,6 +8785,7 @@ export interface AgentSpawnerService {
   readonly depth: number;
   readonly grant?: SubagentGrant;
   readonly budget?: SubagentBudgetReservation;
+  readonly budgetScope?: WorkerBudgetScope;
   readonly parent: AgentSpawnerParent;
   readonly spawn: <
     InputSchema extends Schema.Top,
@@ -8885,9 +8888,11 @@ const makeAgentSpawner = (
   policy: AgentPolicy,
   grant?: SubagentGrant,
   budget?: SubagentBudgetReservation,
+  budgetScope?: WorkerBudgetScope,
 ): AgentSpawnerService => ({
   ...(grant === undefined ? {} : { grant }),
   ...(budget === undefined ? {} : { budget }),
+  ...(budgetScope === undefined ? {} : { budgetScope }),
   policy,
   depth,
   parent,

--- a/packages/platform-cloudflare/test/background-worker-fixture.ts
+++ b/packages/platform-cloudflare/test/background-worker-fixture.ts
@@ -1,8 +1,15 @@
 import * as Subagent from "@effect-agent/capabilities/Subagent";
+import { SubagentReservationsMemoryLive } from "@effect-agent/capabilities/SubagentReservations";
 import * as Agent from "@effect-agent/core/Agent";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { SubagentGrant } from "@effect-agent/core/SubagentContract";
 import { WorkerError } from "@effect-agent/core/Worker";
 import { DurableWorkerBinding } from "@effect-agent/thread/AgentRegistration";
-import { WorkerHostAuthorizer } from "@effect-agent/thread/WorkerHost";
+import {
+  WorkerBudgetAuthorizer,
+  WorkerHostAuthorizer,
+  WorkerHostConfig,
+} from "@effect-agent/thread/WorkerHost";
 import { Effect, Layer, Schema, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
@@ -111,7 +118,136 @@ export const backgroundReportingWorkers = Subagent.make("reported_research", {
   }),
 });
 
+export const independentBudgetSource = Agent.make("cf-independent-source", {
+  input: backgroundSource.input,
+  output: backgroundSource.output,
+  instructions: "Answer as JSON.",
+  toolkit: Toolkit.empty,
+  policy: { maxTurns: 1, maxToolCalls: 1, maxDuration: "1 second", toolConcurrency: 1 },
+});
+
+const independentScout = Agent.make("cf-independent-scout", {
+  input: backgroundTarget.input,
+  output: backgroundTarget.output,
+  instructions: "Answer as JSON.",
+  toolkit: Toolkit.empty,
+  policy: {
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "10 seconds",
+    toolConcurrency: 1,
+    toolResultBounds: { maxBytes: 512 },
+  },
+});
+
+const independentScoutDeclaration = Subagent.make("budget_scout", {
+  target: independentScout,
+  grant: SubagentGrant.make({ allowedToolNames: [], maxDepth: 2, childLifetimes: ["attached"] }),
+  policy: Subagent.SubagentPolicy.make({
+    maxChildren: 1,
+    maxConcurrency: 1,
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "10 seconds",
+    maxInputTokens: 20,
+    maxOutputTokens: 30,
+    maxCostMicrousd: 2,
+    maxResultBytes: 512,
+  }),
+});
+
+const independentPersona = Agent.make("cf-independent-persona", {
+  input: backgroundTarget.input,
+  output: backgroundTarget.output,
+  instructions: "Attach a scout once per task, then answer as JSON.",
+  toolkit: Toolkit.make(independentScoutDeclaration.tool),
+  policy: {
+    maxTurns: 2,
+    maxToolCalls: 1,
+    maxDuration: "20 seconds",
+    toolConcurrency: 1,
+    toolResultBounds: { maxBytes: 1024 },
+  },
+});
+
+export const independentBudgetWorkers = Subagent.make("independent_persona", {
+  target: independentPersona,
+  grant: SubagentGrant.make({
+    allowedToolNames: ["budget_scout"],
+    maxDepth: 2,
+    childLifetimes: ["attached"],
+  }),
+  policy: Subagent.SubagentPolicy.make({
+    maxChildren: 1,
+    maxConcurrency: 1,
+    descendantInvocations: 1,
+    maxTurns: 3,
+    maxToolCalls: 2,
+    maxDuration: "40 seconds",
+    maxResultBytes: 2048,
+  }),
+});
+
+export const independentBudgetGrants = new Set<string>();
+/** A source authorization succeeds before the destination's next admission loses its dependency. */
+export const independentBudgetAdmissionOutages = new Set<string>();
+export const independentBudgetAuthorityCalls = new Map<string, number>();
+export const independentBudgetGates = new Set<string>();
+
+const independentPersonaModel = Model.make(
+  "scripted",
+  "cf-independent-persona",
+  Layer.effect(
+    LanguageModel.LanguageModel,
+    LanguageModel.make({
+      generateText: () => Effect.succeed([]),
+      streamText: ({ prompt }) => {
+        const index = prompt.content.findLastIndex(
+          (message) => message.role === "user" && JSON.stringify(message).includes(":task:"),
+        );
+
+        const task =
+          /background-cf-independent-[a-z0-9-]+:task:[0-9]+/u.exec(
+            JSON.stringify(prompt.content[index]),
+          )?.[0] ?? "missing";
+
+        const finished = prompt.content.slice(index + 1).some((message) => message.role === "tool");
+
+        if (finished) return Stream.fromIterable(finalParts('{"answer":"done"}'));
+
+        const wait = Effect.gen(function* () {
+          while (!independentBudgetGates.has(task)) yield* Effect.sleep("10 millis");
+        });
+
+        const parts: ReadonlyArray<Response.StreamPartEncoded> = [
+          {
+            type: "tool-call",
+            id: "scout-once",
+            name: "budget_scout",
+            params: { question: task },
+            providerExecuted: false,
+          },
+          { type: "finish", reason: "tool-calls", usage: { inputTokens: {}, outputTokens: {} } },
+        ];
+
+        return Stream.fromEffectDrain(wait).pipe(Stream.concat(Stream.fromIterable(parts)));
+      },
+    }),
+  ),
+);
+
+const independentScoutHandlers = Subagent.SubagentRuntime.layer(
+  independentScoutDeclaration,
+  Agent.withModel(independentScout, model),
+).pipe(Layer.provide([SubagentReservationsMemoryLive, IdGenerator.layer]));
+
 export const backgroundWorkerBindings = Effect.all([
+  DurableWorkerBinding.make(Agent.withModel(independentBudgetSource, model), TEST_DIGESTS),
+  DurableWorkerBinding.make(Agent.withModel(independentScout, model), TEST_DIGESTS),
+  DurableWorkerBinding.make(
+    Agent.withModel(independentPersona, independentPersonaModel),
+    TEST_DIGESTS,
+  ).pipe(Effect.provide(independentScoutHandlers)),
   DurableWorkerBinding.make(Agent.withModel(backgroundSource, model), TEST_DIGESTS),
   DurableWorkerBinding.make(Agent.withModel(backgroundTarget, model), TEST_DIGESTS),
   DurableWorkerBinding.make(Agent.withModel(backgroundReportSource, model), TEST_DIGESTS, [
@@ -138,12 +274,45 @@ export const backgroundWorkerBindings = Effect.all([
   ),
 ]);
 
-export const backgroundWorkerAuthority = Layer.succeed(WorkerHostAuthorizer)({
-  authorize: (request) =>
-    request.principal === TEST_PRINCIPAL && request.sourceThreadId.startsWith("background-cf-")
-      ? Effect.succeed(TEST_PRINCIPAL)
-      : WorkerError.make({ operation: request.operation, reason: "denied" }),
-});
+export const backgroundWorkerAuthority = Layer.mergeAll(
+  Layer.succeed(WorkerHostConfig)({
+    maxWorkersPerSource: 32,
+    maxActiveWorkersPerSource: 2,
+    maxInputsPerWorker: 64,
+    maxPendingInputsPerWorker: 8,
+    lifetimeMillis: 86_400_000,
+  }),
+  Layer.succeed(WorkerBudgetAuthorizer)({
+    authorize: (request) =>
+      Effect.gen(function* () {
+        const source = request.source.threadId;
+        const calls = (independentBudgetAuthorityCalls.get(source) ?? 0) + 1;
+
+        independentBudgetAuthorityCalls.set(source, calls);
+
+        const declared =
+          (request.worker.targetAgentId === independentPersona.id &&
+            request.worker.delegationId === independentBudgetWorkers.delegationId) ||
+          (request.worker.targetAgentId === backgroundTarget.id &&
+            request.worker.delegationId === backgroundWorkers.delegationId);
+
+        if (
+          request.principal !== TEST_PRINCIPAL ||
+          !independentBudgetGrants.has(source) ||
+          !declared
+        )
+          return yield* WorkerError.make({ operation: "start", reason: "denied" });
+        if (independentBudgetAdmissionOutages.has(source) && calls > 1)
+          return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+      }),
+  }),
+  Layer.succeed(WorkerHostAuthorizer)({
+    authorize: (request) =>
+      request.principal === TEST_PRINCIPAL && request.sourceThreadId.startsWith("background-cf-")
+        ? Effect.succeed(TEST_PRINCIPAL)
+        : WorkerError.make({ operation: request.operation, reason: "denied" }),
+  }),
+);
 
 /** Explicitly suppress worker wake hints while the recovery test drives stored alarms. */
 export const backgroundWakeDropPrefixes = new Set<string>();

--- a/packages/platform-cloudflare/test/background-workers.test.ts
+++ b/packages/platform-cloudflare/test/background-workers.test.ts
@@ -3,7 +3,7 @@ import { SubagentHost } from "@effect-agent/engine/SubagentHost";
 import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
 import { MessageDeliveryStore } from "@effect-agent/thread/MessageDelivery";
 import { ThreadExportRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
-import { runInDurableObject } from "cloudflare:test";
+import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { Effect } from "effect";
 import { DurableObject } from "effect-cf";
 import { expect, it } from "vite-plus/test";
@@ -11,6 +11,12 @@ import { expect, it } from "vite-plus/test";
 import { CloudflareThreadClient } from "../src/CloudflareThreadClient.ts";
 import {
   backgroundSource,
+  independentBudgetSource,
+  independentBudgetWorkers,
+  independentBudgetGrants,
+  independentBudgetAdmissionOutages,
+  independentBudgetAuthorityCalls,
+  independentBudgetGates,
   backgroundWorkers,
   backgroundWakeDropPrefixes,
   backgroundReportSource,
@@ -277,5 +283,310 @@ it("delivers one frozen report after child eviction and source eviction with all
     backgroundWakeDropPrefixes.delete("worker:");
     droppedMessageWakes.delete(source);
     droppedMessageWakes.delete(started.worker.threadId);
+  }
+}, 20_000);
+
+// Regression: https://github.com/danieljvdm/effect-agent/pull/358
+it("funds native persona Runs independently while joins, eviction and scouts retain one allowance", async () => {
+  const source = `background-cf-independent-${crypto.randomUUID()}`;
+
+  await runClient(
+    Effect.flatMap(CloudflareThreadClient, (client) =>
+      client.submit(
+        { definition: independentBudgetSource },
+        { question: "initialize" },
+        submitOptions(source, "source"),
+      ),
+    ),
+  );
+  await drainAlarmsUntil(source, allSettled(source));
+
+  const launch = () =>
+    withOwner(source, (host) =>
+      Subagent.start(
+        independentBudgetWorkers,
+        { question: `${source}:task:1` },
+        { idempotencyKey: decodeIdempotencyKey("first"), budgetScope: "worker-run" },
+      ).pipe(Effect.provideService(SubagentHost, host)),
+    );
+
+  await expect(launch()).rejects.toThrow();
+  independentBudgetGrants.add(source);
+  backgroundWakeDropPrefixes.add("worker:");
+  droppedMessageWakes.add(source);
+  const started = await launch();
+
+  droppedMessageWakes.add(started.worker.threadId);
+
+  const finish = (thread = started.worker.threadId) =>
+    drainAlarmsUntil(thread, async () => {
+      const records = await readCanonical(thread);
+
+      for (const { record } of records) {
+        if (record.payload._tag === "SubagentRequested") {
+          await drainAlarmsUntil(
+            record.payload.childThreadId,
+            allSettled(record.payload.childThreadId),
+          );
+        }
+      }
+
+      return allSettled(thread)();
+    });
+
+  const sibling = await withOwner(source, (host) =>
+    Subagent.start(
+      independentBudgetWorkers,
+      { question: `${source}:task:4` },
+      { idempotencyKey: decodeIdempotencyKey("sibling"), budgetScope: "worker-run" },
+    ).pipe(Effect.provideService(SubagentHost, host)),
+  );
+
+  droppedMessageWakes.add(sibling.worker.threadId);
+  try {
+    expect(await launch()).toEqual(started);
+    const firstAlarm = runDurableObjectAlarm(stubFor(started.worker.threadId)).catch(() => false);
+
+    await expect
+      .poll(async () =>
+        (await readCanonical(started.worker.threadId)).some(
+          ({ record }) => record.payload._tag === "RunStarted",
+        ),
+      )
+      .toBe(true);
+    const siblingAlarm = runDurableObjectAlarm(stubFor(sibling.worker.threadId)).catch(() => false);
+
+    await expect
+      .poll(async () =>
+        (await readCanonical(sibling.worker.threadId)).some(
+          ({ record }) => record.payload._tag === "RunStarted",
+        ),
+      )
+      .toBe(true);
+    await expect(
+      withOwner(source, (host) =>
+        Subagent.start(
+          independentBudgetWorkers,
+          { question: `${source}:task:5` },
+          { idempotencyKey: decodeIdempotencyKey("third-active"), budgetScope: "worker-run" },
+        ).pipe(Effect.provideService(SubagentHost, host)),
+      ),
+    ).rejects.toThrow();
+    // The root has toolConcurrency=1, but two persona Runs are live and root work remains runnable.
+    await runClient(
+      Effect.flatMap(CloudflareThreadClient, (client) =>
+        client.submit(
+          { definition: independentBudgetSource },
+          { question: "responsive root" },
+          submitOptions(source, "responsive"),
+        ),
+      ),
+    );
+    await drainAlarmsUntil(source, allSettled(source));
+
+    const joined = await withOwner(source, (host) =>
+      Subagent.followUp(
+        independentBudgetWorkers,
+        started.worker,
+        { question: "continue the active task" },
+        { idempotencyKey: decodeIdempotencyKey("joined") },
+      ).pipe(Effect.provideService(SubagentHost, host)),
+    );
+
+    armRuntimeEviction(started.worker.threadId, "turn:after-response-append");
+    independentBudgetGates.add(`${source}:task:1`);
+    await firstAlarm;
+    await finish();
+    expect(armedEvictionsRemaining(started.worker.threadId)).toBe(0);
+    const firstLog = await readCanonical(started.worker.threadId);
+
+    const starts = firstLog.flatMap(({ record }) =>
+      record.payload._tag === "RunStarted" ? [record.payload] : [],
+    );
+
+    expect(starts).toHaveLength(1);
+
+    const settled = firstLog.flatMap(({ record }) =>
+      record.payload._tag === "SubmissionSettled" ? [record.payload] : [],
+    );
+
+    expect(settled).toHaveLength(2);
+    expect(settled.map((row) => row.runId)).toEqual([starts[0]?.runId, starts[0]?.runId]);
+    expect(settled.map((row) => row.outcome)).toEqual(["completed", "completed"]);
+    expect(settled.map((row) => row.submissionId)).toContain(joined.submissionId);
+    for (const round of [2, 3]) {
+      await evict(source);
+      await evict(started.worker.threadId);
+      independentBudgetGates.add(`${source}:task:${round}`);
+
+      const next = await withOwner(source, (host) =>
+        Subagent.followUp(
+          independentBudgetWorkers,
+          started.worker,
+          { question: `${source}:task:${round}` },
+          { idempotencyKey: decodeIdempotencyKey(`later-${round}`) },
+        ).pipe(Effect.provideService(SubagentHost, host)),
+      );
+
+      expect(next.threadId).toBe(started.worker.threadId);
+      expect(next.submissionId).not.toBe(started.receipt.submissionId);
+      await finish();
+    }
+    independentBudgetGates.add(`${source}:task:4`);
+    await siblingAlarm;
+    await finish(sibling.worker.threadId);
+    const siblingLog = await readCanonical(sibling.worker.threadId);
+
+    expect(siblingLog.filter(({ record }) => record.payload._tag === "RunStarted")).toHaveLength(1);
+    const workerLog = await readCanonical(started.worker.threadId);
+
+    const origins = workerLog.flatMap(({ record }) =>
+      record.payload._tag === "WorkerOriginRecorded" ? [record.payload.origin] : [],
+    );
+
+    expect(origins).toHaveLength(1);
+    expect(origins[0]).toMatchObject({
+      budgetScope: "worker-run",
+      depth: 1,
+      source: { threadId: source },
+    });
+    expect(origins[0]?.policy.tokenBudget).toBeUndefined();
+    expect(origins[0]?.policy.costBudgetMicrousd).toBeUndefined();
+
+    const runs = workerLog.flatMap(({ record }) =>
+      record.payload._tag === "RunStarted" ? [record.payload.runId] : [],
+    );
+
+    expect(new Set(runs).size).toBe(3);
+
+    const scouts = workerLog.flatMap(({ record }) =>
+      record.payload._tag === "SubagentRequested" ? [record.payload] : [],
+    );
+
+    expect(scouts).toHaveLength(3);
+    expect(new Set(scouts.map((row) => row.runId)).size).toBe(3);
+    expect(scouts.map((row) => row.depth)).toEqual([2, 2, 2]);
+    expect(scouts.map((row) => row.budget?.caps)).toEqual(
+      Array.from({ length: 3 }, () =>
+        expect.objectContaining({ maxInputTokens: 20, maxOutputTokens: 30, maxCostMicrousd: 2 }),
+      ),
+    );
+    expect(scouts.map((row) => row.policy?.tokenBudget)).toEqual([50, 50, 50]);
+    expect(scouts.map((row) => row.policy?.costBudgetMicrousd)).toEqual([2, 2, 2]);
+
+    const reservations = workerLog.flatMap(({ record }) =>
+      record.payload._tag === "SubtreeBudgetReserved" ? [record.payload] : [],
+    );
+
+    expect(reservations).toHaveLength(3);
+    expect(new Set(reservations.map((row) => row.sourceSubmissionId)).size).toBe(3);
+    for (const scout of scouts) {
+      const child = await readCanonical(scout.childThreadId);
+
+      expect(
+        child.flatMap(({ record }) =>
+          record.payload._tag === "SubagentLineageRecorded"
+            ? [record.payload.parentLink.depth]
+            : [],
+        ),
+      ).toEqual([2]);
+    }
+    const rootLog = await readCanonical(source);
+
+    expect(
+      rootLog.filter(({ record }) => record.payload._tag === "SubtreeBudgetReserved"),
+    ).toHaveLength(0);
+    expect(
+      rootLog.filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+    ).toHaveLength(5);
+    expect(
+      rootLog.filter(({ record }) => record.payload._tag === "SubmissionSettled"),
+    ).toHaveLength(2);
+  } finally {
+    independentBudgetGrants.delete(source);
+    independentBudgetAuthorityCalls.delete(source);
+    for (const round of [1, 2, 3, 4]) independentBudgetGates.delete(`${source}:task:${round}`);
+    droppedMessageWakes.delete(sibling.worker.threadId);
+    backgroundWakeDropPrefixes.delete("worker:");
+    droppedMessageWakes.delete(source);
+    droppedMessageWakes.delete(started.worker.threadId);
+  }
+}, 30_000);
+
+// Regression: https://github.com/danieljvdm/effect-agent/pull/358
+it("retries unavailable worker funding admission with the same durable input identity", async () => {
+  const source = `background-cf-independent-outage-${crypto.randomUUID()}`;
+
+  await runClient(
+    Effect.flatMap(CloudflareThreadClient, (client) =>
+      client.submit(
+        { definition: independentBudgetSource },
+        { question: "initialize" },
+        submitOptions(source, "source"),
+      ),
+    ),
+  );
+  await drainAlarmsUntil(source, allSettled(source));
+  independentBudgetGrants.add(source);
+  independentBudgetAdmissionOutages.add(source);
+  droppedMessageWakes.add(source);
+
+  const launch = () =>
+    withOwner(source, (host) =>
+      Subagent.start(
+        backgroundWorkers,
+        { question: "recover the accepted intent" },
+        { idempotencyKey: decodeIdempotencyKey("outage"), budgetScope: "worker-run" },
+      ).pipe(Effect.provideService(SubagentHost, host)),
+    );
+
+  const deliveries = () =>
+    runInDurableObject(stubFor(source), (instance) =>
+      instance[DurableObject.RunSymbol](
+        Effect.flatMap(MessageDeliveryStore, (store) =>
+          store.list({ ownerThreadId: decodeThreadId(source), limit: 100 }),
+        ),
+      ),
+    );
+
+  try {
+    await expect(launch()).rejects.toThrow();
+    const pending = await deliveries();
+
+    expect(pending.items).toHaveLength(1);
+    const retained = pending.items[0];
+
+    if (retained === undefined) throw new Error("Expected retained worker input");
+    expect(retained.status).toBe("pending");
+    expect(retained.receipt).toBeNull();
+    independentBudgetAdmissionOutages.delete(source);
+    await drainAlarmsUntil(source, async () => {
+      const receipt = (await deliveries()).items[0]?.receipt;
+
+      return receipt !== undefined && receipt !== null;
+    });
+    const recovered = await launch();
+
+    expect(recovered.worker).toEqual(retained.envelope.workerAdmission?.origin.worker);
+    const accepted = await deliveries();
+
+    expect(accepted.items).toHaveLength(1);
+    expect(accepted.items[0]?.key).toEqual(retained.key);
+    expect(accepted.items[0]?.receipt).toEqual(recovered.receipt);
+    expect(await launch()).toEqual(recovered);
+    await drainAlarmsUntil(recovered.worker.threadId, allSettled(recovered.worker.threadId));
+    const log = await readCanonical(recovered.worker.threadId);
+
+    expect(log.filter(({ record }) => record.payload._tag === "RunStarted")).toHaveLength(1);
+    const sourceLog = await readCanonical(source);
+
+    expect(
+      sourceLog.filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+    ).toHaveLength(1);
+  } finally {
+    independentBudgetGrants.delete(source);
+    independentBudgetAdmissionOutages.delete(source);
+    independentBudgetAuthorityCalls.delete(source);
+    droppedMessageWakes.delete(source);
   }
 }, 20_000);

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -346,7 +346,11 @@ export class TestThreadObject extends ThreadObject.make(
     Layer.provide(messageDeliveryFaultLayer),
     Layer.provideMerge(maintenanceClockLayer),
   ),
-  baseOptions,
+  {
+    ...baseOptions,
+    // Scripted providers have no spend; explicit cost-bound scout Runs still require pricing.
+    estimateCostMicrousd: () => Effect.succeed({ costMicrousd: 0 }),
+  },
 ) {
   override wake(): Promise<void> {
     const name = this.ctx.id.name ?? "";

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -3745,6 +3745,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         submission.workerAdmission?.origin.depth ??
         (childLineage?._tag === "SubagentLineageRecorded" ? childLineage.parentLink.depth : 0);
 
+      // worker-run origins supply a frozen ceiling, not usage credit. Only this native
+      // host Run's journal owns usage; joined inputs and replacement Attempts keep its RunId.
       const inheritedBudget =
         submission.workerAdmission?.origin.budget ??
         (childLineage?._tag === "SubagentLineageRecorded" ? childLineage.budget : undefined);
@@ -5762,6 +5764,9 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         delegationDepth,
         ...(inheritedGrant === undefined ? {} : { subagentGrant: inheritedGrant }),
         ...(inheritedBudget === undefined ? {} : { subagentBudget: inheritedBudget }),
+        ...(submission.workerAdmission?.origin.budgetScope === undefined
+          ? {}
+          : { subagentBudgetScope: submission.workerAdmission.origin.budgetScope }),
         runStartedAt: runTiming.startedAt,
         durationDeadline: runTiming.deadline,
         ...(submission.workerAdmission === undefined
@@ -8196,7 +8201,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             .pipe(
               Effect.mapError((cause) =>
                 AdmissionPolicyError.make({
-                  reason: cause.reason === "storage" ? "unavailable" : "refused",
+                  reason:
+                    cause.reason === "storage" || cause.reason === "unavailable"
+                      ? "unavailable"
+                      : "refused",
                   code: `worker-${cause.reason}`,
                 }),
               ),

--- a/packages/thread/src/Records.ts
+++ b/packages/thread/src/Records.ts
@@ -24,7 +24,7 @@ import {
   ToolExecutionKind,
 } from "@effect-agent/core/SubagentContract";
 import { ModelCallUsage, RunUsageSummary } from "@effect-agent/core/Usage";
-import { WorkerRef, WorkerSource } from "@effect-agent/core/Worker";
+import { WorkerBudgetScope, WorkerRef, WorkerSource } from "@effect-agent/core/Worker";
 import { ContextHandoff } from "@effect-agent/engine/ContextWindow";
 import { Schema } from "effect";
 import { Prompt } from "effect/unstable/ai";
@@ -755,6 +755,8 @@ export const WorkerReportingIntent = Schema.Struct({
 export const WorkerOrigin = Schema.Struct({
   worker: WorkerRef,
   source: WorkerSource,
+  /** Omitted retains source-subtree funding; worker-run renews only for a new native Run. */
+  budgetScope: Schema.optionalKey(WorkerBudgetScope),
   targetDigests: DefinitionDigests,
   policy: Schema.toCodecJson(AgentPolicy),
   budget: SubagentBudgetReservation,

--- a/packages/thread/src/WorkerHost.ts
+++ b/packages/thread/src/WorkerHost.ts
@@ -1,5 +1,7 @@
+import type { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import type { ThreadId } from "@effect-agent/core/Identifiers";
-import { WorkerError, type WorkerRef } from "@effect-agent/core/Worker";
+import type { SubagentBudgetReservation } from "@effect-agent/core/SubagentContract";
+import { WorkerError, type WorkerRef, type WorkerSource } from "@effect-agent/core/Worker";
 import { Context, type Effect, Schema } from "effect";
 
 import type { Principal } from "./SubmissionLedger.ts";
@@ -9,6 +11,8 @@ const Positive = Schema.Int.check(Schema.isGreaterThan(0));
 /** Host ceilings apply across all declarations owned by one source Thread. */
 export const WorkerHostLimits = Schema.Struct({
   maxWorkersPerSource: Positive.check(Schema.isLessThanOrEqualTo(100)),
+  /** Active background workers across declarations; omission retains source Tool concurrency. */
+  maxActiveWorkersPerSource: Schema.optionalKey(Positive.check(Schema.isLessThanOrEqualTo(100))),
   maxInputsPerWorker: Positive.check(Schema.isLessThanOrEqualTo(1_000)),
   maxPendingInputsPerWorker: Positive.check(Schema.isLessThanOrEqualTo(100)),
   lifetimeMillis: Positive.check(Schema.isLessThanOrEqualTo(604_800_000)),
@@ -57,5 +61,24 @@ export const WorkerHostAuthorizer = Context.Reference<{
         operation: request.operation,
         reason: "denied",
       }),
+  }),
+});
+
+/**
+ * Deployment-owned permission to fund a root's background worker independently. The decision
+ * covers the exact immutable origin and is checked again before each input admission. It never
+ * changes delegation depth or Tool authority. Omission denies independent funding.
+ */
+export const WorkerBudgetAuthorizer = Context.Reference<{
+  readonly authorize: (request: {
+    readonly source: WorkerSource;
+    readonly principal: Principal;
+    readonly worker: WorkerRef;
+    readonly policy: AgentPolicy;
+    readonly budget: SubagentBudgetReservation;
+  }) => Effect.Effect<void, WorkerError>;
+}>("@effect-agent/thread/WorkerBudgetAuthorizer", {
+  defaultValue: () => ({
+    authorize: () => WorkerError.make({ operation: "start", reason: "denied" }),
   }),
 });

--- a/packages/thread/src/internal/worker-host.ts
+++ b/packages/thread/src/internal/worker-host.ts
@@ -89,7 +89,7 @@ import {
   ThreadRead,
   ThreadTailRequest,
 } from "../ThreadStore.ts";
-import { WorkerHostAuthorizer, WorkerHostConfig } from "../WorkerHost.ts";
+import { WorkerBudgetAuthorizer, WorkerHostAuthorizer, WorkerHostConfig } from "../WorkerHost.ts";
 import {
   definitionDigestsEqual,
   resolveDefinitionBinding,
@@ -151,15 +151,16 @@ const withinPolicy = (origin: WorkerOrigin, source: AgentPolicy, target: AgentPo
   const caps = origin.budget.caps;
   const ceilings = sourceCaps(source);
 
-  for (const [, name] of amountCaps) {
+  for (const [, name] of origin.budgetScope === "worker-run" ? [] : amountCaps) {
     if (caps[name] !== undefined && ceilings[name] !== undefined && caps[name] > ceilings[name])
       return false;
   }
   if (
-    (caps.maxTotalChildInvocations !== undefined &&
+    origin.budgetScope !== "worker-run" &&
+    ((caps.maxTotalChildInvocations !== undefined &&
       caps.maxTotalChildInvocations > source.maxToolCalls) ||
-    (caps.maxConcurrentChildren !== undefined &&
-      caps.maxConcurrentChildren > source.toolConcurrency)
+      (caps.maxConcurrentChildren !== undefined &&
+        caps.maxConcurrentChildren > source.toolConcurrency))
   )
     return false;
   const tokenCeiling = Math.min(source.tokenBudget ?? Infinity, target.tokenBudget ?? Infinity);
@@ -232,6 +233,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     deliveries: yield* Effect.serviceOption(MessageDeliveryStore),
     crypto: yield* Crypto.Crypto,
     authorizer: yield* WorkerHostAuthorizer,
+    budgetAuthorizer: yield* WorkerBudgetAuthorizer,
     limits: yield* WorkerHostConfig,
     failpoint: yield* DurableRuntimeFailpoint,
     status: Option.getOrUndefined(admission)?.submissionStatus ?? control.status,
@@ -239,6 +241,23 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
   const withCrypto = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto>) =>
     Effect.provideService(effect, Crypto.Crypto, deps.crypto);
+
+  const authorizeBudget = Effect.fn("WorkerHost.authorizeBudget")(function* (
+    origin: WorkerOrigin,
+    principal: Principal,
+  ) {
+    if (origin.budgetScope !== "worker-run") return;
+    // Independence changes accounting ownership, never delegation generations.
+    if (origin.depth !== 1) return yield* failure("start", "denied");
+
+    yield* deps.budgetAuthorizer.authorize({
+      source: origin.source,
+      principal,
+      worker: origin.worker,
+      policy: origin.policy,
+      budget: origin.budget,
+    });
+  });
 
   const read = (threadId: ThreadId, operation: WorkerError["operation"]) =>
     deps.store
@@ -400,6 +419,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         current,
         policy: worker.origin.policy,
         budget: worker.origin.budget,
+        budgetScope: worker.origin.budgetScope,
         grant: worker.origin.grant,
         depth: worker.origin.depth,
       };
@@ -415,6 +435,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         current,
         policy: attached.policy,
         budget: attached.budget,
+        budgetScope: undefined,
         grant: attached.grant,
         depth: attached.parentLink.depth,
       };
@@ -428,6 +449,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       current,
       policy,
       budget: undefined,
+      budgetScope: undefined,
       grant: undefined,
       depth: 0,
     };
@@ -544,6 +566,25 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
       if (chargedSlots > slotLimit) return yield* failure("start", "capacity");
       for (const [amount, cap] of amountCaps) {
+        // Zero is the encoded absence of an allocation when this dimension is unconfigured.
+        // It must not become a new cumulative token or dollar ceiling in a descendant.
+        if (
+          source.budgetScope === "worker-run" &&
+          (amount === "inputTokens" || amount === "outputTokens" || amount === "costMicrousd") &&
+          source.budget !== undefined &&
+          source.budget.caps[cap] === undefined &&
+          source.budget.allocation[amount] === 0 &&
+          ceilings[cap] === undefined
+        ) {
+          const charged = rows.reduce(
+            (sum, row) => sum + row.budget.allocation[amount],
+            allocation[amount],
+          );
+
+          if (charged > (caps[cap] ?? Infinity)) return yield* failure("start", "capacity");
+          continue;
+        }
+
         const residual =
           source.budget === undefined
             ? (ceilings[cap] ?? Infinity)
@@ -669,34 +710,48 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         )
       )
         return yield* failure("start", "denied");
-      if (
-        !withinPolicy(
-          origin,
-          source.policy,
-          AgentPolicy.resolve(
+      const independent = origin.budgetScope === "worker-run";
+
+      if (independent && source.depth !== 0) return yield* failure("start", "denied");
+
+      const targetPolicy = independent
+        ? targetBinding.definition.policy
+        : AgentPolicy.resolve(
             targetBinding.definition.policyOverrides ?? targetBinding.definition.policy,
             source.policy,
-          ),
-        )
-      )
+          );
+
+      if (!withinPolicy(origin, independent ? targetPolicy : source.policy, targetPolicy))
         return yield* failure("start", "capacity");
       const ceilings = sourceCaps(source.policy);
 
+      const conservedRows = rows.filter((row) => row.admission.origin.budgetScope !== "worker-run");
+
       const chargedRows =
         source.depth === 0
-          ? rows
-          : rows.filter((row) => row.admission.sourceSubmissionId === admission.sourceSubmissionId);
+          ? conservedRows
+          : conservedRows.filter(
+              (row) => row.admission.sourceSubmissionId === admission.sourceSubmissionId,
+            );
 
-      if (rows.some((row) => !sameCaps(row.admission.origin.budget.caps, caps)))
+      // Independent origins do not belong to this pool. Preserve the retained conserved
+      // origins' cap identity check separately from the current input's charge selection.
+      if (
+        !independent &&
+        conservedRows.some((row) => !sameCaps(row.admission.origin.budget.caps, caps))
+      )
         return yield* failure("start", "capacity");
       if (
+        !independent &&
         chargedRows.reduce(
           (sum, row) => sum + 1 + (row.admission.origin.budget.descendantInvocations ?? 0),
           1 + (origin.budget.descendantInvocations ?? 0),
         ) > Math.min(caps.maxTotalChildInvocations ?? Infinity, source.policy.maxToolCalls)
       )
         return yield* failure("start", "capacity");
-      for (const [amount, cap] of amountCaps) {
+      // Worker-owned Run usage is already durable in the destination's Run journal. Each
+      // Receipt may join an existing Run, so admitting input must never mint an allowance.
+      for (const [amount, cap] of independent ? [] : amountCaps) {
         const limit = Math.min(caps[cap] ?? Infinity, ceilings[cap] ?? Infinity);
 
         if (
@@ -727,26 +782,32 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         pendingOwn >= deps.limits.maxPendingInputsPerWorker ||
         (!activeWorkers.has(origin.worker.threadId) &&
           activeWorkers.size >=
-            Math.min(caps.maxConcurrentChildren ?? Infinity, source.policy.toolConcurrency))
+            Math.min(
+              deps.limits.maxActiveWorkersPerSource ?? source.policy.toolConcurrency,
+              independent
+                ? Infinity
+                : Math.min(caps.maxConcurrentChildren ?? Infinity, source.policy.toolConcurrency),
+            ))
       )
         return yield* failure("start", "capacity");
-      yield* reserveSubtree(
-        origin.source.threadId,
-        SubtreeBudgetReserved.make({
-          reservationId: Schema.decodeSync(SubtreeBudgetReserved.fields.reservationId)(
-            admission.messageId,
-          ),
-          ...(admission.sourceSubmissionId === undefined
-            ? {}
-            : { sourceSubmissionId: admission.sourceSubmissionId }),
-          childThreadId: origin.worker.threadId,
-          lifetime: "background",
-          depth: origin.depth,
-          policy: origin.policy,
-          grant: origin.grant,
-          budget: origin.budget,
-        }),
-      );
+      if (!independent)
+        yield* reserveSubtree(
+          origin.source.threadId,
+          SubtreeBudgetReserved.make({
+            reservationId: Schema.decodeSync(SubtreeBudgetReserved.fields.reservationId)(
+              admission.messageId,
+            ),
+            ...(admission.sourceSubmissionId === undefined
+              ? {}
+              : { sourceSubmissionId: admission.sourceSubmissionId }),
+            childThreadId: origin.worker.threadId,
+            lifetime: "background",
+            depth: origin.depth,
+            policy: origin.policy,
+            grant: origin.grant,
+            budget: origin.budget,
+          }),
+        );
       if (
         yield* append(
           origin.source.threadId,
@@ -814,6 +875,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       access: "send",
       worker: admission.origin.worker,
     });
+    yield* authorizeBudget(admission.origin, options.principal);
     if (
       admission.origin.worker.threadId !== options.threadId ||
       admission.origin.worker.targetAgentId !== agentId ||
@@ -1604,6 +1666,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
             targetDigests: resolved.digests,
             policy: request.policy,
             budget: request.budget,
+            ...(request.budgetScope === undefined ? {} : { budgetScope: request.budgetScope }),
             grant,
             depth: context.depth + 1,
             firstMessageId: messageId,
@@ -1619,14 +1682,21 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
           "start",
         );
 
+        yield* authorizeBudget(origin, principal);
+
+        const targetPolicy =
+          origin.budgetScope === "worker-run"
+            ? resolved.definition.policy
+            : AgentPolicy.resolve(
+                resolved.definition.policyOverrides ?? resolved.definition.policy,
+                context.policy,
+              );
+
         if (
           !withinPolicy(
             origin,
-            context.policy,
-            AgentPolicy.resolve(
-              request.target.policyOverrides ?? request.target.policy,
-              context.policy,
-            ),
+            origin.budgetScope === "worker-run" ? targetPolicy : context.policy,
+            targetPolicy,
           )
         )
           return yield* failure("start", "capacity");

--- a/packages/thread/test/worker-host.test.ts
+++ b/packages/thread/test/worker-host.test.ts
@@ -79,7 +79,11 @@ import {
 } from "../src/SubmissionLedger.ts";
 import { PendingSubmission, SettledSubmission } from "../src/SubmissionStatus.ts";
 import { PreparedInput } from "../src/Subscription.ts";
-import { WorkerHostAuthorizer, WorkerHostConfig } from "../src/WorkerHost.ts";
+import {
+  WorkerBudgetAuthorizer,
+  WorkerHostAuthorizer,
+  WorkerHostConfig,
+} from "../src/WorkerHost.ts";
 
 class ReportService extends Context.Service<ReportService, string>()("test/ReportService") {}
 class PrivateReportFailure extends Schema.TaggedError<PrivateReportFailure>()(
@@ -168,6 +172,7 @@ const reportWith = (
 
 const harness = Effect.fn("workerHostHarness")(function* (
   options: {
+    readonly independentBudget?: boolean;
     readonly sourceReports?: ReadonlyArray<WorkerReporting<WorkerReportPreparationFailure>>;
     readonly targetReports?: ReadonlyArray<WorkerReporting<WorkerReportPreparationFailure>>;
   } = {},
@@ -233,6 +238,12 @@ const harness = Effect.fn("workerHostHarness")(function* (
         definition === sourceAgent ? (options.sourceReports ?? []) : (options.targetReports ?? []),
     })),
   }).pipe(
+    Effect.provideService(WorkerBudgetAuthorizer, {
+      authorize: () =>
+        options.independentBudget === true
+          ? Effect.void
+          : WorkerError.make({ operation: "start", reason: "denied" }),
+    }),
     Effect.provideService(WorkerHostConfig, {
       maxWorkersPerSource: 2,
       maxInputsPerWorker: 3,
@@ -567,6 +578,69 @@ const harness = Effect.fn("workerHostHarness")(function* (
 });
 
 layer(NodeCrypto.layer)((it) => {
+  // Regression: https://github.com/danieljvdm/effect-agent/pull/358
+  it.effect(
+    "requires host funding authority and preserves worker identity and structural limits",
+    () =>
+      Effect.gen(function* () {
+        const denied = yield* harness();
+        const base = request("independent");
+
+        const independent: StartWorkerRequest = {
+          ...base,
+          budgetScope: "worker-run",
+          budget: {
+            ...base.budget,
+            caps: SubagentDelegationCaps.make({
+              maxTotalChildInvocations: 1,
+              maxConcurrentChildren: 1,
+              maxTurns: 2,
+              maxToolCalls: 2,
+              maxDurationMillis: 1_000,
+            }),
+          },
+        };
+
+        expect((yield* denied.host.start(independent).pipe(Effect.flip)).reason).toBe("denied");
+        expect(denied.deliveries.size).toBe(0);
+        const h = yield* harness({ independentBudget: true });
+        const started = yield* h.host.start(independent);
+
+        expect(yield* h.host.start(independent)).toEqual(started);
+        const original = h.submissions.get(started.receipt.submissionId)?.workerAdmission?.origin;
+
+        yield* h.settle(started.receipt);
+        for (const name of ["second", "third"]) {
+          const next = yield* h.host.followUp({
+            worker: started.worker,
+            target,
+            idempotencyKey: Schema.decodeSync(IdempotencyKey)(name),
+            encodedInput: { text: name },
+            encodedParameters: { note: name },
+          });
+
+          expect(h.submissions.get(next.submissionId)?.workerAdmission?.origin).toEqual(original);
+          yield* h.settle(next);
+        }
+        expect(original).toMatchObject({ budgetScope: "worker-run", depth: 1 });
+        expect(
+          h.logs
+            .get(sourceId)
+            ?.filter(({ record }) => record.payload._tag === "SubtreeBudgetReserved"),
+        ).toHaveLength(0);
+        expect(
+          (yield* h.host
+            .followUp({
+              worker: started.worker,
+              target,
+              idempotencyKey: Schema.decodeSync(IdempotencyKey)("fourth"),
+              encodedInput: { text: "fourth" },
+              encodedParameters: {},
+            })
+            .pipe(Effect.flip)).reason,
+        ).toBe("capacity");
+      }),
+  );
   it.effect("concurrent launches cannot oversubscribe one canonical source slot", () =>
     Effect.gen(function* () {
       const h = yield* harness();


### PR DESCRIPTION
Background workers currently reserve their full allowance against the source Thread, including retained completed inputs. A busy conversation can therefore exhaust the capacity for later independent tasks. Add an opt-in `worker-run` budget scope so each newly admitted native Run uses the worker's own policy while retaining its original delegation lineage.

An illustrative caller selects the scope in trusted application code:

```ts
yield* Subagent.start(personaWork, parameters, {
  idempotencyKey,
  budgetScope: "worker-run",
});
```

The host must provide `WorkerBudgetAuthorizer` to authorize the exact source, principal, worker, policy and budget at start and input admission. Its default denies the request. Generated background tools can select the same scope through their author-owned options; models cannot choose it in tool parameters.

```mermaid
flowchart LR
  S[Subagent.start] -->|requested scope| H[WorkerHost]
  H -->|exact funding request| A[WorkerBudgetAuthorizer]
  A -->|authorized| O[Persisted WorkerOrigin]
  O -->|frozen policy and lineage| R[DurableAgentRuntime]
  R -->|usage and deadline| J[Logical Run journal]
```

Steering that joins active work, retries, eviction and rollover retain that Run's usage and deadline. A later independently admitted Run receives a fresh allowance; another Receipt alone creates no credit. Omitted token and dollar ceilings remain omitted. Explicit spending limits, finite execution bounds, depth and tool grants remain enforced, including bounded attached scouts.

`maxActiveWorkersPerSource` separates background capacity from conversational tool concurrency. Existing retained-worker, input and lifetime limits remain. Independent funding is restricted to root-created workers, and funding revocation fences future admissions; cancelling already accepted work remains a separate operation.

Existing origins without the new field keep their conserved accounting behavior. The implementation uses the existing atomic origin persistence and native admission/recovery paths, so no storage migration or second task scheduler is required. Integration with terminal-history repair #364 is being checked separately before release and consumer adoption.
