### PR TITLE
feat(thread): recover from disposable canonical checkpoints

### DIFF
--- a/.changeset/bounded-durable-recovery.md
+++ b/.changeset/bounded-durable-recovery.md
@@ -1,0 +1,10 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/thread": patch
+"@effect-agent/testing": patch
+"@effect-agent/storage-memory": patch
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Resume durable runs from disposable recovery checkpoints while preserving canonical side-effect obligations and cumulative accounting. Support up to 131,072 canonical records in storage, exports, and verification, with preserving upgrades for supported SQLite and Durable Object stores.

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -35,6 +35,30 @@ ID. Decode checkpoint state with its Schema before replaying a suffix. Earlier p
 including empty views, fail decoding and must be discarded and rebuilt from canonical records.
 The canonical record and checkpoint envelope versions remain unchanged.
 
+## Resume through a recovery checkpoint {#recovery-checkpoints}
+
+After a durable compaction or context rollover commits its replacement, the runtime can save a
+recovery checkpoint through `ThreadStore.recoveryCheckpoints`. The checkpoint preserves the
+replacement context, protected instructions and input, cumulative usage and policy accounting,
+the latest replayable tool batch, and required control and Durable Step evidence. Completed Step
+results remain available for reuse after an ownership change.
+
+This optional cache holds one latest snapshot per Thread. Saves require the current producer
+epoch and bind the snapshot to a canonical batch tail. It is separate from the generic
+`ThreadStore.checkpoints` slot used by application projections. Neither slot changes canonical
+history or owns a submission.
+
+Recovery checks the checkpoint's versions, state digest, agent/model/tool definitions, retained
+submissions, and canonical binding before replaying the suffix. The suffix is limited to 4,096
+records, read in pages of at most 1,024. Missing, corrupt, incompatible, or ineligible checkpoints
+fall back to the captured canonical prefix. A longer or incompatible suffix also uses full replay;
+cache capacity never justifies dropping control or Step evidence. Storage infrastructure failures
+remain typed failures.
+
+The canonical log and submission ledger remain authoritative. A history-search index supplies
+retrieval candidates and cannot stand in for this recovery state. Ordinary unresolved tools keep
+the same reconciliation and unknown-outcome rules with or without a checkpoint.
+
 ## Track unfinished work {#operational-obligation}
 
 The submission ledger owns admission, FIFO readiness, attempt ownership, abort intent, recovery,

--- a/docs/guide/certify-adapters.md
+++ b/docs/guide/certify-adapters.md
@@ -21,9 +21,32 @@ records, exports history, and inspects the tail. Appends must be atomic, digest-
 batch ID, checked against the expected tail, and fenced by producer epoch. Reads decode stored
 values through schemas.
 
-Checkpoint support is optional and used only by explicit projection consumers. Retained history
-and durable recovery do not read it. An adapter with checkpoints must also run the checkpoint
-conformance suite.
+`ThreadStore.checkpoints` is optional storage for application projections. An adapter offering it
+must run the generic checkpoint conformance suite. Retained-history execution does not use it.
+
+The separate optional `ThreadStore.recoveryCheckpoints` capability stores one latest recovery
+snapshot per Thread. `SaveRecoveryCheckpointRequest` carries the checkpoint and producer epoch.
+In one transaction, validate epoch equality and the canonical batch tail sequence and digest,
+then replace the cached value. An older snapshot must not replace a newer one; equal-tail
+replacement permits repair. Keep generic projection checkpoints independent of this slot.
+
+Decode stored recovery checkpoints and verify their canonical binding on load. Invalid cache data
+returns `CheckpointRejected`; infrastructure failures remain `ThreadStoreError`. A lookup before
+the latest checkpoint may return no checkpoint. The runtime validates its versioned continuation
+state and falls back to canonical replay when the cache is absent or incompatible. Neither a
+checkpoint nor an evidence index grants ownership or replaces canonical tool and Durable Step
+evidence. See [recovery checkpoints](../concepts/durability#recovery-checkpoints) for eligibility
+and suffix bounds.
+
+Test recovery checkpoint replacement, stale producers, corruption, absence, and reopen after failure,
+interruption, and timeout. Persistent format upgrades must preserve supported stored data in one
+transaction, advance the version marker last, and refuse unsupported or ambiguous layouts without
+resetting them.
+
+The supplied adapters and `ThreadExport` support 131,072 canonical records per Thread. Keep each
+`ThreadRead` page at or below 1,024 records and each `CanonicalBatch` at or below 256. An export
+must preserve one captured snapshot while paging its payload reads; it returns the full record
+array and must not silently truncate history.
 
 Implement `SubmissionLedger.readAbortIntent` as a strongly consistent read of one submission's
 abort intent. The runtime polls this method during execution, so its work must stay independent

--- a/docs/guide/context-management.md
+++ b/docs/guide/context-management.md
@@ -1247,9 +1247,14 @@ returning the first page again. The built-in `ThreadContextHistory.layer` implem
 over every `ThreadStore`; its default scan ceiling and deadline are unchanged, and storage
 adapters need no persisted-format migration.
 
-An evidence index does not replace durable recovery. Journal and recovery-control reconstruction
-still traverse historical canonical records after rollover. Measure that host path separately
-before adopting longer histories; a bounded model prompt does not establish bounded startup work.
+An evidence index supplies retrieval candidates; canonical history and the submission ledger own
+recovery. After a committed rollover, the runtime can use a compatible
+[recovery checkpoint](../concepts/durability#recovery-checkpoints) containing the replacement
+context, cumulative accounting, and retained control and Durable Step evidence. It reads at most
+4,096 suffix records through pages of at most 1,024; an absent, invalid, or incompatible checkpoint
+or suffix falls back to the captured canonical prefix. Checkpoint eligibility is separate from
+index coverage and prompt size, so measure both the checkpoint path and full-replay fallback before
+adopting longer histories.
 
 ### Manage summaries yourself {#explicit-compaction-artifacts}
 

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -407,13 +407,20 @@ uncertainty, payloads and transactional prearming; this extension defines no pro
 ### Adopting these contracts
 
 The persistent adapters automatically upgrade supported predecessor formats on acquisition:
-Cloudflare Thread stores move from version 2 or 3 to 4; Schedule and Subscription stores move
-from version 2 to 3; the combined SQLite file moves from version 7 or 8 to 9. Thread and SQLite
-stores add independently discoverable message delivery storage. Each owning store upgrades in one native transaction and advances
-its version marker last. Reopening after interruption retries the entire uncommitted upgrade.
+Cloudflare Thread stores move from version 2, 3, or 4 to 5; Schedule and Subscription stores move
+from version 2 to 3; the combined SQLite file moves from version 7, 8, or 9 to 10. Thread and SQLite
+stores add a separate slot for the latest recovery checkpoint and, where needed, independently discoverable
+message delivery storage. Each owning store upgrades in one native transaction and advances its
+version marker last. Reopening after interruption retries the entire uncommitted upgrade.
 Namespaces, canonical history and digests, receipts, pending work, ownership, deadlines, alarm
 generations and scan cursors are preserved. Keep the existing namespace/file and the old source
 versions, input bindings and agent registrations needed to finish retained work.
+
+Recovery checkpoints are disposable: missing or incompatible cache state rebuilds from canonical
+history. Upgrades preserve existing generic projection checkpoints. The optional `verifyOnOpen`
+audit checks canonical history and generic projection checkpoints; recovery caches are validated
+when loaded. See [recovery checkpoints](../concepts/durability#recovery-checkpoints) for the bounded
+resume path and its fallback rules.
 
 Legacy subscription configurations become revision 1 and remain the immutable configuration for
 already selected deliveries. Retry counts become the initial generation's automatic attempt count;

--- a/docs/guide/threads.md
+++ b/docs/guide/threads.md
@@ -63,9 +63,9 @@ A failure, defect, timeout, or interruption before commit retains none of the cu
 storage error after commit can leave the whole run recorded, so inspect history before retrying.
 The runtime never retries execution or resumes an interrupted run.
 
-Each encoded input, output, and native Prompt suffix has a 1 MiB limit. Exports have a 65,536
-record limit. If the next run would cross that limit, execution fails before model or tool calls.
-Start a new thread to continue.
+Each encoded input, output, and native Prompt suffix has a 1 MiB limit. The supplied adapters and
+`ThreadExport` support up to 131,072 canonical records per Thread. If the next run would cross
+that limit, execution fails before model or tool calls. Start a new thread to continue.
 
 ### Choose one history owner {#history-policy-and-append-ownership}
 
@@ -126,7 +126,13 @@ is append-only. It records user input, completed model output, settled tool call
 completion or failure, and repairs. Partial tool argument deltas and live queue state are absent.
 
 Immediate history appends `UserInputRecorded`, `ModelCompleted`, and `RunCompleted` together.
-Durable execution records each turn and tool result separately for recovery.
+Durable execution records each turn and tool result separately for recovery. It can resume from a
+[disposable recovery checkpoint](../concepts/durability#recovery-checkpoints) plus a bounded suffix;
+retained-history execution still loads the complete export.
+
+`ThreadStore.read` returns at most 1,024 records per request, and each atomic `CanonicalBatch`
+contains at most 256 records. SQLite and Cloudflare exports read payloads in bounded pages while
+preserving one captured snapshot; the returned export still contains the complete record array.
 
 <a id="store-contract"></a>
 
@@ -138,8 +144,9 @@ Durable execution records each turn and tool result separately for recovery.
 | `@effect-agent/storage-sqlite`     | History that survives a Node process restart        |
 | `@effect-agent/storage-cloudflare` | Durable Object SQLite history and routed operations |
 
-The SQLite adapter supports only the current pre-1.0 schema. Incompatible data fails clearly and
-may require a reset. See [Persistence & durability](../concepts/durability) before claiming that
-active execution survives process loss.
+Persistent adapters upgrade supported predecessor formats atomically while preserving stored
+history and accepted work. Unsupported or ambiguous formats fail without resetting the store.
+See [supported storage upgrades](./operations#adopting-these-contracts) before adopting a new
+version, and [Persistence & durability](../concepts/durability) for execution recovery guarantees.
 
 For a custom adapter, follow the [store contract and certification guide](./certify-adapters#store-contract).

--- a/packages/core/src/Usage.ts
+++ b/packages/core/src/Usage.ts
@@ -211,17 +211,66 @@ const checkedAdd = (
       );
 };
 
-/** Deterministically aggregate canonical per-call usage without making cached tokens free. */
+/**
+ * Deterministically aggregate canonical per-call usage without making cached tokens free.
+ * A validated seed retains earlier call totals and pricing groups without retaining those calls.
+ * Empty contributions do not change completeness; the seed is never mutated.
+ */
 export const summarizeModelUsage = Effect.fn("summarizeModelUsage")(function* (
   calls: ReadonlyArray<ModelCallUsage>,
+  seed?: RunUsageSummary,
 ): Effect.fn.Return<RunUsageSummary, UsageAggregationError> {
-  const inputTokens = emptyInputTokens();
-  const outputTokens = emptyOutputTokens();
+  const initial =
+    seed === undefined
+      ? undefined
+      : yield* Schema.decodeUnknownEffect(RunUsageSummary)(seed).pipe(
+          Effect.mapError(
+            () =>
+              new UsageAggregationError({
+                field: "seed",
+                message: "Canonical usage seed does not satisfy the RunUsageSummary Schema",
+              }),
+          ),
+        );
+
+  const inputTokens = initial === undefined ? emptyInputTokens() : { ...initial.inputTokens };
+  const outputTokens = initial === undefined ? emptyOutputTokens() : { ...initial.outputTokens };
   const groups = new Map<string, MutableUsageGroup>();
-  let modelCalls = 0;
-  let costMicrousd = 0;
+  let modelCalls = initial?.modelCalls ?? 0;
+  let costMicrousd = initial?.costMicrousd ?? 0;
+  const hasSeedCalls = modelCalls > 0;
+
+  let allUsageUnknown =
+    !hasSeedCalls || initial?.usageStatus === undefined || initial.usageStatus === "unknown";
+
+  let allUsageComplete = !hasSeedCalls || initial?.usageStatus === "complete";
+
+  let allPricingUnknown =
+    !hasSeedCalls || initial?.pricingStatus === undefined || initial.pricingStatus === "unknown";
+
+  let allPricingComplete = !hasSeedCalls || initial?.pricingStatus === "complete";
+
+  for (const group of initial?.byModel ?? []) {
+    const key = JSON.stringify([
+      group.provider,
+      group.model,
+      group.responseModel ?? null,
+      group.serviceTier ?? null,
+      group.pricingVersion ?? null,
+    ]);
+
+    groups.set(key, {
+      ...group,
+      inputTokens: { ...group.inputTokens },
+      outputTokens: { ...group.outputTokens },
+    });
+  }
 
   for (const call of calls) {
+    allUsageUnknown &&= call.usageStatus === undefined || call.usageStatus === "unknown";
+    allUsageComplete &&= call.usageStatus === "complete";
+    allPricingUnknown &&= call.pricingStatus !== "estimated";
+    allPricingComplete &&= call.pricingStatus === "estimated";
     modelCalls = yield* checkedAdd("modelCalls", modelCalls, 1);
     inputTokens.total = yield* checkedAdd(
       "inputTokens.total",
@@ -332,18 +381,11 @@ export const summarizeModelUsage = Effect.fn("summarizeModelUsage")(function* (
     inputTokens: InputTokenUsage.make(inputTokens),
     outputTokens: OutputTokenUsage.make(outputTokens),
     costMicrousd,
-    usageStatus: calls.every(
-      (call) => call.usageStatus === undefined || call.usageStatus === "unknown",
-    )
-      ? "unknown"
-      : calls.every((call) => call.usageStatus === "complete")
-        ? "complete"
-        : "partial",
-    pricingStatus: calls.every((call) => call.pricingStatus !== "estimated")
-      ? "unknown"
-      : calls.every((call) => call.pricingStatus === "estimated")
-        ? "complete"
-        : "partial",
+    usageStatus: allUsageUnknown ? "unknown" : allUsageComplete ? "complete" : "partial",
+    pricingStatus: allPricingUnknown ? "unknown" : allPricingComplete ? "complete" : "partial",
+    ...(initial?.unobservedModelCalls === undefined
+      ? {}
+      : { unobservedModelCalls: initial.unobservedModelCalls }),
     byModel: [...groups.values()].map((group) =>
       ModelUsageGroup.make({
         provider: group.provider,

--- a/packages/core/test/provider-usage.test.ts
+++ b/packages/core/test/provider-usage.test.ts
@@ -1,6 +1,11 @@
-import { ModelCallUsage, RunUsageSummary, summarizeModelUsage } from "@effect-agent/core/Usage";
+import {
+  ModelCallUsage,
+  RunUsageSummary,
+  summarizeModelUsage,
+  UsageAggregationError,
+} from "@effect-agent/core/Usage";
 import { Effect, Schema } from "effect";
-import { expect, it } from "vite-plus/test";
+import { expect, expectTypeOf, it } from "vite-plus/test";
 
 const legacy = {
   provider: "test",
@@ -40,5 +45,144 @@ it("decodes legacy usage conservatively and separates actual models sharing a bi
       expect(
         Schema.decodeUnknownExit(RunUsageSummary)(Schema.encodeSync(RunUsageSummary)(summary))._tag,
       ).toBe("Success");
+    }),
+  ));
+
+it("resumes usage aggregation at every split without retaining calls or mutating the seed", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const complete = (model: string) =>
+        ModelCallUsage.make({
+          ...legacy,
+          response: { model },
+          usageStatus: "complete",
+          pricingStatus: "estimated",
+        });
+
+      const calls = [
+        complete("actual-a"),
+        complete("actual-b"),
+        ModelCallUsage.make(legacy),
+        complete("actual-a"),
+        ModelCallUsage.make({ ...legacy, serviceTier: "flex", usageStatus: "partial" }),
+      ];
+
+      const full = yield* summarizeModelUsage(calls);
+
+      expect(full).toMatchObject({
+        modelCalls: 5,
+        inputTokens: { total: 15, uncached: 5, cacheRead: 5, cacheWrite: 5 },
+        outputTokens: { total: 10, text: 5, reasoning: 5 },
+        costMicrousd: 25,
+        usageStatus: "partial",
+        pricingStatus: "partial",
+      });
+      expect(full.byModel.map((group) => group.modelCalls)).toEqual([2, 1, 1, 1]);
+
+      for (let split = 0; split <= calls.length; split += 1) {
+        const seed = yield* summarizeModelUsage(calls.slice(0, split));
+        const encoded = Schema.encodeSync(RunUsageSummary)(seed);
+
+        expectTypeOf(summarizeModelUsage([], seed)).toEqualTypeOf<
+          Effect.Effect<RunUsageSummary, UsageAggregationError>
+        >();
+        expect(yield* summarizeModelUsage(calls.slice(split), seed)).toEqual(full);
+        expect(Schema.encodeSync(RunUsageSummary)(seed)).toEqual(encoded);
+      }
+
+      let incremental = yield* summarizeModelUsage([]);
+
+      for (const call of calls) incremental = yield* summarizeModelUsage([call], incremental);
+      expect(incremental).toEqual(full);
+    }),
+  ));
+
+it("combines completeness conservatively while treating empty summaries as neutral", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const unknown = ModelCallUsage.make(legacy);
+
+      const complete = ModelCallUsage.make({
+        ...legacy,
+        usageStatus: "complete",
+        pricingStatus: "estimated",
+      });
+
+      const cases = [
+        { prefix: [], suffix: [complete], expected: "complete" },
+        { prefix: [complete], suffix: [], expected: "complete" },
+        { prefix: [unknown], suffix: [unknown], expected: "unknown" },
+        { prefix: [complete], suffix: [complete], expected: "complete" },
+        { prefix: [unknown], suffix: [complete], expected: "partial" },
+        { prefix: [complete], suffix: [unknown], expected: "partial" },
+        { prefix: [unknown, complete], suffix: [complete], expected: "partial" },
+      ];
+
+      for (const { prefix, suffix, expected } of cases) {
+        const seed = yield* summarizeModelUsage(prefix);
+        const summary = yield* summarizeModelUsage(suffix, seed);
+
+        expect(summary.usageStatus).toBe(expected);
+        expect(summary.pricingStatus).toBe(expected);
+      }
+      const empty = yield* summarizeModelUsage([]);
+
+      expect(yield* summarizeModelUsage([], empty)).toEqual(empty);
+
+      const seed = RunUsageSummary.make({
+        ...(yield* summarizeModelUsage([unknown])),
+        unobservedModelCalls: 2,
+      });
+
+      expect((yield* summarizeModelUsage([complete], seed)).unobservedModelCalls).toBe(2);
+    }),
+  ));
+
+it("rejects invalid seeds and seeded usage overflow through the typed error channel", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const call = (inputTokens: number, costMicrousd: number) =>
+        ModelCallUsage.make({
+          ...legacy,
+          inputTokens: { total: inputTokens, uncached: inputTokens, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 0, text: 0, reasoning: 0 },
+          costMicrousd,
+        });
+
+      const valid = yield* summarizeModelUsage([call(1, 1)]);
+      const invalid = { ...valid, modelCalls: 2 };
+      const invalidResult = yield* summarizeModelUsage([], invalid).pipe(Effect.flip);
+
+      expect(invalidResult).toBeInstanceOf(UsageAggregationError);
+      expect(invalidResult.field).toBe("seed");
+
+      const cases = [
+        { first: call(Number.MAX_SAFE_INTEGER, 0), next: call(1, 0), field: "inputTokens.total" },
+        { first: call(0, Number.MAX_SAFE_INTEGER), next: call(0, 1), field: "costMicrousd" },
+      ];
+
+      for (const { first, next, field } of cases) {
+        const seed = yield* summarizeModelUsage([first]);
+        const error = yield* summarizeModelUsage([next], seed).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(UsageAggregationError);
+        expect(error.field).toBe(field);
+      }
+      const zero = call(0, 0);
+      const group = (yield* summarizeModelUsage([zero])).byModel[0];
+
+      if (group === undefined) return yield* Effect.die("Expected one usage group");
+
+      const callLimit = RunUsageSummary.make({
+        modelCalls: Number.MAX_SAFE_INTEGER,
+        inputTokens: zero.inputTokens,
+        outputTokens: zero.outputTokens,
+        costMicrousd: 0,
+        byModel: [{ ...group, modelCalls: Number.MAX_SAFE_INTEGER }],
+      });
+
+      expect((yield* summarizeModelUsage([zero], callLimit).pipe(Effect.flip)).field).toBe(
+        "modelCalls",
+      );
     }),
   ));

--- a/packages/platform-node/test/crash/fixtures.ts
+++ b/packages/platform-node/test/crash/fixtures.ts
@@ -12,6 +12,7 @@ import {
   DurableStepError,
   ToolExecutionClass,
 } from "@effect-agent/engine/DurableStep";
+import { RunContextPreparation } from "@effect-agent/engine/RunOptions";
 import { DurableWorkerBinding, type ResolvedBinding } from "@effect-agent/thread/AgentRegistration";
 import { Receipt, type DurableSubmitOptions } from "@effect-agent/thread/DurableAgentRuntime";
 import { DefinitionDigests, Digest } from "@effect-agent/thread/Records";
@@ -64,6 +65,7 @@ export const CrashEnv = {
  * - `submit` — durably submit one Submission and print its Receipt.
  * - `abort-ready` — submit, then durably abort the still-unclaimed Submission.
  * - `run` — submit, then drain the lane to Settlement with a single-turn model.
+ * - `run-checkpoint` — roll over before Turn 3 and kill around the recovery-cache write.
  * - `run-two` — submit two FIFO Submissions, then drain the lane.
  * - `run-blocked` — submit, commit Turn 1 (a tool call), then block Turn 2's model stream until
  *   `EFFECT_AGENT_RELEASE_FILE` appears (writing `EFFECT_AGENT_MARKER_FILE` first).
@@ -101,6 +103,7 @@ export const CrashScenario = Schema.Literals([
   "abort-ready",
   "abort-queued",
   "run",
+  "run-checkpoint",
   "run-two",
   "run-blocked",
   "abort-active",
@@ -339,6 +342,68 @@ export const searchDefinition = Agent.make("crash-search", {
 export const searchToolLayer = searchTools.toLayer({
   search: () => Effect.succeed({ available: true }),
 });
+
+export const CHECKPOINT_INSTRUCTIONS = "Keep original checkpoint instructions.";
+export const CHECKPOINT_HANDOFF = "Keep the checkpoint continuation.";
+
+export const checkpointDefinition = Agent.make("crash-checkpoint", {
+  input: Schema.Struct({ question: Schema.String }),
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: CHECKPOINT_INSTRUCTIONS,
+  toolkit: searchTools,
+  policy: AgentPolicy.make({
+    maxTurns: 4,
+    maxToolCalls: 3,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+    runStatus: "appended",
+  }),
+});
+
+/** The real host asks for native rollover after two committed tool Turns. */
+export const checkpointContextLayer = Layer.succeed(RunContextPreparation, {
+  hook: {
+    prepare: (request) =>
+      Effect.succeed({
+        prompt: request.source,
+        ...(request.turn === 3 && !JSON.stringify(request.source).includes(CHECKPOINT_HANDOFF)
+          ? { rollover: { handoff: CHECKPOINT_HANDOFF, through: request.source.content.length } }
+          : {}),
+      }),
+  },
+});
+
+export const checkpointParts = (turn: number): ReadonlyArray<Response.StreamPartEncoded> => {
+  const finish = {
+    type: "finish",
+    reason: turn <= 3 ? "tool-calls" : "stop",
+    usage: { inputTokens: { total: 100 }, outputTokens: { total: 10 } },
+  } satisfies Response.StreamPartEncoded;
+
+  return turn <= 3
+    ? [
+        {
+          type: "tool-call",
+          id: `checkpoint-call-${turn}`,
+          name: "search",
+          params: { query: `checkpoint-read-${turn}` },
+          providerExecuted: false,
+        },
+        finish,
+      ]
+    : [...finalParts(CHILD_ANSWER).slice(0, -1), finish];
+};
+
+/** File markers count actual handler invocations across process loss. */
+export const makeCheckpointToolLayer = (dir: string) =>
+  searchTools.toLayer({
+    search: ({ query }) =>
+      Effect.sync(() => {
+        recordSupplierCall(dir, "checkpoint-read", query, "available");
+
+        return { available: true };
+      }),
+  });
 
 const bookPolicy = AgentPolicy.make({
   maxTurns: 3,

--- a/packages/platform-node/test/crash/recovery-checkpoint.test.ts
+++ b/packages/platform-node/test/crash/recovery-checkpoint.test.ts
@@ -1,0 +1,193 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { NodeDurableHost } from "@effect-agent/platform-node/NodeDurableHost";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import { LoadCheckpointRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { NodeFileSystem } from "@effect/platform-node";
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer, Option, Stream } from "effect";
+import { LanguageModel, Model, type Prompt } from "effect/unstable/ai";
+
+import {
+  CHECKPOINT_HANDOFF,
+  CHECKPOINT_INSTRUCTIONS,
+  CRASH_QUESTION,
+  checkpointContextLayer,
+  checkpointDefinition,
+  checkpointParts,
+  decodeThreadId,
+  makeCheckpointToolLayer,
+  supplierCounts,
+} from "./fixtures.ts";
+import {
+  CHILD_LEASE_MS,
+  assertConvergence,
+  expectKilled,
+  lookupByKey,
+  readLog,
+  runWorkerToExit,
+  waitOutChildLease,
+  withCrashSite,
+  withHost,
+  withRuntime,
+} from "./harness.ts";
+
+const crashPoints = [
+  { name: "runtime before save", killAt: "checkpoint:before-save", present: false },
+  { name: "runtime after save", killAt: "checkpoint:after-save", present: true },
+  { name: "SQLite before save", killAtStorage: "save-recovery-checkpoint:before", present: false },
+  { name: "SQLite after save", killAtStorage: "save-recovery-checkpoint:after", present: true },
+] as const;
+
+// Each child exits without finalizers after committing the native compaction. Reopening the
+// same SQLite file must treat that canonical record as authoritative with or without its cache.
+layer(NodeFileSystem.layer, { excludeTestServices: true })(
+  "recovery checkpoint process loss",
+  (it) => {
+    it.effect.each(crashPoints)(
+      "recovers after $name",
+      (point) =>
+        withCrashSite((site) =>
+          Effect.gen(function* () {
+            const thread = "checkpoint-crash";
+            const key = "checkpoint-crash";
+            const threadId = decodeThreadId(thread);
+
+            const child = yield* runWorkerToExit({
+              db: site.db,
+              scenario: "run-checkpoint",
+              thread,
+              key,
+              supplierDir: site.supplier,
+              leaseMillis: CHILD_LEASE_MS,
+              ...point,
+            });
+
+            expectKilled(child);
+            expect(supplierCounts(site.supplier)).toEqual({
+              "checkpoint-read:checkpoint-read-1": 1,
+              "checkpoint-read:checkpoint-read-2": 1,
+            });
+
+            const before = yield* withRuntime(
+              site.db,
+              Effect.gen(function* () {
+                const store = yield* ThreadStore;
+                const cache = store.recoveryCheckpoints;
+
+                if (cache === undefined)
+                  throw new Error("SQLite recovery checkpoints are required");
+                const checkpoint = yield* cache.load(LoadCheckpointRequest.make({ threadId }));
+                const records = yield* readLog(thread);
+                const snapshot = yield* lookupByKey(thread, key);
+
+                const compactions = records.filter(
+                  ({ record }) => record.payload._tag === "CompactionCreated",
+                );
+
+                expect(Option.isSome(checkpoint)).toBe(point.present);
+                expect(compactions).toHaveLength(1);
+                expect(JSON.stringify(compactions)).toContain(CHECKPOINT_HANDOFF);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "ModelResponseRecorded"),
+                ).toHaveLength(2);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "ToolCallSettled"),
+                ).toHaveLength(2);
+
+                return { records, submissionId: snapshot.submissionId };
+              }),
+            );
+
+            yield* waitOutChildLease;
+            yield* withHost(
+              site.db,
+              Effect.gen(function* () {
+                const host = yield* NodeDurableHost;
+                const runtime = yield* DurableAgentRuntime;
+
+                const report = host.startupRecovery.find(
+                  (entry) => entry.submissionId === before.submissionId,
+                );
+
+                expect(report?.decision._tag).toBe("ResumeFromTurnBoundary");
+                expect(report?.disposition).toBe("deferred");
+                const requests: Array<Prompt.Prompt> = [];
+
+                const model = Model.make(
+                  "scripted",
+                  "crash-harness",
+                  Layer.effect(
+                    LanguageModel.LanguageModel,
+                    LanguageModel.make({
+                      generateText: () => Effect.succeed([]),
+                      streamText: (request) => {
+                        requests.push(request.prompt);
+
+                        return Stream.fromIterable(checkpointParts(requests.length + 2));
+                      },
+                    }),
+                  ),
+                );
+
+                const settlements = yield* runtime
+                  .processThread(Agent.withModel(checkpointDefinition, model), threadId)
+                  .pipe(Effect.provide(makeCheckpointToolLayer(site.supplier)));
+
+                expect(settlements).toHaveLength(1);
+                expect(settlements[0]?.outcome).toBe("completed");
+                expect(settlements[0]?.usageSummary?.modelCalls).toBe(4);
+                expect(settlements[0]?.usageSummary?.inputTokens.total).toBe(400);
+                expect(settlements[0]?.usageSummary?.outputTokens.total).toBe(40);
+                expect(requests).toHaveLength(2);
+                for (const request of requests) {
+                  const prompt = JSON.stringify(request);
+
+                  expect(prompt).toContain(CRASH_QUESTION);
+                  expect(prompt).toContain(CHECKPOINT_INSTRUCTIONS);
+                  expect(prompt).toContain(CHECKPOINT_HANDOFF);
+                  expect(prompt).not.toContain('"id":"checkpoint-call-1"');
+                  expect(prompt).not.toContain('"id":"checkpoint-call-2"');
+                }
+                const first = JSON.stringify(requests[0]);
+
+                expect(first).toContain("turn 3/4");
+                expect(first).toContain("tool-calls 2/3");
+                expect(first).toContain("tokens 220/");
+                const last = JSON.stringify(requests[1]);
+
+                expect(last).toContain("turn 4/4");
+                expect(last).toContain("tool-calls 3/3");
+                expect(last).toContain("tokens 330/");
+
+                const records = yield* readLog(thread);
+
+                expect(records.slice(0, before.records.length)).toEqual(before.records);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "RunStarted"),
+                ).toHaveLength(1);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "CompactionCreated"),
+                ).toHaveLength(1);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "ModelResponseRecorded"),
+                ).toHaveLength(4);
+                expect(
+                  records.filter(({ record }) => record.payload._tag === "ToolCallSettled"),
+                ).toHaveLength(3);
+                yield* assertConvergence(thread, [before.submissionId], {
+                  site,
+                  counts: {
+                    "checkpoint-read:checkpoint-read-1": 1,
+                    "checkpoint-read:checkpoint-read-2": 1,
+                    "checkpoint-read:checkpoint-read-3": 1,
+                  },
+                });
+              }),
+              { runContext: checkpointContextLayer },
+            );
+          }),
+        ),
+      30_000,
+    );
+  },
+);

