### PR TITLE
perf: benchmark runtime latency and reduce response overhead

### DIFF
--- a/.changeset/quick-primitive-responses.md
+++ b/.changeset/quick-primitive-responses.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/engine": patch
+---
+
+Reduce processing and tracing overhead for fragmented text and reasoning responses while preserving ownership and response limits. Preserve stable output-contract messages so opt-in incremental provider requests can reuse an unchanged prompt prefix.

--- a/.github/workflows/performance-cloudflare.yml
+++ b/.github/workflows/performance-cloudflare.yml
@@ -1,0 +1,123 @@
+name: Manual Cloudflare performance
+
+# Paid, deployed pre-merge/pre-release evidence. Deliberately no PR, push, or schedule trigger.
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: Exact 40-character candidate commit SHA
+        required: true
+        type: string
+      reference:
+        description: Optional exact 40-character reference commit SHA
+        required: false
+        type: string
+      model:
+        description: Real provider model
+        type: choice
+        default: gpt-6-astra
+        options: [gpt-6-astra, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.4-mini]
+      samples:
+        description: Threads per target; each reserves at most $2 (maximum $12 with both targets)
+        type: choice
+        default: "1"
+        options: ["1", "2", "3"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manual-cloudflare-performance
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    # Six bounded samples can consume 48 minutes; leave room for deployment and cleanup.
+    timeout-minutes: 90
+    environment: performance-cloudflare
+    env:
+      CI: "true"
+      VP_GIT_HOOKS: "0"
+      CANDIDATE_SHA: ${{ inputs.candidate }}
+      REFERENCE_SHA: ${{ inputs.reference }}
+      PERFORMANCE_MODEL: ${{ inputs.model }}
+      PERFORMANCE_SAMPLES: ${{ inputs.samples }}
+    steps:
+      - name: Validate immutable revisions
+        shell: bash
+        run: |
+          [[ "$CANDIDATE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ -z "$REFERENCE_SHA" || "$REFERENCE_SHA" =~ ^[a-f0-9]{40}$ ]]
+      - name: Check out candidate and fixture
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.candidate }}
+          path: candidate
+          persist-credentials: false
+      - name: Check out optional reference
+        if: inputs.reference != ''
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.reference }}
+          path: reference
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.0
+      - name: Install each exact lockfile
+        shell: bash
+        run: |
+          cd candidate
+          bunx --package vite-plus@0.3.0 vp install --frozen-lockfile --ignore-scripts
+          if [[ -n "$REFERENCE_SHA" ]]; then
+            cd ../reference
+            ../candidate/node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
+          fi
+      - name: Deploy, evaluate, preserve evidence, and retire resources
+        working-directory: candidate
+        shell: bash
+        env:
+          EFFECT_AGENT_LIVE: "1"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          args=(--model "$PERFORMANCE_MODEL" --samples "$PERFORMANCE_SAMPLES")
+          if [[ -n "$REFERENCE_SHA" ]]; then args+=(--reference-root ../reference); fi
+          vp run --no-cache perf:cloudflare "${args[@]}"
+      - name: Retry recorded cleanup after failure or cancellation
+        if: always()
+        working-directory: candidate
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          if [[ -f .context-continuity-eval/performance/resources.json ]]; then
+            vp run --no-cache perf:cloudflare --cleanup
+          fi
+      - name: Attach readable result
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f candidate/.context-continuity-eval/performance/summary.md ]]; then
+            cat candidate/.context-continuity-eval/performance/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Preserve exact-candidate evidence, including failures
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cloudflare-performance-${{ inputs.candidate }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: candidate/.context-continuity-eval/performance/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -1,0 +1,99 @@
+name: Runtime performance comment
+
+on:
+  workflow_run:
+    workflows: [Runtime performance]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: runtime-performance
+          path: runtime-performance
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Trusted publisher: never check out candidate code, import its report
+      # renderer, install its dependencies, or execute an artifact.
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea9 # v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const read = (name, limit) => {
+              const file = `runtime-performance/${name}`;
+              const stat = fs.lstatSync(file);
+              if (!stat.isFile() || stat.size > limit) throw new Error('Invalid performance artifact');
+              return fs.readFileSync(file, 'utf8');
+            };
+            const number = read('pr-number.txt', 20).trim();
+            if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error('Invalid PR number');
+            const report = JSON.parse(read('report.json', 3000000));
+            if (report.fixture !== 'runtime-v1' || report.profile !== 'pr' ||
+                !/^[a-f0-9]{64}$/.test(report.fixtureSha256) ||
+                !Array.isArray(report.revisions) || report.revisions.length !== 3 ||
+                !Array.isArray(report.batches) || report.batches.length !== 18) {
+              throw new Error('Invalid report contract');
+            }
+            const revision = role => report.revisions.find(value => value.role === role);
+            for (const role of ['base', 'head', 'reference']) {
+              if (!/^[a-f0-9]{40}$/.test(revision(role)?.revision) || revision(role).dirty !== false) throw new Error('Invalid revision');
+            }
+            if (revision('reference').revision !== '596cffba70716b1211ac02de949c4d0f31734b2f') throw new Error('Unexpected reference');
+            const run = context.payload.workflow_run;
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: Number(number) });
+            if (pr.state !== 'open' || pr.head.sha !== run.head_sha || pr.head.sha !== revision('head').revision ||
+                pr.head.repo?.id !== run.head_repository.id || pr.base.sha !== revision('base').revision ||
+                pr.base.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
+            const med = values => {
+              values.sort((a, b) => a - b);
+              const i = (values.length - 1) / 2;
+              return (values[Math.floor(i)] + values[Math.ceil(i)]) / 2;
+            };
+            const expected = ['small-run', 'small-stream', ...[1,64,1024,4096].map(n => `stream-64k-${n}`),
+              'history-65536', 'history-1048576', 'parallel-tools-8', 'tool-rounds-4',
+              ...[0,256,2048].flatMap(n => [`durable-fresh-${n}`, `checkpoint-recovery-${n}`, `settled-ledger-${n}`])];
+            const samples = [];
+            const identities = new Set();
+            for (const batch of report.batches) {
+              const key = `${batch.role}:${batch.cohort}:${batch.cold}`;
+              if (!['base','head','reference'].includes(batch.role) || ![0,1,2].includes(batch.cohort) ||
+                  typeof batch.cold !== 'boolean' || identities.has(key) || batch.exitCode !== 0 || !batch.complete ||
+                  !Array.isArray(batch.report?.samples)) throw new Error('Invalid cohort');
+              identities.add(key);
+              if (batch.cold) continue;
+              if (batch.report.samples.length !== expected.length * 5) throw new Error('Incomplete cohort');
+              const unique = new Set();
+              for (const sample of batch.report.samples) {
+                const id = `${sample.case}:${sample.ordinal}`;
+                if (!expected.includes(sample.case) || ![0,1,2,3,4].includes(sample.ordinal) || unique.has(id) ||
+                    sample.status !== 'passed' || sample.warmup !== (sample.ordinal < 2) ||
+                    !Number.isFinite(sample.totalMs) || sample.totalMs < 0 || sample.totalMs > 180000) throw new Error('Invalid sample');
+                unique.add(id);
+                if (!sample.warmup) samples.push({ role: batch.role, name: sample.case, ms: sample.totalMs });
+              }
+            }
+            const rows = expected.map(name => {
+              const values = role => samples.filter(s => s.name === name && s.role === role).map(s => s.ms);
+              const base = med(values('base')), head = med(values('head')), reference = med(values('reference'));
+              const change = before => before === 0 ? 'n/a' : `${((head / before - 1) * 100).toFixed(1)}%`;
+              return `| ${name} | ${base.toFixed(2)} | ${head.toFixed(2)} | ${reference.toFixed(2)} | ${change(base)} | ${change(reference)} |`;
+            });
+            const marker = '<!-- effect-agent:runtime-performance -->';
+            const body = `${marker}\n### Runtime performance\n\n` +
+              'Informational medians in milliseconds, nine samples per workload and revision. Same fixture bytes and Node runtime; separate lockfiles and public builds.\n\n' +
+              '| Workload | Base | Head | Reference | Head/base | Head/reference |\n| --- | ---: | ---: | ---: | ---: | ---: |\n' + rows.join('\n') +
+              `\n\n[Raw samples, spread, cold process totals, failures, environment, and immutable reference](${run.html_url}) for \`${run.head_sha.slice(0,12)}\`. Timing deltas are not a merge threshold.`;
+            const comments = await github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 });
+            const previous = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
+            if (previous) await github.rest.issues.updateComment({ ...context.repo, comment_id: previous.id, body });
+            else await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number, body });

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,128 @@
+name: Runtime performance
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Scripted measurement size (archive includes 100k retained records)
+        type: choice
+        options: [pr, extended, archive]
+        default: extended
+      base_sha:
+        description: Exact 40-character comparison base SHA
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-performance-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: "true"
+  VP_GIT_HOOKS: "0"
+
+jobs:
+  compare:
+    name: Compare scripted runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 180 }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Validate manual base identity
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+        run: '[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]'
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || inputs.base_sha }}
+          path: .performance-base
+          persist-credentials: false
+
+      # Immutable audited beta67 release, rerun on this machine rather than
+      # comparing historical stopwatch values from another runner.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: 596cffba70716b1211ac02de949c4d0f31734b2f
+          path: .performance-reference
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.20.0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+
+      # Bootstrap vp exactly as ordinary CI. Each checkout owns its lockfile;
+      # installs and builds are sequential and finish before the first sample.
+      - name: Install candidate dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Install base dependencies
+        working-directory: .performance-base
+        run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
+
+      - name: Install immutable reference dependencies
+        working-directory: .performance-reference
+        run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
+
+      - name: Build candidate public packages
+        run: |
+          ./node_modules/.bin/vp run patch:tsgo
+          ./node_modules/.bin/vp run --no-cache -F './packages/*' build
+
+      - name: Build base public packages
+        working-directory: .performance-base
+        run: |
+          ./node_modules/.bin/vp run patch:tsgo
+          ./node_modules/.bin/vp run --no-cache -F './packages/*' build
+
+      - name: Build reference public packages
+        working-directory: .performance-reference
+        run: |
+          ./node_modules/.bin/vp run patch:tsgo
+          ./node_modules/.bin/vp run --no-cache -F './packages/*' build
+
+      - name: Compare sequential cohorts
+        timeout-minutes: ${{ github.event_name == 'pull_request' && 20 || 165 }}
+        # Older releases do not ignore these known declaration artifacts emitted
+        # by their package build. Remove only those generated scratch files.
+        # The subsequent --require-clean check rejects every other modification.
+        shell: bash
+        env:
+          PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || inputs.profile }}
+        run: |
+          for checkout in .performance-base .performance-reference; do
+            rm -f "$checkout/test/fixtures/checkpoints.d.ts" "$checkout/test/fixtures/storage-upgrade.d.ts" "$checkout/test/fixtures/storage-v2.d.ts"
+          done
+          ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --reference-dir .performance-reference --profile "$PROFILE" --require-clean
+
+      - name: Preserve run identity and readable evidence
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p .performance-report
+          echo "$PR_NUMBER" > .performance-report/pr-number.txt
+          if test -f .performance-report/report.md; then cat .performance-report/report.md >> "$GITHUB_STEP_SUMMARY"; fi
+
+      - name: Upload all samples and failures
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-performance
+          path: .performance-report
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ docs/.vitepress/dist
 # .d.ts under src is hand-written; source is always .ts.
 packages/*/src/**/*.d.ts
 scripts/*.d.ts
+test/fixtures/*.d.ts
+.performance-base/
+.performance-reference/
+.performance-report/

--- a/bun.lock
+++ b/bun.lock
@@ -276,6 +276,24 @@
         "vite-plus": "catalog:",
       },
     },
+    "examples/runtime-benchmark": {
+      "name": "@effect-agent/example-runtime-benchmark",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect-agent/core": "workspace:*",
+        "@effect-agent/engine": "workspace:*",
+        "@effect-agent/platform-node": "workspace:*",
+        "@effect-agent/testing": "workspace:*",
+        "@effect-agent/thread": "workspace:*",
+        "@effect/platform-node": "catalog:",
+        "effect": "catalog:",
+        "effect-agent": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:",
+        "vite-plus": "catalog:",
+      },
+    },
     "examples/semantic-memory-eval": {
       "name": "@effect-agent/example-semantic-memory-eval",
       "version": "0.0.0",
@@ -299,7 +317,7 @@
     },
     "packages/capabilities": {
       "name": "@effect-agent/capabilities",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -318,7 +336,7 @@
     },
     "packages/core": {
       "name": "@effect-agent/core",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -330,7 +348,7 @@
     },
     "packages/effect-agent": {
       "name": "effect-agent",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -347,7 +365,7 @@
     },
     "packages/engine": {
       "name": "@effect-agent/engine",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
       },
@@ -363,7 +381,7 @@
     },
     "packages/platform-cloudflare": {
       "name": "@effect-agent/platform-cloudflare",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -401,7 +419,7 @@
     },
     "packages/platform-node": {
       "name": "@effect-agent/platform-node",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -424,7 +442,7 @@
     },
     "packages/pr-review": {
       "name": "@effect-agent/pr-review",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -459,7 +477,7 @@
     },
     "packages/sandbox": {
       "name": "@effect-agent/sandbox",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -471,7 +489,7 @@
     },
     "packages/sandbox-local": {
       "name": "@effect-agent/sandbox-local",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/sandbox": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -489,7 +507,7 @@
     },
     "packages/storage-cloudflare": {
       "name": "@effect-agent/storage-cloudflare",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -512,7 +530,7 @@
     },
     "packages/storage-memory": {
       "name": "@effect-agent/storage-memory",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -531,7 +549,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@effect-agent/storage-sqlite",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -550,7 +568,7 @@
     },
     "packages/testing": {
       "name": "@effect-agent/testing",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -575,7 +593,7 @@
     },
     "packages/thread": {
       "name": "@effect-agent/thread",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -593,7 +611,7 @@
     },
     "packages/workflow": {
       "name": "@effect-agent/workflow",
-      "version": "0.1.0-beta.59",
+      "version": "0.1.0-beta.68",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -908,6 +926,8 @@
     "@effect-agent/example-providers": ["@effect-agent/example-providers@workspace:examples/providers"],
 
     "@effect-agent/example-repo-ops": ["@effect-agent/example-repo-ops@workspace:examples/repo-ops"],
+
+    "@effect-agent/example-runtime-benchmark": ["@effect-agent/example-runtime-benchmark@workspace:examples/runtime-benchmark"],
 
     "@effect-agent/example-semantic-memory-eval": ["@effect-agent/example-semantic-memory-eval@workspace:examples/semantic-memory-eval"],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -46,6 +46,8 @@ See the [package map](reference/packages.md) for public packages and capabilitie
 | ----------------------------------- | ----------------------------------------------------- |
 | `packages/*`                        | Framework and private PR-review integration packages  |
 | `examples/demo`                     | Local browser app                                     |
+| `examples/runtime-benchmark`        | Deterministic public-package runtime comparisons      |
+| `examples/context-continuity-eval`  | Continuity gates and opt-in deployed performance      |
 | `examples/cloudflare-memory`        | Opt-in deployed Thread-to-Memory latency benchmark    |
 | `examples/providers`                | Provider bindings, persistent history, Workflow host  |
 | `examples/repo-ops`                 | Repository evidence auditor                           |
@@ -356,6 +358,42 @@ an esbuild `meta.json`, and `modules.txt` with module contributions. The metafil
 in [esbuild's analyzer](https://esbuild.github.io/analyze/). CI attaches these as `bundle-stats`
 and `bundle-analysis` artifacts and updates one PR comment through a separate trusted workflow.
 The comment workflow becomes active after it is merged into the default branch.
+
+## Runtime performance comparisons
+
+Pull requests run the **Runtime performance** workflow against the exact base, head, and retained
+release reference. The [scripted benchmark](../examples/runtime-benchmark/README.md) runs identical
+fixture bytes against production builds and each revision's own lockfile on the same Node runtime.
+Run `vp run perf:compare --help` for local reproduction. Timing tasks bypass the task cache; keep
+other builds, tests, and benchmarks idle during measurement.
+
+The PR profile covers small runs and streams, fixed-size responses with increasing fragmentation,
+growing prompts, parallel tools and repeated rounds, file-backed SQLite history, checkpoint
+recovery, and settled Submission ledgers. Fresh durable startup includes reopening the host and
+admission; recovery of an existing Run is a separate case. First-model timing ends in the actual
+provider callback. A separate subprocess measurement includes startup and fixture imports.
+Retain raw samples, failures, environment metadata, fixture and artifact hashes, and exact SHAs.
+The trusted comment workflow becomes active after it reaches the default branch.
+
+Latency reports are informational until repeated CI runs establish variance and useful absolute
+and relative thresholds. Deterministic call, concurrency, ownership, tracing, and history-work
+budgets remain correctness gates. The fresh-submission history guard currently permits three
+linear scans plus fixed work; these changes do not claim to eliminate that cost. Checkpoint
+recovery bounds do not establish constant-time fresh admission. Fairness, lock contention, optional
+memory/MCP publication, and large settled-ledger indexing require their own controlled evidence
+before changing those paths.
+
+The separate [manual Cloudflare evaluation](../examples/context-continuity-eval/README.md#manual-deployed-performance-evaluation)
+deploys real model-and-tool workloads through the public HTTP/DO host. Use `vp run perf:cloudflare
+--dry-run` to inspect the deployment plan without credentials. The workflow accepts exact commits
+and runs only on explicit dispatch with its dedicated environment credentials. Its bounded fresh,
+warm, and recovery cases assert consumed tool results, validated output, canonical settlement,
+same-thread continuity, and cleanup. Preserve failure artifacts and retry any recorded cleanup
+before closing an attempt. Offline workerd tests validate the harness, not deployed latency.
+
+Compare matched workloads and clock domains. Local scripted timings do not measure provider
+latency, Cloudflare CPU billing, or provider cache effects. A live report identifies what it can
+observe and must accompany claims about the exact candidate and configuration it measured.
 
 ## CI and hooks
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -162,11 +162,10 @@ export const Definition = Agent.make("answer-question", {
   output: Answer,
   instructions: "Answer the question using the complete tool.",
   toolkit: Tools,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 3,
     maxToolCalls: 3,
     maxDuration: "30 seconds",
-    toolConcurrency: 1,
   }),
   completion: {
     tool: "complete",

--- a/docs/guide/code-mode.md
+++ b/docs/guide/code-mode.md
@@ -99,6 +99,7 @@ const analyst = Agent.make("invoice-analyst", {
     maxTurns: 3,
     maxToolCalls: 6,
     maxDuration: "45 seconds",
+    // This sandbox example runs one generated program at a time.
     toolConcurrency: 1,
   }),
 });

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -41,11 +41,10 @@ const triage = Agent.make("triage", {
   }),
   instructions: "Classify the bug report by severity. Explain your reasoning in one sentence.",
   toolkit: Toolkit.empty,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 2,
     maxToolCalls: 1,
     maxDuration: "30 seconds",
-    toolConcurrency: 1,
   }),
 });
 

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -15,6 +15,18 @@ Every entry point also requires `ThreadHistory`. Use
 `PersistentHistory.layer` with a store to [retain completed runs](./threads#retain-completed-runs).
 History commits before a successful result or `RunCompleted` event becomes visible.
 
+A valid no-tool answer needs one model call. A designated completion Tool can complete without a
+follow-up model call. Independent application Tools default to four concurrent handlers, behind
+the batch's authorization and approval barrier. Use one when execution must be serial or a fixture
+deliberately measures a sequential workflow. Continuity fixtures serialize changes to shared notes;
+Code Mode examples bound generated programs separately. Node host worker concurrency is a separate
+setting.
+
+The immutable output contract retains its message identity across turns, allowing opt-in native
+`ResponseIdTracker` reuse when the rest of the prompt prefix is unchanged. Prepared context,
+compaction, and a resumed Run can still invalidate that prefix. Provider caching and billing depend
+on the selected provider and configuration.
+
 Context preparation is optional. Provide `RunContextPreparation` to load extra context;
 without it, Runs use their normal prompt and compaction behavior. See
 [context management](./context-management#recall-memory) for service-based recall and tagged errors.
@@ -56,6 +68,13 @@ const program = events.pipe(
 
 Events cover run and turn lifecycle, text and reasoning deltas, tool activity, approval requests,
 and one terminal classification. Provider SDK chunks do not enter this stable union.
+
+For structured output, treat text deltas as provisional wire data. Show activity or received-character
+progress until the terminal output passes its Schema; do not display partial JSON as an answer.
+The demo follows this pattern. Plain-text output can render provisional text directly.
+Primitive text and reasoning deltas are copied into owned, Schema-validated values; their transport
+fragmentation does not create one ownership tracing span per delta. Complex metadata retains the
+general bounded ownership path.
 
 The stream uses bounded backpressure. Completion, failure, and interruption close its resources.
 Interrupting the only ephemeral consumer interrupts the run.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -41,11 +41,10 @@ const TravelPlanner = Agent.make("travel-planner", {
   output: Schema.Struct({ itinerary: Schema.Array(Schema.String) }),
   instructions: "Create a practical travel itinerary.",
   toolkit: Toolkit.make(),
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 3,
     maxToolCalls: 1,
     maxDuration: "30 seconds",
-    toolConcurrency: 1,
   }),
 });
 

--- a/docs/snippets/travel-planner/planner.ts
+++ b/docs/snippets/travel-planner/planner.ts
@@ -13,11 +13,10 @@ export const TravelPlanner = Agent.make("travel-planner", {
   instructions: ({ city, days }) =>
     `Find activities with search_activities, then plan ${days} days in ${city}.`,
   toolkit: TravelTools,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 6,
     maxToolCalls: 10,
     maxDuration: "2 minutes",
-    toolConcurrency: 1,
   }),
 });
 

--- a/docs/snippets/travel-planner/researcher.ts
+++ b/docs/snippets/travel-planner/researcher.ts
@@ -15,6 +15,5 @@ export const Researcher = Agent.make("activity-researcher", {
   toolkit: TravelTools,
   policy: {
     maxToolCalls: 8,
-    toolConcurrency: 1,
   },
 });

--- a/examples/code-mode-cloudflare/src/agent.ts
+++ b/examples/code-mode-cloudflare/src/agent.ts
@@ -97,6 +97,8 @@ export const codeModeAgent = Agent.make("warehouse-analyst", {
     maxTurns: 3,
     maxToolCalls: 6,
     maxDuration: "45 seconds",
+    // This fixture exercises one sandbox program at a time. Independent application Tools
+    // normally use the engine default of four concurrent handlers.
     toolConcurrency: 1,
   }),
 });

--- a/examples/context-continuity-eval/README.md
+++ b/examples/context-continuity-eval/README.md
@@ -129,3 +129,88 @@ kill or eviction evidence. Process artifacts also retain SQLite and each barrier
 A partial report, provider outage, exhausted budget, missing credential, unsettled reservation, or
 failed assertion is a failed gate. Pricing is an estimate, not an invoice. There are no inference
 retries or model fallbacks; server-side conversation state and automatic truncation are disabled.
+
+## Manual deployed performance evaluation
+
+`vp run perf:cloudflare` deploys a separate disposable Worker and SQLite Durable Object namespace
+and runs real OpenAI inference through the public Thread HTTP/DO path. The dedicated
+`Manual Cloudflare performance` workflow accepts exact candidate and optional reference SHAs.
+It has only `workflow_dispatch`: PR, push, nightly, and release continuity jobs never select it.
+Configure the `performance-cloudflare` GitHub environment with `OPENAI_API_KEY`,
+`CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_API_TOKEN` secrets, plus the
+`CLOUDFLARE_WORKERS_SUBDOMAIN` variable. Use a dedicated benchmark account/environment with
+Workers/DO deployment and deletion permissions.
+
+Install each checkout with its own lockfile, then run from the candidate checkout:
+
+```sh
+vp run perf:cloudflare --dry-run --output-dir .context-continuity-eval/perf-plan
+
+# Export the same four Cloudflare/provider settings listed above.
+EFFECT_AGENT_LIVE=1 vp run perf:cloudflare --model gpt-6-astra --samples 1 \
+  --reference-root ../reference --output-dir .context-continuity-eval/perf-candidate
+```
+
+The optional reference must support the fixture's public APIs. Both bundles use identical fixture
+source, with public imports resolved against each clean checkout's own installed dependencies.
+Both are minified Workers bundles with the same compatibility date, model settings and limits.
+The source commit, fixture/lockfile/bundle digests, deployed version ID and configuration are
+retained. A changed checkout or a mismatched deployed identity fails validation. For an isolated
+bundle check, use `vp run perf:cloudflare:build --source-root . --output-dir <new-directory>`.
+
+Each sample makes three sequential orders on one thread. The model selects independent price
+and stock tools, consumes both results in subsequent inference, and produces a schema-validated
+computed order. Assertions require exact totals and current evidence codes, successful canonical
+tool records, exactly one durable completion/settlement, and the previous order's total on the
+same-thread follow-up. The fresh-thread probe verifies no canonical history, then initializes the
+host before submission; it is not a guaranteed cold start. The warm case requires the same observed
+incarnation. The recovery case aborts the real DO after confirmed tool-result persistence and
+requires a new incarnation, completed follow-up inference, and no repeated committed tool work.
+Successful Attempt finalization is checked; native abort does not promise finalizers.
+The tool handlers use fixed synthetic price/stock data and each wait 20 ms so their independent
+execution is observable. Their latency does not represent an external inventory backend.
+
+Runs allow 1–3 samples per target, one active submission, two concurrent tools, four turns and four
+tool calls per submission, two minutes per agent run, and eight minutes per sample. A thread permits
+at most 18 model calls, 8,192 input tokens/request, 4,096 output tokens/request, and $2 of conservative
+provider reservations. The maximum is $6 per target or $12 for both targets; these estimates exclude
+Cloudflare charges. Unmetered/interrupted provider calls retain their reservation and block further
+dispatch. No inference is retried. Synthetic data is bounded to three submissions per thread and a
+16 MiB database admission limit. Tokens, returned model identities, cache usage, and cost estimates
+are in the request/response audits. No API keys or authorization headers enter evidence artifacts.
+
+`report.json`, `summary.md`, per-phase snapshots, and deployment logs retain every sample, including
+failures and slow runs. They include admission, queue-to-claim, preparation, input-token preflight,
+the actual Fetch dispatch boundary, first provider delta, tool intervals, canonical commits and
+client delivery. First client-visible feedback means the first **observed canonical model response**
+with 100 ms polling; it does not claim live token streaming. Runner and DO clock domains remain
+separate. The [Workers clock only advances after I/O](https://developers.cloudflare.com/workers/runtime-apis/performance/),
+so a zero synchronous duration is unresolved at that timer precision. Do not add overlapping spans
+or subtract synthetic processing time from provider latency. CPU and heap are explicitly unavailable
+from these request APIs; database bytes and ingress CF-Ray location are retained. Attach a separate
+Cloudflare observability export when CPU billing evidence is required. DO region and provider cache
+state are not controlled. Polling and persisted instrumentation add harness work to both candidates.
+
+Targets alternate by sample without concurrent inference. Timing remains informational: small
+sample counts and provider/cache/placement variance are not a latency gate. Successful end-to-end
+and lifecycle assertions are a separate pass/fail result. Attach the workflow artifact URL and
+`summary.md` to the PR/release for the reported candidate SHA and configuration; evidence from a
+different SHA or fixture does not validate a changed candidate. This repository's offline workerd
+tests use a scripted transport and are explicitly not live-provider or Cloudflare deployment evidence.
+
+Cleanup runs on success, failure, and interruption. Ownership is persisted before upload, including
+ambiguous partial deployments. The command first deploys a
+[deleted class tombstone](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/)
+to remove the entire disposable namespace/data, then deletes and verifies removal of the Worker.
+The workflow retries recorded cleanup in an `always()` step. A failed cleanup fails the run and
+leaves its exact resource names in `resources.json`; retry using the same account credentials:
+
+```sh
+vp run perf:cloudflare --cleanup --output-dir .context-continuity-eval/perf-candidate
+```
+
+Hard runner termination can prevent finalizers and the workflow retry; retain the artifact and run
+that cleanup command. Every owned target must have `cleanupComplete: true` before closing the run.
+Downloaded artifacts can be moved to another machine: cleanup resolves the candidate/reference
+folders beneath `--output-dir` and regenerates the fixed deletion configuration from validated
+Worker names, rather than using artifact-supplied executable/configuration content.

--- a/examples/context-continuity-eval/src/build-performance-cloudflare.ts
+++ b/examples/context-continuity-eval/src/build-performance-cloudflare.ts
@@ -1,0 +1,179 @@
+import { digestJson } from "@effect-agent/thread/Digest";
+import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Console, Effect, FileSystem, Layer, Path, Schema } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { build } from "esbuild";
+
+import { EvaluationError } from "./contracts.ts";
+import { PERFORMANCE_FIXTURE } from "./performance-contracts.ts";
+
+export const PerformanceBuild = Schema.Struct({
+  sourceCommit: Schema.String,
+  dirtyWorkingTree: Schema.Boolean,
+  fixture: Schema.Literal(PERFORMANCE_FIXTURE),
+  fixtureDigest: Schema.String,
+  lockfileDigest: Schema.String,
+  bundleDigest: Schema.String,
+  sourceRoot: Schema.String,
+  directory: Schema.String,
+});
+
+/** The fixture is identical for both builds; every bare import resolves in the selected checkout. */
+export const buildPerformanceCloudflare = Effect.fn("Performance.build")(function* (
+  sourceRoot: string,
+  directory: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  sourceRoot = path.resolve(sourceRoot);
+  directory = path.resolve(directory);
+  const fixtureRoot = path.dirname(yield* path.fromFileUrl(new URL(import.meta.url)));
+
+  const sourceCommit = (yield* spawner.string(
+    ChildProcess.make("git", ["rev-parse", "HEAD"], { cwd: sourceRoot }),
+  )).trim();
+
+  const dirtyWorkingTree =
+    (yield* spawner.string(
+      ChildProcess.make("git", ["status", "--porcelain", "--untracked-files=normal"], {
+        cwd: sourceRoot,
+      }),
+    )).trim().length > 0;
+
+  const fixtureFiles = [
+    "performance-worker.ts",
+    "performance-contracts.ts",
+    "live-model.ts",
+    "request-audit.ts",
+    "host-evidence.ts",
+    "contracts.ts",
+    "profiles.ts",
+    "build-performance-cloudflare.ts",
+    "performance-evaluate.ts",
+    "performance-deployment.ts",
+    "performance-main.ts",
+  ];
+
+  const fixtureDigest = yield* digestJson(
+    yield* Effect.forEach(fixtureFiles, (file) =>
+      fs
+        .readFileString(path.join(fixtureRoot, file))
+        .pipe(Effect.map((contents) => ({ file, contents }))),
+    ),
+  );
+
+  const lockfileDigest = yield* digestJson(
+    yield* fs.readFileString(path.join(sourceRoot, "bun.lock")),
+  );
+
+  yield* fs.makeDirectory(directory, { recursive: true });
+  yield* Effect.tryPromise({
+    try: () =>
+      build({
+        entryPoints: [path.join(fixtureRoot, "performance-worker.ts")],
+        outfile: path.join(directory, "worker.mjs"),
+        bundle: true,
+        minify: true,
+        format: "esm",
+        platform: "browser",
+        target: "es2022",
+        conditions: ["workerd", "worker", "browser"],
+        external: ["cloudflare:*", "node:*"],
+        sourcemap: true,
+        plugins: [
+          {
+            name: "selected-checkout-dependencies",
+            setup(builder) {
+              builder.onResolve({ filter: /^[^./]/ }, (args) => {
+                if (args.path.startsWith("cloudflare:") || args.path.startsWith("node:"))
+                  return { path: args.path, external: true };
+                if (!args.importer.startsWith(`${fixtureRoot}/`)) return;
+
+                return builder.resolve(args.path, {
+                  resolveDir: path.join(sourceRoot, "examples/context-continuity-eval"),
+                  kind: args.kind,
+                });
+              });
+            },
+          },
+        ],
+        define: {
+          PERFORMANCE_SOURCE_COMMIT: JSON.stringify(sourceCommit),
+          PERFORMANCE_DIRTY: JSON.stringify(dirtyWorkingTree),
+          PERFORMANCE_FIXTURE_DIGEST: JSON.stringify(fixtureDigest),
+        },
+      }),
+    catch: () =>
+      EvaluationError.make({
+        stage: "build",
+        message: "Performance bundle failed; reference must support this fixture's public APIs",
+      }),
+  });
+
+  const bundleDigest = yield* digestJson(
+    yield* fs.readFileString(path.join(directory, "worker.mjs")),
+  );
+
+  const finalCommit = (yield* spawner.string(
+    ChildProcess.make("git", ["rev-parse", "HEAD"], { cwd: sourceRoot }),
+  )).trim();
+
+  const finalDirty =
+    (yield* spawner.string(
+      ChildProcess.make("git", ["status", "--porcelain", "--untracked-files=normal"], {
+        cwd: sourceRoot,
+      }),
+    )).trim().length > 0;
+
+  if (finalCommit !== sourceCommit || finalDirty !== dirtyWorkingTree)
+    return yield* EvaluationError.make({
+      stage: "source",
+      message: "Source identity changed during the build",
+    });
+
+  const result: typeof PerformanceBuild.Type = {
+    sourceCommit,
+    dirtyWorkingTree,
+    fixture: PERFORMANCE_FIXTURE,
+    fixtureDigest,
+    lockfileDigest,
+    bundleDigest,
+    sourceRoot,
+    directory,
+  };
+
+  yield* fs.writeFileString(
+    path.join(directory, "build.json"),
+    yield* Schema.encodeEffect(Schema.fromJsonString(PerformanceBuild))(result),
+  );
+
+  return result;
+});
+
+const command = Command.make(
+  "perf:cloudflare:build",
+  {
+    sourceRoot: Flag.directory("source-root").pipe(Flag.withDefault(".")),
+    output: Flag.directory("output-dir").pipe(
+      Flag.withDefault(".context-continuity-eval/performance-build"),
+    ),
+  },
+  Effect.fn(function* ({ sourceRoot, output }) {
+    yield* Console.log(yield* buildPerformanceCloudflare(sourceRoot, output));
+  }),
+).pipe(
+  Command.withDescription(
+    "Build the shared performance fixture against an exact checkout. No deployment or model calls.",
+  ),
+);
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Command.run(command, { version: "1.0.0" }).pipe(
+      Effect.scoped,
+      Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+    ),
+  );

