### PR TITLE
feat(thread): resolve worker policies from captured input

### DIFF
--- a/.changeset/captured-worker-policy.md
+++ b/.changeset/captured-worker-policy.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/capabilities": patch
+"@effect-agent/thread": patch
+---
+
+Resolve background worker policies from host-authorized immutable input while retaining each worker's admitted policy across followups and recovery. Preserve static policy defaults and support an explicitly selected owner Submission for captured source policy.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -218,6 +218,43 @@ input-retention, concurrency, and lifetime limits still apply across the source 
 Set `WorkerHostConfig.maxActiveWorkersPerSource` to bound concurrent background workers separately
 from the root's Tool execution concurrency; omission retains the prior concurrency ceiling.
 
+### Resolve policies from captured input
+
+Supply `WorkerPolicyResolver` from `@effect-agent/thread/WorkerHost` when immutable application
+input captures an execution policy separately from a finite, versioned Agent Definition. Provide
+its implementation through an Effect Layer and retain the Layer's construction dependencies.
+The default returns `Option.none()`, preserving registered policy inheritance and overrides.
+Returning `Option.some(policy)` selects a complete policy without reapplying static overrides.
+Missing authority for an opted-in definition must fail explicitly, rather than returning the
+legacy fallback or loading mutable settings. Use `WorkerError` with reason `unavailable` when
+the same captured evidence can become available on retry.
+
+`Subagent.start` prepares and encodes input before the caller-bound host resolves its target
+policy. Both source start and destination admission validate that exact initial input; destination
+validation also runs before replay returns an existing reservation. Explicit declaration limits
+still narrow the resolved policy. Construct a declaration per invocation from the same immutable
+capture when its allocation includes the worker's own ceiling plus fixed attached-scout reserves.
+Reuse the exact registered target Definition, grant, and reporting projection; this does not
+require a dynamic registration graph or another compiled model Tool.
+
+The initial admission stores the effective policy in the existing immutable worker origin.
+For `RetainedWorker`, a resolver may affirm `origin.policy`; returning a different policy fails.
+Later inputs, joined receipts, retries, and replacement Attempts never select a new worker policy.
+Application follow-up preparation must retain the original authorized capture and change only
+the intended task input. Receiving a new payload does not authorize changing its capture.
+
+Root source resolution receives the exact explicitly selected owner Submission and its registered
+binding, when retained. It never selects the latest input. Programmatic callers can pass
+`sourceSubmissionId` to `durableRuntime.workerHost`; `WorkerHostAuthorizer` receives that locator
+for authorization. Worker and attached source policies continue to come from stored lineage.
+Inspection, listing, observation, and cancellation do not require resolving a source policy.
+Keep retained binding versions available; a policy resolver cannot repair ambiguous historical
+definition identities or reconstruct a missing capture.
+
+Captured source reporting uses the initial owner binding and stores its existing reporting intent
+in the worker origin. A later input from another source revision does not replace that projection;
+terminal preparation validates the original owner retained by the first worker input reservation.
+
 ## Bound child work
 
 Children inherit omitted policy fields from their parent's resolved policy. Explicit child fields

--- a/packages/capabilities/src/internal/subagent-background.ts
+++ b/packages/capabilities/src/internal/subagent-background.ts
@@ -244,14 +244,24 @@ const operations = <
       });
     }
 
+    const prepared = yield* prepare(parameters, caller);
+
+    const effectiveTarget = yield* service.resolveTargetPolicy({
+      target: declaration.target,
+      encodedInput: prepared.encodedInput,
+    });
+
+    const resolvedTarget = Option.getOrUndefined(effectiveTarget);
+
     const resolved = resolveSubagentPolicy(
       declaration,
-      options.budgetScope === "worker-run" ? declaration.target.policy : caller.policy,
+      options.budgetScope === "worker-run"
+        ? (resolvedTarget ?? declaration.target.policy)
+        : caller.policy,
       undefined,
       options.budgetScope === "worker-run" ? "root-attached" : "conserved",
+      resolvedTarget,
     );
