### PR TITLE
feat(thread): maintain live projections through canonical commits

### DIFF
--- a/.changeset/live-thread-projection.md
+++ b/.changeset/live-thread-projection.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/thread": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Add typed Thread projection maintenance with live committed-batch hooks and bounded background backfill. Share host index services with Cloudflare Tools while preserving canonical commits and independent approval publication.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -160,6 +160,27 @@ new generation repairs missed invalidation after a crash. Alarm failures propaga
 retry, and interruption remains interruption. Custom host facts must be committed through
 `ThreadMaintenance.withMutation` to get the same prearm and post-commit hooks.
 
+### Maintain a disposable Thread index
+
+Supply `projection` to `ThreadObject.layer` with a Layer providing
+`ThreadProjectionMaintenance` from `@effect-agent/thread/ThreadProjectionMaintenance`.
+The Layer receives the raw local `ThreadStore` and the same owner `SqlClient`; additional
+services it provides are exposed by the resulting runtime Layer so Tools can share that index.
+
+Implement `applyCommitted(request, result)` to keep an already-caught-up index current through
+the complete committed batch before Tools execute. One batch contains at most 256 records;
+chunk within local byte limits and stop at `result.lastSequence`. An earlier gap belongs to
+bounded `drain` backfill. Rows and their contiguous watermark must commit atomically, including
+records with no indexable content. Replays and concurrent backfill must be idempotent.
+
+The owner serializes canonical append and live projection; it releases that local gate before
+publication. Live failures are logged while the source commit remains authoritative. The native
+alarm runs at most one due backfill batch, and `pendingDeadline` keeps unfinished work scheduled
+across reconstruction. A projection deadline never gates approval publication or runtime work.
+Backfill failures are reported after eligible canonical work, retaining the prearmed generation;
+interruption stops the event. Hooks return typed `ThreadProjectionError` failures, own scoped
+resources, and never write the alarm slot or call source mutation ports.
+
 ## Configure the binding
 
 ```jsonc

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -6,11 +6,17 @@ import {
 } from "@effect-agent/thread/DurableAgentRuntime";
 import { SubmissionLedger, type SubmissionSnapshot } from "@effect-agent/thread/SubmissionLedger";
 import {
+  ThreadProjectionMaintenance,
+  drainDue,
+  type ThreadProjectionError,
+} from "@effect-agent/thread/ThreadProjectionMaintenance";
+import {
   Cause,
   Clock,
   Context,
   DateTime,
   Effect,
+  Exit,
   Fiber,
   Layer,
   Option,
@@ -422,7 +428,8 @@ export class ThreadMutationGate extends Context.Service<
 export type MaintenancePassFailure =
   | DurableWorkerFailure
   | DurableBindingFailure
-  | DurableAlarmError;
+  | DurableAlarmError
+  | ThreadProjectionError;
 
 /**
  * Incremental, quiescent maintenance over a durable dirty/processed generation (issue #93).
@@ -463,6 +470,7 @@ export class ThreadMaintenance extends Context.Service<
     never,
     | ThreadMutationGate
     | ThreadPublication
+    | ThreadProjectionMaintenance
     | DurableAgentRuntime
     | SubmissionLedger
     | DurableAlarmService
@@ -487,12 +495,24 @@ export class ThreadMaintenance extends Context.Service<
       const stalls = yield* Ref.make(0);
       const mutations = yield* ThreadMutationGate;
       const publication = yield* ThreadPublication;
+      const projection = yield* ThreadProjectionMaintenance;
       const messages = yield* ThreadMessageDelivery;
+
+      // A broken disposable index still needs a retry alarm and must not prevent startup.
+      const projectionDeadline = projection.pendingDeadline.pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterrupts(cause)
+            ? Effect.failCause(cause)
+            : Effect.logError("Thread projection deadline unavailable", cause).pipe(
+                Effect.as(Option.some(0)),
+              ),
+        ),
+      );
 
       const pendingDeadline = Effect.gen(function* () {
         return earliestDeadline(
-          yield* publication.pendingDeadline,
-          yield* messages.pendingDeadline,
+          earliestDeadline(yield* publication.pendingDeadline, yield* messages.pendingDeadline),
+          yield* projectionDeadline,
         );
       });
 
@@ -612,6 +632,15 @@ export class ThreadMaintenance extends Context.Service<
         // status RPCs cannot consume the source Attempt's execution window. Join before
         // acknowledging the alarm so the final deadline includes all delivery mutations.
         const delivery = yield* Effect.forkChild(messages.drain);
+
+        // Capture derived-index failures until canonical work has had its turn. Interruption
+        // still stops the event; ordinary failures and defects retain the prearmed generation.
+        const projected = yield* Effect.exit(
+          drainDue.pipe(Effect.provideService(ThreadProjectionMaintenance, projection)),
+        );
+
+        if (Exit.isFailure(projected) && Cause.hasInterrupts(projected.cause))
+          return yield* Effect.failCause(projected.cause);
         const deadline = yield* publication.pendingDeadline;
 
         if (
@@ -624,6 +653,7 @@ export class ThreadMaintenance extends Context.Service<
 
         if (started._tag === "CaughtUp" || Option.isSome(pending)) {
           yield* Fiber.join(delivery);
+          if (Exit.isFailure(projected)) return yield* Effect.failCause(projected.cause);
           yield* failpoint.hit("maintenance:finish:before");
 
           const disposition = yield* mutations.withSnapshot((active) =>
@@ -678,6 +708,7 @@ export class ThreadMaintenance extends Context.Service<
         const settlement = yield* runtime.processThreadHead(identity.threadId, { yieldAfter });
 
         yield* Fiber.join(delivery);
+        if (Exit.isFailure(projected)) return yield* Effect.failCause(projected.cause);
         // Observe residual state before acknowledging this exact pass-start generation.
         const remaining = yield* Stream.runCollect(ledger.scanNonterminal);
         const reports = new Map(recovered.map((report) => [report.submissionId, report]));

--- a/packages/platform-cloudflare/src/internal/layers.ts
+++ b/packages/platform-cloudflare/src/internal/layers.ts
@@ -54,13 +54,14 @@ import {
 } from "@effect-agent/thread/OperationAuthorizer";
 import { ProducerId } from "@effect-agent/thread/Records";
 import { LedgerError, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { ThreadProjectionMaintenance } from "@effect-agent/thread/ThreadProjectionMaintenance";
 import { ThreadStoreError, ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { type WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import type { Crypto } from "effect";
-import { Context, Duration, Effect, Layer, Schema } from "effect";
+import { Cause, Context, Duration, Effect, Layer, Schema, Semaphore } from "effect";
 import { SqlClient } from "effect/unstable/sql/SqlClient";
 
 import {
@@ -188,6 +189,7 @@ export type CloudflareDurableRuntimeServices =
   | ThreadMaintenance
   | ThreadMutationGate
   | ThreadPublication
+  | ThreadProjectionMaintenance
   | ThreadObjectPorts
   | ProgressWaitRegistry
   | SqlClient;
@@ -332,7 +334,7 @@ export const layerConfig = (
     }),
   );
 
-export interface ThreadPublicationOptions<E = never, R = never> {
+export interface ThreadPublicationOptions<E = never, R = never, P = never> {
   /**
    * Optional host outbox consumer, built once per incarnation with RAW LOCAL ThreadStore and
    * SubmissionLedger services. Yield DurableObjectContext and ThreadObjectIdentity for native
@@ -342,6 +344,14 @@ export interface ThreadPublicationOptions<E = never, R = never> {
    * publication after commit. Custom host facts must use ThreadMaintenance.withMutation.
    */
   readonly publication?: Layer.Layer<ThreadPublication, E, R>;
+  /**
+   * Disposable index maintenance, built once with the raw local ThreadStore and owner
+   * SqlClient. Additional services P are exposed by the returned Layer, allowing Tool
+   * handlers and maintenance to share one index instance. Construction is local-only.
+   * Live committed batches run before append returns; bounded backfill uses the native
+   * alarm without delaying execution behind projection backlog.
+   */
+  readonly projection?: Layer.Layer<ThreadProjectionMaintenance | P, E, R>;
 }
 
 /**
@@ -350,15 +360,75 @@ export interface ThreadPublicationOptions<E = never, R = never> {
  * Tool, Schema, and model requirements remain visible until satisfied by Layer composition.
  * Use Layer.unwrap for registration values that need effectful application setup.
  */
-export const layer = <const Entries extends ReadonlyArray<AgentRegistration>, E = never, R = never>(
+const registeredLayer = <
+  const Entries extends ReadonlyArray<AgentRegistration>,
+  E = never,
+  R = never,
+>(
   registrations: Entries,
   options: ThreadPublicationOptions<E, R> = {},
 ) =>
   Layer.unwrap(
-    Effect.map(compileRegistrations(registrations), (bindings) =>
-      layerFromBindings(bindings, options),
-    ),
+    Effect.map(compileRegistrations(registrations), (bindings) => boundLayer(bindings, options)),
   );
+
+/** Preserve additional index services only when a projection Layer is actually supplied. */
+export function layer<
+  const Entries extends ReadonlyArray<AgentRegistration>,
+  E = never,
+  R = never,
+  P = never,
+  PE = never,
+  PR = never,
+>(
+  registrations: Entries,
+  options: Omit<ThreadPublicationOptions<E, R>, "projection"> & {
+    readonly projection: Layer.Layer<ThreadProjectionMaintenance | P, PE, PR>;
+  },
+): Layer.Layer<
+  Layer.Success<ReturnType<typeof registeredLayer<Entries, E | PE, R | PR>>> | P,
+  Layer.Error<ReturnType<typeof registeredLayer<Entries, E | PE, R | PR>>>,
+  Layer.Services<ReturnType<typeof registeredLayer<Entries, E | PE, R | PR>>>
+>;
+
+export function layer<const Entries extends ReadonlyArray<AgentRegistration>, E = never, R = never>(
+  registrations: Entries,
+  options?: ThreadPublicationOptions<E, R>,
+): ReturnType<typeof registeredLayer<Entries, E, R>>;
+
+export function layer<const Entries extends ReadonlyArray<AgentRegistration>, E = never, R = never>(
+  registrations: Entries,
+  options: ThreadPublicationOptions<E, R> = {},
+) {
+  return registeredLayer(registrations, options);
+}
+
+export function layerFromBindings<E = never, R = never, P = never, PE = never, PR = never>(
+  bindings: ReadonlyArray<ResolvedBinding>,
+  options: Omit<ThreadPublicationOptions<E, R>, "projection"> & {
+    readonly projection: Layer.Layer<ThreadProjectionMaintenance | P, PE, PR>;
+  },
+): Layer.Layer<
+  CloudflareDurableRuntimeServices | P,
+  Layer.Error<ReturnType<typeof boundLayer<E | PE, R | PR>>>,
+  Layer.Services<ReturnType<typeof boundLayer<E | PE, R | PR>>>
+>;
+
+export function layerFromBindings<E = never, R = never>(
+  bindings: ReadonlyArray<ResolvedBinding>,
+  options?: ThreadPublicationOptions<E, R>,
+): ReturnType<typeof boundLayer<E, R>>;
+
+export function layerFromBindings(
+  bindings: ReadonlyArray<ResolvedBinding>,
+): ReturnType<typeof boundLayer<never, never>>;
+
+export function layerFromBindings<E = never, R = never>(
+  bindings: ReadonlyArray<ResolvedBinding>,
+  options: ThreadPublicationOptions<E, R> = {},
+) {
+  return boundLayer(bindings, options);
+}
 
 /**
  * Assemble the durable runtime from already-resolved Agent Bindings.
@@ -366,7 +436,7 @@ export const layer = <const Entries extends ReadonlyArray<AgentRegistration>, E 
  * Supply host services through `ThreadObject.make` or `ThreadObject.layerConfig` and
  * the Durable Object context and namespace Layers when composing a custom host.
  */
-export const layerFromBindings = <E = never, R = never>(
+const boundLayer = <E = never, R = never>(
   bindings: ReadonlyArray<ResolvedBinding>,
   options: ThreadPublicationOptions<E, R> = {},
 ): Layer.Layer<
@@ -419,16 +489,24 @@ export const layerFromBindings = <E = never, R = never>(
         Layer.provide(Layer.mergeAll(rawLocalPorts, Layer.effect(SqlClient)(SqlClient))),
       );
 
+      const projection = (options.projection ?? ThreadProjectionMaintenance.layer).pipe(
+        Layer.provide(Layer.mergeAll(rawLocalPorts, Layer.effect(SqlClient)(SqlClient))),
+      );
+
       const localPorts =
-        options.publication === undefined
+        options.publication === undefined && options.projection === undefined
           ? rawLocalPorts
           : Layer.effectContext(
               Effect.gen(function* () {
                 const store = yield* ThreadStore;
                 const ledger = yield* SubmissionLedger;
                 const mutations = yield* ThreadMutationGate;
+                const index = yield* ThreadProjectionMaintenance;
                 const publish = yield* Effect.context<ThreadPublication>();
                 const afterCommit = publishCommitted.pipe(Effect.provide(publish));
+                // A later append cannot mistake its still-projecting predecessor for old backlog.
+                // Publication remains outside this local source/index critical section.
+                const sourceCommits = yield* Semaphore.make(1);
 
                 // Every runtime-owned producer prearms too: a crash between commit and invalidation
                 // leaves a NEW, uncertified generation. Source errors keep their native port types.
@@ -436,7 +514,30 @@ export const layerFromBindings = <E = never, R = never>(
                   ...store,
                   append: (request) =>
                     mutations
-                      .withMutation(store.append(request).pipe(Effect.tap(() => afterCommit)))
+                      .withMutation(
+                        sourceCommits
+                          .withPermit(
+                            store
+                              .append(request)
+                              .pipe(
+                                Effect.tap((result) =>
+                                  index
+                                    .applyCommitted(request, result)
+                                    .pipe(
+                                      Effect.catchCause((cause) =>
+                                        Cause.hasInterrupts(cause)
+                                          ? Effect.interrupt
+                                          : Effect.logError(
+                                              "Thread projection deferred after source commit",
+                                              cause,
+                                            ),
+                                      ),
+                                    ),
+                                ),
+                              ),
+                          )
+                          .pipe(Effect.tap(() => afterCommit)),
+                      )
                       .pipe(
                         Effect.catchTag("DurableAlarmError", (cause) =>
                           ThreadStoreError.make({
@@ -506,6 +607,7 @@ export const layerFromBindings = <E = never, R = never>(
         messageStore,
       ).pipe(
         Layer.provideMerge(publication),
+        Layer.provideMerge(projection),
         Layer.provideMerge(ThreadMutationGate.layer),
         Layer.provideMerge(infrastructure),
       );

--- a/packages/platform-cloudflare/test/harness.ts
+++ b/packages/platform-cloudflare/test/harness.ts
@@ -24,6 +24,7 @@ import { expect } from "vite-plus/test";
 import { decodeThreadId, supplierCountsFor, supplierValuesFor } from "./fixtures.ts";
 import type {
   PublicationThreadObject,
+  ProjectionThreadObject,
   ContextCompactorThreadObject,
   DynamicBindingsThreadObject,
   DeniedThreadObject,
@@ -40,6 +41,7 @@ declare global {
     interface Env {
       THREADS: DurableObjectNamespace<TestThreadObject>;
       PUBLICATIONS: DurableObjectNamespace<PublicationThreadObject>;
+      PROJECTIONS: DurableObjectNamespace<ProjectionThreadObject>;
       LIMITED: DurableObjectNamespace<LimitedThreadObject>;
       TINYDB: DurableObjectNamespace<TinyDatabaseThreadObject>;
       DENIED: DurableObjectNamespace<DeniedThreadObject>;
@@ -61,6 +63,7 @@ declare global {
 
 export type TestNamespace =
   | "PUBLICATIONS"
+  | "PROJECTIONS"
   | "THREADS"
   | "LIMITED"
   | "TINYDB"

--- a/packages/platform-cloudflare/test/projection-fixture.ts
+++ b/packages/platform-cloudflare/test/projection-fixture.ts
@@ -1,0 +1,259 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { DurableWorkerBinding } from "@effect-agent/thread/AgentRegistration";
+import type { CanonicalRecordEnvelope } from "@effect-agent/thread/Records";
+import { CanonicalSequence } from "@effect-agent/thread/Records";
+import {
+  ThreadProjectionError,
+  ThreadProjectionMaintenance,
+} from "@effect-agent/thread/ThreadProjectionMaintenance";
+import { ThreadRead, ThreadStore, ThreadTailRequest } from "@effect-agent/thread/ThreadStore";
+import { Context, Effect, Layer, Option, Schema, Stream } from "effect";
+import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+
+import { DurableObjectContext, ThreadObjectIdentity } from "../src/CloudflareBindings.ts";
+import { TEST_DIGESTS, finalParts, plannerDefinition } from "./fixtures.ts";
+
+interface ProjectionControl {
+  readonly operation?: "live" | "drain";
+  readonly failure?: "failure" | "defect" | "interruption" | "timeout" | "eviction";
+  readonly stage?: "before" | "after";
+  readonly skipLive?: boolean;
+  readonly retryAt?: number;
+  readonly entered?: () => void;
+  readonly release?: Promise<void>;
+}
+
+export const projectionControls = new Map<string, ProjectionControl>();
+export const projectionResources = new Map<string, { acquired: number; released: number }>();
+export const projectionConstructions = new Map<string, number>();
+export const projectionLookups = new Map<string, Array<number>>();
+export const projectionLiveBatches = new Map<string, Array<number>>();
+
+export class ProjectionIndex extends Context.Service<
+  ProjectionIndex,
+  {
+    readonly lookup: Effect.Effect<number, ThreadProjectionError>;
+    readonly watermark: Effect.Effect<number, ThreadProjectionError>;
+    readonly ownerSql: SqlClient;
+  }
+>()("test/ProjectionIndex") {}
+
+const failure = (cause?: unknown) =>
+  ThreadProjectionError.make({
+    operation: "test projection",
+    message: "derived index unavailable",
+    cause,
+  });
+
+/** Real SQLite index and atomic cursor; only fault timing and the model are controlled. */
+export const projectionLayer = Layer.effectContext(
+  Effect.gen(function* () {
+    const { ctx } = yield* DurableObjectContext;
+    const { threadId } = yield* ThreadObjectIdentity;
+    const store = yield* ThreadStore;
+    const sql = yield* SqlClient;
+
+    projectionConstructions.set(threadId, (projectionConstructions.get(threadId) ?? 0) + 1);
+    yield* sql`CREATE TABLE IF NOT EXISTS test_projection_rows (sequence INTEGER PRIMARY KEY, record_id TEXT NOT NULL)`;
+    yield* sql`CREATE TABLE IF NOT EXISTS test_projection_cursor (singleton INTEGER PRIMARY KEY, watermark INTEGER NOT NULL)`;
+    yield* sql`INSERT OR IGNORE INTO test_projection_cursor VALUES (1, 0)`;
+
+    const watermark = sql`SELECT watermark FROM test_projection_cursor WHERE singleton = 1`.pipe(
+      Effect.flatMap(
+        Schema.decodeUnknownEffect(
+          Schema.NonEmptyArray(Schema.Struct({ watermark: Schema.Natural })),
+        ),
+      ),
+      Effect.map((rows) => rows[0].watermark),
+      Effect.mapError(failure),
+    );
+
+    const tail = store.inspectTail(ThreadTailRequest.make({ threadId })).pipe(
+      Effect.map((value) => value.tailSequence),
+      Effect.catchTag("ThreadNotMaterialized", () => Effect.succeed(0)),
+      Effect.mapError(failure),
+    );
+
+    const fault = Effect.fn("projectionFixture.fault")(function* (
+      operation: "live" | "drain",
+      stage: "before" | "after",
+    ) {
+      const control = projectionControls.get(threadId);
+
+      if (control?.operation !== operation || (control.stage ?? "before") !== stage) return;
+      control.entered?.();
+      const release = control.release;
+
+      if (release !== undefined) yield* Effect.promise(() => release);
+      switch (control.failure) {
+        case undefined:
+          return;
+        case "failure":
+          return yield* failure();
+        case "defect":
+          return yield* Effect.die("projection defect");
+        case "interruption":
+          return yield* Effect.interrupt;
+        case "timeout":
+          return yield* Effect.never.pipe(Effect.timeoutOrElse({ duration: 0, orElse: failure }));
+        case "eviction":
+          projectionControls.delete(threadId);
+
+          return yield* Effect.sync(() => ctx.abort("projection commit failpoint"));
+      }
+    });
+
+    const batch = Effect.fn("projectionFixture.batch")(function* (
+      through: number,
+      limit: number,
+      operation: "live" | "drain",
+    ) {
+      const resources = projectionResources.get(threadId) ?? { acquired: 0, released: 0 };
+
+      projectionResources.set(threadId, resources);
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          resources.acquired++;
+        }),
+        () =>
+          Effect.sync(() => {
+            resources.released++;
+          }),
+      );
+      const before = yield* watermark;
+
+      if (before >= through) return;
+      const count = Math.min(limit, through - before);
+
+      const records: ReadonlyArray<CanonicalRecordEnvelope> = yield* store
+        .read(
+          ThreadRead.make({
+            threadId,
+            afterSequence: CanonicalSequence.make(before),
+            limit: count,
+          }),
+        )
+        .pipe(Stream.runCollect, Effect.mapError(failure));
+
+      if (
+        records.length !== count ||
+        records.some((record, index) => record.sequence !== before + index + 1)
+      )
+        return yield* failure();
+      yield* fault(operation, "before");
+      yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            if ((yield* watermark) !== before) return;
+            for (const record of records)
+              yield* sql`INSERT INTO test_projection_rows VALUES (${record.sequence}, ${record.record.recordId})`;
+            yield* sql`UPDATE test_projection_cursor SET watermark = ${before + records.length} WHERE singleton = 1`;
+          }),
+        )
+        .pipe(Effect.mapError(failure));
+      yield* fault(operation, "after");
+    }, Effect.scoped);
+
+    const lookup = Effect.gen(function* () {
+      const captured = yield* tail;
+      const indexed = yield* watermark;
+
+      if (indexed < captured) return yield* failure();
+      const lookups = projectionLookups.get(threadId) ?? [];
+
+      lookups.push(indexed);
+      projectionLookups.set(threadId, lookups);
+
+      return indexed;
+    });
+
+    return Context.make(ProjectionIndex, { lookup, watermark, ownerSql: sql }).pipe(
+      Context.add(ThreadProjectionMaintenance, {
+        applyCommitted: (request, result) =>
+          Effect.gen(function* () {
+            const batches = projectionLiveBatches.get(threadId) ?? [];
+
+            batches.push(request.batch.records.length);
+            projectionLiveBatches.set(threadId, batches);
+            if (
+              projectionControls.get(threadId)?.skipLive ||
+              (yield* watermark) < result.firstSequence - 1
+            )
+              return;
+            yield* batch(result.lastSequence, request.batch.records.length, "live");
+          }),
+        drain: Effect.gen(function* () {
+          yield* batch(yield* tail, 4, "drain");
+        }),
+        pendingDeadline: Effect.gen(function* () {
+          return (yield* watermark) >= (yield* tail)
+            ? Option.none()
+            : Option.some(projectionControls.get(threadId)?.retryAt ?? 0);
+        }),
+      }),
+    );
+  }),
+);
+
+const lookupTools = Toolkit.make(
+  Tool.make("lookup_projection", {
+    parameters: Schema.Struct({}),
+    success: Schema.Natural,
+    failure: ThreadProjectionError,
+    dependencies: [ProjectionIndex],
+  }),
+);
+
+export const projectionDefinition = Agent.make("cf-projection", {
+  input: plannerDefinition.input,
+  output: plannerDefinition.output,
+  instructions: "Look up earlier evidence three times, then finish.",
+  toolkit: lookupTools,
+  policy: { maxTurns: 5, maxToolCalls: 4, maxDuration: "30 seconds" },
+});
+
+const lookupModel = Model.make(
+  "scripted",
+  "projection",
+  Layer.effect(
+    LanguageModel.LanguageModel,
+    LanguageModel.make({
+      generateText: () => Effect.succeed([]),
+      streamText: (options) => {
+        const prompt = JSON.stringify(options.prompt);
+        const next = [1, 2, 3].find((turn) => !prompt.includes(`projection-lookup-${turn}`));
+
+        return Stream.fromIterable(
+          next === undefined
+            ? finalParts('{"answer":"done"}')
+            : [
+                {
+                  type: "tool-call",
+                  id: `projection-lookup-${next}`,
+                  name: "lookup_projection",
+                  params: {},
+                  providerExecuted: false,
+                },
+                {
+                  type: "finish",
+                  reason: "tool-calls",
+                  usage: { inputTokens: {}, outputTokens: {} },
+                },
+              ],
+        );
+      },
+    }),
+  ),
+);
+
+export const makeProjectionBinding = DurableWorkerBinding.make(
+  Agent.withModel(projectionDefinition, lookupModel),
+  TEST_DIGESTS,
+).pipe(
+  Effect.provide(
+    lookupTools.toLayer({
+      lookup_projection: () => Effect.flatMap(ProjectionIndex, (index) => index.lookup),
+    }),
+  ),
+);

--- a/packages/platform-cloudflare/test/projection.test.ts
+++ b/packages/platform-cloudflare/test/projection.test.ts
@@ -147,69 +147,78 @@ const append = (thread: string, request: FencedAppendRequest) =>
   );
 
 describe("live Thread projection and alarm backfill", () => {
-  it("shares one raw-source index and SQL owner with Tools throughout an active Run", () =>
-    withThread(async (thread) => {
-      await submit(thread);
-      await drainAlarmsUntil(thread, allSettled(thread, namespace), { namespace });
-      const lookups = projectionLookups.get(thread);
+  it(
+    "shares one raw-source index and SQL owner with Tools throughout an active Run",
+    () =>
+      withThread(async (thread) => {
+        await submit(thread);
+        await drainAlarmsUntil(thread, allSettled(thread, namespace), { namespace });
+        const lookups = projectionLookups.get(thread);
 
-      expect(lookups).toHaveLength(3);
-      expect(new Set(lookups).size).toBe(3);
-      expect(projectionConstructions.get(thread)).toBe(1);
-      await runInDurableObject(stub(thread), (instance) =>
-        instance[DurableObject.RunSymbol](
-          Effect.gen(function* () {
-            expect((yield* ProjectionIndex).ownerSql).toBe(yield* SqlClient);
-          }),
-        ),
-      );
-      const records = await readCanonical(thread, namespace);
-
-      expect(
-        records
-          .filter((record) => record.record.payload._tag === "ToolCallSettled")
-          .every(
-            (record) =>
-              record.record.payload._tag !== "ToolCallSettled" || !record.record.payload.isFailure,
+        expect(lookups).toHaveLength(3);
+        expect(new Set(lookups).size).toBe(3);
+        expect(projectionConstructions.get(thread)).toBe(1);
+        await runInDurableObject(stub(thread), (instance) =>
+          instance[DurableObject.RunSymbol](
+            Effect.gen(function* () {
+              expect((yield* ProjectionIndex).ownerSql).toBe(yield* SqlClient);
+            }),
           ),
-      ).toBe(true);
-      await quiesce(thread);
-    }));
+        );
+        const records = await readCanonical(thread, namespace);
 
-  it("applies all 256 committed records before returning, replays idempotently, and rejects stale producers", () =>
-    withThread(async (thread) => {
-      const request = await prepareAppend(thread, 256);
-      const result = await append(thread, request);
+        expect(
+          records
+            .filter((record) => record.record.payload._tag === "ToolCallSettled")
+            .every(
+              (record) =>
+                record.record.payload._tag !== "ToolCallSettled" ||
+                !record.record.payload.isFailure,
+            ),
+        ).toBe(true);
+        await quiesce(thread);
+      }),
+    30_000,
+  );
 
-      expect(result.lastSequence).toBe(256);
-      expect(await watermark(thread)).toBe(256);
-      expect((await append(thread, request)).replayed).toBe(true);
-      expect(await watermark(thread)).toBe(256);
-      const calls = projectionLiveBatches.get(thread)?.length;
+  it(
+    "applies all 256 committed records before returning, replays idempotently, and rejects stale producers",
+    () =>
+      withThread(async (thread) => {
+        const request = await prepareAppend(thread, 256);
+        const result = await append(thread, request);
 
-      await runInDurableObject(stub(thread), (instance) =>
-        instance[DurableObject.RunSymbol](
-          Effect.gen(function* () {
-            const store = yield* ThreadStore;
+        expect(result.lastSequence).toBe(256);
+        expect(await watermark(thread)).toBe(256);
+        expect((await append(thread, request)).replayed).toBe(true);
+        expect(await watermark(thread)).toBe(256);
+        const calls = projectionLiveBatches.get(thread)?.length;
 
-            yield* store.materialize(
-              ThreadMaterialization.make({
-                threadId: decodeThreadId(thread),
-                producerEpoch: ProducerEpoch.make(1),
-              }),
-            );
-            const exit = yield* store.append(request).pipe(Effect.exit);
+        await runInDurableObject(stub(thread), (instance) =>
+          instance[DurableObject.RunSymbol](
+            Effect.gen(function* () {
+              const store = yield* ThreadStore;
 
-            expect(Exit.isFailure(exit) && Cause.findErrorOption(exit.cause)).toMatchObject({
-              _tag: "Some",
-              value: { _tag: "FenceRejected" },
-            });
-          }),
-        ),
-      );
-      expect(projectionLiveBatches.get(thread)?.length).toBe(calls);
-      await quiesce(thread);
-    }));
+              yield* store.materialize(
+                ThreadMaterialization.make({
+                  threadId: decodeThreadId(thread),
+                  producerEpoch: ProducerEpoch.make(1),
+                }),
+              );
+              const exit = yield* store.append(request).pipe(Effect.exit);
+
+              expect(Exit.isFailure(exit) && Cause.findErrorOption(exit.cause)).toMatchObject({
+                _tag: "Some",
+                value: { _tag: "FenceRejected" },
+              });
+            }),
+          ),
+        );
+        expect(projectionLiveBatches.get(thread)?.length).toBe(calls);
+        await quiesce(thread);
+      }),
+    30_000,
+  );
 
   it.each(["failure", "defect"] as const)(
     "keeps a canonical commit authoritative after live %s",

--- a/packages/platform-cloudflare/test/projection.test.ts
+++ b/packages/platform-cloudflare/test/projection.test.ts
@@ -1,0 +1,430 @@
+import { ProducerEpoch } from "@effect-agent/thread/Records";
+import { ApprovalDecisionCommand } from "@effect-agent/thread/SubmissionLedger";
+import type { ThreadProjectionMaintenance } from "@effect-agent/thread/ThreadProjectionMaintenance";
+import {
+  FencedAppendRequest,
+  ThreadMaterialization,
+  ThreadStore,
+  ThreadTailRequest,
+} from "@effect-agent/thread/ThreadStore";
+import { env, runInDurableObject } from "cloudflare:test";
+import { Cause, Clock, Context, Effect, Exit, Layer, Schema } from "effect";
+import { DurableObject } from "effect-cf";
+import { TestClock } from "effect/testing";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+
+import type { DurableObjectContext, ThreadObjectNamespace } from "../src/CloudflareBindings.ts";
+import { CloudflareThreadClient } from "../src/CloudflareThreadClient.ts";
+import * as ThreadObject from "../src/ThreadObject.ts";
+import {
+  BOOK_TOOL_CALL_ID,
+  approvalDefinition,
+  plannerDefinition,
+  maintenanceClocks,
+  submitOptions,
+  decodeThreadId,
+  armMaintenancePause,
+  awaitMaintenancePause,
+  releaseMaintenancePause,
+} from "./fixtures.ts";
+import {
+  allSettled,
+  anyInState,
+  drainAlarmsUntil,
+  laneRows,
+  readCanonical,
+  runClient,
+  scheduledAlarm,
+} from "./harness.ts";
+import {
+  ProjectionIndex,
+  projectionLayer,
+  projectionDefinition,
+  projectionControls,
+  projectionResources,
+  projectionConstructions,
+  projectionLookups,
+  projectionLiveBatches,
+} from "./projection-fixture.ts";
+
+const namespace = "PROJECTIONS";
+const stub = (thread: string) => env.PROJECTIONS.get(env.PROJECTIONS.idFromName(thread));
+
+const alarm = (thread: string) =>
+  runInDurableObject(stub(thread), (instance) => Promise.resolve(instance.alarm()));
+
+const watermark = (thread: string) =>
+  runInDurableObject(stub(thread), (instance) =>
+    instance[DurableObject.RunSymbol](Effect.flatMap(ProjectionIndex, (index) => index.watermark)),
+  );
+
+const quiesce = (thread: string) =>
+  drainAlarmsUntil(thread, async () => (await scheduledAlarm(thread, namespace)) === null, {
+    namespace,
+  });
+
+const submit = (
+  thread: string,
+  definition:
+    | typeof projectionDefinition
+    | typeof plannerDefinition
+    | typeof approvalDefinition = projectionDefinition,
+) =>
+  runClient(
+    Effect.flatMap(CloudflareThreadClient, (client) =>
+      client.submit(
+        { definition },
+        { question: "index", ref: thread },
+        submitOptions(thread, thread),
+      ),
+    ),
+    namespace,
+  );
+
+const withThread = (test: (thread: string, now: number) => Promise<void>) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const thread = `projection-${crypto.randomUUID()}`;
+      const now = Date.now() + 86_400_000;
+
+      yield* TestClock.setTime(now);
+      maintenanceClocks.set(thread, yield* Clock.Clock);
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          projectionControls.delete(thread);
+          projectionResources.delete(thread);
+          projectionConstructions.delete(thread);
+          projectionLookups.delete(thread);
+          projectionLiveBatches.delete(thread);
+          maintenanceClocks.delete(thread);
+          releaseMaintenancePause(thread);
+        }),
+      );
+      yield* Effect.promise(() => test(thread, now));
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+const prepareAppend = (thread: string, count: number) =>
+  runInDurableObject(stub(thread), (instance) =>
+    instance[DurableObject.RunSymbol](
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+        const threadId = decodeThreadId(thread);
+
+        yield* store.materialize(
+          ThreadMaterialization.make({ threadId, producerEpoch: ProducerEpoch.make(0) }),
+        );
+        const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+
+        return yield* Schema.decodeUnknownEffect(FencedAppendRequest)({
+          threadId,
+          producerEpoch: tail.producerEpoch,
+          expectedTailSequence: tail.tailSequence,
+          expectedTailDigest: tail.tailDigest,
+          batch: {
+            batchId: `projection-batch-${tail.tailSequence}`,
+            producerId: "projection-test",
+            records: Array.from({ length: count }, (_, index) => ({
+              recordId: `projection-record-${tail.tailSequence + index + 1}`,
+              family: "thread",
+              schemaVersion: 1,
+              deploymentId: "projection-test",
+              createdAt: "2026-09-08T00:00:00.000Z",
+              payload: { _tag: "UserInputRecorded", kind: "user", input: `retained-${index}` },
+            })),
+          },
+        });
+      }),
+    ),
+  );
+
+const append = (thread: string, request: FencedAppendRequest) =>
+  runInDurableObject(stub(thread), (instance) =>
+    instance[DurableObject.RunSymbol](
+      Effect.flatMap(ThreadStore, (store) => store.append(request)),
+    ),
+  );
+
+describe("live Thread projection and alarm backfill", () => {
+  it("shares one raw-source index and SQL owner with Tools throughout an active Run", () =>
+    withThread(async (thread) => {
+      await submit(thread);
+      await drainAlarmsUntil(thread, allSettled(thread, namespace), { namespace });
+      const lookups = projectionLookups.get(thread);
+
+      expect(lookups).toHaveLength(3);
+      expect(new Set(lookups).size).toBe(3);
+      expect(projectionConstructions.get(thread)).toBe(1);
+      await runInDurableObject(stub(thread), (instance) =>
+        instance[DurableObject.RunSymbol](
+          Effect.gen(function* () {
+            expect((yield* ProjectionIndex).ownerSql).toBe(yield* SqlClient);
+          }),
+        ),
+      );
+      const records = await readCanonical(thread, namespace);
+
+      expect(
+        records
+          .filter((record) => record.record.payload._tag === "ToolCallSettled")
+          .every(
+            (record) =>
+              record.record.payload._tag !== "ToolCallSettled" || !record.record.payload.isFailure,
+          ),
+      ).toBe(true);
+      await quiesce(thread);
+    }));
+
+  it("applies all 256 committed records before returning, replays idempotently, and rejects stale producers", () =>
+    withThread(async (thread) => {
+      const request = await prepareAppend(thread, 256);
+      const result = await append(thread, request);
+
+      expect(result.lastSequence).toBe(256);
+      expect(await watermark(thread)).toBe(256);
+      expect((await append(thread, request)).replayed).toBe(true);
+      expect(await watermark(thread)).toBe(256);
+      const calls = projectionLiveBatches.get(thread)?.length;
+
+      await runInDurableObject(stub(thread), (instance) =>
+        instance[DurableObject.RunSymbol](
+          Effect.gen(function* () {
+            const store = yield* ThreadStore;
+
+            yield* store.materialize(
+              ThreadMaterialization.make({
+                threadId: decodeThreadId(thread),
+                producerEpoch: ProducerEpoch.make(1),
+              }),
+            );
+            const exit = yield* store.append(request).pipe(Effect.exit);
+
+            expect(Exit.isFailure(exit) && Cause.findErrorOption(exit.cause)).toMatchObject({
+              _tag: "Some",
+              value: { _tag: "FenceRejected" },
+            });
+          }),
+        ),
+      );
+      expect(projectionLiveBatches.get(thread)?.length).toBe(calls);
+      await quiesce(thread);
+    }));
+
+  it.each(["failure", "defect"] as const)(
+    "keeps a canonical commit authoritative after live %s",
+    (failure) =>
+      withThread(async (thread) => {
+        const request = await prepareAppend(thread, 9);
+
+        projectionControls.set(thread, { operation: "live", failure });
+        expect((await append(thread, request)).lastSequence).toBe(9);
+        expect(await watermark(thread)).toBe(0);
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+        projectionControls.delete(thread);
+        await alarm(thread);
+        expect(await watermark(thread)).toBe(4);
+        await quiesce(thread);
+        expect(await watermark(thread)).toBe(9);
+      }),
+  );
+
+  it.each(["before", "after"] as const)(
+    "resumes bounded backfill after eviction %s its atomic commit",
+    (stage) =>
+      withThread(async (thread) => {
+        const request = await prepareAppend(thread, 9);
+
+        projectionControls.set(thread, { skipLive: true });
+        await append(thread, request);
+        projectionControls.set(thread, { operation: "drain", failure: "eviction", stage });
+        await alarm(thread).catch(() => undefined);
+        expect(await watermark(thread)).toBe(stage === "before" ? 0 : 4);
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+        await quiesce(thread);
+        expect(await watermark(thread)).toBe(9);
+        expect(projectionConstructions.get(thread)).toBe(2);
+        await runInDurableObject(stub(thread), async (_, state) => {
+          const rows = state.storage.sql
+            .exec<{ count: number }>("SELECT count(*) AS count FROM test_projection_rows")
+            .one();
+
+          expect(rows.count).toBe(9);
+        });
+      }),
+  );
+
+  it.each(["failure", "defect", "timeout"] as const)(
+    "runs canonical work before reporting a backfill %s and releases resources",
+    (failure) =>
+      withThread(async (thread) => {
+        projectionControls.set(thread, { skipLive: true });
+        await submit(thread, plannerDefinition);
+        projectionControls.set(thread, { skipLive: true, operation: "drain", failure });
+        await expect(alarm(thread)).rejects.toBeDefined();
+        expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+        expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+        const resources = projectionResources.get(thread);
+
+        expect(resources?.released).toBe(resources?.acquired);
+        projectionControls.delete(thread);
+        await quiesce(thread);
+      }),
+  );
+
+  it("preserves interruption and recovers through the prearmed alarm", () =>
+    withThread(async (thread) => {
+      projectionControls.set(thread, { skipLive: true });
+      await submit(thread, plannerDefinition);
+      projectionControls.set(thread, {
+        skipLive: true,
+        operation: "drain",
+        failure: "interruption",
+      });
+      await expect(alarm(thread)).rejects.toBeDefined();
+      expect((await laneRows(thread, namespace))[0]?.state).not.toBe("settled");
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      const resources = projectionResources.get(thread);
+
+      expect(resources?.released).toBe(resources?.acquired);
+      projectionControls.delete(thread);
+      await quiesce(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+    }));
+
+  it("does not let a future projection deadline gate approval publication or execution", () =>
+    withThread(async (thread, now) => {
+      const receipt = await submit(thread, approvalDefinition);
+
+      await drainAlarmsUntil(thread, anyInState(thread, "suspended", namespace), { namespace });
+      await quiesce(thread);
+      projectionControls.set(thread, { skipLive: true, retryAt: now + 25 });
+      await runClient(
+        Effect.flatMap(CloudflareThreadClient, (client) =>
+          client.resolveApproval(
+            decodeThreadId(thread),
+            ApprovalDecisionCommand.make({
+              submissionId: receipt.submissionId,
+              toolCallId: BOOK_TOOL_CALL_ID,
+              decision: "approved",
+              resolver: "projection-test",
+              reason: "approved",
+            }),
+          ),
+        ),
+        namespace,
+      );
+      await alarm(thread);
+      expect((await laneRows(thread, namespace))[0]?.state).toBe("settled");
+      expect(await watermark(thread)).toBeLessThan(
+        (await readCanonical(thread, namespace)).at(-1)!.sequence,
+      );
+      expect(await scheduledAlarm(thread, namespace)).toBeLessThanOrEqual(now + 25);
+      projectionControls.delete(thread);
+      await quiesce(thread);
+    }));
+
+  it("waits for an in-flight predecessor before committing and serving the next lookup", () =>
+    withThread(async (thread) => {
+      const firstRequest = await prepareAppend(thread, 1);
+      let enter!: () => void;
+      let release!: () => void;
+
+      const entered = new Promise<void>((resolve) => {
+        enter = resolve;
+      });
+
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      projectionControls.set(thread, { operation: "live", entered: enter, release: released });
+      const first = append(thread, firstRequest);
+
+      await entered;
+      // The predecessor has committed its source, but its derived cursor is still at zero.
+      const nextRequest = await prepareAppend(thread, 1);
+
+      projectionControls.delete(thread);
+      armMaintenancePause(thread, "maintenance:mutation:armed");
+
+      const next = runInDurableObject(stub(thread), (instance) =>
+        instance[DurableObject.RunSymbol](
+          Effect.gen(function* () {
+            yield* (yield* ThreadStore).append(nextRequest);
+
+            return yield* (yield* ProjectionIndex).lookup;
+          }).pipe(Effect.exit),
+        ),
+      );
+
+      await awaitMaintenancePause(thread, "maintenance:mutation:armed");
+      releaseMaintenancePause(thread);
+      try {
+        // This read crosses the Object event boundary while the second producer is active.
+        expect((await readCanonical(thread, namespace)).at(-1)?.sequence).toBe(1);
+      } finally {
+        release();
+        await first;
+      }
+      const result = await next;
+
+      expect(Exit.isSuccess(result) && result.value).toBe(2);
+      await quiesce(thread);
+    }));
+
+  it("retains a producer racing projection-only acknowledgement", () =>
+    withThread(async (thread) => {
+      await alarm(thread);
+      const request = await prepareAppend(thread, 1);
+
+      armMaintenancePause(thread, "maintenance:finish:before");
+      const running = alarm(thread);
+
+      await awaitMaintenancePause(thread, "maintenance:finish:before");
+      try {
+        projectionControls.set(thread, { skipLive: true });
+        await append(thread, request);
+      } finally {
+        projectionControls.delete(thread);
+        releaseMaintenancePause(thread);
+        await running;
+      }
+      expect(await scheduledAlarm(thread, namespace)).not.toBeNull();
+      await quiesce(thread);
+      expect(await watermark(thread)).toBe(1);
+    }));
+});
+
+it("exposes index services and preserves distinct publication and projection E/R", () => {
+  class Destination extends Context.Service<Destination, {}>()("test/ProjectionDestination") {}
+  class SetupError extends Schema.TaggedError<SetupError>()("ProjectionSetupError", {}) {}
+
+  const projection = projectionLayer.pipe(
+    Layer.provide(
+      Layer.effect(SqlClient)(
+        Effect.gen(function* () {
+          yield* Destination;
+
+          return yield* SetupError.make({});
+        }),
+      ),
+    ),
+  );
+
+  const runtime = ThreadObject.layer([], { projection }).pipe(
+    Layer.provide(ThreadObject.layerConfig({ deploymentId: "test", producerPrefix: "test" })),
+  );
+
+  expectTypeOf<
+    Extract<Layer.Success<typeof runtime>, ProjectionIndex>
+  >().toEqualTypeOf<ProjectionIndex>();
+  expectTypeOf<Extract<Layer.Services<typeof runtime>, Destination>>().toEqualTypeOf<Destination>();
+  expectTypeOf<Extract<Layer.Error<typeof runtime>, SetupError>>().toEqualTypeOf<SetupError>();
+  expectTypeOf<
+    Extract<Layer.Success<typeof runtime>, ThreadProjectionMaintenance>
+  >().toEqualTypeOf<ThreadProjectionMaintenance>();
+  expectTypeOf<Exclude<Layer.Services<typeof runtime>, Destination>>().toEqualTypeOf<
+    DurableObjectContext | ThreadObjectNamespace
+  >();
+});

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -67,6 +67,7 @@ import {
   observabilityProbeLayer,
   telemetryProbe,
 } from "./observability-fixture.ts";
+import { makeProjectionBinding, projectionLayer } from "./projection-fixture.ts";
 import { publicationLayer } from "./publication-fixture.ts";
 import { makeSubagentTestBindings, transportFaultReason } from "./subagent-fixtures.ts";
 import {
@@ -334,6 +335,22 @@ export class PublicationThreadObject extends ThreadObject.make(
     Layer.provideMerge(maintenanceClockLayer),
   ),
   { ...baseOptions, namespaceBinding: "PUBLICATIONS" },
+) {}
+
+export class ProjectionThreadObject extends ThreadObject.make(
+  Layer.unwrap(
+    Effect.map(Effect.all([makeTestBindings, makeProjectionBinding]), ([bindings, projection]) =>
+      Layer.fresh(ThreadMaintenance.layer).pipe(
+        Layer.provideMerge(DurableAgentRuntime.layerWithBindings([...bindings, projection])),
+      ),
+    ),
+  ).pipe(
+    Layer.provideMerge(
+      ThreadObject.layer([], { projection: projectionLayer, publication: publicationLayer }),
+    ),
+    Layer.provideMerge(maintenanceClockLayer),
+  ),
+  { ...baseOptions, namespaceBinding: "PROJECTIONS" },
 ) {}
 
 export class TestThreadObject extends ThreadObject.make(

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
               durableObjects: {
                 THREADS: { className: "TestThreadObject", useSQLite: true },
                 PUBLICATIONS: { className: "PublicationThreadObject", useSQLite: true },
+                PROJECTIONS: { className: "ProjectionThreadObject", useSQLite: true },
                 MEMORIES: { className: "TestMemoryObject", useSQLite: true },
                 SCHEDULES: { className: "TestScheduleOwnerObject", useSQLite: true },
                 SUBSCRIPTIONS: { className: "TestSubscriptionPartitionObject", useSQLite: true },

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -53,6 +53,7 @@
     "./testing/SubscriptionStoreConformance": "./src/SubscriptionStoreConformance.ts",
     "./testing/ThreadStoreConformance": "./src/ThreadStoreConformance.ts",
     "./ThreadInvariants": "./src/ThreadInvariants.ts",
+    "./ThreadProjectionMaintenance": "./src/ThreadProjectionMaintenance.ts",
     "./ThreadProjection": "./src/ThreadProjection.ts",
     "./ThreadStore": "./src/ThreadStore.ts",
     "./ToolReconciler": "./src/ToolReconciler.ts",

--- a/packages/thread/src/ThreadProjectionMaintenance.ts
+++ b/packages/thread/src/ThreadProjectionMaintenance.ts
@@ -1,0 +1,67 @@
+import { Clock, Context, Effect, Layer, Option, Schema } from "effect";
+
+import type { AppendResult, FencedAppendRequest } from "./ThreadStore.ts";
+
+/** A derived projection failed; the canonical source remains authoritative. */
+export class ThreadProjectionError extends Schema.TaggedError<ThreadProjectionError>()(
+  "ThreadProjectionError",
+  {
+    operation: Schema.String,
+    message: Schema.String,
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
+
+/**
+ * Host-owned, disposable indexes over a canonical Thread. Hooks receive raw local source
+ * ports at construction and must not mutate them or acquire source producer ownership.
+ * Rows and their contiguous watermark commit atomically; an empty projection still consumes
+ * its record. Concurrent work must compare the starting watermark before committing.
+ *
+ * No method owns a scheduler. The platform owns wakeups, durable scheduling metadata and
+ * source-producer fencing. Per-call resources belong to Scope; interruption remains interruption.
+ */
+export interface ThreadProjectionMaintenanceService {
+  /**
+   * Runs after a successful source commit and before dependent Tools can execute. An index
+   * caught up through firstSequence - 1 must process the entire committed range, including
+   * empty records, before returning. Canonical batches contain at most 256 records: chunk
+   * within local byte limits and stop at result.lastSequence, never chase a changing tail.
+   * An earlier gap defers to drain. Replayed or superseded ranges are idempotent no-ops.
+   * Failure must leave the unprocessed prefix visible to pendingDeadline.
+   */
+  readonly applyCommitted: (
+    request: FencedAppendRequest,
+    result: AppendResult,
+  ) => Effect.Effect<void, ThreadProjectionError>;
+  /** One bounded, restartable backfill batch. Never drain until caught up in a loop. */
+  readonly drain: Effect.Effect<void, ThreadProjectionError>;
+  /**
+   * Bounded local inspection. None means caught up; a pending epoch-millisecond deadline
+   * survives reconstruction and repeated reads must not postpone it. Projection backlog
+   * does not gate canonical execution or host approval publication.
+   */
+  readonly pendingDeadline: Effect.Effect<Option.Option<number>, ThreadProjectionError>;
+}
+
+export class ThreadProjectionMaintenance extends Context.Service<
+  ThreadProjectionMaintenance,
+  ThreadProjectionMaintenanceService
+>()("@effect-agent/thread/ThreadProjectionMaintenance") {
+  static readonly layer = Layer.succeed(this)({
+    applyCommitted: () => Effect.void,
+    drain: Effect.void,
+    pendingDeadline: Effect.succeed(Option.none()),
+  });
+}
+
+/** Run at most one due backfill batch, preserving typed failures, defects and interruption. */
+export const drainDue = Effect.gen(function* () {
+  const projection = yield* ThreadProjectionMaintenance;
+  const deadline = yield* projection.pendingDeadline;
+
+  if (Option.isNone(deadline) || deadline.value > (yield* Clock.currentTimeMillis)) return false;
+  yield* projection.drain;
+
+  return true;
+});

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -26,6 +26,7 @@ export * as SubscriptionTools from "./SubscriptionTools.ts";
 export * as SubscriptionTransition from "./SubscriptionTransition.ts";
 export * as ThreadInvariants from "./ThreadInvariants.ts";
 export * as ThreadProjection from "./ThreadProjection.ts";
+export * as ThreadProjectionMaintenance from "./ThreadProjectionMaintenance.ts";
 export * as ThreadStore from "./ThreadStore.ts";
 export * as ToolReconciler from "./ToolReconciler.ts";
 export * as WakeScheduler from "./WakeScheduler.ts";

--- a/packages/thread/test/thread-projection-maintenance.test.ts
+++ b/packages/thread/test/thread-projection-maintenance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Cause, Effect, Exit, Option } from "effect";
+import { TestClock } from "effect/testing";
+
+import {
+  ThreadProjectionError,
+  ThreadProjectionMaintenance,
+  drainDue,
+} from "../src/ThreadProjectionMaintenance.ts";
+
+describe("bounded Thread projection maintenance", () => {
+  it.effect("runs one due batch and never postpones or loops over backlog", () =>
+    Effect.gen(function* () {
+      let deadline: Option.Option<number> = Option.none();
+      let batches = 0;
+
+      const service = ThreadProjectionMaintenance.of({
+        applyCommitted: () => Effect.void,
+        pendingDeadline: Effect.sync(() => deadline),
+        drain: Effect.sync(() => {
+          batches++;
+        }),
+      });
+
+      const run = drainDue.pipe(Effect.provideService(ThreadProjectionMaintenance, service));
+
+      yield* TestClock.setTime(1_000);
+      expect(yield* run).toBe(false);
+      deadline = Option.some(1_001);
+      expect(yield* run).toBe(false);
+      yield* TestClock.adjust(1);
+      expect(yield* run).toBe(true);
+      expect(batches).toBe(1);
+      expect(yield* run).toBe(true);
+      expect(batches).toBe(2);
+    }),
+  );
+
+  it.effect.each(["failure", "defect", "interruption", "timeout"] as const)(
+    "preserves %s and releases scoped batch resources",
+    (mode) =>
+      Effect.gen(function* () {
+        let released = false;
+        const failure = ThreadProjectionError.make({ operation: "drain", message: "retry" });
+
+        const drain = Effect.gen(function* () {
+          yield* Effect.acquireRelease(Effect.void, () =>
+            Effect.sync(() => {
+              released = true;
+            }),
+          );
+          if (mode === "failure") return yield* failure;
+          if (mode === "defect") return yield* Effect.die("projection defect");
+          if (mode === "interruption") return yield* Effect.interrupt;
+
+          return yield* Effect.never.pipe(
+            Effect.timeoutOrElse({
+              duration: 0,
+              orElse: () => failure,
+            }),
+          );
+        }).pipe(Effect.scoped);
+
+        const exit = yield* drainDue.pipe(
+          Effect.provideService(ThreadProjectionMaintenance, {
+            applyCommitted: () => Effect.void,
+            pendingDeadline: Effect.succeed(Option.some(0)),
+            drain,
+          }),
+          Effect.exit,
+        );
+
+        expect(released).toBe(true);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          if (mode === "interruption") expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+          else if (mode === "defect") expect(Cause.hasDies(exit.cause)).toBe(true);
+          else expect(Cause.findErrorOption(exit.cause)).toEqual(Option.some(failure));
+        }
+      }),
+  );
+});

--- a/packages/thread/vite.config.ts
+++ b/packages/thread/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       "src/ThreadStoreConformance.ts",
       "src/ThreadInvariants.ts",
       "src/ThreadProjection.ts",
+      "src/ThreadProjectionMaintenance.ts",
       "src/ThreadStore.ts",
       "src/ToolReconciler.ts",
       "src/WakeScheduler.ts",


### PR DESCRIPTION
Context-history tools can read immediately after their own preparation advances the canonical tail. A host index maintained only after an Attempt finishes is stale at that point, so retrieval stays unavailable throughout active work.

Add a platform-neutral `ThreadProjectionMaintenance` port and a due-only bounded backfill operation in `@effect-agent/thread`. Cloudflare applies each live committed batch before append returns, serializes overlapping source commits through that hook, and uses its existing maintenance alarm to recover older or missed records. Extra services from the projection Layer are exposed to application Tools, sharing one raw local ThreadStore and owner SQL client.

```mermaid
sequenceDiagram
  participant Runtime as DurableAgentRuntime
  participant Host as Cloudflare ThreadObject
  participant Source as Local ThreadStore
  participant Index as ThreadProjectionMaintenance
  Runtime->>Host: append prepared tool records
  Host->>Host: prearm native maintenance generation
  Host->>Source: commit canonical batch
  Host->>Index: applyCommitted(request, result)
  Index-->>Host: contiguous index through committed range
  Host-->>Runtime: canonical append result
  Runtime->>Index: dependent Tool reads shared index
  Host->>Index: one due backfill batch on native alarm
