### PR TITLE
fix: remove KV permissions from performance cleanup

### DIFF
--- a/examples/context-continuity-eval/README.md
+++ b/examples/context-continuity-eval/README.md
@@ -201,7 +201,9 @@ tests use a scripted transport and are explicitly not live-provider or Cloudflar
 Cleanup runs on success, failure, and interruption. Ownership is persisted before upload, including
 ambiguous partial deployments. The command first deploys a
 [deleted class tombstone](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/)
-to remove the entire disposable namespace/data, then deletes and verifies removal of the Worker.
+to remove the entire disposable namespace/data, then deletes the Worker through the Workers API
+and verifies its removal. Cleanup requires Workers Scripts permissions; it does not scan KV
+namespaces or require KV permissions.
 The workflow retries recorded cleanup in an `always()` step. A failed cleanup fails the run and
 leaves its exact resource names in `resources.json`; retry using the same account credentials:
 

--- a/examples/context-continuity-eval/src/performance-deployment.ts
+++ b/examples/context-continuity-eval/src/performance-deployment.ts
@@ -166,7 +166,7 @@ const writeCleanupConfig = Effect.fn("Performance.writeCleanupConfig")(function*
   );
 });
 
-/** Wrangler owns remote mutation. Secret file is scoped outside the evidence directory. */
+/** Wrangler owns uploads and namespace retirement. Secret file is scoped outside the evidence directory. */
 export const makePerformanceDeployment = Effect.fn("Performance.deployment")(function* (
   secretsFile: string | undefined,
   sensitiveValues: ReadonlyArray<Redacted.Redacted<string>> = [],
@@ -328,13 +328,33 @@ export const makePerformanceDeployment = Effect.fn("Performance.deployment")(fun
           path.join(target.directory, "cleanup.json"),
           "--no-bundle",
         ]);
-        yield* run(target, "delete-worker", [
-          "delete",
-          target.name,
-          "--config",
-          path.join(target.directory, "cleanup.json"),
-          "--force",
-        ]);
+        // The fixture owns no KV assets. Wrangler's delete command also scans legacy KV
+        // namespaces after deleting the Worker, requiring unrelated account permissions.
+        yield* client
+          .execute(
+            HttpClientRequest.delete(
+              `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/workers/scripts/${target.name}`,
+            ).pipe(HttpClientRequest.bearerToken(config.apiToken)),
+          )
+          .pipe(
+            Effect.timeout("20 seconds"),
+            Effect.flatMap((response) =>
+              response.status === 404 || (response.status >= 200 && response.status < 300)
+                ? Effect.void
+                : Effect.fail(
+                    EvaluationError.make({
+                      stage: "delete-worker",
+                      message: `Worker deletion failed: ${target.name}`,
+                    }),
+                  ),
+            ),
+            Effect.mapError(() =>
+              EvaluationError.make({
+                stage: "delete-worker",
+                message: `Worker deletion failed: ${target.name}; cleanup may need retry`,
+              }),
+            ),
+          );
         if (yield* exists(target))
           return yield* EvaluationError.make({
             stage: "cleanup",

--- a/examples/context-continuity-eval/test/performance-deployment.test.ts
+++ b/examples/context-continuity-eval/test/performance-deployment.test.ts
@@ -1,0 +1,106 @@
+import { NodeServices } from "@effect/platform-node";
+import { ConfigProvider, Effect, Exit, FileSystem, Layer, Sink, Stream } from "effect";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { expect, it } from "vite-plus/test";
+
+import {
+  makePerformanceDeployment,
+  type PerformanceTarget,
+} from "../src/performance-deployment.ts";
+
+it.each(["deleted", "already-gone", "forbidden", "unconfirmed"] as const)(
+  "retires the namespace and verifies Worker removal without KV access: %s",
+  async (mode) => {
+    const actions: Array<string> = [];
+    let present = true;
+    const name = `effect-agent-perf-${"a".repeat(32)}-candidate`;
+    const url = `https://api.cloudflare.com/client/v4/accounts/${"b".repeat(32)}/workers/scripts/${name}`;
+
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        expect(request.url).toBe(url);
+        expect(request.headers.authorization).toBe("Bearer test-token");
+        actions.push(request.method);
+        let status = present ? 200 : 404;
+
+        if (request.method === "DELETE") {
+          status = mode === "forbidden" ? 403 : mode === "already-gone" ? 404 : 204;
+          if (mode === "deleted" || mode === "already-gone") present = false;
+        }
+
+        return HttpClientResponse.fromWeb(request, new Response(null, { status }));
+      }),
+    );
+
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        if (command._tag !== "StandardCommand") throw new Error("Unexpected piped cleanup command");
+        expect(command.command).toBe("vp");
+        expect(command.args.slice(0, 4)).toEqual(["exec", "wrangler", "deploy", "--config"]);
+        expect(command.args[4]).toMatch(/\/cleanup\.json$/);
+        actions.push("retire-namespace");
+
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(42),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: Sink.drain,
+          stdout: Stream.empty,
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        });
+      }),
+    );
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "performance-cleanup-" });
+
+        const target: typeof PerformanceTarget.Type = {
+          label: "candidate",
+          name,
+          url: "https://unused.example",
+          directory,
+          sourceCommit: "a".repeat(40),
+          cleanupRequired: true,
+          cleanupComplete: false,
+        };
+
+        const deployment = yield* makePerformanceDeployment(undefined);
+
+        return yield* deployment.remove(target).pipe(Effect.exit);
+      }).pipe(
+        Effect.provideService(HttpClient.HttpClient, http),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.scoped,
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            ConfigProvider.layer(
+              ConfigProvider.fromUnknown({
+                CLOUDFLARE_ACCOUNT_ID: "b".repeat(32),
+                CLOUDFLARE_API_TOKEN: "test-token",
+                CLOUDFLARE_WORKERS_SUBDOMAIN: "test",
+                PATH: "/unused",
+                HOME: "/unused",
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(actions).toEqual(
+      mode === "forbidden"
+        ? ["GET", "retire-namespace", "DELETE"]
+        : ["GET", "retire-namespace", "DELETE", "GET"],
+    );
+    expect(Exit.isSuccess(exit)).toBe(mode === "deleted" || mode === "already-gone");
+  },
+);


### PR DESCRIPTION
The live Cloudflare benchmark completed all six agent scenarios, but Wrangler reported cleanup failures after deleting the Workers because its delete command also lists legacy KV namespaces. A token with Workers permissions could therefore fail an otherwise successful run.

Keep namespace retirement through Wrangler, then delete only the recorded Worker through the Workers API and verify its absence. Treat an already-absent Worker as cleaned up; permission failures and an unconfirmed deletion still fail the run. Document that this fixture requires no KV permissions.

Validation: `VITEST_MAX_WORKERS=2 vp run ready` passed, including four adapter regression cases for successful deletion, an already-absent Worker, permission denial, and deletion that cannot be confirmed. CI and automated review passed. A live `gpt-6-astra` comparison at `5abe4217` against `f497de24` passed all six fresh/warm/recovery scenarios and first-attempt cleanup; independent API reads confirmed both Workers were absent. One sample per revision verifies the scenario and lifecycle, not a latency regression threshold.