--- a/examples/context-continuity-eval/src/live-model.ts
+++ b/examples/context-continuity-eval/src/live-model.ts
@@ -89,6 +89,13 @@ export const makeLiveClient = Effect.fn("ContextContinuity.makeLiveClient")(func
   readonly maxCostMicrousd: number;
   readonly phase: Ref.Ref<number>;
   readonly initialUsage?: ModelUsage;
+  readonly maxModelCalls?: number;
+  readonly maxInputTokens?: number;
+  /** Optional example-owned instrumentation; dispatch itself is observed at Fetch. */
+  readonly observe?: (
+    kind: "preflight-start" | "preflight-end" | "first-provider-delta",
+    request: number,
+  ) => Effect.Effect<void>;
 }) {
   const native = yield* OpenAiClient.OpenAiClient;
   const auditSink = yield* RequestAuditSink;
@@ -155,11 +162,16 @@ export const makeLiveClient = Effect.fn("ContextContinuity.makeLiveClient")(func
     }
     const before = yield* Ref.get(state);
 
-    if (before.closed || before.calls >= MAX_MODEL_CALLS)
+    if (
+      before.closed ||
+      before.calls >= Math.min(options.maxModelCalls ?? MAX_MODEL_CALLS, MAX_MODEL_CALLS)
+    )
       return yield* refuse("Evaluation stopped or reached its model-call limit");
     const payload: Payload = { ...original, truncation: "disabled" };
 
     // Count the actual native request before paid inference, including Tool/output schemas.
+    yield* options.observe?.("preflight-start", before.calls + 1) ?? Effect.void;
+
     const tokens = yield* native.client
       .post("/responses/input_tokens", {
         body: HttpBody.jsonUnsafe({
@@ -180,8 +192,9 @@ export const makeLiveClient = Effect.fn("ContextContinuity.makeLiveClient")(func
         Effect.catch(() => refuse("Input-token preflight failed; no inference dispatched")),
       );
 
-    if (tokens > MAX_INPUT_TOKENS)
-      return yield* refuse("Outgoing input exceeded the evaluation's 32000-token bound");
+    yield* options.observe?.("preflight-end", before.calls + 1) ?? Effect.void;
+    if (tokens > Math.min(options.maxInputTokens ?? MAX_INPUT_TOKENS, MAX_INPUT_TOKENS))
+      return yield* refuse("Outgoing input exceeded the evaluation's configured token bound");
     const cost = Math.ceil(tokens * price.input + MAX_OUTPUT_TOKENS * price.output);
 
     if (before.cost + outstanding(before) + cost > options.maxCostMicrousd)
@@ -266,6 +279,7 @@ export const makeLiveClient = Effect.fn("ContextContinuity.makeLiveClient")(func
       refuse("Unexpected non-streaming request in the durable continuity evaluation"),
     createResponseStream: Effect.fn("ContextContinuity.createResponseStream")(function* (original) {
       const { payload, reservation } = yield* admit(original);
+      let firstDelta = true;
 
       const [response, stream] = yield* native.createResponseStream(payload).pipe(
         Effect.timeout("3 minutes"),
@@ -281,8 +295,15 @@ export const makeLiveClient = Effect.fn("ContextContinuity.makeLiveClient")(func
               event.type !== "response.completed" &&
               event.type !== "response.incomplete" &&
               event.type !== "response.failed"
-            )
+            ) {
+              if (firstDelta && event.type.endsWith(".delta")) {
+                firstDelta = false;
+
+                return options.observe?.("first-provider-delta", reservation.id) ?? Effect.void;
+              }
+
               return Effect.void;
+            }
 
             return Schema.decodeUnknownEffect(OpenAiSchema.Response)(event.response).pipe(
               Effect.catch(() => refuse("Invalid provider completion")),

--- a/examples/context-continuity-eval/src/performance-contracts.ts
+++ b/examples/context-continuity-eval/src/performance-contracts.ts
@@ -1,0 +1,148 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { CanonicalRecordEnvelope, DefinitionDigestInput } from "@effect-agent/thread/Records";
+import { Schema } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import { ModelUsage } from "./contracts.ts";
+import { ModelId } from "./live-model.ts";
+import { RequestAudit } from "./request-audit.ts";
+
+export const PERFORMANCE_FIXTURE = "cloudflare-order-v1";
+export const PERFORMANCE_BUDGET = 2_000_000;
+export const PerformancePhase = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 2 }));
+
+export const PerformanceOutput = Schema.Struct({
+  sku: Schema.Literal("lamp"),
+  units: Schema.Int,
+  unitPriceCents: Schema.Int,
+  totalCents: Schema.Int,
+  available: Schema.Boolean,
+  priceEvidence: Schema.String,
+  stockEvidence: Schema.String,
+  previousTotalCents: Schema.NullOr(Schema.Int),
+});
+
+export const performanceToolkit = Toolkit.make(
+  Tool.make("read_price", {
+    description: "Read the current lamp unit price and its evidence code.",
+    parameters: Schema.Struct({ sku: Schema.Literal("lamp") }),
+    success: Schema.Struct({ unitPriceCents: Schema.Int, evidence: Schema.String }),
+  }),
+  Tool.make("read_stock", {
+    description: "Read the current lamp stock and its evidence code. Independent of price.",
+    parameters: Schema.Struct({ sku: Schema.Literal("lamp") }),
+    success: Schema.Struct({ availableUnits: Schema.Int, evidence: Schema.String }),
+  }),
+);
+
+export const performanceDefinition = Agent.make("performance-cloudflare-order", {
+  input: Schema.String,
+  output: PerformanceOutput,
+  instructions:
+    "For every order update call both read_price and read_stock, preferably together. Never reuse stale tool evidence. Use their results to calculate the total in cents and whether stock covers the order. Copy both evidence codes into your final structured output. Carry previousTotalCents from the most recent completed order on this thread; null only for its first order. Do not invent tool values.",
+  toolkit: performanceToolkit,
+  policy: {
+    maxTurns: 4,
+    maxToolCalls: 4,
+    maxDuration: "2 minutes",
+    toolConcurrency: 2,
+    contextTokenLimit: 8_192,
+    onExhaustion: "fail",
+  },
+});
+
+export const performanceSettings = {
+  max_output_tokens: 4_096,
+  reasoning: { effort: "low" },
+  store: false,
+  service_tier: "default",
+  strictJsonSchema: true,
+} as const;
+
+export const PerformanceIdentity = Schema.Struct({
+  sourceCommit: Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/)),
+  dirtyWorkingTree: Schema.Boolean,
+  fixture: Schema.Literal(PERFORMANCE_FIXTURE),
+  fixtureDigest: Schema.String,
+  deploymentId: Schema.String,
+  model: ModelId,
+  maxCostMicrousd: Schema.Literal(PERFORMANCE_BUDGET),
+  maxModelCalls: Schema.Literal(18),
+  maxInputTokens: Schema.Literal(8_192),
+  settings: Schema.Struct({
+    max_output_tokens: Schema.Literal(4_096),
+    reasoning: Schema.Struct({ effort: Schema.Literal("low") }),
+    store: Schema.Literal(false),
+    service_tier: Schema.Literal("default"),
+    strictJsonSchema: Schema.Literal(true),
+  }),
+});
+
+export const PerformanceEvent = Schema.Struct({
+  index: Schema.Natural,
+  phase: PerformancePhase,
+  incarnation: Schema.Int,
+  kind: Schema.String,
+  atMillis: Schema.Finite,
+  request: Schema.NullOr(Schema.Int),
+});
+
+export const PerformanceSnapshot = Schema.Struct({
+  identity: PerformanceIdentity,
+  phase: PerformancePhase,
+  incarnation: Schema.Int,
+  events: Schema.Array(PerformanceEvent),
+  records: Schema.Array(CanonicalRecordEnvelope),
+  audits: Schema.Array(RequestAudit),
+  usage: ModelUsage,
+  failure: Schema.NullOr(Schema.String),
+  databaseBytes: Schema.Natural,
+});
+
+export const PerformanceState = Schema.Struct({
+  identity: PerformanceIdentity,
+  phase: PerformancePhase,
+  incarnation: Schema.Natural,
+  usage: ModelUsage,
+  aborted: Schema.Boolean,
+  closed: Schema.Boolean,
+});
+
+export const emptyPerformanceUsage: typeof ModelUsage.Type = {
+  calls: 0,
+  completedCalls: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  maxInputTokens: 0,
+  estimatedCostMicrousd: 0,
+  reservedCostMicrousd: 0,
+  returnedModels: [],
+};
+
+export const performanceDefinitions = (identity: typeof PerformanceIdentity.Type) =>
+  DefinitionDigestInput.make({
+    agent: {
+      fixture: identity.fixture,
+      fixtureDigest: identity.fixtureDigest,
+      sourceCommit: identity.sourceCommit,
+    },
+    model: { name: identity.model, ...identity.settings },
+    tools: Object.keys(performanceToolkit.tools).map((name) => ({
+      name,
+      revision: identity.fixtureDigest,
+    })),
+  });
+
+export const performanceMessage = (phase: number) =>
+  `Order update ${phase}: quote ${phase + 2} lamps. Read both current tools, compute the order and preserve the previous completed order total.`;
+
+export const expectedPerformanceOutput = (phase: number): typeof PerformanceOutput.Type => ({
+  sku: "lamp",
+  units: phase + 2,
+  unitPriceCents: 3_700,
+  totalCents: (phase + 2) * 3_700,
+  available: true,
+  priceEvidence: `price-${phase}-q7`,
+  stockEvidence: `stock-${phase}-m9`,
+  previousTotalCents: phase === 0 ? null : (phase + 1) * 3_700,
+});

--- a/examples/context-continuity-eval/src/performance-deployment.ts
+++ b/examples/context-continuity-eval/src/performance-deployment.ts
@@ -33,17 +33,21 @@ export class PerformanceDeployment extends Context.Service<
   }
 >()("example/PerformanceDeployment") {}
 
+export class PerformanceOwnership extends Context.Service<
+  PerformanceOwnership,
+  {
+    saveTarget(target: typeof PerformanceTarget.Type): Effect.Effect<void, EvaluationError>;
+  }
+>()("example/PerformanceOwnership") {}
+
 /** Persist ownership before deployment: an interrupted upload may already have created resources. */
 export const withPerformanceDeployment = Effect.fn("Performance.withDeployment")(function* <
   A,
   E,
   R,
->(
-  target: typeof PerformanceTarget.Type,
-  save: (target: typeof PerformanceTarget.Type) => Effect.Effect<void, EvaluationError>,
-  use: Effect.Effect<A, E, R>,
-) {
+>(target: typeof PerformanceTarget.Type, use: Effect.Effect<A, E, R>) {
   const operations = yield* PerformanceDeployment;
+  const ownership = yield* PerformanceOwnership;
 
   if (yield* operations.exists(target))
     return yield* EvaluationError.make({
@@ -54,11 +58,13 @@ export const withPerformanceDeployment = Effect.fn("Performance.withDeployment")
 
   return yield* Effect.uninterruptibleMask((restore) =>
     Effect.gen(function* () {
-      yield* save(owned);
+      yield* ownership.saveTarget(owned);
 
       return yield* restore(operations.deploy(owned).pipe(Effect.andThen(use))).pipe(
         Effect.onExit(() =>
-          operations.remove(owned).pipe(Effect.andThen(save({ ...owned, cleanupComplete: true }))),
+          operations
+            .remove(owned)
+            .pipe(Effect.andThen(ownership.saveTarget({ ...owned, cleanupComplete: true }))),
         ),
       );
     }),

--- a/examples/context-continuity-eval/src/performance-deployment.ts
+++ b/examples/context-continuity-eval/src/performance-deployment.ts
@@ -1,0 +1,339 @@
+import { Config, Context, Effect, FileSystem, Path, Redacted, Schema, Stream } from "effect";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import { type PerformanceBuild } from "./build-performance-cloudflare.ts";
+import { EvaluationError } from "./contracts.ts";
+import { type ModelId } from "./live-model.ts";
+
+export const PerformanceTarget = Schema.Struct({
+  label: Schema.Literals(["candidate", "reference"]),
+  name: Schema.String.check(
+    Schema.isPattern(/^effect-agent-perf-[a-f0-9]{32}-(candidate|reference)$/),
+  ),
+  url: Schema.String,
+  directory: Schema.String,
+  sourceCommit: Schema.String,
+  cleanupRequired: Schema.Boolean,
+  cleanupComplete: Schema.Boolean,
+});
+
+export const PerformanceResources = Schema.Struct({
+  // Match cleanup credentials without publishing the account identifier in artifacts.
+  accountDigest: Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/)),
+  targets: Schema.Array(PerformanceTarget),
+});
+
+export class PerformanceDeployment extends Context.Service<
+  PerformanceDeployment,
+  {
+    exists(target: typeof PerformanceTarget.Type): Effect.Effect<boolean, EvaluationError>;
+    deploy(target: typeof PerformanceTarget.Type): Effect.Effect<void, EvaluationError>;
+    remove(target: typeof PerformanceTarget.Type): Effect.Effect<void, EvaluationError>;
+  }
+>()("example/PerformanceDeployment") {}
+
+/** Persist ownership before deployment: an interrupted upload may already have created resources. */
+export const withPerformanceDeployment = Effect.fn("Performance.withDeployment")(function* <
+  A,
+  E,
+  R,
+>(
+  target: typeof PerformanceTarget.Type,
+  save: (target: typeof PerformanceTarget.Type) => Effect.Effect<void, EvaluationError>,
+  use: Effect.Effect<A, E, R>,
+) {
+  const operations = yield* PerformanceDeployment;
+
+  if (yield* operations.exists(target))
+    return yield* EvaluationError.make({
+      stage: "collision",
+      message: `Disposable Worker already exists: ${target.name}`,
+    });
+  const owned = { ...target, cleanupRequired: true };
+
+  return yield* Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      yield* save(owned);
+
+      return yield* restore(operations.deploy(owned).pipe(Effect.andThen(use))).pipe(
+        Effect.onExit(() =>
+          operations.remove(owned).pipe(Effect.andThen(save({ ...owned, cleanupComplete: true }))),
+        ),
+      );
+    }),
+  );
+});
+
+export const loadPerformanceConfig = Config.all({
+  accountId: Config.schema(
+    Schema.String.check(Schema.isPattern(/^[a-f0-9]{32}$/)),
+    "CLOUDFLARE_ACCOUNT_ID",
+  ),
+  apiToken: Config.redacted("CLOUDFLARE_API_TOKEN"),
+  subdomain: Config.schema(
+    Schema.String.check(Schema.isPattern(/^[a-z0-9-]{1,63}$/)),
+    "CLOUDFLARE_WORKERS_SUBDOMAIN",
+  ),
+});
+
+export const preparePerformanceTarget = Effect.fn("Performance.prepareTarget")(function* (options: {
+  build: typeof PerformanceBuild.Type;
+  label: "candidate" | "reference";
+  run: string;
+  model: ModelId;
+  samples: number;
+  subdomain: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const name = `effect-agent-perf-${options.run}-${options.label}`;
+
+  const target = yield* Schema.decodeUnknownEffect(PerformanceTarget)({
+    label: options.label,
+    name,
+    url: `https://${name}.${options.subdomain}.workers.dev`,
+    directory: options.build.directory,
+    sourceCommit: options.build.sourceCommit,
+    cleanupRequired: false,
+    cleanupComplete: false,
+  });
+
+  const common = {
+    name,
+    compatibility_date: "2026-08-01",
+    compatibility_flags: ["nodejs_compat"],
+    workers_dev: true,
+    preview_urls: false,
+  };
+
+  yield* fs.writeFileString(
+    path.join(target.directory, "wrangler.json"),
+    JSON.stringify({
+      ...common,
+      main: "worker.mjs",
+      observability: { enabled: true, head_sampling_rate: 1 },
+      version_metadata: { binding: "PERFORMANCE_VERSION" },
+      vars: {
+        PERFORMANCE_MODEL: options.model,
+        PERFORMANCE_RUN: options.run,
+        PERFORMANCE_SAMPLES: String(options.samples),
+      },
+      durable_objects: {
+        bindings: [{ name: "PERFORMANCE_THREADS", class_name: "PerformanceThread" }],
+      },
+      exports: { PerformanceThread: { type: "durable-object", storage: "sqlite" } },
+    }),
+  );
+  yield* writeCleanupConfig(target);
+
+  return target;
+});
+
+const writeCleanupConfig = Effect.fn("Performance.writeCleanupConfig")(function* (
+  target: typeof PerformanceTarget.Type,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  yield* fs.makeDirectory(target.directory, { recursive: true });
+
+  const common = {
+    name: target.name,
+    compatibility_date: "2026-08-01",
+    compatibility_flags: ["nodejs_compat"],
+    workers_dev: true,
+    preview_urls: false,
+  };
+
+  yield* fs.writeFileString(
+    path.join(target.directory, "cleanup.mjs"),
+    "export default { fetch() { return new Response('Evaluation resources retired', { status: 410 }); } };\n",
+  );
+  yield* fs.writeFileString(
+    path.join(target.directory, "cleanup.json"),
+    JSON.stringify({
+      ...common,
+      main: "cleanup.mjs",
+      exports: { PerformanceThread: { type: "durable-object", state: "deleted" } },
+    }),
+  );
+});
+
+/** Wrangler owns remote mutation. Secret file is scoped outside the evidence directory. */
+export const makePerformanceDeployment = Effect.fn("Performance.deployment")(function* (
+  secretsFile: string | undefined,
+  sensitiveValues: ReadonlyArray<Redacted.Redacted<string>> = [],
+) {
+  const config = yield* loadPerformanceConfig;
+  const client = yield* HttpClient.HttpClient;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const cwd = path.resolve(path.dirname(yield* path.fromFileUrl(new URL(import.meta.url))), "..");
+  const executableSearchPath = yield* Config.string("PATH");
+  const userHome = yield* Config.string("HOME");
+
+  const run = (
+    target: typeof PerformanceTarget.Type,
+    operation: string,
+    args: ReadonlyArray<string>,
+  ) =>
+    Effect.suspend(() => {
+      let output = "";
+
+      return Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* spawner.spawn(
+            ChildProcess.make("vp", ["exec", "wrangler", ...args], {
+              cwd,
+              stdin: "ignore",
+              stdout: "pipe",
+              stderr: "pipe",
+              extendEnv: false,
+              env: {
+                PATH: executableSearchPath,
+                HOME: userHome,
+                CLOUDFLARE_ACCOUNT_ID: config.accountId,
+                CLOUDFLARE_API_TOKEN: Redacted.value(config.apiToken),
+                CI: "true",
+                NO_COLOR: "1",
+                WRANGLER_SEND_METRICS: "false",
+                WRANGLER_WRITE_LOGS: "false",
+              },
+            }),
+          );
+
+          yield* Stream.runFoldEffect(
+            handle.all,
+            () => "",
+            (all, bytes) => {
+              const next = all + new TextDecoder().decode(bytes);
+
+              output = next;
+
+              return next.length > 256 * 1024
+                ? Effect.fail(
+                    EvaluationError.make({
+                      stage: operation,
+                      message: "Wrangler output bound exceeded",
+                    }),
+                  )
+                : Effect.succeed(next);
+            },
+          );
+          if (Number(yield* handle.exitCode) !== 0)
+            return yield* EvaluationError.make({
+              stage: operation,
+              message: `Wrangler ${operation} failed for ${target.name}; inspect the retained log`,
+            });
+        }),
+      ).pipe(
+        Effect.timeout("3 minutes"),
+        Effect.ensuring(
+          Effect.suspend(() =>
+            fs.writeFileString(
+              path.join(target.directory, `${operation}.log`),
+              [config.apiToken, ...sensitiveValues]
+                .reduce(
+                  (text, value) => text.replaceAll(Redacted.value(value), "[redacted]"),
+                  output,
+                )
+                .replaceAll(config.accountId, "[account]")
+                .slice(0, 256 * 1024),
+              { flag: "a" },
+            ),
+          ).pipe(Effect.orDie),
+        ),
+        Effect.mapError(() =>
+          EvaluationError.make({
+            stage: operation,
+            message: `Wrangler ${operation} failed for ${target.name}; cleanup may need retry`,
+          }),
+        ),
+      );
+    });
+
+  const exists = (target: typeof PerformanceTarget.Type) =>
+    client
+      .execute(
+        HttpClientRequest.get(
+          `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/workers/scripts/${target.name}`,
+        ).pipe(HttpClientRequest.bearerToken(config.apiToken)),
+      )
+      .pipe(
+        Effect.timeout("20 seconds"),
+        Effect.flatMap((response) =>
+          response.status === 404
+            ? Effect.succeed(false)
+            : response.status >= 200 && response.status < 300
+              ? Effect.succeed(true)
+              : Effect.fail(
+                  EvaluationError.make({
+                    stage: "collision",
+                    message: "Could not establish disposable Worker ownership",
+                  }),
+                ),
+        ),
+        Effect.mapError(() =>
+          EvaluationError.make({
+            stage: "collision",
+            message: "Cloudflare Worker existence check failed",
+          }),
+        ),
+      );
+
+  return PerformanceDeployment.of({
+    exists,
+    deploy: (target) =>
+      secretsFile === undefined
+        ? Effect.fail(
+            EvaluationError.make({
+              stage: "secrets",
+              message: "Deployment requires a scoped secret file",
+            }),
+          )
+        : run(target, "deploy", [
+            "deploy",
+            "--config",
+            path.join(target.directory, "wrangler.json"),
+            "--no-bundle",
+            "--secrets-file",
+            secretsFile,
+          ]),
+    remove: (target) =>
+      Effect.gen(function* () {
+        if (!(yield* exists(target))) return;
+        // Downloaded artifact configuration cannot redirect deletion.
+        yield* writeCleanupConfig(target).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.mapError(() =>
+            EvaluationError.make({
+              stage: "cleanup",
+              message: "Cannot prepare the fixed namespace deletion config",
+            }),
+          ),
+        );
+        // This removes the DO namespace and stored data before removing the Worker.
+        yield* run(target, "delete-namespace", [
+          "deploy",
+          "--config",
+          path.join(target.directory, "cleanup.json"),
+          "--no-bundle",
+        ]);
+        yield* run(target, "delete-worker", [
+          "delete",
+          target.name,
+          "--config",
+          path.join(target.directory, "cleanup.json"),
+          "--force",
+        ]);
+        if (yield* exists(target))
+          return yield* EvaluationError.make({
+            stage: "cleanup",
+            message: `Worker deletion was not confirmed: ${target.name}`,
+          });
+      }),
+  });
+});

--- a/examples/context-continuity-eval/src/performance-evaluate.ts
+++ b/examples/context-continuity-eval/src/performance-evaluate.ts
@@ -1,0 +1,538 @@
+import { Receipt } from "@effect-agent/thread/DurableAgentRuntime";
+import { runIdForSubmission } from "@effect-agent/thread/RunJournal";
+import type { Redacted } from "effect";
+import { Clock, Effect, Exit, FileSystem, Path, Schedule, Schema } from "effect";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { EvaluationError } from "./contracts.ts";
+import type { PerformanceIdentity } from "./performance-contracts.ts";
+import {
+  PerformanceOutput,
+  PerformanceSnapshot,
+  expectedPerformanceOutput,
+} from "./performance-contracts.ts";
+
+const Timing = Schema.Record(Schema.String, Schema.NullOr(Schema.Finite));
+
+const AuditedRequest = Schema.Struct({
+  input: Schema.Array(
+    Schema.Struct({
+      type: Schema.optionalKey(Schema.String),
+      role: Schema.optionalKey(Schema.String),
+      output: Schema.optionalKey(Schema.String),
+      content: Schema.optionalKey(
+        Schema.Union([
+          Schema.String,
+          Schema.Array(
+            Schema.Struct({ type: Schema.String, text: Schema.optionalKey(Schema.String) }),
+          ),
+        ]),
+      ),
+    }),
+  ),
+});
+
+const requestParts = (json: string) => {
+  const request = Schema.decodeUnknownOption(Schema.fromJsonString(AuditedRequest))(json);
+
+  return request._tag === "Some" ? request.value.input : [];
+};
+
+export const PerformancePhaseResult = Schema.Struct({
+  phase: Schema.Int,
+  condition: Schema.Literals(["fresh-thread", "warm-retained-history", "committed-tool-recovery"]),
+  runId: Schema.String,
+  passed: Schema.Boolean,
+  failures: Schema.Array(Schema.String),
+  timing: Timing,
+});
+
+export const PerformanceSample = Schema.Struct({
+  target: Schema.String,
+  sample: Schema.Int,
+  passed: Schema.Boolean,
+  failure: Schema.NullOr(Schema.String),
+  initializationProbeMillis: Schema.NullOr(Schema.Finite),
+  phases: Schema.Array(PerformancePhaseResult),
+  closeRequested: Schema.Boolean,
+});
+
+/** Host durations use only the DO clock; client durations use only the runner clock. Never sum these overlapping intervals. */
+export const performanceTiming = (snapshot: typeof PerformanceSnapshot.Type, phase: number) => {
+  const events = snapshot.events.filter((event) => event.phase === phase);
+  const first = (kind: string) => events.find((event) => event.kind === kind)?.atMillis;
+  const last = (kind: string) => events.findLast((event) => event.kind === kind)?.atMillis;
+  const firstDispatch = events.find((event) => event.kind === "provider-http-dispatch");
+
+  const matchingFirstDelta =
+    firstDispatch === undefined
+      ? undefined
+      : events.find(
+          (event) =>
+            event.kind === "first-provider-delta" &&
+            event.request === firstDispatch.request &&
+            event.incarnation === firstDispatch.incarnation,
+        );
+
+  const between = (start: number | undefined, end: number | undefined) =>
+    start === undefined ||
+    end === undefined ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    end < start
+      ? null
+      : end - start;
+
+  return {
+    admissionMillis: between(first("ledger:admit:before"), first("ledger:admit:after")),
+    queueToClaimMillis: between(first("ledger:admit:after"), first("claim:after-claim")),
+    preparationBeforePreflightMillis: between(first("attempt-start"), first("preflight-start")),
+    inputTokenPreflightMillis: between(first("preflight-start"), first("preflight-end")),
+    preparationAfterPreflightMillis: between(
+      first("preflight-end"),
+      first("provider-http-dispatch"),
+    ),
+    ingressToProviderDispatchMillis: between(
+      first("submission-ingress"),
+      first("provider-http-dispatch"),
+    ),
+    providerDispatchToFirstDeltaMillis: between(
+      firstDispatch?.atMillis,
+      matchingFirstDelta?.atMillis,
+    ),
+    priceToolMillis: between(first("tool:read_price:start"), first("tool:read_price:end")),
+    stockToolMillis: between(first("tool:read_stock:start"), first("tool:read_stock:end")),
+    toolBatchWallMillis: between(
+      Math.min(
+        first("tool:read_price:start") ?? Infinity,
+        first("tool:read_stock:start") ?? Infinity,
+      ),
+      Math.max(last("tool:read_price:end") ?? -Infinity, last("tool:read_stock:end") ?? -Infinity),
+    ),
+    toolResultsCommitMillis: between(
+      Math.max(last("tool:read_price:end") ?? -Infinity, last("tool:read_stock:end") ?? -Infinity),
+      first("turn:after-results-append"),
+    ),
+    finalProviderToCanonicalCompletionMillis: between(
+      last("provider-completed"),
+      last("terminalize:after-canonical-append"),
+    ),
+    ingressToCanonicalCompletionMillis: between(
+      first("submission-ingress"),
+      last("terminalize:after-canonical-append"),
+    ),
+  };
+};
+
+export const gradePerformancePhase = Effect.fn("Performance.grade")(function* (
+  snapshot: typeof PerformanceSnapshot.Type,
+  phase: number,
+  receipt: Pick<Receipt, "submissionId">,
+  previousIncarnation: number,
+) {
+  const failures: Array<string> = [];
+  const runId = runIdForSubmission(receipt.submissionId);
+  const records = snapshot.records.map(({ record }) => record.payload);
+
+  const settled = records.filter(
+    (record) => record._tag === "SubmissionSettled" && record.submissionId === receipt.submissionId,
+  );
+
+  const completed = records.filter(
+    (record) => record._tag === "RunCompleted" && record.runId === runId,
+  );
+
+  if (
+    settled.length !== 1 ||
+    settled[0]?._tag !== "SubmissionSettled" ||
+    settled[0].outcome !== "completed"
+  )
+    failures.push("Exactly one completed canonical settlement required");
+  if (
+    completed.length !== 1 ||
+    completed[0]?._tag !== "RunCompleted" ||
+    completed[0].finishReason !== undefined
+  )
+    failures.push("Exactly one unexhausted canonical completion required");
+
+  const output =
+    completed[0]?._tag === "RunCompleted"
+      ? yield* Schema.decodeUnknownEffect(PerformanceOutput)(completed[0].output).pipe(
+          Effect.option,
+        )
+      : undefined;
+
+  const encodedExpected = Schema.encodeSync(Schema.fromJsonString(PerformanceOutput))(
+    expectedPerformanceOutput(phase),
+  );
+
+  if (
+    output === undefined ||
+    output._tag === "None" ||
+    Schema.encodeSync(Schema.fromJsonString(PerformanceOutput))(output.value) !== encodedExpected
+  )
+    failures.push(
+      "Schema-valid order must contain computed totals, current tool evidence, and previous order total",
+    );
+  for (const name of ["read_price", "read_stock"]) {
+    const results = records.filter(
+      (record) =>
+        record._tag === "ToolCallSettled" &&
+        record.runId === runId &&
+        record.toolName === name &&
+        !record.isFailure,
+    );
+
+    if (results.length !== 1) failures.push(`Expected one successful canonical ${name} result`);
+    const canonicalResult = results[0];
+
+    const resultSchema =
+      name === "read_price"
+        ? Schema.Struct({
+            unitPriceCents: Schema.Literal(3_700),
+            evidence: Schema.Literal(`price-${phase}-q7`),
+          })
+        : Schema.Struct({
+            availableUnits: Schema.Literal(12),
+            evidence: Schema.Literal(`stock-${phase}-m9`),
+          });
+
+    if (
+      canonicalResult?._tag !== "ToolCallSettled" ||
+      !Schema.is(resultSchema)(canonicalResult.result)
+    )
+      failures.push(`Canonical ${name} payload differs from the fixture`);
+    if (
+      snapshot.events.filter(
+        (event) => event.phase === phase && event.kind === `tool:${name}:start`,
+      ).length !== 1
+    )
+      failures.push(`Expected one ${name} execution, including across recovery`);
+  }
+
+  const requests = snapshot.audits.filter(
+    (audit) => audit.phase === phase && audit.kind === "request",
+  );
+
+  const expected = expectedPerformanceOutput(phase);
+
+  if (phase > 0) {
+    const previous = records.findLast(
+      (record) => record._tag === "RunCompleted" && record.runId !== runId,
+    );
+
+    const previousOutput =
+      previous?._tag === "RunCompleted"
+        ? Schema.decodeUnknownOption(PerformanceOutput)(previous.output)
+        : undefined;
+
+    const initialAssistantOutputs = requestParts(requests[0]?.json ?? "{}").flatMap((item) =>
+      item.type === "message" && item.role === "assistant"
+        ? typeof item.content === "string"
+          ? [item.content]
+          : (item.content ?? []).flatMap((part) => (part.text === undefined ? [] : [part.text]))
+        : [],
+    );
+
+    const preserved =
+      previousOutput?._tag === "Some" &&
+      initialAssistantOutputs.some((text) => {
+        const decoded = Schema.decodeUnknownOption(Schema.fromJsonString(PerformanceOutput))(text);
+
+        return (
+          decoded._tag === "Some" &&
+          Schema.encodeSync(Schema.fromJsonString(PerformanceOutput))(decoded.value) ===
+            Schema.encodeSync(Schema.fromJsonString(PerformanceOutput))(previousOutput.value)
+        );
+      });
+
+    if (!preserved)
+      failures.push(
+        "Initial provider request must retain the previous canonical assistant order output",
+      );
+  }
+
+  const later = requests.slice(1).some((request) => {
+    const outputs = requestParts(request.json).flatMap((item) =>
+      item.type === "function_call_output" && item.output !== undefined ? [item.output] : [],
+    );
+
+    return (
+      outputs.some(
+        (output) =>
+          Schema.decodeUnknownOption(
+            Schema.fromJsonString(
+              Schema.Struct({
+                unitPriceCents: Schema.Literal(3_700),
+                evidence: Schema.Literal(expected.priceEvidence),
+              }),
+            ),
+          )(output)._tag === "Some",
+      ) &&
+      outputs.some(
+        (output) =>
+          Schema.decodeUnknownOption(
+            Schema.fromJsonString(
+              Schema.Struct({
+                availableUnits: Schema.Literal(12),
+                evidence: Schema.Literal(expected.stockEvidence),
+              }),
+            ),
+          )(output)._tag === "Some",
+      )
+    );
+  });
+
+  if (!later)
+    failures.push("Subsequent real provider request must consume both current tool results");
+  if (
+    requests[0]?.json.includes(expected.priceEvidence) ||
+    requests[0]?.json.includes(expected.stockEvidence)
+  )
+    failures.push("Tool evidence leaked into initial request");
+  if (
+    snapshot.usage.calls !== snapshot.usage.completedCalls ||
+    snapshot.usage.reservedCostMicrousd !== 0 ||
+    snapshot.failure !== null
+  )
+    failures.push("Provider usage must be completely accounted for");
+  const events = snapshot.events.filter((event) => event.phase === phase);
+
+  if (
+    !events.some((event) => event.kind === "provider-http-dispatch") ||
+    !events.some((event) => event.kind === "first-provider-delta")
+  )
+    failures.push("Provider dispatch and first delta evidence required");
+  if (phase === 1 && snapshot.incarnation !== previousIncarnation)
+    failures.push("Warm case changed incarnation; retain sample as failed warm condition");
+  if (
+    phase === 2 &&
+    !(
+      snapshot.incarnation > previousIncarnation &&
+      events.filter((event) => event.kind === "planned-abort-after-tool-commit").length === 1
+    )
+  )
+    failures.push("Recovery requires one confirmed planned abort and a new incarnation");
+  if (
+    !events.some(
+      (event) => event.kind === "attempt-finalized" && event.incarnation === snapshot.incarnation,
+    )
+  )
+    failures.push("Successful attempt finalizer evidence required");
+
+  return {
+    phase,
+    condition:
+      phase === 0
+        ? "fresh-thread"
+        : phase === 1
+          ? "warm-retained-history"
+          : "committed-tool-recovery",
+    runId,
+    passed: failures.length === 0,
+    failures,
+    timing: performanceTiming(snapshot, phase),
+  } satisfies typeof PerformancePhaseResult.Type;
+});
+
+export const runPerformanceSample = Effect.fn("Performance.sample")(function* (options: {
+  readonly url: string;
+  readonly token: Redacted.Redacted<string>;
+  readonly identity: typeof PerformanceIdentity.Type;
+  readonly target: string;
+  readonly sample: number;
+  readonly outputDirectory: string;
+}) {
+  const client = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  let result: typeof PerformanceSample.Type = {
+    target: options.target,
+    sample: options.sample,
+    passed: false,
+    failure: null,
+    initializationProbeMillis: null,
+    phases: [],
+    closeRequested: false,
+  };
+
+  const get = (route: string) =>
+    client.execute(
+      HttpClientRequest.get(`${options.url}${route}?sample=${options.sample}`).pipe(
+        HttpClientRequest.bearerToken(options.token),
+      ),
+    );
+
+  const post = (route: string, body: { phase?: number }) =>
+    client.execute(
+      HttpClientRequest.post(`${options.url}${route}?sample=${options.sample}`).pipe(
+        HttpClientRequest.bearerToken(options.token),
+        HttpClientRequest.bodyJsonUnsafe(body),
+      ),
+    );
+
+  const save = () =>
+    fs.writeFileString(
+      path.join(options.outputDirectory, "sample.json"),
+      Schema.encodeSync(Schema.fromJsonString(PerformanceSample))(result),
+    );
+
+  const snapshot = get("/snapshot").pipe(
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(PerformanceSnapshot)),
+    Effect.timeout("15 seconds"),
+  );
+
+  const observe = snapshot.pipe(
+    Effect.retry({ times: 3, schedule: Schedule.spaced("250 millis") }),
+  );
+
+  yield* fs.makeDirectory(options.outputDirectory, { recursive: true });
+  yield* save();
+
+  const execution = Effect.gen(function* () {
+    const probeStart = yield* Clock.currentTimeMillis;
+    const before = yield* observe;
+
+    result = {
+      ...result,
+      initializationProbeMillis: (yield* Clock.currentTimeMillis) - probeStart,
+    };
+    if (before.records.length > 0)
+      return yield* EvaluationError.make({
+        stage: "fixture",
+        message: "Sample thread already contains canonical history; use a new deployment",
+      });
+    let previousIncarnation = before.incarnation;
+
+    for (const phase of [0, 1, 2]) {
+      const start = yield* Clock.currentTimeMillis;
+
+      const receipt = yield* post("/submit", { phase }).pipe(
+        Effect.flatMap(HttpClientResponse.schemaBodyJson(Receipt)),
+        Effect.timeout("30 seconds"),
+      );
+
+      const receiptMillis = (yield* Clock.currentTimeMillis) - start;
+      let firstFeedbackMillis: number | null = null;
+      let polls = 0;
+
+      const phaseResult = yield* Effect.gen(function* () {
+        for (;;) {
+          const current = yield* observe;
+          const observedAt = yield* Clock.currentTimeMillis;
+
+          polls++;
+          if (JSON.stringify(current.identity) !== JSON.stringify(options.identity))
+            return yield* EvaluationError.make({
+              stage: "source",
+              message: "Deployed identity changed during sample",
+            });
+          yield* fs.writeFileString(
+            path.join(options.outputDirectory, `phase-${phase}-snapshot.json`),
+            yield* Schema.encodeEffect(Schema.fromJsonString(PerformanceSnapshot))(current),
+          );
+          const runId = runIdForSubmission(receipt.submissionId);
+
+          if (
+            firstFeedbackMillis === null &&
+            current.records.some(
+              ({ record }) =>
+                record.payload._tag === "ModelResponseRecorded" && record.payload.runId === runId,
+            )
+          )
+            firstFeedbackMillis = observedAt - start;
+          if (current.failure !== null)
+            return yield* EvaluationError.make({ stage: "provider", message: current.failure });
+          if (
+            current.records.some(
+              ({ record }) =>
+                record.payload._tag === "SubmissionSettled" &&
+                record.payload.submissionId === receipt.submissionId,
+            )
+          ) {
+            // Settlement is visible before the Attempt scope necessarily closes.
+            // Keep observing within the same deadline until its finalizer is confirmed.
+            if (
+              !current.events.some(
+                (event) =>
+                  event.phase === phase &&
+                  event.incarnation === current.incarnation &&
+                  event.kind === "attempt-finalized",
+              )
+            ) {
+              yield* Effect.sleep("100 millis");
+              continue;
+            }
+            const final = current;
+            const grade = yield* gradePerformancePhase(final, phase, receipt, previousIncarnation);
+            const deliveredAt = yield* Clock.currentTimeMillis;
+
+            yield* fs.writeFileString(
+              path.join(options.outputDirectory, `phase-${phase}-snapshot.json`),
+              yield* Schema.encodeEffect(Schema.fromJsonString(PerformanceSnapshot))(final),
+            );
+            previousIncarnation = final.incarnation;
+
+            return {
+              ...grade,
+              timing: {
+                ...grade.timing,
+                clientAdmissionReceiptMillis: receiptMillis,
+                clientFirstCanonicalFeedbackMillis: firstFeedbackMillis,
+                clientValidatedCompletionDeliveryMillis: deliveredAt - start,
+                observationPolls: polls,
+              },
+            };
+          }
+          yield* Effect.sleep("100 millis");
+        }
+      }).pipe(Effect.timeout("150 seconds"));
+
+      result = { ...result, phases: [...result.phases, phaseResult] };
+      yield* save();
+      if (!phaseResult.passed)
+        return yield* EvaluationError.make({
+          stage: "outcome",
+          message: "Order or lifecycle assertions failed",
+        });
+    }
+    result = { ...result, passed: true };
+  }).pipe(Effect.timeout("8 minutes"));
+
+  yield* execution.pipe(
+    Effect.onExit((exit) =>
+      Effect.gen(function* () {
+        if (Exit.isFailure(exit))
+          result = {
+            ...result,
+            passed: false,
+            failure: exit.cause.reasons
+              .flatMap((reason) =>
+                reason._tag === "Fail" && Schema.is(EvaluationError)(reason.error)
+                  ? [`${reason.error.stage}: ${reason.error.message}`]
+                  : [reason._tag],
+              )
+              .join("; "),
+          };
+        // Preserve one final snapshot even after failure, before shutdown loses the host.
+        yield* snapshot.pipe(
+          Effect.flatMap((value) =>
+            fs.writeFileString(
+              path.join(options.outputDirectory, "final-snapshot.json"),
+              Schema.encodeSync(Schema.fromJsonString(PerformanceSnapshot))(value),
+            ),
+          ),
+          Effect.ignore,
+        );
+        const close = yield* post("/close", {}).pipe(Effect.timeout("15 seconds"), Effect.exit);
+
+        result = { ...result, closeRequested: Exit.isSuccess(close) };
+        yield* save();
+      }),
+    ),
+    Effect.catchCause(() => Effect.void),
+  );
+
+  return result;
+});