```

Given an application index whose three methods implement the typed projection contract, registration is:

```ts
const projection = Layer.succeed(ThreadProjectionMaintenance)({
  applyCommitted: index.applyCommitted,
  drain: index.drain,
  pendingDeadline: index.pendingDeadline,
});

ThreadObject.layer(registrations, { projection });
```

An earlier watermark gap defers to bounded backfill; a live range is capped by the committed canonical batch, including the 256-record maximum. Typed indexing failures and defects preserve successful canonical commits and retain retry wakeups; interruption propagates. Projection deadlines participate in alarm scheduling independently of the approval-publication execution gate.

Deterministic coverage exercises lookup inside an active Run, maximum batches, replay and stale-producer rejection, overlapping live commits, eviction before/after projection commits, failure/defect/timeout/interruption, scoped cleanup, and concurrent approval publication. Long-history startup recovery remains separate in [#356](https://github.com/danieljvdm/effect-agent/issues/356).

Validation: `vp run ready` passes on `79d652ae`, including all workspace static checks, test suites, package/example/docs builds, and the Action bundle. The Cloudflare suite passes 507 tests (including all 14 projection cases); its three existing opt-in native-browser cases are skipped. The shared bounded-runner suite passes 5/5. The two largest native projection cases use the neighboring integration suites' 30-second test allowance.
