### PR TITLE
fix(thread): preserve source concurrency and worker delivery

### DIFF
--- a/.changeset/quiet-workers-recover.md
+++ b/.changeset/quiet-workers-recover.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/thread": patch
+"@effect-agent/platform-cloudflare": patch
+---
+
+Resolve source-authorized background concurrency at the canonical reservation boundary, preserving active steering, retained origins, and retryable authority failures. Include the original owner submission in terminal report authorization and preserve native message recovery when applications rebuild Cloudflare runtime maintenance.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -218,6 +218,19 @@ input-retention, concurrency, and lifetime limits still apply across the source 
 Set `WorkerHostConfig.maxActiveWorkersPerSource` to bound concurrent background workers separately
 from the root's Tool execution concurrency; omission retains the prior concurrency ceiling.
 
+When each source has an authorized concurrency preference, provide `WorkerConcurrencyResolver`
+from `@effect-agent/thread/WorkerHost` through an Effect Layer. It receives the immutable source,
+worker, principal, and explicitly selected canonical owner submission. Return `Option.some({
+maxActiveWorkersPerSource })` to narrow the fixed host ceiling, or `Option.none()` to retain it.
+The runtime resolves this limit inside the source reservation CAS loop, including retries after
+competing appends. Counted workers have at least one input awaiting canonical completion; queued
+inputs count, and steering an active worker needs no additional slot. An idle worker must acquire
+a slot before a later input. Lowering the ceiling, including to zero, does not cancel incumbents
+or reject replay of an established reservation. Temporarily unavailable authority must return
+`WorkerError` with reason `unavailable`; it must not silently choose a fallback. This operational
+limit never changes an established worker policy, delegation depth, retained-worker limit, or
+Run allowance.
+
 ### Resolve policies from captured input
 
 Supply `WorkerPolicyResolver` from `@effect-agent/thread/WorkerHost` when immutable application

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -239,8 +239,9 @@ export class ThreadPublication extends Context.Service<
 }
 
 /**
- * @internal Host-assembled message recovery. These obligations outlive source Runs and never
- * defer a ready source Attempt while a destination is processing an accepted message.
+ * Host-assembled message recovery, supplied by ThreadObject.layer even when the application
+ * rebuilds ThreadMaintenance. These obligations outlive source Runs and never defer a ready
+ * source Attempt while a destination is processing an accepted message.
  */
 export const ThreadMessageDelivery = Context.Reference<{
   readonly drain: Effect.Effect<void, DurableAlarmError>;

--- a/packages/platform-cloudflare/src/internal/layers.ts
+++ b/packages/platform-cloudflare/src/internal/layers.ts
@@ -178,7 +178,11 @@ export type CloudflareDurableRuntimeInitializationError =
   | MessageDeliveryError
   | DoStorageInitializationError;
 
-/** The services `ThreadObject.layer` provides, including its single owner SQL client. */
+/**
+ * The services `ThreadObject.layer` provides, including its single owner SQL client.
+ * Its Context also supplies ThreadMessageDelivery (a defaulted Reference, with no required R)
+ * so application-composed maintenance retains the same native message recovery capability.
+ */
 export type CloudflareDurableRuntimeServices =
   | DurableAgentRuntime
   | SubmissionLedger
@@ -605,6 +609,7 @@ const boundLayer = <E = never, R = never>(
         ThreadMaintenance.layer.pipe(Layer.provide(runtimeStack), Layer.provide(messageRecovery)),
         portsEndpointLayer,
         messageStore,
+        messageRecovery,
       ).pipe(
         Layer.provideMerge(publication),
         Layer.provideMerge(projection),

--- a/packages/platform-cloudflare/test/background-worker-fixture.ts
+++ b/packages/platform-cloudflare/test/background-worker-fixture.ts
@@ -2,12 +2,16 @@ import * as Subagent from "@effect-agent/capabilities/Subagent";
 import { SubagentReservationsMemoryLive } from "@effect-agent/capabilities/SubagentReservations";
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import type { ThreadId, SubmissionId } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { MessagingError } from "@effect-agent/core/Messaging";
 import { SubagentGrant } from "@effect-agent/core/SubagentContract";
 import { WorkerError } from "@effect-agent/core/Worker";
 import { DurableWorkerBinding } from "@effect-agent/thread/AgentRegistration";
+import { PeerAuthorizer, PeerRoutes } from "@effect-agent/thread/MessagingHost";
 import {
   WorkerBudgetAuthorizer,
+  WorkerConcurrencyResolver,
   WorkerHostAuthorizer,
   WorkerHostConfig,
   WorkerPolicyResolver,
@@ -224,6 +228,14 @@ export const capturedPolicyWorkers = (policy: AgentPolicy) =>
 
 export const capturedPolicyOutages = new Set<string>();
 
+export const capturedConcurrency = new Map<
+  string,
+  { readonly owner: SubmissionId; readonly limit: number }
+>();
+
+export const privateProgressRoutes = new Map<string, ThreadId>();
+export const customRuntimeThreads = new Set<string>();
+
 export const independentBudgetGrants = new Set<string>();
 /** A source authorization succeeds before the destination's next admission loses its dependency. */
 export const independentBudgetAdmissionOutages = new Set<string>();
@@ -312,6 +324,32 @@ export const backgroundWorkerBindings = Effect.all([
 ]);
 
 export const backgroundWorkerAuthority = Layer.mergeAll(
+  Layer.succeed(PeerRoutes)({
+    resolve: (request) => {
+      const destination = privateProgressRoutes.get(request.source.threadId);
+
+      return destination === undefined
+        ? MessagingError.make({ operation: "send", reason: "route-unavailable" })
+        : Effect.succeed(destination);
+    },
+  }),
+  Layer.succeed(PeerAuthorizer)({
+    authorize: (request) =>
+      request.principal === TEST_PRINCIPAL && privateProgressRoutes.has(request.source.threadId)
+        ? Effect.succeed(TEST_PRINCIPAL)
+        : MessagingError.make({ operation: request.operation, reason: "denied" }),
+  }),
+  Layer.succeed(WorkerConcurrencyResolver)({
+    resolve: (request) => {
+      const capture = capturedConcurrency.get(request.source.threadId);
+
+      if (capture === undefined) return Effect.succeed(Option.none());
+
+      return request.sourceSubmission?.submissionId === capture.owner
+        ? Effect.succeed(Option.some({ maxActiveWorkersPerSource: capture.limit }))
+        : WorkerError.make({ operation: "start", reason: "denied" });
+    },
+  }),
   Layer.succeed(WorkerPolicyResolver)({
     resolveSource: (request) =>
       Effect.gen(function* () {

--- a/packages/platform-cloudflare/test/background-workers.test.ts
+++ b/packages/platform-cloudflare/test/background-workers.test.ts
@@ -27,6 +27,9 @@ import {
   backgroundReportGates,
   capturedPolicySource,
   capturedPolicyWorkers,
+  capturedConcurrency,
+  privateProgressRoutes,
+  customRuntimeThreads,
 } from "./background-worker-fixture.ts";
 import {
   decodeIdempotencyKey,
@@ -117,6 +120,7 @@ it("admits exact captured policies with one registered target and retains them t
 
   expect(firstDeclaration.target).toBe(secondDeclaration.target);
   independentBudgetGrants.add(source);
+  capturedConcurrency.set(source, { owner: ownerReceipt.submissionId, limit: 2 });
   backgroundWakeDropPrefixes.add("worker:");
   droppedMessageWakes.add(source);
 
@@ -132,8 +136,7 @@ it("admits exact captured policies with one registered target and retains them t
       ownerReceipt.submissionId,
     );
 
-  const first = await launch(firstPolicy, 1);
-  const second = await launch(secondPolicy, 3);
+  const [first, second] = await Promise.all([launch(firstPolicy, 1), launch(secondPolicy, 3)]);
 
   const finish = (thread: string) =>
     drainAlarmsUntil(thread, async () => {
@@ -149,6 +152,8 @@ it("admits exact captured policies with one registered target and retains them t
     });
 
   try {
+    await expect(launch(firstPolicy, 4)).rejects.toThrow();
+    capturedConcurrency.set(source, { owner: ownerReceipt.submissionId, limit: 0 });
     expect(await launch(firstPolicy, 1)).toEqual(first);
     const alarm = runDurableObjectAlarm(stubFor(first.worker.threadId)).catch(() => false);
 
@@ -180,6 +185,7 @@ it("admits exact captured policies with one registered target and retains them t
     await evict(source);
     await evict(first.worker.threadId);
     independentBudgetGates.add(`${source}:task:2`);
+    capturedConcurrency.set(source, { owner: ownerReceipt.submissionId, limit: 2 });
 
     const later = await withOwner(
       source,
@@ -251,9 +257,103 @@ it("admits exact captured policies with one registered target and retains them t
   } finally {
     for (const task of [1, 2, 3]) independentBudgetGates.delete(`${source}:task:${task}`);
     independentBudgetGrants.delete(source);
+    capturedConcurrency.delete(source);
     independentBudgetAuthorityCalls.delete(source);
     droppedMessageWakes.delete(source);
     backgroundWakeDropPrefixes.delete("worker:");
+  }
+});
+
+// Regression: https://github.com/danieljvdm/effect-agent/commit/4600d240f44b1ef1fe9b0fc58f39e293a6434f85
+it("drains private worker progress through rebuilt runtime maintenance into an idle parent", async () => {
+  const source = `background-cf-custom-${crypto.randomUUID()}`;
+
+  await runClient(
+    Effect.flatMap(CloudflareThreadClient, (client) =>
+      client.submit(
+        { definition: backgroundSource },
+        { question: "initialize" },
+        submitOptions(source, "source"),
+      ),
+    ),
+  );
+  await drainAlarmsUntil(source, allSettled(source));
+
+  const started = await withOwner(source, (host) =>
+    Subagent.start(
+      backgroundWorkers,
+      { question: "private task" },
+      { idempotencyKey: decodeIdempotencyKey("child") },
+    ).pipe(Effect.provideService(SubagentHost, host)),
+  );
+
+  await drainAlarmsUntil(started.worker.threadId, allSettled(started.worker.threadId));
+  customRuntimeThreads.add(started.worker.threadId);
+  privateProgressRoutes.set(started.worker.threadId, decodeThreadId(source));
+  droppedMessageWakes.add(started.worker.threadId);
+  await evict(started.worker.threadId);
+  try {
+    const sent = await runInDurableObject(stubFor(started.worker.threadId), (instance) =>
+      instance[DurableObject.RunSymbol](
+        Effect.gen(function* () {
+          const runtime = yield* DurableAgentRuntime;
+
+          const host = yield* runtime.messagingHost({
+            sourceThreadId: started.worker.threadId,
+            principal: TEST_PRINCIPAL,
+          });
+
+          return yield* host.send({
+            name: "private_progress",
+            target: backgroundSource,
+            encodedInput: { question: "private bounded progress" },
+            idempotencyKey: decodeIdempotencyKey("progress"),
+          });
+        }),
+      ),
+    );
+
+    expect(sent.status).toBe("pending");
+    // A competing automatic pass can own delivery after a manual alarm returns. Drive the
+    // native owners until the destination has applied this exact message, not merely until
+    // the previously idle parent has no unsettled inputs.
+    await drainAlarmsUntil(started.worker.threadId, async () => {
+      await runDurableObjectAlarm(stubFor(source));
+
+      return (await readCanonical(source)).some(
+        ({ record }) =>
+          record.payload._tag === "UserInputRecorded" &&
+          record.payload.messageAdmission?.sender.threadId === started.worker.threadId &&
+          record.payload.messageAdmission.peerName === "private_progress",
+      );
+    });
+    await drainAlarmsUntil(source, allSettled(source));
+
+    const destination = await readCanonical(source);
+
+    const delivered = destination.filter(
+      ({ record }) =>
+        record.payload._tag === "UserInputRecorded" &&
+        record.payload.messageAdmission !== undefined,
+    );
+
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]?.record.payload).toMatchObject({
+      input: { question: "private bounded progress" },
+      messageAdmission: {
+        sender: { threadId: started.worker.threadId },
+        peerName: "private_progress",
+      },
+    });
+    expect(
+      destination.flatMap(({ record }) =>
+        record.payload._tag === "SubmissionSettled" ? [record.payload.outcome] : [],
+      ),
+    ).toEqual(["completed", "completed"]);
+  } finally {
+    customRuntimeThreads.delete(started.worker.threadId);
+    privateProgressRoutes.delete(started.worker.threadId);
+    droppedMessageWakes.delete(started.worker.threadId);
   }
 });
 

--- a/packages/platform-cloudflare/test/registrations.test.ts
+++ b/packages/platform-cloudflare/test/registrations.test.ts
@@ -14,6 +14,7 @@ import { DurableObjectState, WorkerEnvironment } from "effect-cf";
 import { SqlClient } from "effect/unstable/sql/SqlClient";
 import { describe, expect, expectTypeOf, it } from "vite-plus/test";
 
+import { ThreadMessageDelivery } from "../src/Alarm.ts";
 import {
   PRODUCER_PREFIX,
   plannerDefinition,
@@ -60,6 +61,12 @@ describe("Cloudflare Agent registrations", () => {
 
           const built = yield* Layer.build(runtime);
           const sql = Context.get(built, SqlClient);
+
+          // Regression: https://github.com/danieljvdm/effect-agent/commit/4600d240f44b1ef1fe9b0fc58f39e293a6434f85
+          // References carry no required R, but the host must still supply this actual instance.
+          expect(Context.get(built, ThreadMessageDelivery)).not.toBe(
+            Context.get(Context.empty(), ThreadMessageDelivery),
+          );
 
           // Both native tags come from the one memoized infrastructure Layer shared with ports.
           expect(Context.getOption(built, SqliteClient.SqliteClient)).toEqual(Option.some(sql));

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -30,6 +30,7 @@ import {
   backgroundWorkerBindings,
   backgroundWorkerAuthority,
   backgroundWakeDropPrefixes,
+  customRuntimeThreads,
 } from "./background-worker-fixture.ts";
 import {
   THREADS_BINDING,
@@ -356,7 +357,18 @@ export class ProjectionThreadObject extends ThreadObject.make(
 export class TestThreadObject extends ThreadObject.make(
   Layer.unwrap(
     Effect.map(Effect.all([makeTestBindings, backgroundWorkerBindings]), ([existing, workers]) =>
-      layerFromBindings([...existing, ...workers]),
+      Layer.unwrap(
+        Effect.map(ThreadObjectIdentity, ({ threadId }) =>
+          threadId.startsWith("background-cf-custom-") || customRuntimeThreads.has(threadId)
+            ? Layer.fresh(ThreadMaintenance.layer).pipe(
+                Layer.provideMerge(
+                  DurableAgentRuntime.layerWithBindings([...existing, ...workers]),
+                ),
+                Layer.provideMerge(layerFromBindings([])),
+              )
+            : layerFromBindings([...existing, ...workers]),
+        ),
+      ),
     ),
   ).pipe(
     Layer.provide(backgroundWorkerAuthority),

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -7,7 +7,7 @@ const run: NonNullable<UserConfig["run"]> = {
   tasks: {
     test: {
       command: "vitest run",
-      env: ["BROWSER_TEST_EXECUTABLE"],
+      env: ["BROWSER_TEST_EXECUTABLE", "VITEST_MAX_WORKERS"],
       input: [
         { auto: true },
         { pattern: "bun.lock", base: "workspace" },

--- a/packages/thread/src/WorkerHost.ts
+++ b/packages/thread/src/WorkerHost.ts
@@ -60,6 +60,35 @@ export const WorkerPolicyResolver = Context.Reference<{
 
 const Positive = Schema.Int.check(Schema.isGreaterThan(0));
 
+/** A host-authorized ceiling on active background workers, not retained workers or Run usage. */
+export const WorkerConcurrencyLimit = Schema.Struct({
+  maxActiveWorkersPerSource: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+
+export type WorkerConcurrencyLimit = typeof WorkerConcurrencyLimit.Type;
+
+/**
+ * Optional source-aware operational authority. Resolution occurs inside every new source
+ * reservation attempt, against the same canonical history used for the append CAS. None
+ * preserves WorkerHostConfig; Some can only narrow it. The selected submission is exact,
+ * never the latest input. Implementations must authorize that immutable capture and retain
+ * construction dependencies in Layer R. Unavailable authority must return WorkerError(unavailable).
+ *
+ * One worker occupies a slot while any of its inputs remain unacknowledged. Steering an active
+ * worker does not acquire another slot. Decreases (including zero) do not cancel incumbents;
+ * an idle worker needs a slot again. Idempotent retained reservations do not reacquire slots.
+ */
+export const WorkerConcurrencyResolver = Context.Reference<{
+  readonly resolve: (request: {
+    readonly source: WorkerSource;
+    readonly sourceSubmission?: SubmissionSnapshot;
+    readonly worker: WorkerRef;
+    readonly principal: Principal;
+  }) => Effect.Effect<Option.Option<WorkerConcurrencyLimit>, WorkerError>;
+}>("@effect-agent/thread/WorkerConcurrencyResolver", {
+  defaultValue: () => ({ resolve: () => Effect.succeed(Option.none()) }),
+});
+
 /** Host ceilings apply across all declarations owned by one source Thread. */
 export const WorkerHostLimits = Schema.Struct({
   maxWorkersPerSource: Positive.check(Schema.isLessThanOrEqualTo(100)),

--- a/packages/thread/src/internal/worker-host.ts
+++ b/packages/thread/src/internal/worker-host.ts
@@ -91,6 +91,8 @@ import {
 } from "../ThreadStore.ts";
 import {
   WorkerBudgetAuthorizer,
+  WorkerConcurrencyLimit,
+  WorkerConcurrencyResolver,
   WorkerHostAuthorizer,
   WorkerHostConfig,
   WorkerPolicyResolver,
@@ -242,6 +244,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     authorizer: yield* WorkerHostAuthorizer,
     budgetAuthorizer: yield* WorkerBudgetAuthorizer,
     policyResolver: yield* WorkerPolicyResolver,
+    concurrencyResolver: yield* WorkerConcurrencyResolver,
     limits: yield* WorkerHostConfig,
     failpoint: yield* DurableRuntimeFailpoint,
     status: Option.getOrUndefined(admission)?.submissionStatus ?? control.status,
@@ -700,6 +703,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
     admission: WorkerAdmission,
     inputDigest: Digest,
     input: PersistedJson,
+    principal: Principal,
   ): Effect.fn.Return<void, WorkerError> {
     const origin = admission.origin;
     const id = `worker-input:${admission.messageId}`;
@@ -862,11 +866,26 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         (row) => row.admission.origin.worker.threadId === origin.worker.threadId,
       ).length;
 
+      // Resolve inside the source CAS loop: independently delivered starts must compete
+      // against one canonical prefix. A conflict repeats both authority and capacity reads.
+      const selectedConcurrency = yield* deps.concurrencyResolver.resolve({
+        source: origin.source,
+        worker: origin.worker,
+        principal,
+        ...(source.submission === undefined ? {} : { sourceSubmission: source.submission }),
+      });
+
+      const sourceConcurrency = Option.isSome(selectedConcurrency)
+        ? (yield* decode(WorkerConcurrencyLimit, selectedConcurrency.value, "start"))
+            .maxActiveWorkersPerSource
+        : Infinity;
+
       if (
         pendingOwn >= deps.limits.maxPendingInputsPerWorker ||
         (!activeWorkers.has(origin.worker.threadId) &&
           activeWorkers.size >=
             Math.min(
+              sourceConcurrency,
               deps.limits.maxActiveWorkersPerSource ?? source.policy.toolConcurrency,
               independent
                 ? Infinity
@@ -973,7 +992,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         admission.deliveryPrincipal !== options.principal)
     )
       return yield* failure("start", "worker-mismatch");
-    yield* reservation(admission, inputDigest, input);
+    yield* reservation(admission, inputDigest, input, options.principal);
 
     return admission;
   });
@@ -1209,9 +1228,19 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         };
       }
 
+      // Reporting remains owned by the original allocator, even when a later input joins
+      // or starts another Run. Nested reports authorize the enclosing worker's source owner.
+      const authorizationSourceSubmissionId =
+        sourceOrigin === undefined
+          ? firstInput.admission.sourceSubmissionId
+          : workerAdmission?.sourceSubmissionId;
+
       const authorized = yield* deps.authorizer
         .authorize({
           sourceThreadId: sourceOrigin?.source.threadId ?? origin.source.threadId,
+          ...(authorizationSourceSubmissionId === undefined
+            ? {}
+            : { sourceSubmissionId: authorizationSourceSubmissionId }),
           principal,
           operation: "followUp",
           access: "send",

--- a/packages/thread/test/durable-runtime-types.test.ts
+++ b/packages/thread/test/durable-runtime-types.test.ts
@@ -24,7 +24,11 @@ import { Context, Effect, Layer, Option, type Crypto, type DateTime } from "effe
 import type { DurableRuntimeFailpoint } from "../src/DurableFailpoint.ts";
 import type { makeMessagingRuntime } from "../src/internal/messaging-host.ts";
 import type { makeWorkerRuntime, WorkerInputControl } from "../src/internal/worker-host.ts";
-import { WorkerPolicyResolver } from "../src/WorkerHost.ts";
+import {
+  WorkerConcurrencyResolver,
+  type WorkerConcurrencyLimit,
+  WorkerPolicyResolver,
+} from "../src/WorkerHost.ts";
 
 type Runtime = DurableAgentRuntime["Service"];
 type Head = ReturnType<Runtime["processThreadHead"]>;
@@ -48,8 +52,24 @@ const capturedPolicyLayer = Layer.effect(
   }),
 );
 
+const sourceConcurrencyLayer = Layer.effect(
+  WorkerConcurrencyResolver,
+  Effect.gen(function* () {
+    const evidence = yield* PolicyEvidence;
+
+    return {
+      resolve: () =>
+        Effect.succeed(Option.some({ maxActiveWorkersPerSource: evidence.policy.toolConcurrency })),
+    };
+  }),
+);
+
 it("keeps bounded worker operations and status reads typed without hidden requirements", () => {
   expectTypeOf<Layer.Services<typeof capturedPolicyLayer>>().toEqualTypeOf<PolicyEvidence>();
+  expectTypeOf<Layer.Services<typeof sourceConcurrencyLayer>>().toEqualTypeOf<PolicyEvidence>();
+  expectTypeOf<ReturnType<(typeof WorkerConcurrencyResolver.Service)["resolve"]>>().toEqualTypeOf<
+    Effect.Effect<Option.Option<WorkerConcurrencyLimit>, WorkerError>
+  >();
   expectTypeOf<ReturnType<SubagentHost["Service"]["resolveTargetPolicy"]>>().toEqualTypeOf<
     Effect.Effect<Option.Option<AgentPolicy>, WorkerError>
   >();

--- a/packages/thread/test/worker-host.test.ts
+++ b/packages/thread/test/worker-host.test.ts
@@ -81,6 +81,7 @@ import { PendingSubmission, SettledSubmission } from "../src/SubmissionStatus.ts
 import { PreparedInput } from "../src/Subscription.ts";
 import {
   WorkerBudgetAuthorizer,
+  WorkerConcurrencyResolver,
   WorkerHostAuthorizer,
   WorkerHostConfig,
   WorkerPolicyResolver,
@@ -174,6 +175,8 @@ const reportWith = (
 const harness = Effect.fn("workerHostHarness")(function* (
   options: {
     readonly independentBudget?: boolean;
+    readonly limits?: Partial<typeof WorkerHostConfig.Service>;
+    readonly authorize?: (typeof WorkerHostAuthorizer.Service)["authorize"];
     readonly sourceRevisions?: ReadonlyArray<{
       readonly definition: Agent.AnyDefinition;
       readonly digests: DefinitionDigests;
@@ -266,6 +269,7 @@ const harness = Effect.fn("workerHostHarness")(function* (
       maxInputsPerWorker: 3,
       maxPendingInputsPerWorker: 2,
       lifetimeMillis: 60_000,
+      ...options.limits,
     }),
     Effect.provideService(WorkerHostAuthorizer, {
       authorize: (request) =>
@@ -276,7 +280,9 @@ const harness = Effect.fn("workerHostHarness")(function* (
             request.principal !== principal ||
             !logs.has(request.sourceThreadId)
             ? WorkerError.make({ operation: request.operation, reason: "denied" })
-            : Effect.succeed(principal);
+            : options.authorize === undefined
+              ? Effect.succeed(principal)
+              : options.authorize(request);
         }),
     }),
     Effect.provideService(DurableRuntimeFailpoint, {
@@ -606,6 +612,177 @@ const harness = Effect.fn("workerHostHarness")(function* (
 layer(NodeCrypto.layer)((it) => {
   // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
   it.effect(
+    "serializes source-aware active slots across raced starts, steering and idle reactivation",
+    () =>
+      Effect.gen(function* () {
+        let limit = 1;
+
+        const h = yield* harness({
+          independentBudget: true,
+          limits: { maxWorkersPerSource: 10, maxInputsPerWorker: 10, maxPendingInputsPerWorker: 3 },
+        }).pipe(
+          Effect.provideService(WorkerConcurrencyResolver, {
+            resolve: (request) =>
+              Effect.sync(() => {
+                expect(request.source.threadId).toBe(sourceId);
+                expect(request.principal).toBe(principal);
+                expect(request.sourceSubmission).toBeUndefined();
+
+                return Option.some({ maxActiveWorkersPerSource: limit });
+              }),
+          }),
+        );
+
+        const start = (key: string) => h.host.start({ ...request(key), budgetScope: "worker-run" });
+
+        const raced = yield* Effect.all(
+          [start("slot-a"), start("slot-b")].map((effect) =>
+            effect.pipe(
+              Effect.map(Option.some),
+              Effect.catchTag("WorkerError", () => Effect.succeed(Option.none())),
+            ),
+          ),
+          { concurrency: "unbounded" },
+        );
+
+        expect(raced.filter(Option.isSome)).toHaveLength(1);
+        const first = Option.getOrThrow(raced.find(Option.isSome)!);
+
+        limit = 0;
+
+        const follow = (key: string) =>
+          h.host.followUp({
+            worker: first.worker,
+            target,
+            idempotencyKey: Schema.decodeSync(IdempotencyKey)(key),
+            encodedInput: { text: key },
+            encodedParameters: { note: key },
+          });
+
+        const steering = yield* follow("active-steering");
+
+        expect(yield* follow("active-steering")).toEqual(steering);
+        expect((yield* start("blocked-zero").pipe(Effect.flip)).reason).toBe("capacity");
+        yield* h.settle(first.receipt);
+        // A queued/steering input still owns the slot after the first receipt settles.
+        expect((yield* start("blocked-pending").pipe(Effect.flip)).reason).toBe("capacity");
+        yield* h.settle(steering, "steered", { host: first.receipt });
+        expect((yield* follow("idle-blocked").pipe(Effect.flip)).reason).toBe("capacity");
+        limit = 1;
+        const later = yield* follow("idle-later");
+
+        expect(later.threadId).toEqual(first.worker.threadId);
+        expect(h.submissions.get(later.submissionId)?.workerAdmission?.origin).toEqual(
+          h.submissions.get(first.receipt.submissionId)?.workerAdmission?.origin,
+        );
+        yield* h.settle(later);
+        limit = 1_000;
+        yield* start("host-one");
+        yield* start("host-two");
+        expect((yield* start("host-three").pipe(Effect.flip)).reason).toBe("capacity");
+      }),
+  );
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+  it.effect(
+    "retries unavailable source capacity with the same exact owner and reservation after append loss",
+    () =>
+      Effect.gen(function* () {
+        let unavailable = true;
+        let calls = 0;
+        const ownerId = Schema.decodeSync(SubmissionId)("capacity-owner");
+
+        const h = yield* harness({ independentBudget: true }).pipe(
+          Effect.provideService(WorkerConcurrencyResolver, {
+            resolve: (request) =>
+              Effect.suspend(() => {
+                calls++;
+                expect(request.source.threadId).toBe(sourceId);
+                expect(request.sourceSubmission?.submissionId).toBe(ownerId);
+                expect(request.sourceSubmission?.inputPayload).toBe("captured concurrency one");
+
+                return unavailable
+                  ? WorkerError.make({ operation: "start", reason: "unavailable" })
+                  : Effect.succeed(Option.some({ maxActiveWorkersPerSource: 1 }));
+              }),
+          }),
+        );
+
+        h.submissions.set(
+          ownerId,
+          SubmissionSnapshot.make({
+            submissionId: ownerId,
+            receiptId: Schema.decodeSync(ReceiptId)("capacity-owner-receipt"),
+            threadId: sourceId,
+            principal,
+            idempotencyKey: Schema.decodeSync(IdempotencyKey)("owner"),
+            queueSequence: Schema.decodeSync(QueueSequence)(1),
+            agentId: sourceAgent.id,
+            agentDigests: definitions,
+            deploymentId: Schema.decodeSync(DeploymentId)("test"),
+            inputPayload: "captured concurrency one",
+            inputDigest: digest,
+            state: "settled",
+            createdAt: DateTime.makeUnsafe(yield* Clock.currentTimeMillis),
+          }),
+        );
+
+        const host = yield* h.runtime.acquire({
+          sourceThreadId: sourceId,
+          sourceSubmissionId: ownerId,
+          principal,
+        });
+
+        const start = () => host.start({ ...request("retry-capacity"), budgetScope: "worker-run" });
+
+        // The public host reports the retryable delivery as storage; admission keeps its typed code.
+        expect((yield* start().pipe(Effect.flip)).reason).toBe("storage");
+        expect(calls).toBe(1);
+        expect([...h.deliveries.values()][0]?.status).toBe("pending");
+        const envelope = [...h.deliveries.values()][0]!.envelope;
+
+        expect(
+          (yield* h.runtime
+            .validateAdmission(
+              envelope.workerAdmission!,
+              {
+                threadId: envelope.threadId,
+                principal: envelope.deliveryPrincipal,
+                definitions: envelope.definitions,
+                idempotencyKey: envelope.admissionKey,
+              },
+              envelope.agentId,
+              envelope.inputDigest,
+              envelope.input,
+            )
+            .pipe(Effect.flip)).reason,
+        ).toBe("unavailable");
+        expect(
+          h.logs
+            .get(sourceId)
+            ?.filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+        ).toHaveLength(0);
+        unavailable = false;
+        yield* TestClock.adjust("1 second");
+        h.fail("worker:after-source-append");
+        expect((yield* start().pipe(Effect.flip)).reason).toBe("storage");
+        h.fail(undefined);
+        unavailable = true;
+        const attempts = calls;
+
+        yield* TestClock.adjust("31 seconds");
+        const recovered = yield* start();
+
+        expect(calls).toBe(attempts);
+        expect(yield* start()).toEqual(recovered);
+        expect(
+          h.logs
+            .get(sourceId)
+            ?.filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+        ).toHaveLength(1);
+      }),
+  );
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
+  it.effect(
     "pins captured owner reporting across later owner revisions while preserving legacy context and reports",
     () =>
       Effect.gen(function* () {
@@ -678,8 +855,24 @@ layer(NodeCrypto.layer)((it) => {
 
         let reportsB = 0;
         let reportsC = 0;
+        const reportOwners: Array<SubmissionId | undefined> = [];
 
         const opted = yield* harness({
+          // Regression: https://github.com/danieljvdm/effect-agent/commit/4600d240f44b1ef1fe9b0fc58f39e293a6434f85
+          // A strict owner needs the original locator even after its Run is idle.
+          authorize: (request) =>
+            Effect.gen(function* () {
+              if (request.operation === "followUp") {
+                reportOwners.push(request.sourceSubmissionId);
+                if (request.sourceSubmissionId === undefined)
+                  return yield* WorkerError.make({
+                    operation: request.operation,
+                    reason: "denied",
+                  });
+              }
+
+              return principal;
+            }),
           sourceReports: reportsA,
           sourceRevisions: [
             {
@@ -778,6 +971,7 @@ layer(NodeCrypto.layer)((it) => {
         expect(opted.submissions.get(next.submissionId)!.workerAdmission!.origin).toEqual(origin);
         expect(reportsB).toBe(2);
         expect(reportsC).toBe(0);
+        expect(reportOwners).toEqual([ownerId, laterOwnerId, ownerId]);
         expect(
           [...opted.deliveries.values()]
             .filter((row) => row.envelope.threadId === sourceId)


### PR DESCRIPTION
Background workers need to respect a source’s active-task preference while keeping their execution allowances independent. A new optional `WorkerConcurrencyResolver` narrows the fixed host ceiling inside the canonical reservation loop, so concurrent starts compete for the same slots. Active steering and retained retries keep their existing slot; idle workers acquire one before new work. Temporary authority failures remain retryable.

```text
Worker input → exact source owner → concurrency resolver
             → canonical reservation CAS → destination admission
                ↳ conflict: reread authority and occupied slots
```

For example, a host can allow three active workers per source:

```ts
Layer.succeed(WorkerConcurrencyResolver)({
  resolve: () => Effect.succeed(Option.some({ maxActiveWorkersPerSource: 3 })),
});
```

Return `Option.none()` to preserve the fixed host policy, or `WorkerError` with reason `unavailable` when source authority cannot be read. The resolver changes operational admission only; it adds no token or spending ceiling.

Terminal reports also pass their original owner submission to authorization, including nested workers. Cloudflare’s public runtime layer now retains its existing native message recovery capability when a consumer rebuilds runtime maintenance, allowing private progress to reach an idle parent.