--- a/examples/context-continuity-eval/src/performance-main.ts
+++ b/examples/context-continuity-eval/src/performance-main.ts
@@ -1,0 +1,435 @@
+import { digestJson } from "@effect-agent/thread/Digest";
+import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
+import {
+  Clock,
+  Config,
+  Console,
+  Crypto,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  Redacted,
+  Schedule,
+  Schema,
+} from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
+
+import { buildPerformanceCloudflare, PerformanceBuild } from "./build-performance-cloudflare.ts";
+import { EvaluationError } from "./contracts.ts";
+import { MODEL_IDS } from "./live-model.ts";
+import { PerformanceIdentity } from "./performance-contracts.ts";
+import type { PerformanceTarget } from "./performance-deployment.ts";
+import {
+  PerformanceDeployment,
+  PerformanceResources,
+  loadPerformanceConfig,
+  makePerformanceDeployment,
+  preparePerformanceTarget,
+  withPerformanceDeployment,
+} from "./performance-deployment.ts";
+import { PerformanceSample, runPerformanceSample } from "./performance-evaluate.ts";
+
+const Report = Schema.Struct({
+  version: Schema.Literal(1),
+  status: Schema.Literals(["running", "passed", "failed", "dry-run"]),
+  live: Schema.Boolean,
+  startedAtMillis: Schema.Finite,
+  elapsedMillis: Schema.Finite,
+  builds: Schema.Array(PerformanceBuild),
+  identities: Schema.Array(PerformanceIdentity),
+  samples: Schema.Array(PerformanceSample),
+  failure: Schema.NullOr(Schema.String),
+  conditions: Schema.Record(Schema.String, Schema.Json),
+});
+
+const command = Command.make(
+  "perf:cloudflare",
+  {
+    sourceRoot: Flag.directory("source-root").pipe(
+      Flag.withDefault("."),
+      Flag.withDescription("Clean exact candidate checkout, using its own installed lockfile."),
+    ),
+    referenceRoot: Flag.directory("reference-root").pipe(
+      Flag.optional,
+      Flag.withDescription(
+        "Optional clean reference checkout. Builds the identical fixture against its dependencies.",
+      ),
+    ),
+    model: Flag.choice("model", MODEL_IDS).pipe(Flag.withDefault("gpt-6-astra")),
+    samples: Flag.integer("samples").pipe(
+      Flag.withSchema(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 3 }))),
+      Flag.withDefault(1),
+    ),
+    output: Flag.directory("output-dir").pipe(
+      Flag.withDefault(".context-continuity-eval/performance"),
+    ),
+    dryRun: Flag.boolean("dry-run").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription(
+        "Build and show bounded deployment plan without credentials, deployment, or inference.",
+      ),
+    ),
+    cleanup: Flag.boolean("cleanup").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription(
+        "Retry removal of this output directory's recorded disposable namespace/Workers; no inference.",
+      ),
+    ),
+  },
+  Effect.fn("Performance.command")(function* (options) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = path.resolve(options.output);
+    const resourcesPath = path.join(directory, "resources.json");
+
+    if (options.cleanup) {
+      if (!(yield* fs.exists(resourcesPath))) return;
+
+      let resources = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(PerformanceResources),
+      )(yield* fs.readFileString(resourcesPath));
+
+      resources = {
+        ...resources,
+        targets: resources.targets.map((target) => ({
+          ...target,
+          directory: path.join(directory, target.label),
+        })),
+      };
+      const config = yield* loadPerformanceConfig;
+
+      if (resources.accountDigest !== (yield* digestJson(config.accountId)))
+        return yield* EvaluationError.make({
+          stage: "cleanup",
+          message: "Cleanup account differs from retained ownership manifest",
+        });
+      const operations = yield* makePerformanceDeployment(undefined);
+
+      for (const target of resources.targets) {
+        if (!target.cleanupRequired || target.cleanupComplete) continue;
+        yield* operations.remove(target);
+        resources = {
+          ...resources,
+          targets: resources.targets.map((item) =>
+            item.name === target.name ? { ...target, cleanupComplete: true } : item,
+          ),
+        };
+        yield* fs.writeFileString(
+          resourcesPath,
+          Schema.encodeSync(Schema.fromJsonString(PerformanceResources))(resources),
+        );
+      }
+
+      return;
+    }
+    if (yield* fs.exists(directory))
+      return yield* EvaluationError.make({
+        stage: "evidence",
+        message:
+          "Output directory already exists; choose a new output-dir to retain prior attempts",
+      });
+    yield* fs.makeDirectory(directory, { recursive: true });
+    const start = yield* Clock.currentTimeMillis;
+
+    let report: typeof Report.Type = {
+      version: 1,
+      status: "running",
+      live: !options.dryRun,
+      startedAtMillis: start,
+      elapsedMillis: 0,
+      builds: [],
+      identities: [],
+      samples: [],
+      failure: null,
+      conditions: {
+        fixture: "cloudflare-order-v1",
+        provider: "openai",
+        samplesPerTarget: options.samples,
+        conservativeMaxCostUsdPerTarget: options.samples * 2,
+        inferenceRetries: 0,
+        maxTurnsPerSubmission: 4,
+        maxToolsPerSubmission: 4,
+        toolConcurrency: 2,
+        syntheticToolWaitMillis: 20,
+        concurrentSubmissions: 1,
+        maxInputTokens: 8192,
+        maxOutputTokens: 4096,
+        maxModelCallsPerThread: 18,
+        maxDatabaseBytesPerThread: 16777216,
+        maxSampleMillis: 480000,
+        pollIntervalMillis: 100,
+        optionalProjections: false,
+        publicationAdapters: false,
+        persistedTimingMarks: true,
+        coldStartGuaranteed: false,
+        cpu: null,
+        cpuUnavailableReason:
+          "Worker request APIs do not expose per-event CPU. Attach Cloudflare observability export separately; local profiles are not billing.",
+        heap: null,
+        heapUnavailableReason: "No deployed per-DO heap API.",
+        region: "Ingress CF-Ray suffix recorded in response observation; DO region is not exposed.",
+        clock:
+          "Separate runner and DO wall clocks; workerd clock advances only after I/O, so zero synchronous durations mean unresolved timer precision.",
+        providerCache:
+          "Uncontrolled provider prefix cache; cached token usage retained in response audits. No response-id/conversation reuse.",
+        timingPolicy:
+          "Informational, no latency threshold. Do not sum overlapping intervals or subtract synthetic processing from provider latency.",
+        initialization:
+          "Fresh-thread probe constructs the host before submission; warm requires unchanged incarnation. Recovery aborts after confirmed tool-result commit.",
+      },
+    };
+
+    const save = () =>
+      Effect.gen(function* () {
+        report = { ...report, elapsedMillis: (yield* Clock.currentTimeMillis) - start };
+        yield* fs.writeFileString(
+          path.join(directory, "report.json"),
+          Schema.encodeSync(Schema.fromJsonString(Report))(report),
+        );
+      });
+
+    yield* save();
+
+    const program = Effect.gen(function* () {
+      const candidate = yield* buildPerformanceCloudflare(
+        options.sourceRoot,
+        path.join(directory, "candidate"),
+      );
+
+      const builds = [candidate];
+
+      if (Option.isSome(options.referenceRoot))
+        builds.push(
+          yield* buildPerformanceCloudflare(
+            options.referenceRoot.value,
+            path.join(directory, "reference"),
+          ),
+        );
+      report = { ...report, builds };
+      yield* save();
+      if (options.dryRun) {
+        report = { ...report, status: "dry-run" };
+
+        return;
+      }
+      if (builds.some((build) => build.dirtyWorkingTree))
+        return yield* EvaluationError.make({
+          stage: "source",
+          message: "Live performance requires clean exact candidate and reference checkouts",
+        });
+      if ((yield* Config.string("EFFECT_AGENT_LIVE").pipe(Config.withDefault("0"))) !== "1")
+        return yield* EvaluationError.make({
+          stage: "configuration",
+          message:
+            "Set EFFECT_AGENT_LIVE=1 to authorize deployment and up to $2 per sample per target in provider reservations",
+        });
+      const config = yield* loadPerformanceConfig;
+      const openai = yield* Config.redacted("OPENAI_API_KEY");
+      const run = (yield* (yield* Crypto.Crypto).randomUUIDv4).replaceAll("-", "");
+      const token = Redacted.make(yield* (yield* Crypto.Crypto).randomUUIDv4);
+      const secretPath = yield* fs.makeTempFileScoped({ prefix: "performance-secrets-" });
+
+      yield* fs.writeFileString(
+        secretPath,
+        JSON.stringify({
+          OPENAI_API_KEY: Redacted.value(openai),
+          PERFORMANCE_TOKEN: Redacted.value(token),
+        }),
+        { mode: 0o600 },
+      );
+
+      const targets = yield* Effect.forEach(builds, (build, index) =>
+        preparePerformanceTarget({
+          build,
+          label: index === 0 ? "candidate" : "reference",
+          run,
+          model: options.model,
+          samples: options.samples,
+          subdomain: config.subdomain,
+        }),
+      );
+
+      let resources: typeof PerformanceResources.Type = {
+        accountDigest: yield* digestJson(config.accountId),
+        targets,
+      };
+
+      const saveTarget = (target: typeof PerformanceTarget.Type) =>
+        Effect.gen(function* () {
+          resources = {
+            ...resources,
+            targets: resources.targets.map((current) =>
+              current.name === target.name ? target : current,
+            ),
+          };
+          yield* fs.writeFileString(
+            resourcesPath,
+            Schema.encodeSync(Schema.fromJsonString(PerformanceResources))(resources),
+          );
+        }).pipe(
+          Effect.mapError(() =>
+            EvaluationError.make({
+              stage: "evidence",
+              message: "Cannot persist deployment ownership",
+            }),
+          ),
+        );
+
+      yield* fs.writeFileString(
+        resourcesPath,
+        Schema.encodeSync(Schema.fromJsonString(PerformanceResources))(resources),
+      );
+      const operations = yield* makePerformanceDeployment(secretPath, [openai, token]);
+      const client = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+
+      const evaluate = Effect.gen(function* () {
+        for (const target of targets) {
+          const response = yield* client
+            .execute(
+              HttpClientRequest.get(`${target.url}/identity`).pipe(
+                HttpClientRequest.bearerToken(token),
+              ),
+            )
+            .pipe(
+              Effect.timeout("20 seconds"),
+              Effect.retry({ times: 5, schedule: Schedule.spaced("2 seconds") }),
+            );
+
+          const identity = yield* HttpClientResponse.schemaBodyJson(PerformanceIdentity)(response);
+
+          if (
+            identity.sourceCommit !== target.sourceCommit ||
+            identity.dirtyWorkingTree ||
+            identity.model !== options.model ||
+            identity.fixtureDigest !== candidate.fixtureDigest ||
+            identity.deploymentId.length === 0
+          )
+            return yield* EvaluationError.make({
+              stage: "source",
+              message:
+                "Deployed identity does not match the clean candidate/reference and shared fixture",
+            });
+          report = {
+            ...report,
+            identities: [...report.identities, identity],
+            conditions: {
+              ...report.conditions,
+              [`${target.label}IngressCfRay`]: response.headers["cf-ray"] ?? null,
+            },
+          };
+          yield* save();
+        }
+        for (let sample = 0; sample < options.samples; sample++) {
+          const order = sample % 2 === 0 ? targets : [...targets].reverse();
+
+          for (const target of order) {
+            const identity = report.identities[targets.indexOf(target)];
+
+            if (identity === undefined)
+              return yield* EvaluationError.make({
+                stage: "source",
+                message: "Target identity missing",
+              });
+
+            const result = yield* runPerformanceSample({
+              url: target.url,
+              token,
+              identity,
+              target: target.label,
+              sample,
+              outputDirectory: path.join(directory, `${target.label}-sample-${sample}`),
+            });
+
+            report = { ...report, samples: [...report.samples, result] };
+            yield* save();
+          }
+        }
+        if (report.samples.some((sample) => !sample.passed))
+          return yield* EvaluationError.make({
+            stage: "outcome",
+            message: "At least one agent/lifecycle sample failed; all observations retained",
+          });
+      });
+
+      // Nest lifetimes so both targets coexist; measurements alternate without concurrent inference.
+      const deployed = targets.reduceRight(
+        (use, target) =>
+          withPerformanceDeployment(target, saveTarget, use).pipe(
+            Effect.provideService(PerformanceDeployment, operations),
+          ),
+        evaluate,
+      );
+
+      yield* deployed;
+      report = { ...report, status: "passed" };
+    });
+
+    const exit = yield* program.pipe(
+      Effect.onExit((exit) =>
+        Effect.gen(function* () {
+          if (Exit.isFailure(exit))
+            report = {
+              ...report,
+              status: "failed",
+              failure: exit.cause.reasons
+                .flatMap((reason) =>
+                  reason._tag === "Fail" && Schema.is(EvaluationError)(reason.error)
+                    ? [`${reason.error.stage}: ${reason.error.message}`]
+                    : [reason._tag],
+                )
+                .join("; "),
+            };
+          yield* save();
+
+          const rows = report.samples.flatMap((sample) =>
+            sample.phases.map(
+              (phase) =>
+                `| ${sample.target} | ${sample.sample} | ${phase.condition} | ${phase.passed ? "pass" : "FAIL"} | ${phase.timing.clientValidatedCompletionDeliveryMillis ?? "unavailable"} | ${phase.timing.clientFirstCanonicalFeedbackMillis ?? "unavailable"} |`,
+            ),
+          );
+
+          yield* fs.writeFileString(
+            path.join(directory, "summary.md"),
+            `Cloudflare performance: ${report.status}\n\nCandidate: ${report.builds[0]?.sourceCommit ?? "unbuilt"}. Fixture: ${report.builds[0]?.fixtureDigest ?? "unbuilt"}. Timing is informational; every sample is retained.\n\n| Target | Sample | Condition | Outcome | Delivery ms | First canonical feedback ms |\n|---|---:|---|---|---:|---:|\n${rows.join("\n")}\n\nSee report.json for configuration/limits and each phase snapshot for provider cache/usage, durable records, lifecycle, and raw timing. resources.json must show cleanupComplete for every owned resource.\n`,
+          );
+        }),
+      ),
+      Effect.exit,
+    );
+
+    yield* Console.log(
+      `Cloudflare performance ${report.status}: ${path.join(directory, "summary.md")}`,
+    );
+    if (Exit.isFailure(exit)) return yield* Effect.failCause(exit.cause);
+  }),
+).pipe(
+  Command.withDescription(
+    "Manually deploy exact Cloudflare candidates, run real model-selected tool flows, preserve evidence, and delete disposable namespaces/Workers. Requires Cloudflare account/token/subdomain and OPENAI_API_KEY; never scheduled.",
+  ),
+);
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Command.run(command, { version: "1.0.0" }).pipe(
+      Effect.tapError((error) =>
+        Console.error(
+          Schema.is(EvaluationError)(error)
+            ? `${error.stage}: ${error.message}`
+            : `Performance command failed (${error._tag}); see retained output and --help.`,
+        ),
+      ),
+      Effect.scoped,
+      Effect.provide(Layer.mergeAll(NodeServices.layer, NodeCrypto.layer, FetchHttpClient.layer)),
+      Effect.provideService(FetchHttpClient.RequestInit, { redirect: "error" }),
+    ),
+    { disableErrorReporting: true },
+  );

