### PR TITLE
fix(ci): ignore generated Vite files in Node test cache

### DIFF
--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -102,8 +102,11 @@ the ordinary test command.
 
 Vite Task caches successful results against their inputs. Vitest's mutable result cache is
 disabled so it does not invalidate task caching. CI transfers `node_modules/.vite/task-cache`.
-Direct Vitest tasks exclude generated Vite files and dependency directory listings, but track
-imported dependency files and the lockfile. Failed tasks are never cached.
+Direct Vitest tasks and the Node platform test task exclude generated Vite files and dependency
+directory listings, but track imported dependency files and the lockfile. Failed tasks are never
+cached. Vite Task fingerprints whole files, including package manifests: a version-only change
+can invalidate tests even when their source is unchanged. Keep manifests tracked because exports,
+module type, and dependency declarations also affect execution.
 
 Use `vp run -v test` for cache decisions, `vp run --last-details` for the previous run,
 or `vp run --no-cache test` to rerun every suite.
@@ -371,7 +374,9 @@ the reviewer reads untrusted source through GitHub's API instead.
 Each test-matrix job has its own task-cache key. Successful task results are saved even when
 another task fails. Main pushes run static checks, tests, and builds to populate shared caches
 and validate Action releases. The `ready` fan-in runs only on PRs. Main runs are not cancelled
-by newer pushes.
+by newer pushes. GitHub scopes PR caches to each PR's merge ref, so another PR cannot reuse them.
+A new release PR can restore the latest main results only after those jobs finish saving their
+caches; a release PR created while main CI is still running may restore an older baseline.
 Tests are reused only when task inputs match, never solely because paths did not change.
 
 The pre-commit hook runs `vp check --fix` on staged JavaScript and TypeScript.

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -28,8 +28,7 @@
   },
   "scripts": {
     "build": "vp pack",
-    "check": "tsc --noEmit -p tsconfig.json",
-    "test": "vp test --passWithNoTests"
+    "check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@effect-agent/core": "workspace:*",

--- a/packages/platform-node/vite.config.ts
+++ b/packages/platform-node/vite.config.ts
@@ -1,6 +1,23 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  run: {
+    tasks: {
+      test: {
+        command: "vp test --passWithNoTests",
+        // Fresh runners lack Vite's temporary directories. Ignore those and
+        // dependency directory listings, while retaining dependency file hashes.
+        input: [
+          { auto: true },
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
+        output: [],
+      },
+    },
+  },
   pack: {
     entry: [
       "src/index.ts",


### PR DESCRIPTION
The Node platform test suite reran on fresh runners because Vite Task fingerprinted an empty `.vite-temp` directory. Move its existing test command into a Vite task with the same generated-file and directory-listing exclusions already used by the Cloudflare suites. Source files, dependency manifests, and the lockfile remain tracked; the full CI gate still runs.

Document why version-only release PRs can still miss the cache: Vite+ fingerprints whole manifests, and a newly created release PR may restore an older main cache while main CI is still running. Ignoring manifests would also hide meaningful exports, module-type, and dependency changes, so this change does not do that.

Validation:
- `vp run ready` passed with localhost access required by workerd integration tests.
- Reproduced the original miss by removing an empty `.vite-temp` directory.
- The candidate reused the cache after removing generated directories and after a clean dependency install at the same workspace path.
- Source, export-map, version-only, and lockfile edits still invalidated the targeted Node test task.

Cache experiments were local on macOS with Vite+ 0.3.0; hosted cache reuse remains to be verified. Related investigation: #366.