--- a/packages/platform-node/test/crash/worker-entry.ts
+++ b/packages/platform-node/test/crash/worker-entry.ts
@@ -48,6 +48,10 @@ import {
   approvalDefinition,
   approvalTools,
   coordinatorSubmitSlice,
+  checkpointContextLayer,
+  checkpointDefinition,
+  checkpointParts,
+  makeCheckpointToolLayer,
   crashSubmitOptions,
   decodeThreadId,
   decodeToolCallId,
@@ -181,6 +185,7 @@ const options: NodeDurableAgentRuntimeOptions = {
   wakeScanInterval: 1_000,
   runtimeFailpoint: runtimeKill,
   storageFailpoint: storageKill,
+  ...(env.EFFECT_AGENT_SCENARIO === "run-checkpoint" ? { runContext: checkpointContextLayer } : {}),
 };
 
 const emit = (message: ChildMessage): Effect.Effect<void> =>
@@ -378,6 +383,25 @@ const scenario = Effect.gen(function* () {
       const agent = Agent.withModel(plannerDefinition, model);
 
       yield* emitSettlements(yield* runtime.processThread(agent, threadId));
+
+      return;
+    }
+    case "run-checkpoint": {
+      const model = yield* makeScriptedModel((call) => checkpointParts(call + 1));
+      const agent = Agent.withModel(checkpointDefinition, model);
+
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: CRASH_QUESTION },
+        crashSubmitOptions(env.EFFECT_AGENT_THREAD, idempotencyKey),
+      );
+
+      yield* emit({ kind: "receipt", key: idempotencyKey, receipt });
+      yield* emitSettlements(
+        yield* runtime
+          .processThread(agent, threadId)
+          .pipe(Effect.provide(makeCheckpointToolLayer(requireSupplierDir()))),
+      );
 
       return;
     }

--- a/packages/platform-node/test/recovery-benchmark/entry.ts
+++ b/packages/platform-node/test/recovery-benchmark/entry.ts
@@ -1,0 +1,6 @@
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Effect } from "effect";
+
+import { benchmark } from "./workflow.ts";
+
+NodeRuntime.runMain(benchmark.pipe(Effect.provide(NodeServices.layer)));

--- a/packages/platform-node/test/recovery-benchmark/node-measurements.ts
+++ b/packages/platform-node/test/recovery-benchmark/node-measurements.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+import { cpus, totalmem } from "node:os";
+
+/** Synchronous Node-only measurement boundary; no I/O runs during import. */
+export const environment = () => ({
+  runtime: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  cpu: cpus()[0]?.model ?? "unknown",
+  logicalCpus: cpus().length,
+  ramBytes: totalmem(),
+});
+
+export const nowMillis = () => performance.now();
+export const memoryUsage = () => process.memoryUsage();
+export const collectGarbage = () => global.gc?.();
+export const sha256 = (text: string) => createHash("sha256").update(text).digest("hex");

--- a/packages/platform-node/test/recovery-benchmark/workflow.ts
+++ b/packages/platform-node/test/recovery-benchmark/workflow.ts
@@ -168,10 +168,9 @@ const checkpointBytes = (checkpoint: ThreadCheckpoint) =>
     .byteLength;
 
 /** Deliberately full-history checks. Call only outside measured startup and completion intervals. */
-const verifyPublicContract = Effect.fn("RecoveryBenchmark.verifyPublicContract")(function* (
-  store: ThreadStore["Service"],
-  runtime: DurableAgentRuntime["Service"],
-) {
+const verifyPublicContract = Effect.fn("RecoveryBenchmark.verifyPublicContract")(function* () {
+  const store = yield* ThreadStore;
+  const runtime = yield* DurableAgentRuntime;
   const exported = yield* store.export(ThreadExportRequest.make({ threadId }));
   const encoded = yield* Schema.encodeEffect(ThreadExport)(exported);
   const decoded = yield* Schema.decodeUnknownEffect(ThreadExport)(encoded);
@@ -441,7 +440,9 @@ export const benchmark = Effect.gen(function* () {
       const tags = suffix.map(({ sequence, record }) => ({ sequence, tag: record.payload._tag }));
 
       const publicContract =
-        count === 100000 ? yield* verifyPublicContract(store, runtime) : undefined;
+        count === 100000
+          ? yield* verifyPublicContract().pipe(Effect.provideService(DurableAgentRuntime, runtime))
+          : undefined;
 
       yield* fs.writeFileString(
         `${root}/full-host-${count}-fixture.json`,
@@ -667,7 +668,12 @@ export const benchmark = Effect.gen(function* () {
       // A full export/verification between samples would warm unrelated full-history code.
       // Verify only the final sample after its startup/completion metrics are captured.
       const publicContract =
-        count === 100000 && index === 2 ? yield* verifyPublicContract(counted, runtime) : undefined;
+        count === 100000 && index === 2
+          ? yield* verifyPublicContract().pipe(
+              Effect.provideService(ThreadStore, counted),
+              Effect.provideService(DurableAgentRuntime, runtime),
+            )
+          : undefined;
 
       return {
         revision: config.revision,

--- a/packages/platform-node/test/recovery-benchmark/workflow.ts
+++ b/packages/platform-node/test/recovery-benchmark/workflow.ts
@@ -1,0 +1,789 @@
+import { NewContext } from "@effect-agent/capabilities/ContextTools";
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { RunId, ThreadId, ToolCallId } from "@effect-agent/core/Identifiers";
+import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
+import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import { ledgerLayer } from "@effect-agent/storage-sqlite/SqliteSubmissionLedger";
+import { layer as threadLayer } from "@effect-agent/storage-sqlite/SqliteThreadStore";
+import { IntegrityReport } from "@effect-agent/thread/Admin";
+import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
+import {
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+} from "@effect-agent/thread/DurableAgentRuntime";
+import {
+  DurableRuntimeFailpoint,
+  DurableRuntimeFailpointError,
+} from "@effect-agent/thread/DurableFailpoint";
+import {
+  BatchId,
+  CanonicalBatch,
+  CanonicalSequence,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ModelResponseRecorded,
+  PersistedJson,
+  ProducerEpoch,
+  ProducerId,
+  RecordEnvelope,
+  RecordId,
+  ThreadCreated,
+  ToolCallSettled,
+} from "@effect-agent/thread/Records";
+import {
+  modelResponseRecordId,
+  toolCallSettledRecordId,
+  turnIdForRun,
+} from "@effect-agent/thread/RunJournal";
+import { IdempotencyKey, Principal, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import {
+  FencedAppendRequest,
+  ThreadCheckpoint,
+  ThreadExport,
+  ThreadExportRequest,
+  ThreadMaterialization,
+  ThreadRead,
+  ThreadStore,
+  ThreadTailRequest,
+} from "@effect-agent/thread/ThreadStore";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeCrypto } from "@effect/platform-node";
+import {
+  Array,
+  Cause,
+  Config,
+  Console,
+  DateTime,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  References,
+  Schema,
+  Stream,
+} from "effect";
+import { LanguageModel, Model, Prompt, Tool, Toolkit, type Response } from "effect/unstable/ai";
+
+import {
+  environment,
+  nowMillis,
+  memoryUsage,
+  collectGarbage,
+  sha256,
+} from "./node-measurements.ts";
+
+const BenchmarkConfig = Schema.Struct({
+  mode: Schema.Literals(["seed", "run"]),
+  count: Schema.Literals([1000, 10000, 100000]),
+  root: Schema.NonEmptyString,
+  revision: Schema.NonEmptyString,
+});
+
+const threadId = ThreadId.make("full-host-scaling");
+const deploymentId = DeploymentId.make("recovery-full-run");
+const producerId = ProducerId.make("recovery-full-run");
+
+const definitions = DefinitionDigests.make({
+  agent: Digest.make("a".repeat(64)),
+  model: Digest.make("a".repeat(64)),
+  tools: Digest.make("a".repeat(64)),
+});
+
+const retainedText = "Retained canonical file evidence. ".repeat(12);
+
+const readFile = Tool.make("read_file", {
+  parameters: Schema.Struct({ path: Schema.String }),
+  success: Schema.Struct({ text: Schema.String }),
+}).annotate(ToolExecutionClass, "readonly");
+
+const toolkit = Toolkit.make(NewContext, readFile);
+
+const handlers = toolkit.toLayer({
+  new_context: Effect.succeed,
+  read_file: () => Effect.succeed({ text: "Fixed active suffix evidence." }),
+});
+
+const definition = Agent.make("full-host-scaling", {
+  input: Schema.String,
+  output: Schema.String,
+  instructions: "Finish the active request and answer as JSON.",
+  toolkit,
+  policy: AgentPolicy.make({
+    maxTurns: 30,
+    maxToolCalls: 30,
+    maxDuration: "1 hour",
+    toolConcurrency: 1,
+  }),
+});
+
+const finish: Response.StreamPartEncoded = {
+  type: "finish",
+  reason: "tool-calls",
+  usage: { inputTokens: { total: 100 }, outputTokens: { total: 10 } },
+};
+
+const final: ReadonlyArray<Response.StreamPartEncoded> = [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: '"done"' },
+  { type: "text-end", id: "answer" },
+  {
+    type: "finish",
+    reason: "stop",
+    usage: { inputTokens: { total: 100 }, outputTokens: { total: 10 } },
+  },
+];
+
+const base = (filename: string, failpoint: typeof DurableRuntimeFailpoint.Service) =>
+  Layer.mergeAll(
+    threadLayer({ filename }),
+    ledgerLayer({ filename }),
+    WakeScheduler.layerNoop,
+    ToolReconciler.uncertain,
+    Layer.succeed(DurableRuntimeFailpoint, failpoint),
+    RunToolAuthorization.allowAll,
+    DurableRuntimeConfig.layer({ deploymentId, producerId }),
+  ).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const sha = (value: Schema.Json) => Digest.make(sha256(JSON.stringify(value)));
+
+const promptJson = (prompt: Prompt.Prompt) =>
+  Schema.decodeUnknownSync(PersistedJson)(Schema.encodeSync(Prompt.Prompt)(prompt));
+
+type Phase = "acquire" | "recovery" | "resume" | "completion" | "verification";
+
+const phaseCounts = (): Record<Phase, number> => ({
+  acquire: 0,
+  recovery: 0,
+  resume: 0,
+  completion: 0,
+  verification: 0,
+});
+
+const checkpointBytes = (checkpoint: ThreadCheckpoint) =>
+  new TextEncoder().encode(JSON.stringify(Schema.encodeSync(ThreadCheckpoint)(checkpoint)))
+    .byteLength;
+
+/** Deliberately full-history checks. Call only outside measured startup and completion intervals. */
+const verifyPublicContract = Effect.fn("RecoveryBenchmark.verifyPublicContract")(function* (
+  store: ThreadStore["Service"],
+  runtime: DurableAgentRuntime["Service"],
+) {
+  const exported = yield* store.export(ThreadExportRequest.make({ threadId }));
+  const encoded = yield* Schema.encodeEffect(ThreadExport)(exported);
+  const decoded = yield* Schema.decodeUnknownEffect(ThreadExport)(encoded);
+  const integrity = yield* runtime.verify(threadId);
+
+  if (
+    !integrity.ok ||
+    decoded.records.length !== decoded.tailSequence ||
+    integrity.recordCount !== decoded.records.length ||
+    integrity.tailSequence !== decoded.tailSequence
+  )
+    return yield* Effect.die({
+      message: "Public export or integrity verification failed",
+      integrity,
+    });
+
+  return {
+    exportSchemaRoundTrip: true,
+    exportedRecords: decoded.records.length,
+    exportedTailSequence: decoded.tailSequence,
+    integrity: yield* Schema.encodeEffect(IntegrityReport)(integrity),
+  };
+});
+
+/** Opt-in diagnostic workflow; the caller supplies one cohort and seed/run mode through Config. */
+export const benchmark = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+
+  const config = yield* Schema.decodeUnknownEffect(BenchmarkConfig)({
+    mode: yield* Config.string("EFFECT_AGENT_RECOVERY_BENCHMARK_MODE"),
+    count: yield* Config.number("EFFECT_AGENT_RECOVERY_BENCHMARK_COUNT"),
+    root: yield* Config.string("EFFECT_AGENT_RECOVERY_BENCHMARK_OUT"),
+    revision: yield* Config.string("EFFECT_AGENT_RECOVERY_BENCHMARK_REVISION"),
+  });
+
+  const { mode, count, root } = config;
+
+  yield* fs.makeDirectory(root, { recursive: true });
+  const sourceHashes: Record<string, string> = {};
+
+  for (const path of [
+    "packages/thread/src/DurableAgentRuntime.ts",
+    "packages/thread/src/RunJournal.ts",
+    "packages/thread/src/internal/journal-checkpoint.ts",
+    "packages/thread/src/ThreadStore.ts",
+    "packages/thread/src/Records.ts",
+    "packages/thread/src/ThreadInvariants.ts",
+    "packages/thread/src/DurableFailpoint.ts",
+    "packages/core/src/Usage.ts",
+    "packages/core/src/RunPolicyUsage.ts",
+    "packages/engine/src/internal/agent-runtime.ts",
+    "packages/engine/src/RunOptions.ts",
+    "packages/storage-sqlite/src/SqliteThreadStore.ts",
+    "packages/storage-sqlite/src/SqliteSubmissionLedger.ts",
+    "packages/storage-sqlite/src/internal/sqlite-journal.ts",
+    "packages/storage-sqlite/src/internal/migrations.ts",
+    "packages/storage-sqlite/src/internal/recovery-checkpoint-schema.ts",
+    "packages/storage-sqlite/src/SqliteStorageVersion.ts",
+    "packages/storage-sqlite/src/SqliteStorageError.ts",
+  ])
+    sourceHashes[path] = sha256(yield* fs.readFileString(path));
+
+  const packageInfo = yield* Schema.decodeUnknownEffect(
+    Schema.fromJsonString(Schema.Struct({ version: Schema.String })),
+  )(yield* fs.readFileString("packages/platform-node/package.json"));
+
+  const seedFilename = `${root}/full-host-${count}-seed.sqlite`;
+
+  const seed = Effect.scoped(
+    Effect.gen(function* () {
+      const store = yield* ThreadStore;
+      const createdAt = yield* DateTime.now;
+      const epoch = ProducerEpoch.make(0);
+      let sequence = CanonicalSequence.make(0);
+      let tailDigest = EMPTY_TAIL_DIGEST;
+
+      yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch: epoch }));
+      const started = nowMillis();
+
+      for (let start = 0; start < count; start += 256) {
+        const rows: Array<RecordEnvelope> = [];
+
+        for (let pos = start; pos < Math.min(start + 256, count); pos++) {
+          let payload: typeof RecordEnvelope.Type.payload;
+          let recordId: RecordId;
+
+          if (pos === 0) {
+            payload = ThreadCreated.make({ agentId: definition.id, definitions });
+            recordId = RecordId.make("thread-created");
+          } else {
+            const pair = Math.floor((pos - 1) / 2);
+            const runId = RunId.make(`historic-run-${Math.floor(pair / 20)}`);
+            const turn = (pair % 20) + 1;
+            const callId = ToolCallId.make(`historic-call-${pair}`);
+
+            if (pos % 2 === 1) {
+              const messages = promptJson(
+                Prompt.make([
+                  Prompt.makeMessage("assistant", {
+                    content: [
+                      Prompt.makePart("tool-call", {
+                        id: callId,
+                        name: "read_file",
+                        params: { path: `file-${pair}.ts` },
+                        providerExecuted: false,
+                      }),
+                    ],
+                  }),
+                ]),
+              );
+
+              payload = ModelResponseRecorded.make({
+                runId,
+                turnId: turnIdForRun(runId, turn),
+                turn,
+                messages,
+                messagesDigest: sha(messages),
+                inputTokens: 100,
+                outputTokens: 10,
+              });
+              recordId = modelResponseRecordId(runId, turn);
+            } else {
+              payload = ToolCallSettled.make({
+                runId,
+                toolCallId: callId,
+                toolName: "read_file",
+                result: PersistedJson.make({ text: retainedText }),
+                isFailure: false,
+              });
+              recordId = toolCallSettledRecordId(runId, turn, callId);
+            }
+          }
+          // Even cohort counts end in one assistant-only message; no pending Tool exists in the active Run.
+          if (pos === count - 1) {
+            const runId = RunId.make("historic-terminal");
+
+            const messages = promptJson(
+              Prompt.make([
+                Prompt.makeMessage("assistant", {
+                  content: [Prompt.makePart("text", { text: "Historical cohort finished." })],
+                }),
+              ]),
+            );
+
+            payload = ModelResponseRecorded.make({
+              runId,
+              turnId: turnIdForRun(runId, 1),
+              turn: 1,
+              messages,
+              messagesDigest: sha(messages),
+            });
+            recordId = modelResponseRecordId(runId, 1);
+          }
+          rows.push(
+            RecordEnvelope.make({
+              recordId,
+              family: "thread",
+              schemaVersion: 1,
+              deploymentId,
+              createdAt,
+              payload,
+            }),
+          );
+        }
+        if (!Array.isArrayNonEmpty(rows)) return yield* Effect.die("Empty fixture batch");
+
+        const appended = yield* store.append(
+          FencedAppendRequest.make({
+            threadId,
+            producerEpoch: epoch,
+            expectedTailSequence: sequence,
+            expectedTailDigest: tailDigest,
+            batch: CanonicalBatch.make({
+              batchId: BatchId.make(`seed-${start}`),
+              producerId,
+              records: rows,
+            }),
+          }),
+        );
+
+        sequence = appended.lastSequence;
+        tailDigest = appended.tailDigest;
+      }
+      yield* Console.log(
+        JSON.stringify({ phase: "historical-seed", count, elapsedMs: nowMillis() - started }),
+      );
+      let calls = 0;
+
+      const model = Model.make(
+        "scripted",
+        "full-host-scaling",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: () => {
+              const call = calls++;
+
+              return Stream.fromIterable<Response.StreamPartEncoded>(
+                call === 0
+                  ? [
+                      {
+                        type: "tool-call",
+                        id: "rollover-call",
+                        name: "new_context",
+                        params: { handoff: "Continue the fixed active request." },
+                        providerExecuted: false,
+                      },
+                      finish,
+                    ]
+                  : [
+                      {
+                        type: "tool-call",
+                        id: `active-call-${call}`,
+                        name: "read_file",
+                        params: { path: `active-${call}.ts` },
+                        providerExecuted: false,
+                      },
+                      finish,
+                    ],
+              );
+            },
+          }),
+        ),
+      );
+
+      const agent = Agent.withModel(definition, model);
+      const runtime = yield* DurableAgentRuntime.pipe(Effect.provide(DurableAgentRuntime.layer));
+
+      const receipt = yield* runtime.submit(agent, "Fixed original active request", {
+        threadId,
+        principal: Principal.make("scaling-author"),
+        idempotencyKey: IdempotencyKey.make("active"),
+        definitions,
+      });
+
+      const exit = yield* runtime
+        .processThread(agent, threadId)
+        .pipe(Effect.provide(handlers), Effect.exit);
+
+      if (
+        !(Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof DurableRuntimeFailpointError)
+      )
+        return yield* Effect.die({ message: "seed failed at unexpected boundary", exit });
+      const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+
+      const suffix = yield* store
+        .read(
+          ThreadRead.make({ threadId, afterSequence: CanonicalSequence.make(count), limit: 256 }),
+        )
+        .pipe(Stream.runCollect);
+
+      const boundary = suffix.find(({ record }) => record.payload._tag === "CompactionCreated");
+
+      if (
+        calls !== 7 ||
+        suffix.length !== 18 ||
+        boundary?.sequence !== count + 6 ||
+        tail.tailSequence - boundary.sequence !== 12
+      )
+        return yield* Effect.die({
+          message: "Active suffix fixture changed",
+          calls,
+          tail,
+          boundary,
+        });
+      const tags = suffix.map(({ sequence, record }) => ({ sequence, tag: record.payload._tag }));
+
+      const publicContract =
+        count === 100000 ? yield* verifyPublicContract(store, runtime) : undefined;
+
+      yield* fs.writeFileString(
+        `${root}/full-host-${count}-fixture.json`,
+        JSON.stringify(
+          {
+            historicalRecords: count,
+            tailSequence: tail.tailSequence,
+            modelCalls: calls,
+            suffix: tags,
+            receipt,
+            publicContract,
+          },
+          null,
+          2,
+        ),
+      );
+      yield* Console.log(
+        JSON.stringify({
+          phase: "active-fixture-ready",
+          historicalRecords: count,
+          tailSequence: tail.tailSequence,
+          modelCalls: calls,
+          suffix: tags,
+          publicContract,
+        }),
+      );
+    }),
+  );
+
+  const sample = Effect.fn("RecoveryBenchmark.sample")(function* (index: number) {
+    const filename = `${root}/full-host-${count}-sample-${index}.sqlite`;
+
+    yield* fs.copyFile(seedFilename, filename);
+    let phase: Phase = "acquire";
+    const returned = phaseCounts();
+    const pages = phaseCounts();
+    const inspectTailCalls = phaseCounts();
+    const exportCalls = phaseCounts();
+    const exportedCanonicalRecords = phaseCounts();
+    const checkpointLoadCalls = phaseCounts();
+    const checkpointLoadHits = phaseCounts();
+    const checkpointLoadedBytes = phaseCounts();
+    const checkpointSaveCalls = phaseCounts();
+    const checkpointSubmittedBytes = phaseCounts();
+    const ledgerLookupCalls = phaseCounts();
+    const ledgerSnapshotLoadCalls = phaseCounts();
+    const ledgerScanCalls = phaseCounts();
+    const ledgerScanRows = phaseCounts();
+    let heapAtModel = 0;
+    let rssAtModel = 0;
+    let heapAtModelBeforeGc = 0;
+    let rssAtModelBeforeGc = 0;
+    let peakObservedRss = 0;
+    let promptMessages = 0;
+    let promptBytes = 0;
+    let promptEvidence = "";
+    let firstModelMs = 0;
+    let processStarted = 0;
+    let modelCalls = 0;
+
+    collectGarbage();
+    const before = memoryUsage();
+    const started = nowMillis();
+
+    const program = Effect.gen(function* () {
+      const store = yield* ThreadStore;
+      const ledger = yield* SubmissionLedger;
+      const recoveryCheckpoints = store.recoveryCheckpoints;
+
+      const counted = ThreadStore.of({
+        ...store,
+        inspectTail: (request) =>
+          Effect.suspend(() => {
+            inspectTailCalls[phase]++;
+
+            return store.inspectTail(request);
+          }),
+        export: (request) =>
+          Effect.suspend(() => {
+            exportCalls[phase]++;
+            const requestPhase = phase;
+
+            return store.export(request).pipe(
+              Effect.tap((value) =>
+                Effect.sync(() => {
+                  exportedCanonicalRecords[requestPhase] += value.records.length;
+                }),
+              ),
+            );
+          }),
+        recoveryCheckpoints:
+          recoveryCheckpoints === undefined
+            ? undefined
+            : {
+                load: (request) =>
+                  Effect.suspend(() => {
+                    const requestPhase = phase;
+
+                    checkpointLoadCalls[requestPhase]++;
+
+                    return recoveryCheckpoints.load(request).pipe(
+                      Effect.tap((value) =>
+                        Effect.sync(() => {
+                          if (Option.isSome(value)) {
+                            checkpointLoadHits[requestPhase]++;
+                            checkpointLoadedBytes[requestPhase] += checkpointBytes(value.value);
+                          }
+                        }),
+                      ),
+                    );
+                  }),
+                save: (request) =>
+                  Effect.suspend(() => {
+                    checkpointSaveCalls[phase]++;
+                    checkpointSubmittedBytes[phase] += checkpointBytes(request.checkpoint);
+
+                    return recoveryCheckpoints.save(request);
+                  }),
+              },
+        read: (request) =>
+          Stream.suspend(() => {
+            pages[phase]++;
+            peakObservedRss = Math.max(peakObservedRss, memoryUsage().rss);
+
+            return store.read(request).pipe(
+              Stream.tap(() =>
+                Effect.sync(() => {
+                  returned[phase]++;
+                }),
+              ),
+            );
+          }),
+      });
+
+      const countedLedger = SubmissionLedger.of({
+        ...ledger,
+        lookup: (request) =>
+          Effect.suspend(() => {
+            ledgerLookupCalls[phase]++;
+
+            return ledger.lookup(request);
+          }),
+        loadRecoverySnapshot: (request) =>
+          Effect.suspend(() => {
+            ledgerSnapshotLoadCalls[phase]++;
+
+            return ledger.loadRecoverySnapshot(request);
+          }),
+        scanNonterminal: Stream.suspend(() => {
+          const requestPhase = phase;
+
+          ledgerScanCalls[requestPhase]++;
+
+          return ledger.scanNonterminal.pipe(
+            Stream.tap(() =>
+              Effect.sync(() => {
+                ledgerScanRows[requestPhase]++;
+              }),
+            ),
+          );
+        }),
+      });
+
+      const runtime = yield* DurableAgentRuntime.pipe(
+        Effect.provide(DurableAgentRuntime.layer),
+        Effect.provideService(ThreadStore, counted),
+        Effect.provideService(SubmissionLedger, countedLedger),
+      );
+
+      const acquiredMs = nowMillis() - started;
+
+      phase = "recovery";
+      const recoveryStarted = nowMillis();
+      const reports = yield* runtime.runRecovery;
+      const recoveryMs = nowMillis() - recoveryStarted;
+      const afterRecovery = memoryUsage();
+
+      const model = Model.make(
+        "scripted",
+        "full-host-scaling",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: (request) => {
+              modelCalls++;
+              firstModelMs = nowMillis() - processStarted;
+              promptMessages = request.prompt.content.length;
+              promptEvidence = JSON.stringify(Schema.encodeSync(Prompt.Prompt)(request.prompt));
+              promptBytes = new TextEncoder().encode(promptEvidence).byteLength;
+              const beforeModelGc = memoryUsage();
+
+              heapAtModelBeforeGc = beforeModelGc.heapUsed;
+              rssAtModelBeforeGc = beforeModelGc.rss;
+              collectGarbage();
+              const atModel = memoryUsage();
+
+              heapAtModel = atModel.heapUsed;
+              rssAtModel = atModel.rss;
+              peakObservedRss = Math.max(peakObservedRss, atModel.rss);
+              phase = "completion";
+
+              return Stream.fromIterable(final);
+            },
+          }),
+        ),
+      );
+
+      const agent = Agent.withModel(definition, model);
+
+      phase = "resume";
+      processStarted = nowMillis();
+      const result = yield* runtime.processThread(agent, threadId).pipe(Effect.provide(handlers));
+      const processMs = nowMillis() - processStarted;
+
+      collectGarbage();
+      const after = memoryUsage();
+
+      if (modelCalls !== 1 || result.length !== 1 || result[0]?.outcome !== "completed")
+        return yield* Effect.die({ message: "resume did not complete once", result, modelCalls });
+      phase = "verification";
+
+      // A full export/verification between samples would warm unrelated full-history code.
+      // Verify only the final sample after its startup/completion metrics are captured.
+      const publicContract =
+        count === 100000 && index === 2 ? yield* verifyPublicContract(counted, runtime) : undefined;
+
+      return {
+        revision: config.revision,
+        sourceHashes,
+        packageVersion: packageInfo.version,
+        measurement:
+          "Actual DurableAgentRuntime.runRecovery then processThread, public SQLite adapters; local Node, not Cloudflare",
+        environment: environment(),
+        historicalRecords: count,
+        fixedActiveSuffixRecords: 12,
+        sample: index,
+        state:
+          index === 0
+            ? "fresh process/module imports complete, fresh runtime and SQLite open, OS cache warmed by seed"
+            : "warm process/JIT and OS cache, fresh runtime and SQLite clone",
+        acquiredMs,
+        recoveryMs,
+        resumeToFirstModelMs: firstModelMs,
+        resumedProcessToCompletionMs: processMs,
+        throughFirstModelMs: acquiredMs + recoveryMs + firstModelMs,
+        canonicalRecordsRead: returned,
+        canonicalReadPages: pages,
+        inspectTailCalls,
+        exportCalls,
+        exportedCanonicalRecords,
+        recoveryCheckpointOperations: {
+          supported: recoveryCheckpoints !== undefined,
+          loadCalls: checkpointLoadCalls,
+          loadHits: checkpointLoadHits,
+          loadedBytes: checkpointLoadedBytes,
+          saveCalls: checkpointSaveCalls,
+          submittedBytes: checkpointSubmittedBytes,
+          byteDefinition:
+            "UTF-8 JSON of schema-encoded ThreadCheckpoint; successful loads returned and save requests submitted. Excludes SQLite row overhead and is separate from canonical read records.",
+        },
+        ledgerOperations: {
+          lookupCalls: ledgerLookupCalls,
+          recoverySnapshotLoadCalls: ledgerSnapshotLoadCalls,
+          scanCalls: ledgerScanCalls,
+          scannedRows: ledgerScanRows,
+        },
+        publicContract,
+        publicVerificationRanAfterStartupAndCompletionMetrics: publicContract !== undefined,
+        recoveryReports: reports.map((report) => ({
+          decision: report.decision._tag,
+          disposition: report.disposition,
+        })),
+        resumedModelCalls: modelCalls,
+        promptMessages,
+        promptJsonBytes: promptBytes,
+        promptEvidence,
+        settlements: result.map(({ outcome, submissionId }) => ({ outcome, submissionId })),
+        heapBeforeBytes: before.heapUsed,
+        residentSetBeforeBytes: before.rss,
+        heapAfterRecoveryBeforeGcBytes: afterRecovery.heapUsed,
+        residentSetAfterRecoveryBytes: afterRecovery.rss,
+        heapAtModelBeforeGcBytes: heapAtModelBeforeGc,
+        residentSetAtModelBeforeGcBytes: rssAtModelBeforeGc,
+        residentSetAtModelBytes: rssAtModel,
+        peakObservedResidentSetBytes: peakObservedRss,
+        retainedHeapAtModelBytes: heapAtModel,
+        retainedHeapAtModelDeltaBytes: heapAtModel - before.heapUsed,
+        retainedHeapAfterCompletionBytes: after.heapUsed,
+        retainedHeapAfterCompletionDeltaBytes: after.heapUsed - before.heapUsed,
+        residentSetBytes: after.rss,
+        seedDatabaseBytes: Number((yield* fs.stat(seedFilename)).size),
+      };
+    });
+
+    const result = yield* program.pipe(Effect.provide(base(filename, { hit: () => Effect.void })));
+
+    collectGarbage();
+    yield* Console.log(
+      JSON.stringify({
+        ...result,
+        retainedHeapAfterScopeBytes: memoryUsage().heapUsed,
+        retainedHeapAfterScopeIncludesPublicVerification: result.publicContract !== undefined,
+      }),
+    );
+  }, Effect.scoped);
+
+  let committedResults = 0;
+
+  const program = Effect.gen(function* () {
+    if (mode === "seed") {
+      yield* seed.pipe(
+        Effect.provide(
+          base(seedFilename, {
+            hit: (location) => {
+              if (location === "turn:after-results-append" && ++committedResults === 7)
+                return DurableRuntimeFailpointError.make({ location });
+
+              return Effect.void;
+            },
+          }),
+        ),
+      );
+    } else {
+      for (let index = 0; index < 3; index++) yield* sample(index);
+    }
+  });
+
+  yield* program.pipe(
+    Effect.provideService(References.MinimumLogLevel, "Error"),
+    Effect.tapCause((cause) =>
+      Console.log(
+        JSON.stringify({
+          phase: "failed",
+          mode,
+          historicalRecords: count,
+          revision: config.revision,
+          sourceHashes,
+          environment: environment(),
+          cause: Cause.pretty(cause),
+        }),
+      ),
+    ),
+  );
+});

