### PR TITLE
fix(thread): preserve tool results across subagent suspension

### DIFF
--- a/.changeset/settled-sibling-order.md
+++ b/.changeset/settled-sibling-order.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Preserve earlier tool results when attached subagents suspend a later turn, and restore completed result batches in declaration order so context rollover can continue after recovery.

--- a/packages/testing/test/durable-subagents.test.ts
+++ b/packages/testing/test/durable-subagents.test.ts
@@ -11,6 +11,7 @@ import {
   type SubmissionId,
 } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { ContextRolloverRequest, ContextRolloverTool } from "@effect-agent/engine/ContextWindow";
 import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
 import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
 import {
@@ -1776,6 +1777,140 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         expect(yield* harness.lookupInvocations).toBe(1);
         expect(yield* harness.childInvocations).toBe(1);
       }
+    }),
+  );
+
+  // https://github.com/danieljvdm/effect-agent/commit/c1a6e6a915be73a49b2c266e2df74256f44c25e2
+  // A later suspension duplicated prior Turn results and broke rollover after recovery.
+  it.effect("preserves prior Turn results when a later delegation suspends before rollover", () =>
+    Effect.gen(function* () {
+      const { childBinding } = yield* makeChildFixture;
+      const Failure = Schema.TaggedStruct("LookupFailure", { detail: Schema.String });
+
+      const toolkit = Toolkit.make(
+        researchDelegation.tool,
+        Lookup,
+        Tool.make("fail_lookup", {
+          parameters: Schema.Struct({}),
+          success: Schema.String,
+          failure: Failure,
+          failureMode: "return",
+        }),
+        Tool.make("new_context", {
+          parameters: ContextRolloverRequest,
+          success: ContextRolloverRequest,
+        })
+          .annotate(ToolExecutionClass, "readonly")
+          .annotate(ContextRolloverTool, true),
+      );
+
+      const definition = Agent.make("suspension-after-prior-results", {
+        input: coordinatorDefinition.input,
+        output: coordinatorDefinition.output,
+        instructions: "Preserve completed results, delegate, roll over, then finish.",
+        toolkit,
+        policy: AgentPolicy.make({
+          maxTurns: 8,
+          maxToolCalls: 8,
+          maxDuration: "30 seconds",
+          toolConcurrency: 2,
+        }),
+      });
+
+      const model = yield* makeScriptedModel((call) => {
+        if (call === 0) return toolTurn(toolCall("prior-failure", "fail_lookup", {}));
+        if (call === 1) return toolTurn(toolCall("prior-success", "lookup", { key: "prior" }));
+        if (call === 2)
+          return toolTurn(
+            toolCall("delegate-1", "delegate_research", { topic: "paris" }),
+            toolCall("current-sibling", "lookup", { key: "current" }),
+          );
+        if (call === 3)
+          return toolTurn(
+            toolCall("reset", "new_context", { handoff: "Research and both lookups completed." }),
+          );
+
+        return finalParts('{"report":"done"}');
+      });
+
+      const lookups = yield* Ref.make(0);
+
+      const handlers = Toolkit.make(
+        toolkit.tools.lookup,
+        toolkit.tools.fail_lookup,
+        toolkit.tools.new_context,
+      ).toLayer({
+        lookup: ({ key }) => Ref.update(lookups, (n) => n + 1).pipe(Effect.as({ value: key })),
+        fail_lookup: () => Effect.fail(Failure.make({ detail: "Original typed failure" })),
+        new_context: Effect.succeed,
+      });
+
+      const delegation = SubagentRuntime.layer(researchDelegation, childBinding, {
+        mapChildFailure,
+      }).pipe(Layer.provide(delegationSupport));
+
+      const parentBinding = Agent.withModel(definition, model.model);
+
+      const bindings = [
+        yield* DurableWorkerBinding.make(parentBinding, PARENT_DIGESTS).pipe(
+          Effect.provide(Layer.merge(handlers, delegation)),
+        ),
+        yield* DurableWorkerBinding.make(childBinding, CHILD_DIGESTS),
+      ];
+
+      const runtime = yield* DurableAgentRuntime.pipe(
+        Effect.provide(
+          DurableAgentRuntime.layerWithBindings(bindings).pipe(
+            Layer.provide(RunToolAuthorization.allowAll),
+          ),
+        ),
+      );
+
+      const receipt = yield* runtime.submit(
+        parentBinding,
+        { mission: "regression" },
+        submitOptions("suspension-prior-results", "one"),
+      );
+
+      const run = drive({ runtime });
+
+      yield* run(receipt.threadId);
+      expect((yield* parentState(receipt.submissionId)).state).toBe("suspended");
+      const suspended = yield* readLog(receipt.threadId);
+
+      const prior = suspended.filter(
+        ({ record }) =>
+          record.payload._tag === "ToolCallSettled" &&
+          ["prior-failure", "prior-success"].includes(record.payload.toolCallId),
+      );
+
+      expect(prior).toHaveLength(2);
+      expect(prior[0]?.record.payload).toMatchObject({
+        result: { _tag: "LookupFailure", detail: "Original typed failure" },
+      });
+      yield* run(childThreadIdFor(receipt.submissionId, DELEGATE_CALL));
+      const completed = yield* run(receipt.threadId);
+
+      expect(
+        completed.map((settlement) => settlement.outcome),
+        JSON.stringify(completed),
+      ).toEqual(["completed"]);
+      expect(yield* Ref.get(lookups)).toBe(2);
+      const final = yield* readLog(receipt.threadId);
+
+      expect(
+        final.filter(
+          ({ record }) =>
+            record.payload._tag === "CompactionCreated" && record.payload.kind === "rollover",
+        ),
+      ).toHaveLength(1);
+      expect(
+        final.filter(
+          ({ record }) =>
+            record.payload._tag === "ToolCallSettled" &&
+            ["prior-failure", "prior-success"].includes(record.payload.toolCallId),
+        ),
+      ).toHaveLength(2);
     }),
   );
 

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -6466,7 +6466,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const handleEvent = (event: RunEvent): Effect.Effect<void, DurableWorkerFailure> => {
         switch (event._tag) {
           case "TurnStarted": {
-            return commitPendingTurn;
+            // Suspension owns only this Turn's siblings. Earlier results are already canonical
+            // under their original Turn and must never be re-recorded with a later Turn id.
+            return commitPendingTurn.pipe(
+              Effect.andThen(Effect.sync(() => siblingResults.clear())),
+            );
           }
           case "TurnCompleted": {
             const turnId = event.turnId ?? turnIdForRun(runId, event.turn);

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -941,11 +941,22 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
     }
   });
 
