### PR TITLE
feat: complete ordinary actions from canonical tool receipts

### DIFF
--- a/.changeset/canonical-action-completion.md
+++ b/.changeset/canonical-action-completion.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Add `completionFromTools` to complete a Run from a successful canonical action result without another model turn. Let pure projectors decline completion while preserving ordinary action budgets, authorization, approvals, and durable recovery.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -152,6 +152,12 @@ The single Definition-designated Tool whose successful singleton call projects t
 output Schema and completes the Run immediately. It remains an ordinary external side effect for
 authorization and durability; the designation adds terminal semantics, not exactly-once execution.
 
+**Action completion**
+
+An optional Definition-owned projection from an ordinary action Tool's successful canonical result
+to Agent output. The Tool runs alone and receives no completion-budget exemption. The pure
+projector may decline completion when the whole request remains unfinished.
+
 **Step**  
 A deterministically named sub-operation within one Durable Tool Call. Its result is
 exactly-once-recorded but its external side effect is at-least-once-executed.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -186,6 +186,32 @@ controls the last available turn.
 `completion` decides how a run finishes. `runDisposition` labels its successful output for
 durable readers.
 
+Use `completionFromTools` for an action whose committed result can satisfy the whole request,
+while retaining a separate `completion` tool for ordinary replies. Each declaration names a tool
+and provides a pure projector returning `Option.some(output)` or `Option.none()`:
+
+```ts
+completionFromTools: [{
+  tool: "complete_action",
+  project: ({ parameters, result }) =>
+    parameters.wholeRequestSatisfied && result.status === "committed"
+      ? Option.some(`Created [${result.name}](${result.href}).`)
+      : Option.none(),
+}],
+```
+
+Import `Option` from `effect`. The tool's schemas define the parameters and result in this example.
+Only opt in tools with an explicit whole-request contract; completing the first step of a larger
+request must not end the run. Return `None` for pending approval, partial, or otherwise insufficient
+results. A declared tool failure also continues normally. Invalid output or a throwing projector
+fails the run, rather than treating an unconfirmed result as success.
+
+These action tools must be the only call in their batch and obey ordinary tool, turn, and token
+budgets. They cannot execute in the reserved finalization turn; the existing `completion` tool
+retains that role. Authorization, approvals, cancellation, and durable tool replay rules remain
+unchanged. Recovery re-evaluates the projector from canonical parameters and results, so it must
+be deterministic and perform no effects. Tool names must be distinct across completion declarations.
+
 ## Declare application completion explicitly
 
 Use `runDisposition` when durable readers need an application-defined classification in addition