--- a/packages/storage-cloudflare/src/DoStorageError.ts
+++ b/packages/storage-cloudflare/src/DoStorageError.ts
@@ -116,6 +116,8 @@ export const DoStorageFailpointLocation = Schema.Literals([
   "export:after-thread-read",
   "save-checkpoint:before",
   "save-checkpoint:after",
+  "save-recovery-checkpoint:before",
+  "save-recovery-checkpoint:after",
   "ledger:admit:before",
   "ledger:admit:after",
   "ledger:mark-ready:before",

--- a/packages/storage-cloudflare/src/DoThreadStore.ts
+++ b/packages/storage-cloudflare/src/DoThreadStore.ts
@@ -28,6 +28,9 @@ import {
   FencedAppendRequest,
   LoadCheckpointRequest,
   SaveCheckpointRequest,
+  SaveRecoveryCheckpointRequest,
+  MAX_THREAD_EXPORT_RECORDS,
+  type ThreadRecoveryCheckpoints,
 } from "@effect-agent/thread/ThreadStore";
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
@@ -301,9 +304,9 @@ const groupByKey = <A>(
 };
 
 /**
- * Opt-in full integrity audit (`verifyOnOpen`). Every stored payload is decoded, re-encoded,
- * and re-digested against the canonical chain. Routine opens skip this scan: per-operation
- * Schema decoding plus the digest chain already fail clearly on corrupt rows.
+ * Opt-in integrity audit (`verifyOnOpen`) of canonical payloads, their digest chains and generic
+ * projection checkpoints. Disposable recovery checkpoints are validated when loaded. Routine opens
+ * skip this scan: per-operation Schema decoding fails clearly on corrupt canonical rows.
  */
 const decodeStartupPayloads = Effect.fn("DoThreadStore.decodeStartupPayloads")(function* (
   journal: DoJournal,
@@ -698,7 +701,7 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
 
       const records = yield* Effect.forEach(exported.records, decodeEnvelope);
 
-      if (records.length > 65_536) {
+      if (records.length > MAX_THREAD_EXPORT_RECORDS) {
         return yield* ThreadStoreError.make({
           operation: "decode thread export",
           message: "The thread exceeds the current export record limit.",
@@ -842,6 +845,92 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
     },
   );
 
+  const saveRecoveryCheckpoint: ThreadRecoveryCheckpoints["save"] = Effect.fn(
+    "DoThreadStore.saveRecoveryCheckpoint",
+  )(function* (request) {
+    const validated = yield* Schema.decodeUnknownEffect(
+      Schema.toType(SaveRecoveryCheckpointRequest),
+    )(request).pipe(
+      Effect.mapError((error) => schemaStoreError("validate recovery checkpoint", error)),
+    );
+
+    const checkpointJson = yield* encodeCheckpoint(validated.checkpoint);
+
+    yield* journal
+      .saveRecoveryCheckpoint(validated, checkpointJson)
+      .pipe(
+        Effect.mapError((error) =>
+          error._tag === "CheckpointRejected" ||
+          error._tag === "FenceRejected" ||
+          error._tag === "ThreadNotMaterialized"
+            ? error
+            : storeError("save recovery checkpoint", error),
+        ),
+      );
+  });
+
+  const loadRecoveryCheckpoint: ThreadRecoveryCheckpoints["load"] = Effect.fn(
+    "DoThreadStore.loadRecoveryCheckpoint",
+  )(function* (request) {
+    const validated = yield* Schema.decodeUnknownEffect(Schema.toType(LoadCheckpointRequest))(
+      request,
+    ).pipe(
+      Effect.mapError((error) => schemaStoreError("validate recovery checkpoint lookup", error)),
+    );
+
+    const thread = yield* requireThread(journal, validated.threadId);
+
+    const corrupt = () =>
+      CheckpointRejected.make({ threadId: validated.threadId, reason: "corrupt" });
+
+    const rows = yield* journal
+      .loadRecoveryCheckpoint(validated.threadId)
+      .pipe(
+        Effect.mapError((error) =>
+          error._tag === "DoStorageCorruptionError"
+            ? corrupt()
+            : storeError("load recovery checkpoint", error),
+        ),
+      );
+
+    if (rows.length === 0) return Option.none();
+    if (rows.length !== 1) return yield* corrupt();
+    const row = rows[0];
+
+    const checkpoint = yield* Schema.decodeEffect(Schema.fromJsonString(ThreadCheckpoint))(
+      row.checkpoint_json,
+    ).pipe(Effect.mapError(corrupt));
+
+    if (
+      row.thread_id !== validated.threadId ||
+      checkpoint.threadId !== row.thread_id ||
+      checkpoint.throughSequence !== row.through_sequence ||
+      checkpoint.tailDigest !== row.tail_digest
+    )
+      return yield* corrupt();
+    if (checkpoint.throughSequence > thread.tail_sequence)
+      return yield* CheckpointRejected.make({
+        threadId: validated.threadId,
+        reason: "ahead-of-tail",
+      });
+    if (checkpoint.throughSequence > (validated.atOrBeforeSequence ?? thread.tail_sequence))
+      return Option.none();
+
+    const canonicalDigest = yield* tailDigestAt(
+      journal,
+      checkpoint.threadId,
+      checkpoint.throughSequence,
+    );
+
+    if (canonicalDigest !== checkpoint.tailDigest)
+      return yield* CheckpointRejected.make({
+        threadId: validated.threadId,
+        reason: "digest-mismatch",
+      });
+
+    return Option.some(checkpoint);
+  });
+
   const threadStore = ThreadStore.of({
     append,
     export: exportThread,
@@ -850,6 +939,7 @@ const makeServices = Effect.fn("DoThreadStore.makeServices")(function* () {
     observe,
     read,
     checkpoints: { save: saveCheckpoint, load: loadCheckpoint },
+    recoveryCheckpoints: { save: saveRecoveryCheckpoint, load: loadRecoveryCheckpoint },
   });
 
   return Context.make(ThreadStore, threadStore);

--- a/packages/storage-cloudflare/src/PortProtocol.ts
+++ b/packages/storage-cloudflare/src/PortProtocol.ts
@@ -50,9 +50,9 @@ import { Schema } from "effect";
  *   `recordChildSettled`;
  * - store: `materialize`, `append`, `read` (one page), `inspectTail`, `export`.
  *
- * Every other port operation is lane-local by construction and is NOT given an envelope:
- * honesty over accidental distribution — the routing layer fails such calls fast and typed
- * instead of quietly widening the distributed surface.
+ * Every other port operation is lane-local and has no envelope. A foreign disposable
+ * recovery-cache load returns a miss so the caller can replay canonical history. Other
+ * foreign operations fail fast and typed instead of widening the distributed surface.
  *
  * Failures cross the boundary as the `PortFailure` union and re-decode on the caller side to
  * the SAME tagged error types the local facet would have produced, so routed calls keep

--- a/packages/storage-cloudflare/src/PortRouting.ts
+++ b/packages/storage-cloudflare/src/PortRouting.ts
@@ -849,9 +849,9 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
             ThreadNotMaterialized,
           ).pipe(Effect.map((reply) => reply.export)),
 
-    // Observation and checkpoints are lane-local by construction (plan §1.3): the closed
-    // route-capable store subset is materialize/append/read/inspectTail/export, and a
-    // foreign address on anything else fails fast typed.
+    // Observation and checkpoints are lane-local: the closed route-capable store subset
+    // is materialize/append/read/inspectTail/export. Recovery cache misses can fall back
+    // to those canonical reads, including when the cache belongs to a foreign Object.
     observe: (request) =>
       request.threadId === options.localThreadId
         ? local.observe(request)
@@ -873,9 +873,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
             load: (request) =>
               request.threadId === options.localThreadId
                 ? recoveryCheckpoints.load(request)
-                : Effect.fail(
-                    crossThreadStoreError("thread load recovery checkpoint", request.threadId),
-                  ),
+                : Effect.succeed(Option.none()),
           },
         }),
     ...(checkpoints === undefined
@@ -914,7 +912,8 @@ export const routedSubmissionLedgerLayer = (
 /**
  * Routing decorator over the LOCAL `ThreadStore` facet (plan §1.3): this-thread
  * requests execute locally; foreign materialize/append/read/inspectTail/export travel the
- * transport; foreign observation and checkpoints fail fast typed.
+ * transport. Foreign recovery-cache loads return none for canonical replay; other foreign
+ * checkpoint operations and observation fail fast typed.
  */
 export const routedThreadStoreLayer = (
   options: RoutedPortOptions,

--- a/packages/storage-cloudflare/src/PortRouting.ts
+++ b/packages/storage-cloudflare/src/PortRouting.ts
@@ -720,6 +720,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
 ) {
   const local = yield* ThreadStore;
   const checkpoints = local.checkpoints;
+  const recoveryCheckpoints = local.recoveryCheckpoints;
   const transport = yield* ThreadPortTransport;
   const transportCall: TransportCall = makeTransportCall(transport);
 
@@ -856,6 +857,27 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
         ? local.observe(request)
         : Stream.unwrap(Effect.fail(crossThreadStoreError("thread observe", request.threadId))),
 
+    ...(recoveryCheckpoints === undefined
+      ? {}
+      : {
+          recoveryCheckpoints: {
+            save: (request) =>
+              request.checkpoint.threadId === options.localThreadId
+                ? recoveryCheckpoints.save(request)
+                : Effect.fail(
+                    crossThreadStoreError(
+                      "thread save recovery checkpoint",
+                      request.checkpoint.threadId,
+                    ),
+                  ),
+            load: (request) =>
+              request.threadId === options.localThreadId
+                ? recoveryCheckpoints.load(request)
+                : Effect.fail(
+                    crossThreadStoreError("thread load recovery checkpoint", request.threadId),
+                  ),
+          },
+        }),
     ...(checkpoints === undefined
       ? {}
       : {

--- a/packages/storage-cloudflare/src/internal/do-journal.ts
+++ b/packages/storage-cloudflare/src/internal/do-journal.ts
@@ -1,5 +1,13 @@
+import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
 import { CanonicalSequence, ProducerEpoch } from "@effect-agent/thread/Records";
 import { checkV2ThreadLayout } from "@effect-agent/thread/SqlStorageV2Upgrade";
+import {
+  MAX_THREAD_EXPORT_RECORDS,
+  CheckpointRejected,
+  FenceRejected,
+  ThreadNotMaterialized,
+  type SaveRecoveryCheckpointRequest,
+} from "@effect-agent/thread/ThreadStore";
 import { SqliteMigrator } from "@effect/sql-sqlite-do";
 import { Effect, Schema, Stream } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -18,6 +26,7 @@ import {
 } from "../DoStorageError.ts";
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
 import { CurrentDoStorageVersion, doMigrations } from "./migrations.ts";
+import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 /**
  * Static schema ceiling for stored text columns. Writes are bounded in BYTES by the
@@ -27,7 +36,8 @@ import { CurrentDoStorageVersion, doMigrations } from "./migrations.ts";
  */
 const BoundedStoredText = Schema.String.check(Schema.isMaxLength(2_000_000));
 const BoundedIdentifier = Schema.NonEmptyString.check(Schema.isMaxLength(1024));
-const MAX_RECORDS_PER_THREAD = 65_536;
+const MAX_RECORDS_PER_THREAD = MAX_THREAD_EXPORT_RECORDS;
+const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
 const MAX_IDENTIFIER_LENGTH = 1_024;
 const MAX_READ_PAGE_JSON_BYTES = 4 * 1024 * 1024;
 /** Durable Object SQL storage allows at most 100 bound parameters per statement. */
@@ -338,10 +348,32 @@ const predecessorColumns = {
   ],
 } as const;
 
-const checkPredecessorLayout = Effect.fn("DoJournal.checkPredecessorLayout")(function* () {
+const checkPredecessorLayout = Effect.fn("DoJournal.checkPredecessorLayout")(function* (
+  version: 3 | 4,
+) {
   const sql = yield* SqlClient.SqlClient;
 
-  for (const [table, expected] of Object.entries(predecessorColumns)) {
+  const expectedColumns =
+    version === 3
+      ? predecessorColumns
+      : {
+          ...predecessorColumns,
+          effect_agent_submissions: [
+            ...predecessorColumns.effect_agent_submissions,
+            "worker_admission_json",
+            "message_admission_json",
+          ],
+          effect_agent_message_deliveries: [
+            "owner_thread_id",
+            "message_id",
+            "version",
+            "state",
+            "deadline_at_millis",
+            "record_json",
+          ],
+        };
+
+  for (const [table, expected] of Object.entries(expectedColumns)) {
     const columns = yield* decodeRows(
       Schema.Array(Schema.Struct({ name: BoundedIdentifier })),
       table,
@@ -353,9 +385,9 @@ const checkPredecessorLayout = Effect.fn("DoJournal.checkPredecessorLayout")(fun
 
     if (columns.length !== names.size || columns.some((column) => !names.has(column.name)))
       return yield* DoStorageCompatibilityError.make({
-        actualVersion: 3,
+        actualVersion: version,
         supportedVersion: CurrentDoStorageVersion,
-        message: `The v3 ${table} columns do not match the supported predecessor; no upgrade was committed.`,
+        message: `The v${version} ${table} columns do not match the supported predecessor; no upgrade was committed.`,
       });
   }
 });
@@ -454,7 +486,7 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
       versionRows,
     );
 
-    if (version.value === "2" || version.value === "3") {
+    if (version.value === "2" || version.value === "3" || version.value === "4") {
       yield* sql
         .withTransaction(
           Effect.gen(function* () {
@@ -464,7 +496,10 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
 
             if (current.length === 1 && current[0].value === String(CurrentDoStorageVersion))
               return;
-            if (current.length !== 1 || (current[0].value !== "2" && current[0].value !== "3"))
+            if (
+              current.length !== 1 ||
+              (current[0].value !== "2" && current[0].value !== "3" && current[0].value !== "4")
+            )
               return yield* DoStorageCompatibilityError.make({
                 actualVersion: -1,
                 supportedVersion: CurrentDoStorageVersion,
@@ -485,6 +520,17 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
                 message:
                   "The predecessor store is missing required tables. Retain the original store for inspection; no upgrade was committed.",
               });
+
+            const recoveryTables =
+              yield* sql`SELECT name FROM sqlite_master WHERE type='table' AND name='effect_agent_recovery_checkpoints'`;
+
+            if (recoveryTables.length !== 0)
+              return yield* DoStorageCompatibilityError.make({
+                actualVersion: Number(current[0].value),
+                supportedVersion: CurrentDoStorageVersion,
+                message:
+                  "The predecessor already contains recovery checkpoint storage; refusing ambiguous data without mutation.",
+              });
             if (current[0].value === "2") {
               yield* checkV2ThreadLayout();
               for (const statement of [
@@ -497,18 +543,24 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
                 yield* failpoint("upgrade:after-mutation");
               }
             }
-            if (current[0].value === "3") yield* checkPredecessorLayout();
+            if (current[0].value === "3") yield* checkPredecessorLayout(3);
+            if (current[0].value === "4") yield* checkPredecessorLayout(4);
+            if (current[0].value !== "4") {
+              yield* failpoint("upgrade:before-mutation");
+              yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
+              yield* failpoint("upgrade:after-mutation");
+              yield* failpoint("upgrade:before-mutation");
+              yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN message_admission_json TEXT`;
+              yield* failpoint("upgrade:after-mutation");
+              yield* failpoint("upgrade:before-mutation");
+              yield* createMessageDeliveryTables;
+              yield* failpoint("upgrade:after-mutation");
+            }
             yield* failpoint("upgrade:before-mutation");
-            yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
-            yield* failpoint("upgrade:after-mutation");
-            yield* failpoint("upgrade:before-mutation");
-            yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN message_admission_json TEXT`;
-            yield* failpoint("upgrade:after-mutation");
-            yield* failpoint("upgrade:before-mutation");
-            yield* createMessageDeliveryTables;
+            yield* createRecoveryCheckpointTable;
             yield* failpoint("upgrade:after-mutation");
             yield* failpoint("upgrade:before-version");
-            yield* sql`UPDATE effect_agent_meta SET value='4' WHERE key='storage_version'`;
+            yield* sql`UPDATE effect_agent_meta SET value='5' WHERE key='storage_version'`;
             yield* failpoint("upgrade:after-version");
           }),
         )
@@ -538,7 +590,7 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
         message:
           `The Durable Object uses unsupported storage version ${version.value}; ` +
           `this build supports exactly version ${CurrentDoStorageVersion}. ` +
-          "Only supported v2 and v3 can be upgraded automatically. Keep the original store and use a compatible library version.",
+          "Only supported v2, v3 and v4 can be upgraded automatically. Keep the original store and use a compatible library version.",
       });
     }
   }
@@ -547,7 +599,7 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
     SELECT name
     FROM sqlite_master
     WHERE type = 'table'
-      AND name IN ${sql.in([...REQUIRED_TABLES, "effect_agent_message_deliveries"])}
+      AND name IN ${sql.in([...REQUIRED_TABLES, "effect_agent_message_deliveries", "effect_agent_recovery_checkpoints"])}
     ORDER BY name
   `.pipe(Effect.mapError(storageError("verify storage tables")));
 
@@ -558,7 +610,7 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
     requiredRows,
   );
 
-  if (required.length !== REQUIRED_TABLES.length + 1) {
+  if (required.length !== REQUIRED_TABLES.length + 2) {
     return yield* DoStorageCompatibilityError.make({
       actualVersion: CurrentDoStorageVersion,
       supportedVersion: CurrentDoStorageVersion,
@@ -1069,27 +1121,54 @@ const makeJournal = (
 
           yield* failpoint("export:after-thread-read");
 
-          const recordRows = yield* sql<Record<string, unknown>>`
-            SELECT
-              thread_id,
-              sequence,
-              record_id,
-              batch_id,
-              record_json
-            FROM effect_agent_canonical_records
-            WHERE thread_id = ${threadId}
-            ORDER BY sequence
-          `.pipe(Effect.mapError(storageError("export canonical records")));
+          if (thread.tail_sequence > MAX_RECORDS_PER_THREAD)
+            return yield* DoStorageError.make({
+              operation: "export thread",
+              message: "The thread exceeds the current export record limit.",
+            });
+          const records: Array<RecordRow> = [];
+          let afterSequence = ZERO_SEQUENCE;
 
-          return RawThreadExport.make({
-            thread,
-            records: yield* decodeRows(
-              Schema.Array(RecordRow),
-              "effect_agent_canonical_records",
+          while (afterSequence < thread.tail_sequence) {
+            const limit = Math.min(1_024, thread.tail_sequence - afterSequence);
+
+            const request = RawReadRequest.make({
               threadId,
-              recordRows,
-            ),
-          });
+              fromSequenceExclusive: afterSequence,
+              limit,
+            });
+
+            const plan = yield* read(request);
+            const page = yield* Stream.runCollect(plan.records);
+
+            if (
+              page.length !== limit ||
+              page.some((record, index) => record.sequence !== afterSequence + index + 1)
+            ) {
+              return yield* DoStorageCorruptionError.make({
+                table: "effect_agent_canonical_records",
+                rowKey: threadId,
+                message:
+                  "The exported canonical prefix is not contiguous through its captured tail.",
+              });
+            }
+            records.push(...page);
+            afterSequence = page[page.length - 1].sequence;
+          }
+
+          const beyondTail =
+            yield* sql`SELECT sequence FROM effect_agent_canonical_records WHERE thread_id=${threadId} AND sequence > ${thread.tail_sequence} LIMIT 1`.pipe(
+              Effect.mapError(storageError("verify export tail")),
+            );
+
+          if (beyondTail.length !== 0)
+            return yield* DoStorageCorruptionError.make({
+              table: "effect_agent_canonical_records",
+              rowKey: threadId,
+              message: "Canonical records exist beyond the captured thread tail.",
+            });
+
+          return RawThreadExport.make({ thread, records });
         }),
       )
       .pipe(
@@ -1189,6 +1268,82 @@ const makeJournal = (
           )
         `.pipe(Effect.mapError(storageError("insert checkpoint")));
       }),
+    );
+  });
+
+  const saveRecoveryCheckpoint = Effect.fn("DoJournal.saveRecoveryCheckpoint")(function* (
+    request: SaveRecoveryCheckpointRequest,
+    checkpointJson: string,
+  ) {
+    const { checkpoint } = request;
+
+    if (checkpoint.threadId.length > MAX_IDENTIFIER_LENGTH) {
+      return yield* DoStorageError.make({
+        operation: "save recovery checkpoint",
+        message: "Checkpoint identity exceeds the Durable Object storage bounds.",
+      });
+    }
+    yield* checkValueBound("save recovery checkpoint", checkpointJson);
+    // Keep injected waits outside the storage-backed transaction callback.
+    yield* failpoint("save-recovery-checkpoint:before");
+    yield* withWriteTransaction("recovery checkpoint transaction")(
+      Effect.gen(function* () {
+        const threads = yield* getThread(checkpoint.threadId);
+        const thread = threads[0];
+
+        if (thread === undefined)
+          return yield* ThreadNotMaterialized.make({ threadId: checkpoint.threadId });
+        if (request.producerEpoch !== thread.producer_epoch)
+          return yield* FenceRejected.make({
+            threadId: checkpoint.threadId,
+            actualEpoch: thread.producer_epoch,
+            attemptedEpoch: request.producerEpoch,
+          });
+        if (checkpoint.throughSequence > thread.tail_sequence)
+          return yield* CheckpointRejected.make({
+            threadId: checkpoint.threadId,
+            reason: "ahead-of-tail",
+          });
+
+        const digests =
+          checkpoint.throughSequence === 0
+            ? [EMPTY_TAIL_DIGEST]
+            : yield* getTailDigestAt(checkpoint.threadId, checkpoint.throughSequence);
+
+        if (digests.length !== 1 || digests[0] !== checkpoint.tailDigest)
+          return yield* CheckpointRejected.make({
+            threadId: checkpoint.threadId,
+            reason: "digest-mismatch",
+          });
+
+        yield* sql`
+          INSERT INTO effect_agent_recovery_checkpoints (thread_id, through_sequence, tail_digest, checkpoint_json)
+          VALUES (${checkpoint.threadId}, ${checkpoint.throughSequence}, ${checkpoint.tailDigest}, ${checkpointJson})
+          ON CONFLICT (thread_id) DO UPDATE SET
+            through_sequence = excluded.through_sequence,
+            tail_digest = excluded.tail_digest,
+            checkpoint_json = excluded.checkpoint_json
+          WHERE excluded.through_sequence >= effect_agent_recovery_checkpoints.through_sequence
+        `.pipe(Effect.mapError(storageError("save recovery checkpoint")));
+      }),
+    );
+    yield* failpoint("save-recovery-checkpoint:after");
+  });
+
+  const loadRecoveryCheckpoint = Effect.fn("DoJournal.loadRecoveryCheckpoint")(function* (
+    threadId: string,
+  ) {
+    const rows = yield* sql<Record<string, unknown>>`
+      SELECT thread_id, through_sequence, tail_digest, checkpoint_json
+      FROM effect_agent_recovery_checkpoints
+      WHERE thread_id = ${threadId}
+    `.pipe(Effect.mapError(storageError("load recovery checkpoint")));
+
+    return yield* decodeRows(
+      Schema.Array(CheckpointRow),
+      "effect_agent_recovery_checkpoints",
+      threadId,
+      rows,
     );
   });
 
@@ -1346,6 +1501,8 @@ const makeJournal = (
     getThread,
     getTailDigestAt,
     loadCheckpoint,
+    loadRecoveryCheckpoint,
+    saveRecoveryCheckpoint,
     materialize,
     read,
     saveCheckpoint,

--- a/packages/storage-cloudflare/src/internal/migrations.ts
+++ b/packages/storage-cloudflare/src/internal/migrations.ts
@@ -3,9 +3,10 @@ import { Effect } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
+import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 /** The current storage version recorded in `effect_agent_meta`. */
-export const CurrentDoStorageVersion = 4;
+export const CurrentDoStorageVersion = 5;
 
 /**
  * The Thread Durable Object schema shares its thread and ledger tables with Node/SQLite.
@@ -257,6 +258,7 @@ export const doMigrations = SqliteMigrator.fromRecord({
     `.withoutTransform;
 
     yield* createMessageDeliveryTables;
+    yield* createRecoveryCheckpointTable;
     yield* sql`
       CREATE TABLE effect_agent_meta (
         key TEXT PRIMARY KEY NOT NULL,

--- a/packages/storage-cloudflare/src/internal/recovery-checkpoint-schema.ts
+++ b/packages/storage-cloudflare/src/internal/recovery-checkpoint-schema.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+/** One disposable recovery snapshot per Thread, independent of generic projections. */
+export const createRecoveryCheckpointTable = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE effect_agent_recovery_checkpoints (
+      thread_id TEXT PRIMARY KEY NOT NULL,
+      through_sequence INTEGER NOT NULL,
+      tail_digest TEXT NOT NULL,
+      checkpoint_json TEXT NOT NULL,
+      FOREIGN KEY (thread_id) REFERENCES effect_agent_threads(thread_id) ON DELETE RESTRICT
+    )
+  `.withoutTransform;
+});

--- a/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
+++ b/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
@@ -149,6 +149,68 @@ const services = (
 };
 
 describe("unpatched v2 native storage upgrade", () => {
+  for (const point of [
+    "upgrade:before-mutation",
+    "upgrade:after-mutation",
+    "upgrade:before-version",
+    "upgrade:after-version",
+  ] as const) {
+    it(`preserves v4 data and atomically adds recovery checkpoints at ${point}`, () => {
+      let armed = false;
+
+      return fixture(
+        "thread",
+        (open) =>
+          Effect.gen(function* () {
+            yield* open;
+            const sql = yield* SqlClientService.SqlClient;
+
+            yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
+            yield* sql`UPDATE effect_agent_meta SET value='4' WHERE key='storage_version'`;
+            const before = yield* snapshotStore;
+
+            armed = true;
+            expect(Exit.isFailure(yield* open.pipe(Effect.exit))).toBe(true);
+            expect(yield* snapshotStore).toEqual(before);
+            expect(
+              yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
+            ).toEqual([{ value: "4" }]);
+            armed = false;
+            yield* open;
+            yield* assertPreserved("thread");
+            expect(
+              yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
+            ).toEqual([{ value: "5" }]);
+            expect(yield* sql`SELECT * FROM effect_agent_recovery_checkpoints`).toEqual([]);
+            const upgraded = yield* snapshotStore;
+
+            yield* open;
+            expect(yield* snapshotStore).toEqual(upgraded);
+          }),
+        (location) => (armed && location === point ? "failure" : undefined),
+      );
+    });
+  }
+
+  it("rejects an ambiguous v4 layout without changing retained data or native alarm", () =>
+    fixture("thread", (open) =>
+      Effect.gen(function* () {
+        yield* open;
+        const sql = yield* SqlClientService.SqlClient;
+
+        yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
+        yield* sql`ALTER TABLE effect_agent_submissions RENAME COLUMN message_admission_json TO malformed_column`;
+        yield* sql`UPDATE effect_agent_meta SET value='4' WHERE key='storage_version'`;
+        const before = yield* snapshotStore;
+
+        expect(yield* open.pipe(Effect.result)).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "DoStorageCompatibilityError", actualVersion: 4 },
+        });
+        expect(yield* snapshotStore).toEqual(before);
+      }),
+    ));
+
   for (const [table, column] of [
     ["effect_agent_submissions", "admission_fence_json"],
     ["effect_agent_child_settlements", "child_outcome"],
@@ -164,6 +226,7 @@ describe("unpatched v2 native storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClientService.SqlClient;
 
+            yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`DROP TABLE effect_agent_message_deliveries`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN message_admission_json`;
@@ -201,6 +264,7 @@ describe("unpatched v2 native storage upgrade", () => {
           yield* open;
           const sql = yield* SqlClientService.SqlClient;
 
+          yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
           yield* sql`DROP TABLE effect_agent_message_deliveries`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN message_admission_json`;
@@ -215,7 +279,7 @@ describe("unpatched v2 native storage upgrade", () => {
           yield* assertPreserved("thread");
           expect(
             yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
-          ).toEqual([{ value: "4" }]);
+          ).toEqual([{ value: "5" }]);
           expect(yield* sql`SELECT * FROM effect_agent_message_deliveries`).toEqual([]);
         }),
       (point) => (armed && point === "upgrade:after-version" ? "failure" : undefined),
@@ -236,7 +300,7 @@ describe("unpatched v2 native storage upgrade", () => {
           if (store === "thread") {
             expect(
               yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
-            ).toEqual([{ value: "4" }]);
+            ).toEqual([{ value: "5" }]);
             expect(yield* sql`SELECT * FROM effect_agent_child_settlements`).toEqual([
               {
                 parent_submission_id: "parent",

--- a/packages/storage-cloudflare/test/do-storage.test.ts
+++ b/packages/storage-cloudflare/test/do-storage.test.ts
@@ -2,6 +2,7 @@ import { type DoStorageConfig } from "@effect-agent/storage-cloudflare/DoStorage
 import {
   DoStorageCompatibilityError,
   DoStorageError,
+  DoStorageFailpointError,
   DoValueBoundExceeded,
 } from "@effect-agent/storage-cloudflare/DoStorageError";
 import { DoStorageFailpoint } from "@effect-agent/storage-cloudflare/DoStorageFailpoint";
@@ -20,6 +21,8 @@ import {
 } from "@effect-agent/thread/testing/ThreadStoreConformance";
 import {
   ThreadCheckpoint,
+  ThreadTailRequest,
+  ThreadExportRequest,
   ThreadMaterialization,
   ThreadObservation,
   ThreadRead,
@@ -28,11 +31,24 @@ import {
   FencedAppendRequest,
   LoadCheckpointRequest,
   SaveCheckpointRequest,
+  SaveRecoveryCheckpointRequest,
 } from "@effect-agent/thread/ThreadStore";
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
 import type { Crypto } from "effect";
-import { Cause, Effect, Exit, Layer, Option, Schema, Stream, Tracer } from "effect";
+import {
+  Cause,
+  Deferred,
+  Fiber,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Schema,
+  Stream,
+  Tracer,
+} from "effect";
+import { TestClock } from "effect/testing";
 import * as SqlClientService from "effect/unstable/sql/SqlClient";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -95,7 +111,319 @@ const batch = (
     records,
   });
 
+let recoveryCase = 0;
+
 describe("DoThreadStore", () => {
+  it("rejects canonical records beyond the captured export tail", () =>
+    withThreadStorage("bad-export-tail", (storage) =>
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+        const threadId = thread("bad-export-tail");
+
+        yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }));
+        yield* store.append(
+          FencedAppendRequest.make({
+            threadId,
+            producerEpoch: epoch(1),
+            expectedTailSequence: sequence(0),
+            expectedTailDigest: EMPTY_TAIL_DIGEST,
+            batch: batch("bad-export-tail", [inputRecord("bad-export-tail", "Kyoto")]),
+          }),
+        );
+        yield* Effect.sync(() =>
+          storage.sql.exec(
+            "UPDATE effect_agent_threads SET tail_sequence=0 WHERE thread_id=?",
+            threadId,
+          ),
+        );
+        expect(
+          yield* store.export(ThreadExportRequest.make({ threadId })).pipe(Effect.flip),
+        ).toMatchObject({
+          _tag: "ThreadStoreError",
+          message: expect.stringContaining("beyond the captured thread tail"),
+        });
+      }).pipe(Effect.provide(layer({ storage }))),
+    ));
+
+  it("isolates, fences and replaces one durable recovery checkpoint across reopen", () =>
+    withThreadStorage(`recovery-store:${++recoveryCase}`, (storage) =>
+      Effect.gen(function* () {
+        const checkpoint = yield* Effect.gen(function* () {
+          const store = yield* ThreadStore;
+          const threadId = thread("recovery-store");
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const empty = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "recovery-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          yield* store.checkpoints!.save(SaveCheckpointRequest.make({ checkpoint: empty }));
+          yield* store.recoveryCheckpoints!.save(
+            SaveRecoveryCheckpointRequest.make({ checkpoint: empty, producerEpoch: epoch(1) }),
+          );
+
+          const appended = yield* store.append(
+            FencedAppendRequest.make({
+              threadId,
+              producerEpoch: epoch(1),
+              expectedTailSequence: sequence(0),
+              expectedTailDigest: EMPTY_TAIL_DIGEST,
+              batch: batch("recovery-batch", [
+                inputRecord("recovery-1", "Kyoto"),
+                inputRecord("recovery-2", "Nara"),
+              ]),
+            }),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            ...empty,
+            throughSequence: appended.lastSequence,
+            tailDigest: appended.tailDigest,
+            state: { version: 1 },
+          });
+
+          const save = (checkpoint: ThreadCheckpoint, producerEpoch = epoch(1)) =>
+            store.recoveryCheckpoints!.save(
+              SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch }),
+            );
+
+          yield* save(checkpoint);
+          yield* save(empty);
+          expect(
+            yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+          ).toEqual(Option.some(checkpoint));
+          expect(
+            Option.isNone(
+              yield* store.recoveryCheckpoints!.load(
+                LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: sequence(0) }),
+              ),
+            ),
+          ).toBe(true);
+          expect(
+            yield* save(
+              ThreadCheckpoint.make({ ...checkpoint, throughSequence: sequence(1) }),
+            ).pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "digest-mismatch" });
+          expect(
+            yield* save(
+              ThreadCheckpoint.make({ ...checkpoint, throughSequence: sequence(3) }),
+            ).pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "ahead-of-tail" });
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(2) }),
+          );
+          expect(yield* save(checkpoint).pipe(Effect.flip)).toMatchObject({
+            _tag: "FenceRejected",
+            actualEpoch: 2,
+            attemptedEpoch: 1,
+          });
+
+          const replacement = ThreadCheckpoint.make({
+            ...checkpoint,
+            state: { version: 2 },
+            createdAt: at(3),
+          });
+
+          yield* save(replacement, epoch(2));
+          expect(yield* store.checkpoints!.load(LoadCheckpointRequest.make({ threadId }))).toEqual(
+            Option.some(empty),
+          );
+          expect(
+            (yield* store.export(ThreadExportRequest.make({ threadId }))).records,
+          ).toHaveLength(2);
+
+          return replacement;
+        }).pipe(Effect.provide(layer({ storage })));
+
+        const restored = yield* ThreadStore.pipe(
+          Effect.flatMap((store) =>
+            store.recoveryCheckpoints!.load(
+              LoadCheckpointRequest.make({ threadId: checkpoint.threadId }),
+            ),
+          ),
+          Effect.provide(layer({ storage })),
+        );
+
+        expect(restored).toEqual(Option.some(checkpoint));
+
+        const rows = yield* Effect.sync(() =>
+          storage.sql
+            .exec("SELECT COUNT(*) AS count FROM effect_agent_recovery_checkpoints")
+            .toArray(),
+        );
+
+        expect(rows).toEqual([{ count: 1 }]);
+      }),
+    ));
+
+  for (const corruption of ["json", "version", "thread", "sequence", "digest", "row"] as const) {
+    it(`rejects ${corruption} recovery cache corruption and permits same-tail repair`, () =>
+      withThreadStorage(`recovery-store:${++recoveryCase}`, (storage) =>
+        Effect.gen(function* () {
+          const store = yield* ThreadStore;
+          const threadId = thread("recovery-store");
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "recovery-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          const save = store.recoveryCheckpoints!.save(
+            SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch: epoch(1) }),
+          );
+
+          yield* save;
+          const encoded = yield* Schema.encodeEffect(ThreadCheckpoint)(checkpoint);
+
+          const json =
+            corruption === "json"
+              ? "{"
+              : JSON.stringify({
+                  ...encoded,
+                  ...(corruption === "version" ? { schemaVersion: 99 } : {}),
+                  ...(corruption === "thread" ? { threadId: "foreign" } : {}),
+                  ...(corruption === "sequence" ? { throughSequence: 1 } : {}),
+                  ...(corruption === "digest" ? { tailDigest: "a".repeat(64) } : {}),
+                });
+
+          const storedSequence = corruption === "row" ? -1 : 0;
+
+          yield* Effect.sync(() =>
+            storage.sql.exec(
+              "UPDATE effect_agent_recovery_checkpoints SET checkpoint_json=?, through_sequence=? WHERE thread_id=?",
+              json,
+              storedSequence,
+              threadId,
+            ),
+          );
+          expect(
+            yield* store
+              .recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId }))
+              .pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "corrupt" });
+          yield* save;
+          expect(
+            yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+          ).toEqual(Option.some(checkpoint));
+          expect(
+            (yield* store.inspectTail(ThreadTailRequest.make({ threadId }))).tailSequence,
+          ).toBe(0);
+        }).pipe(Effect.provide(layer({ storage }))),
+      ));
+  }
+
+  for (const location of [
+    "save-recovery-checkpoint:before",
+    "save-recovery-checkpoint:after",
+  ] as const) {
+    for (const mode of ["failure", "defect", "interrupt", "timeout"] as const) {
+      it(`reopens safely after ${mode} at ${location}`, () =>
+        withThreadStorage(`recovery-store:${++recoveryCase}`, (storage) =>
+          Effect.gen(function* () {
+            const threadId = thread("recovery-store");
+
+            const save = Effect.gen(function* () {
+              const store = yield* ThreadStore;
+
+              yield* store.materialize(
+                ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+              );
+
+              const checkpoint = ThreadCheckpoint.make({
+                schemaVersion: 1,
+                threadId,
+                throughSequence: sequence(0),
+                tailDigest: EMPTY_TAIL_DIGEST,
+                engineVersion: "recovery-test",
+                agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+                modelDigest: EMPTY_TAIL_DIGEST,
+                toolDigest: EMPTY_TAIL_DIGEST,
+                state: {},
+                createdAt: at(2),
+              });
+
+              yield* store.recoveryCheckpoints!.save(
+                SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch: epoch(1) }),
+              );
+            });
+
+            const entered = yield* Deferred.make<void>();
+
+            const failed = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const fiber = yield* save.pipe(
+                  Effect.provide(
+                    layer({
+                      storage,
+                      failpoint: (point) =>
+                        point !== location
+                          ? Effect.void
+                          : Deferred.succeed(entered, undefined).pipe(
+                              Effect.andThen(
+                                mode === "failure"
+                                  ? DoStorageFailpointError.make({ location })
+                                  : mode === "defect"
+                                    ? Effect.die("injected checkpoint defect")
+                                    : mode === "interrupt"
+                                      ? Effect.interrupt
+                                      : Effect.never,
+                              ),
+                            ),
+                    }),
+                  ),
+                  Effect.timeout("1 second"),
+                  Effect.forkChild,
+                );
+
+                yield* Deferred.await(entered);
+                if (mode === "timeout") yield* TestClock.adjust("1 second");
+
+                return yield* Fiber.await(fiber);
+              }),
+            );
+
+            expect(Exit.isFailure(failed)).toBe(true);
+            yield* Effect.gen(function* () {
+              const store = yield* ThreadStore;
+
+              expect(
+                Option.isSome(
+                  yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+                ),
+              ).toBe(location === "save-recovery-checkpoint:after");
+              expect(
+                (yield* store.inspectTail(ThreadTailRequest.make({ threadId }))).tailSequence,
+              ).toBe(0);
+            }).pipe(Effect.provide(layer({ storage })));
+          }),
+        ));
+    }
+  }
+
   for (const corruption of ["thread", "sequence", "digest"] as const) {
     it(`rejects checkpoint ${corruption} metadata that disagrees with its row`, () =>
       withThreadStorage(`checkpoint-metadata:${corruption}`, (storage) =>

--- a/packages/storage-cloudflare/test/routing.test.ts
+++ b/packages/storage-cloudflare/test/routing.test.ts
@@ -207,6 +207,7 @@ describe("cross-DO port routing", () => {
         const store = yield* ThreadStore;
 
         expect(store.checkpoints).toBeUndefined();
+        expect(store.recoveryCheckpoints).toBeUndefined();
 
         const missing = yield* store
           .export(
@@ -910,6 +911,12 @@ describe("cross-DO port routing", () => {
         const checkpointFailure = yield* store
           .checkpoints!.load(LoadCheckpointRequest.make({ threadId: thread(foreignConv) }))
           .pipe(Effect.flip);
+
+        const recoveryCheckpointFailure = yield* store
+          .recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId: thread(foreignConv) }))
+          .pipe(Effect.flip);
+
+        expect(recoveryCheckpointFailure).toBeInstanceOf(ThreadStoreError);
 
         expect(checkpointFailure).toBeInstanceOf(ThreadStoreError);
         if (isThreadStoreError(checkpointFailure)) {

--- a/packages/storage-cloudflare/test/routing.test.ts
+++ b/packages/storage-cloudflare/test/routing.test.ts
@@ -912,12 +912,6 @@ describe("cross-DO port routing", () => {
           .checkpoints!.load(LoadCheckpointRequest.make({ threadId: thread(foreignConv) }))
           .pipe(Effect.flip);
 
-        const recoveryCheckpointFailure = yield* store
-          .recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId: thread(foreignConv) }))
-          .pipe(Effect.flip);
-
-        expect(recoveryCheckpointFailure).toBeInstanceOf(ThreadStoreError);
-
         expect(checkpointFailure).toBeInstanceOf(ThreadStoreError);
         if (isThreadStoreError(checkpointFailure)) {
           expect(checkpointFailure.message).toContain("not route-capable");
@@ -926,6 +920,27 @@ describe("cross-DO port routing", () => {
     );
 
     // Fail-fast means fail BEFORE the transport: no delivery was ever attempted.
+    expect(state.calls).toBe(0);
+  });
+
+  it("treats a foreign recovery cache as missing without routing it", async () => {
+    const state = control();
+
+    await withRoutedPorts(
+      "wp2-cache-local",
+      state,
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+
+        const checkpoint = yield* store.recoveryCheckpoints!.load(
+          LoadCheckpointRequest.make({ threadId: thread("wp2-cache-foreign") }),
+        );
+
+        // Runtime recovery can continue through the authorized canonical read route.
+        expect(Option.isNone(checkpoint)).toBe(true);
+      }),
+    );
+
     expect(state.calls).toBe(0);
   });
 

--- a/packages/storage-memory/src/MemoryThreadStore.ts
+++ b/packages/storage-memory/src/MemoryThreadStore.ts
@@ -29,6 +29,9 @@ import {
   FencedAppendRequest,
   LoadCheckpointRequest,
   SaveCheckpointRequest,
+  SaveRecoveryCheckpointRequest,
+  type ThreadRecoveryCheckpoints,
+  MAX_THREAD_EXPORT_RECORDS,
 } from "@effect-agent/thread/ThreadStore";
 import {
   Context,
@@ -44,7 +47,7 @@ import {
 } from "effect";
 
 const MAX_THREADS = 256;
-const MAX_RECORDS_PER_THREAD = 65_536;
+const MAX_RECORDS_PER_THREAD = MAX_THREAD_EXPORT_RECORDS;
 const MAX_CHECKPOINTS_PER_THREAD = 1_024;
 
 const ThreadCapacity = Context.Reference<number>(
@@ -66,6 +69,7 @@ interface StoredThread {
   readonly batches: ReadonlyMap<BatchId, StoredBatch>;
   readonly tailDigests: ReadonlyMap<CanonicalSequence, Digest>;
   readonly checkpoints: ReadonlyMap<CanonicalSequence, ThreadCheckpoint>;
+  readonly recoveryCheckpoint?: ThreadCheckpoint;
 }
 
 interface MemoryState {
@@ -631,6 +635,106 @@ const makeThreadStore = Effect.gen(function* () {
       }),
   );
 
+  const saveRecoveryCheckpoint: ThreadRecoveryCheckpoints["save"] = Effect.fn(
+    "MemoryThreadStore.saveRecoveryCheckpoint",
+  )(function* (unvalidated) {
+    const request = yield* validate(
+      SaveRecoveryCheckpointRequest,
+      "saveRecoveryCheckpoint",
+      unvalidated,
+    );
+
+    const decision = yield* Ref.modify(
+      state,
+      (
+        current,
+      ): readonly [
+        CheckpointDecision | { readonly _tag: "failure"; readonly error: FenceRejected },
+        MemoryState,
+      ] => {
+        const checkpoint = request.checkpoint;
+        const thread = current.threads.get(checkpoint.threadId);
+
+        if (thread === undefined)
+          return [
+            {
+              _tag: "failure",
+              error: ThreadNotMaterialized.make({ threadId: checkpoint.threadId }),
+            },
+            current,
+          ];
+        if (thread.producerEpoch !== request.producerEpoch)
+          return [
+            {
+              _tag: "failure",
+              error: FenceRejected.make({
+                threadId: checkpoint.threadId,
+                actualEpoch: thread.producerEpoch,
+                attemptedEpoch: request.producerEpoch,
+              }),
+            },
+            current,
+          ];
+        if (checkpoint.throughSequence > thread.tailSequence)
+          return [
+            {
+              _tag: "failure",
+              error: CheckpointRejected.make({
+                threadId: checkpoint.threadId,
+                reason: "ahead-of-tail",
+              }),
+            },
+            current,
+          ];
+        if (thread.tailDigests.get(checkpoint.throughSequence) !== checkpoint.tailDigest)
+          return [
+            {
+              _tag: "failure",
+              error: CheckpointRejected.make({
+                threadId: checkpoint.threadId,
+                reason: "digest-mismatch",
+              }),
+            },
+            current,
+          ];
+        if ((thread.recoveryCheckpoint?.throughSequence ?? -1) > checkpoint.throughSequence)
+          return [{ _tag: "success" }, current];
+        const threads = new Map(current.threads);
+
+        threads.set(checkpoint.threadId, { ...thread, recoveryCheckpoint: checkpoint });
+
+        return [{ _tag: "success" }, { threads }];
+      },
+    );
+
+    if (decision._tag === "failure") return yield* decision.error;
+  });
+
+  const loadRecoveryCheckpoint: ThreadRecoveryCheckpoints["load"] = Effect.fn(
+    "MemoryThreadStore.loadRecoveryCheckpoint",
+  )(function* (unvalidated) {
+    const request = yield* validate(LoadCheckpointRequest, "loadRecoveryCheckpoint", unvalidated);
+
+    const thread = yield* Ref.get(state).pipe(
+      Effect.flatMap((current) => findThread(current, request.threadId)),
+    );
+
+    const checkpoint = thread.recoveryCheckpoint;
+
+    if (
+      checkpoint === undefined ||
+      checkpoint.throughSequence > (request.atOrBeforeSequence ?? thread.tailSequence)
+    )
+      return Option.none();
+    if (thread.tailDigests.get(checkpoint.throughSequence) !== checkpoint.tailDigest)
+      return yield* CheckpointRejected.make({
+        threadId: request.threadId,
+        reason: "digest-mismatch",
+      });
+
+    return Option.some(checkpoint);
+  });
+
   return ThreadStore.of({
     materialize,
     append,
@@ -639,6 +743,7 @@ const makeThreadStore = Effect.gen(function* () {
     export: exportThread,
     inspectTail,
     checkpoints: { save: saveCheckpoint, load: loadCheckpoint },
+    recoveryCheckpoints: { save: saveRecoveryCheckpoint, load: loadRecoveryCheckpoint },
   });
 });
 

--- a/packages/storage-memory/test/recovery-checkpoint.test.ts
+++ b/packages/storage-memory/test/recovery-checkpoint.test.ts
@@ -1,0 +1,402 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { ThreadId, ToolCallId } from "@effect-agent/core/Identifiers";
+import { ContextCompactor } from "@effect-agent/engine/ContextCompactor";
+import {
+  DurableStep,
+  DurableStepError,
+  ToolExecutionClass,
+} from "@effect-agent/engine/DurableStep";
+import { RunContextPreparation, RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import { DurableWorkerBinding } from "@effect-agent/thread/AgentRegistration";
+import {
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+} from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeFailpointError } from "@effect-agent/thread/DurableFailpoint";
+import { DefinitionDigests, DeploymentId, Digest, ProducerId } from "@effect-agent/thread/Records";
+import {
+  ApprovalDecisionCommand,
+  IdempotencyKey,
+  Principal,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
+} from "@effect-agent/thread/SubmissionLedger";
+import { DurableRuntimeFailpointTestControl } from "@effect-agent/thread/testing/DurableFailpointTestControl";
+import {
+  LoadCheckpointRequest,
+  ThreadCheckpoint,
+  ThreadExportRequest,
+  ThreadStore,
+} from "@effect-agent/thread/ThreadStore";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeCrypto } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Layer, Option, Schema, Stream } from "effect";
+import { TestClock } from "effect/testing";
+import type { Prompt, Response } from "effect/unstable/ai";
+import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
+
+import { MemorySubmissionLedgerLive } from "../src/MemorySubmissionLedger.ts";
+import { MemoryThreadStoreLive } from "../src/MemoryThreadStore.ts";
+
+const digest = Schema.decodeSync(Digest)("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+
+const base = Layer.mergeAll(
+  MemoryThreadStoreLive,
+  MemorySubmissionLedgerLive,
+  DurableRuntimeFailpointTestControl.layer,
+  WakeScheduler.layerNoop,
+  ToolReconciler.uncertain,
+  DurableRuntimeConfig.layer({
+    deploymentId: DeploymentId.make("checkpoint-test"),
+    producerId: ProducerId.make("checkpoint-test"),
+  }),
+).pipe(Layer.provideMerge(NodeCrypto.layer));
+
+const finish = {
+  type: "finish",
+  reason: "tool-calls",
+  usage: { inputTokens: { total: 100 }, outputTokens: { total: 10 } },
+} satisfies Response.StreamPartEncoded;
+
+const final: ReadonlyArray<Response.StreamPartEncoded> = [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: '"done"' },
+  { type: "text-end", id: "answer" },
+  { ...finish, reason: "stop" },
+];
+
+const scenarios = [
+  "cache",
+  "missing",
+  "corrupt",
+  "incompatible",
+  "definitions",
+  "gap",
+  "uncertain",
+  "deadline",
+  "approval",
+  "steps",
+  "second-rollover",
+  "checkpoint-before-failure",
+  "checkpoint-after-failure",
+  "checkpoint-before-interruption",
+  "checkpoint-after-interruption",
+  "checkpoint-before-defect",
+  "checkpoint-after-defect",
+] as const;
+
+describe("disposable durable recovery checkpoint", () => {
+  it.effect.each(scenarios)("preserves canonical obligations across %s", (scenario) =>
+    Effect.gen(function* () {
+      const store = yield* ThreadStore;
+      const ledger = yield* SubmissionLedger;
+      const failpoints = yield* DurableRuntimeFailpointTestControl;
+      const requests: Array<Prompt.Prompt> = [];
+      let calls = 0;
+      let stepEffects = 0;
+
+      const tools = Toolkit.make(
+        Tool.make("write", {
+          parameters: Tool.EmptyParams,
+          success: Schema.String,
+          dependencies: [DurableStep],
+          failure: DurableStepError,
+        }).annotate(ToolExecutionClass, scenario === "steps" ? "idempotent" : "ordinary"),
+        Tool.make("approve", {
+          parameters: Tool.EmptyParams,
+          success: Schema.String,
+          needsApproval: true,
+        }),
+      );
+
+      const handlers = tools.toLayer({
+        write: () =>
+          Effect.gen(function* () {
+            calls++;
+            if (scenario !== "steps") return "recorded";
+            const steps = yield* DurableStep;
+
+            return yield* steps.do(
+              "write-once",
+              Schema.String,
+              Effect.sync(() => {
+                stepEffects++;
+
+                return "recorded";
+              }),
+            );
+          }),
+        approve: () =>
+          Effect.sync(() => {
+            calls++;
+
+            return "approved";
+          }),
+      });
+
+      const model = Model.make(
+        "scripted",
+        "checkpoint",
+        Layer.effect(
+          LanguageModel.LanguageModel,
+          LanguageModel.make({
+            generateText: () => Effect.succeed([]),
+            streamText: (request) => {
+              requests.push(request.prompt);
+
+              return Stream.fromIterable<Response.StreamPartEncoded>(
+                requests.length <= (scenario === "second-rollover" ? 5 : 4)
+                  ? [
+                      {
+                        type: "tool-call",
+                        id:
+                          scenario === "steps" && requests.length === 4
+                            ? "call-1"
+                            : `call-${requests.length}`,
+                        name:
+                          scenario === "approval" && requests.length === 4 ? "approve" : "write",
+                        params: {},
+                      },
+                      finish,
+                    ]
+                  : final,
+              );
+            },
+          }),
+        ),
+      );
+
+      const agent = Agent.withModel(
+        Agent.make("checkpoint", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Keep original instructions.",
+          toolkit: tools,
+          policy: {
+            maxTurns: 10,
+            maxToolCalls: 10,
+            maxDuration: "30 seconds",
+            runStatus: "appended",
+            contextTokenLimit: 20_000,
+          },
+        }),
+        model,
+      );
+
+      const makeRuntime = Effect.gen(function* () {
+        const binding = yield* DurableWorkerBinding.make(agent, definitions).pipe(
+          Effect.provide(handlers),
+        );
+
+        return yield* DurableAgentRuntime.pipe(
+          Effect.provide(
+            DurableAgentRuntime.layerWithBindings([binding]).pipe(
+              Layer.provide(
+                Layer.mergeAll(RunToolAuthorization.allowAll, ContextCompactor.layerRollover),
+              ),
+            ),
+          ),
+          Effect.provideService(RunContextPreparation, {
+            hook: {
+              prepare: (request) =>
+                Effect.succeed({
+                  prompt: request.source,
+                  ...((request.turn === 3 &&
+                    !JSON.stringify(request.source).includes("Keep the continuation.")) ||
+                  (scenario === "second-rollover" && request.turn === 6)
+                    ? {
+                        rollover: {
+                          handoff:
+                            scenario === "second-rollover" && request.turn === 6
+                              ? "Second continuation."
+                              : "Keep the continuation.",
+                          through: request.source.content.length,
+                        },
+                      }
+                    : {}),
+                }),
+            },
+          }),
+        );
+      });
+
+      const runtime = yield* makeRuntime;
+
+      const receipt = yield* runtime.submit(agent, "Original input", {
+        threadId: ThreadId.make(`checkpoint-${scenario}`),
+        principal: Principal.make("test"),
+        idempotencyKey: IdempotencyKey.make("work"),
+        definitions,
+      });
+
+      yield* failpoints.setHandler((location) => {
+        const atCheckpoint =
+          scenario.startsWith("checkpoint-") &&
+          location ===
+            (scenario.includes("before") ? "checkpoint:before-save" : "checkpoint:after-save");
+
+        const atBatch =
+          !scenario.startsWith("checkpoint-") &&
+          requests.length === 4 &&
+          location ===
+            (scenario === "uncertain"
+              ? "tools:after-prepared-append"
+              : scenario === "approval"
+                ? "approval:after-request-append"
+                : "turn:after-results-append");
+
+        if (!atCheckpoint && !atBatch) return Effect.void;
+        if (scenario.endsWith("interruption")) return Effect.interrupt;
+        if (scenario.endsWith("defect")) return Effect.die("checkpoint crash");
+
+        return DurableRuntimeFailpointError.make({ location });
+      });
+
+      const stopped = yield* Effect.exit(
+        runtime.processThreadHead(receipt.threadId).pipe(Effect.provide(handlers)),
+      );
+
+      expect(Exit.isFailure(stopped)).toBe(true);
+
+      const snapshot = yield* ledger.loadRecoverySnapshot(
+        RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+      );
+
+      expect(snapshot.ownership).toBeUndefined();
+
+      const checkpoint = yield* store.recoveryCheckpoints!.load(
+        LoadCheckpointRequest.make({ threadId: receipt.threadId }),
+      );
+
+      expect(Option.isSome(checkpoint)).toBe(!scenario.includes("checkpoint-before"));
+
+      const original = yield* store.export(
+        ThreadExportRequest.make({ threadId: receipt.threadId }),
+      );
+
+      const requestsBefore = requests.length;
+      const callsBefore = calls;
+
+      yield* failpoints.clear;
+      if (scenario === "deadline") yield* TestClock.adjust("31 seconds");
+      let readRecords = 0;
+      const checkpoints = store.recoveryCheckpoints!;
+
+      const observed = ThreadStore.of({
+        ...store,
+        recoveryCheckpoints:
+          scenario === "missing"
+            ? undefined
+            : {
+                ...checkpoints,
+                load: (request) =>
+                  checkpoints.load(request).pipe(
+                    Effect.map(
+                      Option.map((saved) => {
+                        if (scenario === "corrupt")
+                          return ThreadCheckpoint.make({ ...saved, state: { invalid: true } });
+                        if (scenario === "incompatible")
+                          return ThreadCheckpoint.make({ ...saved, engineVersion: "future" });
+                        if (scenario === "definitions")
+                          return ThreadCheckpoint.make({
+                            ...saved,
+                            agentDefinitionDigest: Digest.make("b".repeat(64)),
+                          });
+
+                        return saved;
+                      }),
+                    ),
+                  ),
+              },
+        read: (request) =>
+          store.read(request).pipe(
+            Stream.filter(
+              (entry) =>
+                scenario !== "gap" ||
+                Option.isNone(checkpoint) ||
+                entry.sequence !== checkpoint.value.throughSequence + 1,
+            ),
+            Stream.tap(() =>
+              Effect.sync(() => {
+                readRecords++;
+              }),
+            ),
+          ),
+      });
+
+      const resumed = yield* makeRuntime.pipe(Effect.provideService(ThreadStore, observed));
+
+      if (scenario === "gap") {
+        expect(Exit.isFailure(yield* Effect.exit(resumed.runRecovery))).toBe(true);
+        expect(requests).toHaveLength(requestsBefore);
+        expect(calls).toBe(callsBefore);
+
+        return;
+      }
+      yield* resumed.runRecovery;
+      if (scenario === "approval") {
+        yield* resumed.resolveApproval(
+          ApprovalDecisionCommand.make({
+            submissionId: receipt.submissionId,
+            toolCallId: ToolCallId.make("call-4"),
+            decision: "approved",
+            resolver: "test",
+            reason: "resume checkpointed approval",
+          }),
+        );
+      }
+
+      const outcome = yield* resumed
+        .processThreadHead(receipt.threadId)
+        .pipe(Effect.provide(handlers));
+
+      if (scenario === "uncertain") {
+        expect(Option.isNone(outcome)).toBe(true);
+        expect(requests).toHaveLength(requestsBefore);
+        expect(calls).toBe(callsBefore);
+
+        const pending = yield* ledger.loadRecoverySnapshot(
+          RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+        );
+
+        expect(pending.submission.state).toBe("unknown");
+      } else if (scenario === "deadline") {
+        expect(Option.isSome(outcome) && outcome.value.outcome).toBe("failed");
+        expect(requests).toHaveLength(requestsBefore);
+        expect(calls).toBe(callsBefore);
+      } else {
+        expect(Option.isSome(outcome) && outcome.value.outcome).toBe("completed");
+        expect(calls).toBe(scenario === "second-rollover" ? 5 : 4);
+        if (scenario === "steps") expect(stepEffects).toBe(3);
+        expect(requests).toHaveLength(scenario === "second-rollover" ? 6 : 5);
+        const prompt = JSON.stringify(requests.at(-1));
+
+        expect(prompt).toContain("Original input");
+        expect(prompt).toContain("Keep original instructions.");
+        expect(prompt).toContain(
+          scenario === "second-rollover" ? "Second continuation." : "Keep the continuation.",
+        );
+        expect(prompt).toContain(scenario === "second-rollover" ? "turn 6/10" : "turn 5/10");
+        expect(prompt).toContain(scenario === "second-rollover" ? "tokens 550/" : "tokens 440/");
+        if (scenario !== "steps") expect(prompt).not.toContain('"id":"call-1"');
+        if (Option.isSome(outcome))
+          expect(outcome.value.usageSummary?.modelCalls).toBe(
+            scenario === "second-rollover" ? 6 : 5,
+          );
+      }
+
+      const completed = yield* store.export(
+        ThreadExportRequest.make({ threadId: receipt.threadId }),
+      );
+
+      expect(completed.records.slice(0, original.records.length)).toEqual(original.records);
+      expect(
+        completed.records.filter(({ record }) => record.payload._tag === "RunStarted"),
+      ).toHaveLength(1);
+      if (scenario === "cache") expect(readRecords).toBeLessThan(original.records.length * 2);
+    }).pipe(Effect.provide(base)),
+  );
+});

--- a/packages/storage-sqlite/src/SqliteStorageError.ts
+++ b/packages/storage-sqlite/src/SqliteStorageError.ts
@@ -110,6 +110,8 @@ export const SqliteStorageFailpointLocation = Schema.Literals([
   "export:after-thread-read",
   "save-checkpoint:before",
   "save-checkpoint:after",
+  "save-recovery-checkpoint:before",
+  "save-recovery-checkpoint:after",
   "ledger:admit:before",
   "ledger:admit:after",
   "ledger:mark-ready:before",

--- a/packages/storage-sqlite/src/SqliteThreadStore.ts
+++ b/packages/storage-sqlite/src/SqliteThreadStore.ts
@@ -28,6 +28,9 @@ import {
   FencedAppendRequest,
   LoadCheckpointRequest,
   SaveCheckpointRequest,
+  SaveRecoveryCheckpointRequest,
+  MAX_THREAD_EXPORT_RECORDS,
+  type ThreadRecoveryCheckpoints,
 } from "@effect-agent/thread/ThreadStore";
 import { NodeCrypto } from "@effect/platform-node";
 import { SqliteClient } from "@effect/sql-sqlite-node";
@@ -292,9 +295,9 @@ const groupByKey = <A>(
 };
 
 /**
- * Opt-in full integrity audit (`verifyOnOpen`). Every stored payload is decoded, re-encoded,
- * and re-digested against the canonical chain. Routine opens skip this scan: per-operation
- * Schema decoding plus the digest chain already fail clearly on corrupt rows.
+ * Opt-in integrity audit (`verifyOnOpen`) of canonical payloads, their digest chains and generic
+ * projection checkpoints. Disposable recovery checkpoints are validated when loaded. Routine opens
+ * skip this scan: per-operation Schema decoding fails clearly on corrupt canonical rows.
  */
 const decodeStartupPayloads = Effect.fn("SqliteThreadStore.decodeStartupPayloads")(function* (
   journal: SqliteJournal,
@@ -687,7 +690,7 @@ const makeServices = Effect.fn("SqliteThreadStore.makeServices")(function* () {
 
       const records = yield* Effect.forEach(exported.records, decodeEnvelope);
 
-      if (records.length > 65_536) {
+      if (records.length > MAX_THREAD_EXPORT_RECORDS) {
         return yield* ThreadStoreError.make({
           operation: "decode thread export",
           message: "The thread exceeds the current export record limit.",
@@ -831,6 +834,92 @@ const makeServices = Effect.fn("SqliteThreadStore.makeServices")(function* () {
     },
   );
 
+  const saveRecoveryCheckpoint: ThreadRecoveryCheckpoints["save"] = Effect.fn(
+    "SqliteThreadStore.saveRecoveryCheckpoint",
+  )(function* (request) {
+    const validated = yield* Schema.decodeUnknownEffect(
+      Schema.toType(SaveRecoveryCheckpointRequest),
+    )(request).pipe(
+      Effect.mapError((error) => schemaStoreError("validate recovery checkpoint", error)),
+    );
+
+    const checkpointJson = yield* encodeCheckpoint(validated.checkpoint);
+
+    yield* journal
+      .saveRecoveryCheckpoint(validated, checkpointJson)
+      .pipe(
+        Effect.mapError((error) =>
+          error._tag === "CheckpointRejected" ||
+          error._tag === "FenceRejected" ||
+          error._tag === "ThreadNotMaterialized"
+            ? error
+            : storeError("save recovery checkpoint", error),
+        ),
+      );
+  });
+
+  const loadRecoveryCheckpoint: ThreadRecoveryCheckpoints["load"] = Effect.fn(
+    "SqliteThreadStore.loadRecoveryCheckpoint",
+  )(function* (request) {
+    const validated = yield* Schema.decodeUnknownEffect(Schema.toType(LoadCheckpointRequest))(
+      request,
+    ).pipe(
+      Effect.mapError((error) => schemaStoreError("validate recovery checkpoint lookup", error)),
+    );
+
+    const thread = yield* requireThread(journal, validated.threadId);
+
+    const corrupt = () =>
+      CheckpointRejected.make({ threadId: validated.threadId, reason: "corrupt" });
+
+    const rows = yield* journal
+      .loadRecoveryCheckpoint(validated.threadId)
+      .pipe(
+        Effect.mapError((error) =>
+          error._tag === "SqliteStorageCorruptionError"
+            ? corrupt()
+            : storeError("load recovery checkpoint", error),
+        ),
+      );
+
+    if (rows.length === 0) return Option.none();
+    if (rows.length !== 1) return yield* corrupt();
+    const row = rows[0];
+
+    const checkpoint = yield* Schema.decodeEffect(Schema.fromJsonString(ThreadCheckpoint))(
+      row.checkpoint_json,
+    ).pipe(Effect.mapError(corrupt));
+
+    if (
+      row.thread_id !== validated.threadId ||
+      checkpoint.threadId !== row.thread_id ||
+      checkpoint.throughSequence !== row.through_sequence ||
+      checkpoint.tailDigest !== row.tail_digest
+    )
+      return yield* corrupt();
+    if (checkpoint.throughSequence > thread.tail_sequence)
+      return yield* CheckpointRejected.make({
+        threadId: validated.threadId,
+        reason: "ahead-of-tail",
+      });
+    if (checkpoint.throughSequence > (validated.atOrBeforeSequence ?? thread.tail_sequence))
+      return Option.none();
+
+    const canonicalDigest = yield* tailDigestAt(
+      journal,
+      checkpoint.threadId,
+      checkpoint.throughSequence,
+    );
+
+    if (canonicalDigest !== checkpoint.tailDigest)
+      return yield* CheckpointRejected.make({
+        threadId: validated.threadId,
+        reason: "digest-mismatch",
+      });
+
+    return Option.some(checkpoint);
+  });
+
   const threadStore = ThreadStore.of({
     append,
     export: exportThread,
@@ -839,6 +928,7 @@ const makeServices = Effect.fn("SqliteThreadStore.makeServices")(function* () {
     observe,
     read,
     checkpoints: { save: saveCheckpoint, load: loadCheckpoint },
+    recoveryCheckpoints: { save: saveRecoveryCheckpoint, load: loadRecoveryCheckpoint },
   });
 
   return Context.make(ThreadStore, threadStore);

--- a/packages/storage-sqlite/src/internal/migrations.ts
+++ b/packages/storage-sqlite/src/internal/migrations.ts
@@ -3,8 +3,9 @@ import { Effect } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
+import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
-export const CurrentSqliteStorageVersion = 9;
+export const CurrentSqliteStorageVersion = 10;
 
 /** Initialize empty storage with the complete current schema. */
 export const sqliteMigrations = SqliteMigrator.fromRecord({
@@ -336,6 +337,7 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
     yield* sql`CREATE INDEX effect_agent_subscription_deliveries_registration ON effect_agent_subscription_deliveries (tenant_id, source_address, owner_id, subscription_id, delivery_key)`
       .withoutTransform;
     yield* createMessageDeliveryTables;
-    yield* sql`PRAGMA user_version = 9`.withoutTransform;
+    yield* createRecoveryCheckpointTable;
+    yield* sql`PRAGMA user_version = 10`.withoutTransform;
   }),
 });

--- a/packages/storage-sqlite/src/internal/recovery-checkpoint-schema.ts
+++ b/packages/storage-sqlite/src/internal/recovery-checkpoint-schema.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+/** One disposable recovery snapshot per Thread, independent of generic projections. */
+export const createRecoveryCheckpointTable = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE effect_agent_recovery_checkpoints (
+      thread_id TEXT PRIMARY KEY NOT NULL,
+      through_sequence INTEGER NOT NULL,
+      tail_digest TEXT NOT NULL,
+      checkpoint_json TEXT NOT NULL,
+      FOREIGN KEY (thread_id) REFERENCES effect_agent_threads(thread_id) ON DELETE RESTRICT
+    )
+  `.withoutTransform;
+});

--- a/packages/storage-sqlite/src/internal/sqlite-journal.ts
+++ b/packages/storage-sqlite/src/internal/sqlite-journal.ts
@@ -1,3 +1,4 @@
+import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
 import { CanonicalSequence, ProducerEpoch } from "@effect-agent/thread/Records";
 import { ScheduleFailpoint, ScheduleFailpointError } from "@effect-agent/thread/Schedule";
 import {
@@ -9,6 +10,13 @@ import {
   SubscriptionFailpoint,
   SubscriptionFailpointError,
 } from "@effect-agent/thread/Subscription";
+import {
+  MAX_THREAD_EXPORT_RECORDS,
+  CheckpointRejected,
+  FenceRejected,
+  ThreadNotMaterialized,
+  type SaveRecoveryCheckpointRequest,
+} from "@effect-agent/thread/ThreadStore";
 import { NodeCrypto } from "@effect/platform-node";
 import { SqliteMigrator } from "@effect/sql-sqlite-node";
 import { Effect, Exit, Schema } from "effect";
@@ -30,11 +38,13 @@ import {
 import { SqliteStorageFailpoint } from "../SqliteStorageFailpoint.ts";
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
 import { CurrentSqliteStorageVersion, sqliteMigrations } from "./migrations.ts";
+import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 const BoundedStoredText = Schema.String.check(Schema.isMaxLength(16 * 1024 * 1024));
 const BoundedIdentifier = Schema.NonEmptyString.check(Schema.isMaxLength(1024));
 const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0));
-const MAX_RECORDS_PER_THREAD = 65_536;
+const MAX_RECORDS_PER_THREAD = MAX_THREAD_EXPORT_RECORDS;
+const ZERO_SEQUENCE = Schema.decodeSync(CanonicalSequence)(0);
 const MAX_STORED_TEXT_BYTES = 16 * 1024 * 1024;
 const MAX_IDENTIFIER_LENGTH = 1_024;
 
@@ -370,10 +380,32 @@ const predecessorColumns = {
   ],
 } as const;
 
-const checkPredecessorLayout = Effect.fn("SqliteJournal.checkPredecessorLayout")(function* () {
+const checkPredecessorLayout = Effect.fn("SqliteJournal.checkPredecessorLayout")(function* (
+  version: 8 | 9,
+) {
   const sql = yield* SqlClient.SqlClient;
 
-  for (const [table, expected] of Object.entries(predecessorColumns)) {
+  const expectedColumns =
+    version === 8
+      ? predecessorColumns
+      : {
+          ...predecessorColumns,
+          effect_agent_submissions: [
+            ...predecessorColumns.effect_agent_submissions,
+            "worker_admission_json",
+            "message_admission_json",
+          ],
+          effect_agent_message_deliveries: [
+            "owner_thread_id",
+            "message_id",
+            "version",
+            "state",
+            "deadline_at_millis",
+            "record_json",
+          ],
+        };
+
+  for (const [table, expected] of Object.entries(expectedColumns)) {
     const columns = yield* decodeRows(
       Schema.Array(Schema.Struct({ name: BoundedIdentifier })),
       table,
@@ -385,9 +417,9 @@ const checkPredecessorLayout = Effect.fn("SqliteJournal.checkPredecessorLayout")
 
     if (columns.length !== names.size || columns.some((column) => !names.has(column.name)))
       return yield* SqliteStorageCompatibilityError.make({
-        actualVersion: 8,
+        actualVersion: version,
         supportedVersion: CurrentSqliteStorageVersion,
-        message: `The v8 ${table} columns do not match the supported predecessor; no upgrade was committed.`,
+        message: `The v${version} ${table} columns do not match the supported predecessor; no upgrade was committed.`,
       });
   }
 });
@@ -439,6 +471,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     version.user_version !== 0 &&
     version.user_version !== 7 &&
     version.user_version !== 8 &&
+    version.user_version !== 9 &&
     version.user_version !== CurrentSqliteStorageVersion
   ) {
     return yield* SqliteStorageCompatibilityError.make({
@@ -447,11 +480,11 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
       message:
         `The SQLite file uses unsupported storage version ${version.user_version}; ` +
         `this build supports exactly version ${CurrentSqliteStorageVersion}. ` +
-        "Only supported v7 and v8 can be upgraded automatically. Keep the original file and use a compatible library version.",
+        "Only supported v7, v8 and v9 can be upgraded automatically. Keep the original file and use a compatible library version.",
     });
   }
 
-  if (version.user_version === 7 || version.user_version === 8) {
+  if (version.user_version === 7 || version.user_version === 8 || version.user_version === 9) {
     yield* sql
       .withTransaction(
         Effect.gen(function* () {
@@ -461,7 +494,9 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
             return;
           if (
             current.length !== 1 ||
-            (current[0].user_version !== 7 && current[0].user_version !== 8)
+            (current[0].user_version !== 7 &&
+              current[0].user_version !== 8 &&
+              current[0].user_version !== 9)
           )
             return yield* SqliteStorageCompatibilityError.make({
               actualVersion: -1,
@@ -486,6 +521,16 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
                 "The predecessor store is missing required tables; no upgrade was committed.",
             });
 
+          const recoveryTables =
+            yield* sql`SELECT name FROM sqlite_master WHERE type='table' AND name='effect_agent_recovery_checkpoints'`;
+
+          if (recoveryTables.length !== 0)
+            return yield* SqliteStorageCompatibilityError.make({
+              actualVersion: current[0].user_version,
+              supportedVersion: CurrentSqliteStorageVersion,
+              message:
+                "The predecessor already contains recovery checkpoint storage; refusing ambiguous data without mutation.",
+            });
           if (current[0].user_version === 7) {
             yield* checkV2ThreadLayout();
             for (const statement of [
@@ -516,18 +561,24 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
               }),
             );
           }
-          if (current[0].user_version === 8) yield* checkPredecessorLayout();
+          if (current[0].user_version === 8 || current[0].user_version === 9)
+            yield* checkPredecessorLayout(current[0].user_version);
+          if (current[0].user_version !== 9) {
+            yield* failpoint("upgrade:before-mutation");
+            yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
+            yield* failpoint("upgrade:after-mutation");
+            yield* failpoint("upgrade:before-mutation");
+            yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN message_admission_json TEXT`;
+            yield* failpoint("upgrade:after-mutation");
+            yield* failpoint("upgrade:before-mutation");
+            yield* createMessageDeliveryTables;
+            yield* failpoint("upgrade:after-mutation");
+          }
           yield* failpoint("upgrade:before-mutation");
-          yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
-          yield* failpoint("upgrade:after-mutation");
-          yield* failpoint("upgrade:before-mutation");
-          yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN message_admission_json TEXT`;
-          yield* failpoint("upgrade:after-mutation");
-          yield* failpoint("upgrade:before-mutation");
-          yield* createMessageDeliveryTables;
+          yield* createRecoveryCheckpointTable;
           yield* failpoint("upgrade:after-mutation");
           yield* failpoint("upgrade:before-version");
-          yield* sql`PRAGMA user_version = 9`;
+          yield* sql`PRAGMA user_version = 10`;
           yield* failpoint("upgrade:after-version");
         }),
       )
@@ -618,7 +669,8 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
         'effect_agent_approval_decisions',
         'effect_agent_unknown_resolutions',
         'effect_agent_schedules',
-        'effect_agent_message_deliveries'
+        'effect_agent_message_deliveries',
+        'effect_agent_recovery_checkpoints'
       )
     ORDER BY name
   `.pipe(Effect.mapError(storageError("verify storage tables")));
@@ -630,7 +682,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     requiredRows,
   );
 
-  if (required.length !== 13) {
+  if (required.length !== 14) {
     return yield* SqliteStorageCompatibilityError.make({
       actualVersion: CurrentSqliteStorageVersion,
       supportedVersion: CurrentSqliteStorageVersion,
@@ -1119,27 +1171,52 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
 
         yield* failpoint("export:after-thread-read");
 
-        const recordRows = yield* sql<Record<string, unknown>>`
-            SELECT
-              thread_id,
-              sequence,
-              record_id,
-              batch_id,
-              record_json
-            FROM effect_agent_canonical_records
-            WHERE thread_id = ${threadId}
-            ORDER BY sequence
-          `.pipe(Effect.mapError(storageError("export canonical records")));
+        if (thread.tail_sequence > MAX_RECORDS_PER_THREAD)
+          return yield* SqliteStorageError.make({
+            operation: "export thread",
+            message: "The thread exceeds the current export record limit.",
+          });
+        const records: Array<RecordRow> = [];
+        let afterSequence = ZERO_SEQUENCE;
 
-        return RawThreadExport.make({
-          thread,
-          records: yield* decodeRows(
-            Schema.Array(RecordRow),
-            "effect_agent_canonical_records",
+        while (afterSequence < thread.tail_sequence) {
+          const limit = Math.min(1_024, thread.tail_sequence - afterSequence);
+
+          const request = RawReadRequest.make({
             threadId,
-            recordRows,
-          ),
-        });
+            fromSequenceExclusive: afterSequence,
+            limit,
+          });
+
+          const page = yield* read(request);
+
+          if (
+            page.length !== limit ||
+            page.some((record, index) => record.sequence !== afterSequence + index + 1)
+          ) {
+            return yield* SqliteStorageCorruptionError.make({
+              table: "effect_agent_canonical_records",
+              rowKey: threadId,
+              message: "The exported canonical prefix is not contiguous through its captured tail.",
+            });
+          }
+          records.push(...page);
+          afterSequence = page[page.length - 1].sequence;
+        }
+
+        const beyondTail =
+          yield* sql`SELECT sequence FROM effect_agent_canonical_records WHERE thread_id=${threadId} AND sequence > ${thread.tail_sequence} LIMIT 1`.pipe(
+            Effect.mapError(storageError("verify export tail")),
+          );
+
+        if (beyondTail.length !== 0)
+          return yield* SqliteStorageCorruptionError.make({
+            table: "effect_agent_canonical_records",
+            rowKey: threadId,
+            message: "Canonical records exist beyond the captured thread tail.",
+          });
+
+        return RawThreadExport.make({ thread, records });
       }),
     );
   });
@@ -1236,6 +1313,83 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
           )
         `.pipe(Effect.mapError(storageError("insert checkpoint")));
       }),
+    );
+  });
+
+  const saveRecoveryCheckpoint = Effect.fn("SqliteJournal.saveRecoveryCheckpoint")(function* (
+    request: SaveRecoveryCheckpointRequest,
+    checkpointJson: string,
+  ) {
+    const { checkpoint } = request;
+
+    if (
+      checkpoint.threadId.length > MAX_IDENTIFIER_LENGTH ||
+      storedTextBytes(checkpointJson) > MAX_STORED_TEXT_BYTES
+    ) {
+      return yield* SqliteStorageError.make({
+        operation: "save recovery checkpoint",
+        message: "Checkpoint identity or encoded JSON exceeds the SQLite storage bounds.",
+      });
+    }
+    yield* withWriteTransaction("recovery checkpoint transaction")(
+      Effect.gen(function* () {
+        const threads = yield* getThread(checkpoint.threadId);
+        const thread = threads[0];
+
+        if (thread === undefined)
+          return yield* ThreadNotMaterialized.make({ threadId: checkpoint.threadId });
+        if (request.producerEpoch !== thread.producer_epoch)
+          return yield* FenceRejected.make({
+            threadId: checkpoint.threadId,
+            actualEpoch: thread.producer_epoch,
+            attemptedEpoch: request.producerEpoch,
+          });
+        if (checkpoint.throughSequence > thread.tail_sequence)
+          return yield* CheckpointRejected.make({
+            threadId: checkpoint.threadId,
+            reason: "ahead-of-tail",
+          });
+
+        const digests =
+          checkpoint.throughSequence === 0
+            ? [EMPTY_TAIL_DIGEST]
+            : yield* getTailDigestAt(checkpoint.threadId, checkpoint.throughSequence);
+
+        if (digests.length !== 1 || digests[0] !== checkpoint.tailDigest)
+          return yield* CheckpointRejected.make({
+            threadId: checkpoint.threadId,
+            reason: "digest-mismatch",
+          });
+
+        yield* failpoint("save-recovery-checkpoint:before");
+        yield* sql`
+          INSERT INTO effect_agent_recovery_checkpoints (thread_id, through_sequence, tail_digest, checkpoint_json)
+          VALUES (${checkpoint.threadId}, ${checkpoint.throughSequence}, ${checkpoint.tailDigest}, ${checkpointJson})
+          ON CONFLICT (thread_id) DO UPDATE SET
+            through_sequence = excluded.through_sequence,
+            tail_digest = excluded.tail_digest,
+            checkpoint_json = excluded.checkpoint_json
+          WHERE excluded.through_sequence >= effect_agent_recovery_checkpoints.through_sequence
+        `.pipe(Effect.mapError(storageError("save recovery checkpoint")));
+      }),
+    );
+    yield* failpoint("save-recovery-checkpoint:after");
+  });
+
+  const loadRecoveryCheckpoint = Effect.fn("SqliteJournal.loadRecoveryCheckpoint")(function* (
+    threadId: string,
+  ) {
+    const rows = yield* sql<Record<string, unknown>>`
+      SELECT thread_id, through_sequence, tail_digest, checkpoint_json
+      FROM effect_agent_recovery_checkpoints
+      WHERE thread_id = ${threadId}
+    `.pipe(Effect.mapError(storageError("load recovery checkpoint")));
+
+    return yield* decodeRows(
+      Schema.Array(CheckpointRow),
+      "effect_agent_recovery_checkpoints",
+      threadId,
+      rows,
     );
   });
 
@@ -1386,6 +1540,8 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     getThread,
     getTailDigestAt,
     loadCheckpoint,
+    loadRecoveryCheckpoint,
+    saveRecoveryCheckpoint,
     materialize,
     read,
     saveCheckpoint,

--- a/packages/storage-sqlite/test/sqlite-storage-upgrade.test.ts
+++ b/packages/storage-sqlite/test/sqlite-storage-upgrade.test.ts
@@ -77,6 +77,67 @@ const withFixture = <A, E>(
   );
 
 describe("supported beta50 storage upgrade", () => {
+  for (const point of [
+    "upgrade:before-mutation",
+    "upgrade:after-mutation",
+    "upgrade:before-version",
+    "upgrade:after-version",
+  ] as const) {
+    it.effect(`preserves v9 data and atomically adds recovery checkpoints at ${point}`, () => {
+      let armed = false;
+
+      return withFixture(
+        (open) =>
+          Effect.gen(function* () {
+            yield* open;
+            const sql = yield* SqlClient.SqlClient;
+
+            yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
+            yield* sql`PRAGMA user_version = 9`;
+            const before = yield* snapshotStore;
+
+            armed = true;
+            expect(Exit.isFailure(yield* open.pipe(Effect.exit))).toBe(true);
+            expect(yield* snapshotStore).toEqual(before);
+            expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 9 }]);
+            armed = false;
+            yield* open;
+            yield* assertPreserved("sqlite");
+            expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
+            expect(yield* sql`SELECT * FROM effect_agent_recovery_checkpoints`).toEqual([]);
+            const upgraded = yield* snapshotStore;
+
+            yield* open;
+            expect(yield* snapshotStore).toEqual(upgraded);
+          }),
+        (location) =>
+          armed && location === point
+            ? SqliteStorageFailpointError.make({ location })
+            : Effect.void,
+      );
+    });
+  }
+
+  it.effect("rejects an ambiguous v9 layout without resetting or changing retained data", () =>
+    withFixture((open) =>
+      Effect.gen(function* () {
+        yield* open;
+        const sql = yield* SqlClient.SqlClient;
+
+        yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
+        yield* sql`ALTER TABLE effect_agent_submissions RENAME COLUMN message_admission_json TO malformed_column`;
+        yield* sql`PRAGMA user_version = 9`;
+        const before = yield* snapshotStore;
+
+        expect(yield* open.pipe(Effect.result)).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "SqliteStorageCompatibilityError", actualVersion: 9 },
+        });
+        expect(yield* snapshotStore).toEqual(before);
+      }),
+    ),
+  );
+
   for (const [table, column] of [
     ["effect_agent_submissions", "admission_fence_json"],
     ["effect_agent_subscriptions", "recovery_present"],
@@ -91,6 +152,7 @@ describe("supported beta50 storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClient.SqlClient;
 
+            yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`DROP TABLE effect_agent_message_deliveries`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN message_admission_json`;
@@ -124,6 +186,7 @@ describe("supported beta50 storage upgrade", () => {
           yield* open;
           const sql = yield* SqlClient.SqlClient;
 
+          yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
           yield* sql`DROP TABLE effect_agent_message_deliveries`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN message_admission_json`;
@@ -137,7 +200,7 @@ describe("supported beta50 storage upgrade", () => {
           armed = false;
           yield* open;
           yield* assertPreserved("sqlite");
-          expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 9 }]);
+          expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
           expect(yield* sql`SELECT * FROM effect_agent_message_deliveries`).toEqual([]);
         }),
       (location) =>
@@ -171,7 +234,7 @@ describe("supported beta50 storage upgrade", () => {
         );
         const sql = yield* SqlClient.SqlClient;
 
-        expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 9 }]);
+        expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
       }),
     ),
   );

