### PR TITLE
perf: reduce startup work and stabilize runtime benchmarks

### DIFF
--- a/.changeset/lean-startup-estimation.md
+++ b/.changeset/lean-startup-estimation.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Reduce fresh durable startup work for uncompacted histories and speed up native prompt token estimation while preserving admission and recovery behavior.

--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -38,7 +38,12 @@ jobs:
             const number = read('pr-number.txt', 20).trim();
             if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error('Invalid PR number');
             const report = JSON.parse(read('report.json', 3000000));
-            if (report.fixture !== 'runtime-v1' || report.profile !== 'pr' ||
+            if (report.fixture !== 'runtime-v2' || report.profile !== 'pr' ||
+                report.referenceVersion !== 'audit-beta67-node24-v1' ||
+                report.activeBatch !== null || report.failure !== null ||
+                report.settings?.batches !== 3 || report.settings?.warmupsPerBatch !== 2 || report.settings?.samplesPerBatch !== 3 ||
+                report.settings?.production !== true || report.settings?.execution !== 'unbundled published ESM' ||
+                report.environment?.node !== 'v24.20.0' ||
                 !/^[a-f0-9]{64}$/.test(report.fixtureSha256) ||
                 !Array.isArray(report.revisions) || report.revisions.length !== 3 ||
                 !Array.isArray(report.batches) || report.batches.length !== 18) {
@@ -46,7 +51,9 @@ jobs:
             }
             const revision = role => report.revisions.find(value => value.role === role);
             for (const role of ['base', 'head', 'reference']) {
-              if (!/^[a-f0-9]{40}$/.test(revision(role)?.revision) || revision(role).dirty !== false) throw new Error('Invalid revision');
+              if (!/^[a-f0-9]{40}$/.test(revision(role)?.revision) || revision(role).dirty !== false ||
+                  !/^[a-f0-9]{64}$/.test(revision(role).lockfileSha256) ||
+                  !/^[a-f0-9]{64}$/.test(revision(role).builtArtifactsSha256)) throw new Error('Invalid revision');
             }
             if (revision('reference').revision !== '596cffba70716b1211ac02de949c4d0f31734b2f') throw new Error('Unexpected reference');
             const run = context.payload.workflow_run;
@@ -67,19 +74,29 @@ jobs:
             for (const batch of report.batches) {
               const key = `${batch.role}:${batch.cohort}:${batch.cold}`;
               if (!['base','head','reference'].includes(batch.role) || ![0,1,2].includes(batch.cohort) ||
-                  typeof batch.cold !== 'boolean' || identities.has(key) || batch.exitCode !== 0 || !batch.complete ||
+                  typeof batch.cold !== 'boolean' || identities.has(key) || batch.exitCode !== 0 || batch.complete !== true ||
+                  batch.failure !== null || !Number.isFinite(batch.subprocessMs) || batch.subprocessMs < 0 ||
+                  batch.report?.fixture !== report.fixture || batch.report?.profile !== report.profile ||
+                  batch.report?.runtime !== report.environment.node || batch.report?.platform !== report.environment.platform ||
+                  batch.report?.architecture !== report.environment.architecture || batch.report?.active !== null || batch.report?.failure !== null ||
                   !Array.isArray(batch.report?.samples)) throw new Error('Invalid cohort');
               identities.add(key);
-              if (batch.cold) continue;
-              if (batch.report.samples.length !== expected.length * 5) throw new Error('Incomplete cohort');
+              const workloads = batch.cold ? ['small-run'] : expected;
+              const ordinals = batch.cold ? [0] : [0,1,2,3,4];
+              if (batch.report.samples.length !== workloads.length * ordinals.length) throw new Error('Incomplete cohort');
               const unique = new Set();
               for (const sample of batch.report.samples) {
                 const id = `${sample.case}:${sample.ordinal}`;
-                if (!expected.includes(sample.case) || ![0,1,2,3,4].includes(sample.ordinal) || unique.has(id) ||
-                    sample.status !== 'passed' || sample.warmup !== (sample.ordinal < 2) ||
-                    !Number.isFinite(sample.totalMs) || sample.totalMs < 0 || sample.totalMs > 180000) throw new Error('Invalid sample');
+                if (!workloads.includes(sample.case) || !ordinals.includes(sample.ordinal) || unique.has(id) ||
+                    sample.status !== 'passed' || sample.failure !== null || sample.failurePhase !== null ||
+                    sample.warmup !== (!batch.cold && sample.ordinal < 2) ||
+                    !Number.isFinite(sample.totalMs) || sample.totalMs < 0 || sample.totalMs > 180000 ||
+                    !Number.isFinite(sample.attemptMs) || !Number.isFinite(sample.setupMs) || sample.setupMs < 0 ||
+                    sample.attemptMs < sample.setupMs + sample.totalMs ||
+                    !Number.isFinite(sample.modelEntryMs) || sample.modelEntryMs < 0 || sample.modelEntryMs > sample.totalMs ||
+                    !Number.isInteger(sample.modelCalls) || sample.modelCalls < 1 || sample.modelCalls !== sample.finalizers) throw new Error('Invalid sample');
                 unique.add(id);
-                if (!sample.warmup) samples.push({ role: batch.role, name: sample.case, ms: sample.totalMs });
+                if (!batch.cold && !sample.warmup) samples.push({ role: batch.role, name: sample.case, ms: sample.totalMs });
               }
             }
             const rows = expected.map(name => {

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: Compare sequential cohorts
         timeout-minutes: ${{ github.event_name == 'pull_request' && 20 || 165 }}
+        # The controller stops at 19m (PR) / 160m (larger profiles), leaving time
+        # for bounded child termination and atomic failure evidence before this outer limit.
         # Older releases do not ignore these known declaration artifacts emitted
         # by their package build. Remove only those generated scratch files.
         # The subsequent --require-clean check rejects every other modification.

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -377,9 +377,10 @@ The trusted comment workflow becomes active after it reaches the default branch.
 
 Latency reports are informational until repeated CI runs establish variance and useful absolute
 and relative thresholds. Deterministic call, concurrency, ownership, tracing, and history-work
-budgets remain correctness gates. The fresh-submission history guard currently permits three
-linear scans plus fixed work; these changes do not claim to eliminate that cost. Checkpoint
-recovery bounds do not establish constant-time fresh admission. Fairness, lock contention, optional
+budgets remain correctness gates. The fresh-submission history guard permits two linear scans plus
+fixed work for histories without compaction. Compacted and checkpoint-seeded views keep their
+existing validation passes. Checkpoint recovery bounds do not establish constant-time fresh admission.
+Fairness, lock contention, optional
 memory/MCP publication, and large settled-ledger indexing require their own controlled evidence
 before changing those paths.
 

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -30,6 +30,12 @@ applied input and terminal outcomes. Projections, checkpoints, indexes, and UI v
 
 Replay rebuilds state from records. It never executes a tool or repeats an external effect.
 
+An Attempt captures a fixed canonical tail and validates contiguous pages. For uncompacted history,
+it gathers control and journal metadata together. Later appends enter through a separately captured
+suffix; a gap or short page fails before that view can drive recovery. Compaction records and
+checkpoint-seeded views use the full journal validation path. Attempt metadata does not replace
+canonical prompt or unresolved-tool validation.
+
 `ThreadProjection` version 2 scopes open tool calls and subagent invocations by Run and Tool Call
 ID. Decode checkpoint state with its Schema before replaying a suffix. Earlier projection states,
 including empty views, fail decoding and must be discarded and rebuilt from canonical records.

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -80,6 +80,10 @@ injects the fault, closes the runtime, and resumes its own Submission. Templates
 when the worker closes and never cross a cohort or revision. This removes repeated fixture setup;
 it does not measure or change the cost of production mutations. The reference SHA is unchanged.
 
+The worker composes the seed initializer, scoped template cache, sample runner, and progress
+writer as Effect services. Sample arguments contain only workload data and timeout settings;
+tests replace service Layers while retaining the same operation clocks and cleanup boundaries.
+
 `modelEntryMs` ends inside `ScriptedModel.assertRequest`, where Effect AI invokes the actual
 normalized provider callback. It does not use ModelStarted events. `totalMs` ends after run/stream
 completion or durable settlement; it includes the operation's correctness checks where those

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -41,8 +41,10 @@ comment workflow validates artifact data and current PR identity without executi
 `--profile smoke` exercises every workload family with one sample and 16 retained records;
 it checks the command, not statistical confidence. `extended` takes 30 samples per revision and
 adds 8,192 records. `archive` adds 100,000 records with nine measured samples. Larger profiles
-are manual workflow-dispatch options and can take substantial time. Individual samples are bounded
-to three minutes; PR child processes to five minutes and the PR job to 30 minutes. Timeouts retain
+are manual workflow-dispatch options and can take substantial time. Individual sample attempts,
+including setup, are bounded to three minutes; PR child processes to five minutes. The controller
+stops after 19 minutes, before the comparison step's 20-minute limit and the job's 30-minute limit,
+and gives interrupted children five seconds to stop before forceful termination. Timeouts retain
 partial evidence and fail correctness. No scheduled or paid execution is configured here.
 
 | Case                      | Completed work and timing boundary                                                                                                                                                                                                                                                                                                                        |
@@ -69,6 +71,15 @@ SQLite uses the production Node assembly and its default scheduling, lease, and 
 configuration; checkpoint cases additionally install the documented host rollover preparation.
 Database teardown and evidence reads are outside the warm-operation interval.
 
+Fixture `runtime-v2` builds worker-local seed templates through those same public adapter
+operations, once per history/ledger size and revision. It closes the full seed runtime and rejects
+any remaining WAL or SHM sidecar before copying the database to each sample's fresh directory.
+Copies share no mutable database state. Fresh submission and checkpoint recovery can reuse the
+same retained-history seed; every recovery sample still constructs and saves its own checkpoint,
+injects the fault, closes the runtime, and resumes its own Submission. Templates are discarded
+when the worker closes and never cross a cohort or revision. This removes repeated fixture setup;
+it does not measure or change the cost of production mutations. The reference SHA is unchanged.
+
 `modelEntryMs` ends inside `ScriptedModel.assertRequest`, where Effect AI invokes the actual
 normalized provider callback. It does not use ModelStarted events. `totalMs` ends after run/stream
 completion or durable settlement; it includes the operation's correctness checks where those
@@ -80,6 +91,16 @@ It includes checkpoint scans/encoding/save but excludes the already committed co
 and is never added to the later recovery interval. Raw samples include observed retained prompt
 message counts. Incomplete or mismatched-runtime batches are explicitly reported and excluded
 from comparison summaries.
+
+`attemptMs` includes setup, the operation, verification, and scope cleanup; `setupMs` ends at the
+operation's start clock and includes initial checkpoint preparation for recovery. Neither is added
+to `totalMs`. The worker atomically replaces its report before a sample and at setup, checkpoint,
+operation, and verification boundaries, retaining the active case, ordinal, warmup flag, and elapsed
+time at the last boundary if it is killed. These filesystem writes happen outside `totalMs`.
+Controller reports identify the active batch and comparison failure; child logs are written as
+output arrives. Stdout and stderr share an 8 MiB raw-byte limit; exceeding it preserves the log
+prefix, terminates the child, and fails the batch. Controller failure details remain in the report.
+A partial report is evidence of an incomplete attempt, never a passing cohort.
 
 Cold measurements launch a separate Node process for one small run. Their wall time includes
 Node startup, all fixture imports (including the durable fixture), one run, assertions, and process

--- a/examples/runtime-benchmark/src/contracts.ts
+++ b/examples/runtime-benchmark/src/contracts.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect";
 
-export const FIXTURE_VERSION = "runtime-v1";
+export const FIXTURE_VERSION = "runtime-v2";
 
 export const REFERENCE = {
   version: "audit-beta67-node24-v1",
@@ -78,11 +78,27 @@ export const WorkerOptions = Schema.Struct({
   output: Schema.String,
 });
 
+export const SamplePhase = Schema.Literals(["setup", "checkpoint", "operation", "verification"]);
+export type SamplePhase = typeof SamplePhase.Type;
+
+export const SampleProgress = Schema.Struct({
+  case: Schema.String,
+  ordinal: Schema.Natural,
+  warmup: Schema.Boolean,
+  phase: SamplePhase,
+  elapsedMs: Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+
+export type SampleProgress = typeof SampleProgress.Type;
+
 export const Sample = Schema.Struct({
   case: Schema.String,
   ordinal: Schema.Natural,
   warmup: Schema.Boolean,
   totalMs: Schema.Finite,
+  attemptMs: Schema.Finite,
+  setupMs: Schema.Finite,
+  failurePhase: Schema.NullOr(SamplePhase),
   modelEntryMs: Schema.NullOr(Schema.Finite),
   checkpointCreationMs: Schema.NullOr(Schema.Finite),
   retainedPromptMessages: Schema.Natural,
@@ -102,6 +118,8 @@ export const WorkerReport = Schema.Struct({
   runtime: Schema.String,
   platform: Schema.String,
   architecture: Schema.String,
+  active: Schema.NullOr(SampleProgress),
+  failure: Schema.NullOr(Schema.String),
   samples: Schema.Array(Sample),
 });
 
@@ -124,17 +142,28 @@ export const completeBatch = (
     ),
   );
 
-  if (report.profile !== options.profile || report.samples.length !== expected.size) return false;
+  if (
+    report.profile !== options.profile ||
+    report.samples.length !== expected.size ||
+    report.active !== null ||
+    report.failure !== null
+  )
+    return false;
 
   return report.samples.every(
     (sample) =>
       expected.delete(`${sample.case}:${sample.ordinal}`) &&
       sample.warmup === sample.ordinal < options.warmups &&
       sample.status === "passed" &&
+      sample.failure === null &&
+      sample.failurePhase === null &&
       sample.totalMs >= 0 &&
+      sample.setupMs >= 0 &&
+      sample.attemptMs >= sample.setupMs + sample.totalMs &&
       sample.modelEntryMs !== null &&
       sample.modelEntryMs >= 0 &&
       sample.modelEntryMs <= sample.totalMs &&
+      sample.modelCalls > 0 &&
       sample.modelCalls === sample.finalizers,
   );
 };

--- a/examples/runtime-benchmark/src/evidence.ts
+++ b/examples/runtime-benchmark/src/evidence.ts
@@ -1,4 +1,17 @@
-import { Effect, FileSystem } from "effect";
+import { Context, Effect, FileSystem, Layer } from "effect";
+import type { PlatformError } from "effect/PlatformError";
+
+import type { SampleProgress } from "./contracts.js";
+
+/** Phase persistence belongs to the worker; samples only report their timing boundaries. */
+export class BenchmarkProgress extends Context.Service<
+  BenchmarkProgress,
+  {
+    readonly record: (progress: SampleProgress) => Effect.Effect<void, PlatformError>;
+  }
+>()("runtime-benchmark/BenchmarkProgress") {
+  static readonly silent = Layer.succeed(BenchmarkProgress, { record: () => Effect.void });
+}
 
 /** A killed writer leaves the previous complete JSON document available to artifact readers. */
 export const writeEvidence = Effect.fn("benchmark.writeEvidence")(function* (

--- a/examples/runtime-benchmark/src/evidence.ts
+++ b/examples/runtime-benchmark/src/evidence.ts
@@ -1,0 +1,12 @@
+import { Effect, FileSystem } from "effect";
+
+/** A killed writer leaves the previous complete JSON document available to artifact readers. */
+export const writeEvidence = Effect.fn("benchmark.writeEvidence")(function* (
+  filename: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+
+  yield* fs.writeFileString(`${filename}.tmp`, contents);
+  yield* fs.rename(`${filename}.tmp`, filename);
+});

--- a/examples/runtime-benchmark/src/fixture.ts
+++ b/examples/runtime-benchmark/src/fixture.ts
@@ -53,6 +53,8 @@ import {
 import {
   Cause,
   Clock,
+  Context,
+  Crypto,
   DateTime,
   type Duration,
   Effect,
@@ -67,19 +69,12 @@ import {
 import { Agent, AgentRuntime } from "effect-agent";
 import { IdGenerator } from "effect-agent/IdGenerator";
 import { ThreadHistory } from "effect-agent/ThreadHistory";
-import type { PlatformError } from "effect/PlatformError";
 import type { LanguageModel } from "effect/unstable/ai";
 import { AiError, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
 
-import {
-  BenchmarkError,
-  check,
-  type Case,
-  type Sample,
-  type SamplePhase,
-  type SampleProgress,
-} from "./contracts.js";
-import type { SeedTemplates } from "./seeds.js";
+import { BenchmarkError, check, type Case, type Sample, type SamplePhase } from "./contracts.js";
+import { BenchmarkProgress } from "./evidence.js";
+import { SeedInitializer, SeedTemplates, type SeedRequest } from "./seeds.js";
 
 const answerSchema = Schema.Struct({ answer: Schema.String });
 
@@ -283,16 +278,44 @@ const seedLedger = Effect.fn("benchmark.seedLedger")(function* (count: number) {
   yield* check(pending.length === 0, "Settled fixture contains unfinished submissions");
 });
 
-/** Each sample owns a fresh script; request capture cannot grow between samples. */
+/** Seed construction uses the same public Node assembly as the measured samples. */
+export const SeedInitializerLive = Layer.effect(
+  SeedInitializer,
+  Effect.gen(function* () {
+    const crypto = yield* Crypto.Crypto;
+
+    return SeedInitializer.of({
+      initialize: Effect.fn("benchmark.initializeSeed")(
+        function* (request: SeedRequest) {
+          if (request.kind === "ledger") yield* seedLedger(request.records);
+          else yield* seedHistory(request.records);
+        },
+        (effect, request) =>
+          effect.pipe(
+            Effect.provide(
+              NodeDurableAgentRuntime.layer({
+                filename: request.filename,
+                deploymentId,
+                producerId,
+              }).pipe(Layer.provide(ContextCompactor.layerRollover)),
+            ),
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.scoped,
+            Effect.mapError((cause) =>
+              BenchmarkError.make({ message: "Cannot initialize benchmark seed", cause }),
+            ),
+          ),
+      ),
+    });
+  }),
+);
+
+/** Each sample owns a fresh script; its operational dependencies remain visible in R. */
 export const runSample = Effect.fn("benchmark.runSample")(function* (
   workload: Case,
   ordinal: number,
   warmup: boolean,
   options: {
-    readonly seeds?: SeedTemplates;
-    readonly onProgress?: (
-      progress: SampleProgress,
-    ) => Effect.Effect<void, PlatformError, FileSystem.FileSystem>;
     readonly timeout?: Duration.Input;
   } = {},
 ) {
@@ -334,16 +357,16 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
   const expectedBytes = JSON.stringify({ answer }).length;
 
   const changePhase = Effect.fn("benchmark.samplePhase")(function* (next: SamplePhase) {
+    const progress = yield* BenchmarkProgress;
+
     phase = next;
-    yield* (
-      options.onProgress?.({
-        case: workload.name,
-        ordinal,
-        warmup,
-        phase,
-        elapsedMs: Number((yield* Clock.monotonicTimeNanos) - attemptStarted) / 1e6,
-      }) ?? Effect.void
-    );
+    yield* progress.record({
+      case: workload.name,
+      ordinal,
+      warmup,
+      phase,
+      elapsedMs: Number((yield* Clock.monotonicTimeNanos) - attemptStarted) / 1e6,
+    });
   });
 
   // Evidence writes happen outside the measured interval, including before the start clock.
@@ -548,9 +571,9 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
       const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-" });
       const filename = `${directory}/thread.sqlite`;
 
-      const host = (crash: boolean, database = filename) =>
+      const host = (crash: boolean) =>
         NodeDurableAgentRuntime.layer({
-          filename: database,
+          filename,
           deploymentId,
           producerId,
           ...(workload.kind === "recovery"
@@ -588,21 +611,13 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
         }).pipe(Layer.provide(ContextCompactor.layerRollover));
 
       // Setup and seeding never enter the reported warm-operation interval.
-      const initialize = Effect.fn("benchmark.initializeSeed")(
-        function* (_database: string) {
-          if (workload.kind === "ledger") yield* seedLedger(workload.records);
-          else yield* seedHistory(workload.records);
-        },
-        (effect, database) => effect.pipe(Effect.provide(host(false, database)), Effect.scoped),
-      );
+      const seeds = yield* SeedTemplates;
 
-      if (options.seeds === undefined) yield* initialize(filename);
-      else
-        yield* options.seeds.copy(
-          `${workload.kind === "ledger" ? "ledger" : "history"}-${workload.records}`,
-          filename,
-          initialize,
-        );
+      yield* seeds.copy({
+        kind: workload.kind === "ledger" ? "ledger" : "history",
+        records: workload.records,
+        filename,
+      });
 
       const submit = Effect.gen(function* () {
         const runtime = yield* DurableAgentRuntime;
@@ -753,3 +768,11 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
 
   return sample;
 });
+
+/** Worker execution is replaceable through a Layer without hiding the sample's requirements. */
+export class BenchmarkRunner extends Context.Service<
+  BenchmarkRunner,
+  { readonly run: typeof runSample }
+>()("runtime-benchmark/BenchmarkRunner") {
+  static readonly layer = Layer.succeed(BenchmarkRunner, { run: runSample });
+}

--- a/examples/runtime-benchmark/src/fixture.ts
+++ b/examples/runtime-benchmark/src/fixture.ts
@@ -54,6 +54,7 @@ import {
   Cause,
   Clock,
   DateTime,
+  type Duration,
   Effect,
   Exit,
   FileSystem,
@@ -66,10 +67,19 @@ import {
 import { Agent, AgentRuntime } from "effect-agent";
 import { IdGenerator } from "effect-agent/IdGenerator";
 import { ThreadHistory } from "effect-agent/ThreadHistory";
+import type { PlatformError } from "effect/PlatformError";
 import type { LanguageModel } from "effect/unstable/ai";
 import { AiError, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
 
-import { BenchmarkError, check, type Case, type Sample } from "./contracts.js";
+import {
+  BenchmarkError,
+  check,
+  type Case,
+  type Sample,
+  type SamplePhase,
+  type SampleProgress,
+} from "./contracts.js";
+import type { SeedTemplates } from "./seeds.js";
 
 const answerSchema = Schema.Struct({ answer: Schema.String });
 
@@ -278,7 +288,16 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
   workload: Case,
   ordinal: number,
   warmup: boolean,
+  options: {
+    readonly seeds?: SeedTemplates;
+    readonly onProgress?: (
+      progress: SampleProgress,
+    ) => Effect.Effect<void, PlatformError, FileSystem.FileSystem>;
+    readonly timeout?: Duration.Input;
+  } = {},
 ) {
+  const attemptStarted = yield* Clock.monotonicTimeNanos;
+  let phase: SamplePhase = "setup";
   let started = 0n;
   let finished = 0n;
   let entered: bigint | undefined;
@@ -314,7 +333,22 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
 
   const expectedBytes = JSON.stringify({ answer }).length;
 
-  const markStart = Clock.monotonicTimeNanos.pipe(
+  const changePhase = Effect.fn("benchmark.samplePhase")(function* (next: SamplePhase) {
+    phase = next;
+    yield* (
+      options.onProgress?.({
+        case: workload.name,
+        ordinal,
+        warmup,
+        phase,
+        elapsedMs: Number((yield* Clock.monotonicTimeNanos) - attemptStarted) / 1e6,
+      }) ?? Effect.void
+    );
+  });
+
+  // Evidence writes happen outside the measured interval, including before the start clock.
+  const markStart = changePhase("operation").pipe(
+    Effect.andThen(Clock.monotonicTimeNanos),
     Effect.tap((time) =>
       Effect.sync(() => {
         started = time;
@@ -328,6 +362,7 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
         finished = time;
       }),
     ),
+    Effect.andThen(changePhase("verification")),
   );
 
   const script = (parts: ReadonlyArray<ScriptedStreamPart>): ScriptedTurnInput => ({
@@ -442,6 +477,7 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
     );
 
   const execute = Effect.gen(function* () {
+    yield* changePhase("setup");
     if (["run", "stream", "tools"].includes(workload.kind)) {
       const turns = [
         ...Array.from({ length: workload.rounds }, (_, round) => script(toolParts(round, 8))),
@@ -512,9 +548,9 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
       const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-" });
       const filename = `${directory}/thread.sqlite`;
 
-      const host = (crash: boolean) =>
+      const host = (crash: boolean, database = filename) =>
         NodeDurableAgentRuntime.layer({
-          filename,
+          filename: database,
           deploymentId,
           producerId,
           ...(workload.kind === "recovery"
@@ -552,9 +588,21 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
         }).pipe(Layer.provide(ContextCompactor.layerRollover));
 
       // Setup and seeding never enter the reported warm-operation interval.
-      if (workload.kind === "ledger")
-        yield* seedLedger(workload.records).pipe(Effect.provide(host(false)), Effect.scoped);
-      else yield* seedHistory(workload.records).pipe(Effect.provide(host(false)), Effect.scoped);
+      const initialize = Effect.fn("benchmark.initializeSeed")(
+        function* (_database: string) {
+          if (workload.kind === "ledger") yield* seedLedger(workload.records);
+          else yield* seedHistory(workload.records);
+        },
+        (effect, database) => effect.pipe(Effect.provide(host(false, database)), Effect.scoped),
+      );
+
+      if (options.seeds === undefined) yield* initialize(filename);
+      else
+        yield* options.seeds.copy(
+          `${workload.kind === "ledger" ? "ledger" : "history"}-${workload.records}`,
+          filename,
+          initialize,
+        );
 
       const submit = Effect.gen(function* () {
         const runtime = yield* DurableAgentRuntime;
@@ -607,6 +655,7 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
       });
 
       if (workload.kind === "recovery") {
+        yield* changePhase("checkpoint");
         yield* Effect.gen(function* () {
           const runtime = yield* DurableAgentRuntime;
 
@@ -674,19 +723,23 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
     yield* check(entered !== undefined && finished >= started, "Missing timing boundary");
   }).pipe(
     Effect.scoped,
-    Effect.timeout("3 minutes"),
+    Effect.timeout(options.timeout ?? "3 minutes"),
     Effect.provideService(References.MinimumLogLevel, "None"),
   );
 
   const result = yield* execute.pipe(Effect.exit);
 
   if (finished === 0n) finished = yield* Clock.monotonicTimeNanos;
+  const attemptFinished = yield* Clock.monotonicTimeNanos;
 
-  return {
+  const sample: Sample = {
     case: workload.name,
     ordinal,
     warmup,
     totalMs: started === 0n ? 0 : Number(finished - started) / 1e6,
+    attemptMs: Number(attemptFinished - attemptStarted) / 1e6,
+    setupMs: Number((started === 0n ? attemptFinished : started) - attemptStarted) / 1e6,
+    failurePhase: Exit.isFailure(result) ? phase : null,
     modelEntryMs: entered === undefined || started === 0n ? null : Number(entered - started) / 1e6,
     checkpointCreationMs,
     retainedPromptMessages,
@@ -696,5 +749,7 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
     outputBytes: expectedBytes,
     status: Exit.isSuccess(result) ? "passed" : "failed",
     failure: Exit.isFailure(result) ? Cause.pretty(result.cause) : null,
-  } satisfies Sample;
+  };
+
+  return sample;
 });

--- a/examples/runtime-benchmark/src/seeds.ts
+++ b/examples/runtime-benchmark/src/seeds.ts
@@ -1,0 +1,46 @@
+import { Effect, FileSystem, Path } from "effect";
+import type { PlatformError } from "effect/PlatformError";
+
+import type { BenchmarkError } from "./contracts.js";
+import { check } from "./contracts.js";
+
+export interface SeedTemplates {
+  readonly copy: <E, R>(
+    key: string,
+    destination: string,
+    initialize: (filename: string) => Effect.Effect<void, E, R>,
+  ) => Effect.Effect<void, E | PlatformError | BenchmarkError, R>;
+}
+
+/** Worker-local, revision-local templates. initialize must finish closing every database owner. */
+export const makeSeedTemplates = Effect.fn("benchmark.makeSeedTemplates")(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-seeds-" });
+  const templates = new Map<string, string>();
+  let attempts = 0;
+
+  const copy: SeedTemplates["copy"] = Effect.fn("benchmark.copySeed")(function* <E, R>(
+    key: string,
+    destination: string,
+    initialize: (filename: string) => Effect.Effect<void, E, R>,
+  ) {
+    let source = templates.get(key);
+
+    if (source === undefined) {
+      const candidate = path.join(directory, `${attempts++}.sqlite`);
+
+      yield* initialize(candidate);
+      // Never copy a live SQLite database or omit committed pages still held in a WAL.
+      yield* check(
+        !(yield* fs.exists(`${candidate}-wal`)) && !(yield* fs.exists(`${candidate}-shm`)),
+        "Seed database is not closed: SQLite WAL/SHM sidecars remain",
+      );
+      templates.set(key, candidate);
+      source = candidate;
+    }
+    yield* fs.copyFile(source, destination);
+  });
+
+  return { copy } satisfies SeedTemplates;
+});

--- a/examples/runtime-benchmark/src/seeds.ts
+++ b/examples/runtime-benchmark/src/seeds.ts
@@ -1,46 +1,62 @@
-import { Effect, FileSystem, Path } from "effect";
+import { Context, Effect, FileSystem, Layer, Path, Schema } from "effect";
 import type { PlatformError } from "effect/PlatformError";
 
 import type { BenchmarkError } from "./contracts.js";
 import { check } from "./contracts.js";
 
-export interface SeedTemplates {
-  readonly copy: <E, R>(
-    key: string,
-    destination: string,
-    initialize: (filename: string) => Effect.Effect<void, E, R>,
-  ) => Effect.Effect<void, E | PlatformError | BenchmarkError, R>;
-}
-
-/** Worker-local, revision-local templates. initialize must finish closing every database owner. */
-export const makeSeedTemplates = Effect.fn("benchmark.makeSeedTemplates")(function* () {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-seeds-" });
-  const templates = new Map<string, string>();
-  let attempts = 0;
-
-  const copy: SeedTemplates["copy"] = Effect.fn("benchmark.copySeed")(function* <E, R>(
-    key: string,
-    destination: string,
-    initialize: (filename: string) => Effect.Effect<void, E, R>,
-  ) {
-    let source = templates.get(key);
-
-    if (source === undefined) {
-      const candidate = path.join(directory, `${attempts++}.sqlite`);
-
-      yield* initialize(candidate);
-      // Never copy a live SQLite database or omit committed pages still held in a WAL.
-      yield* check(
-        !(yield* fs.exists(`${candidate}-wal`)) && !(yield* fs.exists(`${candidate}-shm`)),
-        "Seed database is not closed: SQLite WAL/SHM sidecars remain",
-      );
-      templates.set(key, candidate);
-      source = candidate;
-    }
-    yield* fs.copyFile(source, destination);
-  });
-
-  return { copy } satisfies SeedTemplates;
+export const SeedRequest = Schema.Struct({
+  kind: Schema.Literals(["history", "ledger"]),
+  records: Schema.Natural,
+  filename: Schema.String,
 });
+
+export type SeedRequest = typeof SeedRequest.Type;
+
+/** The initializer must finish closing every database owner before returning. */
+export class SeedInitializer extends Context.Service<
+  SeedInitializer,
+  {
+    readonly initialize: (request: SeedRequest) => Effect.Effect<void, BenchmarkError>;
+  }
+>()("runtime-benchmark/SeedInitializer") {}
+
+export class SeedTemplates extends Context.Service<
+  SeedTemplates,
+  {
+    readonly copy: (request: SeedRequest) => Effect.Effect<void, PlatformError | BenchmarkError>;
+  }
+>()("runtime-benchmark/SeedTemplates") {
+  /** Worker-local, revision-local templates, removed when their Layer closes. */
+  static readonly layer = Layer.effect(
+    SeedTemplates,
+    Effect.gen(function* () {
+      const initializer = yield* SeedInitializer;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-benchmark-seeds-" });
+      const templates = new Map<string, string>();
+      let attempts = 0;
+
+      const copy = Effect.fn("benchmark.copySeed")(function* (request: SeedRequest) {
+        const key = `${request.kind}-${request.records}`;
+        let source = templates.get(key);
+
+        if (source === undefined) {
+          const candidate = path.join(directory, `${attempts++}.sqlite`);
+
+          yield* initializer.initialize({ ...request, filename: candidate });
+          // Never copy a live SQLite database or omit committed pages still held in a WAL.
+          yield* check(
+            !(yield* fs.exists(`${candidate}-wal`)) && !(yield* fs.exists(`${candidate}-shm`)),
+            "Seed database is not closed: SQLite WAL/SHM sidecars remain",
+          );
+          templates.set(key, candidate);
+          source = candidate;
+        }
+        yield* fs.copyFile(source, request.filename);
+      });
+
+      return SeedTemplates.of({ copy });
+    }),
+  );
+}

--- a/examples/runtime-benchmark/src/worker.ts
+++ b/examples/runtime-benchmark/src/worker.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
 import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Cause, Config, Effect, Exit, Layer, Schema } from "effect";
+import { Cause, Config, Effect, Exit, FileSystem, Layer, Schema } from "effect";
 
 import {
   BenchmarkError,
@@ -12,13 +12,13 @@ import {
   type Sample,
   type SampleProgress,
 } from "./contracts.js";
-import { writeEvidence } from "./evidence.js";
-import { runSample } from "./fixture.js";
-import { makeSeedTemplates } from "./seeds.js";
+import { BenchmarkProgress, writeEvidence } from "./evidence.js";
+import { BenchmarkRunner, SeedInitializerLive } from "./fixture.js";
+import { SeedTemplates } from "./seeds.js";
 
+/** The worker owns report persistence and the lifetime of its shared seed cache. */
 export const runWorker = Effect.fn("benchmark.runWorker")(function* (
   options: typeof WorkerOptions.Type,
-  run: typeof runSample = runSample,
 ) {
   const samples: Array<Sample> = [];
   let active: SampleProgress | null = null;
@@ -43,37 +43,45 @@ export const runWorker = Effect.fn("benchmark.runWorker")(function* (
       }),
     );
 
+  const progressLayer = Layer.effect(
+    BenchmarkProgress,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+
+      return BenchmarkProgress.of({
+        record: Effect.fn("benchmark.recordProgress")(function* (progress) {
+          active = progress;
+          yield* persist().pipe(Effect.provideService(FileSystem.FileSystem, fs));
+        }),
+      });
+    }),
+  );
+
   yield* Effect.gen(function* () {
     yield* persist();
-    const seeds = yield* makeSeedTemplates();
+    // Acquire the cache after the first report so acquisition failures leave evidence, too.
+    yield* Effect.gen(function* () {
+      const runner = yield* BenchmarkRunner;
 
-    for (let index = 0; index < options.warmups + options.samples; index++) {
-      const ordered = index % 2 === 0 ? workloads : [...workloads].reverse();
+      for (let index = 0; index < options.warmups + options.samples; index++) {
+        const ordered = index % 2 === 0 ? workloads : [...workloads].reverse();
 
-      for (const workload of ordered) {
-        active = {
-          case: workload.name,
-          ordinal: index,
-          warmup: index < options.warmups,
-          phase: "setup",
-          elapsedMs: 0,
-        };
-        yield* persist();
-        samples.push(
-          yield* run(workload, index, index < options.warmups, {
-            seeds,
-            onProgress: (progress) => {
-              active = progress;
-
-              return persist();
-            },
-          }),
-        );
-        active = null;
-        // Keep partial failures and slow samples even when a later child is interrupted.
-        yield* persist();
+        for (const workload of ordered) {
+          active = {
+            case: workload.name,
+            ordinal: index,
+            warmup: index < options.warmups,
+            phase: "setup",
+            elapsedMs: 0,
+          };
+          yield* persist();
+          samples.push(yield* runner.run(workload, index, index < options.warmups));
+          active = null;
+          // Keep partial failures and slow samples even when a later child is interrupted.
+          yield* persist();
+        }
       }
-    }
+    }).pipe(Effect.provide(Layer.merge(SeedTemplates.layer, progressLayer)));
     if (samples.some((sample) => sample.status === "failed"))
       return yield* BenchmarkError.make({
         message: "Benchmark correctness assertions failed; see raw samples",
@@ -95,6 +103,8 @@ if (import.meta.main)
         yield* Config.string("RUNTIME_BENCHMARK_OPTIONS"),
       );
 
-      yield* runWorker(options);
+      yield* runWorker(options).pipe(
+        Effect.provide(Layer.merge(BenchmarkRunner.layer, SeedInitializerLive)),
+      );
     }).pipe(Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer))),
   );

--- a/examples/runtime-benchmark/src/worker.ts
+++ b/examples/runtime-benchmark/src/worker.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
 import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Config, Effect, FileSystem, Layer, Schema } from "effect";
+import { Cause, Config, Effect, Exit, Layer, Schema } from "effect";
 
 import {
   BenchmarkError,
@@ -10,24 +10,26 @@ import {
   WorkerOptions,
   WorkerReport,
   type Sample,
+  type SampleProgress,
 } from "./contracts.js";
+import { writeEvidence } from "./evidence.js";
 import { runSample } from "./fixture.js";
+import { makeSeedTemplates } from "./seeds.js";
 
-const program = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem;
-
-  const options = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerOptions))(
-    yield* Config.string("RUNTIME_BENCHMARK_OPTIONS"),
-  );
-
+export const runWorker = Effect.fn("benchmark.runWorker")(function* (
+  options: typeof WorkerOptions.Type,
+  run: typeof runSample = runSample,
+) {
   const samples: Array<Sample> = [];
+  let active: SampleProgress | null = null;
+  let failure: string | null = null;
 
   const workloads = options.cold
     ? casesFor(options.profile).slice(0, 1)
     : casesFor(options.profile);
 
   const persist = () =>
-    fs.writeFileString(
+    writeEvidence(
       options.output,
       Schema.encodeSync(Schema.fromJsonString(WorkerReport))({
         fixture: FIXTURE_VERSION,
@@ -35,24 +37,64 @@ const program = Effect.gen(function* () {
         runtime: process.version,
         platform: process.platform,
         architecture: process.arch,
+        active,
+        failure,
         samples,
       }),
     );
 
-  yield* persist();
-  for (let index = 0; index < options.warmups + options.samples; index++) {
-    const ordered = index % 2 === 0 ? workloads : [...workloads].reverse();
+  yield* Effect.gen(function* () {
+    yield* persist();
+    const seeds = yield* makeSeedTemplates();
 
-    for (const workload of ordered) {
-      samples.push(yield* runSample(workload, index, index < options.warmups));
-      // Keep partial failures and slow samples even when a later child is interrupted.
-      yield* persist();
+    for (let index = 0; index < options.warmups + options.samples; index++) {
+      const ordered = index % 2 === 0 ? workloads : [...workloads].reverse();
+
+      for (const workload of ordered) {
+        active = {
+          case: workload.name,
+          ordinal: index,
+          warmup: index < options.warmups,
+          phase: "setup",
+          elapsedMs: 0,
+        };
+        yield* persist();
+        samples.push(
+          yield* run(workload, index, index < options.warmups, {
+            seeds,
+            onProgress: (progress) => {
+              active = progress;
+
+              return persist();
+            },
+          }),
+        );
+        active = null;
+        // Keep partial failures and slow samples even when a later child is interrupted.
+        yield* persist();
+      }
     }
-  }
-  if (samples.some((sample) => sample.status === "failed"))
-    return yield* BenchmarkError.make({
-      message: "Benchmark correctness assertions failed; see raw samples",
-    });
-}).pipe(Effect.scoped, Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer)));
+    if (samples.some((sample) => sample.status === "failed"))
+      return yield* BenchmarkError.make({
+        message: "Benchmark correctness assertions failed; see raw samples",
+      });
+  }).pipe(
+    Effect.scoped,
+    Effect.onExit((exit) => {
+      if (Exit.isFailure(exit)) failure = Cause.pretty(exit.cause);
 
-NodeRuntime.runMain(program);
+      return persist();
+    }),
+  );
+});
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Effect.gen(function* () {
+      const options = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerOptions))(
+        yield* Config.string("RUNTIME_BENCHMARK_OPTIONS"),
+      );
+
+      yield* runWorker(options);
+    }).pipe(Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer))),
+  );

--- a/examples/runtime-benchmark/test/fixture.test.ts
+++ b/examples/runtime-benchmark/test/fixture.test.ts
@@ -38,6 +38,9 @@ it("rejects missing, duplicated, or unfinalized samples even if the subprocess e
     ordinal: 0,
     warmup: false,
     totalMs: 2,
+    attemptMs: 3,
+    setupMs: 0.5,
+    failurePhase: null,
     modelEntryMs: 1,
     checkpointCreationMs: null,
     retainedPromptMessages: 0,
@@ -55,6 +58,8 @@ it("rejects missing, duplicated, or unfinalized samples even if the subprocess e
     runtime: "v24",
     platform: "test",
     architecture: "test",
+    active: null,
+    failure: null,
     samples: [sample],
   };
 

--- a/examples/runtime-benchmark/test/fixture.test.ts
+++ b/examples/runtime-benchmark/test/fixture.test.ts
@@ -10,14 +10,21 @@ import {
   type Sample,
   type WorkerReport,
 } from "../src/contracts.ts";
-import { runSample } from "../src/fixture.ts";
+import { BenchmarkProgress } from "../src/evidence.ts";
+import { runSample, SeedInitializerLive } from "../src/fixture.ts";
+import { SeedTemplates } from "../src/seeds.ts";
 
 it.each(casesFor("smoke"))(
   "validates equivalent completed work in $name",
   async (workload) => {
     const result = await Effect.runPromise(
       runSample(workload, 0, false).pipe(
-        Effect.provide(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+        Effect.provide(
+          Layer.merge(SeedTemplates.layer, BenchmarkProgress.silent).pipe(
+            Layer.provide(SeedInitializerLive),
+            Layer.provideMerge(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+          ),
+        ),
       ),
     );
 

--- a/examples/runtime-benchmark/test/lifecycle.test.ts
+++ b/examples/runtime-benchmark/test/lifecycle.test.ts
@@ -1,6 +1,16 @@
 import { NodeCrypto, NodeServices } from "@effect/platform-node";
-import { Clock, Deferred, Effect, Exit, Fiber, FileSystem, Layer, Schema } from "effect";
-import { expect, it } from "vite-plus/test";
+import {
+  Clock,
+  type Crypto,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Schema,
+} from "effect";
+import { expect, expectTypeOf, it } from "vite-plus/test";
 
 import { MAX_SUBPROCESS_OUTPUT_BYTES, subprocess } from "../../../scripts/runtime-benchmark.ts";
 import {
@@ -10,12 +20,16 @@ import {
   WorkerReport,
   type Sample,
 } from "../src/contracts.ts";
-import { writeEvidence } from "../src/evidence.ts";
-import { runSample } from "../src/fixture.ts";
-import { makeSeedTemplates } from "../src/seeds.ts";
+import { BenchmarkProgress, writeEvidence } from "../src/evidence.ts";
+import { BenchmarkRunner, runSample, SeedInitializerLive } from "../src/fixture.ts";
+import { SeedInitializer, SeedTemplates } from "../src/seeds.ts";
 import { runWorker } from "../src/worker.ts";
 
-const services = Layer.merge(NodeServices.layer, NodeCrypto.layer);
+const services = Layer.mergeAll(
+  NodeServices.layer,
+  SeedInitializerLive.pipe(Layer.provideMerge(NodeCrypto.layer)),
+  BenchmarkProgress.silent,
+);
 
 const sample = (ordinal: number): Sample => ({
   case: "small-run",
@@ -42,12 +56,14 @@ it("keeps phase evidence writes outside the operation clock", async () => {
       const clock = yield* Clock.Clock;
       let nanos = 1n;
 
-      return yield* runSample(casesFor("smoke")[0]!, 0, false, {
-        onProgress: () =>
-          Effect.sync(() => {
-            nanos += 100_000_000n;
-          }),
-      }).pipe(
+      return yield* runSample(casesFor("smoke")[0]!, 0, false).pipe(
+        Effect.provide(SeedTemplates.layer),
+        Effect.provideService(BenchmarkProgress, {
+          record: () =>
+            Effect.sync(() => {
+              nanos += 100_000_000n;
+            }),
+        }),
         Effect.provideService(Clock.Clock, {
           currentTimeMillisUnsafe: () => clock.currentTimeMillisUnsafe(),
           currentTimeNanosUnsafe: () => clock.currentTimeNanosUnsafe(),
@@ -113,7 +129,10 @@ it("retains a failed sample and later successes while rejecting the worker", asy
             : sample(ordinal),
         );
 
-      const result = yield* runWorker(options, runner).pipe(Effect.exit);
+      const result = yield* runWorker(options).pipe(
+        Effect.provideService(BenchmarkRunner, { run: runner }),
+        Effect.exit,
+      );
 
       expect(Exit.isFailure(result)).toBe(true);
 
@@ -129,36 +148,80 @@ it("retains a failed sample and later successes while rejecting the worker", asy
   );
 });
 
+it("preserves a worker report when its seed cache cannot be acquired", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+
+      const options = {
+        profile: "smoke" as const,
+        cold: true,
+        warmups: 0,
+        samples: 1,
+        output: `${directory}/worker.json`,
+      };
+
+      const result = yield* runWorker(options).pipe(
+        Effect.provide(BenchmarkRunner.layer),
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          makeTempDirectoryScoped: () => Effect.die("seed cache unavailable"),
+        }),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(result)).toBe(true);
+
+      const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
+        yield* fs.readFileString(options.output),
+      );
+
+      expect(report.samples).toEqual([]);
+      expect(report.active).toBeNull();
+      expect(report.failure).toContain("seed cache unavailable");
+      expect(completeBatch(report, options)).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
 it("clones closed templates once per key without sharing sample mutations and removes its files", async () => {
   let template = "";
 
   const observed = await Effect.runPromise(
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
+      let initializations = 0;
 
-      yield* Effect.scoped(
+      const initializer = Layer.effect(
+        SeedInitializer,
         Effect.gen(function* () {
-          const seeds = yield* makeSeedTemplates();
-          const directory = yield* fs.makeTempDirectoryScoped();
-          let initializations = 0;
+          const seedFs = yield* FileSystem.FileSystem;
 
-          const initialize = (filename: string) =>
-            Effect.gen(function* () {
-              initializations++;
-              template = filename;
-              yield* fs.writeFileString(filename, "seed");
-            });
-
-          yield* seeds.copy("history-16", `${directory}/one`, initialize);
-          yield* fs.writeFileString(`${directory}/one`, "measured mutation");
-          yield* seeds.copy("history-16", `${directory}/two`, initialize);
-          expect(yield* fs.readFileString(`${directory}/two`)).toBe("seed");
-          expect(yield* fs.readFileString(template)).toBe("seed");
-          expect(initializations).toBe(1);
-          yield* seeds.copy("ledger-16", `${directory}/three`, initialize);
-          expect(initializations).toBe(2);
+          return SeedInitializer.of({
+            initialize: ({ filename }) =>
+              Effect.gen(function* () {
+                initializations++;
+                template = filename;
+                yield* seedFs.writeFileString(filename, "seed");
+              }).pipe(Effect.orDie),
+          });
         }),
       );
+
+      yield* Effect.gen(function* () {
+        const seeds = yield* SeedTemplates;
+        const directory = yield* fs.makeTempDirectoryScoped();
+
+        yield* seeds.copy({ kind: "history", records: 16, filename: `${directory}/one` });
+        yield* fs.writeFileString(`${directory}/one`, "measured mutation");
+        yield* seeds.copy({ kind: "history", records: 16, filename: `${directory}/two` });
+        expect(yield* fs.readFileString(`${directory}/two`)).toBe("seed");
+        expect(yield* fs.readFileString(template)).toBe("seed");
+        expect(initializations).toBe(1);
+        yield* seeds.copy({ kind: "ledger", records: 16, filename: `${directory}/three` });
+        expect(initializations).toBe(2);
+      }).pipe(Effect.provide(SeedTemplates.layer.pipe(Layer.provide(initializer))), Effect.scoped);
 
       return yield* fs.exists(template);
     }).pipe(Effect.provide(services)),
@@ -173,18 +236,29 @@ it.each(["wal", "shm"])(
     await Effect.runPromise(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const seeds = yield* makeSeedTemplates();
         const directory = yield* fs.makeTempDirectoryScoped();
         const destination = `${directory}/copy`;
 
-        const result = yield* seeds
-          .copy("history-16", destination, (filename) =>
-            Effect.gen(function* () {
-              yield* fs.writeFileString(filename, "seed");
-              yield* fs.writeFileString(`${filename}-${sidecar}`, "pending state");
-            }),
-          )
-          .pipe(Effect.exit);
+        const initializer = Layer.effect(
+          SeedInitializer,
+          Effect.gen(function* () {
+            const seedFs = yield* FileSystem.FileSystem;
+
+            return SeedInitializer.of({
+              initialize: ({ filename }) =>
+                Effect.gen(function* () {
+                  yield* seedFs.writeFileString(filename, "seed");
+                  yield* seedFs.writeFileString(`${filename}-${sidecar}`, "pending state");
+                }).pipe(Effect.orDie),
+            });
+          }),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const seeds = yield* SeedTemplates;
+
+          yield* seeds.copy({ kind: "history", records: 16, filename: destination });
+        }).pipe(Effect.provide(SeedTemplates.layer.pipe(Layer.provide(initializer))), Effect.exit);
 
         expect(Exit.isFailure(result)).toBe(true);
         expect(yield* fs.exists(destination)).toBe(false);
@@ -197,37 +271,49 @@ it("uses a fresh template path after interrupted initialization and closes its r
   await Effect.runPromise(
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const seeds = yield* makeSeedTemplates();
       const directory = yield* fs.makeTempDirectoryScoped();
       let closed = false;
       let abandoned = "";
 
-      const first = yield* seeds
-        .copy("history-16", `${directory}/one`, (filename) =>
-          Effect.gen(function* () {
-            abandoned = filename;
-            yield* fs.writeFileString(filename, "incomplete");
-            yield* Effect.addFinalizer(() =>
-              Effect.sync(() => {
-                closed = true;
-              }),
-            );
-
-            return yield* Effect.interrupt;
-          }).pipe(Effect.scoped),
-        )
-        .pipe(Effect.exit);
-
-      expect(Exit.isFailure(first)).toBe(true);
-      expect(closed).toBe(true);
-      yield* seeds.copy("history-16", `${directory}/two`, (filename) =>
+      const initializer = Layer.effect(
+        SeedInitializer,
         Effect.gen(function* () {
-          expect(filename).not.toBe(abandoned);
-          expect(yield* fs.exists(filename)).toBe(false);
-          yield* fs.writeFileString(filename, "complete");
+          const seedFs = yield* FileSystem.FileSystem;
+
+          return SeedInitializer.of({
+            initialize: ({ filename }) =>
+              Effect.gen(function* () {
+                if (abandoned === "") {
+                  abandoned = filename;
+                  yield* seedFs.writeFileString(filename, "incomplete");
+                  yield* Effect.addFinalizer(() =>
+                    Effect.sync(() => {
+                      closed = true;
+                    }),
+                  );
+
+                  return yield* Effect.interrupt;
+                }
+                expect(filename).not.toBe(abandoned);
+                expect(yield* seedFs.exists(filename)).toBe(false);
+                yield* seedFs.writeFileString(filename, "complete");
+              }).pipe(Effect.scoped, Effect.orDie),
+          });
         }),
       );
-      expect(yield* fs.readFileString(`${directory}/two`)).toBe("complete");
+
+      yield* Effect.gen(function* () {
+        const seeds = yield* SeedTemplates;
+
+        const first = yield* seeds
+          .copy({ kind: "history", records: 16, filename: `${directory}/one` })
+          .pipe(Effect.exit);
+
+        expect(Exit.isFailure(first)).toBe(true);
+        expect(closed).toBe(true);
+        yield* seeds.copy({ kind: "history", records: 16, filename: `${directory}/two` });
+        expect(yield* fs.readFileString(`${directory}/two`)).toBe("complete");
+      }).pipe(Effect.provide(SeedTemplates.layer.pipe(Layer.provide(initializer))));
     }).pipe(Effect.scoped, Effect.provide(services)),
   );
 });
@@ -235,13 +321,11 @@ it("uses a fresh template path after interrupted initialization and closes its r
 it("runs fresh durable and recovery samples on isolated copies while rebuilding every checkpoint", async () => {
   await Effect.runPromise(
     Effect.gen(function* () {
-      const seeds = yield* makeSeedTemplates();
-
       for (const workload of casesFor("smoke").filter((entry) =>
         ["durable", "recovery", "ledger"].includes(entry.kind),
       )) {
         for (const ordinal of [0, 1]) {
-          const result = yield* runSample(workload, ordinal, false, { seeds });
+          const result = yield* runSample(workload, ordinal, false);
 
           expect(result.failure).toBeNull();
           expect(result.status).toBe("passed");
@@ -250,7 +334,7 @@ it("runs fresh durable and recovery samples on isolated copies while rebuilding 
           expect(result.attemptMs).toBeGreaterThanOrEqual(result.setupMs + result.totalMs);
         }
       }
-    }).pipe(Effect.scoped, Effect.provide(services)),
+    }).pipe(Effect.provide(SeedTemplates.layer), Effect.scoped, Effect.provide(services)),
   );
 }, 30_000);
 
@@ -261,9 +345,8 @@ it.each(["failure", "defect", "timeout"] as const)(
     const workload = casesFor("smoke").find((entry) => entry.name === "durable-fresh-16")!;
 
     const result = await Effect.runPromise(
-      runSample(workload, 0, false, {
-        timeout: "10 millis",
-        seeds: {
+      runSample(workload, 0, false, { timeout: "10 millis" }).pipe(
+        Effect.provideService(SeedTemplates, {
           copy: () =>
             Effect.gen(function* () {
               yield* Effect.addFinalizer(() =>
@@ -277,8 +360,9 @@ it.each(["failure", "defect", "timeout"] as const)(
 
               return yield* Effect.never;
             }).pipe(Effect.scoped),
-        },
-      }).pipe(Effect.provide(services)),
+        }),
+        Effect.provide(services),
+      ),
     );
 
     expect(result.status).toBe("failed");
@@ -305,24 +389,28 @@ it("persists the active phase and completed samples when the worker is interrupt
         output: `${directory}/worker.json`,
       };
 
-      const runner: typeof runSample = (workload, ordinal, warmup, settings) =>
+      const runner: typeof runSample = (workload, ordinal, warmup) =>
         Effect.gen(function* () {
           if (ordinal === 0) return sample(ordinal);
-          yield* (
-            settings?.onProgress?.({
+          const progress = yield* BenchmarkProgress;
+
+          yield* progress
+            .record({
               case: workload.name,
               ordinal,
               warmup,
               phase: "operation",
               elapsedMs: 7,
-            }) ?? Effect.void
-          ).pipe(Effect.orDie);
+            })
+            .pipe(Effect.orDie);
           yield* Deferred.succeed(entered, undefined);
 
           return yield* Effect.never;
         });
 
-      const fiber = yield* Effect.forkChild(runWorker(options, runner));
+      const fiber = yield* Effect.forkChild(
+        runWorker(options).pipe(Effect.provideService(BenchmarkRunner, { run: runner })),
+      );
 
       yield* Deferred.await(entered);
       yield* Fiber.interrupt(fiber);
@@ -422,4 +510,18 @@ it("caps combined stdout and stderr, retains their prefix, and terminates a chat
       expect(() => process.kill(child.pid, 0)).toThrow(/ESRCH/);
     }).pipe(Effect.scoped, Effect.provide(services)),
   );
+});
+
+it("keeps sample and worker requirements visible in Effect", () => {
+  expectTypeOf<
+    Extract<Effect.Services<ReturnType<typeof runSample>>, BenchmarkProgress | SeedTemplates>
+  >().toEqualTypeOf<BenchmarkProgress | SeedTemplates>();
+  expectTypeOf<
+    Extract<Effect.Services<ReturnType<typeof runWorker>>, BenchmarkRunner | SeedInitializer>
+  >().toEqualTypeOf<BenchmarkRunner | SeedInitializer>();
+  expectTypeOf<Layer.Services<typeof SeedTemplates.layer>>()
+    .extract<SeedInitializer>()
+    .toEqualTypeOf<SeedInitializer>();
+  expectTypeOf<Layer.Services<typeof SeedInitializerLive>>().toEqualTypeOf<Crypto.Crypto>();
+  expectTypeOf<Effect.Error<ReturnType<typeof runSample>>>().toEqualTypeOf<never>();
 });

--- a/examples/runtime-benchmark/test/lifecycle.test.ts
+++ b/examples/runtime-benchmark/test/lifecycle.test.ts
@@ -1,0 +1,425 @@
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Clock, Deferred, Effect, Exit, Fiber, FileSystem, Layer, Schema } from "effect";
+import { expect, it } from "vite-plus/test";
+
+import { MAX_SUBPROCESS_OUTPUT_BYTES, subprocess } from "../../../scripts/runtime-benchmark.ts";
+import {
+  BenchmarkError,
+  casesFor,
+  completeBatch,
+  WorkerReport,
+  type Sample,
+} from "../src/contracts.ts";
+import { writeEvidence } from "../src/evidence.ts";
+import { runSample } from "../src/fixture.ts";
+import { makeSeedTemplates } from "../src/seeds.ts";
+import { runWorker } from "../src/worker.ts";
+
+const services = Layer.merge(NodeServices.layer, NodeCrypto.layer);
+
+const sample = (ordinal: number): Sample => ({
+  case: "small-run",
+  ordinal,
+  warmup: false,
+  totalMs: 1,
+  attemptMs: 3,
+  setupMs: 1,
+  failurePhase: null,
+  modelEntryMs: 0.5,
+  checkpointCreationMs: null,
+  retainedPromptMessages: 0,
+  modelCalls: 1,
+  finalizers: 1,
+  toolCalls: 0,
+  outputBytes: 15,
+  status: "passed",
+  failure: null,
+});
+
+it("keeps phase evidence writes outside the operation clock", async () => {
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const clock = yield* Clock.Clock;
+      let nanos = 1n;
+
+      return yield* runSample(casesFor("smoke")[0]!, 0, false, {
+        onProgress: () =>
+          Effect.sync(() => {
+            nanos += 100_000_000n;
+          }),
+      }).pipe(
+        Effect.provideService(Clock.Clock, {
+          currentTimeMillisUnsafe: () => clock.currentTimeMillisUnsafe(),
+          currentTimeNanosUnsafe: () => clock.currentTimeNanosUnsafe(),
+          currentTimeMillis: clock.currentTimeMillis,
+          currentTimeNanos: clock.currentTimeNanos,
+          sleep: (duration) => clock.sleep(duration),
+          monotonicTimeNanosUnsafe: () => nanos,
+          monotonicTimeNanos: Effect.sync(() => nanos),
+        }),
+      );
+    }).pipe(Effect.provide(services)),
+  );
+
+  expect(result.failure).toBeNull();
+  expect(result.totalMs).toBe(0);
+  expect(result.setupMs).toBe(200);
+  expect(result.attemptMs).toBe(300);
+});
+
+it("preserves the previous complete report when replacement is interrupted", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const filename = `${directory}/report.json`;
+
+      yield* writeEvidence(filename, '{"complete":1}');
+
+      const result = yield* writeEvidence(filename, '{"complete":2}').pipe(
+        Effect.provideService(FileSystem.FileSystem, { ...fs, rename: () => Effect.interrupt }),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(result)).toBe(true);
+      expect(yield* fs.readFileString(filename)).toBe('{"complete":1}');
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("retains a failed sample and later successes while rejecting the worker", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+
+      const options = {
+        profile: "smoke" as const,
+        cold: true,
+        warmups: 0,
+        samples: 2,
+        output: `${directory}/worker.json`,
+      };
+
+      const runner: typeof runSample = (_workload, ordinal) =>
+        Effect.succeed(
+          ordinal === 0
+            ? {
+                ...sample(ordinal),
+                status: "failed",
+                failure: "expected failure",
+                failurePhase: "operation",
+              }
+            : sample(ordinal),
+        );
+
+      const result = yield* runWorker(options, runner).pipe(Effect.exit);
+
+      expect(Exit.isFailure(result)).toBe(true);
+
+      const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
+        yield* fs.readFileString(options.output),
+      );
+
+      expect(report.samples.map((entry) => entry.status)).toEqual(["failed", "passed"]);
+      expect(report.active).toBeNull();
+      expect(report.failure).toContain("Benchmark correctness assertions failed");
+      expect(completeBatch(report, options)).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("clones closed templates once per key without sharing sample mutations and removes its files", async () => {
+  let template = "";
+
+  const observed = await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const seeds = yield* makeSeedTemplates();
+          const directory = yield* fs.makeTempDirectoryScoped();
+          let initializations = 0;
+
+          const initialize = (filename: string) =>
+            Effect.gen(function* () {
+              initializations++;
+              template = filename;
+              yield* fs.writeFileString(filename, "seed");
+            });
+
+          yield* seeds.copy("history-16", `${directory}/one`, initialize);
+          yield* fs.writeFileString(`${directory}/one`, "measured mutation");
+          yield* seeds.copy("history-16", `${directory}/two`, initialize);
+          expect(yield* fs.readFileString(`${directory}/two`)).toBe("seed");
+          expect(yield* fs.readFileString(template)).toBe("seed");
+          expect(initializations).toBe(1);
+          yield* seeds.copy("ledger-16", `${directory}/three`, initialize);
+          expect(initializations).toBe(2);
+        }),
+      );
+
+      return yield* fs.exists(template);
+    }).pipe(Effect.provide(services)),
+  );
+
+  expect(observed).toBe(false);
+});
+
+it.each(["wal", "shm"])(
+  "rejects a seed with a remaining SQLite %s and never publishes a copy",
+  async (sidecar) => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const seeds = yield* makeSeedTemplates();
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const destination = `${directory}/copy`;
+
+        const result = yield* seeds
+          .copy("history-16", destination, (filename) =>
+            Effect.gen(function* () {
+              yield* fs.writeFileString(filename, "seed");
+              yield* fs.writeFileString(`${filename}-${sidecar}`, "pending state");
+            }),
+          )
+          .pipe(Effect.exit);
+
+        expect(Exit.isFailure(result)).toBe(true);
+        expect(yield* fs.exists(destination)).toBe(false);
+      }).pipe(Effect.scoped, Effect.provide(services)),
+    );
+  },
+);
+
+it("uses a fresh template path after interrupted initialization and closes its resources", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const seeds = yield* makeSeedTemplates();
+      const directory = yield* fs.makeTempDirectoryScoped();
+      let closed = false;
+      let abandoned = "";
+
+      const first = yield* seeds
+        .copy("history-16", `${directory}/one`, (filename) =>
+          Effect.gen(function* () {
+            abandoned = filename;
+            yield* fs.writeFileString(filename, "incomplete");
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                closed = true;
+              }),
+            );
+
+            return yield* Effect.interrupt;
+          }).pipe(Effect.scoped),
+        )
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(first)).toBe(true);
+      expect(closed).toBe(true);
+      yield* seeds.copy("history-16", `${directory}/two`, (filename) =>
+        Effect.gen(function* () {
+          expect(filename).not.toBe(abandoned);
+          expect(yield* fs.exists(filename)).toBe(false);
+          yield* fs.writeFileString(filename, "complete");
+        }),
+      );
+      expect(yield* fs.readFileString(`${directory}/two`)).toBe("complete");
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("runs fresh durable and recovery samples on isolated copies while rebuilding every checkpoint", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const seeds = yield* makeSeedTemplates();
+
+      for (const workload of casesFor("smoke").filter((entry) =>
+        ["durable", "recovery", "ledger"].includes(entry.kind),
+      )) {
+        for (const ordinal of [0, 1]) {
+          const result = yield* runSample(workload, ordinal, false, { seeds });
+
+          expect(result.failure).toBeNull();
+          expect(result.status).toBe("passed");
+          expect(result.checkpointCreationMs === null).toBe(workload.kind !== "recovery");
+          expect(result.modelCalls).toBe(result.finalizers);
+          expect(result.attemptMs).toBeGreaterThanOrEqual(result.setupMs + result.totalMs);
+        }
+      }
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+}, 30_000);
+
+it.each(["failure", "defect", "timeout"] as const)(
+  "retains setup %s with elapsed time and finalization",
+  async (failure) => {
+    let closed = false;
+    const workload = casesFor("smoke").find((entry) => entry.name === "durable-fresh-16")!;
+
+    const result = await Effect.runPromise(
+      runSample(workload, 0, false, {
+        timeout: "10 millis",
+        seeds: {
+          copy: () =>
+            Effect.gen(function* () {
+              yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                  closed = true;
+                }),
+              );
+              if (failure === "failure")
+                return yield* BenchmarkError.make({ message: "seed failed" });
+              if (failure === "defect") return yield* Effect.die("seed defect");
+
+              return yield* Effect.never;
+            }).pipe(Effect.scoped),
+        },
+      }).pipe(Effect.provide(services)),
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.failurePhase).toBe("setup");
+    expect(result.failure).not.toBeNull();
+    expect(result.totalMs).toBe(0);
+    expect(result.attemptMs).toBeGreaterThan(0);
+    expect(closed).toBe(true);
+  },
+);
+
+it("persists the active phase and completed samples when the worker is interrupted", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const entered = yield* Deferred.make<void>();
+
+      const options = {
+        profile: "smoke" as const,
+        cold: true,
+        warmups: 0,
+        samples: 2,
+        output: `${directory}/worker.json`,
+      };
+
+      const runner: typeof runSample = (workload, ordinal, warmup, settings) =>
+        Effect.gen(function* () {
+          if (ordinal === 0) return sample(ordinal);
+          yield* (
+            settings?.onProgress?.({
+              case: workload.name,
+              ordinal,
+              warmup,
+              phase: "operation",
+              elapsedMs: 7,
+            }) ?? Effect.void
+          ).pipe(Effect.orDie);
+          yield* Deferred.succeed(entered, undefined);
+
+          return yield* Effect.never;
+        });
+
+      const fiber = yield* Effect.forkChild(runWorker(options, runner));
+
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(fiber);
+
+      const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
+        yield* fs.readFileString(options.output),
+      );
+
+      expect(report.samples).toEqual([sample(0)]);
+      expect(report.active).toMatchObject({
+        case: "small-run",
+        ordinal: 1,
+        phase: "operation",
+        elapsedMs: 7,
+      });
+      expect(report.failure).not.toBeNull();
+      expect(completeBatch(report, options)).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("writes child output before completion and kills an interrupted child", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const log = `${directory}/child.log`;
+
+      const fiber = yield* Effect.forkChild(
+        subprocess(
+          process.execPath,
+          ["-e", "console.log(JSON.stringify({pid:process.pid})); setInterval(() => {}, 1000)"],
+          directory,
+          {},
+          log,
+        ),
+      );
+
+      yield* Effect.gen(function* () {
+        while (!(yield* fs.exists(log)) || !(yield* fs.readFileString(log)).includes("pid"))
+          yield* Effect.sleep("10 millis");
+      }).pipe(Effect.timeout("5 seconds"));
+
+      const child = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(Schema.Struct({ pid: Schema.Int })),
+      )(yield* fs.readFileString(log));
+
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(() => process.kill(child.pid, 0)).toThrow(/ESRCH/);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("caps combined stdout and stderr, retains their prefix, and terminates a chatty child", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const log = `${directory}/child.log`;
+
+      // Each stream is below the cap. Only their combined output exceeds it.
+      const childScript = `
+      require('node:fs').writeFileSync('child.json', JSON.stringify({pid:process.pid}));
+      process.stdout.write('retained prefix\\n');
+      process.stdout.write(Buffer.alloc(5 * 1024 * 1024, 'o'), () => {
+        process.stderr.write(Buffer.alloc(5 * 1024 * 1024, 'e'));
+      });
+      setInterval(() => {}, 1000);
+    `;
+
+      const failure = yield* subprocess(
+        process.execPath,
+        ["-e", childScript],
+        directory,
+        {},
+        log,
+      ).pipe(Effect.flip, Effect.timeout("10 seconds"));
+
+      expect(failure._tag).toBe("BenchmarkError");
+      expect(failure.message).toContain(`exceeded ${MAX_SUBPROCESS_OUTPUT_BYTES} bytes`);
+      const retained = yield* fs.readFile(log);
+
+      expect(retained.byteLength).toBe(MAX_SUBPROCESS_OUTPUT_BYTES);
+      const text = new TextDecoder().decode(retained);
+
+      expect(text.startsWith("retained prefix\n")).toBe(true);
+      expect(text).toContain("oooo");
+      expect(text).toContain("eeee");
+
+      const child = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(Schema.Struct({ pid: Schema.Int })),
+      )(yield* fs.readFileString(`${directory}/child.json`));
+
+      expect(() => process.kill(child.pid, 0)).toThrow(/ESRCH/);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});

--- a/examples/runtime-benchmark/test/report.test.ts
+++ b/examples/runtime-benchmark/test/report.test.ts
@@ -29,6 +29,8 @@ it("reports and excludes an invalid batch even when its process exited successfu
       timingGate: "informational",
     },
     revisions: [],
+    activeBatch: null,
+    failure: null,
     batches: [
       {
         role: "head",
@@ -44,12 +46,17 @@ it("reports and excludes an invalid batch even when its process exited successfu
           runtime: "v22",
           platform: "test",
           architecture: "test",
+          active: null,
+          failure: null,
           samples: [
             {
               case: "small-run",
               ordinal: 0,
               warmup: false,
               totalMs: 0.01,
+              attemptMs: 1,
+              setupMs: 0.5,
+              failurePhase: null,
               modelEntryMs: 0.005,
               checkpointCreationMs: null,
               retainedPromptMessages: 0,
@@ -71,4 +78,31 @@ it("reports and excludes an invalid batch even when its process exited successfu
   expect(rendered).toContain("Invalid/incomplete batches: 1; processes recorded: 1/6");
   expect(rendered).toContain("Worker runtime differs from the controller");
   expect(rendered).toContain("| small-run | n/a | n/a | n/a |");
+
+  const interrupted = renderPerformanceReport({
+    ...report,
+    activeBatch: { role: "reference", cohort: 0, cold: false },
+    failure: "TimeoutException: comparison deadline",
+    batches: report.batches.map((batch) => ({
+      ...batch,
+      exitCode: -1,
+      report:
+        batch.report === null
+          ? null
+          : {
+              ...batch.report,
+              active: {
+                case: "settled-ledger-16",
+                ordinal: 0,
+                warmup: false,
+                phase: "setup",
+                elapsedMs: 1200,
+              },
+            },
+    })),
+  });
+
+  expect(interrupted).toContain("Interrupted active batch: reference/0/warm");
+  expect(interrupted).toContain("Comparison failure: TimeoutException: comparison deadline");
+  expect(interrupted).toContain("settled-ledger-16:0 setup at 1200.00 ms");
 });

--- a/examples/runtime-benchmark/test/trusted-report.test.ts
+++ b/examples/runtime-benchmark/test/trusted-report.test.ts
@@ -1,0 +1,277 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+
+import { expect, it } from "vite-plus/test";
+
+import type { PerformanceReport } from "../../../scripts/runtime-benchmark.ts";
+import { casesFor, FIXTURE_VERSION, REFERENCE } from "../src/contracts.ts";
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] extends object ? Mutable<T[K]> : T[K] };
+type Report = Mutable<typeof PerformanceReport.Type>;
+const head = "a".repeat(40);
+const base = "b".repeat(40);
+
+const makeReport = (): Report => ({
+  fixture: FIXTURE_VERSION,
+  fixtureSha256: "c".repeat(64),
+  transpiler: "test",
+  profile: "pr",
+  referenceVersion: REFERENCE.version,
+  activeBatch: null,
+  failure: null,
+  environment: {
+    node: "v24.20.0",
+    platform: "linux",
+    architecture: "x64",
+    release: "test",
+    cpu: "test",
+    cpuCount: 2,
+    memoryBytes: 1,
+  },
+  settings: {
+    batches: 3,
+    warmupsPerBatch: 2,
+    samplesPerBatch: 3,
+    production: true,
+    execution: "unbundled published ESM",
+    timingGate: "informational",
+  },
+  revisions: (["base", "head", "reference"] as const).map((role) => ({
+    role,
+    revision: role === "base" ? base : role === "head" ? head : REFERENCE.revision,
+    dirty: false,
+    lockfileSha256: "d".repeat(64),
+    builtArtifactsSha256: "e".repeat(64),
+    effect: "test",
+  })),
+  batches: [0, 1, 2].flatMap((cohort) =>
+    (["base", "head", "reference"] as const).flatMap((role) =>
+      [true, false].map((cold) => ({
+        role,
+        cohort,
+        cold,
+        subprocessMs: 1000,
+        exitCode: 0,
+        complete: true,
+        failure: null,
+        report: {
+          fixture: FIXTURE_VERSION,
+          profile: "pr" as const,
+          runtime: "v24.20.0",
+          platform: "linux",
+          architecture: "x64",
+          active: null,
+          failure: null,
+          samples: (cold ? casesFor("pr").slice(0, 1) : casesFor("pr")).flatMap((workload) =>
+            Array.from({ length: cold ? 1 : 5 }, (_, ordinal) => ({
+              case: workload.name,
+              ordinal,
+              warmup: !cold && ordinal < 2,
+              totalMs: 2,
+              attemptMs: 4,
+              setupMs: 1,
+              failurePhase: null,
+              modelEntryMs: 1,
+              checkpointCreationMs: workload.kind === "recovery" ? 1 : null,
+              retainedPromptMessages: 0,
+              modelCalls: 1,
+              finalizers: 1,
+              toolCalls: 0,
+              outputBytes: 15,
+              status: "passed" as const,
+              failure: null,
+            })),
+          ),
+        },
+      })),
+    ),
+  ),
+});
+
+// Exercise the exact trusted inline publisher, with artifact bytes and GitHub writes isolated.
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/performance-comment.yml", import.meta.url),
+  "utf8",
+);
+
+const script = workflow.split("          script: |\n")[1]!.replace(/^ {12}/gm, "");
+
+const publish = async (report: Report, currentHead = head) => {
+  const comments: string[] = [];
+
+  const files: Record<string, string> = {
+    "runtime-performance/report.json": JSON.stringify(report),
+    "runtime-performance/pr-number.txt": "1",
+  };
+
+  const execution: Promise<unknown> = runInNewContext(`(async () => { ${script} })()`, {
+    require: (name: string) => {
+      if (name !== "node:fs") throw new Error("Unexpected trusted publisher import");
+
+      return {
+        lstatSync: (file: string) => ({
+          isFile: () => true,
+          size: Buffer.byteLength(files[file]!),
+        }),
+        readFileSync: (file: string) => files[file],
+      };
+    },
+    context: {
+      repo: { owner: "owner", repo: "repository" },
+      payload: {
+        workflow_run: {
+          head_sha: head,
+          head_repository: { id: 1 },
+          html_url: "https://example.test/run",
+        },
+      },
+    },
+    github: {
+      rest: {
+        pulls: {
+          get: async () => ({
+            data: {
+              number: 1,
+              state: "open",
+              head: { sha: currentHead, repo: { id: 1 } },
+              base: { sha: base, repo: { full_name: "owner/repository" } },
+            },
+          }),
+        },
+        issues: {
+          listComments: () => {},
+          createComment: async (value: { body: string }) => {
+            comments.push(value.body);
+          },
+          updateComment: async () => {
+            throw new Error("Unexpected update");
+          },
+        },
+      },
+      paginate: async () => [],
+    },
+  });
+
+  await execution;
+
+  return comments;
+};
+
+it("publishes all 18 valid cohorts and rejects stale PR identity", async () => {
+  const comments = await publish(makeReport());
+
+  expect(comments).toHaveLength(1);
+  expect(comments[0]).toContain("nine samples per workload and revision");
+  expect(comments[0]).toContain("| settled-ledger-2048 |");
+  expect(await publish(makeReport(), "f".repeat(40))).toEqual([]);
+});
+
+const mutations: ReadonlyArray<readonly [string, (report: Report) => void]> = [
+  [
+    "missing batch",
+    (report) => {
+      report.batches.pop();
+    },
+  ],
+  [
+    "duplicated identity",
+    (report) => {
+      report.batches[1] = report.batches[0]!;
+    },
+  ],
+  [
+    "missing cold sample",
+    (report) => {
+      report.batches[0]!.report = { ...report.batches[0]!.report!, samples: [] };
+    },
+  ],
+  [
+    "missing warm sample",
+    (report) => {
+      report.batches[1]!.report = { ...report.batches[1]!.report!, samples: [] };
+    },
+  ],
+  [
+    "failed cold process",
+    (report) => {
+      report.batches[0]!.exitCode = -1;
+    },
+  ],
+  [
+    "incomplete warm process",
+    (report) => {
+      report.batches[1]!.complete = false;
+    },
+  ],
+  [
+    "different runtime",
+    (report) => {
+      report.batches[0]!.report = { ...report.batches[0]!.report!, runtime: "v22.0.0" };
+    },
+  ],
+  [
+    "different fixture",
+    (report) => {
+      report.fixtureSha256 = "invalid";
+    },
+  ],
+  [
+    "missing public artifact hash",
+    (report) => {
+      report.revisions[1]!.builtArtifactsSha256 = "";
+    },
+  ],
+  [
+    "dirty head",
+    (report) => {
+      report.revisions[1]!.dirty = true;
+    },
+  ],
+  [
+    "active sample",
+    (report) => {
+      report.batches[0]!.report = {
+        ...report.batches[0]!.report!,
+        active: { case: "small-run", ordinal: 0, warmup: false, phase: "setup", elapsedMs: 1 },
+      };
+    },
+  ],
+  [
+    "controller interruption",
+    (report) => {
+      report.failure = "Interrupted";
+    },
+  ],
+  [
+    "active batch",
+    (report) => {
+      report.activeBatch = { role: "head", cohort: 2, cold: false };
+    },
+  ],
+  [
+    "unfinalized model",
+    (report) => {
+      const worker = report.batches[0]!.report!;
+
+      report.batches[0]!.report = {
+        ...worker,
+        samples: [{ ...worker.samples[0]!, finalizers: 0 }],
+      };
+    },
+  ],
+  [
+    "impossible setup timing",
+    (report) => {
+      const worker = report.batches[0]!.report!;
+
+      report.batches[0]!.report = { ...worker, samples: [{ ...worker.samples[0]!, setupMs: 10 }] };
+    },
+  ],
+];
+
+it.each(mutations)("rejects %s before commenting", async (_name, mutate) => {
+  const report = makeReport();
+
+  mutate(report);
+  await expect(publish(report)).rejects.toThrow(/Invalid|Incomplete|Unexpected/);
+});

--- a/packages/engine/src/internal/compaction.ts
+++ b/packages/engine/src/internal/compaction.ts
@@ -71,19 +71,34 @@ export const isContextOverflowMessage = (text: string): boolean =>
   CONTEXT_OVERFLOW_PATTERN.test(text);
 
 const utf8Length = (text: string): number => {
-  let bytes = 0;
+  let bytes = text.length;
 
-  for (const character of text) {
-    const codePoint = character.codePointAt(0) ?? 0;
+  for (let index = 0; index < text.length; index++) {
+    const codeUnit = text.charCodeAt(index);
 
-    bytes += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+    if (codeUnit <= 0x7f) continue;
+    if (codeUnit <= 0x7ff) {
+      bytes++;
+      continue;
+    }
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff && index + 1 < text.length) {
+      const next = text.charCodeAt(index + 1);
+
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        // The two UTF-16 code units already contributed two of the four UTF-8 bytes.
+        bytes += 2;
+        index++;
+        continue;
+      }
+    }
+    bytes += 2;
   }
 
   return bytes;
 };
 
 /**
- * Deterministic chars/4 token estimate over one message's structural JSON.
+ * Deterministic UTF-8 bytes/4 token estimate over one message's structural JSON.
  * Conservative for prose, slightly generous for dense JSON — the estimate
  * only gates WHEN to compact, never what is preserved.
  */

--- a/packages/engine/test/compaction.test.ts
+++ b/packages/engine/test/compaction.test.ts
@@ -32,6 +32,7 @@ import {
   Context,
   Deferred,
   Effect,
+  Encoding,
   Exit,
   Fiber,
   Layer,
@@ -1094,6 +1095,103 @@ layer(testLayer)("engine compaction and overflow recovery", (it) => {
       expect(one).toBeGreaterThan(0);
       expect(estimateMessageTokens(message)).toBe(one);
       expect(estimatePromptTokens([message, message])).toBe(one * 2);
+    }),
+  );
+
+  it.effect("counts structural JSON UTF-8 bytes across Unicode boundaries and escapes", () =>
+    Effect.sync(() => {
+      const texts = [
+        "",
+        "ASCII text",
+        '\u0000\b\t\n\r"\\',
+        "\u007f\u0080\u07ff\u0800\ud7ff\ue000\uffff",
+        "é漢😀ñΩ",
+        "\ud800",
+        "\udbff",
+        "\udc00",
+        "\udfff",
+        "\ud800\udc00\udbff\udfff",
+        "\ud800\ud800\udc00",
+        "\ud800a\udfff",
+      ];
+
+      let seed = 17;
+
+      for (let sample = 0; sample < 256; sample++) {
+        let text = "";
+
+        for (let index = 0; index < sample % 53; index++) {
+          seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+          text += String.fromCharCode(seed & 0xffff);
+        }
+        texts.push(text);
+      }
+      for (const text of texts) {
+        // Adjacent lengths exercise every remainder in the per-message rounding.
+        for (const suffix of ["", "a", "ab", "abc"]) {
+          const message = Prompt.userMessage({
+            content: [Prompt.textPart({ text: text + suffix })],
+          });
+
+          // Effect's encoder uses native UTF-8 encoding, independently of the estimator.
+          const utf8Bytes = Encoding.encodeHex(JSON.stringify(message)).length / 2;
+
+          expect(estimateMessageTokens(message)).toBe(Math.ceil(utf8Bytes / 4));
+        }
+      }
+    }),
+  );
+
+  it.effect("retains JSON serialization failures, projections, and fresh mutable estimates", () =>
+    Effect.sync(() => {
+      const cyclic = Prompt.systemMessage({ content: "cycle" });
+
+      Object.defineProperty(cyclic, "self", { value: cyclic, enumerable: true });
+
+      for (const message of [
+        cyclic,
+        Object.assign(Prompt.systemMessage({ content: "bigint" }), { value: 1n }),
+        Object.assign(Prompt.systemMessage({ content: "undefined" }), {
+          toJSON: () => undefined,
+        }),
+        Object.assign(Prompt.systemMessage({ content: "throws" }), {
+          toJSON: () => {
+            throw new Error("Cannot serialize message");
+          },
+        }),
+      ]) {
+        expect(estimateMessageTokens(message)).toBe(0);
+      }
+
+      const projected = Object.assign(Prompt.systemMessage({ content: "projection" }), {
+        toJSON: () => ({ values: [null, undefined, Number.NaN, "😀"] }),
+      });
+
+      const projectedBytes = Encoding.encodeHex(JSON.stringify(projected)).length / 2;
+
+      expect(estimateMessageTokens(projected)).toBe(Math.ceil(projectedBytes / 4));
+
+      let content = "brief";
+      let reads = 0;
+      const mutable = Prompt.systemMessage({ content });
+
+      Object.defineProperty(mutable, "content", {
+        enumerable: true,
+        get: () => {
+          reads++;
+
+          return content;
+        },
+      });
+      for (const next of ["brief", "growth é漢😀".repeat(100)]) {
+        content = next;
+
+        const utf8Bytes =
+          Encoding.encodeHex(JSON.stringify(Prompt.systemMessage({ content }))).length / 2;
+
+        expect(estimateMessageTokens(mutable)).toBe(Math.ceil(utf8Bytes / 4));
+      }
+      expect(reads).toBe(2);
     }),
   );
 

--- a/packages/storage-memory/test/runtime-history-cost.test.ts
+++ b/packages/storage-memory/test/runtime-history-cost.test.ts
@@ -1,6 +1,6 @@
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
-import { ThreadId } from "@effect-agent/core/Identifiers";
+import { RunId, ThreadId } from "@effect-agent/core/Identifiers";
 import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
 import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
 import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
@@ -14,9 +14,12 @@ import {
   BatchId,
   CanonicalBatch,
   CanonicalSequence,
+  CompactionCreated,
   DefinitionDigests,
   DeploymentId,
   Digest,
+  ModelCompleted,
+  PersistedJson,
   ProducerEpoch,
   ProducerId,
   RecordEnvelope,
@@ -24,18 +27,26 @@ import {
   RepairAnnotated,
   ThreadCreated,
 } from "@effect-agent/thread/Records";
-import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import {
+  IdempotencyKey,
+  Principal,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
+} from "@effect-agent/thread/SubmissionLedger";
 import {
   FencedAppendRequest,
   ThreadMaterialization,
   ThreadStore,
+  ThreadStoreError,
+  ThreadTailRequest,
+  type ThreadRead,
 } from "@effect-agent/thread/ThreadStore";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { NodeCrypto } from "@effect/platform-node";
 import { expect, it } from "@effect/vitest";
-import { Array, DateTime, Effect, Layer, Schema, Stream } from "effect";
-import { LanguageModel, Model, Toolkit, type Response } from "effect/unstable/ai";
+import { Array, Cause, DateTime, Effect, Exit, Layer, Schema, Stream } from "effect";
+import { LanguageModel, Model, Prompt, Toolkit, type Response } from "effect/unstable/ai";
 
 const digest = Schema.decodeSync(Digest)("a".repeat(64));
 const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
@@ -73,18 +84,34 @@ const base = Layer.mergeAll(
   }),
 ).pipe(Layer.provideMerge(NodeCrypto.layer));
 
-const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: number) {
+type ReadFault = "gap" | "short" | "failure" | "defect" | "interruption";
+type ReadPhase = "prefix" | "suffix" | "fold";
+
+const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (
+  historySize: number,
+  fault?: { readonly kind: ReadFault; readonly phase: ReadPhase },
+  raceAppend = false,
+  withCompaction = false,
+) {
   const store = yield* ThreadStore;
   const threadId = Schema.decodeSync(ThreadId)(`history-cost-${historySize}`);
   const producerEpoch = Schema.decodeSync(ProducerEpoch)(0);
   const createdAt = yield* DateTime.now;
   let tailSequence = Schema.decodeSync(CanonicalSequence)(0);
   let tailDigest = EMPTY_TAIL_DIGEST;
+  const retainedInputs: Array<string> = [];
 
   yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch }));
   for (let start = 0; start < historySize; start += 256) {
-    const records = Array.makeBy(Math.min(256, historySize - start), (offset) =>
-      RecordEnvelope.make({
+    const records = Array.makeBy(Math.min(256, historySize - start), (offset) => {
+      const position = start + offset;
+      const input = `retained input ${position}`;
+      const compaction = withCompaction && position === 128;
+      const retained = position > 0 && position % 4 === 0 && !compaction;
+
+      if (retained) retainedInputs.push(input);
+
+      return RecordEnvelope.make({
         recordId: Schema.decodeSync(RecordId)(`history-seed:${start + offset}`),
         family: "thread",
         schemaVersion: 1,
@@ -93,9 +120,33 @@ const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: 
         payload:
           start + offset === 0
             ? ThreadCreated.make({ agentId: definition.id, definitions })
-            : RepairAnnotated.make({ reason: "history-cost", details: { text: "x".repeat(128) } }),
-      }),
-    );
+            : compaction
+              ? CompactionCreated.make({
+                  runId: RunId.make("prior-compaction"),
+                  turn: 1,
+                  kind: "summarize",
+                  coversThrough: Schema.decodeSync(CanonicalSequence)(0),
+                  summary: "Invalid zero coverage must not hide retained input",
+                })
+              : retained
+                ? ModelCompleted.make({
+                    runId: RunId.make(`retained:${position}`),
+                    output: "retained answer",
+                    messages: Schema.decodeUnknownSync(PersistedJson)(
+                      Schema.encodeSync(Prompt.Prompt)(
+                        Prompt.make([
+                          { role: "user", content: input },
+                          { role: "assistant", content: "retained answer" },
+                        ]),
+                      ),
+                    ),
+                  })
+                : RepairAnnotated.make({
+                    reason: "history-cost",
+                    details: { text: "x".repeat(128) },
+                  }),
+      });
+    });
 
     const appended = yield* store.append(
       FencedAppendRequest.make({
@@ -117,13 +168,107 @@ const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: 
   let returnedRecords = 0;
   let measured = false;
 
+  let openedPages = 0;
+  let closedPages = 0;
+  let prefixTraversals = 0;
+  let injected = false;
+  let raced = false;
+  const requests: Array<ThreadRead> = [];
+
   const counted = ThreadStore.of({
     ...store,
     read: (request) =>
-      store.read(request).pipe(
+      Stream.suspend(() => {
+        openedPages++;
+        requests.push(request);
+        if (request.afterSequence === undefined) prefixTraversals++;
+
+        const inject =
+          !injected &&
+          fault !== undefined &&
+          (fault.phase === "suffix"
+            ? request.afterSequence === historySize
+            : request.afterSequence === 1_024 &&
+              prefixTraversals === (fault.phase === "prefix" ? 1 : 2));
+
+        if (inject) {
+          injected = true;
+          switch (fault.kind) {
+            case "gap":
+              return store.read(request).pipe(Stream.drop(1));
+            case "short":
+              return Stream.empty;
+            case "failure":
+              return Stream.fail(
+                ThreadStoreError.make({ operation: "history test", message: "read unavailable" }),
+              );
+            case "defect":
+              return Stream.die("read defect");
+            case "interruption":
+              return Stream.fromEffect(Effect.interrupt);
+          }
+        }
+
+        if (raceAppend && !raced && request.afterSequence === 1_024) {
+          raced = true;
+
+          return Stream.unwrap(
+            Effect.gen(function* () {
+              const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+              const input = "retained input racing append";
+
+              retainedInputs.push(input);
+              yield* store
+                .append(
+                  FencedAppendRequest.make({
+                    threadId,
+                    producerEpoch: tail.producerEpoch,
+                    expectedTailSequence: tail.tailSequence,
+                    expectedTailDigest: tail.tailDigest,
+                    batch: CanonicalBatch.make({
+                      batchId: BatchId.make("racing-history"),
+                      producerId: ProducerId.make("history-cost"),
+                      records: [
+                        RecordEnvelope.make({
+                          recordId: RecordId.make("racing-history"),
+                          family: "thread",
+                          schemaVersion: 1,
+                          createdAt,
+                          deploymentId: DeploymentId.make("history-cost"),
+                          payload: ModelCompleted.make({
+                            runId: RunId.make("racing-history"),
+                            output: "racing answer",
+                            messages: Schema.decodeUnknownSync(PersistedJson)(
+                              Schema.encodeSync(Prompt.Prompt)(
+                                Prompt.make([
+                                  { role: "user", content: input },
+                                  { role: "assistant", content: "racing answer" },
+                                ]),
+                              ),
+                            ),
+                          }),
+                        }),
+                      ],
+                    }),
+                  }),
+                )
+                .pipe(Effect.orDie);
+
+              return store.read(request);
+            }),
+          );
+        }
+
+        return store.read(request);
+      }).pipe(
         Stream.tap(() =>
           Effect.sync(() => {
             if (!measured) returnedRecords++;
+          }),
+        ),
+        Stream.ensuring(
+          Effect.sync(() => {
+            closedPages++;
           }),
         ),
       ),
@@ -136,10 +281,20 @@ const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: 
       LanguageModel.LanguageModel,
       LanguageModel.make({
         generateText: () => Effect.succeed([]),
-        streamText: () =>
+        streamText: (request) =>
           Stream.fromEffect(
             Effect.sync(() => {
               measured = true;
+
+              const userTexts = request.prompt.content.flatMap((message) =>
+                message.role === "user"
+                  ? message.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
+                  : [],
+              );
+
+              expect(userTexts.filter((text) => text.startsWith("retained input "))).toEqual(
+                retainedInputs,
+              );
             }),
           ).pipe(Stream.flatMap(() => Stream.fromIterable(response))),
       }),
@@ -153,15 +308,31 @@ const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (historySize: 
     Effect.provideService(ThreadStore, counted),
   );
 
-  yield* runtime.submit(agent, "measure", {
+  const receipt = yield* runtime.submit(agent, "measure", {
     threadId,
     principal: Schema.decodeSync(Principal)("history-cost"),
     idempotencyKey: Schema.decodeSync(IdempotencyKey)("history-cost"),
     definitions,
   });
-  yield* runtime.processThread(agent, threadId);
 
-  return { returnedRecords, measured };
+  const exit = yield* runtime.processThread(agent, threadId).pipe(Effect.exit);
+  const ledger = yield* SubmissionLedger;
+
+  const snapshot = yield* ledger.loadRecoverySnapshot(
+    RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+  );
+
+  return {
+    returnedRecords,
+    measured,
+    exit,
+    openedPages,
+    closedPages,
+    requests,
+    injected,
+    raced,
+    snapshot,
+  };
 });
 
 it.live("bounds startup history reads while retaining the complete fixed prefix", () =>
@@ -169,8 +340,72 @@ it.live("bounds startup history reads while retaining the complete fixed prefix"
     for (const historySize of [1, 11, 2051]) {
       const measurement = yield* measure(historySize).pipe(Effect.provide(base));
 
+      expect(Exit.isSuccess(measurement.exit)).toBe(true);
       expect(measurement.measured).toBe(true);
-      expect(measurement.returnedRecords).toBeLessThanOrEqual(3 * historySize + 6);
+      expect(measurement.openedPages).toBe(measurement.closedPages);
+      expect(measurement.snapshot.ownership).toBeUndefined();
+      expect(measurement.returnedRecords).toBeLessThanOrEqual(2 * historySize + 6);
     }
+  }),
+);
+
+it.live.each([
+  { kind: "gap", phase: "prefix" },
+  { kind: "short", phase: "prefix" },
+  { kind: "failure", phase: "prefix" },
+  { kind: "defect", phase: "prefix" },
+  { kind: "interruption", phase: "prefix" },
+  { kind: "gap", phase: "suffix" },
+  { kind: "failure", phase: "suffix" },
+  { kind: "interruption", phase: "suffix" },
+  { kind: "gap", phase: "fold" },
+  { kind: "short", phase: "fold" },
+] satisfies ReadonlyArray<{ readonly kind: ReadFault; readonly phase: ReadPhase }>)(
+  "releases startup reads and ownership after $phase $kind",
+  (fault) =>
+    Effect.gen(function* () {
+      const result = yield* measure(1_025, fault).pipe(Effect.provide(base));
+
+      expect(result.injected).toBe(true);
+      expect(result.measured).toBe(false);
+      expect(Exit.isFailure(result.exit)).toBe(true);
+      expect(result.openedPages).toBe(result.closedPages);
+      expect(result.snapshot.ownership).toBeUndefined();
+      expect(result.snapshot.reservation).toBeUndefined();
+      expect(result.requests.every((request) => request.limit <= 1_024)).toBe(true);
+      if (Exit.isFailure(result.exit) && ["gap", "short", "failure"].includes(fault.kind))
+        expect(Cause.hasFails(result.exit.cause)).toBe(true);
+    }),
+);
+
+it.live("captures the initial tail and incorporates racing appends through a later suffix", () =>
+  Effect.gen(function* () {
+    const result = yield* measure(1_025, undefined, true).pipe(Effect.provide(base));
+
+    expect(result.raced).toBe(true);
+    expect(result.measured).toBe(true);
+    expect(Exit.isSuccess(result.exit)).toBe(true);
+    expect(
+      result.requests.slice(0, 2).map(({ afterSequence, limit }) => [afterSequence ?? 0, limit]),
+    ).toEqual([
+      [0, 1_024],
+      [1_024, 1],
+    ]);
+    expect(result.returnedRecords).toBeLessThanOrEqual(2 * 1_026 + 6);
+    expect(result.openedPages).toBe(result.closedPages);
+    expect(result.snapshot.ownership).toBeUndefined();
+  }),
+);
+
+it.live("falls back to ordinary journal scans when any compaction metadata is present", () =>
+  Effect.gen(function* () {
+    const result = yield* measure(1_025, undefined, false, true).pipe(Effect.provide(base));
+
+    expect(result.measured).toBe(true);
+    expect(Exit.isSuccess(result.exit)).toBe(true);
+    expect(result.returnedRecords).toBeGreaterThanOrEqual(3 * 1_025);
+    expect(result.returnedRecords).toBeLessThanOrEqual(3 * 1_025 + 6);
+    expect(result.openedPages).toBe(result.closedPages);
+    expect(result.snapshot.ownership).toBeUndefined();
   }),
 );

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -134,6 +134,7 @@ import {
   RECOVERY_ENGINE_VERSION,
   checkpointSuffixCompatible,
 } from "./internal/journal-checkpoint.ts";
+import { makeJournalMetadata, type JournalMetadata } from "./internal/journal-metadata.ts";
 import { makeMessagingRuntime } from "./internal/messaging-host.ts";
 import { makeWorkerRuntime, WorkerInputControl } from "./internal/worker-host.ts";
 import {
@@ -3853,6 +3854,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     canonical: Stream.Stream<CanonicalRecordEnvelope, ThreadStoreError | ThreadNotMaterialized>,
     canonicalThrough: CanonicalSequence,
     journalSeed: JournalCheckpointSeed | undefined,
+    journalMetadata: JournalMetadata | undefined,
     lineage: AttemptLineage,
     approvalDecisions: ReadonlyArray<ApprovalDecisionIntent>,
     runTiming: { readonly startedAt: DateTime.Utc; readonly deadline: DateTime.Utc },
@@ -3868,6 +3870,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         runId,
         (boundary) => boundaries.push(boundary),
         journalSeed,
+        journalMetadata,
       );
 
       const saveRecoveryCheckpoint = Effect.fn("DurableAgentRuntime.saveRecoveryCheckpoint")(
@@ -6919,8 +6922,24 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       const initialThrough = controlThrough;
       const initialView = yield* recoveryView(threadId, initialThrough, [submissionId]);
 
+      let journalMetadata =
+        initialView.seed === undefined
+          ? makeJournalMetadata(runIdForSubmission(submissionId))
+          : undefined;
+
+      const retainControl = controlRecords([submissionId]);
+
+      const collectControl = (record: CanonicalRecordEnvelope): boolean => {
+        // Compaction payloads may carry large summaries or handoffs. Keep their metadata
+        // scoped to ordinary projection, never retained across this Attempt's model waits.
+        if (record.record.payload._tag === "CompactionCreated") journalMetadata = undefined;
+        else journalMetadata?.add(record);
+
+        return retainControl(record);
+      };
+
       let records: ReadonlyArray<CanonicalRecordEnvelope> = yield* Stream.runCollect(
-        initialView.canonical.pipe(Stream.filter(controlRecords([submissionId]))),
+        initialView.canonical.pipe(Stream.filter(collectControl)),
       );
 
       // The append-only prefix remains valid for this Attempt. Retain only this Run's control
@@ -6937,7 +6956,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
             threadId,
             controlThrough,
             through,
-            controlRecords([submissionId]),
+            collectControl,
           );
 
           records = [...records, ...suffix];
@@ -7135,6 +7154,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
           canonical,
           tail.tailSequence,
           initialView.seed,
+          journalMetadata?.snapshot(),
           lineage,
           approvalDecisionIntents,
           runTiming,

--- a/packages/thread/src/RunJournal.ts
+++ b/packages/thread/src/RunJournal.ts
@@ -23,6 +23,7 @@ import { Prompt } from "effect/unstable/ai";
 
 import { digestJson, type DigestError } from "./Digest.ts";
 import { type JournalCheckpointSeed } from "./internal/journal-checkpoint.ts";
+import { makeJournalMetadata, type JournalMetadata } from "./internal/journal-metadata.ts";
 import {
   BatchId,
   CanonicalBatch,
@@ -547,6 +548,8 @@ export interface JournalBoundary {
  * rollovers additionally validate covered Tool batches before rebuilding Prompt and usage. Metadata and the
  * live Prompt remain resident; covered historical message/tool payloads do not. An uncompacted Prompt still grows
  * with its conversation, so hosts must configure an appropriate context compaction policy.
+ * Prepared metadata must describe exactly this stream and seed through the same fixed tail;
+ * it skips only the metadata scan, never covered-Tool validation or the canonical fold.
  * @internal
  */
 export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalStream")(function* <
@@ -557,6 +560,7 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   ownerRunId: RunId | undefined,
   onBoundary?: (boundary: JournalBoundary) => void,
   seed?: JournalCheckpointSeed,
+  preparedMetadata?: JournalMetadata,
 ): Effect.fn.Return<RunJournalProjection, RunJournalError | E, R> {
   if (seed !== undefined && seed.runId !== ownerRunId)
     return yield* journalError("Recovery checkpoint belongs to another Run");
@@ -582,58 +586,30 @@ export const projectRunJournalStream = Effect.fn("RunJournal.projectRunJournalSt
   // would orphan the tool message from its declaring response. Orphaned
   // settleds (filtered later by the fold) still contribute spans —
   // over-invalidating is the fail-safe direction.
-  const firstSequenceByRun = new Map<string, number>();
+  if (
+    preparedMetadata !== undefined &&
+    (preparedMetadata.ownerRunId !== ownerRunId || preparedMetadata.seed !== seed)
+  )
+    return yield* journalError("Prepared journal metadata belongs to another replay");
 
-  if (seed?.firstSequence !== undefined) firstSequenceByRun.set(seed.runId, seed.firstSequence);
-  const lastResponseSequenceByRun = new Map<string, number>();
-  const terminalSequenceByRun = new Map<string, number>();
-  const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
-  const settledToolCallRecordIds = new Set<string>();
-  const settledById = new Map<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>();
-  const compactions: Array<{ readonly payload: CompactionCreated; readonly sequence: number }> = [];
+  let metadata = preparedMetadata;
 
-  yield* Stream.runForEach(records, (envelope) =>
-    Effect.sync(() => {
-      const payload = envelope.record.payload;
+  if (metadata === undefined) {
+    const collected = makeJournalMetadata(ownerRunId, seed);
 
-      if (
-        (payload._tag === "RunCompleted" ||
-          payload._tag === "RunFailed" ||
-          payload._tag === "SubmissionSettled") &&
-        payload.runId !== undefined &&
-        !terminalSequenceByRun.has(payload.runId)
-      ) {
-        terminalSequenceByRun.set(payload.runId, envelope.sequence);
-      }
-      if (payload._tag === "CompactionCreated") {
-        compactions.push({ payload, sequence: envelope.sequence });
+    yield* Stream.runForEach(records, (envelope) => Effect.sync(() => collected.add(envelope)));
+    metadata = collected.snapshot();
+  }
 
-        return;
-      }
-      if ("runId" in payload && typeof payload.runId === "string") {
-        if (!firstSequenceByRun.has(payload.runId)) {
-          firstSequenceByRun.set(payload.runId, envelope.sequence);
-        }
-      }
-      if (payload._tag === "ModelResponseRecorded") {
-        lastResponseSequenceByRun.set(payload.runId, envelope.sequence);
-      } else if (payload._tag === "ToolCallSettled") {
-        settledToolCallRecordIds.add(envelope.record.recordId);
-        if (payload.runId === ownerRunId)
-          settledById.set(envelope.record.recordId, {
-            isFailure: payload.isFailure,
-            ...(payload.budgetRejected === undefined
-              ? {}
-              : { budgetRejected: payload.budgetRejected }),
-          });
-        const from = lastResponseSequenceByRun.get(payload.runId);
-
-        if (from !== undefined && from < envelope.sequence) {
-          settledSpans.push({ from, to: envelope.sequence });
-        }
-      }
-    }),
-  );
+  const {
+    firstSequenceByRun,
+    lastResponseSequenceByRun,
+    terminalSequenceByRun,
+    settledSpans,
+    settledToolCallRecordIds,
+    settledById,
+    compactions,
+  } = metadata;
 
   const settledCoverage = compactions.reduce(
     (through, { payload }) =>

--- a/packages/thread/src/internal/journal-metadata.ts
+++ b/packages/thread/src/internal/journal-metadata.ts
@@ -1,0 +1,97 @@
+import { type RunId } from "@effect-agent/core/Identifiers";
+
+import {
+  type CanonicalRecordEnvelope,
+  type CompactionCreated,
+  type ToolCallSettled,
+} from "../Records.ts";
+import { type JournalCheckpointSeed } from "./journal-checkpoint.ts";
+
+/** Metadata for one exact canonical prefix, including the same optional checkpoint seed. */
+export interface JournalMetadata {
+  readonly ownerRunId: RunId | undefined;
+  readonly seed: JournalCheckpointSeed | undefined;
+  readonly firstSequenceByRun: ReadonlyMap<string, number>;
+  readonly lastResponseSequenceByRun: ReadonlyMap<string, number>;
+  readonly terminalSequenceByRun: ReadonlyMap<string, number>;
+  readonly settledSpans: ReadonlyArray<{ readonly from: number; readonly to: number }>;
+  readonly settledToolCallRecordIds: ReadonlySet<string>;
+  readonly settledById: ReadonlyMap<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>;
+  readonly compactions: ReadonlyArray<{
+    readonly payload: CompactionCreated;
+    readonly sequence: number;
+  }>;
+}
+
+/**
+ * Attempt-local metadata collector. Feed every validated record exactly once, in canonical order,
+ * including records omitted from the control view. A snapshot is independent of later suffix
+ * additions and may only accompany a replay stream bounded at that same captured tail.
+ */
+export const makeJournalMetadata = (
+  ownerRunId: RunId | undefined,
+  seed?: JournalCheckpointSeed,
+) => {
+  const firstSequenceByRun = new Map<string, number>();
+
+  if (seed?.firstSequence !== undefined) firstSequenceByRun.set(seed.runId, seed.firstSequence);
+  const lastResponseSequenceByRun = new Map<string, number>();
+  const terminalSequenceByRun = new Map<string, number>();
+  const settledSpans: Array<{ readonly from: number; readonly to: number }> = [];
+  const settledToolCallRecordIds = new Set<string>();
+  const settledById = new Map<string, Pick<ToolCallSettled, "isFailure" | "budgetRejected">>();
+  const compactions: Array<{ readonly payload: CompactionCreated; readonly sequence: number }> = [];
+
+  return {
+    add: (envelope: CanonicalRecordEnvelope): void => {
+      const payload = envelope.record.payload;
+
+      if (
+        (payload._tag === "RunCompleted" ||
+          payload._tag === "RunFailed" ||
+          payload._tag === "SubmissionSettled") &&
+        payload.runId !== undefined &&
+        !terminalSequenceByRun.has(payload.runId)
+      )
+        terminalSequenceByRun.set(payload.runId, envelope.sequence);
+      if (payload._tag === "CompactionCreated") {
+        compactions.push({ payload, sequence: envelope.sequence });
+
+        return;
+      }
+      if (
+        "runId" in payload &&
+        typeof payload.runId === "string" &&
+        !firstSequenceByRun.has(payload.runId)
+      )
+        firstSequenceByRun.set(payload.runId, envelope.sequence);
+      if (payload._tag === "ModelResponseRecorded") {
+        lastResponseSequenceByRun.set(payload.runId, envelope.sequence);
+      } else if (payload._tag === "ToolCallSettled") {
+        settledToolCallRecordIds.add(envelope.record.recordId);
+        if (payload.runId === ownerRunId)
+          settledById.set(envelope.record.recordId, {
+            isFailure: payload.isFailure,
+            ...(payload.budgetRejected === undefined
+              ? {}
+              : { budgetRejected: payload.budgetRejected }),
+          });
+        const from = lastResponseSequenceByRun.get(payload.runId);
+
+        if (from !== undefined && from < envelope.sequence)
+          settledSpans.push({ from, to: envelope.sequence });
+      }
+    },
+    snapshot: (): JournalMetadata => ({
+      ownerRunId,
+      seed,
+      firstSequenceByRun: new Map(firstSequenceByRun),
+      lastResponseSequenceByRun: new Map(lastResponseSequenceByRun),
+      terminalSequenceByRun: new Map(terminalSequenceByRun),
+      settledSpans: [...settledSpans],
+      settledToolCallRecordIds: new Set(settledToolCallRecordIds),
+      settledById: new Map(settledById),
+      compactions: [...compactions],
+    }),
+  };
+};

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -8,6 +8,7 @@ import {
   ObservationOffset,
   ProducerId,
   RecordEnvelope,
+  RecordId,
   type CanonicalBatch,
 } from "@effect-agent/thread/Records";
 import {
@@ -41,6 +42,8 @@ import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it, layer } from "@effect/vitest";
 import { DateTime, Effect, Schema, Stream } from "effect";
 import { Prompt } from "effect/unstable/ai";
+
+import { makeJournalMetadata } from "../src/internal/journal-metadata.ts";
 
 const SUBMISSION_ID = Schema.decodeSync(SubmissionId)("submission-journal");
 const RUN_ID = runIdForSubmission(SUBMISSION_ID);
@@ -1131,6 +1134,29 @@ describe("engine compaction records and projection (RUN-026)", () => {
             expect(promptText(projection.prompt)).not.toContain("Uncommitted handoff");
             expect(projection.prompt.content.slice(0, 2)).toEqual(toolTurnAppended.slice(0, 2));
             expect(toolResults(projection.prompt)).toEqual([{ bookingRef: "flight-42" }]);
+
+            const metadata = makeJournalMetadata(RUN_ID);
+
+            for (const record of [...records, rollover]) metadata.add(record);
+            let traversals = 0;
+
+            const source = Stream.suspend(() => {
+              traversals++;
+
+              return Stream.fromIterable([...records, rollover]);
+            });
+
+            const prepared = yield* projectRunJournalStream(
+              source,
+              RUN_ID,
+              undefined,
+              undefined,
+              metadata.snapshot(),
+            );
+
+            expect(prepared).toEqual(projection);
+            // Reusing metadata retains covered-Tool validation before the final fold.
+            expect(traversals).toBe(2);
           }),
       );
 
@@ -1582,6 +1608,63 @@ describe("engine compaction records and projection (RUN-026)", () => {
           ).pipe(Effect.flip);
 
           expect(failure._tag).toBe("RunJournalError");
+        }),
+    );
+
+    it.effect(
+      "keeps prepared metadata bound to its captured prefix when later evidence arrives",
+      () =>
+        Effect.gen(function* () {
+          const batch = yield* turnCanonicalBatch(turnInput(toolTurnAppended));
+          const records = envelopesOf([batch]);
+
+          const replacement = envelopeAt(
+            records.length + 1,
+            auditRecord("captured-summary", compactionPayload({ coversThrough: records.length })),
+          );
+
+          const prefix = [...records, replacement];
+          const metadata = makeJournalMetadata(LATER_RUN_ID);
+
+          for (const record of prefix) metadata.add(record);
+          const captured = metadata.snapshot();
+          const settled = records.find(({ record }) => record.payload._tag === "ToolCallSettled");
+
+          if (settled === undefined) return yield* Effect.die("Expected a settled Tool fixture");
+
+          // Late settlement evidence would invalidate the summary in a newer prefix.
+          const late = envelopeAt(
+            prefix.length + 1,
+            RecordEnvelope.make({
+              ...settled.record,
+              recordId: RecordId.make("late-settlement"),
+            }),
+          );
+
+          metadata.add(late);
+
+          const projected = yield* projectRunJournalStream(
+            Stream.fromIterable(prefix),
+            LATER_RUN_ID,
+            undefined,
+            undefined,
+            captured,
+          );
+
+          expect(promptText(projected.prompt)).toContain("Goal: book the Kyoto trip");
+          expect(toolResults(projected.prompt)).toEqual([]);
+          expect(projected).toEqual(yield* projectRunJournal(prefix, LATER_RUN_ID));
+
+          const newer = yield* projectRunJournalStream(
+            Stream.fromIterable([...prefix, late]),
+            LATER_RUN_ID,
+            undefined,
+            undefined,
+            metadata.snapshot(),
+          );
+
+          expect(promptText(newer.prompt)).not.toContain("Goal: book the Kyoto trip");
+          expect(newer).toEqual(yield* projectRunJournal([...prefix, late], LATER_RUN_ID));
         }),
     );
 

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -19,6 +19,7 @@ import {
   WorkerOptions,
   WorkerReport,
 } from "../examples/runtime-benchmark/src/contracts.ts";
+import { writeEvidence } from "../examples/runtime-benchmark/src/evidence.ts";
 import { PublishManifest, withPublishManifests } from "./release-publish.ts";
 
 const Revision = Schema.Struct({
@@ -70,19 +71,35 @@ export const PerformanceReport = Schema.Struct({
   }),
   revisions: Schema.Array(Revision),
   batches: Schema.Array(Batch),
+  activeBatch: Schema.NullOr(
+    Schema.Struct({
+      role: Revision.fields.role,
+      cohort: Schema.Natural,
+      cold: Schema.Boolean,
+    }),
+  ),
+  failure: Schema.NullOr(Schema.String),
 });
 
 type PerformanceReport = typeof PerformanceReport.Type;
 
 const sha256 = (content: string | Uint8Array) => createHash("sha256").update(content).digest("hex");
 
-const subprocess = Effect.fn("benchmark.subprocess")(function* (
+/** Shared raw-byte budget for stdout and stderr, including the retained log prefix. */
+export const MAX_SUBPROCESS_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+export const subprocess = Effect.fn("benchmark.subprocess")(function* (
   executable: string,
   args: ReadonlyArray<string>,
   cwd: string,
   env: Record<string, string> = {},
+  logFile?: string,
 ) {
   const started = yield* Clock.monotonicTimeNanos;
+  const fs = yield* FileSystem.FileSystem;
+  let outputBytes = 0;
+
+  if (logFile !== undefined) yield* fs.writeFileString(logFile, "");
 
   const child = yield* ChildProcess.make(executable, args, {
     cwd,
@@ -90,12 +107,29 @@ const subprocess = Effect.fn("benchmark.subprocess")(function* (
     extendEnv: true,
     stdout: "pipe",
     stderr: "pipe",
+    forceKillAfter: "5 seconds",
   });
+
+  const retain = Effect.fn("benchmark.retainOutput")(function* (chunk: Uint8Array) {
+    // Reserve synchronously across both readers. Finish accepted writes even if the
+    // other reader overflows, so cancellation cannot erase an already retained prefix.
+    const prefix = chunk.subarray(0, MAX_SUBPROCESS_OUTPUT_BYTES - outputBytes);
+
+    outputBytes += prefix.byteLength;
+    if (logFile !== undefined && prefix.byteLength > 0)
+      yield* fs.writeFile(logFile, prefix, { flag: "a" });
+    if (prefix.byteLength !== chunk.byteLength)
+      return yield* BenchmarkError.make({
+        message: `Child output exceeded ${MAX_SUBPROCESS_OUTPUT_BYTES} bytes across stdout and stderr; retained the bounded prefix`,
+      });
+
+    return prefix;
+  }, Effect.uninterruptible);
 
   const [stdout, stderr, exitCode] = yield* Effect.all(
     [
-      Stream.mkString(Stream.decodeText(child.stdout)),
-      Stream.mkString(Stream.decodeText(child.stderr)),
+      Stream.mkString(Stream.decodeText(child.stdout.pipe(Stream.mapEffect(retain)))),
+      Stream.mkString(Stream.decodeText(child.stderr.pipe(Stream.mapEffect(retain)))),
       child.exitCode,
     ],
     { concurrency: 3 },
@@ -285,6 +319,12 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
     "",
     `Correctness failures: ${failures.length}; failed subprocesses: ${failedProcesses}.`,
     `Invalid/incomplete batches: ${incomplete.length}; processes recorded: ${report.batches.length}/${report.settings.batches * 6}. Incomplete batches are excluded from comparison summaries.`,
+    ...(report.activeBatch === null
+      ? []
+      : [
+          `Interrupted active batch: ${report.activeBatch.role}/${report.activeBatch.cohort}/${report.activeBatch.cold ? "cold" : "warm"}.`,
+        ]),
+    ...(report.failure === null ? [] : [`Comparison failure: ${report.failure.split("\n")[0]}`]),
     ...incomplete.map(
       (batch) =>
         `${batch.role}/${batch.cohort}/${batch.cold ? "cold" : "warm"}: ${(batch.failure ?? "Missing or invalid worker report").split("\n")[0]}`,
@@ -297,6 +337,27 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
     lines.push(
       `${revision.role}: ${revision.revision}${revision.dirty ? " (dirty working tree)" : ""}; Effect ${revision.effect}; lock ${revision.lockfileSha256}`,
     );
+  lines.push(
+    "",
+    "Worker wall time includes seed setup, assertions, cleanup, and report writes. Unallocated time includes startup, reporting, shutdown, controller overhead, and any unfinished attempt; these costs are not individually measured:",
+    "",
+    "| Batch | Process ms | Sample attempts ms | Sample setup ms | Unallocated ms | Last active sample |",
+    "| --- | ---: | ---: | ---: | ---: | --- |",
+  );
+  for (const batch of report.batches) {
+    const active = batch.report?.active;
+    const attempts = batch.report?.samples.reduce((sum, sample) => sum + sample.attemptMs, 0) ?? 0;
+    const setup = batch.report?.samples.reduce((sum, sample) => sum + sample.setupMs, 0) ?? 0;
+
+    const lastActive =
+      active === null || active === undefined
+        ? "none"
+        : `${active.case}:${active.ordinal} ${active.phase} at ${active.elapsedMs.toFixed(2)} ms`;
+
+    lines.push(
+      `| ${batch.role}/${batch.cohort}/${batch.cold ? "cold" : "warm"} | ${batch.subprocessMs.toFixed(2)} | ${attempts.toFixed(2)} | ${setup.toFixed(2)} | ${(batch.subprocessMs - attempts).toFixed(2)} | ${lastActive} |`,
+    );
+  }
 
   return lines.join("\n") + "\n";
 };
@@ -325,8 +386,8 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
   yield* Effect.tryPromise({
     try: () =>
       build({
-        entryPoints: ["contracts.ts", "fixture.ts", "worker.ts"].map((file) =>
-          path.join(source, file),
+        entryPoints: ["contracts.ts", "fixture.ts", "worker.ts", "evidence.ts", "seeds.ts"].map(
+          (file) => path.join(source, file),
         ),
         outdir: fixtures,
         bundle: false,
@@ -366,7 +427,7 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
 
   yield* check(
     node.exitCode === 0 && node.stdout.trim().startsWith("v24."),
-    "runtime-v1 requires Node 24; changing the runtime requires a versioned reference reset",
+    `${FIXTURE_VERSION} requires Node 24; changing the runtime requires a versioned reference reset`,
   );
 
   const sizes =
@@ -381,6 +442,8 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
           };
 
   const batches: Array<Batch> = [];
+  let activeBatch: PerformanceReport["activeBatch"] = null;
+  let failure: string | null = null;
 
   const report: PerformanceReport = {
     fixture: FIXTURE_VERSION,
@@ -405,14 +468,20 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
     },
     revisions: stages.map((stage) => stage.revision),
     batches,
+    get activeBatch() {
+      return activeBatch;
+    },
+    get failure() {
+      return failure;
+    },
   };
 
   const persist = Effect.gen(function* () {
-    yield* fs.writeFileString(
+    yield* writeEvidence(
       path.join(output, "report.json"),
       yield* Schema.encodeEffect(Schema.fromJsonString(PerformanceReport))(report),
     );
-    yield* fs.writeFileString(path.join(output, "report.md"), renderPerformanceReport(report));
+    yield* writeEvidence(path.join(output, "report.md"), renderPerformanceReport(report));
   });
 
   const measure = Effect.gen(function* () {
@@ -425,6 +494,10 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
         for (const stage of ordered) {
           const name = `${cohort}-${stage.revision.role}-${cold ? "cold" : "warm"}`;
           const outputFile = path.join(output, `${name}.json`);
+          const logFile = path.join(output, `${name}.log`);
+
+          activeBatch = { role: stage.revision.role, cohort, cold };
+          yield* persist;
 
           yield* Console.error(`Measuring ${name} (${options.profile})`);
 
@@ -436,90 +509,106 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
             output: outputFile,
           };
 
-          const childStarted = yield* Clock.monotonicTimeNanos;
+          yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const childStarted = yield* Clock.monotonicTimeNanos;
 
-          const childExit = yield* subprocess(
-            "node",
-            [path.join(stage.stage, "fixture/worker.js")],
-            stage.stage,
-            {
-              NODE_ENV: "production",
-              RUNTIME_BENCHMARK_OPTIONS: Schema.encodeSync(Schema.fromJsonString(WorkerOptions))(
-                workerOptions,
-              ),
-            },
-          ).pipe(
-            Effect.timeout(
-              cold
-                ? "30 seconds"
-                : options.profile === "pr" || options.profile === "smoke"
-                  ? "5 minutes"
-                  : "90 minutes",
-            ),
-            Effect.exit,
+              const childExit = yield* restore(
+                subprocess(
+                  "node",
+                  [path.join(stage.stage, "fixture/worker.js")],
+                  stage.stage,
+                  {
+                    NODE_ENV: "production",
+                    RUNTIME_BENCHMARK_OPTIONS: Schema.encodeSync(
+                      Schema.fromJsonString(WorkerOptions),
+                    )(workerOptions),
+                  },
+                  logFile,
+                ).pipe(
+                  Effect.timeout(
+                    cold
+                      ? "30 seconds"
+                      : options.profile === "pr" || options.profile === "smoke"
+                        ? "5 minutes"
+                        : "90 minutes",
+                  ),
+                ),
+              ).pipe(Effect.exit);
+
+              const result = Exit.isSuccess(childExit)
+                ? childExit.value
+                : {
+                    stdout: "",
+                    stderr: Cause.pretty(childExit.cause),
+                    exitCode: -1,
+                    subprocessMs: Number((yield* Clock.monotonicTimeNanos) - childStarted) / 1e6,
+                  };
+
+              const decodedReport = (yield* fs.exists(outputFile))
+                ? yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
+                    yield* fs.readFileString(outputFile),
+                  ).pipe(Effect.exit)
+                : null;
+
+              const childReport =
+                decodedReport !== null && Exit.isSuccess(decodedReport)
+                  ? decodedReport.value
+                  : null;
+
+              const workMatches = childReport !== null && completeBatch(childReport, workerOptions);
+
+              const environmentMatches =
+                childReport !== null &&
+                childReport.runtime === report.environment.node &&
+                childReport.platform === report.environment.platform &&
+                childReport.architecture === report.environment.architecture;
+
+              batches.push({
+                role: stage.revision.role,
+                cohort,
+                cold,
+                subprocessMs: result.subprocessMs,
+                exitCode: result.exitCode,
+                complete: workMatches && environmentMatches,
+                report: childReport,
+                failure:
+                  decodedReport !== null && Exit.isFailure(decodedReport)
+                    ? Cause.pretty(decodedReport.cause)
+                    : result.exitCode !== 0
+                      ? result.stderr
+                      : !workMatches
+                        ? "Missing, duplicated, failed, or unfinalized workload samples"
+                        : !environmentMatches
+                          ? "Worker runtime/platform/architecture differs from the controller"
+                          : null,
+              });
+              activeBatch = null;
+              yield* persist;
+              if (Exit.isFailure(childExit) && Cause.hasInterrupts(childExit.cause))
+                return yield* Effect.failCause(childExit.cause);
+            }),
           );
-
-          const result = Exit.isSuccess(childExit)
-            ? childExit.value
-            : {
-                stdout: "",
-                stderr: Cause.pretty(childExit.cause),
-                exitCode: -1,
-                subprocessMs: Number((yield* Clock.monotonicTimeNanos) - childStarted) / 1e6,
-              };
-
-          yield* fs.writeFileString(
-            path.join(output, `${name}.log`),
-            result.stdout + result.stderr,
-          );
-
-          const decodedReport = (yield* fs.exists(outputFile))
-            ? yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WorkerReport))(
-                yield* fs.readFileString(outputFile),
-              ).pipe(Effect.exit)
-            : null;
-
-          const childReport =
-            decodedReport !== null && Exit.isSuccess(decodedReport) ? decodedReport.value : null;
-
-          const workMatches = childReport !== null && completeBatch(childReport, workerOptions);
-
-          const environmentMatches =
-            childReport !== null &&
-            childReport.runtime === report.environment.node &&
-            childReport.platform === report.environment.platform &&
-            childReport.architecture === report.environment.architecture;
-
-          batches.push({
-            role: stage.revision.role,
-            cohort,
-            cold,
-            subprocessMs: result.subprocessMs,
-            exitCode: result.exitCode,
-            complete: workMatches && environmentMatches,
-            report: childReport,
-            failure:
-              decodedReport !== null && Exit.isFailure(decodedReport)
-                ? Cause.pretty(decodedReport.cause)
-                : result.exitCode !== 0
-                  ? result.stderr
-                  : !workMatches
-                    ? "Missing, duplicated, failed, or unfinalized workload samples"
-                    : !environmentMatches
-                      ? "Worker runtime/platform/architecture differs from the controller"
-                      : null,
-          });
-          yield* persist;
         }
     }
-  }).pipe(Effect.onExit(() => persist));
+  }).pipe(
+    Effect.timeout(
+      options.profile === "pr" || options.profile === "smoke" ? "19 minutes" : "160 minutes",
+    ),
+    Effect.onExit((exit) => {
+      if (Exit.isFailure(exit)) failure = Cause.pretty(exit.cause);
+
+      return persist;
+    }),
+  );
 
   yield* withPublishManifests(base.stage, () =>
     withPublishManifests(head.stage, () => withPublishManifests(reference.stage, () => measure)),
   );
   yield* Console.log(renderPerformanceReport(report));
   yield* check(
-    batches.every((batch) => batch.exitCode === 0 && batch.complete),
+    batches.length === sizes.batches * 6 &&
+      batches.every((batch) => batch.exitCode === 0 && batch.complete),
     "Benchmark correctness failed; timings are informational but incomplete work is rejected",
   );
 


### PR DESCRIPTION
Fresh durable runs reuse metadata gathered during their control scan, reducing uncompacted history reads from `3N + 6` to `2N + 6`. Compacted and checkpoint-seeded histories retain their recovery path. Native prompt estimation counts UTF-8 bytes without iterator allocations while preserving Unicode, serialization, and mutable-input behavior.

The runtime benchmark clones closed, isolated SQLite seed databases instead of rebuilding identical history for every sample. It retains three rotating cohorts, nine warm samples per workload and revision, and the existing timeout limits. Scoped Effect services own initialization and progress reporting; atomic partial reports and bounded child logs preserve failure evidence.

Validation: full `VITEST_MAX_WORKERS=2 vp run --concurrency-limit 2 ready` passed (3,164 tests passed, seven existing opt-in skips), CI and review passed, and the production-package smoke completed. Regressions cover scan bounds and races, compaction fallback, Unicode estimation, typed dependencies, seed isolation, cancellation, child cleanup, and report completeness.

Three fresh hosted PR-profile runs used exact head `b225706d14b7c77f3454e86594c9aade6a28a56d`, base `8f474402734021f9463314ca72b03837c46dc3c1`, and fixture `0bf0ceb81ce3a87eb880250f920e38427ebda233c9829226fbc582f36b6069fb`:

| Run | Comparison wall | Fresh 2,048-record median, base → head | 1 MiB history median, base → head |
| --- | ---: | ---: | ---: |
| [PR run](https://github.com/danieljvdm/effect-agent/actions/runs/34294316773) | 8m33s | 437.95 → 350.35 ms (−20.0%) | 18.15 → 15.97 ms (−12.0%) |
| [Confirmation 1](https://github.com/danieljvdm/effect-agent/actions/runs/34294506857) | 6m19s | 412.67 → 279.53 ms (−32.3%) | 18.69 → 14.77 ms (−21.0%) |
| [Confirmation 2](https://github.com/danieljvdm/effect-agent/actions/runs/34294508866) | 5m48s | 674.04 → 434.73 ms (−35.5%) | 21.17 → 17.97 ms (−15.1%) |

All completed 18/18 batches with no correctness failures. Each attached artifact retains individual samples, outliers, quartiles, setup/attempt costs, and runtime/build identities. The confirmations are manual dispatches of the same PR profile, with the same controller and worker budgets; runner CPUs differ, so medians are compared within each run. Timing remains informational.

Checkpoint construction remains linear with no demonstrated improvement. Estimator visits, calls, and serialization counts are unchanged; mutable caller payloads are not cached. Small-workload results and noisy unrelated cells do not establish a general speedup. Existing compaction/recovery safety takes priority over extending metadata reuse to unsupported histories.