--- a/packages/core/src/Agent.ts
+++ b/packages/core/src/Agent.ts
@@ -1,4 +1,4 @@
-import type { Effect, Layer, Schema } from "effect";
+import type { Effect, Layer, Option, Schema } from "effect";
 import * as S from "effect/Schema";
 import type { AiError, LanguageModel, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
 
@@ -66,6 +66,29 @@ type CompletionToolFor<ToolkitValue extends Toolkit.Any, Output> = {
   > & { readonly tool: Name };
 }[keyof ToolkitValue["tools"] & string];
 
+/**
+ * An ordinary action Tool whose canonical success may satisfy the whole request.
+ * Projectors must be pure and deterministic: recovery re-evaluates them. None preserves
+ * ordinary continuation; Some is validated as the Agent output. These Tools must run alone
+ * and never receive the required completion Tool's exhaustion allowance.
+ */
+export interface CompletionFromToolDeclaration<
+  Parameters = unknown,
+  Result = unknown,
+  Output = unknown,
+> {
+  readonly tool: string;
+  readonly project: (input: CompletionProjectionInput<Parameters, Result>) => Option.Option<Output>;
+}
+
+type CompletionFromToolFor<ToolkitValue extends Toolkit.Any, Output> = {
+  readonly [Name in keyof ToolkitValue["tools"] & string]: CompletionFromToolDeclaration<
+    Tool.Parameters<ToolkitValue["tools"][Name]>,
+    Tool.Success<ToolkitValue["tools"][Name]>,
+    Output
+  > & { readonly tool: Name };
+}[keyof ToolkitValue["tools"] & string];
+
 /** Immutable, model-agnostic schemas, behavior, tools, and bounds for an agent. */
 export interface Definition<
   InputSchema extends Schema.Top,
@@ -93,6 +116,7 @@ export interface Definition<
   readonly policyOverrides?: Partial<AgentPolicyInput> | undefined;
   /** Optional successful Tool result that projects directly to the Agent output and settles. */
   readonly completion?: CompletionToolDeclaration | undefined;
+  readonly completionFromTools?: ReadonlyArray<CompletionFromToolDeclaration> | undefined;
   readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
@@ -117,6 +141,9 @@ export interface DefinitionOptions<
   readonly toolkit: ToolkitValue;
   readonly policy?: Partial<AgentPolicyInput> | undefined;
   readonly completion?: CompletionToolFor<ToolkitValue, OutputSchema["Type"]> | undefined;
+  readonly completionFromTools?:
+    | ReadonlyArray<CompletionFromToolFor<ToolkitValue, OutputSchema["Type"]>>
+    | undefined;
   readonly runDisposition?: RunDispositionValue | undefined;
   readonly description?: string | undefined;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
@@ -374,11 +401,24 @@ export function make(
     readonly toolkit: Toolkit.Any;
     readonly policy?: Partial<AgentPolicyInput> | undefined;
     readonly completion?: CompletionToolDeclaration | undefined;
+    readonly completionFromTools?: ReadonlyArray<CompletionFromToolDeclaration> | undefined;
     readonly runDisposition?: RunDispositionDeclaration<never, Schema.Top> | undefined;
     readonly description?: string | undefined;
     readonly metadata?: Readonly<Record<string, string>> | undefined;
   },
 ): AnyDefinition {
+  const completionNames = new Set<string>();
+
+  for (const declaration of options.completionFromTools ?? []) {
+    if (declaration.tool === options.completion?.tool || completionNames.has(declaration.tool)) {
+      throw new Error(`Tool ${declaration.tool} has more than one completion declaration`);
+    }
+    if (options.toolkit.tools[declaration.tool] === undefined) {
+      throw new Error(`Unknown completion Tool ${declaration.tool}`);
+    }
+    completionNames.add(declaration.tool);
+  }
+
   return Object.freeze({
     ...options,
     policy: AgentPolicy.resolve(options.policy),
@@ -387,6 +427,12 @@ export function make(
     metadata: options.metadata === undefined ? undefined : Object.freeze({ ...options.metadata }),
     completion:
       options.completion === undefined ? undefined : Object.freeze({ ...options.completion }),
+    completionFromTools:
+      options.completionFromTools === undefined
+        ? undefined
+        : Object.freeze(
+            options.completionFromTools.map((declaration) => Object.freeze({ ...declaration })),
+          ),
     runDisposition:
       options.runDisposition === undefined
         ? undefined

--- a/packages/core/test/agent-types.test.ts
+++ b/packages/core/test/agent-types.test.ts
@@ -7,7 +7,7 @@ import {
   type ContextOverflowError,
 } from "@effect-agent/core/AgentError";
 import { AgentPolicy, type CompactionPolicy } from "@effect-agent/core/AgentPolicy";
-import { Context, Effect, Layer, Schema, Stream } from "effect";
+import { Context, Effect, Layer, Option, Schema, Stream } from "effect";
 import { type AiError, LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -174,6 +174,20 @@ const terminalDefinition = Agent.make("terminal-type-proof", {
   },
 });
 
+const actionCompletionDefinition = Agent.make("action-type-proof", {
+  input: Schema.String,
+  output: Schema.Struct({ message: Schema.String, messageId: Schema.String }),
+  instructions: "Deliver one action.",
+  toolkit: DeliveryTools,
+  completionFromTools: [
+    {
+      tool: "post_message",
+      project: ({ parameters, result }) =>
+        Option.some({ message: parameters.message, messageId: result.messageId }),
+    },
+  ],
+});
+
 type ExpectedRequirements =
   | InstructionContext
   | ModelConfig
@@ -292,6 +306,8 @@ describe("Agent type inference", () => {
     expect(runDispositionFailureProof).toBe(true);
     expect(Object.isFrozen(dispositionDefinition.runDisposition)).toBe(true);
     expect(Object.isFrozen(terminalDefinition.completion)).toBe(true);
+    expect(Object.isFrozen(actionCompletionDefinition.completionFromTools)).toBe(true);
+    expect(Object.isFrozen(actionCompletionDefinition.completionFromTools?.[0])).toBe(true);
     expect(agent.definition).toBe(definition);
     expect(agent.model).toBe(model);
     expect(Object.isFrozen(definition)).toBe(true);

--- a/packages/engine/src/AgentRuntime.ts
+++ b/packages/engine/src/AgentRuntime.ts
@@ -3,6 +3,7 @@ export {
   decodeFinalOutput,
   encodeRunDisposition,
   projectCompletionOutput,
+  projectCompletionFromToolOutput,
   run,
   runUnknown,
   start,

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -1,6 +1,7 @@
 import type * as Agent from "@effect-agent/core/Agent";
 import {
   type CompletionToolDeclaration,
+  type CompletionFromToolDeclaration,
   type Definition,
   type InputPromptSource,
   type InstructionSource,
@@ -4528,18 +4529,18 @@ const decodeFinalOutput = Effect.fn("AgentRuntime.decodeFinalOutput")(function* 
 const encodeOutputCandidate = Effect.fn("AgentRuntime.encodeOutputCandidate")(function* <
   AgentValue extends Agent.Any,
 >(agent: AgentValue, candidate: unknown) {
-  const decoded = yield* Schema.decodeUnknownEffect(agent.definition.output)(candidate).pipe(
+  const encoded = yield* Schema.encodeUnknownEffect(agent.definition.output)(candidate).pipe(
     Effect.mapError((cause) =>
       AgentOutputError.make({
-        message: cause.message,
+        message: `Completion Tool output failed Schema encoding: ${cause.message}`,
       }),
     ),
   );
 
-  const encoded = yield* Schema.encodeUnknownEffect(agent.definition.output)(decoded).pipe(
+  const decoded = yield* Schema.decodeUnknownEffect(agent.definition.output)(encoded).pipe(
     Effect.mapError((cause) =>
       AgentOutputError.make({
-        message: `Completion Tool output failed Schema encoding: ${cause.message}`,
+        message: `Completion Tool output failed canonical decoding: ${cause.message}`,
       }),
     ),
   );
@@ -4555,15 +4556,15 @@ const encodeOutputCandidate = Effect.fn("AgentRuntime.encodeOutputCandidate")(fu
   return { encoded: json, decoded };
 });
 
-const projectCompletionOutput = Effect.fn("AgentRuntime.projectCompletionOutput")(function* <
+const projectToolResult = Effect.fn("AgentRuntime.projectToolResult")(function* <
   AgentValue extends Agent.Any,
 >(
   agent: AgentValue,
-  declaration: CompletionToolDeclaration,
+  declaration: CompletionToolDeclaration | CompletionFromToolDeclaration,
   parameters: unknown,
   result: unknown,
 ): Effect.fn.Return<
-  { readonly encoded: Schema.Json; readonly decoded: Agent.Output<AgentValue> },
+  unknown,
   AgentOutputError | ModelProtocolError,
   AgentCompletionProjectionRequirements<AgentValue>
 > {
@@ -4601,8 +4602,38 @@ const projectCompletionOutput = Effect.fn("AgentRuntime.projectCompletionOutput"
       }),
   });
 
-  return yield* encodeOutputCandidate(agent, projected);
+  return projected;
 });
+
+const projectCompletionOutput = Effect.fn("AgentRuntime.projectCompletionOutput")(function* <
+  AgentValue extends Agent.Any,
+>(agent: AgentValue, declaration: CompletionToolDeclaration, parameters: unknown, result: unknown) {
+  return yield* encodeOutputCandidate(
+    agent,
+    yield* projectToolResult(agent, declaration, parameters, result),
+  );
+});
+
+/** Reconstruct optional action completion identically for live execution and canonical recovery. */
+const projectCompletionFromToolOutput = Effect.fn("AgentRuntime.projectCompletionFromToolOutput")(
+  function* <AgentValue extends Agent.Any>(
+    agent: AgentValue,
+    declaration: CompletionFromToolDeclaration,
+    parameters: unknown,
+    result: unknown,
+  ) {
+    const projected = yield* projectToolResult(agent, declaration, parameters, result);
+
+    if (!Option.isOption(projected)) {
+      return yield* AgentOutputError.make({
+        message: "Action completion projector did not return an Option",
+      });
+    }
+    if (Option.isNone(projected)) return Option.none();
+
+    return Option.some(yield* encodeOutputCandidate(agent, projected.value));
+  },
+);
 
 const encodeRunDispositionCandidate = Effect.fn("AgentRuntime.encodeRunDisposition")(function* <
   Output,
@@ -5725,6 +5756,12 @@ const makeTurn = <
             completionTool !== undefined &&
             trace.applicationToolCalls.some((call) => call.name === completionTool);
 
+          const declaresActionCompletion = trace.applicationToolCalls.some((call) =>
+            agent.definition.completionFromTools?.some(
+              (declaration) => declaration.tool === call.name,
+            ),
+          );
+
           const declaresRollover = trace.applicationToolCalls.some(
             (call) =>
               hasTool(agent.definition.toolkit.tools, call.name) &&
@@ -5734,7 +5771,10 @@ const makeTurn = <
               ),
           );
 
-          if (declaresRollover && (trace.toolCalls.size !== 1 || declaresCompletion)) {
+          if (
+            declaresRollover &&
+            (trace.toolCalls.size !== 1 || declaresCompletion || declaresActionCompletion)
+          ) {
             return failRunEventStream(
               ModelProtocolError.make({
                 message:
@@ -5743,10 +5783,12 @@ const makeTurn = <
             );
           }
 
-          if (declaresCompletion && trace.toolCalls.size !== 1) {
+          if ((declaresCompletion || declaresActionCompletion) && trace.toolCalls.size !== 1) {
             return failRunEventStream(
               ModelProtocolError.make({
-                message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`,
+                message: declaresCompletion
+                  ? `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+                  : "An action completion Tool must be the only Tool Call in its batch",
               }),
             );
           }
@@ -6342,33 +6384,56 @@ const toolBatchContinuation = <
 
       const completion = agent.definition.completion;
 
-      const completionResult =
-        completion !== undefined &&
+      const successfulResult =
         trace.applicationToolCalls.length === 1 &&
         orderedResults.length === 1 &&
-        orderedResults[0]?.name === completion.tool &&
-        orderedResults[0].isFailure === false
+        orderedResults[0]?.isFailure === false
           ? orderedResults[0]
           : undefined;
 
-      if (completion !== undefined && completionResult !== undefined) {
+      const actionCompletion = agent.definition.completionFromTools?.find(
+        (declaration) => declaration.tool === successfulResult?.name,
+      );
+
+      let selectedOutput: Option.Option<{
+        readonly encoded: Schema.Json;
+        readonly decoded: Agent.Output<typeof agent>;
+      }> = Option.none();
+
+      if (
+        successfulResult !== undefined &&
+        (successfulResult.name === completion?.tool || actionCompletion !== undefined)
+      ) {
         const call = trace.applicationCallDescriptors[0];
 
         if (call === undefined) {
           return failRunEventStream(
             ModelProtocolError.make({
-              message: `Completion Tool ${completion.tool} has no canonical call descriptor`,
+              message: "Completion Tool has no canonical call descriptor",
             }),
           );
         }
+        if (actionCompletion !== undefined) {
+          selectedOutput = yield* projectCompletionFromToolOutput(
+            agent,
+            actionCompletion,
+            call.parameters,
+            successfulResult.encodedResult,
+          );
+        } else if (completion !== undefined) {
+          selectedOutput = Option.some(
+            yield* projectCompletionOutput(
+              agent,
+              completion,
+              call.parameters,
+              successfulResult.encodedResult,
+            ),
+          );
+        }
+      }
 
-        const output = yield* projectCompletionOutput(
-          agent,
-          completion,
-          call.parameters,
-          completionResult.encodedResult,
-        );
-
+      if (Option.isSome(selectedOutput)) {
+        const output = selectedOutput.value;
         const bounds = effectiveRunBounds(agent.definition.policy, options);
 
         const exhausted = context.tokenExhausted
@@ -6556,9 +6621,14 @@ const makeResumeTurn = <
       }
       const completionTool = agent.definition.completion?.tool;
 
+      const actionCompletionCall = trace.applicationToolCalls.find((call) =>
+        agent.definition.completionFromTools?.some((declaration) => declaration.tool === call.name),
+      );
+
       if (
-        completionTool !== undefined &&
-        trace.applicationToolCalls.some((call) => call.name === completionTool) &&
+        (actionCompletionCall !== undefined ||
+          (completionTool !== undefined &&
+            trace.applicationToolCalls.some((call) => call.name === completionTool))) &&
         trace.toolCalls.size !== 1
       ) {
         return failRunEventStream(
@@ -6574,9 +6644,11 @@ const makeResumeTurn = <
         trace.applicationToolCalls[0]?.name === completionTool;
 
       if (
-        completionBatch &&
-        completionTool !== undefined &&
-        Context.get(tools[completionTool].annotations, ContextRolloverTool)
+        (completionBatch &&
+          completionTool !== undefined &&
+          Context.get(tools[completionTool].annotations, ContextRolloverTool)) ||
+        (actionCompletionCall !== undefined &&
+          Context.get(tools[actionCompletionCall.name].annotations, ContextRolloverTool))
       ) {
         return failRunEventStream(
           ModelProtocolError.make({ message: "A context rollover Tool cannot complete the Run" }),
@@ -9171,6 +9243,7 @@ export {
   decodeFinalOutput,
   encodeRunDisposition,
   projectCompletionOutput,
+  projectCompletionFromToolOutput,
   run,
   runUnknown,
   start,

--- a/packages/engine/src/internal/output-contract.ts
+++ b/packages/engine/src/internal/output-contract.ts
@@ -66,8 +66,8 @@ const contractDirective = (definition: Agent.AnyDefinition): string =>
       "JSON that is valid against this JSON Schema — no prose, no Markdown code fences, nothing " +
       `before or after the JSON. When calling the "${definition.completion.tool}" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool's parameter schema instead. The engine projects the successful completion Tool result into the Agent output.`;
 
-const requiredCompletionDirective = (tool: string): string =>
-  `Final output contract: complete only by calling the required completion Tool ${JSON.stringify(tool)} ` +
+const requiredCompletionDirective = (tool: string, hasAlternatives: boolean): string =>
+  `Final output contract: ${hasAlternatives ? "otherwise complete" : "complete only"} by calling the required completion Tool ${JSON.stringify(tool)} ` +
   "as the sole Tool Call in its batch. Do not emit an ordinary final assistant text answer. " +
   "The Tool's canonical parameters and successful result are projected and validated as the Agent output.";
 
@@ -87,7 +87,12 @@ const rendered = (message: string): OutputContract => ({
 
 const renderOutputSchemaContract = (definition: Agent.AnyDefinition): OutputContract => {
   if (definition.completion?.required === true) {
-    return rendered(requiredCompletionDirective(definition.completion.tool));
+    return rendered(
+      requiredCompletionDirective(
+        definition.completion.tool,
+        (definition.completionFromTools?.length ?? 0) > 0,
+      ),
+    );
   }
   if (isTextOutput(definition.output)) {
     return rendered(
@@ -120,7 +125,18 @@ export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputCon
   const cached = outputContracts.get(definition);
 
   if (cached !== undefined) return cached;
-  const contract = renderOutputSchemaContract(definition);
+  const base = renderOutputSchemaContract(definition);
+  const alternatives = definition.completionFromTools ?? [];
+
+  const contract =
+    base._tag === "rendered" && alternatives.length > 0
+      ? rendered(
+          `The following action Tools may complete the Run from their successful canonical result: ${alternatives.map((declaration) => JSON.stringify(declaration.tool)).join(", ")}. ` +
+            "Call such a Tool alone, following its parameter schema. It may complete the Run only when it satisfies the whole request. " +
+            "An incomplete or pending result continues the Run. These actions are unavailable during finalization after budget exhaustion.\n\n" +
+            base.message,
+        )
+      : base;
 
   outputContracts.set(definition, contract);
 

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -15,7 +15,7 @@ import {
   type RunContextHook,
 } from "@effect-agent/engine/RunOptions";
 import { type ThreadHistory } from "@effect-agent/engine/ThreadHistory";
-import { Context, Effect, Layer, Schema, SchemaGetter, type Scope, Stream } from "effect";
+import { Context, Effect, Layer, Option, Schema, SchemaGetter, type Scope, Stream } from "effect";
 import { LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
 import { expectTypeOf, it } from "vite-plus/test";
 
@@ -285,7 +285,7 @@ it("preserves disjoint tool schemas and callbacks with different input types", (
     inputPrompt: ({ topic }) => Effect.map(TopicInstructions, (prefix) => `${prefix}: ${topic}`),
     toolkit: topicTools,
     policy: planner.policy,
-    completion: { tool: "complete", project: ({ result }) => result },
+    completionFromTools: [{ tool: "complete", project: ({ result }) => Option.some(result) }],
   });
 
   type Selected = typeof planner | typeof topic;

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -1056,6 +1056,256 @@ layer(testLayer)("context economics — bounding, tracking, status, exhaustion",
       }),
   );
 
+  // https://linear.app/reve-ai/issue/KOM-144
+  it.effect.each(["committed", "pending", "failure"] as const)(
+    "action completion settles only a committed whole-request result: %s",
+    (outcome) =>
+      Effect.gen(function* () {
+        class ActionFailure extends Schema.TaggedError<ActionFailure>()("ActionFailure", {}) {}
+
+        const Create = Tool.make("complete_action", {
+          parameters: Schema.Struct({ name: Schema.String, wholeRequestSatisfied: Schema.Boolean }),
+          success: Schema.Struct({
+            status: Schema.Literals(["committed", "pending"]),
+            href: Schema.String,
+          }),
+          failure: ActionFailure,
+          failureMode: "return",
+        });
+
+        const tools = Toolkit.make(Create, PostMessageTool);
+
+        const definition = Agent.make("action-completion", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Complete one requested action or explain what remains.",
+          toolkit: tools,
+          policy: { maxTurns: 3, maxToolCalls: 3 },
+          completion: {
+            tool: "post_message",
+            required: true,
+            project: ({ parameters }) => parameters.message,
+          },
+          completionFromTools: [
+            {
+              tool: "complete_action",
+              project: ({ parameters, result }) =>
+                parameters.wholeRequestSatisfied && result.status === "committed"
+                  ? Option.some(`Created [${parameters.name}](${result.href}).`)
+                  : Option.none(),
+            },
+          ],
+        });
+
+        const { model, requests } = scriptedModel([
+          toolCallParts("create-1", "complete_action", {
+            name: "Project",
+            wholeRequestSatisfied: true,
+          }),
+          toolCallParts("reply-1", "post_message", { message: "Action needs attention." }),
+        ]);
+
+        const handlerStarts = yield* Ref.make(0);
+
+        const result = yield* AgentRuntime.run(
+          Agent.withModel(definition, model),
+          "Create Project",
+        ).pipe(
+          Effect.provide(
+            tools.toLayer({
+              complete_action: () =>
+                Ref.update(handlerStarts, (count) => count + 1).pipe(
+                  Effect.andThen(
+                    outcome === "failure"
+                      ? ActionFailure.make({})
+                      : Effect.succeed({ status: outcome, href: "/project/1" }),
+                  ),
+                ),
+              post_message: () => Effect.succeed({ messageId: "reply-1" }),
+            }),
+          ),
+        );
+
+        expect(result.output).toBe(
+          outcome === "committed" ? "Created [Project](/project/1)." : "Action needs attention.",
+        );
+        expect(requests).toHaveLength(outcome === "committed" ? 1 : 2);
+        expect(yield* Ref.get(handlerStarts)).toBe(1);
+        expect(promptText(requests[0]!.prompt)).toContain("satisfies the whole request");
+      }),
+  );
+
+  it.effect.each(["mixed", "tokens", "tool-calls", "turns"] as const)(
+    "action completion cannot bypass ordinary admission: %s",
+    (boundary) =>
+      Effect.gen(function* () {
+        const tools = Toolkit.make(PostMessageTool, SearchTool);
+
+        const definition = Agent.make("bounded-action-completion", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Use search for the action and post_message to finish.",
+          toolkit: tools,
+          policy: {
+            maxTurns: boundary === "turns" ? 1 : 4,
+            maxToolCalls: boundary === "tool-calls" ? 1 : 4,
+            tokenBudget: 10_000,
+          },
+          completion: {
+            tool: "post_message",
+            required: true,
+            project: ({ parameters }) => parameters.message,
+          },
+          completionFromTools: [{ tool: "search", project: ({ result }) => Option.some(result) }],
+        });
+
+        const action = toolCallParts(
+          "action-1",
+          "search",
+          {},
+          boundary === "tokens" ? usageOf(9_000, 4_000) : emptyUsage,
+        );
+
+        const first =
+          boundary === "mixed"
+            ? [
+                ...action.slice(0, -1),
+                {
+                  type: "tool-call" as const,
+                  id: "reply-mixed",
+                  name: "post_message",
+                  params: { message: "invalid" },
+                  providerExecuted: false,
+                },
+                { type: "finish" as const, reason: "tool-calls" as const, usage: emptyUsage },
+              ]
+            : action;
+
+        const { model, requests } = scriptedModel([
+          ...(boundary === "tool-calls" || boundary === "turns"
+            ? [toolCallParts("ordinary-1", "post_message", { message: "ordinary failure" })]
+            : []),
+          first,
+          toolCallParts("reply-final", "post_message", { message: "No action performed." }),
+        ]);
+
+        // A failed required completion consumes the first turn/call without ending the Run.
+        class DeliveryFailure extends Schema.TaggedError<DeliveryFailure>()(
+          "DeliveryFailure",
+          {},
+        ) {}
+
+        const failingPost = Tool.make("post_message", {
+          parameters: PostMessageTool.parametersSchema,
+          success: PostMessageTool.successSchema,
+          failure: DeliveryFailure,
+          failureMode: "return",
+        });
+
+        const executable = Toolkit.make(failingPost, SearchTool);
+        const starts = yield* Ref.make(0);
+        const posts = yield* Ref.make(0);
+
+        const result = yield* AgentRuntime.run(
+          Agent.withModel({ ...definition, toolkit: executable }, model),
+          "act",
+        ).pipe(
+          Effect.provide(
+            executable.toLayer({
+              search: () =>
+                Ref.update(starts, (count) => count + 1).pipe(Effect.as("must not happen")),
+              post_message: () =>
+                Ref.updateAndGet(posts, (count) => count + 1).pipe(
+                  Effect.flatMap((count) =>
+                    count === 1 && (boundary === "tool-calls" || boundary === "turns")
+                      ? DeliveryFailure.make({})
+                      : Effect.succeed({ messageId: "reply" }),
+                  ),
+                ),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(yield* Ref.get(starts)).toBe(0);
+        if (boundary === "mixed" || boundary === "turns")
+          expect(failureFrom(result)).toBeInstanceOf(ModelProtocolError);
+        else {
+          expect(Exit.isSuccess(result)).toBe(true);
+          if (Exit.isSuccess(result)) expect(result.value.output).toBe("No action performed.");
+        }
+        expect(requests.length).toBeLessThanOrEqual(3);
+      }),
+  );
+
+  it.effect.each(["completion", "completionFromTools"] as const)(
+    "completion projectors encode decoded output before canonical validation: %s",
+    (kind) =>
+      Effect.gen(function* () {
+        const definition = Agent.make("transformed-completion", {
+          input: Schema.String,
+          output: Schema.NumberFromString,
+          instructions: "Return the committed numeric result.",
+          toolkit: searchToolkit,
+          ...(kind === "completion"
+            ? { completion: { tool: "search" as const, project: () => 42 } }
+            : {
+                completionFromTools: [{ tool: "search" as const, project: () => Option.some(42) }],
+              }),
+        });
+
+        const { model, requests } = scriptedModel([
+          toolCallParts("transformed-action", "search", {}),
+        ]);
+
+        const result = yield* AgentRuntime.run(Agent.withModel(definition, model), "act").pipe(
+          Effect.provide(searchToolkit.toLayer({ search: () => Effect.succeed("committed") })),
+        );
+
+        expect(result.output).toBe(42);
+        expect(requests).toHaveLength(1);
+      }),
+  );
+
+  it.effect.each(["throws", "invalid-output"] as const)(
+    "action completion rejects an invalid projector after the action: %s",
+    (mode) =>
+      Effect.gen(function* () {
+        const definition = Agent.make("invalid-action-completion", {
+          input: Schema.String,
+          output: Schema.String.check(Schema.isMinLength(1)),
+          instructions: "Act once.",
+          toolkit: searchToolkit,
+          completionFromTools: [
+            {
+              tool: "search",
+              project: () => {
+                if (mode === "throws") throw new Error("projection failed");
+
+                return Option.some("");
+              },
+            },
+          ],
+        });
+
+        const { model, requests } = scriptedModel([toolCallParts("action-invalid", "search", {})]);
+        const starts = yield* Ref.make(0);
+
+        const exit = yield* AgentRuntime.run(Agent.withModel(definition, model), "act").pipe(
+          Effect.provide(
+            searchToolkit.toLayer({
+              search: () => Ref.update(starts, (n) => n + 1).pipe(Effect.as("done")),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(failureFrom(exit)).toMatchObject({ _tag: "AgentOutputError" });
+        expect(yield* Ref.get(starts)).toBe(1);
+        expect(requests).toHaveLength(1);
+      }),
+  );
+
   it.effect(
     "RUN-032: required completion uses native required Tool choice until the completion Tool settles",
     () =>

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -63,6 +63,8 @@ import {
   Principal,
   QueueSequence,
   RecoverySnapshotRequest,
+  ResolutionCompletedWithResult,
+  UnknownResolutionCommand,
   Settlement,
   SubmissionLedger,
   SubmissionLookupById,
@@ -217,6 +219,65 @@ const dispositionDefinition = Agent.make("durable-run-disposition", {
     fromOutput: (output) => output.runDisposition,
   },
 });
+
+const makeReceiptCompletionFixture = (needsApproval = false) => {
+  const Create = Tool.make("create", {
+    parameters: Schema.Struct({ name: Schema.String }),
+    success: Schema.Struct({
+      name: Schema.String,
+      href: Schema.String,
+      complete: Schema.Boolean,
+    }),
+    needsApproval,
+  });
+
+  const Respond = Tool.make("respond", {
+    parameters: Schema.Struct({ answer: Schema.String }),
+    success: Schema.Struct({ answer: Schema.String }),
+  });
+
+  const tools = Toolkit.make(Create, Respond);
+
+  const definition = Agent.make("durable-receipt-completion", {
+    input: Schema.Struct({ question: Schema.String }),
+    output: Schema.Struct({ answer: Schema.String }),
+    instructions: "Use create only when creation satisfies the whole request; otherwise respond.",
+    toolkit: tools,
+    policy: AgentPolicy.make({
+      maxTurns: 3,
+      maxToolCalls: 2,
+      maxDuration: "30 seconds",
+      toolConcurrency: 1,
+    }),
+    completion: {
+      tool: "respond",
+      required: true,
+      project: ({ result }) => result,
+    },
+    completionFromTools: [
+      {
+        tool: "create",
+        project: ({ result }) =>
+          result.complete
+            ? Option.some({ answer: `Created ${result.name}: ${result.href}` })
+            : Option.none(),
+      },
+    ],
+  });
+
+  return { definition, tools };
+};
+
+const receiptCreateParts: ReadonlyArray<Response.StreamPartEncoded> = [
+  {
+    type: "tool-call",
+    id: "create-1",
+    name: "create",
+    params: { name: "requested name" },
+    providerExecuted: false,
+  },
+  { type: "finish", reason: "tool-calls", usage },
+];
 
 // `readonly` keeps the P4 canonical record shape byte-stable (plan §4.3): an unannotated tool
 // fails closed to `uncertain` and gains `ToolCallPrepared` records under the P5 split commits.
@@ -1481,6 +1542,364 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
         });
       }),
   );
+
+  it.effect("recovers canonical receipt completion without repeating the action or model", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const { definition, tools } = makeReceiptCompletionFixture();
+      const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+      const createCalls = yield* Ref.make(0);
+      const respondCalls = yield* Ref.make(0);
+
+      const toolLayer = tools.toLayer({
+        create: () =>
+          Ref.update(createCalls, (count) => count + 1).pipe(
+            Effect.as({ name: "Committed name", href: "/projects/created-1", complete: true }),
+          ),
+        respond: (parameters) =>
+          Ref.update(respondCalls, (count) => count + 1).pipe(Effect.as(parameters)),
+      });
+
+      const agent = Agent.withModel(definition, scripted.model);
+      const thread = "thread-receipt-completion-recovery";
+      const options = submitOptions(thread, "receipt-completion-recovery-1");
+      const input = { question: "Create requested name." };
+      const receipt = yield* runtime.submit(agent, input, options);
+
+      yield* armFailpoint("turn:after-results-append");
+
+      const crashed = yield* Effect.exit(
+        runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer)),
+      );
+
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      expect(yield* Ref.get(createCalls)).toBe(1);
+      expect(scripted.prompts).toHaveLength(1);
+      yield* clearFailpoint;
+
+      const settled = yield* runtime
+        .processThread(agent, decodeThreadId(thread))
+        .pipe(Effect.provide(toolLayer));
+
+      expect(settled).toHaveLength(1);
+      expect(settled[0]?.outcome).toBe("completed");
+      expect(yield* runtime.awaitSettlement(receipt)).toEqual(settled[0]);
+      const repeated = yield* runtime.submit(agent, input, options);
+
+      expect(repeated.submissionId).toBe(receipt.submissionId);
+      expect(
+        yield* runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer)),
+      ).toHaveLength(0);
+      expect(yield* Ref.get(createCalls)).toBe(1);
+      expect(yield* Ref.get(respondCalls)).toBe(0);
+      expect(scripted.prompts).toHaveLength(1);
+      const payloads = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+      expect(payloads.filter((payload) => payload._tag === "ModelResponseRecorded")).toHaveLength(
+        1,
+      );
+      expect(payloads.filter((payload) => payload._tag === "ToolCallSettled")).toHaveLength(1);
+      expect(payloads.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(1);
+      expect(payloads.filter((payload) => payload._tag === "SubmissionSettled")).toHaveLength(1);
+      expect(payloads.at(-1)).toMatchObject({
+        _tag: "SubmissionSettled",
+        result: { answer: "Created Committed name: /projects/created-1" },
+      });
+    }),
+  );
+
+  it.effect(
+    "receipt completion projects a recovered external result without another model call",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const fixture = makeReceiptCompletionFixture();
+        const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+        const agent = Agent.withModel(fixture.definition, scripted.model);
+        const thread = "thread-receipt-recovered-result";
+        const starts = yield* Ref.make(0);
+
+        const tools = fixture.tools.toLayer({
+          create: () =>
+            Ref.update(starts, (count) => count + 1).pipe(
+              Effect.as({ name: "Project", href: "/project/1", complete: true }),
+            ),
+          respond: ({ answer }) => Effect.succeed({ answer }),
+        });
+
+        const receipt = yield* runtime.submit(
+          agent,
+          { question: "create" },
+          submitOptions(thread, "recovered-result"),
+        );
+
+        yield* armFailpoint("tools:after-prepared-append");
+
+        const crashed = yield* runtime
+          .processThread(agent, decodeThreadId(thread))
+          .pipe(Effect.provide(tools), Effect.exit);
+
+        expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+        yield* clearFailpoint;
+        yield* runtime.runRecovery;
+        expect(yield* lookupState(receipt.submissionId)).toBe("unknown");
+        yield* runtime.resolveUnknown(
+          UnknownResolutionCommand.make({
+            submissionId: receipt.submissionId,
+            toolCallId: Schema.decodeSync(ToolCallId)("create-1"),
+            author: "operator",
+            reason: "The authoritative product receipt confirms committed creation",
+            resolution: ResolutionCompletedWithResult.make({
+              result: { name: "Project", href: "/project/1", complete: true },
+              isFailure: false,
+            }),
+          }),
+        );
+        yield* armFailpoint("turn:after-results-append");
+
+        const afterProjection = yield* runtime
+          .processThread(agent, decodeThreadId(thread))
+          .pipe(Effect.provide(tools), Effect.exit);
+
+        expect(failureTag(afterProjection)).toBe("DurableRuntimeFailpointError");
+        yield* clearFailpoint;
+
+        const settled = yield* runtime
+          .processThread(agent, decodeThreadId(thread))
+          .pipe(Effect.provide(tools));
+
+        expect(settled[0]?.outcome).toBe("completed");
+        expect(yield* Ref.get(starts)).toBe(0);
+        expect(scripted.prompts).toHaveLength(1);
+        const records = yield* readLog(thread);
+
+        expect(
+          records.filter(({ record }) => record.payload._tag === "ToolCallSettled"),
+        ).toHaveLength(1);
+        expect(records.filter(({ record }) => record.payload._tag === "RunCompleted")).toHaveLength(
+          1,
+        );
+        expect(records.at(-1)?.record.payload).toMatchObject({
+          _tag: "SubmissionSettled",
+          result: { answer: "Created Project: /project/1" },
+        });
+      }),
+  );
+
+  it.effect("receipt completion preserves transformed output through canonical recovery", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const fixture = makeReceiptCompletionFixture();
+
+      const definition = Agent.make("transformed-receipt-completion", {
+        input: fixture.definition.input,
+        output: Schema.NumberFromString,
+        instructions: "Complete from the committed action.",
+        toolkit: fixture.tools,
+        completionFromTools: [{ tool: "create", project: () => Option.some(42) }],
+      });
+
+      const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+      const agent = Agent.withModel(definition, scripted.model);
+      const thread = "thread-transformed-receipt-completion";
+      const starts = yield* Ref.make(0);
+
+      const tools = fixture.tools.toLayer({
+        create: () =>
+          Ref.update(starts, (count) => count + 1).pipe(
+            Effect.as({ name: "Project", href: "/project/1", complete: true }),
+          ),
+        respond: ({ answer }) => Effect.succeed({ answer }),
+      });
+
+      yield* runtime.submit(
+        agent,
+        { question: "create" },
+        submitOptions(thread, "transformed-receipt"),
+      );
+      yield* armFailpoint("turn:after-results-append");
+
+      const crashed = yield* runtime
+        .processThread(agent, decodeThreadId(thread))
+        .pipe(Effect.provide(tools), Effect.exit);
+
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      yield* clearFailpoint;
+
+      const settled = yield* runtime
+        .processThread(agent, decodeThreadId(thread))
+        .pipe(Effect.provide(tools));
+
+      expect(settled[0]?.outcome).toBe("completed");
+      expect(yield* Ref.get(starts)).toBe(1);
+      expect(scripted.prompts).toHaveLength(1);
+      const records = yield* readLog(thread);
+
+      expect(
+        records.find(({ record }) => record.payload._tag === "RunCompleted")?.record.payload,
+      ).toMatchObject({ output: "42" });
+      expect(records.at(-1)?.record.payload).toMatchObject({
+        _tag: "SubmissionSettled",
+        result: "42",
+      });
+    }),
+  );
+
+  it.effect("a declined receipt completion recovers and continues to required respond", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const { definition, tools } = makeReceiptCompletionFixture();
+
+      const scripted = yield* makeScriptedModel((call) =>
+        call === 0
+          ? receiptCreateParts
+          : [
+              {
+                type: "tool-call",
+                id: "respond-1",
+                name: "respond",
+                params: { answer: "Creation is incomplete; additional input is required." },
+                providerExecuted: false,
+              },
+              { type: "finish", reason: "tool-calls", usage },
+            ],
+      );
+
+      const createCalls = yield* Ref.make(0);
+      const respondCalls = yield* Ref.make(0);
+
+      const toolLayer = tools.toLayer({
+        create: () =>
+          Ref.update(createCalls, (count) => count + 1).pipe(
+            Effect.as({ name: "Partial name", href: "/projects/partial-1", complete: false }),
+          ),
+        respond: (parameters) =>
+          Ref.update(respondCalls, (count) => count + 1).pipe(Effect.as(parameters)),
+      });
+
+      const agent = Agent.withModel(definition, scripted.model);
+      const thread = "thread-receipt-completion-declined";
+
+      const receipt = yield* runtime.submit(
+        agent,
+        { question: "Create and finish the project." },
+        submitOptions(thread, "receipt-completion-declined-1"),
+      );
+
+      yield* armFailpoint("turn:after-results-append");
+
+      const crashed = yield* Effect.exit(
+        runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer)),
+      );
+
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      const beforeRecovery = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+      expect(beforeRecovery.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(0);
+      expect(yield* Ref.get(createCalls)).toBe(1);
+      expect(yield* Ref.get(respondCalls)).toBe(0);
+      yield* clearFailpoint;
+      yield* runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer));
+
+      expect((yield* runtime.awaitSettlement(receipt)).outcome).toBe("completed");
+      expect(scripted.prompts).toHaveLength(2);
+      expect(yield* Ref.get(createCalls)).toBe(1);
+      expect(yield* Ref.get(respondCalls)).toBe(1);
+      const payloads = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+      expect(payloads.filter((payload) => payload._tag === "ModelResponseRecorded")).toHaveLength(
+        2,
+      );
+      expect(payloads.filter((payload) => payload._tag === "ToolCallSettled")).toHaveLength(2);
+      expect(payloads.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(1);
+      expect(payloads.at(-1)).toMatchObject({
+        _tag: "SubmissionSettled",
+        result: { answer: "Creation is incomplete; additional input is required." },
+      });
+    }),
+  );
+
+  for (const decision of ["approved", "aborted"] as const) {
+    it.effect(`receipt completion preserves ${decision} approval suspension`, () =>
+      Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const { definition, tools } = makeReceiptCompletionFixture(true);
+        const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+        const createCalls = yield* Ref.make(0);
+        const respondCalls = yield* Ref.make(0);
+
+        const toolLayer = tools.toLayer({
+          create: () =>
+            Ref.update(createCalls, (count) => count + 1).pipe(
+              Effect.as({ name: "Approved name", href: "/projects/approved-1", complete: true }),
+            ),
+          respond: (parameters) =>
+            Ref.update(respondCalls, (count) => count + 1).pipe(Effect.as(parameters)),
+        });
+
+        const agent = Agent.withModel(definition, scripted.model);
+        const thread = `thread-receipt-completion-${decision}`;
+
+        const receipt = yield* runtime.submit(
+          agent,
+          { question: "Create a project after approval." },
+          submitOptions(thread, `receipt-completion-${decision}-1`),
+        );
+
+        yield* runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer));
+        expect(yield* Ref.get(createCalls)).toBe(0);
+        expect(yield* Ref.get(respondCalls)).toBe(0);
+        const suspended = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+        expect(
+          suspended.filter((payload) => payload._tag === "ToolApprovalRequested"),
+        ).toHaveLength(1);
+        expect(suspended.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(0);
+
+        if (decision === "approved") {
+          yield* runtime.resolveApproval(
+            ApprovalDecisionCommand.make({
+              submissionId: receipt.submissionId,
+              toolCallId: Schema.decodeSync(ToolCallId)("create-1"),
+              decision: "approved",
+              resolver: "operator",
+              reason: "approve the requested creation",
+            }),
+          );
+          yield* runtime
+            .processThread(agent, decodeThreadId(thread))
+            .pipe(Effect.provide(toolLayer));
+        } else {
+          yield* runtime.abort(
+            AbortCommand.make({
+              submissionId: receipt.submissionId,
+              author: "operator",
+              reason: "cancel before approval",
+            }),
+          );
+          yield* runtime.runRecovery;
+        }
+
+        const settlement = yield* runtime.awaitSettlement(receipt);
+
+        expect(settlement.outcome).toBe(decision === "approved" ? "completed" : "aborted");
+        expect(yield* Ref.get(createCalls)).toBe(decision === "approved" ? 1 : 0);
+        expect(yield* Ref.get(respondCalls)).toBe(0);
+        expect(scripted.prompts).toHaveLength(1);
+        const payloads = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+        expect(payloads.filter((payload) => payload._tag === "SubmissionSettled")).toHaveLength(1);
+        expect(payloads.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(
+          decision === "approved" ? 1 : 0,
+        );
+        expect(payloads.find((payload) => payload._tag === "SubmissionSettled")?.result).toEqual(
+          decision === "approved"
+            ? { answer: "Created Approved name: /projects/approved-1" }
+            : undefined,
+        );
+      }),
+    );
+  }
 
   it.effect(
     "RUN-032 resumes an over-token completion delivery under final-answer mode after the response commit",
@@ -2903,6 +3322,51 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
 });
 
 layer(corruptedCompletionTestLayer)("RUN-032 recovered completion validation", (it) => {
+  it.effect("rejects a recovered receipt completion that disagrees with the canonical result", () =>
+    Effect.gen(function* () {
+      const runtime = yield* DurableAgentRuntime;
+      const { definition, tools } = makeReceiptCompletionFixture();
+      const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+      const createCalls = yield* Ref.make(0);
+      const respondCalls = yield* Ref.make(0);
+
+      const toolLayer = tools.toLayer({
+        create: () =>
+          Ref.update(createCalls, (count) => count + 1).pipe(
+            Effect.as({ name: "Canonical name", href: "/projects/canonical-1", complete: true }),
+          ),
+        respond: (parameters) =>
+          Ref.update(respondCalls, (count) => count + 1).pipe(Effect.as(parameters)),
+      });
+
+      const agent = Agent.withModel(definition, scripted.model);
+      const thread = "thread-hostile-receipt-completion";
+
+      yield* runtime.submit(
+        agent,
+        { question: "Create a project." },
+        submitOptions(thread, "hostile-receipt-completion-1"),
+      );
+      yield* armFailpoint("turn:after-results-append");
+
+      const crashed = yield* Effect.exit(
+        runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer)),
+      );
+
+      expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+      yield* clearFailpoint;
+
+      const recovered = yield* Effect.exit(
+        runtime.processThread(agent, decodeThreadId(thread)).pipe(Effect.provide(toolLayer)),
+      );
+
+      expect(failureTag(recovered)).toBe("RunJournalError");
+      expect(yield* Ref.get(createCalls)).toBe(1);
+      expect(yield* Ref.get(respondCalls)).toBe(0);
+      expect(scripted.prompts).toHaveLength(1);
+    }),
+  );
+
   it.effect("rejects a no-Tool marker whose output disagrees with its canonical response", () =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
@@ -4185,6 +4649,7 @@ layer(testLayer)("RUN-026 durable compaction and usage re-seed", (it) => {
         expect(failureTag(interrupted)).toBe("DurableRuntimeFailpointError");
         expect(model.prompts).toHaveLength(0);
         yield* clearFailpoint;
+
         const settled = yield* runtime.processThread(agent, decodeThreadId(thread));
 
         expect(settled[0]?.outcome).toBe("completed");

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -1730,6 +1730,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
   const pendingToolBatchFor = Effect.fn("DurableAgentRuntime.pendingToolBatchFor")(function* (
     records: ReadonlyArray<CanonicalRecordEnvelope>,
     runId: ReturnType<typeof runIdForSubmission>,
+    completionTools: ReadonlyArray<string> = [],
   ): Effect.fn.Return<PendingToolBatch | undefined, RunJournalError> {
     let lastResponse: { readonly turn: number; readonly messages: PersistedJson } | undefined;
 
@@ -1794,7 +1795,17 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         settled.push({ id: call.id, ...recorded });
       }
     }
-    if (settled.length >= calls.length) return undefined;
+
+    const projectSettledCompletion =
+      calls.length === 1 &&
+      calls[0] !== undefined &&
+      completionTools.includes(calls[0].name) &&
+      settled[0]?.isFailure === false &&
+      !records.some(
+        ({ record }) => record.payload._tag === "RunCompleted" && record.payload.runId === runId,
+      );
+
+    if (settled.length >= calls.length && !projectSettledCompletion) return undefined;
 
     return {
       turn: lastResponse.turn,
@@ -4156,7 +4167,12 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           message: "The child Run has no matching canonical lineage and execution bounds",
         });
       }
-      const pending = yield* pendingToolBatchFor(records, runId);
+
+      const pending = yield* pendingToolBatchFor(
+        records,
+        runId,
+        agent.definition.completionFromTools?.map((declaration) => declaration.tool),
+      );
 
       const resumeProjection =
         pending === undefined
@@ -4519,6 +4535,10 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           const completion = agent.definition.completion;
           const call = calls[0];
 
+          const actionCompletion = agent.definition.completionFromTools?.find(
+            (declaration) => declaration.tool === call?.name,
+          );
+
           const settled =
             call === undefined
               ? undefined
@@ -4530,23 +4550,38 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 )?.record.payload;
 
           if (
-            completion === undefined ||
             declared.total !== 1 ||
             calls.length !== 1 ||
-            call?.name !== completion.tool ||
+            call === undefined ||
+            (call.name !== completion?.tool && actionCompletion === undefined) ||
             settled?._tag !== "ToolCallSettled" ||
-            settled.toolName !== completion.tool ||
+            settled.toolName !== call.name ||
             settled.isFailure
           ) {
             return yield* RunJournalError.make({
               message: `Run ${runId} has a terminal completion marker without one successful declared completion Tool result`,
             });
           }
-          expectedOutput = yield* AgentRuntime.projectCompletionOutput(
-            agent,
-            completion,
-            call.params,
-            settled.result,
+
+          const projected = yield* (
+            actionCompletion !== undefined
+              ? AgentRuntime.projectCompletionFromToolOutput(
+                  agent,
+                  actionCompletion,
+                  call.params,
+                  settled.result,
+                )
+              : completion !== undefined
+                ? Effect.map(
+                    AgentRuntime.projectCompletionOutput(
+                      agent,
+                      completion,
+                      call.params,
+                      settled.result,
+                    ),
+                    Option.some,
+                  )
+                : Effect.succeed(Option.none())
           ).pipe(
             Effect.mapError((cause) =>
               RunJournalError.make({
@@ -4555,6 +4590,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               }),
             ),
           );
+
+          if (Option.isNone(projected)) {
+            return yield* RunJournalError.make({
+              message: `Run ${runId} completion Tool declined its recorded terminal output`,
+            });
+          }
+          expectedOutput = projected.value;
         } else {
           const responseText = yield* terminalAssistantText(response.messages);
 
@@ -6363,14 +6405,36 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             resultParts.push(...parts);
             remaining.push(Prompt.makeMessage("tool", { content: parts }));
           }
-          if (toolParts > 0) {
+
+          const settledCompletionPart =
+            completedRun === undefined || toolParts > 0
+              ? undefined
+              : appended
+                  .flatMap((message) => (message.role === "tool" ? message.content : []))
+                  .find(
+                    (part) =>
+                      part.type === "tool-result" &&
+                      !part.isFailure &&
+                      agent.definition.completionFromTools?.some(
+                        (declaration) => declaration.tool === part.name,
+                      ),
+                  );
+
+          if (settledCompletionPart?.type === "tool-result") {
+            resultParts.push(settledCompletionPart);
+            remaining.push(Prompt.makeMessage("tool", { content: [settledCompletionPart] }));
+          }
+
+          if (toolParts > 0 || settledCompletionPart !== undefined) {
             const completion = agent.definition.completion;
             const completionPart = resultParts[0];
 
             const runCompletion =
-              completion !== undefined &&
               resultParts.length === 1 &&
-              completionPart?.name === completion.tool &&
+              (completionPart?.name === completion?.tool ||
+                agent.definition.completionFromTools?.some(
+                  (declaration) => declaration.tool === completionPart?.name,
+                )) &&
               completionPart.isFailure !== true &&
               completedRun !== undefined
                 ? completedRun
@@ -6388,8 +6452,25 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               ...(runCompletion === undefined ? {} : { runCompletion }),
             });
 
-            yield* appendBatch(ctx, batch);
-            for (const record of batch.records) knownIds.add(record.recordId);
+            // A recovered external receipt is already canonical. Commit only the terminal
+            // marker at the same results boundary; never duplicate or rewrite its result.
+            let pendingBatch = batch;
+
+            if (settledCompletionPart !== undefined) {
+              const completionRecord = batch.records.find(
+                (record) => record.payload._tag === "RunCompleted",
+              );
+
+              if (completionRecord === undefined || knownIds.has(completionRecord.recordId)) {
+                return yield* RunJournalError.make({
+                  message: "Recovered action completion has no new terminal record",
+                });
+              }
+              pendingBatch = CanonicalBatch.make({ ...batch, records: [completionRecord] });
+            }
+
+            yield* appendBatch(ctx, pendingBatch);
+            for (const record of pendingBatch.records) knownIds.add(record.recordId);
             yield* hit("turn:after-results-append");
           }
         } else {


### PR DESCRIPTION
A successful application action can already contain everything needed for a final reply, but Effect Agent currently reserves completion for one unconditional tool. Registering a mutating action there also gives it the finalization budget exception and prevents keeping `respond` as the normal completion path.

Add `completionFromTools` for ordinary action tools whose canonical success may satisfy the whole request. A pure projector returns `Option.some(output)` to settle or `Option.none()` to continue. These tools run alone and keep ordinary turn, tool-call, token, authorization, approval, and cancellation constraints; the existing `completion` tool retains its finalization role. Recovery derives the output from the canonical receipt and commits any missing terminal marker without repeating the action or requesting another model response.

```ts
Agent.make("assistant", {
  input: Schema.String,
  output: Schema.String,
  toolkit: Toolkit.make(CompleteAction, Respond),
  instructions: "Use CompleteAction only when its action satisfies the entire request.",
  completion: { tool: "respond", required: true, project: ({ result }) => result },
  completionFromTools: [{
    tool: "complete_action",
    project: ({ result }) => result.status === "completed"
      ? Option.some(result.reply)
      : Option.none(),
  }],
})
```

The example illustrates the contract; application handlers still own truthful committed outcomes and whole-request eligibility. Transformed output schemas encode the projected Type to the canonical wire value before validation. KOM-144 will consume this through a released version. Hosted consumer speedup is not yet measured, and consumer validation requires a published package version.

Related: https://linear.app/reve-ai/issue/KOM-144