--- a/packages/storage-sqlite/test/sqlite-storage.test.ts
+++ b/packages/storage-sqlite/test/sqlite-storage.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@effect-agent/thread/testing/ThreadStoreConformance";
 import {
   ThreadCheckpoint,
+  ThreadTailRequest,
   ThreadExportRequest,
   ThreadMaterialization,
   ThreadObservation,
@@ -43,6 +44,7 @@ import {
   FencedAppendRequest,
   LoadCheckpointRequest,
   SaveCheckpointRequest,
+  SaveRecoveryCheckpointRequest,
   type AppendResult,
 } from "@effect-agent/thread/ThreadStore";
 import { NodeCrypto, NodeFileSystem } from "@effect/platform-node";
@@ -201,6 +203,319 @@ const withTemporaryDatabase = <A, E>(
   ).pipe(Effect.provide(NodeFileSystem.layer));
 
 describe("SqliteThreadStore", () => {
+  it.effect("rejects canonical records beyond the captured export tail", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const store = yield* ThreadStore;
+
+        yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }));
+        yield* store.append(
+          FencedAppendRequest.make({
+            threadId,
+            producerEpoch: epoch(1),
+            expectedTailSequence: sequence(0),
+            expectedTailDigest: EMPTY_TAIL_DIGEST,
+            batch: batch("bad-export-tail", [inputRecord("bad-export-tail", "Kyoto")]),
+          }),
+        );
+        yield* withSql(
+          filename,
+          Effect.flatMap(
+            SqlClientService.SqlClient,
+            (sql) =>
+              sql`UPDATE effect_agent_threads SET tail_sequence=0 WHERE thread_id=${threadId}`,
+          ),
+        );
+        expect(
+          yield* store.export(ThreadExportRequest.make({ threadId })).pipe(Effect.flip),
+        ).toMatchObject({
+          _tag: "ThreadStoreError",
+          message: expect.stringContaining("beyond the captured thread tail"),
+        });
+      }).pipe(Effect.provide(layer({ filename }))),
+    ),
+  );
+
+  it.effect("isolates, fences and replaces one durable recovery checkpoint across reopen", () =>
+    withTemporaryDatabase((filename) =>
+      Effect.gen(function* () {
+        const checkpoint = yield* Effect.gen(function* () {
+          const store = yield* ThreadStore;
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const empty = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "recovery-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          yield* store.checkpoints!.save(SaveCheckpointRequest.make({ checkpoint: empty }));
+          yield* store.recoveryCheckpoints!.save(
+            SaveRecoveryCheckpointRequest.make({ checkpoint: empty, producerEpoch: epoch(1) }),
+          );
+
+          const appended = yield* store.append(
+            FencedAppendRequest.make({
+              threadId,
+              producerEpoch: epoch(1),
+              expectedTailSequence: sequence(0),
+              expectedTailDigest: EMPTY_TAIL_DIGEST,
+              batch: batch("recovery-batch", [
+                inputRecord("recovery-1", "Kyoto"),
+                inputRecord("recovery-2", "Nara"),
+              ]),
+            }),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            ...empty,
+            throughSequence: appended.lastSequence,
+            tailDigest: appended.tailDigest,
+            state: { version: 1 },
+          });
+
+          const save = (checkpoint: ThreadCheckpoint, producerEpoch = epoch(1)) =>
+            store.recoveryCheckpoints!.save(
+              SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch }),
+            );
+
+          yield* save(checkpoint);
+          yield* save(empty);
+          expect(
+            yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+          ).toEqual(Option.some(checkpoint));
+          expect(
+            Option.isNone(
+              yield* store.recoveryCheckpoints!.load(
+                LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: sequence(0) }),
+              ),
+            ),
+          ).toBe(true);
+          expect(
+            yield* save(
+              ThreadCheckpoint.make({ ...checkpoint, throughSequence: sequence(1) }),
+            ).pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "digest-mismatch" });
+          expect(
+            yield* save(
+              ThreadCheckpoint.make({ ...checkpoint, throughSequence: sequence(3) }),
+            ).pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "ahead-of-tail" });
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(2) }),
+          );
+          expect(yield* save(checkpoint).pipe(Effect.flip)).toMatchObject({
+            _tag: "FenceRejected",
+            actualEpoch: 2,
+            attemptedEpoch: 1,
+          });
+
+          const replacement = ThreadCheckpoint.make({
+            ...checkpoint,
+            state: { version: 2 },
+            createdAt: at(3),
+          });
+
+          yield* save(replacement, epoch(2));
+          expect(yield* store.checkpoints!.load(LoadCheckpointRequest.make({ threadId }))).toEqual(
+            Option.some(empty),
+          );
+          expect(
+            (yield* store.export(ThreadExportRequest.make({ threadId }))).records,
+          ).toHaveLength(2);
+
+          return replacement;
+        }).pipe(Effect.provide(layer({ filename })));
+
+        const restored = yield* ThreadStore.pipe(
+          Effect.flatMap((store) =>
+            store.recoveryCheckpoints!.load(
+              LoadCheckpointRequest.make({ threadId: checkpoint.threadId }),
+            ),
+          ),
+          Effect.provide(layer({ filename })),
+        );
+
+        expect(restored).toEqual(Option.some(checkpoint));
+
+        const rows = yield* withSql(
+          filename,
+          Effect.flatMap(
+            SqlClientService.SqlClient,
+            (sql) => sql`SELECT COUNT(*) AS count FROM effect_agent_recovery_checkpoints`,
+          ),
+        );
+
+        expect(rows).toEqual([{ count: 1 }]);
+      }),
+    ),
+  );
+
+  for (const corruption of ["json", "version", "thread", "sequence", "digest", "row"] as const) {
+    it.effect(`rejects ${corruption} recovery cache corruption and permits same-tail repair`, () =>
+      withTemporaryDatabase((filename) =>
+        Effect.gen(function* () {
+          const store = yield* ThreadStore;
+
+          yield* store.materialize(
+            ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+          );
+
+          const checkpoint = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId,
+            throughSequence: sequence(0),
+            tailDigest: EMPTY_TAIL_DIGEST,
+            engineVersion: "recovery-test",
+            agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+            modelDigest: EMPTY_TAIL_DIGEST,
+            toolDigest: EMPTY_TAIL_DIGEST,
+            state: {},
+            createdAt: at(2),
+          });
+
+          const save = store.recoveryCheckpoints!.save(
+            SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch: epoch(1) }),
+          );
+
+          yield* save;
+          const encoded = yield* Schema.encodeEffect(ThreadCheckpoint)(checkpoint);
+
+          const json =
+            corruption === "json"
+              ? "{"
+              : JSON.stringify({
+                  ...encoded,
+                  ...(corruption === "version" ? { schemaVersion: 99 } : {}),
+                  ...(corruption === "thread" ? { threadId: "foreign" } : {}),
+                  ...(corruption === "sequence" ? { throughSequence: 1 } : {}),
+                  ...(corruption === "digest" ? { tailDigest: "a".repeat(64) } : {}),
+                });
+
+          const storedSequence = corruption === "row" ? -1 : 0;
+
+          yield* withSql(
+            filename,
+            Effect.flatMap(
+              SqlClientService.SqlClient,
+              (sql) =>
+                sql`UPDATE effect_agent_recovery_checkpoints SET checkpoint_json=${json}, through_sequence=${storedSequence} WHERE thread_id=${threadId}`,
+            ),
+          );
+          expect(
+            yield* store
+              .recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId }))
+              .pipe(Effect.flip),
+          ).toMatchObject({ _tag: "CheckpointRejected", reason: "corrupt" });
+          yield* save;
+          expect(
+            yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+          ).toEqual(Option.some(checkpoint));
+          expect(
+            (yield* store.inspectTail(ThreadTailRequest.make({ threadId }))).tailSequence,
+          ).toBe(0);
+        }).pipe(Effect.provide(layer({ filename }))),
+      ),
+    );
+  }
+
+  for (const location of [
+    "save-recovery-checkpoint:before",
+    "save-recovery-checkpoint:after",
+  ] as const) {
+    for (const mode of ["failure", "defect", "interrupt", "timeout"] as const) {
+      it.effect(`reopens safely after ${mode} at ${location}`, () =>
+        withTemporaryDatabase((filename) =>
+          Effect.gen(function* () {
+            const save = Effect.gen(function* () {
+              const store = yield* ThreadStore;
+
+              yield* store.materialize(
+                ThreadMaterialization.make({ threadId, producerEpoch: epoch(1) }),
+              );
+
+              const checkpoint = ThreadCheckpoint.make({
+                schemaVersion: 1,
+                threadId,
+                throughSequence: sequence(0),
+                tailDigest: EMPTY_TAIL_DIGEST,
+                engineVersion: "recovery-test",
+                agentDefinitionDigest: EMPTY_TAIL_DIGEST,
+                modelDigest: EMPTY_TAIL_DIGEST,
+                toolDigest: EMPTY_TAIL_DIGEST,
+                state: {},
+                createdAt: at(2),
+              });
+
+              yield* store.recoveryCheckpoints!.save(
+                SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch: epoch(1) }),
+              );
+            });
+
+            const entered = yield* Deferred.make<void>();
+
+            const failed = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const fiber = yield* save.pipe(
+                  Effect.provide(
+                    layer({
+                      filename,
+                      failpoint: (point) =>
+                        point !== location
+                          ? Effect.void
+                          : Deferred.succeed(entered, undefined).pipe(
+                              Effect.andThen(
+                                mode === "failure"
+                                  ? SqliteStorageFailpointError.make({ location })
+                                  : mode === "defect"
+                                    ? Effect.die("injected checkpoint defect")
+                                    : mode === "interrupt"
+                                      ? Effect.interrupt
+                                      : Effect.never,
+                              ),
+                            ),
+                    }),
+                  ),
+                  Effect.timeout("1 second"),
+                  Effect.forkChild,
+                );
+
+                yield* Deferred.await(entered);
+                if (mode === "timeout") yield* TestClock.adjust("1 second");
+
+                return yield* Fiber.await(fiber);
+              }),
+            );
+
+            expect(Exit.isFailure(failed)).toBe(true);
+            yield* Effect.gen(function* () {
+              const store = yield* ThreadStore;
+
+              expect(
+                Option.isSome(
+                  yield* store.recoveryCheckpoints!.load(LoadCheckpointRequest.make({ threadId })),
+                ),
+              ).toBe(location === "save-recovery-checkpoint:after");
+              expect(
+                (yield* store.inspectTail(ThreadTailRequest.make({ threadId }))).tailSequence,
+              ).toBe(0);
+            }).pipe(Effect.provide(layer({ filename })));
+          }),
+        ),
+      );
+    }
+  }
+
   for (const corruption of ["thread", "sequence", "digest"] as const) {
     it.effect(`rejects checkpoint ${corruption} metadata that disagrees with its row`, () =>
       withTemporaryDatabase((filename) =>

--- a/packages/testing/src/Certification.ts
+++ b/packages/testing/src/Certification.ts
@@ -161,8 +161,8 @@ export const CERTIFICATION_SCENARIOS: ReadonlyArray<CertificationScenario> = [
 
 /**
  * Coordinator failpoint locations that none of the six scenario shapes can reach, recorded
- * honestly instead of silently claimed: all three sit on operator/abort paths the shapes do
- * not take. They are pinned in-process by the P5/S2 suites
+ * honestly instead of silently claimed. These require operator, compaction, reservation, or
+ * background-worker paths the shapes do not take. They are pinned in-process by the P5/S2 suites
  * (`packages/testing/test/durable-tools.test.ts` "resolveUnknown is idempotent across the
  * intent failpoint", `durable-runtime.test.ts` abort rows,
  * `durable-subagents.test.ts` abort propagation) and by the process-kill/eviction crash
@@ -170,6 +170,9 @@ export const CERTIFICATION_SCENARIOS: ReadonlyArray<CertificationScenario> = [
  * protocol change that silently stops exercising a location fails the certification.
  */
 export const TIER2_UNREACHED_LOCATIONS: ReadonlyArray<DurableRuntimeFailpointLocation> = [
+  // Tier 2 has no native compaction; dedicated checkpoint process-loss tests cover these.
+  "checkpoint:before-save",
+  "checkpoint:after-save",
   "abort:after-intent",
   // Compaction requires a `contextTokenLimit` policy plus prior-Run history
   // none of the six scenario shapes carries; pinned in-process by the

--- a/packages/testing/test/persistent-threads.test.ts
+++ b/packages/testing/test/persistent-threads.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@effect-agent/thread/Records";
 import { replayThread } from "@effect-agent/thread/ThreadProjection";
 import {
+  MAX_THREAD_EXPORT_RECORDS,
   ThreadExportRequest,
   ThreadMaterialization,
   ThreadStore,
@@ -697,16 +698,18 @@ describe("persistent threads", () => {
         let tailDigest = EMPTY_TAIL_DIGEST;
 
         // Seed through the store's public append contract without thousands of model calls.
-        for (let start = 0; start < 65_532; start += 256) {
-          const records = Array.makeBy(Math.min(256, 65_532 - start), (offset) =>
-            RecordEnvelope.make({
-              recordId: Schema.decodeSync(RecordId)(`seed:${start + offset}`),
-              family: "thread",
-              schemaVersion: 1,
-              createdAt,
-              deploymentId: Schema.decodeSync(DeploymentId)("history-limit-test"),
-              payload: RepairAnnotated.make({ reason: "history seed", details: {} }),
-            }),
+        for (let start = 0; start < MAX_THREAD_EXPORT_RECORDS - 4; start += 256) {
+          const records = Array.makeBy(
+            Math.min(256, MAX_THREAD_EXPORT_RECORDS - 4 - start),
+            (offset) =>
+              RecordEnvelope.make({
+                recordId: Schema.decodeSync(RecordId)(`seed:${start + offset}`),
+                family: "thread",
+                schemaVersion: 1,
+                createdAt,
+                deploymentId: Schema.decodeSync(DeploymentId)("history-limit-test"),
+                payload: RepairAnnotated.make({ reason: "history seed", details: {} }),
+              }),
           );
 
           const batch = yield* CanonicalBatch.makeEffect({
@@ -751,7 +754,7 @@ describe("persistent threads", () => {
         const before = yield* exported;
         const prompt = yield* loadHistory(threadId);
 
-        expect(before.records).toHaveLength(65_535);
+        expect(before.records).toHaveLength(MAX_THREAD_EXPORT_RECORDS - 1);
         expect(prompt.content.map((message) => message.role)).toEqual([
           "system",
           "user",
@@ -761,7 +764,7 @@ describe("persistent threads", () => {
         ]);
         expect(yield* run("overflow").pipe(Effect.flip)).toMatchObject({
           _tag: "ThreadHistoryError",
-          message: expect.stringContaining("65536"),
+          message: expect.stringContaining(String(MAX_THREAD_EXPORT_RECORDS)),
         });
         expect(yield* Ref.get(modelCalls)).toBe(2);
         expect(yield* Ref.get(toolCalls)).toBe(1);

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -16,6 +16,7 @@ import { IdGenerator } from "@effect-agent/core/IdGenerator";
 import { type MessageAdmission, type MessagingError } from "@effect-agent/core/Messaging";
 import { Receipt } from "@effect-agent/core/Receipt";
 import { type ExhaustedLimit, type RunEvent } from "@effect-agent/core/RunEvent";
+import { RunPolicyUsage } from "@effect-agent/core/RunPolicyUsage";
 import {
   SubagentBudgetReservation,
   SubagentReservationAmounts,
@@ -125,6 +126,13 @@ import {
   resolveWorkerBinding,
 } from "./internal/agent-registration.ts";
 import { inspectForeignDiagnostic, safeUnknownString } from "./internal/foreign-diagnostic.ts";
+import {
+  JournalCheckpointSeed,
+  RecoveryCheckpointState,
+  RecoveryCheckpointContents,
+  RECOVERY_ENGINE_VERSION,
+  checkpointSuffixCompatible,
+} from "./internal/journal-checkpoint.ts";
 import { makeMessagingRuntime } from "./internal/messaging-host.ts";
 import { makeWorkerRuntime, WorkerInputControl } from "./internal/worker-host.ts";
 import {
@@ -133,8 +141,8 @@ import {
   OperationDenied,
 } from "./OperationAuthorizer.ts";
 import {
-  type CanonicalRecordPayload,
   type CanonicalRecordEnvelope,
+  type CanonicalRecordPayload,
   type DeploymentId,
   type Digest,
   type ProducerId,
@@ -305,7 +313,8 @@ import {
   ThreadTailRequest,
   FencedAppendRequest,
   LoadCheckpointRequest,
-  type ThreadCheckpoint,
+  ThreadCheckpoint,
+  SaveRecoveryCheckpointRequest,
 } from "./ThreadStore.ts";
 import { PreparedToolCallEvidence, ToolReconciler } from "./ToolReconciler.ts";
 import { WakeScheduler } from "./WakeScheduler.ts";
@@ -1152,12 +1161,129 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     submissionIds: ReadonlyArray<SubmissionId>,
   ) {
     const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+    const view = yield* recoveryView(threadId, tail.tailSequence, submissionIds);
 
     return yield* Stream.runCollect(
-      canonicalRange(threadId, tail.tailSequence).pipe(
-        Stream.filter(controlRecords(submissionIds)),
+      view.canonical.pipe(Stream.filter(controlRecords(submissionIds))),
+    );
+  });
+
+  /** A checkpoint is useful only for its explicitly retained submissions and exact definitions. */
+  const recoveryView = Effect.fn("DurableAgentRuntime.recoveryView")(function* (
+    threadId: ThreadId,
+    throughSequence: CanonicalSequence,
+    submissionIds: ReadonlyArray<SubmissionId>,
+  ): Effect.fn.Return<
+    {
+      readonly canonical: Stream.Stream<
+        CanonicalRecordEnvelope,
+        ThreadStoreError | ThreadNotMaterialized
+      >;
+      readonly seed?: JournalCheckpointSeed;
+    },
+    ThreadStoreError | ThreadNotMaterialized
+  > {
+    const full = { canonical: canonicalRange(threadId, throughSequence) };
+
+    if (store.recoveryCheckpoints === undefined) return full;
+
+    const loaded = yield* store.recoveryCheckpoints
+      .load(LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: throughSequence }))
+      .pipe(Effect.catchTag("CheckpointRejected", () => Effect.succeed(Option.none())));
+
+    if (Option.isNone(loaded)) return full;
+    const checkpoint = loaded.value;
+
+    if (
+      checkpoint.engineVersion !== RECOVERY_ENGINE_VERSION ||
+      checkpoint.threadId !== threadId ||
+      checkpoint.throughSequence > throughSequence ||
+      throughSequence - checkpoint.throughSequence > 4_096
+    )
+      return full;
+
+    const decoded = yield* Schema.decodeUnknownEffect(RecoveryCheckpointContents)(
+      checkpoint.state,
+    ).pipe(Effect.option);
+
+    if (Option.isNone(decoded)) return full;
+    const { state, digest } = decoded.value;
+
+    if (
+      !submissionIds.every((id) => state.submissionIds.includes(id)) ||
+      state.seed.runId !== runIdForSubmission(state.submissionId)
+    )
+      return full;
+
+    const encoded = yield* Schema.encodeEffect(RecoveryCheckpointState)(state).pipe(
+      Effect.mapError((cause) =>
+        ThreadStoreError.make({
+          operation: "decode recovery checkpoint",
+          message: "Invalid recovery state",
+          cause,
+        }),
       ),
     );
+
+    const actualDigest = yield* withCrypto(digestJson(encoded)).pipe(
+      Effect.mapError((cause) =>
+        ThreadStoreError.make({
+          operation: "decode recovery checkpoint",
+          message: cause.message,
+          cause,
+        }),
+      ),
+    );
+
+    if (digest !== actualDigest) return full;
+
+    const owner = yield* ledger
+      .lookup(SubmissionLookupById.make({ submissionId: state.submissionId }))
+      .pipe(
+        Effect.mapError((cause) =>
+          ThreadStoreError.make({
+            operation: "recovery checkpoint compatibility",
+            message: cause.message,
+            cause,
+          }),
+        ),
+      );
+
+    if (
+      Option.isNone(owner) ||
+      owner.value.threadId !== threadId ||
+      owner.value.agentDigests.agent !== checkpoint.agentDefinitionDigest ||
+      owner.value.agentDigests.model !== checkpoint.modelDigest ||
+      owner.value.agentDigests.tools !== checkpoint.toolDigest
+    )
+      return full;
+    const replacement = state.seed.compaction;
+
+    if (
+      replacement.threadId !== threadId ||
+      replacement.sequence > checkpoint.throughSequence ||
+      replacement.record.payload._tag !== "CompactionCreated" ||
+      replacement.record.payload.kind === "clear-tool-results" ||
+      replacement.record.payload.coversThrough < state.seed.throughSequence ||
+      replacement.record.payload.coversThrough >= replacement.sequence ||
+      state.records.some(
+        (record) => record.threadId !== threadId || record.sequence > checkpoint.throughSequence,
+      ) ||
+      !state.records.some(
+        (record) =>
+          record.sequence === replacement.sequence &&
+          record.record.recordId === replacement.record.recordId,
+      )
+    )
+      return full;
+
+    const suffix = yield* Stream.runCollect(
+      canonicalRange(threadId, throughSequence, checkpoint.throughSequence),
+    );
+
+    if (!checkpointSuffixCompatible(state.seed, suffix, state.records)) return full;
+
+    return { canonical: Stream.fromIterable([...state.records, ...suffix]), seed: state.seed };
   });
 
   const readAllTolerant = Effect.fn("DurableAgentRuntime.readAllTolerant")(
@@ -1218,12 +1344,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     if (Option.isNone(tail))
       return { records: [], materialized: false, throughSequence: ZERO_SEQUENCE, submissionIds };
 
-    const records = yield* readCanonicalRange(
-      threadId,
-      ZERO_SEQUENCE,
-      tail.value.tailSequence,
-      controlRecords(submissionIds),
-    ).pipe(
+    const records = yield* recoveryView(threadId, tail.value.tailSequence, submissionIds).pipe(
+      Effect.flatMap((view) =>
+        Stream.runCollect(view.canonical.pipe(Stream.filter(controlRecords(submissionIds)))),
+      ),
       Effect.catchTag("ThreadNotMaterialized", (error) =>
         ThreadStoreError.make({
           operation: "read recovery history",
@@ -3724,6 +3848,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     records: ReadonlyArray<CanonicalRecordEnvelope>,
     canonical: Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized>,
     canonicalThrough: CanonicalSequence,
+    journalSeed: JournalCheckpointSeed | undefined,
     lineage: AttemptLineage,
     approvalDecisions: ReadonlyArray<ApprovalDecisionIntent>,
     runTiming: { readonly startedAt: DateTime.Utc; readonly deadline: DateTime.Utc },
@@ -3734,8 +3859,267 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const runId = runIdForSubmission(submissionId);
       const boundaries: Array<JournalBoundary> = [];
 
-      const journal = yield* projectRunJournalStream(canonical, runId, (boundary) =>
-        boundaries.push(boundary),
+      const journal = yield* projectRunJournalStream(
+        canonical,
+        runId,
+        (boundary) => boundaries.push(boundary),
+        journalSeed,
+      );
+
+      const saveRecoveryCheckpoint = Effect.fn("DurableAgentRuntime.saveRecoveryCheckpoint")(
+        function* (compactionId: RecordId): Effect.fn.Return<void, DurableWorkerFailure> {
+          if (store.recoveryCheckpoints === undefined) return;
+          const tail = yield* Ref.get(ctx.tailRef);
+
+          const source = Stream.concat(
+            canonical,
+            canonicalRange(ctx.threadId, tail.sequence, canonicalThrough),
+          );
+
+          let compaction: CanonicalRecordEnvelope | undefined;
+          let latestResponse: CanonicalSequence | undefined;
+          let firstSequence = journalSeed?.firstSequence;
+          const orchestrationCalls = new Set<string>();
+
+          yield* Stream.runForEach(source, (entry) =>
+            Effect.sync(() => {
+              const payload = entry.record.payload;
+
+              if (entry.record.recordId === compactionId) compaction = entry;
+              if (!("runId" in payload) || payload.runId !== runId) return;
+              firstSequence ??= entry.sequence;
+              if (payload._tag === "ModelResponseRecorded") latestResponse = entry.sequence;
+              if (
+                payload._tag === "ToolCallPrepared" &&
+                (payload.executionKind === "delegation" ||
+                  payload.executionKind === "orchestration")
+              )
+                orchestrationCalls.add(payload.toolCallId);
+            }),
+          );
+          if (
+            compaction === undefined ||
+            compaction.record.payload._tag !== "CompactionCreated" ||
+            compaction.record.payload.kind === "clear-tool-results"
+          )
+            return;
+          const replacement = compaction;
+          const covered = compaction.record.payload.coversThrough;
+
+          const retiredThrough = decodeCanonicalSequence(
+            Math.min(covered, (latestResponse ?? covered + 1) - 1),
+          );
+
+          if (retiredThrough <= (journalSeed?.throughSequence ?? 0)) return;
+
+          const retired = yield* projectRunJournalStream(
+            source.pipe(Stream.filter((entry) => entry.sequence <= retiredThrough)),
+            runId,
+            undefined,
+            journalSeed,
+          );
+
+          const detailed = yield* summarizeModelUsage(
+            retired.usage.modelUsage,
+            retired.usage.summarizedModelUsage,
+          ).pipe(
+            Effect.mapError((cause) =>
+              RunJournalError.make({ message: "Retired usage exceeds accounting bounds", cause }),
+            ),
+          );
+
+          const protectedContext = retired.protectedContext ?? journal.protectedContext;
+          // The first native rollover may precede this Attempt's first journal snapshot response.
+          const current = yield* projectRunJournalStream(source, runId, undefined, journalSeed);
+          const protectedMessages = protectedContext ?? current.protectedContext;
+
+          const encodedContext =
+            protectedMessages === undefined
+              ? undefined
+              : yield* Schema.encodeEffect(Prompt.Prompt)(protectedMessages).pipe(
+                  Effect.flatMap(decodePersisted),
+                  Effect.mapError((cause) =>
+                    RunJournalError.make({ message: "Cannot checkpoint protected context", cause }),
+                  ),
+                );
+
+          let frontier = journalSeed?.frontier;
+
+          const retained = yield* Stream.runCollect(
+            source.pipe(
+              Stream.filter((entry) => {
+                if (entry.sequence > retiredThrough) return true;
+                const payload = entry.record.payload;
+
+                if (payload._tag === "ModelResponseRecorded" || payload._tag === "ToolCallSettled")
+                  frontier = { sequence: entry.sequence, tag: payload._tag };
+                if (
+                  payload._tag === "ThreadCreated" ||
+                  payload._tag === "SubagentLineageRecorded" ||
+                  payload._tag === "WorkerOriginRecorded"
+                )
+                  return true;
+                if (!("runId" in payload) || payload.runId !== runId) return false;
+                if ("toolCallId" in payload && orchestrationCalls.has(payload.toolCallId))
+                  return true;
+                switch (payload._tag) {
+                  case "ModelResponseRecorded":
+                  case "ToolCallPrepared":
+                  case "ToolCallSettled":
+                  case "ToolCallUnknown":
+                  case "ToolCallResolved":
+                  case "ToolApprovalRequested":
+                  case "ToolApprovalDecided":
+                  case "CompactionCreated":
+                  case "RunPolicyUsageReserved":
+                    return false;
+                  default:
+                    return true;
+                }
+              }),
+            ),
+          );
+
+          const ids = new Set<SubmissionId>([submissionId]);
+
+          for (const {
+            record: { payload },
+          } of retained)
+            if (payload._tag === "UserInputRecorded" && payload.submissionId !== undefined)
+              ids.add(payload.submissionId);
+
+          const validated = yield* Effect.try({
+            try: () =>
+              RecoveryCheckpointState.make({
+                schemaVersion: 1,
+                policyAccountingVersion: 1,
+                submissionId,
+                submissionIds: [...ids],
+                seed: JournalCheckpointSeed.make({
+                  runId,
+                  throughSequence: retiredThrough,
+                  ...(firstSequence === undefined ? {} : { firstSequence }),
+                  committedTurns: retired.committedTurns,
+                  policyUsage: retired.policyUsage,
+                  modelCalls: retired.usage.modelCalls,
+                  unobservedModelCalls: retired.usage.unobservedModelCalls ?? 0,
+                  inputTokens: retired.usage.inputTokens,
+                  outputTokens: retired.usage.outputTokens,
+                  lastInputTokens: retired.usage.lastInputTokens,
+                  lastOutputTokens: retired.usage.lastOutputTokens,
+                  costMicrousd: retired.usage.costMicrousd,
+                  summarizedModelUsage: detailed,
+                  ...(current.contextWindowId === undefined
+                    ? {}
+                    : { contextWindowId: current.contextWindowId }),
+                  ...(frontier === undefined ? {} : { frontier }),
+                  ...(encodedContext === undefined ? {} : { protectedContext: encodedContext }),
+                  compaction: replacement,
+                }),
+                records: retained,
+              }),
+            catch: (cause) =>
+              RunJournalError.make({ message: "Recovery checkpoint exceeds cache bounds", cause }),
+          }).pipe(Effect.option);
+
+          // Capacity is a cache eligibility limit, never a reason to truncate canonical evidence.
+          if (Option.isNone(validated)) return;
+
+          // Removing proof must not make a previously invalid historical compaction valid.
+          // Check the disposable projection against the canonical source before publishing it.
+          const replayed = yield* projectRunJournalStream(
+            Stream.fromIterable(retained),
+            runId,
+            undefined,
+            validated.value.seed,
+          ).pipe(Effect.option);
+
+          if (Option.isNone(replayed)) return;
+          const candidate = replayed.value;
+          const equalPrompt = Schema.toEquivalence(Prompt.Prompt);
+
+          if (
+            !equalPrompt(current.prompt, candidate.prompt) ||
+            !equalPrompt(current.historyBefore, candidate.historyBefore) ||
+            !Schema.toEquivalence(Schema.optional(Prompt.Prompt))(
+              current.protectedContext,
+              candidate.protectedContext,
+            ) ||
+            current.contextWindowId !== candidate.contextWindowId ||
+            current.pendingContextToolCallId !== candidate.pendingContextToolCallId ||
+            current.committedTurns !== candidate.committedTurns ||
+            !Schema.toEquivalence(RunPolicyUsage)(current.policyUsage, candidate.policyUsage) ||
+            (
+              [
+                "modelCalls",
+                "inputTokens",
+                "outputTokens",
+                "lastInputTokens",
+                "lastOutputTokens",
+                "costMicrousd",
+              ] as const
+            ).some((field) => current.usage[field] !== candidate.usage[field]) ||
+            (current.usage.unobservedModelCalls ?? 0) !==
+              (candidate.usage.unobservedModelCalls ?? 0)
+          )
+            return;
+
+          const summaries = yield* Effect.all(
+            [current, candidate].map((projection) =>
+              summarizeModelUsage(
+                projection.usage.modelUsage,
+                projection.usage.summarizedModelUsage,
+              ),
+            ),
+          ).pipe(Effect.option);
+
+          if (
+            Option.isNone(summaries) ||
+            summaries.value[0] === undefined ||
+            summaries.value[1] === undefined ||
+            !Schema.toEquivalence(RunUsageSummary)(summaries.value[0], summaries.value[1])
+          )
+            return;
+
+          const encoded = yield* Schema.encodeEffect(RecoveryCheckpointState)(validated.value).pipe(
+            Effect.option,
+          );
+
+          if (Option.isNone(encoded)) return;
+          const digest = yield* withCrypto(digestJson(encoded.value));
+
+          // JSON serialization duplicates shared in-memory references without weakening the
+          // persisted depth/node/byte guard (which rejects cyclic/shared object graphs).
+          const contents = yield* Schema.encodeEffect(
+            Schema.fromJsonString(RecoveryCheckpointContents),
+          )(RecoveryCheckpointContents.make({ state: validated.value, digest })).pipe(
+            Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(PersistedJson))),
+            Effect.option,
+          );
+
+          if (Option.isNone(contents)) return;
+
+          const checkpoint = ThreadCheckpoint.make({
+            schemaVersion: 1,
+            threadId: ctx.threadId,
+            throughSequence: tail.sequence,
+            tailDigest: tail.digest,
+            engineVersion: RECOVERY_ENGINE_VERSION,
+            agentDefinitionDigest: submission.agentDigests.agent,
+            modelDigest: submission.agentDigests.model,
+            toolDigest: submission.agentDigests.tools,
+            state: contents.value,
+            createdAt: replacement.record.createdAt,
+          });
+
+          yield* hit("checkpoint:before-save");
+          yield* store.recoveryCheckpoints
+            .save(
+              SaveRecoveryCheckpointRequest.make({ checkpoint, producerEpoch: ctx.producerEpoch }),
+            )
+            .pipe(Effect.catchTag("CheckpointRejected", () => Effect.void));
+          yield* hit("checkpoint:after-save");
+        },
       );
 
       const childLineage = records.find(
@@ -3773,7 +4157,12 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const resumeProjection =
         pending === undefined
           ? journal
-          : yield* projectRunJournalStream(withoutPendingBatch(canonical, pending, runId), runId);
+          : yield* projectRunJournalStream(
+              withoutPendingBatch(canonical, pending, runId),
+              runId,
+              undefined,
+              journalSeed,
+            );
 
       const tools: Record<string, Tool.Any> = agent.definition.toolkit.tools;
 
@@ -3929,7 +4318,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           }
           const detailedCalls = [...journal.usage.modelUsage, ...stagedCalls];
 
-          const detailed = yield* summarizeModelUsage(detailedCalls).pipe(
+          const detailed = yield* summarizeModelUsage(
+            detailedCalls,
+            journal.usage.summarizedModelUsage,
+          ).pipe(
             Effect.mapError((cause) =>
               RunJournalError.make({
                 message: "Run detailed usage exceeds safe-integer accounting bounds",
@@ -4681,7 +5073,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               sourceBoundaries = [];
               sourceJournal = yield* recordHalt(
                 projectRunJournalStream(
-                  canonicalRange(ctx.threadId, tail.sequence).pipe(
+                  Stream.concat(
+                    canonical,
+                    canonicalRange(ctx.threadId, tail.sequence, canonicalThrough),
+                  ).pipe(
                     Stream.filter(
                       (envelope) =>
                         envelope.record.payload._tag !== "CompactionCreated" ||
@@ -4690,6 +5085,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                   ),
                   runId,
                   (boundary) => sourceBoundaries.push(boundary),
+                  journalSeed,
                 ),
               );
             }
@@ -4829,6 +5225,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             );
             knownIds.add(recordId);
             yield* recordHalt(hit("compaction:after-canonical-append"));
+            if (commit.kind !== "clear-tool-results")
+              yield* recordHalt(saveRecoveryCheckpoint(recordId));
           }),
       };
 
@@ -6500,11 +6898,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       let controlThrough = (yield* store.inspectTail(ThreadTailRequest.make({ threadId })))
         .tailSequence;
 
-      let records: ReadonlyArray<CanonicalRecordEnvelope> = yield* readCanonicalRange(
-        threadId,
-        ZERO_SEQUENCE,
-        controlThrough,
-        controlRecords([submissionId]),
+      const initialThrough = controlThrough;
+      const initialView = yield* recoveryView(threadId, initialThrough, [submissionId]);
+
+      let records: ReadonlyArray<CanonicalRecordEnvelope> = yield* Stream.runCollect(
+        initialView.canonical.pipe(Stream.filter(controlRecords([submissionId]))),
       );
 
       // The append-only prefix remains valid for this Attempt. Retain only this Run's control
@@ -6702,7 +7100,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
       while (true) {
         const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
-        const canonical = canonicalRange(threadId, tail.tailSequence);
+
+        const canonical = Stream.concat(
+          initialView.canonical,
+          canonicalRange(threadId, tail.tailSequence, initialThrough),
+        );
 
         const currentRecords = yield* refreshControl(tail.tailSequence);
 
@@ -6714,6 +7116,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           currentRecords,
           canonical,
           tail.tailSequence,
+          initialView.seed,
           lineage,
           approvalDecisionIntents,
           runTiming,
@@ -8147,11 +8550,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       snapshot.hostSubmissionId !== undefined &&
       !history.submissionIds.includes(snapshot.hostSubmissionId)
     ) {
-      const hostRecords = yield* readCanonicalRange(
-        submission.threadId,
-        ZERO_SEQUENCE,
-        history.throughSequence,
-        controlRecords([snapshot.hostSubmissionId]),
+      const hostId = snapshot.hostSubmissionId;
+      const hostView = yield* recoveryView(submission.threadId, history.throughSequence, [hostId]);
+
+      const hostRecords = yield* Stream.runCollect(
+        hostView.canonical.pipe(Stream.filter(controlRecords([hostId]))),
       );
 
       const merged = new Map(history.records.map((entry) => [entry.sequence, entry]));

--- a/packages/thread/src/DurableFailpoint.ts
+++ b/packages/thread/src/DurableFailpoint.ts
@@ -26,6 +26,8 @@ export const DurableRuntimeFailpointLocation = Schema.Literals([
   "turn:after-results-append",
   "compaction:before-canonical-append",
   "compaction:after-canonical-append",
+  "checkpoint:before-save",
+  "checkpoint:after-save",
   "tools:after-prepared-append",
   "tools:before-prepared-append",
   "policy:before-reservation-append",

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -7,7 +7,11 @@ import {
 } from "@effect-agent/core/Identifiers";
 import { type ExhaustedLimit } from "@effect-agent/core/RunEvent";
 import { RunPolicyUsage } from "@effect-agent/core/RunPolicyUsage";
-import { ModelCallUsage, summarizeModelUsage } from "@effect-agent/core/Usage";
+import {
+  ModelCallUsage,
+  summarizeModelUsage,
+  type RunUsageSummary,
+} from "@effect-agent/core/Usage";
 import {
   CLEARED_TOOL_RESULT,
   COMPACTION_SUMMARY_PREFIX,
@@ -18,10 +22,11 @@ import { type Crypto, Effect, Schema, Stream, type DateTime } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
 import { digestJson, type DigestError } from "./Digest.ts";
+import { type JournalCheckpointSeed } from "./internal/journal-checkpoint.ts";
 import {
   BatchId,
   CanonicalBatch,
-  type CompactionCreated,
+  CompactionCreated,
   ModelResponseRecorded,
   PersistedJson,
   RecordEnvelope,
@@ -360,6 +365,8 @@ export interface RunJournalUsage {
   readonly costMicrousd: number;
   /** Canonical per-call detail used for settlement aggregation and recovery. */
   readonly modelUsage: ReadonlyArray<ModelCallUsage>;
+  /** Detailed usage of retired records, grouped without retaining per-call payloads. */
+  readonly summarizedModelUsage?: RunUsageSummary | undefined;
 }
 
 export interface RunJournalProjection {
@@ -549,13 +556,17 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   records: Stream.Stream<CanonicalRecordEnvelope, E, R>,
   ownerRunId: RunId | undefined,
   onBoundary?: (boundary: JournalBoundary) => void,
+  seed?: JournalCheckpointSeed,
 ): Effect.fn.Return<RunJournalProjection, RunJournalError | E, R> {
+  if (seed !== undefined && seed.runId !== ownerRunId)
+    return yield* journalError("Recovery checkpoint belongs to another Run");
+
   let state: FoldState = {
     all: [],
     before: [],
     pendingTools: [],
     pendingToolsForRun: false,
-    committedTurns: 0,
+    committedTurns: seed?.committedTurns ?? 0,
   };
 
   // RUN-026 pre-scan: the widest VALID compaction bounds govern the fold. A
@@ -572,6 +583,8 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   // settleds (filtered later by the fold) still contribute spans —
   // over-invalidating is the fail-safe direction.
   const firstSequenceByRun = new Map<string, number>();
+
+  if (seed?.firstSequence !== undefined) firstSequenceByRun.set(seed.runId, seed.firstSequence);
   const lastResponseSequenceByRun = new Map<string, number>();
   const terminalSequenceByRun = new Map<string, number>();
   const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
@@ -648,8 +661,12 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   const incompleteResponseSequences: Array<{ readonly sequence: number; readonly runId: RunId }> =
     [];
 
-  let ownerPrefixSequence = Number.POSITIVE_INFINITY;
-  let protectedContext: Prompt.Prompt | undefined;
+  let ownerPrefixSequence = seed?.firstSequence ?? Number.POSITIVE_INFINITY;
+
+  let protectedContext: Prompt.Prompt | undefined =
+    seed?.protectedContext === undefined
+      ? undefined
+      : yield* decodePromptMessages(seed.protectedContext);
 
   if (settledCoverage > 0) {
     yield* Stream.runForEach(records, (envelope) =>
@@ -694,6 +711,11 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     const { runId, coversThrough } = payload;
 
     if (coversThrough <= 0 || coversThrough >= ownSequence) return false;
+    if (seed !== undefined && ownSequence === seed.compaction.sequence)
+      return (
+        seed.compaction.record.payload._tag === "CompactionCreated" &&
+        Schema.toEquivalence(CompactionCreated)(payload, seed.compaction.record.payload)
+      );
     const ownerFirst = firstSequenceByRun.get(runId);
 
     if (payload.kind === "summarize" && ownerFirst !== undefined && coversThrough >= ownerFirst)
@@ -718,8 +740,8 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   let replacement: CompactionCreated | undefined;
   let summarizeSequence = -1;
   let clearBound = 0;
-  let latestWindowId: string | undefined;
-  let latestWindowSequence = -1;
+  let latestWindowId: string | undefined = seed?.contextWindowId;
+  let latestWindowSequence = seed?.throughSequence ?? -1;
   let rolloverCoveredThrough = 0;
 
   for (const { payload, sequence } of compactions) {
@@ -755,6 +777,9 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
 
   const replacementLength = replacement === undefined ? 0 : retainedPrefix.length + 1;
 
+  if (seed?.frontier !== undefined)
+    onBoundary?.({ ...seed.frontier, promptLength: replacementLength });
+
   const emitSummary = () => {
     if (summaryEmitted || replacement === undefined) return;
     summaryEmitted = true;
@@ -779,19 +804,20 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   };
 
   const modelUsage: Array<ModelCallUsage> = [];
-  let unobservedModelCalls = 0;
+  let unobservedModelCalls = seed?.unobservedModelCalls ?? 0;
 
   const usage = {
-    modelCalls: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    lastInputTokens: 0,
-    lastOutputTokens: 0,
-    costMicrousd: 0,
+    modelCalls: seed?.modelCalls ?? 0,
+    inputTokens: seed?.inputTokens ?? 0,
+    outputTokens: seed?.outputTokens ?? 0,
+    lastInputTokens: seed?.lastInputTokens ?? 0,
+    lastOutputTokens: seed?.lastOutputTokens ?? 0,
+    costMicrousd: seed?.costMicrousd ?? 0,
     modelUsage,
+    ...(seed === undefined ? {} : { summarizedModelUsage: seed.summarizedModelUsage }),
   };
 
-  let usageTurn = 0;
+  let usageTurn = seed?.committedTurns ?? 0;
 
   const incompleteToolTurns = new Set<string>();
   const incompleteToolCalls = new Set<string>();
@@ -799,11 +825,11 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   let ownerTerminated = false;
 
   const policyUsage = {
-    committedTurns: 0,
-    toolCalls: 0,
-    programmaticToolCalls: 0,
-    consecutiveToolFailures: 0,
-    finalizationUsed: false,
+    committedTurns: seed?.policyUsage.committedTurns ?? 0,
+    toolCalls: seed?.policyUsage.toolCalls ?? 0,
+    programmaticToolCalls: seed?.policyUsage.programmaticToolCalls ?? 0,
+    consecutiveToolFailures: seed?.policyUsage.consecutiveToolFailures ?? 0,
+    finalizationUsed: seed?.policyUsage.finalizationUsed ?? false,
   };
 
   const accountResponse = Effect.fn("RunJournal.accountResponse")(function* (
@@ -829,6 +855,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
       for (const recordId of declaredRecordIds) incompleteToolCalls.add(recordId);
     }
     if (payload.runId !== ownerRunId) return;
+    if (seed !== undefined && envelope.sequence <= seed.throughSequence) return;
     if (payload.turn === 1 && payload.runScopedPrefixLength !== undefined) {
       protectedContext = Prompt.fromMessages(
         messages.content.slice(0, payload.runScopedPrefixLength),
@@ -943,6 +970,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
         ownerTerminated = true;
 
       if (payload._tag === "RunPolicyUsageReserved" && payload.runId === ownerRunId) {
+        if (seed !== undefined && envelope.sequence <= seed.throughSequence) return;
         if (
           payload.programmaticToolCalls < policyUsage.programmaticToolCalls ||
           (policyUsage.finalizationUsed && !payload.finalizationUsed)
@@ -957,6 +985,12 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
       // message of its own; records at or below the summarize bound render as
       // the one summary message emitted at the covered/kept transition.
       if (payload._tag === "CompactionCreated") return;
+      if (
+        seed !== undefined &&
+        envelope.sequence <= seed.throughSequence &&
+        (payload._tag === "ModelResponseRecorded" || payload._tag === "ToolCallSettled")
+      )
+        return;
       if (envelope.sequence <= summarizeBound) {
         // Projecting an earlier Run after a later summary still accounts for its covered responses.
         if (payload._tag === "ModelResponseRecorded" && payload.runId === ownerRunId) {

--- a/packages/thread/src/ThreadInvariants.ts
+++ b/packages/thread/src/ThreadInvariants.ts
@@ -258,7 +258,8 @@ export const verifyThreadInvariants = Effect.fn("Thread.verifyThreadInvariants")
     const expectedInputs = ordered.map((row) => submissionInputRecordId(row.submissionId));
     const expectedSet = new Set<string>(expectedInputs);
     const inputOrder = recordIds.filter((recordId) => expectedSet.has(recordId));
-    const expectedPresent = expectedInputs.filter((expected) => inputOrder.includes(expected));
+    const presentInputs = new Set(inputOrder);
+    const expectedPresent = expectedInputs.filter((expected) => presentInputs.has(expected));
 
     const matches =
       inputOrder.length === expectedPresent.length &&
@@ -302,8 +303,10 @@ export const verifyThreadInvariants = Effect.fn("Thread.verifyThreadInvariants")
     const expectedSet = new Set<string>(expectedSettlements);
     const settlementOrder = recordIds.filter((recordId) => expectedSet.has(recordId));
 
+    const presentSettlements = new Set(settlementOrder);
+
     const expectedPresent = expectedSettlements.filter((expected) =>
-      settlementOrder.includes(expected),
+      presentSettlements.has(expected),
     );
 
     const matches =

--- a/packages/thread/src/ThreadStore.ts
+++ b/packages/thread/src/ThreadStore.ts
@@ -187,7 +187,8 @@ export interface ThreadCheckpoints {
  * Saves atomically validate the producer epoch and canonical batch tail. An older snapshot
  * cannot replace a newer one; equal-tail replacement repairs disposable state. Invalid cached
  * data fails with CheckpointRejected, while infrastructure failures remain ThreadStoreError.
- * Loading at an earlier tail may return none. Canonical records and the ledger remain authority.
+ * Loading at an earlier tail or outside the adapter's cache locality may return none so callers
+ * can replay canonical records. Canonical records and the ledger remain authority.
  */
 export interface ThreadRecoveryCheckpoints {
   readonly save: (

--- a/packages/thread/src/ThreadStore.ts
+++ b/packages/thread/src/ThreadStore.ts
@@ -74,7 +74,7 @@ export class ThreadTail extends Schema.Class<ThreadTail>("@effect-agent/thread/T
 }) {}
 
 /** Maximum canonical records represented by one Thread export. */
-export const MAX_THREAD_EXPORT_RECORDS = 65_536;
+export const MAX_THREAD_EXPORT_RECORDS = 131_072;
 
 export class ThreadExport extends Schema.Class<ThreadExport>("@effect-agent/thread/ThreadExport")({
   format: Schema.Literal("effect-agent/thread@1"),
@@ -105,6 +105,14 @@ export class SaveCheckpointRequest extends Schema.Class<SaveCheckpointRequest>(
   "@effect-agent/thread/SaveCheckpointRequest",
 )({
   checkpoint: ThreadCheckpoint,
+}) {}
+
+/** Replace the disposable recovery view only under the current canonical producer fence. */
+export class SaveRecoveryCheckpointRequest extends Schema.Class<SaveRecoveryCheckpointRequest>(
+  "@effect-agent/thread/SaveRecoveryCheckpointRequest",
+)({
+  checkpoint: ThreadCheckpoint,
+  producerEpoch: ProducerEpoch,
 }) {}
 
 export class LoadCheckpointRequest extends Schema.Class<LoadCheckpointRequest>(
@@ -148,7 +156,7 @@ export class CheckpointRejected extends Schema.TaggedError<CheckpointRejected>()
   "CheckpointRejected",
   {
     threadId: ThreadId,
-    reason: Schema.Literals(["ahead-of-tail", "digest-mismatch", "unsupported-version"]),
+    reason: Schema.Literals(["ahead-of-tail", "digest-mismatch", "unsupported-version", "corrupt"]),
   },
 ) {}
 
@@ -172,6 +180,23 @@ export interface ThreadCheckpoints {
     Option.Option<ThreadCheckpoint>,
     ThreadStoreError | ThreadNotMaterialized | CheckpointRejected
   >;
+}
+
+/**
+ * Optional latest-only recovery cache, independent of application projection checkpoints.
+ * Saves atomically validate the producer epoch and canonical batch tail. An older snapshot
+ * cannot replace a newer one; equal-tail replacement repairs disposable state. Invalid cached
+ * data fails with CheckpointRejected, while infrastructure failures remain ThreadStoreError.
+ * Loading at an earlier tail may return none. Canonical records and the ledger remain authority.
+ */
+export interface ThreadRecoveryCheckpoints {
+  readonly save: (
+    request: SaveRecoveryCheckpointRequest,
+  ) => Effect.Effect<
+    void,
+    ThreadStoreError | ThreadNotMaterialized | CheckpointRejected | FenceRejected
+  >;
+  readonly load: ThreadCheckpoints["load"];
 }
 
 export class ThreadStore extends Context.Service<
@@ -200,5 +225,6 @@ export class ThreadStore extends Context.Service<
     ) => Effect.Effect<ThreadTail, ThreadStoreError | ThreadNotMaterialized>;
     /** Absent when this adapter does not support disposable checkpoints. */
     readonly checkpoints?: ThreadCheckpoints | undefined;
+    readonly recoveryCheckpoints?: ThreadRecoveryCheckpoints | undefined;
   }
 >()("@effect-agent/thread/ThreadStore") {}

--- a/packages/thread/src/internal/journal-checkpoint.ts
+++ b/packages/thread/src/internal/journal-checkpoint.ts
@@ -1,0 +1,102 @@
+import { RunId, SubmissionId } from "@effect-agent/core/Identifiers";
+import { RunPolicyUsage } from "@effect-agent/core/RunPolicyUsage";
+import { RunUsageSummary } from "@effect-agent/core/Usage";
+import { Option, Schema } from "effect";
+import { Prompt } from "effect/unstable/ai";
+
+import { CanonicalRecordEnvelope, CanonicalSequence, Digest, PersistedJson } from "../Records.ts";
+
+/** Retired accounting is additive; the latest Tool batch always remains replayable verbatim. */
+export class JournalCheckpointSeed extends Schema.Class<JournalCheckpointSeed>(
+  "@effect-agent/thread/internal/JournalCheckpointSeed",
+)({
+  runId: RunId,
+  throughSequence: CanonicalSequence,
+  firstSequence: Schema.optionalKey(CanonicalSequence),
+  committedTurns: Schema.Natural,
+  policyUsage: RunPolicyUsage,
+  modelCalls: Schema.Natural,
+  unobservedModelCalls: Schema.Natural,
+  inputTokens: Schema.Natural,
+  outputTokens: Schema.Natural,
+  lastInputTokens: Schema.Natural,
+  lastOutputTokens: Schema.Natural,
+  costMicrousd: Schema.Natural,
+  summarizedModelUsage: RunUsageSummary,
+  protectedContext: Schema.optionalKey(PersistedJson),
+  contextWindowId: Schema.optionalKey(Schema.String),
+  frontier: Schema.optionalKey(
+    Schema.Struct({
+      sequence: CanonicalSequence,
+      tag: Schema.Literals(["ModelResponseRecorded", "ToolCallSettled"]),
+    }),
+  ),
+  /** Canonical replacement whose covered batches were validated before retirement. */
+  compaction: CanonicalRecordEnvelope,
+}) {}
+
+/** A bounded sparse projection, never a canonical log or a submission-ownership record. */
+export class RecoveryCheckpointState extends Schema.Class<RecoveryCheckpointState>(
+  "@effect-agent/thread/internal/RecoveryCheckpointState",
+)({
+  schemaVersion: Schema.Literal(1),
+  policyAccountingVersion: Schema.Literal(1),
+  submissionId: SubmissionId,
+  submissionIds: Schema.Array(SubmissionId).check(Schema.isMaxLength(4_096)),
+  seed: JournalCheckpointSeed,
+  records: Schema.Array(CanonicalRecordEnvelope).check(Schema.isMaxLength(4_096)),
+}) {}
+
+export class RecoveryCheckpointContents extends Schema.Class<RecoveryCheckpointContents>(
+  "@effect-agent/thread/internal/RecoveryCheckpointContents",
+)({
+  state: RecoveryCheckpointState,
+  digest: Digest,
+}) {}
+
+export const RECOVERY_ENGINE_VERSION = "effect-agent/recovery@1";
+
+/**
+ * Late evidence can invalidate an old compaction. Such histories use full canonical replay;
+ * an omitted run/turn must never be treated as proven absent by a sparse projection.
+ */
+export const checkpointSuffixCompatible = (
+  seed: JournalCheckpointSeed,
+  records: ReadonlyArray<CanonicalRecordEnvelope>,
+  retained: ReadonlyArray<CanonicalRecordEnvelope>,
+): boolean =>
+  records.every(({ sequence, record: { payload } }) => {
+    if ("runId" in payload && payload.runId !== undefined && payload.runId !== seed.runId)
+      return false;
+    if ("turn" in payload && payload.turn <= seed.committedTurns) return false;
+    if (payload._tag === "ToolCallSettled" || payload._tag === "ToolCallResolved") {
+      // These records have no turn. The retained declaration/preparation proves their scope.
+      return [...retained, ...records].some(
+        ({ sequence: declarationSequence, record: { payload: candidate } }) => {
+          if (
+            candidate._tag !== "ModelResponseRecorded" ||
+            candidate.runId !== payload.runId ||
+            candidate.turn <= seed.committedTurns ||
+            seed.compaction.record.payload._tag !== "CompactionCreated" ||
+            declarationSequence <= seed.compaction.record.payload.coversThrough ||
+            declarationSequence >= sequence
+          )
+            return false;
+          const decoded = Schema.decodeUnknownOption(Prompt.Prompt)(candidate.messages);
+
+          return (
+            Option.isSome(decoded) &&
+            decoded.value.content.some(
+              (message) =>
+                message.role === "assistant" &&
+                message.content.some(
+                  (part) => part.type === "tool-call" && part.id === payload.toolCallId,
+                ),
+            )
+          );
+        },
+      );
+    }
+
+    return payload._tag !== "CompactionCreated" || payload.coversThrough >= seed.throughSequence;
+  });

--- a/packages/thread/test/recovery-checkpoint-schema.test.ts
+++ b/packages/thread/test/recovery-checkpoint-schema.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+
+import {
+  RecoveryCheckpointContents,
+  checkpointSuffixCompatible,
+} from "../src/internal/journal-checkpoint.ts";
+import { CanonicalRecordEnvelope } from "../src/Records.ts";
+import { SaveRecoveryCheckpointRequest } from "../src/ThreadStore.ts";
+
+// Encoded fixtures pin the disposable format independently of runtime constructors.
+const digest = "a".repeat(64);
+const runId = "run:checkpoint-fixture";
+
+const envelope = (sequence: number, payload: unknown) => ({
+  threadId: "checkpoint-fixture",
+  batchId: `batch-${sequence}`,
+  sequence,
+  offset: `fixture:${sequence}`,
+  record: {
+    recordId: `record-${sequence}`,
+    family: "thread",
+    schemaVersion: 1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    deploymentId: "fixture",
+    payload,
+  },
+});
+
+const replacement = envelope(5, {
+  _tag: "CompactionCreated",
+  runId,
+  turn: 3,
+  kind: "rollover",
+  coversThrough: 4,
+  handoff: "Continue the original request.",
+});
+
+const state = {
+  schemaVersion: 1,
+  policyAccountingVersion: 1,
+  submissionId: "checkpoint-fixture",
+  submissionIds: ["checkpoint-fixture"],
+  seed: {
+    runId,
+    throughSequence: 2,
+    firstSequence: 1,
+    committedTurns: 1,
+    policyUsage: {
+      committedTurns: 1,
+      toolCalls: 0,
+      programmaticToolCalls: 0,
+      consecutiveToolFailures: 0,
+      finalizationUsed: false,
+    },
+    modelCalls: 1,
+    unobservedModelCalls: 0,
+    inputTokens: 10,
+    outputTokens: 2,
+    lastInputTokens: 10,
+    lastOutputTokens: 2,
+    costMicrousd: 0,
+    summarizedModelUsage: {
+      modelCalls: 0,
+      inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 0, text: 0, reasoning: 0 },
+      costMicrousd: 0,
+      byModel: [],
+      usageStatus: "unknown",
+      pricingStatus: "unknown",
+      unobservedModelCalls: 0,
+    },
+    protectedContext: {
+      content: [{ role: "system", content: "Original instructions.", options: {} }],
+    },
+    contextWindowId: "context:checkpoint-fixture:3",
+    frontier: { sequence: 2, tag: "ModelResponseRecorded" },
+    compaction: replacement,
+  },
+  records: [replacement],
+};
+
+const contents = { state, digest };
+
+const checkpoint = {
+  schemaVersion: 1,
+  threadId: "checkpoint-fixture",
+  throughSequence: 5,
+  tailDigest: digest,
+  engineVersion: "effect-agent/recovery@1",
+  agentDefinitionDigest: digest,
+  modelDigest: digest,
+  toolDigest: digest,
+  state: contents,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const decodeEnvelope = Schema.decodeUnknownSync(CanonicalRecordEnvelope);
+
+const response = (sequence: number) =>
+  decodeEnvelope(
+    envelope(sequence, {
+      _tag: "ModelResponseRecorded",
+      runId,
+      turnId: `turn:${runId}:2`,
+      turn: 2,
+      messages: {
+        content: [
+          {
+            role: "assistant",
+            options: {},
+            content: [
+              {
+                type: "tool-call",
+                id: "call",
+                name: "write",
+                params: {},
+                providerExecuted: false,
+                options: {},
+              },
+            ],
+          },
+        ],
+      },
+      messagesDigest: digest,
+    }),
+  );
+
+const settled = (sequence: number) =>
+  decodeEnvelope(
+    envelope(sequence, {
+      _tag: "ToolCallSettled",
+      runId,
+      toolCallId: "call",
+      toolName: "write",
+      result: "recorded",
+      isFailure: false,
+    }),
+  );
+
+describe("recovery checkpoint compatibility", () => {
+  it("round-trips the fenced request and versioned state as JSON", () => {
+    const codec = Schema.fromJsonString(SaveRecoveryCheckpointRequest);
+    const encoded = JSON.stringify({ checkpoint, producerEpoch: 7 });
+    const decoded = Schema.decodeUnknownSync(codec)(encoded);
+
+    expect(JSON.parse(Schema.encodeSync(codec)(decoded))).toEqual(JSON.parse(encoded));
+    const saved = Schema.decodeUnknownSync(RecoveryCheckpointContents)(decoded.checkpoint.state);
+
+    expect(Schema.encodeSync(RecoveryCheckpointContents)(saved)).toEqual(contents);
+  });
+
+  it.each(["schemaVersion", "policyAccountingVersion"])("rejects incompatible %s", (field) => {
+    expect(
+      Schema.decodeUnknownExit(RecoveryCheckpointContents)({
+        ...contents,
+        state: { ...state, [field]: 2 },
+      })._tag,
+    ).toBe("Failure");
+  });
+
+  it("rejects late results whose declarations are already covered, missing, or in the future", () => {
+    const seed = Schema.decodeUnknownSync(RecoveryCheckpointContents)(contents).state.seed;
+
+    expect(checkpointSuffixCompatible(seed, [settled(7)], [response(3)])).toBe(false);
+    expect(checkpointSuffixCompatible(seed, [settled(7)], [])).toBe(false);
+    expect(checkpointSuffixCompatible(seed, [settled(7), response(8)], [])).toBe(false);
+    expect(checkpointSuffixCompatible(seed, [response(6), settled(7)], [])).toBe(true);
+  });
+});


### PR DESCRIPTION
Durable recovery currently reads retained history once in recovery and four more times before the resumed model request. A fixed twelve-record active suffix returned 5,090 / 50,090 canonical records at 1k / 10k history, and the public 65,536-record limit prevented the 100k cohort.

This adds a versioned, disposable recovery checkpoint after a canonical summary or rollover. Adapters bind its latest-only slot to a canonical batch-tail digest and producer epoch. The runtime validates state/accounting versions, definition digests, checksum and projection compatibility, restores the control/accounting state, then reads a contiguous suffix to the captured canonical tail. Missing, corrupt, incompatible or ineligible checkpoints fall back to canonical replay. The ledger and canonical journal retain authority; unresolved ordinary side effects are never automatically re-executed.

```mermaid
flowchart LR
  C[Canonical compaction committed] -->|fenced save bound to batch tail| K[Disposable recovery checkpoint]
  R[DurableAgentRuntime recovery] -->|capture tail; load optional cache| K
  K -->|valid state and definitions| S[Replay contiguous canonical suffix]
  K -->|missing or rejected| F[Replay complete canonical history in pages]
  S --> J[Seeded RunJournal and recovery control]
  F --> J
  L[SubmissionLedger] -->|ownership, definitions, accounting authority| R
  J --> M[Resume model or pending obligations]
```

The checkpoint preserves evaluated instructions/input, context-window identity and boundaries, usage/deadlines, pending tools and results, approvals, durable Step evidence, and lineage. It is bounded to 4,096 retained records and 1 MiB; suffix replay is bounded to 4,096 records before falling back. Existing adapters without the optional capability keep working. A projection watermark is deliberately insufficient: it cannot establish recovery obligations or cumulative accounting.

Storage/export/verification share a 131,072-record ceiling, with append batches of at most 256 and canonical read/export pages of at most 1,024. SQLite 7/8/9 upgrades atomically to 10; Durable Object 2/3/4 upgrades atomically to 5. Supported data is preserved, while unsupported or ambiguous stores fail without mutation. Canonical record format is unchanged. Generic checkpoints remain a separate capability so unrelated projections cannot displace recovery state. Recovery-cache loads for foreign Durable Objects return a cache miss and use the authorized canonical read route; cache writes remain local and fenced.

For adapter integrators, the optional port returns `Option<ThreadCheckpoint>`; runtime callers need no new option. This illustrative probe is inside `Effect.gen`, with a validated `threadId` and captured `tailSequence` (imports omitted):

```ts
const store = yield* ThreadStore;
const cached = store.recoveryCheckpoints === undefined
  ? Option.none()
  : yield* store.recoveryCheckpoints.load(
      LoadCheckpointRequest.make({ threadId, atOrBeforeSequence: tailSequence }),
    ).pipe(Effect.catchTag("CheckpointRejected", () => Effect.succeed(Option.none())));
```

A miss/rejected cache permits canonical replay; infrastructure and missing-thread failures remain typed errors. The runtime additionally checks definition/accounting compatibility before using any returned cache.

Local public-runtime evidence (Node 24.20.0, macOS arm64, M4 Max, 16 logical CPUs, 128 GiB; scripted model, no paid calls):

| Historical records | Baseline canonical records before model | Candidate recovery + resume records | Baseline cold / warm median | Candidate cold / warm median |
| --- | ---: | ---: | ---: | ---: |
| 1,000 | 5,090 | 12 + 12 | 232.6 / 189.1 ms | 38.6 / 15.5 ms |
| 10,000 | 50,090 | 12 + 12 | 1,754.2 / 3,897.3 ms | 40.4 / 16.2 ms |
| 100,000 | Public append limit rejected seed | 12 + 12 | Unavailable | 38.1 / 16.2 ms |

Each cohort uses one fresh-process sample after imports and two warm-process samples with fresh SQLite/runtime scopes; the OS cache is warmed by seeding. All samples are retained. Baseline warm 10k samples varied from 1,803.9 to 5,990.7 ms during concurrent local work, so read-volume invariance is stronger evidence than a precise latency multiplier. Candidate warm samples range from 14.3 to 17.1 ms. A separate 1k confirmation after renaming a same-length fixture identity retained identical read counts (61.7 ms cold, 25.4 / 19.3 ms warm); those extra samples are retained separately and are not pooled with the comparison. A further separate 100k confirmation after moving untimed verification dependencies into Effect requirements also passes with unchanged startup read counts and a 100,021-record final export; it is not pooled with the comparison. All nine comparison samples issue exactly one resumed model request and one settlement with the same 17-message, roughly 3.34 KiB prompt and cumulative turn/token accounting.

Before the model, each candidate reads two canonical pages (24 records), loads the checkpoint twice (7,457 / 7,477 / 7,497 serialized bytes per load), and makes eight tail inspections. Ledger control reads are three lookups, four recovery-snapshot loads, and one scan returning one row, identical across cohorts. Recovery and resume latency/memory, checkpoint traffic, ledger control reads, and canonical reads are measured separately in the fixture output. Cold recovery is 11.0–12.0 ms and resume-to-model is 20.2–22.3 ms. At the model, post-GC heap is 70.8–72.4 MB and RSS 265.8–270.3 MB across cohorts; these are process observations, not hosted Worker CPU.

The 100k cohort publicly exports and schema-round-trips 100,018 records before resume and 100,021 after completion, outside timing windows. Public `runtime.verify` passes; its digest-chain check explicitly skips unavailable batch-producer metadata. A separate public SQLite `verifyOnOpen: true` acquisition passes the full adapter digest-chain audit at 100,021 records.

Reproduce with `vp node --experimental-transform-types --expose-gc packages/platform-node/test/recovery-benchmark/entry.ts`, setting `EFFECT_AGENT_RECOVERY_BENCHMARK_MODE=seed` then `run`, `EFFECT_AGENT_RECOVERY_BENCHMARK_COUNT=1000|10000|100000`, `EFFECT_AGENT_RECOVERY_BENCHMARK_OUT` to a fresh directory, and `EFFECT_AGENT_RECOVERY_BENCHMARK_REVISION` to the measured revision. The fixture records environment, source hashes, phase counters and memory, and validates the resumed prompt/settlement.

Validation: all required [CI jobs and `ready`](https://github.com/danieljvdm/effect-agent/actions/runs/34261598023) pass at `ab3ae23744a6e9e15d0fce4e3d9ffb45fb5f7159`, as do review and consumer bundle checks. Coverage includes 17 checkpoint runtime cases, four encoded compatibility/suffix fixtures, four real process-kill cases, adapter contracts and preserving schema upgrades. The 100k export/runtime verification and full adapter digest audit pass. Locally, all 403 testing-package tests, 508 Cloudflare runtime tests and 154 Cloudflare storage tests pass in completed package runs, but full `vp run ready` attempts encounter variable packaging/Cloudflare timeouts under concurrent machine load, including with `VITEST_MAX_WORKERS=1`; no successful local full-ready receipt is claimed. The final CI storage job passed on an unchanged retry after its 1,000-event subscription conformance case exceeded 30 seconds (it passed in 15.0 seconds on the initial PR CI and 22.1 seconds locally). Failed receipts are retained; assertions, public guards, timeout limits and tooling are unchanged.

Related to #356; keep the issue open. Actual Cloudflare host invocation latency and CPU are unproven: no authorized recovery benchmark endpoint was available, and this work does not deploy one. Local workerd adapter/crash tests do not establish that host gate. Consumer adoption requires an actually published compatible fixed-group release; this PR does not merge, publish, deploy, or change #372's paid evaluator.