-
-    const prepared = yield* prepare(parameters, caller);
 
     const encodedGrant = yield* Schema.encodeEffect(SubagentGrant)(grant).pipe(
       Effect.mapError(() => projectionFailure("input")),

--- a/packages/capabilities/src/internal/subagent-policy.ts
+++ b/packages/capabilities/src/internal/subagent-policy.ts
@@ -20,16 +20,16 @@ export const resolveSubagentPolicy = (
   parent: AgentPolicy,
   parentCaps?: SubagentDelegationCaps,
   mode: "root-attached" | "conserved" = "conserved",
+  resolvedTarget?: AgentPolicy,
 ) => {
   // A root attached declaration has its own explicit pool. Child overrides retain
   // that established behavior; background and inherited subtree launches also obey
   // the source's own ceilings, before their shared reservation checks the residual.
   const parentCeiling = mode === "conserved" ? parent : undefined;
 
-  const inherited = AgentPolicy.resolve(
-    delegation.target.policyOverrides ?? delegation.target.policy,
-    parent,
-  );
+  const inherited =
+    resolvedTarget ??
+    AgentPolicy.resolve(delegation.target.policyOverrides ?? delegation.target.policy, parent);
 
   const policy =
     delegation.policy ??

--- a/packages/capabilities/test/subagent-background.test.ts
+++ b/packages/capabilities/test/subagent-background.test.ts
@@ -22,7 +22,7 @@ import {
 } from "@effect-agent/engine/SubagentHost";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Context, Deferred, Effect, Exit, Fiber, Ref, Schema, Stream } from "effect";
+import { Cause, Context, Deferred, Effect, Exit, Fiber, Option, Ref, Schema, Stream } from "effect";
 import { TestClock } from "effect/testing";
 import { Toolkit } from "effect/unstable/ai";
 
@@ -104,6 +104,7 @@ const settled: WorkerObservation = {
 const host = (overrides: Partial<SubagentHost["Service"]> = {}): SubagentHost["Service"] => ({
   ...SubagentHost.unavailable,
   context: Effect.succeed(caller),
+  resolveTargetPolicy: () => Effect.succeed(Option.none()),
   start: () => Effect.succeed(started),
   followUp: () => Effect.succeed(nextReceipt),
   inspect: () => Effect.succeed(settled),
@@ -120,6 +121,80 @@ const host = (overrides: Partial<SubagentHost["Service"]> = {}): SubagentHost["S
 class ProjectionDenied extends Schema.TaggedError<ProjectionDenied>()("ProjectionDenied", {}) {}
 
 describe("Subagent background authoring", () => {
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+  it.effect(
+    "resolves captured target policy after preparation and applies only explicit declaration narrowing",
+    () =>
+      Effect.gen(function* () {
+        const events: Array<string> = [];
+
+        const captured = AgentPolicy.make({
+          maxTurns: 9,
+          maxToolCalls: 12,
+          maxDuration: "2 minutes",
+          toolConcurrency: 3,
+        });
+
+        const declared = Subagent.make("research", {
+          target,
+          parameters: target.input,
+          prepareInput: (input) =>
+            Effect.sync(() => {
+              events.push("prepare");
+
+              return input;
+            }),
+          policy: Subagent.SubagentPolicy.make({
+            maxChildren: 1,
+            maxConcurrency: 1,
+            descendantInvocations: 1,
+            maxTurns: 7,
+            maxToolCalls: 10,
+            maxDuration: "3 minutes",
+          }),
+        });
+
+        yield* Subagent.start(
+          declared,
+          { amount: 7 },
+          { idempotencyKey: key, budgetScope: "worker-run" },
+        ).pipe(
+          Effect.provideService(
+            SubagentHost,
+            host({
+              resolveTargetPolicy: (request) =>
+                Effect.sync(() => {
+                  events.push("resolve");
+                  expect(request.target).toBe(target);
+                  expect(request.encodedInput).toEqual({ amount: "7" });
+
+                  return Option.some(captured);
+                }),
+              start: (request) =>
+                Effect.sync(() => {
+                  events.push("start");
+                  expect(request.target).toBe(target);
+                  expect(request.policy).toMatchObject({
+                    maxTurns: 7,
+                    maxToolCalls: 10,
+                    toolConcurrency: 3,
+                  });
+                  expect(request.policy.tokenBudget).toBeUndefined();
+                  expect(request.policy.costBudgetMicrousd).toBeUndefined();
+                  expect(request.budget).toMatchObject({
+                    allocation: { turns: 7, toolCalls: 10 },
+                    descendantInvocations: 1,
+                  });
+
+                  return started;
+                }),
+            }),
+          ),
+        );
+        expect(events).toEqual(["prepare", "resolve", "start"]);
+      }),
+  );
+
   it.effect(
     "encodes typed starts and same-thread follow-ups, and projects saved parameters and target output",
     () =>

--- a/packages/engine/src/SubagentHost.ts
+++ b/packages/engine/src/SubagentHost.ts
@@ -14,7 +14,7 @@ import {
   type WorkerStarted,
   type WorkerSummary,
 } from "@effect-agent/core/Worker";
-import type { Effect } from "effect";
+import type { Effect, Option } from "effect";
 import { Context, Schema, Stream } from "effect";
 
 /** Prepared values cross this port only to be Schema-decoded before durable storage. */
@@ -112,6 +112,11 @@ export class SubagentHost extends Context.Service<
   SubagentHost,
   {
     readonly context: Effect.Effect<WorkerContext, WorkerError>;
+    /** Resolve prepared input through host authority; None retains legacy target inheritance. */
+    readonly resolveTargetPolicy: (request: {
+      readonly target: Agent.AnyDefinition;
+      readonly encodedInput: unknown;
+    }) => Effect.Effect<Option.Option<AgentPolicy>, WorkerError>;
     readonly start: (request: StartWorkerRequest) => Effect.Effect<WorkerStarted, WorkerError>;
     readonly followUp: (request: FollowUpWorkerRequest) => Effect.Effect<Receipt, WorkerError>;
     readonly inspect: (
@@ -146,6 +151,7 @@ export class SubagentHost extends Context.Service<
 >()("@effect-agent/engine/SubagentHost") {
   static readonly unavailable: SubagentHost["Service"] = {
     context: WorkerError.make({ operation: "context", reason: "unavailable" }),
+    resolveTargetPolicy: () => WorkerError.make({ operation: "start", reason: "unavailable" }),
     start: () => WorkerError.make({ operation: "start", reason: "unavailable" }),
     followUp: () => WorkerError.make({ operation: "followUp", reason: "unavailable" }),
     inspect: () => WorkerError.make({ operation: "inspect", reason: "unavailable" }),

--- a/packages/platform-cloudflare/test/background-worker-fixture.ts
+++ b/packages/platform-cloudflare/test/background-worker-fixture.ts
@@ -1,6 +1,7 @@
 import * as Subagent from "@effect-agent/capabilities/Subagent";
 import { SubagentReservationsMemoryLive } from "@effect-agent/capabilities/SubagentReservations";
 import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
 import { SubagentGrant } from "@effect-agent/core/SubagentContract";
 import { WorkerError } from "@effect-agent/core/Worker";
@@ -9,8 +10,9 @@ import {
   WorkerBudgetAuthorizer,
   WorkerHostAuthorizer,
   WorkerHostConfig,
+  WorkerPolicyResolver,
 } from "@effect-agent/thread/WorkerHost";
-import { Effect, Layer, Schema, Stream } from "effect";
+import { Duration, Effect, Layer, Option, Schema, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 import { TEST_DIGESTS, TEST_PRINCIPAL, finalParts } from "./fixtures.ts";
@@ -126,6 +128,19 @@ export const independentBudgetSource = Agent.make("cf-independent-source", {
   policy: { maxTurns: 1, maxToolCalls: 1, maxDuration: "1 second", toolConcurrency: 1 },
 });
 
+const capturedInput = Schema.Struct({
+  question: Schema.String,
+  policy: Schema.toCodecJson(AgentPolicy),
+});
+
+export const capturedPolicySource = Agent.make("cf-captured-source", {
+  input: capturedInput,
+  output: backgroundSource.output,
+  instructions: "Answer as JSON.",
+  toolkit: Toolkit.empty,
+  policy: { maxTurns: 1, maxToolCalls: 1, maxDuration: "1 second", toolConcurrency: 1 },
+});
+
 const independentScout = Agent.make("cf-independent-scout", {
   input: backgroundTarget.input,
   output: backgroundTarget.output,
@@ -157,7 +172,10 @@ const independentScoutDeclaration = Subagent.make("budget_scout", {
 });
 
 const independentPersona = Agent.make("cf-independent-persona", {
-  input: backgroundTarget.input,
+  input: Schema.Struct({
+    question: Schema.String,
+    policy: Schema.optionalKey(Schema.toCodecJson(AgentPolicy)),
+  }),
   output: backgroundTarget.output,
   instructions: "Attach a scout once per task, then answer as JSON.",
   toolkit: Toolkit.make(independentScoutDeclaration.tool),
@@ -187,6 +205,24 @@ export const independentBudgetWorkers = Subagent.make("independent_persona", {
     maxResultBytes: 2048,
   }),
 });
+
+/** Construct author-owned reservations without constructing another registered Definition. */
+export const capturedPolicyWorkers = (policy: AgentPolicy) =>
+  Subagent.make("independent_persona", {
+    target: independentPersona,
+    grant: independentBudgetWorkers.grant,
+    policy: Subagent.SubagentPolicy.make({
+      maxChildren: 1,
+      maxConcurrency: 1,
+      descendantInvocations: 1,
+      maxTurns: policy.maxTurns + 1,
+      maxToolCalls: policy.maxToolCalls + 1,
+      maxDuration: Duration.millis(Duration.toMillis(policy.maxDuration) + 20_000),
+      maxResultBytes: policy.toolResultBounds.maxBytes + 1024,
+    }),
+  });
+
+export const capturedPolicyOutages = new Set<string>();
 
 export const independentBudgetGrants = new Set<string>();
 /** A source authorization succeeds before the destination's next admission loses its dependency. */
@@ -242,6 +278,7 @@ const independentScoutHandlers = Subagent.SubagentRuntime.layer(
 ).pipe(Layer.provide([SubagentReservationsMemoryLive, IdGenerator.layer]));
 
 export const backgroundWorkerBindings = Effect.all([
+  DurableWorkerBinding.make(Agent.withModel(capturedPolicySource, model), TEST_DIGESTS),
   DurableWorkerBinding.make(Agent.withModel(independentBudgetSource, model), TEST_DIGESTS),
   DurableWorkerBinding.make(Agent.withModel(independentScout, model), TEST_DIGESTS),
   DurableWorkerBinding.make(
@@ -275,6 +312,37 @@ export const backgroundWorkerBindings = Effect.all([
 ]);
 
 export const backgroundWorkerAuthority = Layer.mergeAll(
+  Layer.succeed(WorkerPolicyResolver)({
+    resolveSource: (request) =>
+      Effect.gen(function* () {
+        if (request.definition !== capturedPolicySource) return Option.none();
+        if (request.submission === undefined)
+          return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+
+        const input = yield* Schema.decodeUnknownEffect(capturedInput)(
+          request.submission.inputPayload,
+        ).pipe(Effect.mapError(() => WorkerError.make({ operation: "start", reason: "denied" })));
+
+        return Option.some(input.policy);
+      }),
+    resolveTarget: (request) =>
+      Effect.gen(function* () {
+        if (request.source.agentId !== capturedPolicySource.id) return Option.none();
+        if (request.definition !== independentPersona)
+          return yield* WorkerError.make({ operation: "start", reason: "denied" });
+        if (capturedPolicyOutages.has(request.source.threadId))
+          return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+        if (request._tag === "RetainedWorker") return Option.some(request.origin.policy);
+        if (request.sourceSubmission === undefined)
+          return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+
+        const input = yield* Schema.decodeUnknownEffect(capturedInput)(request.input).pipe(
+          Effect.mapError(() => WorkerError.make({ operation: "start", reason: "denied" })),
+        );
+
+        return Option.some(input.policy);
+      }),
+  }),
   Layer.succeed(WorkerHostConfig)({
     maxWorkersPerSource: 32,
     maxActiveWorkersPerSource: 2,

--- a/packages/platform-cloudflare/test/background-workers.test.ts
+++ b/packages/platform-cloudflare/test/background-workers.test.ts
@@ -1,4 +1,6 @@
 import * as Subagent from "@effect-agent/capabilities/Subagent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import type { SubmissionId } from "@effect-agent/core/Identifiers";
 import { SubagentHost } from "@effect-agent/engine/SubagentHost";
 import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
 import { MessageDeliveryStore } from "@effect-agent/thread/MessageDelivery";
@@ -23,6 +25,8 @@ import {
   backgroundReportProjections,
   backgroundReportingWorkers,
   backgroundReportGates,
+  capturedPolicySource,
+  capturedPolicyWorkers,
 } from "./background-worker-fixture.ts";
 import {
   decodeIdempotencyKey,
@@ -44,6 +48,7 @@ const evict = async (thread: string) => {
 const withOwner = <A, E>(
   source: string,
   use: (host: SubagentHost["Service"]) => Effect.Effect<A, E>,
+  sourceSubmissionId?: SubmissionId,
 ) =>
   runInDurableObject(stubFor(source), (instance) =>
     instance[DurableObject.RunSymbol](
@@ -53,12 +58,204 @@ const withOwner = <A, E>(
         const host = yield* runtime.workerHost({
           sourceThreadId: decodeThreadId(source),
           principal: TEST_PRINCIPAL,
+          ...(sourceSubmissionId === undefined ? {} : { sourceSubmissionId }),
         });
 
         return yield* use(host);
       }),
     ),
   );
+
+// Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+it("admits exact captured policies with one registered target and retains them through native eviction, joins and scouts", async () => {
+  const source = `background-cf-independent-captured-${crypto.randomUUID()}`;
+
+  const sourcePolicy = AgentPolicy.make({
+    maxTurns: 9,
+    maxToolCalls: 8,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  });
+
+  const ownerReceipt = await runClient(
+    Effect.flatMap(CloudflareThreadClient, (client) =>
+      client.submit(
+        { definition: capturedPolicySource },
+        { question: "initialize", policy: sourcePolicy },
+        submitOptions(source, "source"),
+      ),
+    ),
+  );
+
+  await drainAlarmsUntil(source, allSettled(source));
+  // Read controls do not require an arbitrary owner input. Resolving a captured policy does.
+  expect(
+    await withOwner(source, (host) =>
+      host.list({
+        delegationId: independentBudgetWorkers.delegationId,
+        target: independentBudgetWorkers.target,
+        limit: 10,
+      }),
+    ),
+  ).toEqual({ items: [], next: null });
+  await expect(withOwner(source, (host) => host.context)).rejects.toThrow();
+  const context = await withOwner(source, (host) => host.context, ownerReceipt.submissionId);
+
+  expect(context.policy).toEqual(sourcePolicy);
+
+  const firstPolicy = AgentPolicy.make({
+    maxTurns: 4,
+    maxToolCalls: 3,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+    toolResultBounds: { maxBytes: 1024 },
+  });
+
+  const secondPolicy = AgentPolicy.make({ ...firstPolicy, maxTurns: 7, maxToolCalls: 5 });
+  const firstDeclaration = capturedPolicyWorkers(firstPolicy);
+  const secondDeclaration = capturedPolicyWorkers(secondPolicy);
+
+  expect(firstDeclaration.target).toBe(secondDeclaration.target);
+  independentBudgetGrants.add(source);
+  backgroundWakeDropPrefixes.add("worker:");
+  droppedMessageWakes.add(source);
+
+  const launch = (policy: AgentPolicy, task: number) =>
+    withOwner(
+      source,
+      (host) =>
+        Subagent.start(
+          capturedPolicyWorkers(policy),
+          { question: `${source}:task:${task}`, policy },
+          { idempotencyKey: decodeIdempotencyKey(`captured-${task}`), budgetScope: "worker-run" },
+        ).pipe(Effect.provideService(SubagentHost, host)),
+      ownerReceipt.submissionId,
+    );
+
+  const first = await launch(firstPolicy, 1);
+  const second = await launch(secondPolicy, 3);
+
+  const finish = (thread: string) =>
+    drainAlarmsUntil(thread, async () => {
+      for (const { record } of await readCanonical(thread)) {
+        if (record.payload._tag === "SubagentRequested")
+          await drainAlarmsUntil(
+            record.payload.childThreadId,
+            allSettled(record.payload.childThreadId),
+          );
+      }
+
+      return allSettled(thread)();
+    });
+
+  try {
+    expect(await launch(firstPolicy, 1)).toEqual(first);
+    const alarm = runDurableObjectAlarm(stubFor(first.worker.threadId)).catch(() => false);
+
+    await expect
+      .poll(async () =>
+        (await readCanonical(first.worker.threadId)).some(
+          ({ record }) => record.payload._tag === "RunStarted",
+        ),
+      )
+      .toBe(true);
+
+    const joined = await withOwner(
+      source,
+      (host) =>
+        Subagent.followUp(
+          firstDeclaration,
+          first.worker,
+          { question: "continue with the retained policy" },
+          { idempotencyKey: decodeIdempotencyKey("captured-joined") },
+        ).pipe(Effect.provideService(SubagentHost, host)),
+      ownerReceipt.submissionId,
+    );
+
+    armRuntimeEviction(first.worker.threadId, "turn:after-response-append");
+    independentBudgetGates.add(`${source}:task:1`);
+    await alarm;
+    await finish(first.worker.threadId);
+    expect(armedEvictionsRemaining(first.worker.threadId)).toBe(0);
+    await evict(source);
+    await evict(first.worker.threadId);
+    independentBudgetGates.add(`${source}:task:2`);
+
+    const later = await withOwner(
+      source,
+      (host) =>
+        Subagent.followUp(
+          firstDeclaration,
+          first.worker,
+          { question: `${source}:task:2`, policy: firstPolicy },
+          { idempotencyKey: decodeIdempotencyKey("captured-later") },
+        ).pipe(Effect.provideService(SubagentHost, host)),
+      ownerReceipt.submissionId,
+    );
+
+    await finish(first.worker.threadId);
+    independentBudgetGates.add(`${source}:task:3`);
+    await finish(second.worker.threadId);
+    for (const [started, policy] of [
+      [first, firstPolicy],
+      [second, secondPolicy],
+    ] as const) {
+      const records = await readCanonical(started.worker.threadId);
+
+      const origins = records.flatMap(({ record }) =>
+        record.payload._tag === "WorkerOriginRecorded" ? [record.payload.origin] : [],
+      );
+
+      expect(origins).toHaveLength(1);
+      expect(origins[0]?.policy).toEqual(policy);
+      expect(origins[0]?.budget.allocation.turns).toBe(policy.maxTurns + 1);
+      expect(origins[0]?.policy.tokenBudget).toBeUndefined();
+      expect(origins[0]?.policy.costBudgetMicrousd).toBeUndefined();
+
+      const scouts = records.flatMap(({ record }) =>
+        record.payload._tag === "SubagentRequested" ? [record.payload] : [],
+      );
+
+      expect(scouts).toHaveLength(started === first ? 2 : 1);
+      for (const scout of scouts) {
+        expect(scout.depth).toBe(2);
+        expect(scout.policy?.tokenBudget).toBe(50);
+        const child = await readCanonical(scout.childThreadId);
+
+        expect(child.some(({ record }) => record.payload._tag === "ModelResponseRecorded")).toBe(
+          true,
+        );
+        expect(
+          child
+            .filter(({ record }) => record.payload._tag === "SubmissionSettled")
+            .map(({ record }) => record.payload),
+        ).toEqual([expect.objectContaining({ outcome: "completed" })]);
+      }
+    }
+    const records = await readCanonical(first.worker.threadId);
+
+    const settlements = records.flatMap(({ record }) =>
+      record.payload._tag === "SubmissionSettled" ? [record.payload] : [],
+    );
+
+    expect(settlements).toHaveLength(3);
+    const initial = settlements.find((row) => row.submissionId === first.receipt.submissionId);
+
+    expect(settlements.find((row) => row.submissionId === joined.submissionId)?.runId).toBe(
+      initial?.runId,
+    );
+    expect(settlements.find((row) => row.submissionId === later.submissionId)?.runId).not.toBe(
+      initial?.runId,
+    );
+    expect(settlements.every((row) => row.outcome === "completed")).toBe(true);
+  } finally {
+    for (const task of [1, 2, 3]) independentBudgetGates.delete(`${source}:task:${task}`);
+    independentBudgetGrants.delete(source);
+    independentBudgetAuthorityCalls.delete(source);
+    droppedMessageWakes.delete(source);
+    backgroundWakeDropPrefixes.delete("worker:");
+  }
+});
 
 it("reopens a background worker and admits follow-up input across Objects after its source has settled", async () => {
   const source = `background-cf-${crypto.randomUUID()}`;

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -8272,7 +8272,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       options.workerAdmission === undefined
         ? undefined
         : yield* workerRuntime
-            .validateAdmission(options.workerAdmission, options, agent.definition.id, inputDigest)
+            .validateAdmission(
+              options.workerAdmission,
+              options,
+              agent.definition.id,
+              inputDigest,
+              inputPayload,
+            )
             .pipe(
               Effect.mapError((cause) =>
                 AdmissionPolicyError.make({
@@ -9272,6 +9278,8 @@ export class DurableAgentRuntime extends Context.Service<
     readonly workerHost: (request: {
       readonly sourceThreadId: ThreadId;
       readonly principal: Principal;
+      /** Exact retained owner input for captured source policy; never selects the latest input. */
+      readonly sourceSubmissionId?: SubmissionId;
     }) => Effect.Effect<SubagentHost["Service"], WorkerError>;
     readonly messagingHost: (request: {
       readonly sourceThreadId: ThreadId;

--- a/packages/thread/src/WorkerHost.ts
+++ b/packages/thread/src/WorkerHost.ts
@@ -1,10 +1,62 @@
+import type * as Agent from "@effect-agent/core/Agent";
 import type { AgentPolicy } from "@effect-agent/core/AgentPolicy";
-import type { ThreadId } from "@effect-agent/core/Identifiers";
+import type { SubmissionId, ThreadId } from "@effect-agent/core/Identifiers";
 import type { SubagentBudgetReservation } from "@effect-agent/core/SubagentContract";
 import { WorkerError, type WorkerRef, type WorkerSource } from "@effect-agent/core/Worker";
-import { Context, type Effect, Schema } from "effect";
+import { Context, Effect, Option, Schema } from "effect";
 
-import type { Principal } from "./SubmissionLedger.ts";
+import type { DefinitionDigests, Digest, PersistedJson, WorkerOrigin } from "./Records.ts";
+import type { Principal, SubmissionSnapshot } from "./SubmissionLedger.ts";
+
+/** Host-verified source input; absence never means the latest input in the Thread. */
+export interface WorkerPolicySource {
+  readonly threadId: ThreadId;
+  readonly definition: Agent.AnyDefinition;
+  readonly definitions: DefinitionDigests;
+  readonly submission?: SubmissionSnapshot;
+}
+
+/** Initial input is validated again at destination admission, including idempotent replay. */
+export type WorkerPolicyTarget = {
+  readonly definition: Agent.AnyDefinition;
+  readonly definitions: DefinitionDigests;
+  readonly source: WorkerSource;
+} & (
+  | {
+      readonly _tag: "InitialInput";
+      readonly sourceSubmission?: SubmissionSnapshot;
+      readonly input: PersistedJson;
+      readonly inputDigest: Digest;
+    }
+  | {
+      readonly _tag: "RetainedWorker";
+      /** Verified against canonical source history before this request reaches the resolver. */
+      readonly origin: WorkerOrigin;
+    }
+);
+
+/**
+ * Opt-in host authority for policies captured in immutable application input. None preserves
+ * the registered Definition's existing policy/override semantics. Some is a complete policy,
+ * never merged with static overrides. Decode and authorize the exact captured revision; do not
+ * read mutable settings or substitute a current capture for missing historical authority.
+ * RetainedWorker may affirm only origin.policy, never replace a continuing worker's allowance.
+ * Return WorkerError(unavailable) for temporarily unavailable authority so delivery can retry.
+ * Implementations are acquired through Effect Layers; capture their dependencies in Layer R.
+ */
+export const WorkerPolicyResolver = Context.Reference<{
+  readonly resolveSource: (
+    request: WorkerPolicySource,
+  ) => Effect.Effect<Option.Option<AgentPolicy>, WorkerError>;
+  readonly resolveTarget: (
+    request: WorkerPolicyTarget,
+  ) => Effect.Effect<Option.Option<AgentPolicy>, WorkerError>;
+}>("@effect-agent/thread/WorkerPolicyResolver", {
+  defaultValue: () => ({
+    resolveSource: () => Effect.succeed(Option.none()),
+    resolveTarget: () => Effect.succeed(Option.none()),
+  }),
+});
 
 const Positive = Schema.Int.check(Schema.isGreaterThan(0));
 
@@ -44,6 +96,8 @@ export const WorkerHostConfig = Context.Reference<WorkerHostLimits>(
  */
 export interface WorkerHostAuthorizationRequest {
   readonly sourceThreadId: ThreadId;
+  /** An explicitly selected owner input; authorize this locator as well as the Thread. */
+  readonly sourceSubmissionId?: SubmissionId;
   readonly principal: Principal;
   readonly operation: WorkerError["operation"];
   readonly access: "context" | "read" | "send" | "control";

--- a/packages/thread/src/internal/worker-host.ts
+++ b/packages/thread/src/internal/worker-host.ts
@@ -89,7 +89,13 @@ import {
   ThreadRead,
   ThreadTailRequest,
 } from "../ThreadStore.ts";
-import { WorkerBudgetAuthorizer, WorkerHostAuthorizer, WorkerHostConfig } from "../WorkerHost.ts";
+import {
+  WorkerBudgetAuthorizer,
+  WorkerHostAuthorizer,
+  WorkerHostConfig,
+  WorkerPolicyResolver,
+  type WorkerPolicyTarget,
+} from "../WorkerHost.ts";
 import {
   definitionDigestsEqual,
   resolveDefinitionBinding,
@@ -115,6 +121,7 @@ const sameAdmission = Schema.toEquivalence(WorkerAdmission);
 const sameReporting = Schema.toEquivalence(Schema.UndefinedOr(WorkerReportingIntent));
 const sameJson = Schema.toEquivalence(PersistedJson);
 const sameCaps = Schema.toEquivalence(SubagentDelegationCaps);
+const samePolicy = Schema.toEquivalence(AgentPolicy);
 
 const amountCaps = [
   ["turns", "maxTurns"],
@@ -234,6 +241,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     crypto: yield* Crypto.Crypto,
     authorizer: yield* WorkerHostAuthorizer,
     budgetAuthorizer: yield* WorkerBudgetAuthorizer,
+    policyResolver: yield* WorkerPolicyResolver,
     limits: yield* WorkerHostConfig,
     failpoint: yield* DurableRuntimeFailpoint,
     status: Option.getOrUndefined(admission)?.submissionStatus ?? control.status,
@@ -388,6 +396,8 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     const nested =
       worker?._tag === "WorkerOriginRecorded" || attached?._tag === "SubagentLineageRecorded";
 
+    let ownerSubmission: SubmissionSnapshot | undefined;
+
     if (nested && submissionId === undefined) return yield* failure("start", "denied");
     if (submissionId !== undefined) {
       const submission = yield* deps.ledger
@@ -400,6 +410,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         submission.value.agentId !== created.agentId
       )
         return yield* failure("start", "denied");
+      ownerSubmission = submission.value;
       if (
         worker?._tag === "WorkerOriginRecorded" &&
         (submission.value.workerAdmission === undefined ||
@@ -417,6 +428,9 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     if (worker?._tag === "WorkerOriginRecorded")
       return {
         current,
+        binding,
+        submission: ownerSubmission,
+        policyOverride: Option.none<AgentPolicy>(),
         policy: worker.origin.policy,
         budget: worker.origin.budget,
         budgetScope: worker.origin.budgetScope,
@@ -433,6 +447,9 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
       return {
         current,
+        binding,
+        submission: ownerSubmission,
+        policyOverride: Option.none<AgentPolicy>(),
         policy: attached.policy,
         budget: attached.budget,
         budgetScope: undefined,
@@ -441,18 +458,61 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       };
     }
 
-    const policy = binding?.definition.policy;
+    const ownerBinding =
+      ownerSubmission === undefined
+        ? undefined
+        : deps.bindings.find(
+            (entry) =>
+              entry.agentId === ownerSubmission.agentId &&
+              definitionDigestsEqual(entry.digests, ownerSubmission.agentDigests),
+          );
 
-    if (policy === undefined) return yield* failure("start", "declaration-unavailable");
+    const selectedBinding = ownerBinding ?? binding;
+
+    if (selectedBinding === undefined) return yield* failure("start", "declaration-unavailable");
+
+    const selected = yield* deps.policyResolver.resolveSource({
+      threadId,
+      definition: selectedBinding.definition,
+      definitions: ownerSubmission?.agentDigests ?? selectedBinding.digests,
+      ...(ownerSubmission === undefined ? {} : { submission: ownerSubmission }),
+    });
+
+    if (Option.isSome(selected) && ownerSubmission !== undefined && ownerBinding === undefined)
+      return yield* failure("start", "declaration-unavailable");
+    const effectiveBinding = Option.isSome(selected) ? selectedBinding : binding;
+
+    if (effectiveBinding === undefined) return yield* failure("start", "declaration-unavailable");
+
+    const policy = Option.isNone(selected)
+      ? effectiveBinding.definition.policy
+      : yield* decode(AgentPolicy, selected.value, "start");
 
     return {
       current,
+      binding: effectiveBinding,
+      submission: ownerSubmission,
+      policyOverride: Option.map(selected, () => policy),
       policy,
       budget: undefined,
       budgetScope: undefined,
       grant: undefined,
       depth: 0,
     };
+  });
+
+  const resolveTargetPolicy = Effect.fn("WorkerHost.resolveTargetPolicy")(function* (
+    request: WorkerPolicyTarget,
+  ) {
+    const selected = yield* deps.policyResolver.resolveTarget(request);
+
+    if (Option.isNone(selected)) return selected;
+    const policy = yield* decode(AgentPolicy, selected.value, "start");
+
+    if (request._tag === "RetainedWorker" && !samePolicy(policy, request.origin.policy))
+      return yield* failure("start", "worker-mismatch");
+
+    return Option.some(policy);
   });
 
   const reserveSubtree = Effect.fn("WorkerHost.reserveSubtree")(function* (
@@ -639,6 +699,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
   const reservation = Effect.fn("WorkerHost.reserveInput")(function* (
     admission: WorkerAdmission,
     inputDigest: Digest,
+    input: PersistedJson,
   ): Effect.fn.Return<void, WorkerError> {
     const origin = admission.origin;
     const id = `worker-input:${admission.messageId}`;
@@ -656,12 +717,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
           !sameAdmission(existing.admission, admission)
         )
           return yield* failure("start", "idempotency-conflict");
-
-        return;
       }
-      const now = yield* Clock.currentTimeMillis;
-
-      if (now >= origin.expiresAtMillis) return yield* failure("start", "capacity");
       const first = current.records[0]?.record.payload;
 
       if (first?._tag !== "ThreadCreated" || first.agentId !== origin.source.agentId)
@@ -681,18 +737,9 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         return yield* failure("start", "worker-mismatch");
       if (prior === undefined && admission.messageId !== origin.firstMessageId)
         return yield* failure("start", "not-found");
-      if (
-        (prior === undefined && origins.size >= deps.limits.maxWorkersPerSource) ||
-        own.length >= deps.limits.maxInputsPerWorker
-      )
-        return yield* failure("start", "capacity");
       const caps = origin.budget.caps;
 
-      const sourceBinding = deps.bindings.find(
-        (entry) =>
-          entry.agentId === first.agentId &&
-          definitionDigestsEqual(entry.digests, first.definitions),
-      );
+      const sourceBinding = source.binding;
 
       const targetBinding = deps.bindings.find(
         (entry) =>
@@ -702,6 +749,55 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
       if (sourceBinding === undefined || targetBinding === undefined)
         return yield* failure("start", "declaration-unavailable");
+      yield* Schema.decodeUnknownEffect(Schema.toEncoded(targetBinding.definition.input))(
+        input,
+      ).pipe(Effect.mapError(() => failure("start", "corrupt")));
+
+      const targetRequest = {
+        definition: targetBinding.definition,
+        definitions: targetBinding.digests,
+        source: origin.source,
+      };
+
+      const selected = yield* resolveTargetPolicy(
+        admission.messageId === origin.firstMessageId
+          ? {
+              ...targetRequest,
+              _tag: "InitialInput",
+              input,
+              inputDigest,
+              ...(source.submission === undefined ? {} : { sourceSubmission: source.submission }),
+            }
+          : { ...targetRequest, _tag: "RetainedWorker", origin: prior ?? origin },
+      );
+
+      const independent = origin.budgetScope === "worker-run";
+
+      const targetPolicy = Option.isSome(selected)
+        ? selected.value
+        : independent
+          ? targetBinding.definition.policy
+          : AgentPolicy.resolve(
+              targetBinding.definition.policyOverrides ?? targetBinding.definition.policy,
+              source.policy,
+            );
+
+      // Captured authority is checked on replay too, before the retained reservation returns.
+      // Static callers retain the old idempotent-return behavior.
+      if (
+        (existing === undefined || Option.isSome(selected)) &&
+        !withinPolicy(origin, independent ? targetPolicy : source.policy, targetPolicy)
+      )
+        return yield* failure("start", "capacity");
+      if (existing !== undefined) return;
+      const now = yield* Clock.currentTimeMillis;
+
+      if (now >= origin.expiresAtMillis) return yield* failure("start", "capacity");
+      if (
+        (prior === undefined && origins.size >= deps.limits.maxWorkersPerSource) ||
+        own.length >= deps.limits.maxInputsPerWorker
+      )
+        return yield* failure("start", "capacity");
       if (
         prior === undefined &&
         !sameReporting(
@@ -710,19 +806,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         )
       )
         return yield* failure("start", "denied");
-      const independent = origin.budgetScope === "worker-run";
-
       if (independent && source.depth !== 0) return yield* failure("start", "denied");
-
-      const targetPolicy = independent
-        ? targetBinding.definition.policy
-        : AgentPolicy.resolve(
-            targetBinding.definition.policyOverrides ?? targetBinding.definition.policy,
-            source.policy,
-          );
-
-      if (!withinPolicy(origin, independent ? targetPolicy : source.policy, targetPolicy))
-        return yield* failure("start", "capacity");
       const ceilings = sourceCaps(source.policy);
 
       const conservedRows = rows.filter((row) => row.admission.origin.budgetScope !== "worker-run");
@@ -865,11 +949,15 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     options: DurableSubmitOptions,
     agentId: Agent.AnyDefinition["id"],
     inputDigest: Digest,
+    input: PersistedJson,
   ) {
     const admission = yield* decode(WorkerAdmission, unvalidated, "start");
 
     yield* deps.authorizer.authorize({
       sourceThreadId: admission.origin.source.threadId,
+      ...(admission.sourceSubmissionId === undefined
+        ? {}
+        : { sourceSubmissionId: admission.sourceSubmissionId }),
       principal: options.principal,
       operation: "start",
       access: "send",
@@ -885,7 +973,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         admission.deliveryPrincipal !== options.principal)
     )
       return yield* failure("start", "worker-mismatch");
-    yield* reservation(admission, inputDigest);
+    yield* reservation(admission, inputDigest, input);
 
     return admission;
   });
@@ -979,16 +1067,25 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       const hostSubmission = selected.value;
       const hostAdmission = selected.value.workerAdmission;
 
-      const source = yield* sourceAuthority(
-        origin.source.threadId,
-        hostAdmission.sourceSubmissionId,
+      const sourceHistory = yield* read(origin.source.threadId, "inspect");
+
+      const firstInput = requests(sourceHistory.records).find(
+        (row) => row.admission.messageId === origin.firstMessageId,
       );
 
-      const created = source.current.records[0]?.record.payload;
+      if (firstInput === undefined || !sameOrigin(firstInput.admission.origin, origin))
+        return yield* failure("inspect", "corrupt");
+
+      // Reporting stays with the original owner even when a later input came from another
+      // source revision. Per-input parameters still belong to the settled Run.
+      const source = yield* sourceAuthority(
+        origin.source.threadId,
+        firstInput.admission.sourceSubmissionId,
+      );
 
       if (
-        created?._tag !== "ThreadCreated" ||
-        !definitionDigestsEqual(created.definitions, intent.sourceDigests)
+        source.binding === undefined ||
+        !definitionDigestsEqual(source.binding.digests, intent.sourceDigests)
       )
         return refused("declaration-unavailable");
 
@@ -1284,6 +1381,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     ) =>
       deps.authorizer.authorize({
         sourceThreadId: context.source.threadId,
+        ...(sourceSubmissionId === undefined ? {} : { sourceSubmissionId }),
         principal,
         operation,
         access,
@@ -1294,6 +1392,36 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       resolveDefinitionBinding(deps.bindings, target).pipe(
         Effect.mapError(() => failure(operation, "declaration-unavailable")),
       );
+
+    const preparedTarget = Effect.fn("WorkerHost.preparedTarget")(function* (
+      target: Agent.AnyDefinition,
+      encodedInput: unknown,
+    ) {
+      const resolved = yield* binding(target, "start");
+
+      yield* Schema.decodeUnknownEffect(Schema.toEncoded(target.input))(encodedInput).pipe(
+        Effect.mapError(() => failure("start", "corrupt")),
+      );
+      const input = yield* decode(PersistedJson, encodedInput, "start");
+
+      const inputDigest = yield* withCrypto(digestJson(input)).pipe(
+        Effect.mapError(storageFailure("start")),
+      );
+
+      const source = yield* sourceAuthority(context.source.threadId, sourceSubmissionId);
+
+      const policy = yield* resolveTargetPolicy({
+        _tag: "InitialInput",
+        definition: resolved.definition,
+        definitions: resolved.digests,
+        source: context.source,
+        ...(source.submission === undefined ? {} : { sourceSubmission: source.submission }),
+        input,
+        inputDigest,
+      });
+
+      return { resolved, source, policy };
+    });
 
     const findOrigin = Effect.fn("WorkerHost.findOrigin")(function* (
       worker: WorkerRef,
@@ -1604,17 +1732,29 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     });
 
     return {
-      context: authorize("context", "context").pipe(Effect.as(context)),
+      context: Effect.gen(function* () {
+        yield* authorize("context", "context");
+        if (context.depth !== 0) return context;
+        const source = yield* sourceAuthority(context.source.threadId, sourceSubmissionId);
+
+        return {
+          ...context,
+          policy: Option.getOrElse(source.policyOverride, () => context.policy),
+        };
+      }),
+      resolveTargetPolicy: Effect.fn("WorkerHost.resolvePreparedTargetPolicy")(function* (request) {
+        yield* authorize("start", "send");
+
+        return (yield* preparedTarget(request.target, request.encodedInput)).policy;
+      }),
       start: Effect.fn("WorkerHost.start")(function* (request) {
         const principal = yield* authorize("start", "send");
 
         if (context.depth !== 0 && sourceSubmissionId === undefined)
           return yield* failure("start", "denied");
-        const resolved = yield* binding(request.target, "start");
-
-        yield* Schema.decodeUnknownEffect(Schema.toEncoded(request.target.input))(
-          request.encodedInput,
-        ).pipe(Effect.mapError(() => failure("start", "corrupt")));
+        const prepared = yield* preparedTarget(request.target, request.encodedInput);
+        const resolved = prepared.resolved;
+        const sourcePolicy = Option.getOrElse(prepared.source.policyOverride, () => context.policy);
 
         const grant = yield* Schema.decodeUnknownEffect(SubagentGrant)(request.encodedGrant).pipe(
           Effect.mapError(() => failure("start", "corrupt")),
@@ -1634,17 +1774,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
         const now = yield* Clock.currentTimeMillis;
         const previousOrigin = existing?.envelope.workerAdmission?.origin;
-        const source = yield* read(context.source.threadId, "start");
-        const created = source.records[0]?.record.payload;
-
-        const sourceBinding =
-          created?._tag === "ThreadCreated"
-            ? deps.bindings.find(
-                (entry) =>
-                  entry.agentId === created.agentId &&
-                  definitionDigestsEqual(entry.digests, created.definitions),
-              )
-            : undefined;
+        const sourceBinding = prepared.source.binding;
 
         if (sourceBinding === undefined) return yield* failure("start", "declaration-unavailable");
 
@@ -1684,18 +1814,19 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
         yield* authorizeBudget(origin, principal);
 
-        const targetPolicy =
-          origin.budgetScope === "worker-run"
+        const targetPolicy = Option.isSome(prepared.policy)
+          ? prepared.policy.value
+          : origin.budgetScope === "worker-run"
             ? resolved.definition.policy
             : AgentPolicy.resolve(
                 resolved.definition.policyOverrides ?? resolved.definition.policy,
-                context.policy,
+                sourcePolicy,
               );
 
         if (
           !withinPolicy(
             origin,
-            origin.budgetScope === "worker-run" ? targetPolicy : context.policy,
+            origin.budgetScope === "worker-run" ? targetPolicy : sourcePolicy,
             targetPolicy,
           )
         )
@@ -1715,6 +1846,14 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       followUp: Effect.fn("WorkerHost.followUp")(function* (request) {
         const principal = yield* authorize("followUp", "send", request.worker);
         const origin = yield* findOrigin(request.worker, request.target, "followUp");
+
+        yield* resolveTargetPolicy({
+          _tag: "RetainedWorker",
+          definition: request.target,
+          definitions: origin.targetDigests,
+          source: origin.source,
+          origin,
+        });
 
         yield* Schema.decodeUnknownEffect(Schema.toEncoded(request.target.input))(
           request.encodedInput,
@@ -1890,11 +2029,15 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
   const acquire = Effect.fn("WorkerHost.acquire")(function* (request: {
     readonly sourceThreadId: ThreadId;
     readonly principal: Principal;
+    readonly sourceSubmissionId?: SubmissionId;
   }) {
     const { sourceThreadId, principal } = request;
 
     yield* deps.authorizer.authorize({
       sourceThreadId,
+      ...(request.sourceSubmissionId === undefined
+        ? {}
+        : { sourceSubmissionId: request.sourceSubmissionId }),
       principal,
       operation: "context",
       access: "context",
@@ -1940,6 +2083,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         ...(retained?.grant === undefined ? {} : { grant: retained.grant }),
       },
       principal,
+      request.sourceSubmissionId,
     );
   });
 

--- a/packages/thread/test/durable-runtime-types.test.ts
+++ b/packages/thread/test/durable-runtime-types.test.ts
@@ -1,4 +1,5 @@
-import { type ThreadId } from "@effect-agent/core/Identifiers";
+import type { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { type ThreadId, type SubmissionId } from "@effect-agent/core/Identifiers";
 import type { MessagingError } from "@effect-agent/core/Messaging";
 import type { WorkerError } from "@effect-agent/core/Worker";
 import type { MessagingHost } from "@effect-agent/engine/MessagingHost";
@@ -18,11 +19,12 @@ import {
 import { type SubmissionStatus } from "@effect-agent/thread/SubmissionStatus";
 import type { ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { expectTypeOf, it } from "@effect/vitest";
-import type { Crypto, DateTime, Effect, Option } from "effect";
+import { Context, Effect, Layer, Option, type Crypto, type DateTime } from "effect";
 
 import type { DurableRuntimeFailpoint } from "../src/DurableFailpoint.ts";
 import type { makeMessagingRuntime } from "../src/internal/messaging-host.ts";
 import type { makeWorkerRuntime, WorkerInputControl } from "../src/internal/worker-host.ts";
+import { WorkerPolicyResolver } from "../src/WorkerHost.ts";
 
 type Runtime = DurableAgentRuntime["Service"];
 type Head = ReturnType<Runtime["processThreadHead"]>;
@@ -30,7 +32,27 @@ type Status = ReturnType<Runtime["submissionStatus"]>;
 type Inspection = ReturnType<Runtime["inspectSubmissionStatus"]>;
 type Recovery = ReturnType<Runtime["recoverSubmission"]>;
 
+class PolicyEvidence extends Context.Service<PolicyEvidence, { readonly policy: AgentPolicy }>()(
+  "test/PolicyEvidence",
+) {}
+
+const capturedPolicyLayer = Layer.effect(
+  WorkerPolicyResolver,
+  Effect.gen(function* () {
+    const evidence = yield* PolicyEvidence;
+
+    return {
+      resolveSource: () => Effect.succeed(Option.some(evidence.policy)),
+      resolveTarget: () => Effect.succeed(Option.some(evidence.policy)),
+    };
+  }),
+);
+
 it("keeps bounded worker operations and status reads typed without hidden requirements", () => {
+  expectTypeOf<Layer.Services<typeof capturedPolicyLayer>>().toEqualTypeOf<PolicyEvidence>();
+  expectTypeOf<ReturnType<SubagentHost["Service"]["resolveTargetPolicy"]>>().toEqualTypeOf<
+    Effect.Effect<Option.Option<AgentPolicy>, WorkerError>
+  >();
   expectTypeOf<Effect.Services<ReturnType<typeof makeWorkerRuntime>>>().toEqualTypeOf<
     ThreadStore | SubmissionLedger | Crypto.Crypto | DurableRuntimeFailpoint | WorkerInputControl
   >();
@@ -38,7 +60,13 @@ it("keeps bounded worker operations and status reads typed without hidden requir
     ThreadStore | Crypto.Crypto
   >();
   expectTypeOf<Parameters<Runtime["workerHost"]>>().toEqualTypeOf<
-    [request: { readonly sourceThreadId: ThreadId; readonly principal: Principal }]
+    [
+      request: {
+        readonly sourceThreadId: ThreadId;
+        readonly principal: Principal;
+        readonly sourceSubmissionId?: SubmissionId;
+      },
+    ]
   >();
   expectTypeOf<ReturnType<Runtime["workerHost"]>>().toEqualTypeOf<
     Effect.Effect<SubagentHost["Service"], WorkerError>

--- a/packages/thread/test/worker-host.test.ts
+++ b/packages/thread/test/worker-host.test.ts
@@ -83,6 +83,7 @@ import {
   WorkerBudgetAuthorizer,
   WorkerHostAuthorizer,
   WorkerHostConfig,
+  WorkerPolicyResolver,
 } from "../src/WorkerHost.ts";
 
 class ReportService extends Context.Service<ReportService, string>()("test/ReportService") {}
@@ -173,6 +174,11 @@ const reportWith = (
 const harness = Effect.fn("workerHostHarness")(function* (
   options: {
     readonly independentBudget?: boolean;
+    readonly sourceRevisions?: ReadonlyArray<{
+      readonly definition: Agent.AnyDefinition;
+      readonly digests: DefinitionDigests;
+      readonly reporting?: ReadonlyArray<WorkerReporting<WorkerReportPreparationFailure>>;
+    }>;
     readonly sourceReports?: ReadonlyArray<WorkerReporting<WorkerReportPreparationFailure>>;
     readonly targetReports?: ReadonlyArray<WorkerReporting<WorkerReportPreparationFailure>>;
   } = {},
@@ -229,13 +235,24 @@ const harness = Effect.fn("workerHostHarness")(function* (
     deploymentId: Schema.decodeSync(DeploymentId)("test"),
     producerId: Schema.decodeSync(ProducerId)("test"),
     settlementPollInterval: Duration.millis(5),
-    bindings: [sourceAgent, target].map((definition) => ({
+    bindings: [
+      sourceAgent,
+      target,
+      ...(options.sourceRevisions ?? []).map((revision) => revision.definition),
+    ].map((definition) => ({
       definition,
       agentId: definition.id,
-      digests: definitions,
+      digests:
+        options.sourceRevisions?.find((revision) => revision.definition === definition)?.digests ??
+        definitions,
       attempt: () => Effect.succeed(Option.none()),
       reporting:
-        definition === sourceAgent ? (options.sourceReports ?? []) : (options.targetReports ?? []),
+        definition === sourceAgent
+          ? (options.sourceReports ?? [])
+          : (options.sourceRevisions?.find((revision) => revision.definition === definition)
+              ?.reporting ??
+            options.targetReports ??
+            []),
     })),
   }).pipe(
     Effect.provideService(WorkerBudgetAuthorizer, {
@@ -424,11 +441,20 @@ const harness = Effect.fn("workerHostHarness")(function* (
           };
 
           yield* runtime
-            .validateAdmission(metadata, options, envelope.agentId, envelope.inputDigest)
+            .validateAdmission(
+              metadata,
+              options,
+              envelope.agentId,
+              envelope.inputDigest,
+              envelope.input,
+            )
             .pipe(
               Effect.mapError((error) =>
                 AdmissionPolicyError.make({
-                  reason: error.reason === "storage" ? "unavailable" : "refused",
+                  reason:
+                    error.reason === "storage" || error.reason === "unavailable"
+                      ? "unavailable"
+                      : "refused",
                   code: `worker-${error.reason}`,
                 }),
               ),
@@ -578,6 +604,308 @@ const harness = Effect.fn("workerHostHarness")(function* (
 });
 
 layer(NodeCrypto.layer)((it) => {
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+  it.effect(
+    "pins captured owner reporting across later owner revisions while preserving legacy context and reports",
+    () =>
+      Effect.gen(function* () {
+        const ownerId = Schema.decodeSync(SubmissionId)("source-owner");
+        const revisedDigest = Schema.decodeSync(Digest)("b".repeat(64));
+        const revisedDigests = DefinitionDigests.make({ ...definitions, agent: revisedDigest });
+
+        const revised = Agent.make(sourceAgent.id, {
+          input: sourceAgent.input,
+          output: sourceAgent.output,
+          instructions: "Revised source",
+          toolkit: Toolkit.empty,
+          policy: AgentPolicy.make({ ...sourceAgent.policy, maxTurns: 30 }),
+        });
+
+        const snapshot = SubmissionSnapshot.make({
+          submissionId: ownerId,
+          threadId: sourceId,
+          queueSequence: Schema.decodeSync(QueueSequence)(1),
+          principal,
+          idempotencyKey: Schema.decodeSync(IdempotencyKey)("source-owner"),
+          agentId: sourceAgent.id,
+          agentDigests: revisedDigests,
+          deploymentId: Schema.decodeSync(DeploymentId)("test"),
+          inputPayload: "immutable capture",
+          inputDigest: digest,
+          receiptId: Schema.decodeSync(ReceiptId)("source-owner"),
+          state: "ready",
+          createdAt: DateTime.makeUnsafe(0),
+        });
+
+        const reportsA = [reportWith(() => Effect.succeed({ encodedInput: "report:A" }))];
+        const legacy = yield* harness({ sourceReports: reportsA });
+
+        legacy.submissions.set(ownerId, snapshot);
+
+        const context = {
+          source: { _tag: "programmatic" as const, threadId: sourceId, agentId: sourceAgent.id },
+          policy: revised.policy,
+          depth: 0,
+        };
+
+        const legacyFacet = legacy.runtime.facet(context, principal, ownerId);
+
+        expect((yield* legacyFacet.context).policy).toEqual(revised.policy);
+        const started = yield* legacyFacet.start(request("legacy-owner"));
+
+        expect(started.receipt.threadId).toBe(started.worker.threadId);
+        yield* legacy.settle(started.receipt);
+        expect(
+          [...legacy.deliveries.values()]
+            .filter((row) => row.envelope.threadId === sourceId)
+            .map((row) => row.envelope),
+        ).toEqual([expect.objectContaining({ definitions, input: "report:A" })]);
+
+        const laterOwnerId = Schema.decodeSync(SubmissionId)("later-source-owner");
+
+        const laterDigests = DefinitionDigests.make({
+          ...definitions,
+          agent: Schema.decodeSync(Digest)("c".repeat(64)),
+        });
+
+        const laterDefinition = Agent.make(sourceAgent.id, {
+          input: sourceAgent.input,
+          output: sourceAgent.output,
+          instructions: "Later source",
+          toolkit: Toolkit.empty,
+          policy: AgentPolicy.make({ ...sourceAgent.policy, maxTurns: 40 }),
+        });
+
+        let reportsB = 0;
+        let reportsC = 0;
+
+        const opted = yield* harness({
+          sourceReports: reportsA,
+          sourceRevisions: [
+            {
+              definition: revised,
+              digests: revisedDigests,
+              reporting: [
+                reportWith((report) =>
+                  Effect.sync(() => {
+                    reportsB++;
+                    expect(report.context.policy).toEqual(revised.policy);
+
+                    return { encodedInput: "report:B" };
+                  }),
+                ),
+              ],
+            },
+            {
+              definition: laterDefinition,
+              digests: laterDigests,
+              reporting: [
+                reportWith(() =>
+                  Effect.sync(() => {
+                    reportsC++;
+
+                    return { encodedInput: "report:C" };
+                  }),
+                ),
+              ],
+            },
+          ],
+        }).pipe(
+          Effect.provideService(WorkerPolicyResolver, {
+            resolveSource: (request) =>
+              Effect.gen(function* () {
+                if (request.submission === undefined)
+                  return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+                if (request.submission.submissionId === laterOwnerId) {
+                  expect(request.definition).toBe(laterDefinition);
+                  expect(request.definitions).toEqual(laterDigests);
+
+                  return Option.some(laterDefinition.policy);
+                }
+                expect(request.definition).toBe(revised);
+                expect(request.definitions).toEqual(revisedDigests);
+                expect(request.submission.inputPayload).toBe("immutable capture");
+
+                return Option.some(revised.policy);
+              }),
+            resolveTarget: () => Effect.succeed(Option.none()),
+          }),
+        );
+
+        opted.submissions.set(ownerId, snapshot);
+        expect((yield* opted.host.context.pipe(Effect.flip)).reason).toBe("unavailable");
+        expect(
+          yield* opted.host.list({ target, delegationId: request("list").delegationId, limit: 10 }),
+        ).toEqual({ items: [], next: null });
+
+        const selected = yield* opted.runtime.acquire({
+          sourceThreadId: sourceId,
+          principal,
+          sourceSubmissionId: ownerId,
+        });
+
+        expect((yield* selected.context).policy).toEqual(revised.policy);
+        const worker = yield* selected.start(request("owner-B-worker"));
+        const origin = opted.submissions.get(worker.receipt.submissionId)!.workerAdmission!.origin;
+
+        expect(origin.reporting?.sourceDigests).toEqual(revisedDigests);
+        yield* opted.settle(worker.receipt);
+        opted.submissions.set(
+          laterOwnerId,
+          SubmissionSnapshot.make({
+            ...snapshot,
+            submissionId: laterOwnerId,
+            agentDigests: laterDigests,
+            inputPayload: "later immutable capture",
+          }),
+        );
+
+        const laterSource = yield* opted.runtime.acquire({
+          sourceThreadId: sourceId,
+          principal,
+          sourceSubmissionId: laterOwnerId,
+        });
+
+        const next = yield* laterSource.followUp({
+          worker: worker.worker,
+          target,
+          idempotencyKey: Schema.decodeSync(IdempotencyKey)("owner-C-followup"),
+          encodedInput: { text: "next" },
+          encodedParameters: { note: "next" },
+        });
+
+        yield* opted.settle(next);
+        expect(opted.submissions.get(next.submissionId)!.workerAdmission!.origin).toEqual(origin);
+        expect(reportsB).toBe(2);
+        expect(reportsC).toBe(0);
+        expect(
+          [...opted.deliveries.values()]
+            .filter((row) => row.envelope.threadId === sourceId)
+            .map((row) => row.envelope),
+        ).toEqual([
+          expect.objectContaining({ definitions: revisedDigests, input: "report:B" }),
+          expect.objectContaining({ definitions: revisedDigests, input: "report:B" }),
+        ]);
+      }),
+  );
+
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+  it.effect(
+    "revalidates captured authority across a reserved admission retry and freezes later worker policy",
+    () =>
+      Effect.gen(function* () {
+        const captured = AgentPolicy.make({
+          ...policy,
+          maxTurns: 7,
+          maxToolCalls: 6,
+          maxDuration: "4 seconds",
+        });
+
+        let unavailable = false;
+        let replaceRetained = false;
+        let initialCalls = 0;
+
+        const h = yield* harness({ independentBudget: true }).pipe(
+          Effect.provideService(WorkerPolicyResolver, {
+            resolveSource: () => Effect.succeed(Option.none()),
+            resolveTarget: (input) =>
+              Effect.gen(function* () {
+                if (unavailable)
+                  return yield* WorkerError.make({ operation: "start", reason: "unavailable" });
+                if (input._tag === "RetainedWorker")
+                  return Option.some(replaceRetained ? policy : input.origin.policy);
+                initialCalls++;
+                expect(input.input).toEqual({ text: "captured" });
+                expect(input.definition).toBe(target);
+
+                return Option.some(captured);
+              }),
+          }),
+        );
+
+        const base = request("captured");
+
+        const start: StartWorkerRequest = {
+          ...base,
+          policy: captured,
+          budgetScope: "worker-run",
+          budget: {
+            caps: SubagentDelegationCaps.make({
+              maxTotalChildInvocations: 1,
+              maxConcurrentChildren: 1,
+              maxTurns: 8,
+              maxToolCalls: 7,
+              maxDurationMillis: 5_000,
+            }),
+            allocation: SubagentReservationAmounts.make({
+              ...base.budget.allocation,
+              turns: 8,
+              toolCalls: 7,
+              durationMillis: 5_000,
+            }),
+            descendantInvocations: 1,
+          },
+        };
+
+        h.fail("worker:after-source-append");
+        yield* h.host.start(start).pipe(Effect.flip);
+        h.fail(undefined);
+        const delivery = [...h.deliveries.values()][0]!;
+        const metadata = delivery.envelope.workerAdmission!;
+
+        const admissionOptions = {
+          threadId: delivery.envelope.threadId,
+          definitions: delivery.envelope.definitions,
+          principal,
+          idempotencyKey: delivery.envelope.admissionKey,
+        };
+
+        unavailable = true;
+        expect(
+          (yield* h.runtime
+            .validateAdmission(
+              metadata,
+              admissionOptions,
+              target.id,
+              delivery.envelope.inputDigest,
+              delivery.envelope.input,
+            )
+            .pipe(Effect.flip)).reason,
+        ).toBe("unavailable");
+        expect(h.submissions.size).toBe(0);
+        unavailable = false;
+        yield* TestClock.adjust("1 second");
+        const started = yield* h.host.start(start);
+
+        expect(initialCalls).toBeGreaterThanOrEqual(4);
+        const origin = h.submissions.get(started.receipt.submissionId)!.workerAdmission!.origin;
+
+        expect(origin.policy).toEqual(captured);
+        expect(
+          h.logs
+            .get(sourceId)!
+            .filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+        ).toHaveLength(1);
+        yield* h.settle(started.receipt);
+
+        const followup = {
+          worker: started.worker,
+          target,
+          idempotencyKey: Schema.decodeSync(IdempotencyKey)("later"),
+          encodedInput: { text: "different later input" },
+          encodedParameters: { note: "later" },
+        };
+
+        replaceRetained = true;
+        expect((yield* h.host.followUp(followup).pipe(Effect.flip)).reason).toBe("worker-mismatch");
+        expect(h.deliveries.size).toBe(1);
+        replaceRetained = false;
+        const next = yield* h.host.followUp(followup);
+
+        expect(h.submissions.get(next.submissionId)!.workerAdmission!.origin).toEqual(origin);
+      }),
+  );
+
   // Regression: https://github.com/danieljvdm/effect-agent/pull/358
   it.effect(
     "requires host funding authority and preserves worker identity and structural limits",
@@ -1741,12 +2069,14 @@ layer(NodeCrypto.layer)((it) => {
           options,
           report.envelope.agentId,
           report.envelope.inputDigest,
+          report.envelope.input,
         );
         yield* h.runtime.validateAdmission(
           metadata,
           options,
           report.envelope.agentId,
           report.envelope.inputDigest,
+          report.envelope.input,
         );
 
         const charged = h.logs


### PR DESCRIPTION
Background workers could only inherit policies from registered definitions, even when an application had already authorized a different policy in immutable input. Resolve that captured policy after input preparation and validate it again at destination admission, including replay of an existing reservation.

```mermaid
sequenceDiagram
    participant Caller as Subagent.start
    participant Host as SubagentHost
    participant Policy as WorkerPolicyResolver
    participant Destination as DurableAgentRuntime
    Caller->>Caller: Prepare and encode immutable input
    Caller->>Host: Resolve target policy for prepared input
    Host->>Policy: Authorize exact input and owner Submission
    Caller->>Host: Start with explicit declaration limits
    Host->>Destination: Admit input with worker origin
    Destination->>Policy: Revalidate captured authority
    Destination->>Destination: Retain admitted policy across Runs and recovery
```

`WorkerPolicyResolver` is an optional Effect service: `None` preserves static inheritance; `Some(policy)` selects a complete policy without reapplying static overrides. Explicit declaration limits still narrow the result. Its Layer retains any construction dependencies in `R`.

Programmatic callers can select the exact owner input when acquiring a host:

```ts
// Inside Effect.gen; runtime, principal, and owner are already authorized.
const host = yield* runtime.workerHost({
  sourceThreadId: owner.threadId,
  sourceSubmissionId: owner.submissionId,
  principal,
});
const context = yield* host.context;
// context.policy comes from that retained input when the resolver opts in.
```

A continuing worker retains its original policy and reporting projection across follow-ups, joined receipts, retries and replacement Attempts. `RetainedWorker` may affirm `origin.policy`; replacing it fails. Temporarily unavailable captured authority returns a retryable `WorkerError` rather than silently falling back. Read and control operations remain independent of captured policy resolution.

The application must retain and authorize the original capture, reuse the registered target definition, and provide all required policy evidence. This adds no persisted schema or platform-specific runtime path.
