### PR TITLE
fix(thread): keep settlement usage equivalent across recovery

### DIFF
--- a/.changeset/consistent-settlement-usage.md
+++ b/.changeset/consistent-settlement-usage.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Omit empty uncommitted model usage from settlements so uninterrupted completion and crash recovery produce equivalent canonical records.

--- a/packages/platform-cloudflare/test/chaos.test.ts
+++ b/packages/platform-cloudflare/test/chaos.test.ts
@@ -206,6 +206,11 @@ describe("DC chaos-abort evidence equivalence", () => {
         { thread: lane("seeded-chaos-planner"), definition: plannerDefinition },
       ] as const;
 
+      // Force recovery from RunCompleted, before settlement reservation; the seeded schedule
+      // alone may miss the empty-usage mismatch introduced by:
+      // https://github.com/danieljvdm/effect-agent/commit/21431ae6cacd78e6330b1017c2768f4f9c347b7a
+      armRuntimeEviction(lanes[1].thread, "turn:after-canonical-append");
+
       const receipts = [
         await submitTo(lanes[0].definition, lanes[0].thread),
         await submitTo(lanes[1].definition, lanes[1].thread),
@@ -247,6 +252,7 @@ describe("DC chaos-abort evidence equivalence", () => {
         await drainAlarmsUntil(thread, allSettled(thread));
         await assertConvergence(thread);
       }
+      expect(armedEvictionsRemaining(lanes[1].thread)).toBe(0);
       expect(
         normalizedEvidence(await readCanonical(lanes[0].thread), receipts[0], lanes[0].thread),
       ).toEqual(

--- a/packages/storage-memory/test/provider-usage.test.ts
+++ b/packages/storage-memory/test/provider-usage.test.ts
@@ -167,7 +167,7 @@ for (const failure of ["open-part", "missing-usage", "continuation", "invalid-es
           unobservedModelCalls: retainsUsage ? 0 : 1,
           pricingStatus: retainsUsage ? "complete" : "partial",
         });
-        expect(settlement?.uncommittedModelUsage).toHaveLength(retainsUsage ? 1 : 0);
+        expect(settlement?.uncommittedModelUsage?.length).toBe(retainsUsage ? 1 : undefined);
         if (settlement === undefined) throw new Error("expected terminal accounting");
 
         const committedCalls = responses.flatMap(({ record }) =>
@@ -423,7 +423,6 @@ it.live(
 
         expect(settlement).toMatchObject({
           outcome: "completed",
-          uncommittedModelUsage: [],
           usageSummary: {
             modelCalls: 3,
             costMicrousd: 75,
@@ -432,6 +431,7 @@ it.live(
             pricingStatus: "partial",
           },
         });
+        expect(settlement).not.toHaveProperty("uncommittedModelUsage");
         expect(
           records
             .flatMap(({ record }) =>

--- a/packages/testing/src/fixtures/travel-planner/phase6.ts
+++ b/packages/testing/src/fixtures/travel-planner/phase6.ts
@@ -987,7 +987,6 @@ export const phase6TravelPlannerGoldenEvidence: Schema.Json = [
             },
           ],
         },
-        uncommittedModelUsage: [],
         usageSummary: {
           usageStatus: "partial",
           pricingStatus: "unknown",

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -2699,7 +2699,9 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           ? { policyLimit: outcome.policyLimit }
           : {}),
         ...(outcome.usageSummary === undefined ? {} : { usageSummary: outcome.usageSummary }),
-        ...(includeRunId && outcome.uncommittedModelUsage !== undefined
+        ...(includeRunId &&
+        outcome.uncommittedModelUsage !== undefined &&
+        outcome.uncommittedModelUsage.length > 0
           ? { uncommittedModelUsage: outcome.uncommittedModelUsage }
           : {}),
       }),


### PR DESCRIPTION
A crash after `RunCompleted` was persisted but before settlement produced a different canonical record from uninterrupted completion: recovery omitted `uncommittedModelUsage`, while the live path wrote an empty array. This caused the Cloudflare chaos failure in #390.

Omit empty uncommitted usage when constructing settlements, preserve populated usage, and force this crash boundary in the existing chaos test. Existing persisted records remain readable and unchanged.
