### PR TITLE
fix(engine): preserve canonical responses across durable resume

### DIFF
--- a/.changeset/preserve-resumed-model-response.md
+++ b/.changeset/preserve-resumed-model-response.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Preserve the canonical assistant response when resuming a durable Tool batch so provider metadata and assistant content survive recovery and subsequent context rollover.

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -794,6 +794,13 @@ export interface RunTurnResume {
    * tool-call message. Optional: absent keeps the prior behavior byte-for-byte.
    */
   readonly leadingMessages?: Prompt.Prompt | undefined;
+  /**
+   * The pending Turn's canonical assistant response, including text, reasoning and provider
+   * options. Durable hosts pass the decoded response after its leading messages. Execution
+   * still uses the independently validated `calls`; this exact response enters history instead
+   * of reconstructing it from call descriptors that cannot preserve every provider field.
+   */
+  readonly responseMessages?: Prompt.Prompt | undefined;
 }
 
 /** Run-level scheduler override; it may only make the Agent's finite bound stricter. */

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -516,6 +516,8 @@ const toolCounter = Metric.counter("effect_agent_tool_calls_total", {
  * value and performs its own decode before invoking the handler.
  */
 interface TurnTrace {
+  /** A resumed Turn already has an authoritative model response in canonical history. */
+  readonly replayedResponse?: Prompt.Prompt | undefined;
   /** Number of decoded provider parts retained or inspected during this model call. */
   responsePartCount: number;
   /** Conservative retained-memory estimate across decoded provider parts. */
@@ -4086,6 +4088,8 @@ const decodeEventJson = Effect.fn("AgentRuntime.decodeEventJson")(
  * handler results remain Tool messages for the next model request.
  */
 const promptFromTurnParts = (trace: TurnTrace): Prompt.Prompt => {
+  if (trace.replayedResponse !== undefined) return trace.replayedResponse;
+
   const responsePrompt = Prompt.fromResponseParts(
     trace.parts.filter((part) => !(part.type === "tool-result" && part.providerExecuted)),
   );
@@ -6456,6 +6460,7 @@ const makeResumeTurn = <
       }
 
       const trace: TurnTrace = {
+        replayedResponse: resume.responseMessages,
         responsePartCount: 0,
         responsePartBytes: 0,
         parts: [],

--- a/packages/testing/test/durable-subagents.test.ts
+++ b/packages/testing/test/durable-subagents.test.ts
@@ -1782,6 +1782,8 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
 
   // https://github.com/danieljvdm/effect-agent/commit/c1a6e6a915be73a49b2c266e2df74256f44c25e2
   // A later suspension duplicated prior Turn results and broke rollover after recovery.
+  // https://linear.app/reve-ai/issue/KOM-127
+  // Real provider metadata and assistant content must also survive the resumed declaration.
   it.effect("preserves prior Turn results when a later delegation suspends before rollover", () =>
     Effect.gen(function* () {
       const { childBinding } = yield* makeChildFixture;
@@ -1817,12 +1819,21 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         }),
       });
 
-      const model = yield* makeScriptedModel((call) => {
+      const model = yield* makeScriptedModel((index) => {
+        if (index === 0) return finalParts('{"report":"prior task"}');
+        const call = index - 1;
+
         if (call === 0) return toolTurn(toolCall("prior-failure", "fail_lookup", {}));
         if (call === 1) return toolTurn(toolCall("prior-success", "lookup", { key: "prior" }));
         if (call === 2)
           return toolTurn(
-            toolCall("delegate-1", "delegate_research", { topic: "paris" }),
+            { type: "text-start", id: "delegation-note" },
+            { type: "text-delta", id: "delegation-note", delta: "Delegating the retained task." },
+            { type: "text-end", id: "delegation-note" },
+            {
+              ...toolCall("delegate-1", "delegate_research", { topic: "paris" }),
+              metadata: { openai: { itemId: "fc_provider_item" } },
+            },
             toolCall("current-sibling", "lookup", { key: "current" }),
           );
         if (call === 3)
@@ -1866,26 +1877,36 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         ),
       );
 
+      const prior = yield* runtime.submit(
+        parentBinding,
+        { mission: "prior task" },
+        submitOptions("suspension-prior-results", "prior"),
+      );
+
+      const run = drive({ runtime });
+
+      expect((yield* run(prior.threadId)).map((settlement) => settlement.outcome)).toEqual([
+        "completed",
+      ]);
+
       const receipt = yield* runtime.submit(
         parentBinding,
         { mission: "regression" },
         submitOptions("suspension-prior-results", "one"),
       );
 
-      const run = drive({ runtime });
-
       yield* run(receipt.threadId);
       expect((yield* parentState(receipt.submissionId)).state).toBe("suspended");
       const suspended = yield* readLog(receipt.threadId);
 
-      const prior = suspended.filter(
+      const priorResults = suspended.filter(
         ({ record }) =>
           record.payload._tag === "ToolCallSettled" &&
           ["prior-failure", "prior-success"].includes(record.payload.toolCallId),
       );
 
-      expect(prior).toHaveLength(2);
-      expect(prior[0]?.record.payload).toMatchObject({
+      expect(priorResults).toHaveLength(2);
+      expect(priorResults[0]?.record.payload).toMatchObject({
         result: { _tag: "LookupFailure", detail: "Original typed failure" },
       });
       yield* run(childThreadIdFor(receipt.submissionId, DELEGATE_CALL));
@@ -1895,6 +1916,25 @@ layer(testLayer)("S2 durable attached Subagents (WP4 coordinator)", (it) => {
         completed.map((settlement) => settlement.outcome),
         JSON.stringify(completed),
       ).toEqual(["completed"]);
+
+      const resumedAssistant = model.prompts[4]?.content.find(
+        (message) =>
+          message.role === "assistant" &&
+          message.content.some((part) => part.type === "tool-call" && part.id === "delegate-1"),
+      );
+
+      expect(resumedAssistant).toMatchObject({
+        role: "assistant",
+        content: [
+          { type: "text", text: "Delegating the retained task." },
+          {
+            type: "tool-call",
+            id: "delegate-1",
+            options: { openai: { itemId: "fc_provider_item" } },
+          },
+          { type: "tool-call", id: "current-sibling" },
+        ],
+      });
       expect(yield* Ref.get(lookups)).toBe(2);
       const final = yield* readLog(receipt.threadId);
 

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -4702,6 +4702,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       // committed inside the pending record — re-enter official history through the engine so
       // the resumed live model context does not silently drop them.
       let resumeLeadingMessages: Prompt.Prompt | undefined;
+      let resumeResponseMessages: Prompt.Prompt | undefined;
 
       if (pending !== undefined) {
         const pendingMessages = yield* decodePrompt(pending.messages).pipe(
@@ -4721,6 +4722,11 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         if (firstAssistant > 0) {
           resumeLeadingMessages = Prompt.fromMessages(
             pendingMessages.content.slice(0, firstAssistant),
+          );
+        }
+        if (firstAssistant >= 0) {
+          resumeResponseMessages = Prompt.fromMessages(
+            pendingMessages.content.slice(firstAssistant),
           );
         }
       }
@@ -6248,6 +6254,9 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 ...(resumeLeadingMessages === undefined
                   ? {}
                   : { leadingMessages: resumeLeadingMessages }),
+                ...(resumeResponseMessages === undefined
+                  ? {}
+                  : { responseMessages: resumeResponseMessages }),
               },
             }),
         ...(preparedContext === undefined ? {} : { context: preparedContext }),


### PR DESCRIPTION
Resuming a durable Tool batch rebuilt its assistant response from call descriptors, dropping provider options and accompanying assistant text. In KOM-127's real attached-scout flow this made the resumed prompt differ from its canonical record, so a later context rollover failed with `CompactionError`.

The durable host now passes the decoded assistant response through the optional `RunTurnResume.responseMessages` field. The interpreter reuses that exact response when continuing history, while Tool execution still follows the validated call descriptors and recorded results. Hosts that omit the field retain the existing reconstruction behavior.

```ts
// A durable host resumes the pending response after its leading instructions/input.
responseMessages: Prompt.fromMessages(pendingMessages.content.slice(firstAssistant))
```

```mermaid
flowchart LR
  R[ModelResponseRecorded.messages] --> H[DurableAgentRuntime]
  H -->|leadingMessages + responseMessages| E[Resumed interpreter history]
  H -->|calls + settled| T[Validated Tool batch]
  T -->|completed results| E
```

Fixes the provider-metadata recovery failure found during [KOM-127](https://linear.app/reve-ai/issue/KOM-127).