+  let pendingToolOrder = new Map<string, number>();
+
   const flushTools = Effect.fn("RunJournal.flushTools")(function* (
     current: FoldState,
   ): Effect.fn.Return<FoldState, RunJournalError> {
     if (current.pendingTools.length === 0) return current;
-    const toolMessage = yield* toolMessageFromSettled(current.pendingTools);
+
+    // Suspension can persist an ordinary sibling before a delegated call joins. Model context
+    // still uses declaration order, matching the live interpreter's completed results batch.
+    const ordered = current.pendingTools.toSorted(
+      (left, right) =>
+        (pendingToolOrder.get(left.record.toolCallId) ?? Number.MAX_SAFE_INTEGER) -
+        (pendingToolOrder.get(right.record.toolCallId) ?? Number.MAX_SAFE_INTEGER),
+    );
+
+    const toolMessage = yield* toolMessageFromSettled(ordered);
 
     current.all.push(toolMessage);
     if (!current.pendingToolsForRun) current.before.push(toolMessage);
@@ -1068,6 +1079,10 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
       if (payload._tag !== "ModelResponseRecorded") return;
       const messages = yield* decodePromptMessages(payload.messages);
       const forRun = payload.runId === ownerRunId;
+
+      pendingToolOrder = new Map(
+        declaredApplicationToolCallIds(messages).map((id, index) => [id, index]),
+      );
 
       yield* accountResponse(envelope, payload, messages);
 


### PR DESCRIPTION
Attached subagent suspension could append tool results from an earlier turn again under the current turn, then reconstruct sibling results in settlement order. A later context rollover rejected that reconstructed prefix and failed the Run.

Keep the suspension result buffer within its turn and reconstruct result batches in model declaration order. This preserves the original typed results and lets the same Run continue through delegation recovery and rollover without replaying completed tools. Persisted record formats are unchanged.

The regression reproduces the duplicated results before the fix and now completes delegation, recovery, and rollover. The focused 68-test slice and full `vp run ready` pass; the full run used `VITEST_MAX_WORKERS=2` after concurrent runs hit varying Cloudflare five-second timeouts.