--- a/examples/context-continuity-eval/src/performance-main.ts
+++ b/examples/context-continuity-eval/src/performance-main.ts
@@ -30,6 +30,7 @@ import { PerformanceIdentity } from "./performance-contracts.ts";
 import type { PerformanceTarget } from "./performance-deployment.ts";
 import {
   PerformanceDeployment,
+  PerformanceOwnership,
   PerformanceResources,
   loadPerformanceConfig,
   makePerformanceDeployment,
@@ -363,8 +364,9 @@ const command = Command.make(
       // Nest lifetimes so both targets coexist; measurements alternate without concurrent inference.
       const deployed = targets.reduceRight(
         (use, target) =>
-          withPerformanceDeployment(target, saveTarget, use).pipe(
+          withPerformanceDeployment(target, use).pipe(
             Effect.provideService(PerformanceDeployment, operations),
+            Effect.provideService(PerformanceOwnership, { saveTarget }),
           ),
         evaluate,
       );

--- a/examples/context-continuity-eval/src/performance-worker.ts
+++ b/examples/context-continuity-eval/src/performance-worker.ts
@@ -1,0 +1,467 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import {
+  DurableObjectContext,
+  ThreadObjectIdentity,
+  ThreadObjectNamespace,
+} from "@effect-agent/platform-cloudflare/CloudflareBindings";
+import { CloudflareThreadClient } from "@effect-agent/platform-cloudflare/CloudflareThreadClient";
+import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
+import { digestDefinitions } from "@effect-agent/thread/Digest";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
+import { BrowserCrypto } from "@effect/platform-browser";
+import { Context, Effect, Layer, Redacted, Ref, Schema } from "effect";
+import { DurableObject, WorkerEnvironment } from "effect-cf";
+import { FetchHttpClient } from "effect/unstable/http";
+
+import { EvaluationError, type ModelUsage } from "./contracts.ts";
+import { readLog } from "./host-evidence.ts";
+import { makeLiveClient } from "./live-model.ts";
+import {
+  PERFORMANCE_BUDGET,
+  PERFORMANCE_FIXTURE,
+  PerformanceIdentity,
+  PerformancePhase,
+  PerformanceSnapshot,
+  PerformanceState,
+  PerformanceEvent,
+  emptyPerformanceUsage,
+  performanceDefinition,
+  performanceDefinitions,
+  performanceMessage,
+  performanceSettings,
+  performanceToolkit,
+} from "./performance-contracts.ts";
+import { RequestAudit, RequestAuditSink } from "./request-audit.ts";
+
+declare const PERFORMANCE_SOURCE_COMMIT: string;
+declare const PERFORMANCE_DIRTY: boolean;
+declare const PERFORMANCE_FIXTURE_DIGEST: string;
+declare global {
+  namespace Cloudflare {
+    interface Env {
+      PERFORMANCE_THREADS: DurableObjectNamespace<PerformanceThread>;
+      PERFORMANCE_TOKEN: string;
+      PERFORMANCE_VERSION: { id: string; tag?: string; timestamp?: string };
+      PERFORMANCE_MODEL: string;
+      PERFORMANCE_RUN: string;
+      PERFORMANCE_SAMPLES: string;
+      OPENAI_API_KEY: string;
+    }
+  }
+}
+
+const identityFor = (env: Cloudflare.Env) =>
+  Schema.decodeUnknownEffect(PerformanceIdentity)({
+    sourceCommit: PERFORMANCE_SOURCE_COMMIT,
+    dirtyWorkingTree: PERFORMANCE_DIRTY,
+    fixture: PERFORMANCE_FIXTURE,
+    fixtureDigest: PERFORMANCE_FIXTURE_DIGEST,
+    deploymentId: env.PERFORMANCE_VERSION.id,
+    model: env.PERFORMANCE_MODEL,
+    maxCostMicrousd: PERFORMANCE_BUDGET,
+    maxModelCalls: 18,
+    maxInputTokens: 8_192,
+    settings: performanceSettings,
+  });
+
+class PerformanceHost extends Context.Service<
+  PerformanceHost,
+  {
+    prepare(phase: number): Effect.Effect<void, EvaluationError>;
+    readonly snapshot: Effect.Effect<typeof PerformanceSnapshot.Type, EvaluationError>;
+    readonly close: Effect.Effect<void>;
+  }
+>()("example/PerformanceHost") {}
+const callbacks = new WeakMap<DurableObjectState, (kind: string) => Effect.Effect<void>>();
+
+const application = Layer.unwrap(
+  Effect.gen(function* () {
+    const { ctx } = yield* DurableObjectContext;
+    const { threadId } = yield* ThreadObjectIdentity;
+    const env = yield* WorkerEnvironment;
+    const identity = yield* identityFor(env);
+
+    ctx.storage.sql.exec(
+      "CREATE TABLE IF NOT EXISTS performance_evidence (path TEXT PRIMARY KEY, value TEXT NOT NULL)",
+    );
+
+    const put = (path: string, value: string) =>
+      ctx.storage.sql.exec(
+        "INSERT OR REPLACE INTO performance_evidence(path,value) VALUES (?,?)",
+        path,
+        value,
+      );
+
+    const read = (prefix: string) =>
+      ctx.storage.sql
+        .exec<{ value: string }>(
+          "SELECT value FROM performance_evidence WHERE path LIKE ? ORDER BY path",
+          prefix,
+        )
+        .toArray();
+
+    const stored = read("state")[0]?.value;
+
+    let state: typeof PerformanceState.Type =
+      stored === undefined
+        ? {
+            identity,
+            phase: 0,
+            incarnation: 0,
+            usage: emptyPerformanceUsage,
+            aborted: false,
+            closed: false,
+          }
+        : yield* Schema.decodeUnknownEffect(Schema.fromJsonString(PerformanceState))(stored);
+
+    if (JSON.stringify(identity) !== JSON.stringify(state.identity))
+      return yield* EvaluationError.make({
+        stage: "source",
+        message: "Performance identity changed across incarnations",
+      });
+    state = { ...state, incarnation: state.incarnation + 1 };
+
+    const persist = () =>
+      put("state", Schema.encodeSync(Schema.fromJsonString(PerformanceState))(state));
+
+    persist();
+    let index = read("event-%").length;
+
+    // Native boundary clock: workerd freezes time between I/O. These are wall marks,
+    // not CPU measurements, and cannot measure synchronous preparation below that resolution.
+    const mark = (kind: string, request: number | null = null) => {
+      if (index >= 2_048) throw new Error("Performance evidence bound exceeded");
+
+      const event = {
+        index: ++index,
+        phase: state.phase,
+        incarnation: state.incarnation,
+        kind,
+        atMillis: Date.now(),
+        request,
+      };
+
+      put(
+        `event-${index.toString().padStart(5, "0")}`,
+        Schema.encodeSync(Schema.fromJsonString(PerformanceEvent))(event),
+      );
+    };
+
+    mark("incarnation-start");
+    const phase = yield* Ref.make(state.phase);
+    let usage: Effect.Effect<ModelUsage> = Effect.succeed(state.usage);
+    let requestNumber = state.usage.calls + 1;
+
+    const auditedFetch: typeof globalThis.fetch = (input, init) => {
+      if (state.closed) return Promise.reject(new Error("Performance host closed"));
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+      if (new URL(url).pathname === "/v1/responses") mark("provider-http-dispatch", requestNumber);
+
+      return globalThis.fetch(input, init);
+    };
+
+    const live = yield* makeLiveClient({
+      model: identity.model,
+      maxCostMicrousd: PERFORMANCE_BUDGET,
+      maxModelCalls: 18,
+      maxInputTokens: 8_192,
+      phase,
+      initialUsage: state.usage,
+      observe: (kind, request) =>
+        Effect.sync(() => {
+          requestNumber = request;
+          mark(kind, request);
+        }),
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          Layer.succeed(RequestAuditSink, {
+            write: (event) =>
+              Effect.gen(function* () {
+                put(
+                  `audit-${event.request.toString().padStart(3, "0")}-${event.kind}`,
+                  yield* Schema.encodeEffect(Schema.fromJsonString(RequestAudit))(event),
+                );
+                state = { ...state, usage: yield* usage };
+                persist();
+                mark(
+                  event.kind === "request" ? "reservation-persisted" : "provider-completed",
+                  event.request,
+                );
+              }).pipe(
+                Effect.mapError(() =>
+                  EvaluationError.make({
+                    stage: "evidence",
+                    message: "Cannot persist request accounting",
+                  }),
+                ),
+              ),
+          }),
+          OpenAiClient.layer({ apiKey: Redacted.make(env.OPENAI_API_KEY) }).pipe(
+            Layer.provide(
+              FetchHttpClient.layer.pipe(
+                Layer.provide(Layer.succeed(FetchHttpClient.Fetch, auditedFetch)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    usage = live.snapshot;
+
+    const tools = performanceToolkit.toLayer({
+      read_price: () =>
+        Effect.gen(function* () {
+          mark("tool:read_price:start");
+          yield* Effect.sleep("20 millis");
+          mark("tool:read_price:end");
+
+          return { unitPriceCents: 3_700, evidence: `price-${state.phase}-q7` };
+        }),
+      read_stock: () =>
+        Effect.gen(function* () {
+          mark("tool:read_stock:start");
+          yield* Effect.sleep("20 millis");
+          mark("tool:read_stock:end");
+
+          return { availableUnits: 12, evidence: `stock-${state.phase}-m9` };
+        }),
+    });
+
+    const host = ThreadObject.layer([
+      {
+        agent: performanceDefinition,
+        model: OpenAiLanguageModel.model(identity.model, performanceSettings),
+        definitions: performanceDefinitions(identity),
+        attemptLayer: () =>
+          Layer.effectDiscard(
+            Effect.acquireRelease(
+              Effect.sync(() => mark("attempt-start")),
+              () => Effect.sync(() => mark("attempt-finalized")),
+            ),
+          ),
+      },
+    ]).pipe(
+      Layer.provide(Layer.merge(tools, Layer.succeed(OpenAiClient.OpenAiClient, live.client))),
+    );
+
+    return Layer.effectContext(
+      Effect.gen(function* () {
+        const services = yield* Effect.context<ThreadObject.Services>();
+
+        const hit = (kind: string) =>
+          Effect.gen(function* () {
+            mark(kind);
+            if (kind === "turn:after-results-append" && state.phase === 2 && !state.aborted) {
+              state = { ...state, aborted: true, usage: yield* usage };
+              persist();
+              mark("planned-abort-after-tool-commit");
+              yield* Effect.promise(() => ctx.storage.sync());
+              ctx.abort("performance fixture: committed tool batch recovery");
+            }
+          });
+
+        callbacks.set(ctx, hit);
+
+        return Context.add(services, PerformanceHost, {
+          prepare: (next) =>
+            Effect.gen(function* () {
+              if (state.closed || next < state.phase || next > state.phase + 1)
+                return yield* EvaluationError.make({
+                  stage: "phase",
+                  message: "Invalid performance phase",
+                });
+              if (next > state.phase) {
+                const records = yield* readLog(threadId).pipe(
+                  Effect.mapError(() =>
+                    EvaluationError.make({ stage: "phase", message: "Previous order unavailable" }),
+                  ),
+                );
+
+                if (
+                  records.filter(({ record }) => record.payload._tag === "SubmissionSettled")
+                    .length !== next
+                )
+                  return yield* EvaluationError.make({
+                    stage: "phase",
+                    message: "Previous order is not settled",
+                  });
+              }
+              state = { ...state, phase: next };
+              yield* Ref.set(phase, next);
+              persist();
+              mark("submission-ingress");
+            }).pipe(Effect.provide(services)),
+          snapshot: Effect.gen(function* () {
+            const records = yield* readLog(threadId).pipe(
+              Effect.catchTag("ThreadNotMaterialized", () => Effect.succeed([])),
+            );
+
+            if (records.length > 1_024)
+              return yield* EvaluationError.make({
+                stage: "evidence",
+                message: "Canonical fixture bound exceeded",
+              });
+
+            return {
+              identity,
+              phase: state.phase,
+              incarnation: state.incarnation,
+              events: yield* Effect.forEach(read("event-%"), (r) =>
+                Schema.decodeUnknownEffect(Schema.fromJsonString(PerformanceEvent))(r.value),
+              ),
+              records,
+              audits: yield* Effect.forEach(read("audit-%"), (r) =>
+                Schema.decodeUnknownEffect(Schema.fromJsonString(RequestAudit))(r.value),
+              ),
+              usage: yield* usage,
+              failure: yield* live.failure,
+              databaseBytes: ctx.storage.sql.databaseSize,
+            };
+          }).pipe(
+            Effect.provide(services),
+            Effect.mapError(() =>
+              EvaluationError.make({ stage: "evidence", message: "Performance snapshot failed" }),
+            ),
+          ),
+          close: Effect.gen(function* () {
+            state = { ...state, closed: true, usage: yield* usage };
+            persist();
+            yield* Effect.promise(() => ctx.storage.sync());
+            ctx.abort("performance fixture: close before resource deletion");
+          }),
+        });
+      }),
+    ).pipe(Layer.provide(host));
+  }),
+);
+
+export class PerformanceThread extends ThreadObject.make(application, {
+  namespaceBinding: "PERFORMANCE_THREADS",
+  deploymentId: "performance-cloudflare-v1",
+  producerPrefix: "performance-eval",
+  ownershipLeaseDuration: 2_000,
+  leaseRenewalInterval: 500,
+  alarmBackoffBase: 100,
+  alarmBackoffCap: 1_000,
+  maxQueueDepthPerLane: 1,
+  maxInputBytes: 2_048,
+  maxDatabaseBytes: 16 * 1024 * 1024,
+  runtimeFailpoint: (ctx) => (location) =>
+    Effect.suspend(() => callbacks.get(ctx)?.(location) ?? Effect.void),
+  storageFailpoint: (ctx) => (location) =>
+    Effect.suspend(() =>
+      location === "ledger:admit:before" ||
+      location === "ledger:admit:after" ||
+      location === "ledger:claim:after" ||
+      location === "append:before" ||
+      location === "append:after"
+        ? (callbacks.get(ctx)?.(location) ?? Effect.void)
+        : Effect.void,
+    ),
+}) {
+  prepare(phase: number) {
+    return this[DurableObject.RunSymbol](
+      Effect.flatMap(PerformanceHost, (host) => host.prepare(phase)),
+    );
+  }
+  snapshot() {
+    return this[DurableObject.RunSymbol](
+      Effect.flatMap(PerformanceHost, (host) => host.snapshot).pipe(
+        Effect.flatMap(Schema.encodeEffect(PerformanceSnapshot)),
+      ),
+    );
+  }
+  close() {
+    return this[DurableObject.RunSymbol](Effect.flatMap(PerformanceHost, (host) => host.close));
+  }
+}
+
+export default {
+  fetch(request: Request, env: Cloudflare.Env): Promise<Response> {
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        if (
+          !env.PERFORMANCE_TOKEN ||
+          request.headers.get("authorization") !== `Bearer ${env.PERFORMANCE_TOKEN}`
+        )
+          return new Response("Unauthorized", { status: 401 });
+        const identity = yield* identityFor(env);
+        const url = new URL(request.url);
+
+        if (url.pathname === "/identity") return Response.json(identity);
+
+        const sample = yield* Schema.decodeUnknownEffect(
+          Schema.FiniteFromString.check(
+            Schema.isBetween({ minimum: 0, maximum: 2 }),
+            Schema.isInt(),
+          ),
+        )(url.searchParams.get("sample"));
+
+        const samples = yield* Schema.decodeUnknownEffect(
+          Schema.FiniteFromString.check(
+            Schema.isBetween({ minimum: 1, maximum: 3 }),
+            Schema.isInt(),
+          ),
+        )(env.PERFORMANCE_SAMPLES);
+
+        if (sample >= samples)
+          return new Response("Sample outside deployment budget", { status: 400 });
+        const name = `performance-${env.PERFORMANCE_RUN}-${sample}`;
+        const stub = env.PERFORMANCE_THREADS.getByName(name);
+
+        const rpc = <A>(f: () => Promise<A>) =>
+          Effect.tryPromise({
+            try: f,
+            catch: () => EvaluationError.make({ stage: "host", message: "Performance RPC failed" }),
+          });
+
+        if (url.pathname === "/snapshot") return Response.json(yield* rpc(() => stub.snapshot()));
+        if (url.pathname === "/close" && request.method === "POST") {
+          // Native abort intentionally rejects its RPC; deletion is performed by the owner.
+          yield* rpc(() => stub.close()).pipe(Effect.ignore);
+
+          return Response.json({ closeRequested: true });
+        }
+        if (url.pathname !== "/submit" || request.method !== "POST")
+          return new Response("Not found", { status: 404 });
+
+        const input = yield* Schema.decodeUnknownEffect(Schema.Struct({ phase: PerformancePhase }))(
+          yield* rpc(() => request.json()),
+        );
+
+        yield* rpc(() => stub.prepare(input.phase));
+        const definitions = yield* digestDefinitions(performanceDefinitions(identity));
+
+        const receipt = yield* CloudflareThreadClient.use((client) =>
+          client.submit({ definition: performanceDefinition }, performanceMessage(input.phase), {
+            threadId: ThreadId.make(name),
+            principal: Principal.make("performance-eval"),
+            idempotencyKey: IdempotencyKey.make(`phase-${input.phase}`),
+            definitions,
+          }),
+        );
+
+        return Response.json(receipt);
+      }).pipe(
+        Effect.provide(
+          CloudflareThreadClient.layer.pipe(
+            Layer.provideMerge(
+              Layer.merge(
+                BrowserCrypto.layer,
+                ThreadObjectNamespace.layer(env.PERFORMANCE_THREADS),
+              ),
+            ),
+          ),
+        ),
+        Effect.scoped,
+        Effect.catch(() =>
+          Effect.succeed(new Response("Performance host failed", { status: 500 })),
+        ),
+      ),
+    );
+  },
+};

--- a/examples/context-continuity-eval/test/performance.test.ts
+++ b/examples/context-continuity-eval/test/performance.test.ts
@@ -5,7 +5,7 @@ import { Effect, Exit, FileSystem, Layer, Redacted, Schema } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { build } from "esbuild";
 import { convertV4MiniflareOptions, Miniflare } from "miniflare";
-import { expect, it } from "vite-plus/test";
+import { expect, expectTypeOf, it } from "vite-plus/test";
 
 import { EvaluationError } from "../src/contracts.ts";
 import {
@@ -15,6 +15,7 @@ import {
 } from "../src/performance-contracts.ts";
 import {
   PerformanceDeployment,
+  PerformanceOwnership,
   withPerformanceDeployment,
   type PerformanceTarget,
 } from "../src/performance-deployment.ts";
@@ -26,12 +27,14 @@ import {
 
 it.each([
   "success",
+  "ownership-save-failure",
   "upload-failure",
   "flow-failure",
   "defect",
   "interruption",
   "timeout",
   "cleanup-failure",
+  "cleanup-save-failure",
 ] as const)("owns disposable cleanup through %s", async (mode) => {
   const actions: Array<string> = [];
 
@@ -47,26 +50,41 @@ it.each([
 
   const fail = EvaluationError.make({ stage: "test", message: "expected" });
 
+  const deployment = withPerformanceDeployment(
+    target,
+    mode === "flow-failure"
+      ? Effect.fail(fail)
+      : mode === "defect"
+        ? Effect.die("fixture defect")
+        : mode === "interruption"
+          ? Effect.interrupt
+          : mode === "timeout"
+            ? Effect.never.pipe(
+                Effect.timeout("1 millis"),
+                Effect.mapError(() => fail),
+              )
+            : Effect.void,
+  );
+
+  expectTypeOf<Effect.Services<typeof deployment>>().toEqualTypeOf<
+    PerformanceDeployment | PerformanceOwnership
+  >();
+  expectTypeOf<Effect.Error<typeof deployment>>().toEqualTypeOf<EvaluationError>();
+
   const exit = await Effect.runPromise(
-    withPerformanceDeployment(
-      target,
-      (saved) =>
-        Effect.sync(() => {
-          actions.push(saved.cleanupComplete ? "cleaned" : "owned");
-        }),
-      mode === "flow-failure"
-        ? Effect.fail(fail)
-        : mode === "defect"
-          ? Effect.die("fixture defect")
-          : mode === "interruption"
-            ? Effect.interrupt
-            : mode === "timeout"
-              ? Effect.never.pipe(
-                  Effect.timeout("1 millis"),
-                  Effect.mapError(() => fail),
-                )
-              : Effect.void,
-    ).pipe(
+    deployment.pipe(
+      Effect.provideService(PerformanceOwnership, {
+        saveTarget: (saved) =>
+          Effect.sync(() => {
+            actions.push(saved.cleanupComplete ? "save-cleanup" : "save-ownership");
+          }).pipe(
+            Effect.andThen(
+              mode === (saved.cleanupComplete ? "cleanup-save-failure" : "ownership-save-failure")
+                ? Effect.fail(fail)
+                : Effect.void,
+            ),
+          ),
+      }),
       Effect.provideService(PerformanceDeployment, {
         exists: () => Effect.succeed(false),
         deploy: () =>
@@ -83,9 +101,11 @@ it.each([
   );
 
   expect(actions).toEqual(
-    mode === "cleanup-failure"
-      ? ["owned", "deploy", "remove"]
-      : ["owned", "deploy", "remove", "cleaned"],
+    mode === "ownership-save-failure"
+      ? ["save-ownership"]
+      : mode === "cleanup-failure"
+        ? ["save-ownership", "deploy", "remove"]
+        : ["save-ownership", "deploy", "remove", "save-cleanup"],
   );
   expect(Exit.isSuccess(exit)).toBe(mode === "success");
 });
@@ -104,7 +124,13 @@ it("refuses existing Workers without deployment or deletion", async () => {
   };
 
   const exit = await Effect.runPromise(
-    withPerformanceDeployment(target, () => Effect.void, Effect.void).pipe(
+    withPerformanceDeployment(target, Effect.void).pipe(
+      Effect.provideService(PerformanceOwnership, {
+        saveTarget: () =>
+          Effect.sync(() => {
+            actions.push("save");
+          }),
+      }),
       Effect.provideService(PerformanceDeployment, {
         exists: () => Effect.succeed(true),
         deploy: () =>

--- a/examples/context-continuity-eval/test/performance.test.ts
+++ b/examples/context-continuity-eval/test/performance.test.ts
@@ -1,0 +1,439 @@
+import { fileURLToPath } from "node:url";
+
+import { NodeServices } from "@effect/platform-node";
+import { Effect, Exit, FileSystem, Layer, Redacted, Schema } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { build } from "esbuild";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
+import { expect, it } from "vite-plus/test";
+
+import { EvaluationError } from "../src/contracts.ts";
+import {
+  PerformanceIdentity,
+  PerformanceSnapshot,
+  expectedPerformanceOutput,
+} from "../src/performance-contracts.ts";
+import {
+  PerformanceDeployment,
+  withPerformanceDeployment,
+  type PerformanceTarget,
+} from "../src/performance-deployment.ts";
+import {
+  gradePerformancePhase,
+  performanceTiming,
+  runPerformanceSample,
+} from "../src/performance-evaluate.ts";
+
+it.each([
+  "success",
+  "upload-failure",
+  "flow-failure",
+  "defect",
+  "interruption",
+  "timeout",
+  "cleanup-failure",
+] as const)("owns disposable cleanup through %s", async (mode) => {
+  const actions: Array<string> = [];
+
+  const target: typeof PerformanceTarget.Type = {
+    label: "candidate",
+    name: `effect-agent-perf-${"a".repeat(32)}-candidate`,
+    url: "https://example.test",
+    directory: "/unused",
+    sourceCommit: "a".repeat(40),
+    cleanupRequired: false,
+    cleanupComplete: false,
+  };
+
+  const fail = EvaluationError.make({ stage: "test", message: "expected" });
+
+  const exit = await Effect.runPromise(
+    withPerformanceDeployment(
+      target,
+      (saved) =>
+        Effect.sync(() => {
+          actions.push(saved.cleanupComplete ? "cleaned" : "owned");
+        }),
+      mode === "flow-failure"
+        ? Effect.fail(fail)
+        : mode === "defect"
+          ? Effect.die("fixture defect")
+          : mode === "interruption"
+            ? Effect.interrupt
+            : mode === "timeout"
+              ? Effect.never.pipe(
+                  Effect.timeout("1 millis"),
+                  Effect.mapError(() => fail),
+                )
+              : Effect.void,
+    ).pipe(
+      Effect.provideService(PerformanceDeployment, {
+        exists: () => Effect.succeed(false),
+        deploy: () =>
+          Effect.sync(() => actions.push("deploy")).pipe(
+            Effect.andThen(mode === "upload-failure" ? Effect.fail(fail) : Effect.void),
+          ),
+        remove: () =>
+          Effect.sync(() => actions.push("remove")).pipe(
+            Effect.andThen(mode === "cleanup-failure" ? Effect.fail(fail) : Effect.void),
+          ),
+      }),
+      Effect.exit,
+    ),
+  );
+
+  expect(actions).toEqual(
+    mode === "cleanup-failure"
+      ? ["owned", "deploy", "remove"]
+      : ["owned", "deploy", "remove", "cleaned"],
+  );
+  expect(Exit.isSuccess(exit)).toBe(mode === "success");
+});
+
+it("refuses existing Workers without deployment or deletion", async () => {
+  const actions: Array<string> = [];
+
+  const target: typeof PerformanceTarget.Type = {
+    label: "candidate",
+    name: `effect-agent-perf-${"a".repeat(32)}-candidate`,
+    url: "https://example.test",
+    directory: "/unused",
+    sourceCommit: "a".repeat(40),
+    cleanupRequired: false,
+    cleanupComplete: false,
+  };
+
+  const exit = await Effect.runPromise(
+    withPerformanceDeployment(target, () => Effect.void, Effect.void).pipe(
+      Effect.provideService(PerformanceDeployment, {
+        exists: () => Effect.succeed(true),
+        deploy: () =>
+          Effect.sync(() => {
+            actions.push("deploy");
+          }),
+        remove: () =>
+          Effect.sync(() => {
+            actions.push("remove");
+          }),
+      }),
+      Effect.exit,
+    ),
+  );
+
+  expect(Exit.isFailure(exit)).toBe(true);
+  expect(actions).toEqual([]);
+});
+
+/** Offline transport fixture only; this does not constitute deployed/live evidence. */
+it("verifies tool consumption, fresh/warm/recovery, exact identity, timing and finalizers through workerd", async () => {
+  const bundled = await build({
+    entryPoints: [fileURLToPath(new URL("../src/performance-worker.ts", import.meta.url).href)],
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    external: ["cloudflare:*", "node:*"],
+    conditions: ["workerd", "worker", "browser"],
+    define: {
+      PERFORMANCE_SOURCE_COMMIT: JSON.stringify("a".repeat(40)),
+      PERFORMANCE_DIRTY: "false",
+      PERFORMANCE_FIXTURE_DIGEST: JSON.stringify("fixture-test"),
+    },
+  });
+
+  const script = bundled.outputFiles[0]?.text;
+
+  if (script === undefined) throw new Error("No bundle");
+  let countedInput = 0;
+  const calls = new Map<number, number>();
+
+  const runtime = new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script,
+      modulesRoot: "/",
+      compatibilityDate: "2026-08-01",
+      compatibilityFlags: ["nodejs_compat"],
+      durableObjects: { PERFORMANCE_THREADS: { className: "PerformanceThread", useSQLite: true } },
+      bindings: {
+        PERFORMANCE_TOKEN: "test-token",
+        OPENAI_API_KEY: "test-only",
+        PERFORMANCE_MODEL: "gpt-6-astra",
+        PERFORMANCE_RUN: "offline",
+        PERFORMANCE_SAMPLES: "1",
+        PERFORMANCE_VERSION: { id: "offline-only" },
+      },
+      outboundService: async (request) => {
+        const json = await request.text();
+
+        if (new URL(request.url).hostname !== "api.openai.com")
+          throw new Error("Unexpected outbound host");
+        if (request.url.endsWith("/input_tokens")) {
+          countedInput = Math.ceil(json.length / 4);
+
+          return Response.json({ object: "response.input_tokens", input_tokens: countedInput });
+        }
+
+        const phase = Math.max(
+          ...[...json.matchAll(/Order update (\d+)/g)].map((match) => Number(match[1])),
+        );
+
+        const ordinal = calls.get(phase) ?? 0;
+
+        calls.set(phase, ordinal + 1);
+        const text = JSON.stringify(expectedPerformanceOutput(phase));
+
+        const output =
+          ordinal === 0
+            ? ["read_price", "read_stock"].map((name, index) => ({
+                type: "function_call",
+                id: `fc_${phase}_${index}`,
+                call_id: `call_${phase}_${index}`,
+                name,
+                arguments: JSON.stringify({ sku: "lamp" }),
+                status: "completed",
+              }))
+            : [
+                {
+                  type: "message",
+                  id: `msg_${phase}`,
+                  role: "assistant",
+                  status: "completed",
+                  content: [{ type: "output_text", text, annotations: [] }],
+                },
+              ];
+
+        const events = output.flatMap((item, output_index) => [
+          { type: "response.output_item.added", output_index, item },
+          ...(item.type === "function_call"
+            ? [
+                {
+                  type: "response.function_call_arguments.delta",
+                  output_index,
+                  item_id: item.id,
+                  delta: JSON.stringify({ sku: "lamp" }),
+                },
+                {
+                  type: "response.function_call_arguments.done",
+                  output_index,
+                  item_id: item.id,
+                  arguments: JSON.stringify({ sku: "lamp" }),
+                },
+              ]
+            : [
+                {
+                  type: "response.output_text.delta",
+                  output_index,
+                  item_id: item.id,
+                  content_index: 0,
+                  delta: text,
+                },
+              ]),
+          { type: "response.output_item.done", output_index, item },
+        ]);
+
+        return new Response(
+          [
+            ...events,
+            {
+              type: "response.completed",
+              response: {
+                id: `resp_${phase}_${ordinal}`,
+                object: "response",
+                model: "gpt-6-astra",
+                created_at: 1,
+                status: "completed",
+                service_tier: "default",
+                output,
+                usage: {
+                  input_tokens: countedInput,
+                  output_tokens: 100,
+                  total_tokens: countedInput + 100,
+                  input_tokens_details: { cached_tokens: 0 },
+                  output_tokens_details: { reasoning_tokens: 0 },
+                },
+              },
+            },
+          ]
+            .map(
+              (event, sequence_number) =>
+                `data: ${JSON.stringify({ ...event, sequence_number })}\n\n`,
+            )
+            .join(""),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+    }),
+  );
+
+  try {
+    expect((await runtime.dispatchFetch("https://eval.test/identity")).status).toBe(401);
+
+    const localFetch: typeof globalThis.fetch = async (input, init) => {
+      const request = new Request(input, init);
+
+      const response = await runtime.dispatchFetch(request.url, {
+        method: request.method,
+        headers: Object.fromEntries(request.headers),
+        ...(request.method === "POST" ? { body: await request.text() } : {}),
+      });
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: Object.fromEntries(response.headers),
+      });
+    };
+
+    const identity = Schema.decodeUnknownSync(PerformanceIdentity)(
+      await (
+        await localFetch("https://eval.test/identity", {
+          headers: { authorization: "Bearer test-token" },
+        })
+      ).json(),
+    );
+
+    const evidence = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const outputDirectory = yield* fs.makeTempDirectoryScoped({ prefix: "performance-test-" });
+
+        const result = yield* runPerformanceSample({
+          url: "https://eval.test",
+          token: Redacted.make("test-token"),
+          identity,
+          target: "offline-scripted",
+          sample: 0,
+          outputDirectory,
+        });
+
+        const snapshots = yield* Effect.forEach([0, 1, 2], (phase) =>
+          fs
+            .readFileString(`${outputDirectory}/phase-${phase}-snapshot.json`)
+            .pipe(
+              Effect.flatMap(
+                Schema.decodeUnknownEffect(Schema.fromJsonString(PerformanceSnapshot)),
+              ),
+            ),
+        );
+
+        return { result, snapshots };
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            FetchHttpClient.layer.pipe(
+              Layer.provide(Layer.succeed(FetchHttpClient.Fetch, localFetch)),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(evidence.result.failure).toBeNull();
+    expect(evidence.result.phases.flatMap((phase) => phase.failures)).toEqual([]);
+    expect(evidence.result.passed).toBe(true);
+    expect(evidence.result.closeRequested).toBe(true);
+    expect([...calls.values()]).toEqual([2, 2, 2]);
+    const final = evidence.snapshots[2];
+
+    if (final === undefined) throw new Error("Missing final evidence");
+
+    const settlement = final.records.findLast(
+      ({ record }) => record.payload._tag === "SubmissionSettled",
+    )?.record.payload;
+
+    if (settlement?._tag !== "SubmissionSettled") throw new Error("Missing settlement");
+
+    const rejected = await Effect.runPromise(
+      gradePerformancePhase(
+        {
+          ...final,
+          audits: final.audits.filter((audit) => audit.phase !== 2),
+          records: final.records.map((envelope) =>
+            envelope.record.payload._tag === "ToolCallSettled"
+              ? {
+                  ...envelope,
+                  record: {
+                    ...envelope.record,
+                    payload: { ...envelope.record.payload, result: {} },
+                  },
+                }
+              : envelope,
+          ),
+        },
+        2,
+        { submissionId: settlement.submissionId },
+        evidence.snapshots[1]?.incarnation ?? 0,
+      ),
+    );
+
+    expect(rejected.passed).toBe(false);
+    expect(rejected.failures).toContain("Canonical read_price payload differs from the fixture");
+    expect(rejected.failures).toContain("Canonical read_stock payload differs from the fixture");
+    expect(rejected.failures).toContain(
+      "Subsequent real provider request must consume both current tool results",
+    );
+
+    const firstRequest = final.audits.find(
+      (audit) => audit.phase === 2 && audit.kind === "request",
+    );
+
+    const missingHistory = await Effect.runPromise(
+      gradePerformancePhase(
+        {
+          ...final,
+          audits: final.audits.map((audit) => {
+            if (audit !== firstRequest) return audit;
+
+            const request = Schema.decodeUnknownSync(
+              Schema.fromJsonString(
+                Schema.Struct({ input: Schema.Array(Schema.Record(Schema.String, Schema.Json)) }),
+              ),
+            )(audit.json);
+
+            return {
+              ...audit,
+              json: JSON.stringify({
+                ...request,
+                input: request.input.filter((part) => part.role !== "assistant"),
+              }),
+            };
+          }),
+        },
+        2,
+        { submissionId: settlement.submissionId },
+        evidence.snapshots[1]?.incarnation ?? 0,
+      ),
+    );
+
+    expect(missingHistory.passed).toBe(false);
+    expect(missingHistory.failures).toContain(
+      "Initial provider request must retain the previous canonical assistant order output",
+    );
+    expect(final.incarnation).toBeGreaterThan(evidence.snapshots[1]?.incarnation ?? 0);
+    expect(final.events.filter((event) => event.kind === "provider-http-dispatch")).toHaveLength(6);
+    expect(performanceTiming({ ...final, events: [] }, 0).toolResultsCommitMillis).toBeNull();
+
+    const firstDispatch = final.events.find(
+      (event) => event.phase === 0 && event.kind === "provider-http-dispatch",
+    );
+
+    const withoutFirstDelta = {
+      ...final,
+      events: final.events.filter(
+        (event) =>
+          !(
+            event.kind === "first-provider-delta" &&
+            event.request === firstDispatch?.request &&
+            event.incarnation === firstDispatch?.incarnation
+          ),
+      ),
+    };
+
+    expect(performanceTiming(withoutFirstDelta, 0).providerDispatchToFirstDeltaMillis).toBeNull();
+  } finally {
+    await runtime.dispose();
+  }
+}, 45_000);

--- a/examples/context-continuity-eval/test/types.test.ts
+++ b/examples/context-continuity-eval/test/types.test.ts
@@ -15,6 +15,11 @@ import { expectTypeOf, it } from "vite-plus/test";
 import { cloudflareDefinition, cloudflareModelSettings } from "../src/cloudflare-contracts.ts";
 import { notesNamespace } from "../src/host-evidence.ts";
 import { makeLiveClient } from "../src/live-model.ts";
+import {
+  performanceDefinition,
+  performanceSettings,
+  performanceToolkit,
+} from "../src/performance-contracts.ts";
 import { manifestLayer } from "../src/pressure.ts";
 import type { RequestAuditSink } from "../src/request-audit.ts";
 
@@ -71,4 +76,28 @@ it("preserves native model, history and durable note requirements in the pressur
     OpenAiClient.OpenAiClient | RequestAuditSink
   >();
   expectTypeOf<Effect.Error<typeof client>>().toEqualTypeOf<never>();
+});
+
+it("preserves the performance fixture's native model and runtime requirements", () => {
+  const run = AgentRuntime.run(
+    Agent.withModel(
+      performanceDefinition,
+      OpenAiLanguageModel.model("gpt-6-astra", performanceSettings),
+    ),
+    "quote",
+  ).pipe(
+    Effect.provide(
+      performanceToolkit.toLayer({
+        read_price: () => Effect.succeed({ unitPriceCents: 1, evidence: "price" }),
+        read_stock: () => Effect.succeed({ availableUnits: 1, evidence: "stock" }),
+      }),
+    ),
+  );
+
+  expectTypeOf<Effect.Services<typeof run>>().toEqualTypeOf<
+    OpenAiClient.OpenAiClient | IdGenerator | ThreadHistory
+  >();
+  expectTypeOf<Effect.Error<typeof run>>().toEqualTypeOf<
+    AgentRuntime.AgentRuntimeFailure<typeof performanceDefinition>
+  >();
 });

--- a/examples/demo/src/demo/general-chat.ts
+++ b/examples/demo/src/demo/general-chat.ts
@@ -208,11 +208,10 @@ export const FixtureChatDefinition = Agent.make("general-chat-fixture", {
   output: ChatOutput,
   instructions: GeneralChatInstructions,
   toolkit: FixtureChatToolkit,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 2,
     maxToolCalls: 2,
     maxDuration: "30 seconds",
-    toolConcurrency: 1,
   }),
   description: "General chat with deterministic offline application tools.",
   metadata: {

--- a/examples/demo/src/demo/openai-profile.ts
+++ b/examples/demo/src/demo/openai-profile.ts
@@ -44,11 +44,10 @@ export const OpenAiChatDefinition = Agent.make("general-chat-openai", {
   output: ChatOutput,
   instructions: GeneralChatInstructions,
   toolkit: OpenAiChatToolkit,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 4,
     maxToolCalls: 6,
     maxDuration: "45 seconds",
-    toolConcurrency: 1,
   }),
   description: "General chat with real arithmetic and OpenAI-hosted web research.",
   metadata: {

--- a/examples/demo/src/demo/run-activity.test.ts
+++ b/examples/demo/src/demo/run-activity.test.ts
@@ -56,7 +56,7 @@ describe("run activity projection", () => {
     ).toEqual({
       phase: "composing",
       label: "Writing the response…",
-      detail: "Assistant text stream",
+      detail: "5 response characters received",
     });
   });
 

--- a/examples/demo/src/demo/run-activity.ts
+++ b/examples/demo/src/demo/run-activity.ts
@@ -93,6 +93,7 @@ export const projectRunActivity = (
   };
 
   let hasToolResult = false;
+  let responseCharacters = 0;
   const tools = new Map<string, ToolActivity>();
 
   for (const event of events) {
@@ -107,6 +108,7 @@ export const projectRunActivity = (
       }
       case "TurnStarted":
       case "ModelStarted": {
+        responseCharacters = 0;
         activity = hasToolResult
           ? {
               phase: "composing",
@@ -129,10 +131,11 @@ export const projectRunActivity = (
         break;
       }
       case "TextDelta": {
+        responseCharacters += event.text.length;
         activity = {
           phase: "composing",
           label: "Writing the response…",
-          detail: "Assistant text stream",
+          detail: `${responseCharacters.toLocaleString("en-US")} response characters received`,
         };
         break;
       }

--- a/examples/providers/src/history.ts
+++ b/examples/providers/src/history.ts
@@ -21,11 +21,10 @@ const definition = Agent.make("history-example", {
   output: Schema.String,
   instructions: "Answer using the thread history.",
   toolkit: Toolkit.empty,
-  policy: AgentPolicy.make({
+  policy: AgentPolicy.resolve({
     maxTurns: 2,
     maxToolCalls: 1,
     maxDuration: "30 seconds",
-    toolConcurrency: 1,
   }),
 });
 

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -1,0 +1,109 @@
+# Scripted runtime benchmark
+
+This leaf consumer measures public production packages with deterministic Effect AI responses.
+It makes no provider requests. Correctness assertions fail the command; latency changes are
+informational until CI variance supports workload-specific relative and absolute thresholds.
+
+Run from the repository root with Node 24 and the repository's Bun/Vite+ toolchain. Prepare three
+checkouts, install each checkout's own lockfile, and build before measuring:
+
+```sh
+git worktree add --detach /tmp/effect-agent-base <exact-base-sha>
+git worktree add --detach /tmp/effect-agent-reference 596cffba70716b1211ac02de949c4d0f31734b2f
+vp install --frozen-lockfile
+vp run -F './packages/*' build
+cd /tmp/effect-agent-base
+vp install --frozen-lockfile
+vp run -F './packages/*' build
+rm -f test/fixtures/checkpoints.d.ts test/fixtures/storage-upgrade.d.ts test/fixtures/storage-v2.d.ts
+cd /tmp/effect-agent-reference
+vp install --frozen-lockfile
+vp run -F './packages/*' build
+rm -f test/fixtures/checkpoints.d.ts test/fixtures/storage-upgrade.d.ts test/fixtures/storage-v2.d.ts
+cd <candidate-checkout>
+vp run perf:compare --base-dir /tmp/effect-agent-base --reference-dir /tmp/effect-agent-reference --profile pr --out-dir /tmp/performance-001
+```
+
+Use `--require-clean` for exact-commit evidence. A local dirty checkout is labeled in the report;
+its measurements do not validate the committed SHA. Each output directory preserves one attempt
+and cannot replace an existing report. Do not run builds, tests, or other benchmarks during a
+measurement. `perf:compare` always bypasses task caching. `--help` describes the public arguments.
+The cleanup lines remove only declaration artifacts emitted by older package builds in those
+disposable checkouts. Every other modified or untracked file fails clean-checkout validation.
+
+The PR workflow uses exact PR base/head commits, an immutable release reference, Node 24.20.0,
+and sequential production builds. It runs three rotating cohorts (base/head/reference,
+head/reference/base, reference/base/head). Each warm cohort has two warmups and three measured
+samples per case: nine measured samples per revision. Workload order reverses between samples.
+All warmups, measured samples, slow values, and failures remain in JSON artifacts. The trusted
+comment workflow validates artifact data and current PR identity without executing candidate code.
+
+`--profile smoke` exercises every workload family with one sample and 16 retained records;
+it checks the command, not statistical confidence. `extended` takes 30 samples per revision and
+adds 8,192 records. `archive` adds 100,000 records with nine measured samples. Larger profiles
+are manual workflow-dispatch options and can take substantial time. Individual samples are bounded
+to three minutes; PR child processes to five minutes and the PR job to 30 minutes. Timeouts retain
+partial evidence and fail correctness. No scheduled or paid execution is configured here.
+
+| Case                      | Completed work and timing boundary                                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Small run/stream          | One validated final answer and exactly one model invocation; warm operation begins after application Layer acquisition.                                                                                                                                                                                                                                   |
+| Fragmentation             | Exactly 65,536 JSON response bytes in 1/64/1,024/4,096 deltas. Stream delivery must reproduce every chunk and the final answer. All four sizes run on PRs.                                                                                                                                                                                                |
+| Prompt history            | A small answer with 64 KiB or 1 MiB of prior text. History creation occurs before timing.                                                                                                                                                                                                                                                                 |
+| Parallel tools and rounds | Eight 2 ms tools per round, concurrency four, one or four rounds. Subsequent normalized provider requests must contain every successful result. Actual overlap, call bounds, and finalizers are checked.                                                                                                                                                  |
+| Fresh durable submission  | A new Submission after 0/256/2,048 retained canonical records in a file-backed SQLite database. Each sample creates its own database; setup/seeding is excluded. Timing includes reopening the full Node durable runtime, admission, execution, and settlement.                                                                                           |
+| Checkpoint recovery       | Persist a native rollover checkpoint, inject the public after-save fault, close the runtime, and reopen the same file. Measure resuming that same Submission separately from fresh submission. One completed tool must not run again; the resumed answer must be canonical.                                                                               |
+| Settled ledger            | Seed settled adapter rows in a separate lane without growing canonical history. Measure reopening the Node runtime, fresh admission, a full public nonterminal scan, execution, and settlement. The scan must return only the new Submission. Synthetic ledger seeding is an adapter fixture, not evidence of a production canonical settlement protocol. |
+
+Retained-history seeds contain ThreadCreated followed by complete input/model/completion triples
+matching the immediate PersistentHistory format, with shared Run identities and schema-encoded
+user/assistant message suffixes. At most two RepairAnnotated records pad the requested exact
+record count. These are adapter fixtures of completed retained Runs, with no outstanding seed
+Submissions. The provider callback must receive every seeded question and answer before fresh
+inference; checkpoint resume must receive the handoff without retired history. The separate
+64 KiB/1 MiB prompt cases assert their exact history text at the same callback. Each measured
+durable completion must have one new canonical RunCompleted with the exact output and retain
+the entire original archive. Seed writes use the adapters' normal public
+operations and existing failpoints. The benchmark introduces no persisted format or migration.
+SQLite uses the production Node assembly and its default scheduling, lease, and durability
+configuration; checkpoint cases additionally install the documented host rollover preparation.
+Database teardown and evidence reads are outside the warm-operation interval.
+
+`modelEntryMs` ends inside `ScriptedModel.assertRequest`, where Effect AI invokes the actual
+normalized provider callback. It does not use ModelStarted events. `totalMs` ends after run/stream
+completion or durable settlement; it includes the operation's correctness checks where those
+checks are inline. Every sample uses a new finite script, verifies exhaustion, and counts model
+stream finalizers. The first recovery attempt is verified before its counters are reset.
+`checkpointCreationMs` separately measures native checkpoint construction and persistence from
+`compaction:after-canonical-append` through `checkpoint:after-save`, before injecting the fault.
+It includes checkpoint scans/encoding/save but excludes the already committed compaction append
+and is never added to the later recovery interval. Raw samples include observed retained prompt
+message counts. Incomplete or mismatched-runtime batches are explicitly reported and excluded
+from comparison summaries.
+
+Cold measurements launch a separate Node process for one small run. Their wall time includes
+Node startup, all fixture imports (including the durable fixture), one run, assertions, and process
+shutdown. These are labeled subprocess totals, not isolated import latency or a minimal SDK
+startup claim. Warm cohorts live in separate long-running child processes.
+
+The fixture is transpiled once without bundling, then identical JavaScript bytes are copied to
+all three stages. Framework stages contain only public `dist` artifacts and npm-ready manifests;
+they cannot resolve framework TypeScript source. External dependencies come from each revision's
+own installation. Reports identify exact commits, dirty state, lockfile hashes, built artifact
+hashes, fixture hash/version, runtime, operating system, CPU, memory, sample counts, median,
+interquartile range, and process failures. The artifact includes the exact transpiled fixture.
+
+The retained reference is `audit-beta67-node24-v1`, commit
+`596cffba70716b1211ac02de949c4d0f31734b2f`. It is rebuilt and rerun on the same machine as each
+candidate to expose gradual drift. Historical stopwatch numbers are never used as the baseline.
+To reset it, change the version and immutable SHA in `src/contracts.ts`, both workflow validators,
+and this guide together; explain the release selection and fixture/runtime change in the PR.
+Keep the previous artifacts. Incompatible historical APIs must fail clearly rather than silently
+substituting source code or skipping cases. A new fixture changes the measurement definition and
+requires a version bump; report environment changes before interpreting across-run trends.
+
+Read the full spread and raw samples before drawing a conclusion. Re-run a suspected regression
+with another matched cohort. Small-sample p95, local source timings, or differing provider workloads
+do not establish an SLO, Cloudflare CPU billing, or a competitive ranking. Deterministic engine
+and adapter work-budget tests remain the PR regression gates; timing evidence complements them.
+Fairness and lock contention need dedicated controlled load cases when those host changes land.

--- a/examples/runtime-benchmark/package.json
+++ b/examples/runtime-benchmark/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@effect-agent/example-runtime-benchmark",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit -p tsconfig.json",
+    "test": "vp test"
+  },
+  "dependencies": {
+    "@effect-agent/core": "workspace:*",
+    "@effect-agent/engine": "workspace:*",
+    "@effect-agent/platform-node": "workspace:*",
+    "@effect-agent/testing": "workspace:*",
+    "@effect-agent/thread": "workspace:*",
+    "@effect/platform-node": "catalog:",
+    "effect": "catalog:",
+    "effect-agent": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/runtime-benchmark/src/contracts.ts
+++ b/examples/runtime-benchmark/src/contracts.ts
@@ -1,0 +1,160 @@
+import { Effect, Schema } from "effect";
+
+export const FIXTURE_VERSION = "runtime-v1";
+
+export const REFERENCE = {
+  version: "audit-beta67-node24-v1",
+  revision: "596cffba70716b1211ac02de949c4d0f31734b2f",
+} as const;
+
+export class BenchmarkError extends Schema.TaggedError<BenchmarkError>()("BenchmarkError", {
+  message: Schema.String,
+  cause: Schema.optionalKey(Schema.Defect()),
+}) {}
+
+export const check = Effect.fn("benchmark.check")(function* (condition: boolean, message: string) {
+  if (!condition) return yield* BenchmarkError.make({ message });
+});
+
+export const Profile = Schema.Literals(["smoke", "pr", "extended", "archive"]);
+export type Profile = typeof Profile.Type;
+
+export const Case = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.Literals(["run", "stream", "tools", "durable", "recovery", "ledger"]),
+  chunks: Schema.Natural,
+  outputBytes: Schema.Natural,
+  historyBytes: Schema.Natural,
+  records: Schema.Natural,
+  rounds: Schema.Natural,
+});
+
+export type Case = typeof Case.Type;
+
+const workload = (
+  name: string,
+  kind: Case["kind"],
+  options: Partial<Omit<Case, "name" | "kind">> = {},
+): Case => ({
+  name,
+  kind,
+  chunks: 1,
+  outputBytes: 0,
+  historyBytes: 0,
+  records: 0,
+  rounds: 0,
+  ...options,
+});
+
+/** Profile sizes are fixed fixture inputs, never derived from the measured revision. */
+export const casesFor = (profile: Profile): ReadonlyArray<Case> => [
+  workload("small-run", "run"),
+  workload("small-stream", "stream"),
+  ...[1, 64, 1_024, 4_096].map((chunks) =>
+    workload(`stream-64k-${chunks}`, "stream", { chunks, outputBytes: 65_536 }),
+  ),
+  ...[65_536, 1_048_576].map((historyBytes) =>
+    workload(`history-${historyBytes}`, "run", { historyBytes }),
+  ),
+  workload("parallel-tools-8", "tools", { rounds: 1 }),
+  workload("tool-rounds-4", "tools", { rounds: 4 }),
+  ...[
+    0,
+    ...(profile === "smoke" ? [16] : [256, 2_048]),
+    ...(profile === "extended" || profile === "archive" ? [8_192] : []),
+    ...(profile === "archive" ? [100_000] : []),
+  ].flatMap((records) => [
+    workload(`durable-fresh-${records}`, "durable", { records }),
+    workload(`checkpoint-recovery-${records}`, "recovery", { records }),
+    workload(`settled-ledger-${records}`, "ledger", { records }),
+  ]),
+];
+
+export const WorkerOptions = Schema.Struct({
+  cold: Schema.Boolean,
+  profile: Profile,
+  warmups: Schema.Natural.check(Schema.isLessThanOrEqualTo(20)),
+  samples: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 100 })),
+  output: Schema.String,
+});
+
+export const Sample = Schema.Struct({
+  case: Schema.String,
+  ordinal: Schema.Natural,
+  warmup: Schema.Boolean,
+  totalMs: Schema.Finite,
+  modelEntryMs: Schema.NullOr(Schema.Finite),
+  checkpointCreationMs: Schema.NullOr(Schema.Finite),
+  retainedPromptMessages: Schema.Natural,
+  modelCalls: Schema.Natural,
+  finalizers: Schema.Natural,
+  toolCalls: Schema.Natural,
+  outputBytes: Schema.Natural,
+  status: Schema.Literals(["passed", "failed"]),
+  failure: Schema.NullOr(Schema.String),
+});
+
+export type Sample = typeof Sample.Type;
+
+export const WorkerReport = Schema.Struct({
+  fixture: Schema.Literal(FIXTURE_VERSION),
+  profile: Profile,
+  runtime: Schema.String,
+  platform: Schema.String,
+  architecture: Schema.String,
+  samples: Schema.Array(Sample),
+});
+
+export type WorkerReport = typeof WorkerReport.Type;
+
+export const completeBatch = (
+  report: WorkerReport,
+  options: typeof WorkerOptions.Type,
+): boolean => {
+  const workloads = options.cold
+    ? casesFor(options.profile).slice(0, 1)
+    : casesFor(options.profile);
+
+  const expected = new Set(
+    workloads.flatMap((workload) =>
+      Array.from(
+        { length: options.warmups + options.samples },
+        (_, ordinal) => `${workload.name}:${ordinal}`,
+      ),
+    ),
+  );
+
+  if (report.profile !== options.profile || report.samples.length !== expected.size) return false;
+
+  return report.samples.every(
+    (sample) =>
+      expected.delete(`${sample.case}:${sample.ordinal}`) &&
+      sample.warmup === sample.ordinal < options.warmups &&
+      sample.status === "passed" &&
+      sample.totalMs >= 0 &&
+      sample.modelEntryMs !== null &&
+      sample.modelEntryMs >= 0 &&
+      sample.modelEntryMs <= sample.totalMs &&
+      sample.modelCalls === sample.finalizers,
+  );
+};
+
+export const summary = (values: ReadonlyArray<number>) => {
+  const sorted = [...values].sort((a, b) => a - b);
+
+  const quantile = (p: number) => {
+    const index = (sorted.length - 1) * p;
+    const lower = sorted[Math.floor(index)] ?? 0;
+
+    return lower + ((sorted[Math.ceil(index)] ?? lower) - lower) * (index % 1);
+  };
+
+  return {
+    count: sorted.length,
+    median: quantile(0.5),
+    q1: quantile(0.25),
+    q3: quantile(0.75),
+    min: sorted[0] ?? 0,
+    max: sorted.at(-1) ?? 0,
+  };
+};

--- a/examples/runtime-benchmark/src/fixture.ts
+++ b/examples/runtime-benchmark/src/fixture.ts
@@ -1,0 +1,700 @@
+import { AgentId, RunId, ThreadId } from "@effect-agent/core/Identifiers";
+import { ContextCompactor } from "@effect-agent/engine/ContextCompactor";
+import { RunContextPreparation } from "@effect-agent/engine/RunOptions";
+import { NodeDurableAgentRuntime } from "@effect-agent/platform-node/NodeDurableAgentRuntime";
+import {
+  ScriptedModel,
+  type ScriptedTurnInput,
+  type ScriptedStreamPart,
+} from "@effect-agent/testing/ScriptedModel";
+import { digestJson } from "@effect-agent/thread/Digest";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeFailpointError } from "@effect-agent/thread/DurableFailpoint";
+import {
+  BatchId,
+  CanonicalBatch,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ModelCompleted,
+  PersistedJson,
+  ProducerEpoch,
+  ProducerId,
+  RecordEnvelope,
+  RecordId,
+  RepairAnnotated,
+  RunCompleted,
+  SubmissionSettled,
+  SubmissionSettledRecord,
+  ThreadCreated,
+  UserInputRecorded,
+} from "@effect-agent/thread/Records";
+import { runIdForSubmission } from "@effect-agent/thread/RunJournal";
+import {
+  AdmissionRequest,
+  ClaimRequest,
+  IdempotencyKey,
+  MarkReadyRequest,
+  Principal,
+  SettlementFinalization,
+  SettlementReservation,
+  SubmissionLedger,
+  submissionSettlementId,
+  submissionSettlementRecordId,
+} from "@effect-agent/thread/SubmissionLedger";
+import {
+  FencedAppendRequest,
+  LoadCheckpointRequest,
+  ThreadExportRequest,
+  ThreadMaterialization,
+  ThreadStore,
+  ThreadTailRequest,
+} from "@effect-agent/thread/ThreadStore";
+import {
+  Cause,
+  Clock,
+  DateTime,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  References,
+  Schema,
+  Stream,
+} from "effect";
+import { Agent, AgentRuntime } from "effect-agent";
+import { IdGenerator } from "effect-agent/IdGenerator";
+import { ThreadHistory } from "effect-agent/ThreadHistory";
+import type { LanguageModel } from "effect/unstable/ai";
+import { AiError, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
+
+import { BenchmarkError, check, type Case, type Sample } from "./contracts.js";
+
+const answerSchema = Schema.Struct({ answer: Schema.String });
+
+const tool = Tool.make("work", {
+  parameters: Schema.Struct({ index: Schema.Int }),
+  success: Schema.Int,
+});
+
+const toolkit = Toolkit.make(tool);
+
+const agent = Agent.make("runtime-benchmark", {
+  input: Schema.String,
+  output: answerSchema,
+  instructions: "Return the requested answer.",
+  toolkit,
+  policy: { maxTurns: 10, maxToolCalls: 64, maxDuration: "30 seconds", toolConcurrency: 4 },
+});
+
+const digest = Schema.decodeSync(Digest)("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+const threadId = Schema.decodeSync(ThreadId)("benchmark-thread");
+const deploymentId = Schema.decodeSync(DeploymentId)("runtime-benchmark-v1");
+const producerId = Schema.decodeSync(ProducerId)("runtime-benchmark");
+const principal = Schema.decodeSync(Principal)("benchmark");
+const now = DateTime.makeUnsafe("2026-09-08T00:00:00.000Z");
+
+const ambientModel = Layer.effectContext(
+  Effect.context<LanguageModel.LanguageModel | Model.ProviderName | Model.ModelName>(),
+);
+
+const binding = { definition: agent, model: ambientModel };
+
+const finalParts = (answer: string, chunks: number): ReadonlyArray<ScriptedStreamPart> => {
+  const text = JSON.stringify({ answer });
+  const parts: Array<ScriptedStreamPart> = [{ type: "text-start", id: "answer" }];
+
+  for (let index = 0; index < chunks; index++) {
+    parts.push({
+      type: "text-delta",
+      id: "answer",
+      delta: text.slice(
+        Math.floor((index * text.length) / chunks),
+        Math.floor(((index + 1) * text.length) / chunks),
+      ),
+    });
+  }
+  parts.push(
+    { type: "text-end", id: "answer" },
+    { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+  );
+
+  return parts;
+};
+
+const toolParts = (round: number, count: number): ReadonlyArray<ScriptedStreamPart> => [
+  ...Array.from({ length: count }, (_, index) => ({
+    type: "tool-call" as const,
+    id: `call-${round}-${index}`,
+    name: "work",
+    params: { index },
+    providerExecuted: false,
+  })),
+  { type: "finish", reason: "tool-calls", usage: { inputTokens: {}, outputTokens: {} } },
+];
+
+const retainedRuns = (records: number) => Math.max(0, Math.floor((records - 1) / 3));
+const retainedInput = (index: number) => `retained input ${index}`;
+const retainedOutput = (index: number) => ({ answer: `retained-${index}` });
+
+/** Match PersistentHistory's input/model/completion triples with native prompt suffixes. */
+const seedHistory = Effect.fn("benchmark.seedHistory")(function* (count: number) {
+  const store = yield* ThreadStore;
+
+  yield* store.materialize(
+    ThreadMaterialization.make({ threadId, producerEpoch: Schema.decodeSync(ProducerEpoch)(0) }),
+  );
+  for (let start = 0; start < count; start += 256) {
+    const records: Array<RecordEnvelope> = [];
+
+    for (let position = start; position < Math.min(start + 256, count); position++) {
+      const index = Math.floor((position - 1) / 3);
+      const runId = RunId.make(`retained-run-${index}`);
+      let payload: RecordEnvelope["payload"];
+
+      if (position === 0) payload = ThreadCreated.make({ agentId: agent.id, definitions });
+      else if (index >= retainedRuns(count))
+        payload = RepairAnnotated.make({ reason: "fixture padding", details: { position } });
+      else if ((position - 1) % 3 === 0)
+        payload = UserInputRecorded.make({ kind: "user", runId, input: retainedInput(index) });
+      else if ((position - 1) % 3 === 1) {
+        const messages = yield* Schema.decodeUnknownEffect(PersistedJson)(
+          yield* Schema.encodeEffect(Prompt.Prompt)(
+            Prompt.make([
+              { role: "user", content: JSON.stringify(retainedInput(index)) },
+              { role: "assistant", content: JSON.stringify(retainedOutput(index)) },
+            ]),
+          ),
+        );
+
+        payload = ModelCompleted.make({ runId, output: retainedOutput(index), messages });
+      } else payload = RunCompleted.make({ runId, output: retainedOutput(index) });
+      records.push(
+        RecordEnvelope.make({
+          recordId: RecordId.make(`retained-${position}`),
+          family: "thread",
+          schemaVersion: 1,
+          createdAt: now,
+          deploymentId,
+          payload,
+        }),
+      );
+    }
+
+    const [first, ...rest] = records;
+
+    if (first === undefined)
+      return yield* BenchmarkError.make({ message: "Empty retained-history batch" });
+
+    const batch = CanonicalBatch.make({
+      batchId: BatchId.make(`retained-${start}`),
+      producerId,
+      records: [first, ...rest],
+    });
+
+    const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+
+    yield* store.append(
+      FencedAppendRequest.make({
+        threadId,
+        batch,
+        expectedTailSequence: tail.tailSequence,
+        expectedTailDigest: tail.tailDigest,
+        producerEpoch: tail.producerEpoch,
+      }),
+    );
+  }
+});
+
+/** Adapter-only settled rows isolate ledger growth from canonical-history growth. */
+const seedLedger = Effect.fn("benchmark.seedLedger")(function* (count: number) {
+  const ledger = yield* SubmissionLedger;
+  const inputDigest = yield* digestJson("fixture");
+  const seedThread = Schema.decodeSync(ThreadId)("settled-ledger-fixture");
+
+  for (let index = 0; index < count; index++) {
+    const admitted = yield* ledger.admit(
+      AdmissionRequest.make({
+        threadId: seedThread,
+        principal,
+        idempotencyKey: Schema.decodeSync(IdempotencyKey)(`seed-${index}`),
+        agentId: Schema.decodeSync(AgentId)("runtime-benchmark"),
+        agentDigests: definitions,
+        deploymentId,
+        inputPayload: "fixture",
+        inputDigest,
+      }),
+    );
+
+    yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+    const claim = yield* ledger.claim(ClaimRequest.make({ threadId: seedThread, producerId }));
+
+    if (Option.isNone(claim)) return yield* check(false, "Ledger seed could not claim its row");
+    const settlementId = submissionSettlementId(admitted.submissionId);
+
+    const payload = yield* Schema.decodeUnknownEffect(SubmissionSettledRecord)(
+      SubmissionSettled.make({
+        submissionId: admitted.submissionId,
+        settlementId,
+        receiptId: admitted.receiptId,
+        outcome: "aborted",
+      }),
+    );
+
+    const record = RecordEnvelope.make({
+      recordId: submissionSettlementRecordId(admitted.submissionId),
+      family: "thread",
+      schemaVersion: 1,
+      createdAt: now,
+      deploymentId,
+      payload,
+    });
+
+    const recordDigest = yield* digestJson(yield* Schema.encodeEffect(RecordEnvelope)(record));
+
+    yield* ledger.reserveSettlement(
+      SettlementReservation.make({
+        submissionId: admitted.submissionId,
+        ownershipToken: claim.value.ownershipToken,
+        settlementId,
+        outcome: "aborted",
+        record,
+        recordDigest,
+      }),
+    );
+    yield* ledger.finalizeSettlement(
+      SettlementFinalization.make({ submissionId: admitted.submissionId, settlementId }),
+    );
+  }
+  const pending = yield* Stream.runCollect(ledger.scanNonterminal);
+
+  yield* check(pending.length === 0, "Settled fixture contains unfinished submissions");
+});
+
+/** Each sample owns a fresh script; request capture cannot grow between samples. */
+export const runSample = Effect.fn("benchmark.runSample")(function* (
+  workload: Case,
+  ordinal: number,
+  warmup: boolean,
+) {
+  let started = 0n;
+  let finished = 0n;
+  let entered: bigint | undefined;
+  let calls = 0;
+  let finalized = 0;
+  let toolCalls = 0;
+  let activeTools = 0;
+  let maxActiveTools = 0;
+  let recovering = false;
+  let checkpointStarted: bigint | undefined;
+  let checkpointCreationMs: number | null = null;
+  let retainedPromptMessages = 0;
+  const priorText = "h".repeat(workload.historyBytes);
+  const expectedRetainedRuns = workload.kind === "ledger" ? 0 : retainedRuns(workload.records);
+
+  const expectedUsers = new Set(
+    Array.from({ length: expectedRetainedRuns }, (_, index) =>
+      JSON.stringify(retainedInput(index)),
+    ),
+  );
+
+  const expectedAssistants = new Set(
+    Array.from({ length: expectedRetainedRuns }, (_, index) =>
+      JSON.stringify(retainedOutput(index)),
+    ),
+  );
+
+  // outputBytes includes the JSON envelope, keeping total bytes fixed across fragmentation.
+  const answer =
+    workload.outputBytes === 0
+      ? "ok"
+      : "x".repeat(workload.outputBytes - JSON.stringify({ answer: "" }).length);
+
+  const expectedBytes = JSON.stringify({ answer }).length;
+
+  const markStart = Clock.monotonicTimeNanos.pipe(
+    Effect.tap((time) =>
+      Effect.sync(() => {
+        started = time;
+      }),
+    ),
+  );
+
+  const markFinish = Clock.monotonicTimeNanos.pipe(
+    Effect.tap((time) =>
+      Effect.sync(() => {
+        finished = time;
+      }),
+    ),
+  );
+
+  const script = (parts: ReadonlyArray<ScriptedStreamPart>): ScriptedTurnInput => ({
+    _tag: "Stream",
+    parts,
+    termination: { _tag: "Complete" },
+    assertRequest: (request) =>
+      Effect.gen(function* () {
+        entered ??= yield* Clock.monotonicTimeNanos;
+
+        const userTexts = request.prompt.content
+          .filter((message) => message.role === "user")
+          .flatMap((message) => message.content)
+          .filter((part) => part.type === "text")
+          .map((part) => part.text);
+
+        const assistantTexts = request.prompt.content
+          .filter((message) => message.role === "assistant")
+          .flatMap((message) => message.content)
+          .filter((part) => part.type === "text")
+          .map((part) => part.text);
+
+        const retainedUsers = userTexts.filter((text) => text.startsWith('"retained input '));
+
+        const retainedAssistants = assistantTexts.filter((text) =>
+          text.startsWith('{"answer":"retained-'),
+        );
+
+        retainedPromptMessages = retainedUsers.length + retainedAssistants.length;
+
+        const historyMatches =
+          workload.historyBytes === 0 ||
+          userTexts.filter((text) => text === priorText).length === 1;
+
+        const retainedMatches = recovering
+          ? retainedPromptMessages === 0 &&
+            userTexts.some((text) => text.includes("Benchmark continuation"))
+          : retainedUsers.length === expectedUsers.size &&
+            new Set(retainedUsers).size === expectedUsers.size &&
+            retainedUsers.every((text) => expectedUsers.has(text)) &&
+            retainedAssistants.length === expectedAssistants.size &&
+            new Set(retainedAssistants).size === expectedAssistants.size &&
+            retainedAssistants.every((text) => expectedAssistants.has(text));
+
+        if (!historyMatches || !retainedMatches || !userTexts.includes('"Answer"'))
+          return yield* AiError.AiError.make({
+            module: "runtime-benchmark",
+            method: "assertRequest",
+            reason: AiError.UnknownError.make({
+              description: `Provider prompt lost or duplicated required history/input (history=${historyMatches}, retained=${retainedMatches}, retainedMessages=${retainedPromptMessages}, recovering=${recovering})`,
+            }),
+          });
+        if (calls > 0 && workload.kind === "tools") {
+          const results = request.prompt.content
+            .filter((message) => message.role === "tool")
+            .flatMap((message) => message.content)
+            .filter((part) => part.type === "tool-result");
+
+          if (
+            results.length !== calls * 8 ||
+            results.some(
+              (part) => part.isFailure || part.result !== Number(part.id.split("-").at(-1)),
+            )
+          )
+            return yield* AiError.AiError.make({
+              module: "runtime-benchmark",
+              method: "assertRequest",
+              reason: AiError.UnknownError.make({
+                description: "Scripted provider did not receive successful previous tool results",
+              }),
+            });
+        }
+        calls++;
+      }),
+    onStreamFinalize: Effect.sync(() => {
+      finalized++;
+    }),
+  });
+
+  const model = (turns: ReadonlyArray<ScriptedTurnInput>) =>
+    Layer.mergeAll(
+      ScriptedModel.layer(turns),
+      Layer.succeed(Model.ProviderName, "scripted"),
+      Layer.succeed(Model.ModelName, "runtime-benchmark"),
+    );
+
+  const handlers = toolkit.toLayer({
+    work: ({ index }) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => {
+          toolCalls++;
+          activeTools++;
+          maxActiveTools = Math.max(maxActiveTools, activeTools);
+        }),
+        () => Effect.sleep("2 millis").pipe(Effect.as(index)),
+        () =>
+          Effect.sync(() => {
+            activeTools--;
+          }),
+      ),
+  });
+
+  const inspectScript = Effect.gen(function* () {
+    const scripted = yield* ScriptedModel;
+
+    yield* scripted.assertExhausted;
+  });
+
+  const verify = (output: unknown) =>
+    Schema.decodeUnknownEffect(answerSchema)(output).pipe(
+      Effect.flatMap((result) => check(result.answer === answer, "Incorrect final answer")),
+    );
+
+  const execute = Effect.gen(function* () {
+    if (["run", "stream", "tools"].includes(workload.kind)) {
+      const turns = [
+        ...Array.from({ length: workload.rounds }, (_, round) => script(toolParts(round, 8))),
+        script(finalParts(answer, workload.chunks)),
+      ];
+
+      const history =
+        workload.historyBytes === 0
+          ? Prompt.empty
+          : Prompt.make([{ role: "user", content: priorText }]);
+
+      yield* Effect.gen(function* () {
+        yield* markStart;
+        if (workload.kind === "stream") {
+          let completions = 0;
+          let chunks = 0;
+          let text = "";
+
+          yield* AgentRuntime.stream(agent, "Answer", {
+            history,
+            bufferLimits: { maxModelResponseParts: 8_192 },
+          }).pipe(
+            Stream.runForEach((event) =>
+              event._tag === "RunCompleted"
+                ? verify(event.output).pipe(
+                    Effect.tap(() =>
+                      Effect.sync(() => {
+                        completions++;
+                      }),
+                    ),
+                  )
+                : event._tag === "TextDelta"
+                  ? Effect.sync(() => {
+                      chunks++;
+                      text += event.text;
+                    })
+                  : Effect.void,
+            ),
+          );
+          yield* check(completions === 1, "Stream did not complete exactly once");
+          yield* check(
+            chunks === workload.chunks && text === JSON.stringify({ answer }),
+            "Stream dropped or duplicated response chunks",
+          );
+        } else {
+          const result = yield* AgentRuntime.run(agent, "Answer", { history });
+
+          yield* verify(result.output);
+          yield* check(result.turns === workload.rounds + 1, "Unexpected model turn count");
+        }
+        yield* markFinish;
+        yield* inspectScript;
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(model(turns), handlers, IdGenerator.layer, ThreadHistory.layerTransient),
+        ),
+        Effect.scoped,
+      );
+      yield* check(calls === workload.rounds + 1, "Unexpected provider call count");
+      yield* check(
+        toolCalls === workload.rounds * 8 && activeTools === 0 && maxActiveTools <= 4,
+        "Tool work or finalizers changed",
+      );
+      if (workload.rounds > 0)
+        yield* check(maxActiveTools > 1, "Independent tools stopped overlapping");
+    } else {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-" });
+      const filename = `${directory}/thread.sqlite`;
+
+      const host = (crash: boolean) =>
+        NodeDurableAgentRuntime.layer({
+          filename,
+          deploymentId,
+          producerId,
+          ...(workload.kind === "recovery"
+            ? {
+                runContext: Layer.succeed(RunContextPreparation, {
+                  hook: {
+                    prepare: (request) =>
+                      Effect.succeed({
+                        prompt: request.source,
+                        ...(request.turn === 2 &&
+                        !JSON.stringify(request.source).includes("Benchmark continuation")
+                          ? {
+                              rollover: {
+                                handoff: "Benchmark continuation",
+                                through: request.source.content.length,
+                              },
+                            }
+                          : {}),
+                      }),
+                  },
+                }),
+              }
+            : {}),
+          runtimeFailpoint: (location) =>
+            Effect.gen(function* () {
+              if (location === "compaction:after-canonical-append")
+                checkpointStarted = yield* Clock.monotonicTimeNanos;
+              if (location === "checkpoint:after-save") {
+                if (checkpointStarted !== undefined)
+                  checkpointCreationMs ??=
+                    Number((yield* Clock.monotonicTimeNanos) - checkpointStarted) / 1e6;
+                if (crash) return yield* DurableRuntimeFailpointError.make({ location });
+              }
+            }),
+        }).pipe(Layer.provide(ContextCompactor.layerRollover));
+
+      // Setup and seeding never enter the reported warm-operation interval.
+      if (workload.kind === "ledger")
+        yield* seedLedger(workload.records).pipe(Effect.provide(host(false)), Effect.scoped);
+      else yield* seedHistory(workload.records).pipe(Effect.provide(host(false)), Effect.scoped);
+
+      const submit = Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+
+        return yield* runtime.submit({ definition: agent }, "Answer", {
+          threadId,
+          principal,
+          idempotencyKey: Schema.decodeSync(IdempotencyKey)("measured"),
+          definitions,
+        });
+      });
+
+      const finish = Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const receipt = yield* submit;
+
+        if (workload.kind === "ledger") {
+          const ledger = yield* SubmissionLedger;
+          const pending = yield* Stream.runCollect(ledger.scanNonterminal);
+
+          yield* check(
+            pending.length === 1 && pending[0]?.submissionId === receipt.submissionId,
+            "Ledger scan did not isolate the new submission",
+          );
+        }
+        yield* runtime.processThread(binding, threadId);
+        const settlement = yield* runtime.awaitSettlement(receipt);
+
+        yield* markFinish;
+        yield* check(settlement.outcome === "completed", "Durable submission did not complete");
+        const store = yield* ThreadStore;
+        const log = yield* store.export(ThreadExportRequest.make({ threadId }));
+
+        const completed = log.records.filter(
+          ({ record }) =>
+            record.payload._tag === "RunCompleted" &&
+            record.payload.runId === runIdForSubmission(receipt.submissionId),
+        );
+
+        yield* check(completed.length === 1, "Expected one canonical RunCompleted");
+        yield* check(
+          log.records.filter(({ record }) => record.recordId.startsWith("retained-")).length ===
+            (workload.kind === "ledger" ? 0 : workload.records),
+          "Retained canonical archive changed during the measured submission",
+        );
+        for (const envelope of completed)
+          if (envelope.record.payload._tag === "RunCompleted")
+            yield* verify(envelope.record.payload.output);
+        yield* inspectScript;
+      });
+
+      if (workload.kind === "recovery") {
+        yield* Effect.gen(function* () {
+          const runtime = yield* DurableAgentRuntime;
+
+          yield* submit;
+          const attempt = yield* runtime.processThread(binding, threadId).pipe(Effect.exit);
+
+          const fault = Exit.isFailure(attempt)
+            ? Cause.findErrorOption(attempt.cause)
+            : Option.none();
+
+          yield* check(
+            Option.isSome(fault) &&
+              fault.value._tag === "DurableRuntimeFailpointError" &&
+              fault.value.location === "checkpoint:after-save",
+            `Expected checkpoint fault was not observed: ${Exit.isFailure(attempt) ? Cause.pretty(attempt.cause) : "attempt succeeded"}`,
+          );
+          const store = yield* ThreadStore;
+
+          const checkpoint =
+            store.recoveryCheckpoints === undefined
+              ? Option.none()
+              : yield* store.recoveryCheckpoints.load(LoadCheckpointRequest.make({ threadId }));
+
+          yield* check(Option.isSome(checkpoint), "Recovery fixture has no persisted checkpoint");
+          yield* inspectScript;
+        }).pipe(
+          Effect.provide(Layer.mergeAll(host(true), model([script(toolParts(0, 1))]), handlers)),
+          Effect.scoped,
+        );
+        yield* check(
+          finalized === calls && activeTools === 0,
+          "Checkpoint fault did not finalize model/tools",
+        );
+        calls = 0;
+        finalized = 0;
+        entered = undefined;
+        recovering = true;
+        yield* markStart;
+        yield* finish.pipe(
+          Effect.provide(
+            Layer.mergeAll(host(false), model([script(finalParts(answer, 1))]), handlers),
+          ),
+          Effect.scoped,
+        );
+        yield* check(toolCalls === 1, "Checkpoint recovery repeated completed tools");
+        yield* check(
+          checkpointCreationMs !== null && checkpointCreationMs >= 0,
+          "Missing inline checkpoint creation interval",
+        );
+      } else {
+        yield* markStart;
+        yield* finish.pipe(
+          Effect.provide(
+            Layer.mergeAll(host(false), model([script(finalParts(answer, 1))]), handlers),
+          ),
+          Effect.scoped,
+        );
+      }
+      yield* check(calls === 1, "Durable submission made extra model calls");
+    }
+    yield* check(
+      finalized === calls && activeTools === 0,
+      "Model/tool resources were not finalized",
+    );
+    yield* check(entered !== undefined && finished >= started, "Missing timing boundary");
+  }).pipe(
+    Effect.scoped,
+    Effect.timeout("3 minutes"),
+    Effect.provideService(References.MinimumLogLevel, "None"),
+  );
+
+  const result = yield* execute.pipe(Effect.exit);
+
+  if (finished === 0n) finished = yield* Clock.monotonicTimeNanos;
+
+  return {
+    case: workload.name,
+    ordinal,
+    warmup,
+    totalMs: started === 0n ? 0 : Number(finished - started) / 1e6,
+    modelEntryMs: entered === undefined || started === 0n ? null : Number(entered - started) / 1e6,
+    checkpointCreationMs,
+    retainedPromptMessages,
+    modelCalls: calls,
+    finalizers: finalized,
+    toolCalls,
+    outputBytes: expectedBytes,
+    status: Exit.isSuccess(result) ? "passed" : "failed",
+    failure: Exit.isFailure(result) ? Cause.pretty(result.cause) : null,
+  } satisfies Sample;
+});

--- a/examples/runtime-benchmark/src/worker.ts
+++ b/examples/runtime-benchmark/src/worker.ts
@@ -1,0 +1,58 @@
+import process from "node:process";
+
+import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Config, Effect, FileSystem, Layer, Schema } from "effect";
+
+import {
+  BenchmarkError,
+  casesFor,
+  FIXTURE_VERSION,
+  WorkerOptions,
+  WorkerReport,
+  type Sample,
+} from "./contracts.js";
+import { runSample } from "./fixture.js";
+
+const program = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+
+  const options = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerOptions))(
+    yield* Config.string("RUNTIME_BENCHMARK_OPTIONS"),
+  );
+
+  const samples: Array<Sample> = [];
+
+  const workloads = options.cold
+    ? casesFor(options.profile).slice(0, 1)
+    : casesFor(options.profile);
+
+  const persist = () =>
+    fs.writeFileString(
+      options.output,
+      Schema.encodeSync(Schema.fromJsonString(WorkerReport))({
+        fixture: FIXTURE_VERSION,
+        profile: options.profile,
+        runtime: process.version,
+        platform: process.platform,
+        architecture: process.arch,
+        samples,
+      }),
+    );
+
+  yield* persist();
+  for (let index = 0; index < options.warmups + options.samples; index++) {
+    const ordered = index % 2 === 0 ? workloads : [...workloads].reverse();
+
+    for (const workload of ordered) {
+      samples.push(yield* runSample(workload, index, index < options.warmups));
+      // Keep partial failures and slow samples even when a later child is interrupted.
+      yield* persist();
+    }
+  }
+  if (samples.some((sample) => sample.status === "failed"))
+    return yield* BenchmarkError.make({
+      message: "Benchmark correctness assertions failed; see raw samples",
+    });
+}).pipe(Effect.scoped, Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer)));
+
+NodeRuntime.runMain(program);

--- a/examples/runtime-benchmark/test/fixture.test.ts
+++ b/examples/runtime-benchmark/test/fixture.test.ts
@@ -1,0 +1,83 @@
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Effect, Layer } from "effect";
+import { expect, it } from "vite-plus/test";
+
+import {
+  casesFor,
+  completeBatch,
+  FIXTURE_VERSION,
+  summary,
+  type Sample,
+  type WorkerReport,
+} from "../src/contracts.ts";
+import { runSample } from "../src/fixture.ts";
+
+it.each(casesFor("smoke"))(
+  "validates equivalent completed work in $name",
+  async (workload) => {
+    const result = await Effect.runPromise(
+      runSample(workload, 0, false).pipe(
+        Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+      ),
+    );
+
+    expect(result.failure).toBeNull();
+    expect(result.status).toBe("passed");
+    expect(result.modelCalls).toBe(result.finalizers);
+    expect(result.checkpointCreationMs === null).toBe(workload.kind !== "recovery");
+    expect(result.retainedPromptMessages).toBe(
+      workload.kind === "durable" ? 2 * Math.max(0, Math.floor((workload.records - 1) / 3)) : 0,
+    );
+  },
+  30_000,
+);
+
+it("rejects missing, duplicated, or unfinalized samples even if the subprocess exits successfully", () => {
+  const sample: Sample = {
+    case: "small-run",
+    ordinal: 0,
+    warmup: false,
+    totalMs: 2,
+    modelEntryMs: 1,
+    checkpointCreationMs: null,
+    retainedPromptMessages: 0,
+    modelCalls: 1,
+    finalizers: 1,
+    toolCalls: 0,
+    outputBytes: 15,
+    status: "passed",
+    failure: null,
+  };
+
+  const report: WorkerReport = {
+    fixture: FIXTURE_VERSION,
+    profile: "smoke",
+    runtime: "v24",
+    platform: "test",
+    architecture: "test",
+    samples: [sample],
+  };
+
+  const options = {
+    cold: true,
+    profile: "smoke" as const,
+    warmups: 0,
+    samples: 1,
+    output: "unused",
+  };
+
+  expect(completeBatch(report, options)).toBe(true);
+  expect(completeBatch({ ...report, samples: [] }, options)).toBe(false);
+  expect(completeBatch({ ...report, samples: [sample, sample] }, options)).toBe(false);
+  expect(completeBatch({ ...report, samples: [{ ...sample, finalizers: 0 }] }, options)).toBe(
+    false,
+  );
+  expect(summary([1, 2, 3, 4, 100])).toEqual({
+    count: 5,
+    median: 3,
+    q1: 2,
+    q3: 4,
+    min: 1,
+    max: 100,
+  });
+});

--- a/examples/runtime-benchmark/test/report.test.ts
+++ b/examples/runtime-benchmark/test/report.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "vite-plus/test";
+
+import type { PerformanceReport } from "../../../scripts/runtime-benchmark.ts";
+import { renderPerformanceReport } from "../../../scripts/runtime-benchmark.ts";
+import { FIXTURE_VERSION, REFERENCE } from "../src/contracts.ts";
+
+it("reports and excludes an invalid batch even when its process exited successfully", () => {
+  const report: typeof PerformanceReport.Type = {
+    fixture: FIXTURE_VERSION,
+    fixtureSha256: "fixture",
+    transpiler: "test",
+    profile: "smoke",
+    referenceVersion: REFERENCE.version,
+    environment: {
+      platform: "test",
+      release: "test",
+      architecture: "test",
+      cpu: "test",
+      cpuCount: 1,
+      memoryBytes: 1,
+      node: "v24",
+    },
+    settings: {
+      batches: 1,
+      warmupsPerBatch: 0,
+      samplesPerBatch: 1,
+      production: true,
+      execution: "unbundled published ESM",
+      timingGate: "informational",
+    },
+    revisions: [],
+    batches: [
+      {
+        role: "head",
+        cohort: 0,
+        cold: false,
+        subprocessMs: 1,
+        exitCode: 0,
+        complete: false,
+        failure: "Worker runtime differs from the controller",
+        report: {
+          fixture: FIXTURE_VERSION,
+          profile: "smoke",
+          runtime: "v22",
+          platform: "test",
+          architecture: "test",
+          samples: [
+            {
+              case: "small-run",
+              ordinal: 0,
+              warmup: false,
+              totalMs: 0.01,
+              modelEntryMs: 0.005,
+              checkpointCreationMs: null,
+              retainedPromptMessages: 0,
+              modelCalls: 1,
+              finalizers: 1,
+              toolCalls: 0,
+              outputBytes: 15,
+              status: "passed",
+              failure: null,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const rendered = renderPerformanceReport(report);
+
+  expect(rendered).toContain("Invalid/incomplete batches: 1; processes recorded: 1/6");
+  expect(rendered).toContain("Worker runtime differs from the controller");
+  expect(rendered).toContain("| small-run | n/a | n/a | n/a |");
+});

--- a/examples/runtime-benchmark/tsconfig.json
+++ b/examples/runtime-benchmark/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "types": ["node"] },
+  "include": ["src", "test"]
+}

--- a/examples/runtime-benchmark/vite.config.ts
+++ b/examples/runtime-benchmark/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  test: { cache: false, silent: "passed-only" },
+});

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -107,6 +107,7 @@ import { SubagentHost } from "../SubagentHost.ts";
 import { ThreadHistory, ThreadHistoryError } from "../ThreadHistory.ts";
 import { boundedValueFootprint, utf8ByteLength } from "./bounded-value.ts";
 import { insertOutputContract, isTextOutput, outputSchemaContract } from "./output-contract.ts";
+import { ownPrimitiveDelta } from "./primitive-delta.ts";
 import {
   boundedCanonicalJsonSnapshot,
   boundedJsonSnapshot,
@@ -794,7 +795,7 @@ const modelResponseCodecFor = (toolkit: Toolkit.Any) => {
   return codec;
 };
 
-const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(function* <
+const ownModelResponsePartGeneral = Effect.fn("AgentRuntime.ownModelResponsePart")(function* <
   Tools extends Record<string, Tool.Any>,
 >(
   part: unknown,
@@ -860,6 +861,23 @@ const ownModelResponsePart = Effect.fn("AgentRuntime.ownModelResponsePart")(func
 
   return { ownedPart, retainedBytes };
 });
+
+const ownModelResponsePart = <Tools extends Record<string, Tool.Any>>(
+  part: unknown,
+  toolkit: Toolkit.Toolkit<Tools>,
+  usage: ModelResponseBufferUsage,
+  limits: EffectiveRunBufferLimits,
+): ReturnType<typeof ownModelResponsePartGeneral> =>
+  Effect.suspend((): ReturnType<typeof ownModelResponsePartGeneral> => {
+    const primitive =
+      usage.responsePartCount < limits.maxModelResponseParts
+        ? ownPrimitiveDelta(part, limits.maxModelResponseBytes - usage.responsePartBytes)
+        : undefined;
+
+    return primitive === undefined
+      ? ownModelResponsePartGeneral(part, toolkit, usage, limits)
+      : Effect.succeed(primitive);
+  });
 
 const consumeModelResponsePart = (
   usage: ModelResponseBufferUsage,
@@ -5491,9 +5509,9 @@ const makeTurn = <
           ).pipe(
             Effect.flatMap((outgoing) => {
               const providerPrompt =
-                outputContractMessage === undefined
+                outputContract._tag !== "rendered"
                   ? outgoing
-                  : insertOutputContract(outgoing, outputContractMessage);
+                  : insertOutputContract(outgoing, outputContract.part);
 
               // Prepared and transient context can change at every Turn. A
               // final full-prompt check closes the per-call boundary for grace

--- a/packages/engine/src/internal/output-contract.ts
+++ b/packages/engine/src/internal/output-contract.ts
@@ -49,6 +49,7 @@ type OutputContract =
       readonly _tag: "rendered";
       /** The complete system-message text: directive plus the derived JSON Schema. */
       readonly message: string;
+      readonly part: Prompt.SystemMessage;
     }
   | {
       readonly _tag: "unrenderable";
@@ -72,44 +73,58 @@ const requiredCompletionDirective = (tool: string): string =>
 
 /**
  * Render the model-visible final-output contract for one definition. The
- * derivation is pure and cheap relative to a model call (providers derive
- * every Tool's JSON Schema per request the same way), so no cache is kept.
+ * derivation and message identity are stable for an immutable definition.
  * An output Schema the Effect AI derivation cannot represent is reported as
  * `unrenderable`; the caller falls back to the prior behavior — the contract
  * is guidance, and a Schema that decodes but does not render must not become
  * a new failure mode.
  */
-export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputContract => {
+const rendered = (message: string): OutputContract => ({
+  _tag: "rendered",
+  message,
+  part: Prompt.makeMessage("system", { content: message }),
+});
+
+const renderOutputSchemaContract = (definition: Agent.AnyDefinition): OutputContract => {
   if (definition.completion?.required === true) {
-    return {
-      _tag: "rendered",
-      message: requiredCompletionDirective(definition.completion.tool),
-    };
+    return rendered(requiredCompletionDirective(definition.completion.tool));
   }
   if (isTextOutput(definition.output)) {
-    return {
-      _tag: "rendered",
-      message:
-        "Final output contract: write the final reply as ordinary assistant text, without JSON wrapping. " +
+    return rendered(
+      "Final output contract: write the final reply as ordinary assistant text, without JSON wrapping. " +
         "An empty reply is valid only when allowed by the output Schema and the task instructions." +
         (definition.completion === undefined
           ? ""
           : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead; the engine projects its successful result into the Agent output.`),
-    };
+    );
   }
   try {
     const jsonSchema = Tool.getJsonSchemaFromSchema(definition.output);
 
-    return {
-      _tag: "rendered",
-      message: `${contractDirective(definition)}\n\n${JSON.stringify(jsonSchema, undefined, 2)}`,
-    };
+    return rendered(
+      `${contractDirective(definition)}\n\n${JSON.stringify(jsonSchema, undefined, 2)}`,
+    );
   } catch (cause) {
     return {
       _tag: "unrenderable",
       reason: cause instanceof Error ? cause.message : String(cause),
     };
   }
+};
+
+// Native incremental-response tracking recognizes message objects, not rendered text.
+// Weak keys retain neither discarded definitions nor their Schema graphs.
+const outputContracts = new WeakMap<Agent.AnyDefinition, OutputContract>();
+
+export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputContract => {
+  const cached = outputContracts.get(definition);
+
+  if (cached !== undefined) return cached;
+  const contract = renderOutputSchemaContract(definition);
+
+  outputContracts.set(definition, contract);
+
+  return contract;
 };
 
 /**
@@ -124,7 +139,10 @@ export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputCon
  * block keeps author content and contract together on every provider and
  * preserves the author's per-message cache-control annotations.
  */
-export const insertOutputContract = (prompt: Prompt.Prompt, message: string): Prompt.Prompt => {
+export const insertOutputContract = (
+  prompt: Prompt.Prompt,
+  message: Prompt.SystemMessage,
+): Prompt.Prompt => {
   const content = prompt.content;
   let insertAt = 0;
 
@@ -134,9 +152,5 @@ export const insertOutputContract = (prompt: Prompt.Prompt, message: string): Pr
     }
   }
 
-  return Prompt.fromMessages([
-    ...content.slice(0, insertAt),
-    Prompt.makeMessage("system", { content: message }),
-    ...content.slice(insertAt),
-  ]);
+  return Prompt.fromMessages([...content.slice(0, insertAt), message, ...content.slice(insertAt)]);
 };

--- a/packages/engine/src/internal/primitive-delta.ts
+++ b/packages/engine/src/internal/primitive-delta.ts
@@ -1,0 +1,79 @@
+import { Option, Schema } from "effect";
+import { Response } from "effect/unstable/ai";
+
+import { boundedValueFootprint, utf8ByteLength } from "./bounded-value.ts";
+
+const brand = "~effect/ai/Content/Part";
+const keys = [brand, "type", "id", "delta", "metadata"];
+
+const decode = Schema.decodeUnknownOption(
+  Schema.toType(Schema.Union([Response.TextDeltaPart, Response.ReasoningDeltaPart])),
+);
+
+const overhead = (type: "text-delta" | "reasoning-delta") => ({
+  source: boundedValueFootprint(
+    Response.makePart(type, { id: "", delta: "" }),
+    Number.MAX_SAFE_INTEGER,
+  ),
+  encoded: boundedValueFootprint(
+    { type, id: "", delta: "", metadata: {} },
+    Number.MAX_SAFE_INTEGER,
+  ),
+});
+
+const overheads = {
+  "text-delta": overhead("text-delta"),
+  "reasoning-delta": overhead("reasoning-delta"),
+};
+
+/**
+ * Copy the common primitive delta into owned data before native Schema validation.
+ * Descriptor checks select this optimization; they do not replace the native codec.
+ * Extra fields, accessors, and nonempty metadata use the general ownership path.
+ * No provider object survives, including an empty metadata object's hidden storage.
+ * Unlike a generic footprint shortcut, this cannot retain an exotic backing buffer.
+ */
+export const ownPrimitiveDelta = (part: unknown, maxBytes: number) => {
+  try {
+    if (part === null || typeof part !== "object") return undefined;
+    if (Array.isArray(part) || ArrayBuffer.isView(part)) return undefined;
+    const prototype = Object.getPrototypeOf(part);
+
+    if (prototype !== Object.prototype && prototype !== null) return undefined;
+    if (Reflect.ownKeys(part).length !== keys.length) return undefined;
+    const snapshot: Record<string, unknown> = {};
+
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(part, key);
+
+      if (descriptor === undefined || !("value" in descriptor)) return undefined;
+      snapshot[key] = descriptor.value;
+    }
+    const { type, id, delta, metadata } = snapshot;
+
+    if (type !== "text-delta" && type !== "reasoning-delta") return undefined;
+    if (typeof id !== "string" || typeof delta !== "string") return undefined;
+    if (metadata === null || typeof metadata !== "object") return undefined;
+    if (Array.isArray(metadata) || ArrayBuffer.isView(metadata)) return undefined;
+    const metadataPrototype = Object.getPrototypeOf(metadata);
+
+    if (metadataPrototype !== Object.prototype && metadataPrototype !== null) return undefined;
+    if (Reflect.ownKeys(metadata).length !== 0) return undefined;
+    const fixed = overheads[type];
+
+    if (fixed.source === undefined || fixed.encoded === undefined) return undefined;
+    const bytes = utf8ByteLength(id) + utf8ByteLength(delta);
+
+    if (bytes + fixed.source > maxBytes || bytes + fixed.encoded > maxBytes) return undefined;
+    // Never pass the provider's metadata object (or any other object) to the decoder.
+    snapshot.metadata = {};
+    const validated = decode(snapshot);
+
+    if (Option.isNone(validated)) return undefined;
+
+    return { ownedPart: validated.value, retainedBytes: bytes + fixed.encoded };
+  } catch {
+    // Reflection may throw for proxies. The general path owns the typed failure.
+    return undefined;
+  }
+};

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -58,6 +58,7 @@ import {
 
 import { boundedValueFootprint } from "../src/internal/bounded-value.ts";
 import { errorMessage, errorTag } from "../src/internal/error-diagnostic.ts";
+import { ownPrimitiveDelta } from "../src/internal/primitive-delta.ts";
 import { boundedJsonSnapshot } from "../src/internal/provider-result-staging.ts";
 import { emitThenAfter, isolateToolDerivative } from "../src/internal/tool-derivative.ts";
 import {
@@ -4194,6 +4195,130 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect((yield* Ref.get(byteEvents)).at(-1)?._tag).toBe("RunFailed");
     }),
   );
+
+  it.effect("keeps tracing bounded when identical output is fragmented into more deltas", () =>
+    Effect.gen(function* () {
+      const answer = "x".repeat(4_096);
+      const text = JSON.stringify({ answer });
+      const counts: Array<number> = [];
+
+      for (const chunks of [1, 512]) {
+        let spans = 0;
+        let textBytes = 0;
+        const width = Math.ceil(text.length / chunks);
+        const parts: Array<Response.StreamPartEncoded> = [{ type: "text-start", id: "answer" }];
+
+        for (let start = 0; start < text.length; start += width) {
+          parts.push({ type: "text-delta", id: "answer", delta: text.slice(start, start + width) });
+        }
+        parts.push({ type: "text-end", id: "answer" }, { type: "finish", reason: "stop", usage });
+
+        const tracer = Tracer.make({
+          span(options) {
+            spans++;
+
+            return new Tracer.NativeSpan(options);
+          },
+        });
+
+        const result = yield* AgentRuntime.stream(makeAgent(parts), {
+          question: "fragmentation",
+        }).pipe(
+          Stream.tap((event) =>
+            Effect.sync(() => {
+              if (event._tag === "TextDelta") textBytes += event.text.length;
+            }),
+          ),
+          Stream.runCollect,
+          Effect.provideService(Tracer.Tracer, tracer),
+        );
+
+        expect(result.at(-1)).toMatchObject({ _tag: "RunCompleted", output: { answer }, turns: 1 });
+        expect(textBytes).toBe(text.length);
+        counts.push(spans);
+      }
+      // A larger transport chunk count must not produce proportional tracing work.
+      expect(counts[1]).toBeLessThanOrEqual(counts[0]! + 4);
+    }),
+  );
+
+  it("owns primitive text and reasoning deltas while preserving source and retained bounds", () => {
+    for (const type of ["text-delta", "reasoning-delta"] as const) {
+      const source = {
+        "~effect/ai/Content/Part": "~effect/ai/Content/Part",
+        type,
+        id: "reply",
+        delta: "é😀\ud800",
+        metadata: {},
+      };
+
+      const sourceBytes = boundedValueFootprint(source, 1_024)!;
+      const encoded = { type, id: source.id, delta: source.delta, metadata: {} };
+      const owned = ownPrimitiveDelta(source, sourceBytes);
+
+      expect(owned?.ownedPart).toEqual(source);
+      expect(owned?.ownedPart).not.toBe(source);
+      expect(owned?.ownedPart.metadata).not.toBe(source.metadata);
+      expect(owned?.retainedBytes).toBe(boundedValueFootprint(encoded, 1_024));
+      expect(ownPrimitiveDelta(source, sourceBytes - 1)).toBeUndefined();
+      source.delta = "changed";
+      expect(owned?.ownedPart.delta).toBe("é😀\ud800");
+      expect(
+        ownPrimitiveDelta({ ...source, metadata: { provider: { value: 1 } } }, 1_024),
+      ).toBeUndefined();
+      expect(
+        ownPrimitiveDelta({ ...source, hidden: new ArrayBuffer(4_096) }, 1_024),
+      ).toBeUndefined();
+      expect(ownPrimitiveDelta({ ...source, delta: 42 }, 1_024)).toBeUndefined();
+      expect(
+        ownPrimitiveDelta({ ...source, "~effect/ai/Content/Part": "invalid" }, 1_024),
+      ).toBeUndefined();
+      let reads = 0;
+
+      Object.defineProperty(source, "delta", {
+        get: () => {
+          reads++;
+
+          return "accessor";
+        },
+      });
+      expect(ownPrimitiveDelta(source, 1_024)).toBeUndefined();
+      expect(reads).toBe(0);
+    }
+  });
+
+  it("rejects disguised indexed storage before materializing its keys", () => {
+    const indexed = [Array.from({ length: 4_096 }, () => 0), new Uint8Array(4_096)];
+    const ownKeys = Reflect.ownKeys;
+    let indexedKeyRequests = 0;
+
+    for (const value of indexed) Object.setPrototypeOf(value, Object.prototype);
+    Reflect.ownKeys = (value) => {
+      if (indexed.some((candidate) => candidate === value)) indexedKeyRequests++;
+
+      return ownKeys(value);
+    };
+    try {
+      for (const value of indexed) {
+        expect(ownPrimitiveDelta(value, 1_024)).toBeUndefined();
+        expect(
+          ownPrimitiveDelta(
+            {
+              "~effect/ai/Content/Part": "~effect/ai/Content/Part",
+              type: "text-delta",
+              id: "reply",
+              delta: "text",
+              metadata: value,
+            },
+            1_024,
+          ),
+        ).toBeUndefined();
+      }
+      expect(indexedKeyRequests).toBe(0);
+    } finally {
+      Reflect.ownKeys = ownKeys;
+    }
+  });
 
   it.effect("reserves one bounded Run event slot for a typed terminal failure", () =>
     Effect.gen(function* () {

--- a/packages/engine/test/output-contract.test.ts
+++ b/packages/engine/test/output-contract.test.ts
@@ -7,7 +7,15 @@ import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import * as Output from "@effect-agent/engine/Output";
 import { expect, layer } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Logger, Option, Ref, Schema, Stream } from "effect";
-import { LanguageModel, Model, Prompt, type Response, Tool, Toolkit } from "effect/unstable/ai";
+import {
+  LanguageModel,
+  Model,
+  Prompt,
+  type Response,
+  ResponseIdTracker,
+  Tool,
+  Toolkit,
+} from "effect/unstable/ai";
 
 import { insertOutputContract, outputSchemaContract } from "../src/internal/output-contract.ts";
 import { RunContextPreparationPassthrough } from "../src/RunOptions.ts";
@@ -279,6 +287,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
           LanguageModel.LanguageModel,
           Effect.gen(function* () {
             const turn = yield* Ref.make(0);
+            const tracker = yield* ResponseIdTracker.make;
 
             return yield* LanguageModel.make({
               generateText: () => Effect.succeed([]),
@@ -287,6 +296,31 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
                   Ref.getAndUpdate(turn, (value) => value + 1).pipe(
                     Effect.map((value) => {
                       requests.push(options.prompt);
+                      if (value === 0) {
+                        tracker.markParts(options.prompt.content, "response-1");
+                      } else {
+                        const incremental = tracker.prepareUnsafe(options.prompt);
+
+                        expect(Option.isSome(incremental)).toBe(true);
+                        if (Option.isSome(incremental)) {
+                          expect(incremental.value.previousResponseId).toBe("response-1");
+                          expect(
+                            incremental.value.prompt.content.map((message) => message.role),
+                          ).toEqual(["tool", "user"]);
+                          expect(JSON.stringify(incremental.value.prompt).length).toBeLessThan(
+                            JSON.stringify(options.prompt).length,
+                          );
+                        }
+
+                        const changed = Prompt.fromMessages([
+                          Prompt.makeMessage("system", {
+                            content: "Changed prepared instructions",
+                          }),
+                          ...options.prompt.content.slice(1),
+                        ]);
+
+                        expect(Option.isNone(tracker.prepareUnsafe(changed))).toBe(true);
+                      }
 
                       return Stream.fromIterable<Response.StreamPartEncoded>(
                         value === 0
@@ -703,7 +737,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
   });
 
   it.effect("inserts after the last system message, extending the last contiguous block", () => {
-    const contract = "contract-text";
+    const contract = Prompt.makeMessage("system", { content: "contract-text" });
     const system = (content: string) => Prompt.makeMessage("system", { content });
 
     const user = Prompt.makeMessage("user", {
@@ -714,12 +748,12 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
     const empty = insertOutputContract(Prompt.empty, contract);
 
     expect(roles(empty)).toEqual(["system"]);
-    expect(systemText(empty.content[0]!)).toBe(contract);
+    expect(systemText(empty.content[0]!)).toBe(contract.content);
 
     const userOnly = insertOutputContract(Prompt.fromMessages([user]), contract);
 
     expect(roles(userOnly)).toEqual(["system", "user"]);
-    expect(systemText(userOnly.content[0]!)).toBe(contract);
+    expect(systemText(userOnly.content[0]!)).toBe(contract.content);
 
     const doubleSystem = insertOutputContract(
       Prompt.fromMessages([system("a"), system("b"), user]),
@@ -727,7 +761,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
     );
 
     expect(roles(doubleSystem)).toEqual(["system", "system", "system", "user"]);
-    expect(systemText(doubleSystem.content[2]!)).toBe(contract);
+    expect(systemText(doubleSystem.content[2]!)).toBe(contract.content);
 
     // Only the last contiguous system group survives on Anthropic (a prior
     // Thread's instructions ahead of this Run's evaluated instructions,
@@ -739,7 +773,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
     );
 
     expect(roles(resumed)).toEqual(["system", "user", "system", "system", "user"]);
-    expect(systemText(resumed.content[3]!)).toBe(contract);
+    expect(systemText(resumed.content[3]!)).toBe(contract.content);
 
     return Effect.void;
   });

--- a/packages/testing/test/toolchain.test.ts
+++ b/packages/testing/test/toolchain.test.ts
@@ -125,6 +125,7 @@ const exampleNames = [
   "pr-review-eval",
   "providers",
   "repo-ops",
+  "runtime-benchmark",
   "semantic-memory-eval",
 ] as const;
 

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -1,0 +1,577 @@
+import { createHash } from "node:crypto";
+import { arch, cpus, platform, release, totalmem } from "node:os";
+
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Cause, Clock, Console, Effect, Exit, FileSystem, Path, Schema, Stream } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { ChildProcess } from "effect/unstable/process";
+import { build, version as esbuildVersion } from "esbuild";
+
+import {
+  BenchmarkError,
+  casesFor,
+  check,
+  completeBatch,
+  FIXTURE_VERSION,
+  Profile,
+  REFERENCE,
+  summary,
+  WorkerOptions,
+  WorkerReport,
+} from "../examples/runtime-benchmark/src/contracts.ts";
+import { PublishManifest, withPublishManifests } from "./release-publish.ts";
+
+const Revision = Schema.Struct({
+  role: Schema.Literals(["base", "head", "reference"]),
+  revision: Schema.String,
+  dirty: Schema.Boolean,
+  lockfileSha256: Schema.String,
+  builtArtifactsSha256: Schema.String,
+  effect: Schema.String,
+});
+
+type Revision = typeof Revision.Type;
+
+const Batch = Schema.Struct({
+  role: Revision.fields.role,
+  cohort: Schema.Natural,
+  cold: Schema.Boolean,
+  subprocessMs: Schema.Finite,
+  exitCode: Schema.Int,
+  complete: Schema.Boolean,
+  report: Schema.NullOr(WorkerReport),
+  failure: Schema.NullOr(Schema.String),
+});
+
+type Batch = typeof Batch.Type;
+
+export const PerformanceReport = Schema.Struct({
+  fixture: Schema.Literal(FIXTURE_VERSION),
+  fixtureSha256: Schema.String,
+  transpiler: Schema.String,
+  profile: Profile,
+  referenceVersion: Schema.Literal(REFERENCE.version),
+  environment: Schema.Struct({
+    platform: Schema.String,
+    release: Schema.String,
+    architecture: Schema.String,
+    cpu: Schema.String,
+    cpuCount: Schema.Natural,
+    memoryBytes: Schema.Natural,
+    node: Schema.String,
+  }),
+  settings: Schema.Struct({
+    batches: Schema.Natural,
+    warmupsPerBatch: Schema.Natural,
+    samplesPerBatch: Schema.Natural,
+    production: Schema.Literal(true),
+    execution: Schema.Literal("unbundled published ESM"),
+    timingGate: Schema.Literal("informational"),
+  }),
+  revisions: Schema.Array(Revision),
+  batches: Schema.Array(Batch),
+});
+
+type PerformanceReport = typeof PerformanceReport.Type;
+
+const sha256 = (content: string | Uint8Array) => createHash("sha256").update(content).digest("hex");
+
+const subprocess = Effect.fn("benchmark.subprocess")(function* (
+  executable: string,
+  args: ReadonlyArray<string>,
+  cwd: string,
+  env: Record<string, string> = {},
+) {
+  const started = yield* Clock.monotonicTimeNanos;
+
+  const child = yield* ChildProcess.make(executable, args, {
+    cwd,
+    env,
+    extendEnv: true,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = yield* Effect.all(
+    [
+      Stream.mkString(Stream.decodeText(child.stdout)),
+      Stream.mkString(Stream.decodeText(child.stderr)),
+      child.exitCode,
+    ],
+    { concurrency: 3 },
+  );
+
+  return {
+    stdout,
+    stderr,
+    exitCode,
+    subprocessMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+  };
+}, Effect.scoped);
+
+/** Copy only public dist artifacts; external dependencies resolve from this revision's install. */
+const stageCheckout = Effect.fn("benchmark.stageCheckout")(function* (
+  root: string,
+  role: Revision["role"],
+  fixtures: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const stage = yield* fs.makeTempDirectoryScoped({ prefix: `runtime-benchmark-${role}-` });
+  const resolved = yield* fs.realPath(root);
+  const git = yield* subprocess("git", ["rev-parse", "HEAD"], resolved);
+
+  yield* check(
+    git.exitCode === 0 && /^[a-f0-9]{40}$/.test(git.stdout.trim()),
+    `Cannot resolve ${role} checkout SHA`,
+  );
+
+  const status = yield* subprocess(
+    "git",
+    ["status", "--porcelain", "--untracked-files=all"],
+    resolved,
+  );
+
+  yield* check(status.exitCode === 0, `Cannot inspect ${role} checkout state`);
+
+  const effect = yield* Schema.decodeUnknownEffect(
+    Schema.fromJsonString(Schema.Struct({ version: Schema.String })),
+  )(yield* fs.readFileString(path.join(resolved, "node_modules/effect/package.json")));
+
+  yield* fs.copyFile(path.join(resolved, "package.json"), path.join(stage, "package.json"));
+  yield* fs.copy(fixtures, path.join(stage, "fixture"));
+  yield* fs.makeDirectory(path.join(stage, "node_modules"), { recursive: true });
+  const builtFiles: Array<string> = [];
+
+  // Never link the workspace scope: all framework imports must reach the staged dist graph.
+  for (const entry of yield* fs.readDirectory(path.join(resolved, "node_modules"))) {
+    if (entry.startsWith(".") || entry === "@effect-agent" || entry === "effect-agent") continue;
+    yield* fs.symlink(
+      path.join(resolved, "node_modules", entry),
+      path.join(stage, "node_modules", entry),
+    );
+  }
+  for (const directory of (yield* fs.readDirectory(path.join(resolved, "packages"))).sort()) {
+    if (directory.startsWith(".")) continue;
+    const source = path.join(resolved, "packages", directory);
+
+    const manifest = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(PublishManifest))(
+      yield* fs.readFileString(path.join(source, "package.json")),
+    );
+
+    if (manifest.private === true) continue;
+    const destination = path.join(stage, "packages", directory);
+
+    yield* fs.makeDirectory(destination, { recursive: true });
+    yield* fs.copyFile(path.join(source, "package.json"), path.join(destination, "package.json"));
+    yield* fs.copy(path.join(source, "dist"), path.join(destination, "dist"));
+    for (const file of (yield* fs.readDirectory(path.join(destination, "dist"), {
+      recursive: true,
+    })).sort()) {
+      if (file.endsWith(".mjs"))
+        builtFiles.push(
+          `${manifest.name}/${file}:${sha256(yield* fs.readFile(path.join(destination, "dist", file)))}`,
+        );
+    }
+    const link = path.join(stage, "node_modules", manifest.name);
+
+    yield* fs.makeDirectory(path.dirname(link), { recursive: true });
+    yield* fs.symlink(destination, link);
+  }
+
+  return {
+    stage,
+    revision: {
+      role,
+      revision: git.stdout.trim(),
+      dirty: status.stdout.trim() !== "",
+      lockfileSha256: sha256(yield* fs.readFile(path.join(resolved, "bun.lock"))),
+      builtArtifactsSha256: sha256(builtFiles.join("\n")),
+      effect: effect.version,
+    } satisfies Revision,
+  };
+});
+
+export const renderPerformanceReport = (report: PerformanceReport): string => {
+  const lines = [
+    "Timing is informational. Median [Q1–Q3] in milliseconds; every measured sample and outlier is retained.",
+    "",
+    "| Workload | Base total | Head total | Reference total | Head/base | Head/reference | Head model entry |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ];
+
+  const format = (value: ReturnType<typeof summary>) =>
+    value.count === 0
+      ? "n/a"
+      : `${value.median.toFixed(2)} [${value.q1.toFixed(2)}–${value.q3.toFixed(2)}]`;
+
+  for (const workload of casesFor(report.profile)) {
+    const samples = (role: Revision["role"]) =>
+      report.batches
+        .filter(
+          (batch) => batch.role === role && !batch.cold && batch.complete && batch.exitCode === 0,
+        )
+        .flatMap((batch) => batch.report?.samples ?? [])
+        .filter(
+          (sample) => sample.case === workload.name && !sample.warmup && sample.status === "passed",
+        );
+
+    const base = summary(samples("base").map((sample) => sample.totalMs));
+    const head = summary(samples("head").map((sample) => sample.totalMs));
+    const reference = summary(samples("reference").map((sample) => sample.totalMs));
+
+    const entry = summary(
+      samples("head").flatMap((sample) =>
+        sample.modelEntryMs === null ? [] : [sample.modelEntryMs],
+      ),
+    );
+
+    const delta = (baseline: ReturnType<typeof summary>) =>
+      baseline.count === 0 || head.count === 0 || baseline.median === 0
+        ? "n/a"
+        : `${((head.median / baseline.median - 1) * 100).toFixed(1)}%`;
+
+    lines.push(
+      `| ${workload.name} | ${format(base)} | ${format(head)} | ${format(reference)} | ${delta(base)} | ${delta(reference)} | ${format(entry)} |`,
+    );
+  }
+  lines.push(
+    "",
+    "Inline checkpoint construction and save (outside recovery total):",
+    "",
+    "| Workload | Base | Head | Reference |",
+    "| --- | ---: | ---: | ---: |",
+  );
+  for (const workload of casesFor(report.profile).filter(
+    (workload) => workload.kind === "recovery",
+  )) {
+    const checkpoints = (role: Revision["role"]) =>
+      summary(
+        report.batches
+          .filter(
+            (batch) => batch.role === role && !batch.cold && batch.complete && batch.exitCode === 0,
+          )
+          .flatMap((batch) => batch.report?.samples ?? [])
+          .filter(
+            (sample) =>
+              sample.case === workload.name && !sample.warmup && sample.status === "passed",
+          )
+          .flatMap((sample) =>
+            sample.checkpointCreationMs === null ? [] : [sample.checkpointCreationMs],
+          ),
+      );
+
+    lines.push(
+      `| ${workload.name} | ${format(checkpoints("base"))} | ${format(checkpoints("head"))} | ${format(checkpoints("reference"))} |`,
+    );
+  }
+  lines.push(
+    "",
+    "Cold subprocess totals include Node startup, imports, one small run, assertions, and process shutdown:",
+  );
+  for (const role of ["base", "head", "reference"] as const)
+    lines.push(
+      `${role}: ${format(summary(report.batches.filter((batch) => batch.role === role && batch.cold && batch.complete && batch.exitCode === 0).map((batch) => batch.subprocessMs)))}`,
+    );
+
+  const failures = report.batches.flatMap(
+    (batch) => batch.report?.samples.filter((sample) => sample.status === "failed") ?? [],
+  );
+
+  const failedProcesses = report.batches.filter((batch) => batch.exitCode !== 0).length;
+  const incomplete = report.batches.filter((batch) => !batch.complete);
+
+  lines.push(
+    "",
+    `Correctness failures: ${failures.length}; failed subprocesses: ${failedProcesses}.`,
+    `Invalid/incomplete batches: ${incomplete.length}; processes recorded: ${report.batches.length}/${report.settings.batches * 6}. Incomplete batches are excluded from comparison summaries.`,
+    ...incomplete.map(
+      (batch) =>
+        `${batch.role}/${batch.cohort}/${batch.cold ? "cold" : "warm"}: ${(batch.failure ?? "Missing or invalid worker report").split("\n")[0]}`,
+    ),
+    `Fixture ${report.fixture} (${report.fixtureSha256}); reference ${report.referenceVersion}.`,
+    `Node ${report.environment.node}; ${report.environment.platform}/${report.environment.architecture}; ${report.environment.cpu}.`,
+    `Samples per workload/revision: ${report.settings.samplesPerBatch * report.settings.batches}; warmups: ${report.settings.warmupsPerBatch * report.settings.batches}.`,
+  );
+  for (const revision of report.revisions)
+    lines.push(
+      `${revision.role}: ${revision.revision}${revision.dirty ? " (dirty working tree)" : ""}; Effect ${revision.effect}; lock ${revision.lockfileSha256}`,
+    );
+
+  return lines.join("\n") + "\n";
+};
+
+export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (options: {
+  root: string;
+  base: string;
+  reference: string;
+  output: string;
+  profile: Profile;
+  requireClean: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = path.resolve(options.root);
+  const output = path.resolve(options.output);
+
+  yield* fs.makeDirectory(output, { recursive: true });
+  yield* check(
+    !(yield* fs.exists(path.join(output, "report.json"))),
+    "Output already contains a report; choose a new --out-dir to preserve evidence",
+  );
+  const fixtures = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-fixture-" });
+  const source = path.join(root, "examples/runtime-benchmark/src");
+
+  yield* Effect.tryPromise({
+    try: () =>
+      build({
+        entryPoints: ["contracts.ts", "fixture.ts", "worker.ts"].map((file) =>
+          path.join(source, file),
+        ),
+        outdir: fixtures,
+        bundle: false,
+        platform: "node",
+        format: "esm",
+        target: "node24",
+        sourcemap: false,
+        minify: false,
+        logLevel: "silent",
+      }),
+    catch: (cause) => BenchmarkError.make({ message: "Cannot transpile benchmark fixture", cause }),
+  });
+
+  const fixtureBytes = yield* Effect.forEach((yield* fs.readDirectory(fixtures)).sort(), (file) =>
+    fs
+      .readFileString(path.join(fixtures, file))
+      .pipe(Effect.map((contents) => `${file}\n${contents}`)),
+  );
+
+  yield* fs.copy(fixtures, path.join(output, "fixture"));
+  // All compilation and staging finishes before any measurements start.
+  const base = yield* stageCheckout(path.resolve(options.base), "base", fixtures);
+  const head = yield* stageCheckout(root, "head", fixtures);
+  const reference = yield* stageCheckout(path.resolve(options.reference), "reference", fixtures);
+  const stages = [base, head, reference];
+
+  yield* check(
+    reference.revision.revision === REFERENCE.revision && !reference.revision.dirty,
+    `Reference must be clean immutable ${REFERENCE.revision} (${REFERENCE.version})`,
+  );
+  if (options.requireClean)
+    yield* check(
+      stages.every((stage) => !stage.revision.dirty),
+      "--require-clean rejected modified checkouts",
+    );
+  const node = yield* subprocess("node", ["--version"], root);
+
+  yield* check(
+    node.exitCode === 0 && node.stdout.trim().startsWith("v24."),
+    "runtime-v1 requires Node 24; changing the runtime requires a versioned reference reset",
+  );
+
+  const sizes =
+    options.profile === "smoke"
+      ? { batches: 1, warmupsPerBatch: 0, samplesPerBatch: 1 }
+      : options.profile === "pr"
+        ? { batches: 3, warmupsPerBatch: 2, samplesPerBatch: 3 }
+        : {
+            batches: 3,
+            warmupsPerBatch: 5,
+            samplesPerBatch: options.profile === "archive" ? 3 : 10,
+          };
+
+  const batches: Array<Batch> = [];
+
+  const report: PerformanceReport = {
+    fixture: FIXTURE_VERSION,
+    fixtureSha256: sha256(fixtureBytes.join("\n")),
+    transpiler: `esbuild ${esbuildVersion} (fixture syntax only; no bundling)`,
+    profile: options.profile,
+    referenceVersion: REFERENCE.version,
+    environment: {
+      platform: platform(),
+      release: release(),
+      architecture: arch(),
+      cpu: cpus()[0]?.model ?? "unknown",
+      cpuCount: cpus().length,
+      memoryBytes: totalmem(),
+      node: node.stdout.trim(),
+    },
+    settings: {
+      ...sizes,
+      production: true,
+      execution: "unbundled published ESM",
+      timingGate: "informational",
+    },
+    revisions: stages.map((stage) => stage.revision),
+    batches,
+  };
+
+  const persist = Effect.gen(function* () {
+    yield* fs.writeFileString(
+      path.join(output, "report.json"),
+      yield* Schema.encodeEffect(Schema.fromJsonString(PerformanceReport))(report),
+    );
+    yield* fs.writeFileString(path.join(output, "report.md"), renderPerformanceReport(report));
+  });
+
+  const measure = Effect.gen(function* () {
+    yield* persist;
+    for (let cohort = 0; cohort < sizes.batches; cohort++) {
+      // Rotate who goes first on the same runner; no concurrent builds, tests, or revisions.
+      const ordered = [...stages.slice(cohort % 3), ...stages.slice(0, cohort % 3)];
+
+      for (const cold of [true, false])
+        for (const stage of ordered) {
+          const name = `${cohort}-${stage.revision.role}-${cold ? "cold" : "warm"}`;
+          const outputFile = path.join(output, `${name}.json`);
+
+          yield* Console.error(`Measuring ${name} (${options.profile})`);
+
+          const workerOptions = {
+            cold,
+            profile: options.profile,
+            warmups: cold ? 0 : sizes.warmupsPerBatch,
+            samples: cold ? 1 : sizes.samplesPerBatch,
+            output: outputFile,
+          };
+
+          const childStarted = yield* Clock.monotonicTimeNanos;
+
+          const childExit = yield* subprocess(
+            "node",
+            [path.join(stage.stage, "fixture/worker.js")],
+            stage.stage,
+            {
+              NODE_ENV: "production",
+              RUNTIME_BENCHMARK_OPTIONS: Schema.encodeSync(Schema.fromJsonString(WorkerOptions))(
+                workerOptions,
+              ),
+            },
+          ).pipe(
+            Effect.timeout(
+              cold
+                ? "30 seconds"
+                : options.profile === "pr" || options.profile === "smoke"
+                  ? "5 minutes"
+                  : "90 minutes",
+            ),
+            Effect.exit,
+          );
+
+          const result = Exit.isSuccess(childExit)
+            ? childExit.value
+            : {
+                stdout: "",
+                stderr: Cause.pretty(childExit.cause),
+                exitCode: -1,
+                subprocessMs: Number((yield* Clock.monotonicTimeNanos) - childStarted) / 1e6,
+              };
+
+          yield* fs.writeFileString(
+            path.join(output, `${name}.log`),
+            result.stdout + result.stderr,
+          );
+
+          const decodedReport = (yield* fs.exists(outputFile))
+            ? yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
+                yield* fs.readFileString(outputFile),
+              ).pipe(Effect.exit)
+            : null;
+
+          const childReport =
+            decodedReport !== null && Exit.isSuccess(decodedReport) ? decodedReport.value : null;
+
+          const workMatches = childReport !== null && completeBatch(childReport, workerOptions);
+
+          const environmentMatches =
+            childReport !== null &&
+            childReport.runtime === report.environment.node &&
+            childReport.platform === report.environment.platform &&
+            childReport.architecture === report.environment.architecture;
+
+          batches.push({
+            role: stage.revision.role,
+            cohort,
+            cold,
+            subprocessMs: result.subprocessMs,
+            exitCode: result.exitCode,
+            complete: workMatches && environmentMatches,
+            report: childReport,
+            failure:
+              decodedReport !== null && Exit.isFailure(decodedReport)
+                ? Cause.pretty(decodedReport.cause)
+                : result.exitCode !== 0
+                  ? result.stderr
+                  : !workMatches
+                    ? "Missing, duplicated, failed, or unfinalized workload samples"
+                    : !environmentMatches
+                      ? "Worker runtime/platform/architecture differs from the controller"
+                      : null,
+          });
+          yield* persist;
+        }
+    }
+  }).pipe(Effect.onExit(() => persist));
+
+  yield* withPublishManifests(base.stage, () =>
+    withPublishManifests(head.stage, () => withPublishManifests(reference.stage, () => measure)),
+  );
+  yield* Console.log(renderPerformanceReport(report));
+  yield* check(
+    batches.every((batch) => batch.exitCode === 0 && batch.complete),
+    "Benchmark correctness failed; timings are informational but incomplete work is rejected",
+  );
+
+  return report;
+}, Effect.scoped);
+
+export const command = Command.make(
+  "runtime-benchmark",
+  {
+    base: Flag.string("base-dir").pipe(
+      Flag.withDescription(
+        "Exact base checkout, installed with its lockfile and production packages built.",
+      ),
+    ),
+    reference: Flag.string("reference-dir").pipe(
+      Flag.withDescription(`Clean built immutable reference ${REFERENCE.revision}.`),
+    ),
+    output: Flag.string("out-dir").pipe(
+      Flag.withDefault(".performance-report"),
+      Flag.withDescription("New artifact directory; existing reports are never overwritten."),
+    ),
+    profile: Flag.choice("profile", ["smoke", "pr", "extended", "archive"]).pipe(
+      Flag.withDefault("pr"),
+      Flag.withDescription(
+        "Bounded PR cohort, larger local matrix, or manual 100k-record archive profile.",
+      ),
+    ),
+    requireClean: Flag.boolean("require-clean").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Reject modified or untracked files in any checkout (required by CI)."),
+    ),
+  },
+  Effect.fn(function* ({ base, reference, output, profile, requireClean }) {
+    const path = yield* Path.Path;
+
+    const root = path.resolve(
+      path.dirname(yield* path.fromFileUrl(new URL(import.meta.url))),
+      "..",
+    );
+
+    yield* compareRuntime({ root, base, reference, output, profile, requireClean });
+  }),
+).pipe(
+  Command.withDescription(
+    "Compare public built packages on one runner against PR base and a retained reference; no provider calls.",
+  ),
+);
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Command.run(command, { version: FIXTURE_VERSION }).pipe(
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    ),
+  );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,6 +166,18 @@ export default defineConfig({
       scripts: true,
     },
     tasks: {
+      "perf:compare": {
+        cache: false,
+        command: "bun scripts/runtime-benchmark.ts",
+      },
+      "perf:cloudflare": {
+        cache: false,
+        command: "bun examples/context-continuity-eval/src/performance-main.ts",
+      },
+      "perf:cloudflare:build": {
+        cache: false,
+        command: "bun examples/context-continuity-eval/src/build-performance-cloudflare.ts",
+      },
       "bundle:compare": {
         cache: false,
         command: "bun scripts/bundle-size.ts",


### PR DESCRIPTION
Fragmented text and reasoning responses repeatedly paid for generic ownership codecs and one tracing span per delta. Copy the common bounded primitive shape into owned data, validate it with native Effect schemas, and retain the general path for complex parts. Cache immutable output-contract messages so native opt-in incremental requests can recognize an unchanged prompt prefix.

Add a public-package benchmark on every PR, comparing exact base/head commits and a retained release reference with identical fixture bytes, matching Node runtimes, and each checkout's lockfile. It covers small runs/streams, fixed-size fragmented output, growing prompts, parallel tools, SQLite history, checkpoint creation/recovery, and settled ledgers. Correctness assertions gate the run; timings remain informational, with raw samples and spread retained.

```mermaid
flowchart LR
  F[Versioned scripted fixture] --> B[Built PR base]
  F --> H[Built PR head]
  F --> R[Built retained release]
  B --> A[Validated samples and comparison artifacts]
  H --> A
  R --> A
```

Add a separate manual Cloudflare evaluation using real model-selected tools, validated orders, retained history, and forced Durable Object recovery. It records actual provider dispatch and lifecycle timing, bounds spending and resources, and retires disposable Workers/namespaces with retryable cleanup evidence. The deployment lifecycle acquires ownership persistence through an Effect service supplied by the CLI. General examples use the default tool concurrency; the demo shows received-character progress until structured output validates.

```sh
vp run perf:compare --base-dir ../base --reference-dir ../reference --require-clean
vp run perf:cloudflare --dry-run
```

Validation:

- `VITEST_MAX_WORKERS=2 vp run ready` passed, including crash/fault suites, examples, docs, and Action builds. Unrestricted runs reproduced the known Cloudflare timeout sensitivity and additional process-kill/timeouts; assertions and timeouts were preserved.
- The clean committed PR profile at `6c05d0a` passed all 864 samples including warmups/cold runs. On Node 24.20.0 / Apple M4 Max, the 64 KiB / 4,096-chunk median fell from 415.82 ms [411.23–438.99] to 146.91 ms [143.46–149.31], 64.7% lower; retained reference: 414.11 ms. Brackets are Q1–Q3; nine measured samples per revision across three rotating cohorts. These are local scripted processing times, not hosted latency.
- Clean candidate/reference Cloudflare dry-run builds at `6c05d0a` passed with the same fixture digest. The evaluator's 71 offline tests passed after the ownership service refactor, including tool/history rejection, recovery, finalization, cleanup failures, and ownership/cleanup persistence failures. Type assertions verify the persistence requirement remains in the Effect environment.
- The offline demo was exercised in the browser and its final screenshot retained locally.

Live Cloudflare/OpenAI validation passed all six fresh/warm/recovery scenarios and first-attempt cleanup after the [cleanup follow-up](https://github.com/danieljvdm/effect-agent/pull/394). The exact tested candidate was `5abe4217`, compared with `f497de24` using `gpt-6-astra`; independent API reads confirmed both temporary Workers were absent. One sample per revision verifies the scenario and lifecycle; provider variance makes these timings informational. Fresh-history work still has its existing `3N + 6` budget; timing reports do not claim constant-time durable startup or provider/billing improvements.


