### PR TITLE
perf: reduce ledger reads and batch ephemeral history updates

### DIFF
--- a/.changeset/batched-ephemeral-history.md
+++ b/.changeset/batched-ephemeral-history.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/capabilities": patch
+---
+
+Build EphemeralThreads history suffixes in one atomic update while preserving exact prefix validation, limits, and mutable prompt values.

--- a/.changeset/lean-ledger-observation.md
+++ b/.changeset/lean-ledger-observation.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/storage-sqlite": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Index unfinished submissions and seek between recovery scan pages with an automatic data-preserving storage upgrade. Replay settled outcomes without acquiring a write transaction.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: Scripted measurement size (archive includes 100k retained records)
+        description: Scripted profile (diagnostic runs manual base/head probes)
         type: choice
-        options: [pr, extended, archive]
+        options: [pr, extended, archive, diagnostic]
         default: extended
       base_sha:
         description: Exact 40-character comparison base SHA
@@ -29,7 +29,7 @@ jobs:
   compare:
     name: Compare scripted runtime
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 180 }}
+    timeout-minutes: ${{ (github.event_name == 'pull_request' || inputs.profile == 'diagnostic') && 30 || 180 }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -51,6 +51,7 @@ jobs:
       # Immutable audited beta67 release, rerun on this machine rather than
       # comparing historical stopwatch values from another runner.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
         with:
           ref: 596cffba70716b1211ac02de949c4d0f31734b2f
           path: .performance-reference
@@ -74,6 +75,7 @@ jobs:
         run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
 
       - name: Install immutable reference dependencies
+        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
         working-directory: .performance-reference
         run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
 
@@ -89,13 +91,14 @@ jobs:
           ./node_modules/.bin/vp run --no-cache -F './packages/*' build
 
       - name: Build reference public packages
+        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
         working-directory: .performance-reference
         run: |
           ./node_modules/.bin/vp run patch:tsgo
           ./node_modules/.bin/vp run --no-cache -F './packages/*' build
 
       - name: Compare sequential cohorts
-        timeout-minutes: ${{ github.event_name == 'pull_request' && 20 || 165 }}
+        timeout-minutes: ${{ (github.event_name == 'pull_request' || inputs.profile == 'diagnostic') && 20 || 165 }}
         # The controller stops at 19m (PR) / 160m (larger profiles), leaving time
         # for bounded child termination and atomic failure evidence before this outer limit.
         # Older releases do not ignore these known declaration artifacts emitted
@@ -108,7 +111,11 @@ jobs:
           for checkout in .performance-base .performance-reference; do
             rm -f "$checkout/test/fixtures/checkpoints.d.ts" "$checkout/test/fixtures/storage-upgrade.d.ts" "$checkout/test/fixtures/storage-v2.d.ts"
           done
-          ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --reference-dir .performance-reference --profile "$PROFILE" --require-clean
+          if [ "$PROFILE" = diagnostic ]; then
+            ./node_modules/.bin/vp run --no-cache perf:diagnose --base-dir .performance-base --require-clean
+          else
+            ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --reference-dir .performance-reference --profile "$PROFILE" --require-clean
+          fi
 
       - name: Preserve run identity and readable evidence
         if: always()

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -416,14 +416,22 @@ checkpoints continue to populate and compare these fields; absent metadata falls
 canonical replay.
 
 The persistent adapters automatically upgrade supported predecessor formats on acquisition:
-Cloudflare Thread stores move from version 2, 3, or 4 to 5; Schedule and Subscription stores move
-from version 2 to 3; the combined SQLite file moves from version 7, 8, or 9 to 10. Thread and SQLite
-stores add a separate slot for the latest recovery checkpoint and, where needed, independently discoverable
-message delivery storage. Each owning store upgrades in one native transaction and advances its
-version marker last. Reopening after interruption retries the entire uncommitted upgrade.
+Cloudflare Thread stores move from version 2, 3, 4, or 5 to 6; Schedule and Subscription stores move
+from version 2 to 3; the combined SQLite file moves from version 7, 8, 9, or 10 to 11. Thread and SQLite
+stores add an index containing only unfinished submissions, plus recovery checkpoint and message
+delivery storage where those are missing from a supported predecessor. Recovery scans use the
+index in Thread and queue order, seeking from the previous page's cursor without revisiting its
+prefix. Each owning store upgrades in one native transaction and advances its version marker
+last. Reopening after interruption retries the entire uncommitted upgrade.
 Namespaces, canonical history and digests, receipts, pending work, ownership, deadlines, alarm
 generations and scan cursors are preserved. Keep the existing namespace/file and the old source
 versions, input bindings and agent registrations needed to finish retained work.
+
+Repeated settlement finalization reads an already settled submission and its reservation together
+without acquiring a write transaction. A first finalization adds one read probe before the existing
+write transaction, which rechecks the current state. SQLite settlement observation can therefore
+read committed state while another connection holds the write lock. Runtime status still loads the
+recovery snapshot to materialize its response; this change does not remove that work.
 
 Recovery checkpoints are disposable: missing or incompatible cache state rebuilds from canonical
 history. Upgrades preserve existing generic projection checkpoints. The optional `verifyOnOpen`

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -131,4 +131,87 @@ Read the full spread and raw samples before drawing a conclusion. Re-run a suspe
 with another matched cohort. Small-sample p95, local source timings, or differing provider workloads
 do not establish an SLO, Cloudflare CPU billing, or a competitive ranking. Deterministic engine
 and adapter work-budget tests remain the PR regression gates; timing evidence complements them.
-Fairness and lock contention need dedicated controlled load cases when those host changes land.
+The manual diagnostics below separate fairness and lock contention from isolated run latency.
+Keep timing informational until repeated matched cohorts establish a workload-specific relative
+and absolute regression threshold. Current hosted runs show substantial machine and storage
+variance; one small-sample tail estimate or percentage alone is not a release gate. Confirm a
+suspected regression in a fresh matched run and retain both results before changing a baseline.
+
+## Manual diagnostics
+
+`vp run perf:diagnose` runs the separate `runtime-diagnostic-v1` fixture against clean, built
+base/head checkouts. Install each checkout's own lockfile and build its public packages as above.
+Run this command from the candidate checkout, with no concurrent builds, tests, or measurements:
+
+```sh
+vp run perf:diagnose --base-dir /tmp/effect-agent-base --require-clean --out-dir /tmp/diagnostic-001
+```
+
+The manual workflow's `diagnostic` choice runs the same command and skips the immutable-reference
+checkout. Ordinary PRs still run the unchanged `runtime-v2` matrix and trusted report validator.
+Diagnostics run base/head followed by head/base, with two warmups and five measured samples per
+cohort: ten measured samples per case and revision. They use the same production-package staging,
+published manifests, own-lockfile dependencies, built-artifact identities, and identical unbundled
+fixture bytes. This task never uses a cached measurement.
+
+The policy matrix crosses one/four rounds, zero/two/twenty-millisecond authorization delays, and
+zero/twenty-millisecond per-Turn model-Layer acquisition delays. Each round declares eight tools
+with twenty-millisecond handlers and concurrency four; every cell uses the same immediate approval
+hook. The finite scripted provider must consume all successful results in declaration order. The
+probe verifies authorization ordering, complete-batch approval before handler entry, actual handler
+overlap, and every model/handler finalizer. The synthetic delays expose scheduling behavior; they do
+not estimate provider latency or prove an optimization.
+
+The capability cases use these bounded public operations:
+
+| Family      | Work and timing boundary                                                                                                                                                                                                                                                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| History     | Apply unchanged, one-message, or 64-message suffixes to a native 256-message prefix; include a 64-Thread store and the 768/256-message capacity boundary. A matched two-provider, one-tool Run compares history hooks on/off. Setup and verification are excluded.                                                                                            |
+| Memory      | Compare one-provider Runs with recall off, empty, or populated. Measure recall and actual fixture-file reader I/O separately; verify scoped reader release.                                                                                                                                                                                                   |
+| Remembering | Compare the same two-provider, one-tool foreground Run on/off while a previous extraction is held in another host Scope. Verify no foreground extraction/profile I/O; then release the worker and report admission, background completion, and profile readiness separately. The two-job public-port fixture excludes disk durability and host queue latency. |
+| MCP         | Compare the same two-provider Run and three echo results using local handlers or real MCP HTTP transport with an in-process responder. Report connection, reused calls, foreground work, and owned-Scope closure; a fresh connection verifies credentials and discovery. No network is used.                                                                  |
+| Subagents   | Compare the same two-provider parent and two projected results with local handlers or two actual child providers sharing one child slot. Report preparation, actual provider entry, slot wait, and completion separately. A named ten-millisecond first-provider hold creates controlled contention and remains included in elapsed times.                    |
+
+The ledger cases scan a closed seed with 8,192 settled and sixteen unfinished submissions, or a
+768-row unfinished ledger. Each sample receives a fresh copy; the seed is constructed once per
+worker through public admission/claim/settlement operations. Reports separate seed/setup cost
+from scan latency and retain the actual adapter SQL counts and query plans. Healthy finalization
+replay, runtime status observation, and active finalization are measured separately; status still
+includes its ordinary recovery-snapshot work. The statement counter excludes the driver's
+transaction BEGIN/COMMIT commands.
+
+Contention cases compare the same replay/status operation while another Node process holds a
+SQLite write transaction for zero, 25, or 100 milliseconds after a readiness handshake. That
+process releases its lock independently of the observer's event loop. Observer latency excludes
+process startup and handshake; the report retains both the requested-window duration and full
+lock occupancy through rollback. Writer and observer timestamps share Node's same-host `hrtime`
+domain; overlap uses the conservative interval after acquisition and before rollback begins.
+Samples that miss the writer window remain in the report with `noWriterOverlap=1`; consult the
+overlap counters before claiming contention. A healthy read may finish while the writer still
+holds its lock. These cases do not measure event-loop lag or change the adapter's busy timeout.
+A subsequent public write and scoped process finalization verify release.
+
+Fairness cases run four independent tool-heavy Threads and one short Thread with one, two, or
+four registered Node host workers. Each busy Run uses four 100-millisecond tools with concurrency
+two. Initial-backlog and warm-arrival cases retain every Thread's admission, Attempt/provider
+entry, observed settlement, active maxima, and finalizers. Request-to-Attempt time includes
+admission; observed settlement includes ordinary wake and polling cadence. Warm arrival records
+actual activity rather than assuming all workers are saturated. Host creation, canonical
+verification, and shutdown remain outside the operation clock. These probes preserve existing
+worker defaults and make no strict round-robin, preemption, or starvation guarantee.
+
+Reports retain total elapsed wall time, named millisecond intervals, natural-number counters, and
+at most 512 phase marks per sample. Marks are in-memory and included in operation timing. Atomic
+phase-report writes occur before the operation clock or after its end. Authorization sums, handler
+phases, and model lifetimes can overlap and must not be added together. Post-authorization wait
+includes framework dispatch and bounded scheduling; public hooks cannot isolate semaphore wait.
+Native subagent span offsets flush at Run exit, including failure, so mark array order need not be
+chronological; use their operation-relative monotonic offsets.
+No diagnostic reports CPU time. Compare matched medians and interquartile ranges, including the
+retained slow samples, and preserve the complete environment and exact revision identities.
+
+Each sample, including fixture setup, is bounded to two minutes, each child to five minutes, and the controller to nineteen
+minutes. The existing shared eight-MiB child-output cap and five-second force-kill grace apply.
+Worker reports are limited to sixteen MiB when read by the controller. Partial phase marks, completed
+samples, failures, and timeouts remain in atomic JSON reports. Missing, duplicated, failed, incomplete,
+or mismatched-runtime batches fail the command and never enter comparison summaries.

--- a/examples/runtime-benchmark/src/diagnostic-capabilities.ts
+++ b/examples/runtime-benchmark/src/diagnostic-capabilities.ts
@@ -1,0 +1,1683 @@
+import {
+  ScriptedModel,
+  type ScriptedStreamPart,
+  type ScriptedTurnInput,
+} from "@effect-agent/testing/ScriptedModel";
+import {
+  Clock,
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Schema,
+  Scope,
+  Stream,
+  Tracer,
+} from "effect";
+import { Agent, AgentRuntime } from "effect-agent";
+import * as EphemeralThreads from "effect-agent/EphemeralThreads";
+import { RunId, ThreadId } from "effect-agent/Identifiers";
+import { IdGenerator } from "effect-agent/IdGenerator";
+import * as Mcp from "effect-agent/Mcp";
+import * as McpClient from "effect-agent/McpClient";
+import * as Memory from "effect-agent/Memory";
+import * as MemoryNamespace from "effect-agent/MemoryNamespace";
+import {
+  MemoryAttribution,
+  MemoryContent,
+  MemoryLookup,
+  MemoryPassage,
+  MemoryRecallLimits,
+} from "effect-agent/MemoryReference";
+import {
+  applyMemoryWrite,
+  MemoryKey,
+  MemoryReader,
+  MemoryScope,
+  MemoryWriter,
+  type MemoryDocument,
+} from "effect-agent/MemoryStore";
+import * as Remembering from "effect-agent/Remembering";
+import * as Protocol from "effect-agent/RememberingStore";
+import { toRunThreadOptions } from "effect-agent/RunHooks";
+import * as Subagent from "effect-agent/Subagent";
+import * as Reservations from "effect-agent/SubagentReservations";
+import { ThreadHistory } from "effect-agent/ThreadHistory";
+import { AiError, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { BenchmarkError, check } from "./contracts.js";
+import { capabilityCases } from "./diagnostic-cases.js";
+import {
+  DiagnosticCase,
+  DiagnosticProgress,
+  type DiagnosticMark,
+  type DiagnosticResult,
+} from "./diagnostic-contracts.js";
+
+export { capabilityCases } from "./diagnostic-cases.js";
+
+/** Faults are test-only fixture inputs; the public diagnostic inventory always uses "none". */
+export const DiagnosticFault = Context.Reference("runtime-benchmark/DiagnosticFault", {
+  defaultValue: (): "none" | "mcp-malformed-discovery" | "mcp-call-failure" => "none",
+});
+
+/** Every mark uses elapsed monotonic wall time from this sample's operation start. */
+const elapsed = (start: bigint) =>
+  Clock.monotonicTimeNanos.pipe(Effect.map((now) => Number(now - start) / 1_000_000));
+
+const providerCheck = <A, E>(effect: Effect.Effect<A, E>) =>
+  effect.pipe(
+    Effect.mapError((error) =>
+      AiError.AiError.make({
+        module: "capability-diagnostic",
+        method: "assertRequest",
+        reason: AiError.UnknownError.make({ description: String(error) }),
+      }),
+    ),
+  );
+
+const finalParts: ReadonlyArray<ScriptedStreamPart> = [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: '{"answer":"done"}' },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+];
+
+const work = Tool.make("diagnostic_work", {
+  parameters: Schema.Struct({ index: Schema.Int }),
+  success: Schema.Int,
+});
+
+const toolkit = Toolkit.make(work);
+
+const definition = Agent.make("capability-diagnostic", {
+  input: Schema.String,
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: "Return the requested answer.",
+  toolkit,
+  policy: { maxTurns: 4, maxToolCalls: 4, maxDuration: "10 seconds", toolConcurrency: 2 },
+});
+
+const historyPrompt = (count: number) =>
+  Prompt.make(
+    Array.from({ length: count }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `${index}: ${"retained text ".repeat(20)}`,
+    })),
+  );
+
+const encodedPrompt = Schema.encodeEffect(Schema.fromJsonString(Prompt.Prompt));
+
+const historyCase = Effect.fn("diagnostic.history")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+
+  yield* progress.phase("setup");
+  const threads = yield* EphemeralThreads.EphemeralThreads;
+  const threadId = ThreadId.make("diagnostic-thread-0");
+  const seedRun = RunId.make("diagnostic-seed");
+  const runId = RunId.make("diagnostic-operation");
+  const prefix = workload.parameters.prefix ?? 256;
+  const suffix = workload.parameters.suffix ?? 0;
+  const threadCount = workload.parameters.threads ?? 1;
+  const original = historyPrompt(prefix);
+
+  for (let index = 0; index < threadCount; index++) {
+    const id = ThreadId.make(`diagnostic-thread-${index}`);
+
+    yield* threads.create(id);
+    yield* threads.recordHistory(id, seedRun, original);
+  }
+  // Fresh by-value prefix: the measured API must not depend on object identity.
+  const incoming = historyPrompt(prefix + suffix);
+  const expected = yield* encodedPrompt(incoming);
+
+  yield* progress.phase("operation");
+  const start = yield* Clock.monotonicTimeNanos;
+  const snapshot = yield* threads.recordHistory(threadId, runId, incoming);
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  yield* check(snapshot.nextSequence === prefix + suffix, "History sequence mismatch");
+  yield* check(
+    (yield* encodedPrompt(EphemeralThreads.threadPrompt(snapshot))) === expected,
+    "History native messages changed",
+  );
+  yield* check(
+    snapshot.messages.every(
+      (entry, index) =>
+        entry.sequence === index && entry.runId === (index < prefix ? seedRun : runId),
+    ),
+    "History changed prefix ownership or suffix run IDs",
+  );
+  yield* check(
+    snapshot.contentBytes ===
+      snapshot.messages.reduce((total, entry) => total + entry.encodedBytes, 0),
+    "History byte accounting mismatch",
+  );
+  for (let index = 1; index < threadCount; index++) {
+    yield* check(
+      (yield* threads.snapshot(ThreadId.make(`diagnostic-thread-${index}`))).nextSequence ===
+        prefix,
+      "History mutated another thread",
+    );
+  }
+
+  return {
+    totalMs,
+    metrics: [{ name: "recordHistory", value: totalMs }],
+    counters: [
+      { name: "prefixMessages", value: prefix },
+      { name: "suffixMessages", value: suffix },
+      { name: "threads", value: threadCount },
+      { name: "committedMessages", value: snapshot.nextSequence },
+      { name: "contentBytes", value: snapshot.contentBytes },
+    ],
+  };
+});
+
+const historyRunCase = Effect.fn("diagnostic.historyRun")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+
+  yield* progress.phase("setup");
+  const threads = yield* EphemeralThreads.EphemeralThreads;
+  const threadId = ThreadId.make("diagnostic-run-thread");
+  const runId = RunId.make("diagnostic-run");
+  const prefix = historyPrompt(workload.parameters.prefix ?? 256);
+
+  const expectedPrefix = yield* Effect.forEach(prefix.content, (message) =>
+    Schema.encodeEffect(Schema.fromJsonString(Prompt.Message))(message),
+  );
+
+  yield* threads.create(threadId);
+  yield* threads.recordHistory(threadId, RunId.make("seed"), prefix);
+  const enabled = workload.parameters.enabled === 1;
+
+  const options = enabled
+    ? yield* toRunThreadOptions(threadId, runId)
+    : { threadId, history: prefix };
+
+  let calls = 0;
+  let finalized = 0;
+  let tools = 0;
+  let start = 0n;
+  const entries: Array<number> = [];
+
+  const turns: Array<ScriptedTurnInput> = [0, 1].map((turn) => ({
+    _tag: "Stream",
+    termination: { _tag: "Complete" },
+    assertRequest: (request) =>
+      providerCheck(
+        Effect.gen(function* () {
+          calls++;
+          const at = yield* elapsed(start);
+
+          entries.push(at);
+          yield* progress.mark({ name: `provider.${turn}`, elapsedMs: at });
+
+          const messages = yield* Effect.forEach(request.prompt.content, (message) =>
+            Schema.encodeEffect(Schema.fromJsonString(Prompt.Message))(message),
+          );
+
+          // Engine instructions can prepend a system message. Match the exact ordered native prefix.
+          const prefixStart = messages.indexOf(expectedPrefix[0] ?? "");
+
+          yield* check(
+            prefixStart >= 0 &&
+              expectedPrefix.every((message, index) => messages[prefixStart + index] === message),
+            "Run lost or changed exact initial history",
+          );
+          if (turn === 1) {
+            const results = request.prompt.content
+              .filter((message) => message.role === "tool")
+              .flatMap((message) => message.content)
+              .filter((part) => part.type === "tool-result");
+
+            yield* check(
+              tools === 1 &&
+                results.length === 1 &&
+                results[0]?.id === "work-0" &&
+                results[0]?.result === 7,
+              "Second provider lost the exact tool result",
+            );
+          }
+        }),
+      ),
+    parts:
+      turn === 0
+        ? [
+            {
+              type: "tool-call",
+              id: "work-0",
+              name: "diagnostic_work",
+              params: { index: 7 },
+              providerExecuted: false,
+            },
+            { type: "finish", reason: "tool-calls", usage: { inputTokens: {}, outputTokens: {} } },
+          ]
+        : finalParts,
+    onStreamFinalize: Effect.sync(() => {
+      finalized++;
+    }),
+  }));
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer(turns),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "capability-diagnostic"),
+  );
+
+  yield* progress.phase("operation");
+  start = yield* Clock.monotonicTimeNanos;
+
+  const output = yield* Effect.scoped(
+    Effect.gen(function* () {
+      const result = yield* AgentRuntime.run(definition, "Answer", { ...options, runId });
+
+      yield* (yield* ScriptedModel).assertExhausted;
+
+      return result;
+    }),
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        model,
+        toolkit.toLayer({
+          diagnostic_work: ({ index }) =>
+            Effect.sync(() => {
+              tools++;
+
+              return index;
+            }),
+        }),
+        IdGenerator.layer,
+        ThreadHistory.layerTransient,
+      ),
+    ),
+  );
+
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  const snapshot = yield* threads.snapshot(threadId);
+
+  yield* check(
+    output.output.answer === "done" && calls === 2 && finalized === 2 && tools === 1,
+    "History Run work/finalizers mismatch",
+  );
+  yield* check(
+    enabled
+      ? snapshot.nextSequence > prefix.content.length
+      : snapshot.nextSequence === prefix.content.length,
+    "History hook retention mismatch",
+  );
+  yield* check(
+    (yield* encodedPrompt(
+      Prompt.fromMessages(
+        snapshot.messages.slice(0, prefix.content.length).map((entry) => entry.message),
+      ),
+    )) === (yield* encodedPrompt(prefix)),
+    "History Run changed the committed prefix",
+  );
+
+  return {
+    totalMs,
+    metrics: entries.map((value, index) => ({ name: `providerEntry.${index}`, value })),
+    counters: [
+      { name: "modelCalls", value: calls },
+      { name: "modelFinalizers", value: finalized },
+      { name: "toolCalls", value: tools },
+      { name: "retainedMessages", value: snapshot.nextSequence },
+    ],
+  };
+});
+
+const memoryContent = MemoryContent.make({
+  text: "The diagnostic preference is a concise answer.",
+  attributions: [
+    MemoryAttribution.make({
+      originId: "diagnostic-source",
+      speaker: "Fixture",
+      observers: [],
+      locator: "fixture://message/1",
+      activityAt: 10,
+      interpretation: "reported preference",
+    }),
+  ],
+  metadata: { topic: "diagnostic" },
+  recordedAt: 20,
+  extractedAt: 30,
+});
+
+const memoryLookup = MemoryLookup.make({
+  _tag: "Found",
+  passages: [
+    MemoryPassage.make({
+      version: 1,
+      source: { id: "diagnostic", locator: "fixture://message/1", revision: "r1" },
+      passageId: "document",
+      content: memoryContent,
+    }),
+  ],
+});
+
+const recallLimits = MemoryRecallLimits.make({
+  maxSources: 1,
+  maxItems: 1,
+  maxBytes: 16_384,
+  maxTokens: 16_384,
+  timeoutMillis: 1_000,
+});
+
+const memoryRunCase = Effect.fn("diagnostic.memoryRun")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+  const fs = yield* FileSystem.FileSystem;
+
+  yield* progress.phase("setup");
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "capability-memory-" });
+  const path = `${directory}/passage.json`;
+
+  yield* fs.writeFileString(
+    path,
+    yield* Schema.encodeEffect(Schema.fromJsonString(MemoryLookup))(memoryLookup),
+  );
+  const mode = workload.parameters.mode ?? 0;
+  let start = 0n;
+  let readers = 0;
+  let readerFinalizers = 0;
+  let loads = 0;
+  let models = 0;
+  let modelFinalizers = 0;
+  let readerIoMs = 0;
+  let recallMs = 0;
+  let providerMs = 0;
+
+  const read = Effect.gen(function* () {
+    yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        readers++;
+      }),
+      () =>
+        Effect.gen(function* () {
+          readerFinalizers++;
+          yield* progress
+            .mark({ name: "memory.reader.finalized", elapsedMs: yield* elapsed(start) })
+            .pipe(Effect.orDie);
+        }),
+    );
+    const ioStart = yield* Clock.monotonicTimeNanos;
+    const json = yield* fs.readFileString(path);
+
+    readerIoMs += yield* elapsed(ioStart);
+    yield* progress.mark({ name: "memory.readerIO.complete", elapsedMs: yield* elapsed(start) });
+
+    return yield* Schema.decodeUnknownEffect(Schema.fromJsonString(MemoryLookup))(json);
+  });
+
+  const load = Effect.gen(function* () {
+    loads++;
+    if (mode === 1) return "";
+    const recallStart = yield* Clock.monotonicTimeNanos;
+
+    const recalled = yield* Memory.recall(
+      [{ id: "diagnostic", essential: true, read }],
+      recallLimits,
+    );
+
+    recallMs = yield* elapsed(recallStart);
+    yield* check(recalled.passages.length === 1, "Memory recall lost its passage");
+
+    return recalled.text;
+  });
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer([
+      {
+        _tag: "Stream",
+        termination: { _tag: "Complete" },
+        parts: finalParts,
+        assertRequest: (request) =>
+          providerCheck(
+            Effect.gen(function* () {
+              models++;
+              providerMs = yield* elapsed(start);
+              yield* progress.mark({ name: "provider.0", elapsedMs: providerMs });
+              const encoded = yield* encodedPrompt(request.prompt);
+
+              yield* check(
+                encoded.includes(memoryContent.text) === (mode === 2),
+                "Memory prompt content mismatch",
+              );
+            }),
+          ),
+        onStreamFinalize: Effect.sync(() => {
+          modelFinalizers++;
+        }),
+      },
+    ]),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "capability-diagnostic"),
+  );
+
+  yield* progress.phase("operation");
+  start = yield* Clock.monotonicTimeNanos;
+
+  const output = yield* Effect.scoped(
+    Effect.gen(function* () {
+      const result = yield* AgentRuntime.run(
+        definition,
+        "Answer",
+        mode === 0 ? {} : { transientContext: { load: () => load } },
+      );
+
+      yield* (yield* ScriptedModel).assertExhausted;
+
+      return result;
+    }),
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        model,
+        toolkit.toLayer({ diagnostic_work: ({ index }) => Effect.succeed(index) }),
+        IdGenerator.layer,
+        ThreadHistory.layerTransient,
+      ),
+    ),
+  );
+
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  yield* check(
+    output.output.answer === "done" && models === 1 && modelFinalizers === 1,
+    "Memory Run work/finalizers mismatch",
+  );
+  yield* check(
+    readers === (mode === 2 ? 1 : 0) &&
+      readerFinalizers === readers &&
+      loads === (mode === 0 ? 0 : 1),
+    "Memory optional work or reader finalization mismatch",
+  );
+
+  return {
+    totalMs,
+    metrics: [
+      { name: "providerEntry", value: providerMs },
+      { name: "recall", value: recallMs },
+      { name: "readerIO", value: readerIoMs },
+    ],
+    counters: [
+      { name: "modelCalls", value: models },
+      { name: "modelFinalizers", value: modelFinalizers },
+      { name: "contextLoads", value: loads },
+      { name: "readerCalls", value: readers },
+      { name: "readerFinalizers", value: readerFinalizers },
+    ],
+  };
+});
+
+const rpcRequest = Schema.fromJsonString(
+  Schema.Struct({
+    id: Schema.optionalKey(Schema.Union([Schema.String, Schema.Finite])),
+    method: Schema.String,
+    params: Schema.optionalKey(Schema.Unknown),
+  }),
+);
+
+const rpcResponse = Schema.fromJsonString(
+  Schema.Struct({
+    jsonrpc: Schema.Literal("2.0"),
+    id: Schema.Union([Schema.String, Schema.Finite]),
+    result: Schema.Json,
+  }),
+);
+
+/** Real public MCP HTTP transport and protocol, with a bounded in-process HTTP responder.
+ * This measures neither network latency nor a remote server. Each connection owns one session.
+ */
+const mcpCase = Effect.fn("diagnostic.mcp")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+  const fault = yield* DiagnosticFault;
+
+  yield* progress.phase("setup");
+  const enabled = workload.parameters.enabled === 1;
+  let start = 0n;
+  let connects = 0;
+  let discoveries = 0;
+  let calls = 0;
+  let closed = 0;
+  let modelCalls = 0;
+  let modelFinalizers = 0;
+  let localCalls = 0;
+  let activeSession: string | undefined;
+  let activeCredential: string | undefined;
+  const metrics: Array<{ name: string; value: number }> = [];
+
+  const client = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      if (request.method === "DELETE") {
+        yield* check(
+          activeSession !== undefined && request.headers["mcp-session-id"] === activeSession,
+          "MCP closed the wrong session",
+        );
+        yield* check(
+          request.headers["authorization"] === activeCredential,
+          "MCP finalizer reused stale credentials",
+        );
+        closed++;
+        activeSession = undefined;
+        activeCredential = undefined;
+        yield* progress.mark({ name: "mcp.session.closed", elapsedMs: yield* elapsed(start) });
+
+        return HttpClientResponse.fromWeb(request, new globalThis.Response(null, { status: 200 }));
+      }
+      const web = yield* HttpClientRequest.toWeb(request);
+
+      const body = yield* Effect.tryPromise({
+        try: () => web.text(),
+        catch: (cause) =>
+          BenchmarkError.make({ message: "MCP fixture request body failed", cause }),
+      });
+
+      yield* check(body.length <= 16_384, "MCP fixture request exceeded its fixed bound");
+      const message = yield* Schema.decodeUnknownEffect(rpcRequest)(body);
+      let result: Schema.Json = {};
+
+      if (message.method === "initialize") {
+        yield* check(activeSession === undefined, "MCP overlapped owned sessions");
+        connects++;
+        activeSession = `session-${connects}`;
+        activeCredential = `fixture-credential-${connects}`;
+        result = {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "in-process-http-diagnostic", version: "1" },
+        };
+      }
+      yield* check(
+        request.headers["authorization"] === activeCredential,
+        "MCP reused stale credentials",
+      );
+      if (message.method !== "initialize")
+        yield* check(
+          request.headers["mcp-session-id"] === activeSession,
+          "MCP lost the owned session",
+        );
+      if (message.id === undefined)
+        return HttpClientResponse.fromWeb(request, new globalThis.Response(null, { status: 202 }));
+      if (message.method === "tools/list") {
+        discoveries++;
+        result =
+          fault === "mcp-malformed-discovery"
+            ? { tools: [{ name: 12 }] }
+            : {
+                tools: Array.from({ length: 8 }, (_, index) => ({
+                  name: index === 0 ? "echo" : `unused_${index}`,
+                  description: "Fixed diagnostic echo tool",
+                  inputSchema: {
+                    type: "object",
+                    properties: { message: { type: "string" } },
+                    required: ["message"],
+                    additionalProperties: false,
+                  },
+                })),
+              };
+      }
+      if (message.method === "tools/call") {
+        const params = yield* Schema.decodeUnknownEffect(
+          Schema.Struct({
+            name: Schema.Literal("echo"),
+            arguments: Schema.Struct({ message: Schema.String }),
+          }),
+        )(message.params);
+
+        calls++;
+        result = {
+          content: [{ type: "text", text: params.arguments.message }],
+          structuredContent: { echoed: params.arguments.message },
+          ...(fault === "mcp-call-failure" ? { isError: true } : {}),
+        };
+      }
+
+      const json = yield* Schema.encodeEffect(rpcResponse)({
+        jsonrpc: "2.0",
+        id: message.id,
+        result,
+      });
+
+      return HttpClientResponse.fromWeb(
+        request,
+        new globalThis.Response(json, {
+          status: 200,
+          headers: { "content-type": "application/json", "mcp-session-id": activeSession ?? "" },
+        }),
+      );
+    }).pipe(
+      Effect.catch((cause) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new globalThis.Response(String(cause), { status: 500 }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  const request = Mcp.McpConnectionRequest.make({
+    serverId: "fixture",
+    maxToolCount: 8,
+    maxToolDescriptionBytes: 256,
+    maxDiscoveryBytes: 16_384,
+    connectTimeoutMillis: 5_000,
+  });
+
+  const localToolName: string = "echo";
+
+  const localTool = Tool.make(localToolName, {
+    parameters: Schema.Struct({ message: Schema.String }),
+    success: Schema.Struct({ echoed: Schema.String }),
+  });
+
+  const localToolkit = Toolkit.make(localTool);
+
+  const localHandlers = localToolkit.toLayer({
+    echo: ({ message }) =>
+      Effect.sync(() => {
+        localCalls++;
+
+        return { echoed: message };
+      }),
+  });
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer(
+      [0, 1].map((turn): ScriptedTurnInput => ({
+        _tag: "Stream",
+        termination: { _tag: "Complete" },
+        parts:
+          turn === 0
+            ? [
+                {
+                  type: "tool-call",
+                  id: "mcp-run-call",
+                  name: "echo",
+                  params: { message: "run-echo" },
+                  providerExecuted: false,
+                },
+                {
+                  type: "finish",
+                  reason: "tool-calls",
+                  usage: { inputTokens: {}, outputTokens: {} },
+                },
+              ]
+            : finalParts,
+        assertRequest: (provider) =>
+          providerCheck(
+            Effect.gen(function* () {
+              modelCalls++;
+              yield* progress.mark({
+                name: `mcp.provider.${turn}`,
+                elapsedMs: yield* elapsed(start),
+              });
+              if (turn === 1) {
+                const results = provider.prompt.content
+                  .filter((message) => message.role === "tool")
+                  .flatMap((message) => message.content)
+                  .filter((part) => part.type === "tool-result");
+
+                yield* check(
+                  results.length === 1 &&
+                    results[0]?.isFailure === false &&
+                    (yield* encodedPrompt(provider.prompt)).includes("run-echo"),
+                  "MCP Run lost its successful remote tool result",
+                );
+              }
+            }),
+          ),
+        onStreamFinalize: Effect.sync(() => {
+          modelFinalizers++;
+        }),
+      })),
+    ),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "mcp-diagnostic"),
+  );
+
+  yield* progress.phase("operation");
+  start = yield* Clock.monotonicTimeNanos;
+  for (let session = 1; session <= (enabled ? 2 : 1); session++) {
+    const connectionStart = yield* Clock.monotonicTimeNanos;
+    let closeStart = 0n;
+
+    const connector = McpClient.layer([
+      McpClient.McpHttpTransport.make({
+        serverId: "fixture",
+        url: "http://mcp.test/mcp",
+        headers: { authorization: `fixture-credential-${session}` },
+      }),
+    ]).pipe(Layer.provide(Layer.succeed(HttpClient.HttpClient, client)));
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const connection = enabled
+          ? yield* Mcp.connectMcp(request).pipe(Effect.provide(connector))
+          : undefined;
+
+        if (enabled) {
+          metrics.push({ name: `connect.${session}`, value: yield* elapsed(connectionStart) });
+          yield* progress.mark({
+            name: `mcp.connected.${session}`,
+            elapsedMs: yield* elapsed(start),
+          });
+        }
+
+        // The general connection port erases dynamic tool types. Check the exact public
+        // transport schemas before reconstructing a typed Toolkit from the same Tool objects.
+        const remoteTools = Object.values(connection?.toolkit.tools ?? {}).filter(
+          (tool): tool is McpClient.McpTool =>
+            tool.parametersSchema === Schema.Unknown &&
+            tool.successSchema === McpClient.McpToolResult &&
+            tool.failureSchema === McpClient.McpToolCallFailed &&
+            tool.failureMode === "return",
+        );
+
+        if (enabled) yield* check(remoteTools.length === 8, "MCP transport tool contracts changed");
+
+        const executableTools: Array<McpClient.McpTool | typeof localTool> =
+          connection === undefined ? [localTool] : remoteTools;
+
+        const tools = Toolkit.make(...executableTools);
+
+        const handlers: Layer.Layer<Tool.Handler<string>> | undefined =
+          connection?.handlers ?? (enabled ? undefined : localHandlers);
+
+        if (handlers === undefined)
+          return yield* BenchmarkError.make({
+            message: "MCP connection did not provide executable handlers",
+          });
+        if (session === 1) {
+          yield* Effect.gen(function* () {
+            const ready = yield* tools;
+
+            for (let index = 0; index < 2; index++) {
+              yield* progress.mark({
+                name: `mcp.call.begin.${index}`,
+                elapsedMs: yield* elapsed(start),
+              });
+              const callStart = yield* Clock.monotonicTimeNanos;
+
+              const results = yield* Stream.runCollect(
+                yield* ready.handle("echo", { message: `reuse-${index}` }),
+              );
+
+              metrics.push({ name: `reusedCall.${index}`, value: yield* elapsed(callStart) });
+              const last = results.at(-1);
+
+              yield* check(last !== undefined && !last.isFailure, "MCP reused call failed");
+
+              const expected = enabled
+                ? Schema.decodeUnknownOption(McpClient.McpToolResult)(last?.result)
+                : undefined;
+
+              if (expected !== undefined) {
+                const content =
+                  expected._tag === "Some"
+                    ? yield* Schema.decodeUnknownEffect(Schema.Struct({ echoed: Schema.String }))(
+                        expected.value.structuredContent,
+                      )
+                    : undefined;
+
+                yield* check(
+                  content?.echoed === `reuse-${index}`,
+                  "MCP reused call changed its result",
+                );
+              }
+            }
+            const runStart = yield* Clock.monotonicTimeNanos;
+
+            const result = yield* AgentRuntime.run(
+              Agent.make("mcp-diagnostic", {
+                input: Schema.String,
+                output: Schema.Struct({ answer: Schema.String }),
+                instructions: "Echo, then answer.",
+                toolkit: tools,
+                policy: { maxTurns: 3, maxToolCalls: 2, maxDuration: "10 seconds" },
+              }),
+              "Answer",
+            );
+
+            metrics.push({ name: "foregroundRun", value: yield* elapsed(runStart) });
+            yield* check(result.output.answer === "done", "MCP Run output mismatch");
+            yield* (yield* ScriptedModel).assertExhausted;
+          }).pipe(
+            Effect.provide(
+              Layer.mergeAll(handlers, model, IdGenerator.layer, ThreadHistory.layerTransient),
+            ),
+          );
+        }
+        closeStart = yield* Clock.monotonicTimeNanos;
+      }),
+    );
+    if (enabled) metrics.push({ name: `scopeClose.${session}`, value: yield* elapsed(closeStart) });
+  }
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  yield* check(modelCalls === 2 && modelFinalizers === 2, "MCP model work/finalizers mismatch");
+  yield* check(
+    enabled
+      ? connects === 2 &&
+          discoveries === 2 &&
+          calls === 3 &&
+          closed === 2 &&
+          activeSession === undefined
+      : connects === 0 && calls === 0 && closed === 0 && localCalls === 3,
+    "MCP session reuse, work, or owned closure mismatch",
+  );
+
+  return {
+    totalMs,
+    metrics,
+    counters: [
+      { name: "modelCalls", value: modelCalls },
+      { name: "modelFinalizers", value: modelFinalizers },
+      { name: "toolCalls", value: enabled ? calls : localCalls },
+      { name: "connections", value: connects },
+      { name: "discoveries", value: discoveries },
+      { name: "sessionFinalizers", value: closed },
+    ],
+  };
+});
+
+const sources = MemoryNamespace.define({
+  name: "diagnostic/messages",
+  version: 1,
+  identity: Schema.String,
+});
+
+const targets = MemoryNamespace.define({
+  name: "diagnostic/profiles",
+  version: 1,
+  identity: Schema.String,
+});
+
+const intentFor = (id: string) =>
+  Protocol.Intent.make({
+    version: 1,
+    id,
+    invocationId: `invocation-${id}`,
+    source: {
+      key: MemoryKey.make({ namespace: sources.make("tenant"), id }),
+      locator: `fixture://message/${id}`,
+      revision: "r1",
+      position: { authorityGeneration: "fixture", sequence: 1 },
+    },
+    target: MemoryKey.make({ namespace: targets.make("tenant"), id: "profile" }),
+  });
+
+/** Local bounded public-port timing fixture, not evidence about disk durability or host queues.
+ * An already-running extraction is held in its host Scope while the foreground admits a new job.
+ */
+const rememberingCase = Effect.fn("diagnostic.remembering")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+  const failpoint = yield* Protocol.MutationFailpoint;
+
+  yield* progress.phase("setup");
+  const enabled = workload.parameters.enabled === 1;
+  const previous = intentFor("previous");
+  const incoming = intentFor("incoming");
+  const held = yield* Deferred.make<void>();
+  const release = yield* Deferred.make<void>();
+  const jobs = new Map<string, Protocol.Checkpoint>();
+  let document: MemoryDocument | null = null;
+  let sourceLoads = 0;
+  let extractions = 0;
+  let incomingExtractions = 0;
+  let extractionFinalizers = 0;
+  let reads = 0;
+  let writes = 0;
+  let modelCalls = 0;
+  let modelFinalizers = 0;
+  let admissions = 0;
+  let start = 0n;
+  let admissionMs = 0;
+  let foregroundMs = 0;
+  let backgroundReadyMs = 0;
+  let profileReadyMs = 0;
+
+  const store: Protocol.Store = {
+    admit: Effect.fn(function* (intent) {
+      const existing = jobs.get(intent.id);
+
+      if (existing !== undefined)
+        return yield* Protocol.AdmissionError.make({ reason: "conflict" });
+      if (jobs.size >= 2) return yield* Protocol.AdmissionError.make({ reason: "capacity" });
+      jobs.set(
+        intent.id,
+        Protocol.Checkpoint.make({
+          intent,
+          version: 0,
+          suppression: null,
+          progress: { _tag: "Pending" },
+        }),
+      );
+
+      return Protocol.Admission.make({ id: intent.id, status: "queued" });
+    }),
+    read: Effect.fn(function* (intent) {
+      const value = jobs.get(intent.id);
+
+      if (value === undefined) return yield* Protocol.CheckpointError.make({ reason: "missing" });
+
+      return value;
+    }),
+    save: Effect.fn(function* ({ intent, expectedVersion, progress: nextProgress }) {
+      const current = yield* store.read(intent);
+
+      if (current.version !== expectedVersion)
+        return yield* Protocol.CheckpointError.make({ reason: "fenced" });
+
+      const next = Protocol.Checkpoint.make({
+        ...current,
+        version: current.version + 1,
+        progress: nextProgress,
+      });
+
+      jobs.set(intent.id, next);
+
+      return next;
+    }),
+    // This sample only admits two distinct jobs. Unsupported mutation fails closed.
+    invalidate: () => Effect.fail(Protocol.AdmissionError.make({ reason: "conflict" })),
+  };
+
+  const reader = MemoryReader.fromAdapter({
+    get: () =>
+      Effect.sync(() => {
+        reads++;
+
+        return document;
+      }),
+  });
+
+  const writer = MemoryWriter.fromAdapter({
+    change: (command) =>
+      Effect.gen(function* () {
+        const next = yield* applyMemoryWrite(document, command, 100);
+
+        document = next;
+        writes++;
+
+        return next;
+      }),
+  });
+
+  const processor = Remembering.make({
+    proposal: Schema.Struct({ text: Schema.String }),
+    loadSource: (intent: ReturnType<typeof intentFor>) =>
+      Effect.sync(() => {
+        sourceLoads++;
+
+        return Remembering.SourceSnapshot.make({
+          source: intent.source,
+          text: "A fixed diagnostic fact.",
+        });
+      }),
+    extract: (snapshot, intent) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => {
+          extractions++;
+          if (intent.id === incoming.id) incomingExtractions++;
+        }),
+        () =>
+          Effect.gen(function* () {
+            yield* progress.mark({
+              name: `remember.extract.${intent.id}`,
+              elapsedMs: yield* elapsed(start),
+            });
+            if (intent.id === previous.id) {
+              yield* Deferred.succeed(held, undefined);
+              yield* Deferred.await(release);
+            }
+
+            return {
+              value: { text: snapshot.text },
+              evidence: [
+                Protocol.Evidence.make({
+                  source: {
+                    id: snapshot.source.key.id,
+                    locator: snapshot.source.locator,
+                    revision: snapshot.source.revision,
+                  },
+                  quote: snapshot.text,
+                  startByte: 0,
+                  endByte: new TextEncoder().encode(snapshot.text).byteLength,
+                }),
+              ],
+            };
+          }),
+        () =>
+          Effect.gen(function* () {
+            extractionFinalizers++;
+            yield* progress
+              .mark({
+                name: `remember.extract.finalized.${intent.id}`,
+                elapsedMs: yield* elapsed(start),
+              })
+              .pipe(Effect.orDie);
+          }),
+      ),
+    merge: ({ proposal }) =>
+      Effect.succeed({
+        _tag: "Put" as const,
+        locator: "fixture://profile",
+        content: MemoryContent.make({ ...memoryContent, text: proposal.value.text }),
+        scopes: [MemoryScope.make("private")],
+      }),
+    cleanup: () => Effect.succeed({ _tag: "NoChange" as const }),
+  });
+
+  const rememberTool = Tool.make("remember", {
+    parameters: Schema.Struct({ index: Schema.Int }),
+    success: Schema.Literal("accepted"),
+  });
+
+  const rememberToolkit = Toolkit.make(rememberTool);
+
+  const handlers = rememberToolkit.toLayer({
+    remember: () =>
+      providerCheck(
+        Effect.gen(function* () {
+          const begin = yield* Clock.monotonicTimeNanos;
+
+          if (enabled) {
+            const admitted = yield* Remembering.admit(store, incoming).pipe(
+              Effect.provideService(Protocol.MutationFailpoint, failpoint),
+            );
+
+            yield* check(admitted.status === "queued", "Remembering admission was not queued");
+            admissions++;
+          }
+          admissionMs = yield* elapsed(begin);
+          if (enabled)
+            yield* progress.mark({
+              name: "remember.admission.complete",
+              elapsedMs: yield* elapsed(start),
+            });
+
+          return "accepted" as const;
+        }),
+      ),
+  });
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer(
+      [0, 1].map((turn): ScriptedTurnInput => ({
+        _tag: "Stream",
+        termination: { _tag: "Complete" },
+        parts:
+          turn === 0
+            ? [
+                {
+                  type: "tool-call",
+                  id: "remember-call",
+                  name: "remember",
+                  params: { index: 0 },
+                  providerExecuted: false,
+                },
+                {
+                  type: "finish",
+                  reason: "tool-calls",
+                  usage: { inputTokens: {}, outputTokens: {} },
+                },
+              ]
+            : finalParts,
+        assertRequest: (request) =>
+          providerCheck(
+            Effect.gen(function* () {
+              modelCalls++;
+              yield* progress.mark({
+                name: `remember.provider.${turn}`,
+                elapsedMs: yield* elapsed(start),
+              });
+              if (turn === 1)
+                yield* check(
+                  (yield* encodedPrompt(request.prompt)).includes("accepted") &&
+                    incomingExtractions === 0 &&
+                    writes === 0,
+                  "Foreground ran remembering extraction or writes",
+                );
+            }),
+          ),
+        onStreamFinalize: Effect.sync(() => {
+          modelFinalizers++;
+        }),
+      })),
+    ),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "remembering-diagnostic"),
+  );
+
+  const host = yield* Scope.make();
+
+  yield* Effect.addFinalizer((exit) => Scope.close(host, exit));
+  if (enabled) yield* Remembering.admit(store, previous);
+  yield* progress.phase("operation");
+  start = yield* Clock.monotonicTimeNanos;
+
+  const worker = enabled
+    ? yield* Effect.gen(function* () {
+        for (const intent of [previous, incoming]) {
+          for (let transition = 0; transition < 3; transition++)
+            yield* processor.advance({
+              intent,
+              store,
+              limits: Remembering.Limits.make({
+                maxSourceBytes: 1_024,
+                maxProposalBytes: 4_096,
+                timeoutMillis: 5_000,
+              }),
+              extractionEnabled: true,
+            });
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(MemoryReader, reader), Layer.succeed(MemoryWriter, writer)),
+        ),
+        Effect.forkIn(host),
+      )
+    : undefined;
+
+  if (enabled) yield* Deferred.await(held);
+  const foregroundStart = yield* Clock.monotonicTimeNanos;
+
+  const result = yield* Effect.scoped(
+    Effect.gen(function* () {
+      const output = yield* AgentRuntime.run(
+        Agent.make("remembering-diagnostic", {
+          input: Schema.String,
+          output: Schema.Struct({ answer: Schema.String }),
+          instructions: "Admit remembering, then answer.",
+          toolkit: rememberToolkit,
+          policy: { maxTurns: 3, maxToolCalls: 2, maxDuration: "10 seconds" },
+        }),
+        "Answer",
+      );
+
+      yield* (yield* ScriptedModel).assertExhausted;
+
+      return output;
+    }),
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(handlers, model).pipe(
+        Layer.provideMerge(Layer.merge(IdGenerator.layer, ThreadHistory.layerTransient)),
+      ),
+    ),
+  );
+
+  foregroundMs = yield* elapsed(foregroundStart);
+  const foregroundExtractions = incomingExtractions;
+  const foregroundReads = reads;
+  const foregroundWrites = writes;
+
+  yield* check(
+    incomingExtractions === 0 &&
+      writes === 0 &&
+      reads === 0 &&
+      (!enabled || jobs.get(incoming.id)?.progress._tag === "Pending"),
+    "Foreground awaited background readiness",
+  );
+  yield* progress.mark({ name: "remember.foreground.complete", elapsedMs: yield* elapsed(start) });
+  const resumeStart = yield* Clock.monotonicTimeNanos;
+
+  yield* Deferred.succeed(release, undefined);
+  if (worker !== undefined) yield* Fiber.join(worker);
+  backgroundReadyMs = yield* elapsed(resumeStart);
+  if (enabled) {
+    profileReadyMs = yield* elapsed(start);
+    yield* progress.mark({ name: "remember.profile.ready", elapsedMs: profileReadyMs });
+  }
+  yield* Scope.close(host, Exit.void);
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  yield* check(
+    result.output.answer === "done" && modelCalls === 2 && modelFinalizers === 2,
+    "Remembering foreground work/finalizers mismatch",
+  );
+  yield* check(
+    enabled
+      ? extractions === 2 &&
+          extractionFinalizers === 2 &&
+          writes === 2 &&
+          [...jobs.values()].every(
+            (job) => job.progress._tag === "Completed" && job.progress.outcome === "applied",
+          )
+      : sourceLoads === 0 && extractions === 0 && writes === 0,
+    "Remembering background completed work mismatch",
+  );
+
+  return {
+    totalMs,
+    metrics: [
+      { name: "foregroundRun", value: foregroundMs },
+      ...(enabled
+        ? [
+            { name: "admission", value: admissionMs },
+            { name: "backgroundAfterRelease", value: backgroundReadyMs },
+            { name: "profileReadyFromOperationStart", value: profileReadyMs },
+          ]
+        : []),
+    ],
+    counters: [
+      { name: "modelCalls", value: modelCalls },
+      { name: "modelFinalizers", value: modelFinalizers },
+      { name: "foregroundExtractions", value: foregroundExtractions },
+      { name: "foregroundProfileReads", value: foregroundReads },
+      { name: "foregroundProfileWrites", value: foregroundWrites },
+      { name: "admissions", value: admissions },
+      { name: "sourceLoads", value: sourceLoads },
+      { name: "backgroundExtractions", value: extractions },
+      { name: "extractionFinalizers", value: extractionFinalizers },
+      { name: "profileReads", value: reads },
+      { name: "profileWrites", value: writes },
+    ],
+  };
+});
+
+/** Two attached children share one real child slot. The first provider deliberately waits
+ * ten milliseconds after both slot requests arrive; slot timing includes that labeled hold.
+ * Actual runtime span boundaries precede preparation and admission, unlike SubagentStarted.
+ */
+const subagentCase = Effect.fn("diagnostic.subagent")(function* (workload: DiagnosticCase) {
+  const progress = yield* DiagnosticProgress;
+  const clock = yield* Clock.Clock;
+  const reservations = yield* Reservations.SubagentReservations;
+
+  yield* progress.phase("setup");
+  const enabled = workload.parameters.enabled === 1;
+  let start = 0n;
+  let entries = 0;
+  let joins = 0;
+  let slotRequests = 0;
+  let releases = 0;
+  let releaseRequests = 0;
+  let prepared = 0;
+  let projected = 0;
+  let children = 0;
+  let childFinalizers = 0;
+  let active = 0;
+  let maxActive = 0;
+  let parents = 0;
+  let parentFinalizers = 0;
+  let localCalls = 0;
+  let traceOverflow = false;
+  const traceMarks: Array<DiagnosticMark> = [];
+  const metrics: Array<{ name: string; value: number }> = [];
+
+  const traceMark = (name: string) => {
+    if (traceMarks.length >= 64) {
+      traceOverflow = true;
+
+      return;
+    }
+    traceMarks.push({
+      name,
+      elapsedMs: Number(clock.monotonicTimeNanosUnsafe() - start) / 1_000_000,
+    });
+  };
+
+  const tracer = Tracer.make({
+    span(options) {
+      const role =
+        options.name === "SubagentRuntime.diag_child"
+          ? "invocation"
+          : options.name === "SubagentReservations.acquireChildSlot"
+            ? "slot"
+            : options.name === "SubagentReservations.release"
+              ? "release"
+              : undefined;
+
+      const index =
+        role === "invocation"
+          ? entries++
+          : role === "slot"
+            ? slotRequests++
+            : role === "release"
+              ? releaseRequests++
+              : -1;
+
+      const begin = clock.monotonicTimeNanosUnsafe();
+
+      if (role !== undefined) traceMark(`subagent.${role}.begin.${index}`);
+
+      return new (class extends Tracer.NativeSpan {
+        // Do not retain provider prompts, span attributes, events, or linked spans.
+        override attribute() {}
+        override event() {}
+        override addLinks() {}
+        override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>) {
+          if (role !== undefined) {
+            traceMark(`subagent.${role}.end.${index}`);
+            if (role === "invocation") joins++;
+            if (role === "release") releases++;
+            if (metrics.length < 64)
+              metrics.push({
+                name: `${role}.${index}`,
+                value: Number(clock.monotonicTimeNanosUnsafe() - begin) / 1_000_000,
+              });
+            else traceOverflow = true;
+          }
+          super.end(endTime, exit);
+        }
+      })({ ...options, links: [] });
+    },
+  });
+
+  const child = Agent.make("diagnostic-child", {
+    input: Schema.Struct({ question: Schema.String }),
+    output: Schema.Struct({ answer: Schema.String }),
+    instructions: "Return the diagnostic answer.",
+    toolkit: Toolkit.empty,
+    policy: { maxTurns: 1, maxToolCalls: 1, maxDuration: "10 seconds" },
+  });
+
+  const delegation = Subagent.make("diag_child", {
+    description: "Run one bounded diagnostic child.",
+    target: child,
+    parameters: Schema.Struct({ topic: Schema.String }),
+    success: Schema.Struct({ summary: Schema.String }),
+    failure: BenchmarkError,
+    prepareInput: ({ topic }) =>
+      Effect.gen(function* () {
+        prepared++;
+        yield* progress.mark({
+          name: `subagent.prepare.begin.${topic}`,
+          elapsedMs: yield* elapsed(start),
+        });
+        const value = { question: topic };
+
+        yield* progress.mark({
+          name: `subagent.prepare.end.${topic}`,
+          elapsedMs: yield* elapsed(start),
+        });
+
+        return value;
+      }),
+    projectResult: (output, _context, parameters) =>
+      Effect.gen(function* () {
+        projected++;
+        yield* progress.mark({
+          name: `subagent.project.${parameters.topic}`,
+          elapsedMs: yield* elapsed(start),
+        });
+
+        return { summary: `${parameters.topic}:${output.answer}` };
+      }),
+    policy: Subagent.SubagentPolicy.make({
+      maxChildren: 2,
+      maxConcurrency: 1,
+      maxTurns: 1,
+      maxToolCalls: 1,
+      maxDuration: "10 seconds",
+    }),
+  });
+
+  const childModel = Model.make(
+    "scripted",
+    "diagnostic-child",
+    ScriptedModel.layer([
+      {
+        _tag: "Stream",
+        termination: { _tag: "Complete" },
+        parts: finalParts,
+        assertRequest: (request) =>
+          providerCheck(
+            Effect.gen(function* () {
+              const index = children++;
+
+              active++;
+              maxActive = Math.max(maxActive, active);
+              yield* progress.mark({
+                name: `subagent.childProvider.${index}`,
+                elapsedMs: yield* elapsed(start),
+              });
+              yield* check(
+                (yield* encodedPrompt(request.prompt)).includes(`topic-${index}`),
+                "Child preparation changed input or order",
+              );
+              if (index === 0) {
+                yield* Effect.gen(function* () {
+                  while (slotRequests < 2) yield* Effect.yieldNow;
+                }).pipe(Effect.timeout("2 seconds"));
+                yield* progress.mark({
+                  name: "subagent.queued.ready",
+                  elapsedMs: yield* elapsed(start),
+                });
+                yield* Effect.sleep("10 millis");
+              }
+            }),
+          ),
+        onStreamFinalize: Effect.sync(() => {
+          childFinalizers++;
+          active--;
+        }),
+      },
+    ]),
+  );
+
+  const local = Tool.make("diag_child", {
+    parameters: Schema.Struct({ topic: Schema.String }),
+    success: Schema.Struct({ summary: Schema.String }),
+  });
+
+  const localToolkit = Toolkit.make(local);
+  const tools = enabled ? Toolkit.make(delegation.tool) : localToolkit;
+
+  const handlers = enabled
+    ? Subagent.SubagentRuntime.layer(delegation, Agent.withModel(child, childModel), {
+        mapChildFailure: (failure) =>
+          BenchmarkError.make({ message: `Diagnostic child failed: ${failure._tag}` }),
+      })
+    : localToolkit.toLayer({
+        diag_child: ({ topic }) =>
+          Effect.sync(() => {
+            localCalls++;
+
+            return { summary: `${topic}:done` };
+          }),
+      });
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer(
+      [0, 1].map((turn): ScriptedTurnInput => ({
+        _tag: "Stream",
+        termination: { _tag: "Complete" },
+        parts:
+          turn === 0
+            ? [
+                ...[0, 1].map((index) => ({
+                  type: "tool-call" as const,
+                  id: `child-call-${index}`,
+                  name: "diag_child",
+                  params: { topic: `topic-${index}` },
+                  providerExecuted: false,
+                })),
+                {
+                  type: "finish",
+                  reason: "tool-calls",
+                  usage: { inputTokens: {}, outputTokens: {} },
+                },
+              ]
+            : finalParts,
+        assertRequest: (request) =>
+          providerCheck(
+            Effect.gen(function* () {
+              parents++;
+              yield* progress.mark({
+                name: `subagent.parentProvider.${turn}`,
+                elapsedMs: yield* elapsed(start),
+              });
+              if (turn === 1) {
+                const results = request.prompt.content
+                  .filter((message) => message.role === "tool")
+                  .flatMap((message) => message.content)
+                  .filter((part) => part.type === "tool-result");
+
+                yield* check(
+                  results.length === 2 && results.every((part) => !part.isFailure),
+                  "Parent did not join two successful child results",
+                );
+                const encoded = yield* encodedPrompt(request.prompt);
+
+                yield* check(
+                  encoded.includes("topic-0:done") && encoded.includes("topic-1:done"),
+                  "Parent lost projected child results",
+                );
+              }
+            }),
+          ),
+        onStreamFinalize: Effect.sync(() => {
+          parentFinalizers++;
+        }),
+      })),
+    ),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "diagnostic-parent"),
+  );
+
+  yield* progress.phase("operation");
+  start = yield* Clock.monotonicTimeNanos;
+
+  const result = yield* Effect.scoped(
+    Effect.gen(function* () {
+      const output = yield* AgentRuntime.run(
+        Agent.make("subagent-diagnostic", {
+          input: Schema.String,
+          output: Schema.Struct({ answer: Schema.String }),
+          instructions: "Call both diagnostic children, then answer.",
+          toolkit: tools,
+          policy: { maxTurns: 3, maxToolCalls: 2, maxDuration: "30 seconds", toolConcurrency: 2 },
+        }),
+        "Answer",
+      );
+
+      yield* (yield* ScriptedModel).assertExhausted;
+
+      return output;
+    }),
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(handlers, model).pipe(
+        Layer.provideMerge(Layer.merge(IdGenerator.layer, ThreadHistory.layerTransient)),
+      ),
+    ),
+    Effect.withTracer(tracer),
+    // Flush bounded trace scalars even when the Run fails or is interrupted.
+    Effect.ensuring(
+      Effect.suspend(() =>
+        Effect.forEach(traceMarks, (mark) => progress.mark(mark), { discard: true }),
+      ).pipe(Effect.orDie),
+    ),
+  );
+
+  const totalMs = yield* elapsed(start);
+
+  yield* progress.phase("verification");
+  yield* check(
+    !traceOverflow && result.output.answer === "done" && parents === 2 && parentFinalizers === 2,
+    "Subagent parent work or bounded trace mismatch",
+  );
+  if (enabled) {
+    const snapshot = yield* reservations.parentSnapshot(result.runId);
+
+    yield* check(
+      snapshot.totalChildInvocations === 2 &&
+        snapshot.reservations.length === 2 &&
+        snapshot.reservations.every((reservation) => reservation.status === "released"),
+      "Subagent reservations did not settle",
+    );
+    yield* check(
+      entries === 2 &&
+        joins === 2 &&
+        slotRequests === 2 &&
+        releases === 2 &&
+        prepared === 2 &&
+        projected === 2 &&
+        children === 2 &&
+        childFinalizers === 2 &&
+        active === 0 &&
+        maxActive === 1,
+      "Subagent work, concurrency, or owned finalizers mismatch",
+    );
+  } else
+    yield* check(
+      localCalls === 2 && entries === 0 && children === 0,
+      "Disabled subagents performed optional work",
+    );
+
+  return {
+    totalMs,
+    metrics,
+    counters: [
+      { name: "parentModelCalls", value: parents },
+      { name: "parentModelFinalizers", value: parentFinalizers },
+      { name: "childModelCalls", value: children },
+      { name: "childModelFinalizers", value: childFinalizers },
+      { name: "preparations", value: prepared },
+      { name: "projections", value: projected },
+      { name: "slotRequests", value: slotRequests },
+      { name: "releasedReservations", value: releases },
+      { name: "joinedInvocations", value: joins },
+      { name: "maxActiveChildren", value: maxActive },
+      { name: "inducedProviderHoldMillis", value: enabled ? 10 : 0 },
+      { name: "toolCalls", value: enabled ? entries : localCalls },
+    ],
+  };
+});
+
+/** Each call builds fresh service state; no process-global cache survives a sample. */
+export const runCapabilityCase = Effect.fn("diagnostic.runCapabilityCase")(
+  function* (workload: DiagnosticCase) {
+    const selected = capabilityCases.find((item) => item.name === workload.name);
+    const encodeCase = Schema.encodeEffect(Schema.fromJsonString(DiagnosticCase));
+
+    yield* check(
+      selected !== undefined && (yield* encodeCase(selected)) === (yield* encodeCase(workload)),
+      "Unknown or modified capability diagnostic case",
+    );
+
+    const result: DiagnosticResult = yield* Effect.scoped(
+      Effect.gen(function* () {
+        if (workload.name.startsWith("history-run-")) return yield* historyRunCase(workload);
+        if (workload.family === "history") return yield* historyCase(workload);
+        if (workload.family === "mcp") return yield* mcpCase(workload);
+        if (workload.name.startsWith("remembering-run-"))
+          return yield* rememberingCase(workload).pipe(
+            Effect.provide(Protocol.MutationFailpoint.layer),
+          );
+        if (workload.family === "subagent")
+          return yield* subagentCase(workload).pipe(
+            Effect.provide(Reservations.SubagentReservationsMemoryLive),
+          );
+
+        return yield* memoryRunCase(workload);
+      }),
+    ).pipe(Effect.provide(EphemeralThreads.EphemeralThreadsLive));
+
+    return result;
+  },
+  Effect.mapError((error) =>
+    Schema.is(BenchmarkError)(error)
+      ? error
+      : BenchmarkError.make({
+          message: `Capability diagnostic failed: ${String(error)}`,
+          cause: error,
+        }),
+  ),
+);

--- a/examples/runtime-benchmark/src/diagnostic-cases.ts
+++ b/examples/runtime-benchmark/src/diagnostic-cases.ts
@@ -1,0 +1,103 @@
+import type { DiagnosticCase } from "./diagnostic-contracts.js";
+
+/** Fixed request data only: safe for both the Bun controller and Node workers. */
+export const policyCases: ReadonlyArray<DiagnosticCase> = [1, 4].flatMap((rounds) =>
+  [0, 2, 20].flatMap((authorizationMs) =>
+    [0, 20].map((modelAcquisitionMs) => ({
+      name: `policy-rounds-${rounds}-authorize-${authorizationMs}-model-${modelAcquisitionMs}`,
+      family: "policy" as const,
+      parameters: { rounds, authorizationMs, modelAcquisitionMs },
+    })),
+  ),
+);
+
+export const capabilityCases: ReadonlyArray<DiagnosticCase> = [
+  ...[
+    { name: "history-unchanged", suffix: 0, threads: 1 },
+    { name: "history-single", suffix: 1, threads: 1 },
+    { name: "history-suffix-64", suffix: 64, threads: 1 },
+    { name: "history-64-threads", suffix: 64, threads: 64 },
+  ].map(({ name, suffix, threads }) => ({
+    name,
+    family: "history" as const,
+    parameters: { prefix: 256, suffix, threads },
+  })),
+  {
+    name: "history-near-bound",
+    family: "history",
+    parameters: { prefix: 768, suffix: 256, threads: 1 },
+  },
+  ...[0, 1].map((enabled) => ({
+    name: `history-run-${enabled ? "on" : "off"}`,
+    family: "history" as const,
+    parameters: { enabled, prefix: 256 },
+  })),
+  ...[0, 1, 2].map((mode) => ({
+    name: `memory-run-${["off", "empty", "recall"][mode]}`,
+    family: "memory" as const,
+    parameters: { mode },
+  })),
+  ...[0, 1].map((enabled) => ({
+    name: `mcp-in-process-http-${enabled ? "on" : "off"}`,
+    family: "mcp" as const,
+    parameters: { enabled },
+  })),
+  ...[0, 1].map((enabled) => ({
+    name: `remembering-run-${enabled ? "on" : "off"}`,
+    family: "memory" as const,
+    parameters: { enabled },
+  })),
+  ...[0, 1].map((enabled) => ({
+    name: `subagent-run-${enabled ? "on" : "off"}`,
+    family: "subagent" as const,
+    parameters: { enabled },
+  })),
+];
+
+export const ledgerCases: ReadonlyArray<DiagnosticCase> = [
+  {
+    name: "ledger-scan-sparse-8192-16",
+    family: "ledger",
+    parameters: { mode: 0, settled: 8192, unfinished: 16 },
+  },
+  {
+    name: "ledger-scan-dense-768",
+    family: "ledger",
+    parameters: { mode: 0, settled: 0, unfinished: 768 },
+  },
+  { name: "ledger-finalize-active", family: "ledger", parameters: { mode: 1, repeats: 1 } },
+  ...[2, 3].flatMap((mode) => [
+    {
+      name: `ledger-${mode === 2 ? "replay" : "status"}-repeat-${mode === 2 ? 32 : 16}`,
+      family: "ledger" as const,
+      parameters: { mode, repeats: mode === 2 ? 32 : 16, holdMs: -1 },
+    },
+    ...[0, 25, 100].map((holdMs) => ({
+      name: `ledger-${mode === 2 ? "replay" : "status"}-writer-${holdMs}`,
+      family: "ledger" as const,
+      parameters: { mode, repeats: 1, holdMs },
+    })),
+  ]),
+];
+
+export const fairnessCases: ReadonlyArray<DiagnosticCase> = [1, 2, 4].flatMap((workerConcurrency) =>
+  [0, 1].map((warmArrival) => ({
+    name: `fairness-workers-${workerConcurrency}-${warmArrival ? "warm" : "initial"}`,
+    family: "fairness" as const,
+    parameters: {
+      workerConcurrency,
+      warmArrival,
+      busyThreads: 4,
+      toolCalls: 4,
+      toolConcurrency: 2,
+      toolDelayMs: 100,
+    },
+  })),
+);
+
+export const diagnosticCases: ReadonlyArray<DiagnosticCase> = [
+  ...policyCases,
+  ...capabilityCases,
+  ...ledgerCases,
+  ...fairnessCases,
+];

--- a/examples/runtime-benchmark/src/diagnostic-contracts.ts
+++ b/examples/runtime-benchmark/src/diagnostic-contracts.ts
@@ -1,0 +1,128 @@
+import type { Effect } from "effect";
+import { Context, Schema } from "effect";
+
+import type { BenchmarkError } from "./contracts.js";
+
+export const DIAGNOSTIC_VERSION = "runtime-diagnostic-v1";
+export const MAX_DIAGNOSTIC_MARKS = 512;
+export const DIAGNOSTIC_SIZES = { cohorts: 2, warmups: 2, samples: 5 } as const;
+
+const Name = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(96));
+const Millis = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0));
+const Failure = Schema.NullOr(Schema.String.check(Schema.isMaxLength(8_192)));
+
+export const DiagnosticCase = Schema.Struct({
+  name: Name,
+  family: Schema.Literals(["policy", "history", "memory", "mcp", "subagent", "ledger", "fairness"]),
+  parameters: Schema.Record(Name, Schema.Finite).check(Schema.isMaxProperties(16)),
+});
+
+export type DiagnosticCase = typeof DiagnosticCase.Type;
+
+export const DiagnosticResult = Schema.Struct({
+  totalMs: Millis,
+  metrics: Schema.Array(Schema.Struct({ name: Name, value: Millis })).check(Schema.isMaxLength(64)),
+  counters: Schema.Array(Schema.Struct({ name: Name, value: Schema.Natural })).check(
+    Schema.isMaxLength(64),
+  ),
+});
+
+export type DiagnosticResult = typeof DiagnosticResult.Type;
+
+export const DiagnosticPhase = Schema.Literals(["setup", "operation", "verification"]);
+export type DiagnosticPhase = typeof DiagnosticPhase.Type;
+export const DiagnosticMark = Schema.Struct({ name: Name, elapsedMs: Millis });
+export type DiagnosticMark = typeof DiagnosticMark.Type;
+
+export const DiagnosticMarks = Schema.Array(DiagnosticMark).check(
+  Schema.isMaxLength(MAX_DIAGNOSTIC_MARKS),
+);
+
+/** Phase persistence is outside operation clocks; bounded marks are in-memory and inclusive. */
+export class DiagnosticProgress extends Context.Service<
+  DiagnosticProgress,
+  {
+    readonly phase: (phase: DiagnosticPhase) => Effect.Effect<void, BenchmarkError>;
+    readonly mark: (mark: DiagnosticMark) => Effect.Effect<void, BenchmarkError>;
+  }
+>()("runtime-benchmark/DiagnosticProgress") {}
+
+export const DiagnosticWorkerOptions = Schema.Struct({
+  output: Schema.String,
+  warmups: Schema.Natural.check(Schema.isLessThanOrEqualTo(2)),
+  samples: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 5 })),
+  timeoutMs: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120_000 })),
+});
+
+export type DiagnosticWorkerOptions = typeof DiagnosticWorkerOptions.Type;
+
+export const DiagnosticActive = Schema.Struct({
+  case: Name,
+  ordinal: Schema.Natural,
+  warmup: Schema.Boolean,
+  phase: DiagnosticPhase,
+  elapsedMs: Millis,
+  marks: DiagnosticMarks,
+});
+
+export type DiagnosticActive = typeof DiagnosticActive.Type;
+
+export const DiagnosticSample = Schema.Struct({
+  case: Name,
+  ordinal: Schema.Natural,
+  warmup: Schema.Boolean,
+  attemptMs: Millis,
+  phase: DiagnosticPhase,
+  result: Schema.NullOr(DiagnosticResult),
+  marks: DiagnosticMarks,
+  status: Schema.Literals(["passed", "failed"]),
+  failure: Failure,
+});
+
+export type DiagnosticSample = typeof DiagnosticSample.Type;
+
+export const DiagnosticWorkerReport = Schema.Struct({
+  fixture: Schema.Literal(DIAGNOSTIC_VERSION),
+  runtime: Schema.String,
+  platform: Schema.String,
+  architecture: Schema.String,
+  active: Schema.NullOr(DiagnosticActive),
+  failure: Failure,
+  samples: Schema.Array(DiagnosticSample).check(Schema.isMaxLength(448)),
+});
+
+export type DiagnosticWorkerReport = typeof DiagnosticWorkerReport.Type;
+
+/** Failed, duplicate, absent, or mismatched samples cannot become comparative evidence. */
+export const completeDiagnosticBatch = (
+  report: DiagnosticWorkerReport,
+  options: DiagnosticWorkerOptions,
+  workloads: ReadonlyArray<DiagnosticCase>,
+): boolean => {
+  const expected = new Set(
+    workloads.flatMap((workload) =>
+      Array.from(
+        { length: options.warmups + options.samples },
+        (_, ordinal) => `${workload.name}:${ordinal}`,
+      ),
+    ),
+  );
+
+  if (report.active !== null || report.failure !== null || report.samples.length !== expected.size)
+    return false;
+
+  return report.samples.every(
+    (sample) =>
+      expected.delete(`${sample.case}:${sample.ordinal}`) &&
+      sample.warmup === sample.ordinal < options.warmups &&
+      sample.status === "passed" &&
+      sample.failure === null &&
+      sample.phase === "verification" &&
+      sample.result !== null &&
+      sample.attemptMs >= sample.result.totalMs &&
+      new Set(sample.result.metrics.map(({ name }) => name)).size ===
+        sample.result.metrics.length &&
+      new Set(sample.result.counters.map(({ name }) => name)).size ===
+        sample.result.counters.length,
+  );
+};

--- a/examples/runtime-benchmark/src/diagnostic-fairness.ts
+++ b/examples/runtime-benchmark/src/diagnostic-fairness.ts
@@ -1,0 +1,486 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { NodeDurableHost } from "@effect-agent/platform-node/NodeDurableHost";
+import { ScriptedModel, type ScriptedStreamPart } from "@effect-agent/testing/ScriptedModel";
+import { type AgentAttemptContext } from "@effect-agent/thread/AgentRegistration";
+import { digestDefinitions } from "@effect-agent/thread/Digest";
+import { type Receipt } from "@effect-agent/thread/DurableAgentRuntime";
+import { DefinitionDigestInput } from "@effect-agent/thread/Records";
+import {
+  IdempotencyKey,
+  Principal,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
+} from "@effect-agent/thread/SubmissionLedger";
+import { ThreadExportRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { NodeCrypto } from "@effect/platform-node";
+import { Clock, Deferred, Effect, Fiber, FileSystem, Layer, Path, Schema } from "effect";
+import { Agent } from "effect-agent";
+import { AiError, Model, Tool, Toolkit } from "effect/unstable/ai";
+
+import { BenchmarkError, check } from "./contracts.js";
+import { fairnessCases } from "./diagnostic-cases.js";
+import {
+  DiagnosticProgress,
+  type DiagnosticCase,
+  type DiagnosticResult,
+} from "./diagnostic-contracts.js";
+
+export { fairnessCases } from "./diagnostic-cases.js";
+
+const work = Tool.make("fairness_work", {
+  parameters: Schema.Struct({ index: Schema.Natural }),
+  success: Schema.Natural,
+});
+
+const toolkit = Toolkit.make(work);
+const principal = Principal.make("fairness-diagnostic");
+const labels = ["busy0", "busy1", "busy2", "busy3", "short"] as const;
+const encodeInput = Schema.encodeSync(Schema.fromJsonString(Schema.String));
+const FairnessOutput = Schema.Struct({ answer: Schema.String });
+
+const finalParts = (label: string): ReadonlyArray<ScriptedStreamPart> => [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: JSON.stringify({ answer: label }) },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+];
+
+/**
+ * Existing registered Node workers only: one independent Submission per lane, no joining or
+ * preemption claim. Request-to-Attempt includes admission, since the public API does not expose
+ * the exact ready timestamp. Settlement time is when awaitSettlement observes it (including
+ * wake/poll costs), not the canonical commit time. Host acquisition/close and verification are
+ * outside totalMs; submitted work, worker startup/stop, and in-memory marks are inside it.
+ */
+export const runFairnessCase = Effect.fn("diagnostic.fairness")(
+  function* (workload: DiagnosticCase) {
+    const selected = fairnessCases.find((entry) => entry.name === workload.name);
+
+    yield* check(
+      selected !== undefined &&
+        workload.family === "fairness" &&
+        Object.keys(workload.parameters).length === Object.keys(selected.parameters).length &&
+        Object.entries(selected.parameters).every(
+          ([key, value]) => workload.parameters[key] === value,
+        ),
+      "Unknown or modified fairness diagnostic case",
+    );
+    if (selected === undefined)
+      return yield* BenchmarkError.make({ message: "Unknown fairness diagnostic case" });
+
+    const concurrency = selected.parameters.workerConcurrency!;
+    const warmArrival = selected.parameters.warmArrival === 1;
+    const progress = yield* DiagnosticProgress;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    yield* progress.phase("setup");
+    const directory = yield* fs.makeTempDirectoryScoped({ prefix: "fairness-diagnostic-" });
+    const firstBusyTool = yield* Deferred.make<void>();
+    let started = 0n;
+    let activeAttempts = 0;
+    let maxAttempts = 0;
+    let attemptsOpened = 0;
+    let attemptsClosed = 0;
+    let activeTools = 0;
+    let maxTools = 0;
+    let toolsOpened = 0;
+    let toolsClosed = 0;
+    let modelsOpened = 0;
+    let modelsClosed = 0;
+    let providers = 0;
+    let streamsClosed = 0;
+    let shortAdmissionActiveAttempts = 0;
+    let shortAdmissionActiveTools = 0;
+
+    const stamp = Effect.fn("diagnostic.fairnessMark")(function* (name: string) {
+      const elapsedMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+      yield* progress.mark({ name, elapsedMs });
+
+      return elapsedMs;
+    });
+
+    const lanes = labels.map((label) => ({
+      label,
+      busy: label !== "short",
+      threadId: ThreadId.make(label === "short" ? "z-short" : `a-${label}`),
+      input: `Run ${label}`,
+      encodedInput: encodeInput(`Run ${label}`),
+      requestAt: -1,
+      acceptedAt: -1,
+      attemptAt: -1,
+      providerAt: -1,
+      observedAt: -1,
+      closedAt: -1,
+      active: 0,
+      maxActive: 0,
+      toolCalls: 0,
+      claimedSubmissionId: "",
+      receipt: undefined as Receipt | undefined,
+    }));
+
+    const registrations = lanes.map((lane) => {
+      const definition = Agent.make(`fairness-${lane.label}`, {
+        input: Schema.String,
+        output: FairnessOutput,
+        instructions: "Perform the requested work and answer.",
+        toolkit,
+        policy: { maxTurns: 3, maxToolCalls: 4, maxDuration: "20 seconds", toolConcurrency: 2 },
+      });
+
+      const parts: ReadonlyArray<ReadonlyArray<ScriptedStreamPart>> = lane.busy
+        ? [
+            [
+              ...Array.from({ length: 4 }, (_, index) => ({
+                type: "tool-call" as const,
+                id: `${lane.label}-${index}`,
+                name: "fairness_work",
+                params: { index },
+                providerExecuted: false,
+              })),
+              {
+                type: "finish",
+                reason: "tool-calls",
+                usage: { inputTokens: {}, outputTokens: {} },
+              },
+            ],
+            finalParts(lane.label),
+          ]
+        : [finalParts(lane.label)];
+
+      const model = Layer.mergeAll(
+        ScriptedModel.layer(
+          parts.map((parts, turn) => ({
+            _tag: "Stream" as const,
+            parts,
+            termination: { _tag: "Complete" as const },
+            assertRequest: (request) =>
+              Effect.gen(function* () {
+                const at = yield* stamp(`provider.${lane.label}.${turn}`);
+
+                if (lane.providerAt < 0) lane.providerAt = at;
+                providers++;
+
+                const users = request.prompt.content
+                  .filter((message) => message.role === "user")
+                  .flatMap((message) => message.content)
+                  .filter((part) => part.type === "text")
+                  .map((part) => part.text);
+
+                const results = request.prompt.content
+                  .filter((message) => message.role === "tool")
+                  .flatMap((message) => message.content)
+                  .filter((part) => part.type === "tool-result");
+
+                yield* check(
+                  users.includes(lane.encodedInput) &&
+                    results.length === turn * 4 &&
+                    results.every(
+                      (part, index) =>
+                        part.id === `${lane.label}-${index}` &&
+                        !part.isFailure &&
+                        part.result === index,
+                    ),
+                  "Fairness provider lost, reordered, or duplicated input/tool results",
+                );
+              }).pipe(
+                Effect.mapError((cause) =>
+                  AiError.AiError.make({
+                    module: "fairness-diagnostic",
+                    method: "assertRequest",
+                    reason: AiError.UnknownError.make({ description: cause.message }),
+                  }),
+                ),
+              ),
+            onStreamFinalize: Effect.sync(() => {
+              streamsClosed++;
+            }),
+          })),
+        ),
+        Layer.succeed(Model.ProviderName, "scripted"),
+        Layer.succeed(Model.ModelName, `fairness-${lane.label}`),
+        Layer.effectDiscard(
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              modelsOpened++;
+            }),
+            () =>
+              Effect.sync(() => {
+                modelsClosed++;
+              }).pipe(Effect.andThen(stamp(`model.closed.${lane.label}`)), Effect.orDie),
+          ).pipe(Effect.tap(() => stamp(`model.open.${lane.label}`).pipe(Effect.orDie))),
+        ),
+      );
+
+      return {
+        agent: Agent.withModel(definition, model),
+        definitions: DefinitionDigestInput.make({
+          agent: `fairness-${lane.label}-v1`,
+          model: "scripted-v1",
+          tools: ["work-v1"],
+        }),
+        attemptLayer: ({ threadId, submissionId }: AgentAttemptContext) =>
+          toolkit.toLayer(
+            Effect.gen(function* () {
+              yield* check(threadId === lane.threadId, "Attempt resolved the wrong lane").pipe(
+                Effect.orDie,
+              );
+              // Acquisition itself cannot block: the release is registered before any hook runs.
+              yield* Effect.acquireRelease(
+                Effect.sync(() => {
+                  lane.active++;
+                  lane.maxActive = Math.max(lane.maxActive, lane.active);
+                  activeAttempts++;
+                  attemptsOpened++;
+                  maxAttempts = Math.max(maxAttempts, activeAttempts);
+                }),
+                () =>
+                  Effect.gen(function* () {
+                    lane.active--;
+                    activeAttempts--;
+                    attemptsClosed++;
+                    lane.closedAt = yield* stamp(`attempt.closed.${lane.label}`);
+                  }).pipe(Effect.orDie),
+              );
+              lane.attemptAt = yield* stamp(`attempt.open.${lane.label}`).pipe(Effect.orDie);
+              lane.claimedSubmissionId = submissionId;
+              // A warm worker may claim before host.submit returns its Receipt.
+              if (lane.receipt !== undefined)
+                yield* check(
+                  lane.receipt.submissionId === submissionId,
+                  "Attempt identity mismatch",
+                ).pipe(Effect.orDie);
+
+              return {
+                fairness_work: ({ index }: { index: number }) =>
+                  Effect.acquireUseRelease(
+                    Effect.sync(() => {
+                      lane.toolCalls++;
+                      activeTools++;
+                      toolsOpened++;
+                      maxTools = Math.max(maxTools, activeTools);
+                    }),
+                    () =>
+                      Effect.gen(function* () {
+                        yield* stamp(`tool.open.${lane.label}.${index}`);
+                        yield* Deferred.succeed(firstBusyTool, undefined);
+                        yield* Effect.sleep(100);
+
+                        return index;
+                      }),
+                    () =>
+                      Effect.gen(function* () {
+                        activeTools--;
+                        toolsClosed++;
+                        yield* stamp(`tool.closed.${lane.label}.${index}`);
+                      }).pipe(Effect.orDie),
+                  ).pipe(Effect.orDie),
+              };
+            }),
+          ),
+      };
+    });
+
+    const digests = yield* Effect.forEach(registrations, (entry) =>
+      digestDefinitions(entry.definitions),
+    ).pipe(Effect.provide(NodeCrypto.layer));
+
+    const hostLayer = NodeDurableHost.layerRegistered(registrations, {
+      filename: path.join(directory, "fairness.sqlite"),
+      deploymentId: "fairness-diagnostic",
+      producerId: "fairness-diagnostic",
+      workerConcurrency: concurrency,
+    });
+
+    const result = yield* Effect.gen(function* () {
+      const host = yield* NodeDurableHost;
+      const store = yield* ThreadStore;
+      const ledger = yield* SubmissionLedger;
+
+      const submit = Effect.fn("diagnostic.fairnessSubmit")(function* (index: number) {
+        const lane = lanes[index]!;
+
+        lane.requestAt = yield* stamp(`request.${lane.label}`);
+        if (!lane.busy) {
+          shortAdmissionActiveAttempts = activeAttempts;
+          shortAdmissionActiveTools = activeTools;
+        }
+        lane.receipt = yield* host.submit(registrations[index]!.agent, lane.input, {
+          threadId: lane.threadId,
+          principal,
+          idempotencyKey: IdempotencyKey.make(`input-${lane.label}`),
+          definitions: digests[index]!,
+        });
+        lane.acceptedAt = yield* stamp(`accepted.${lane.label}`);
+      });
+
+      yield* progress.phase("operation");
+      started = yield* Clock.monotonicTimeNanos;
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          // runResolvedWorkers already creates C workers; fork exactly one pool.
+          const worker = warmArrival
+            ? yield* host.runResolvedWorkers.pipe(Effect.forkScoped)
+            : undefined;
+
+          for (let index = 0; index < 4; index++) yield* submit(index);
+          if (warmArrival) {
+            yield* Deferred.await(firstBusyTool);
+            yield* check(activeTools > 0, "Warm short arrival missed the active busy workload");
+          }
+          yield* submit(4);
+          const pool = worker ?? (yield* host.runResolvedWorkers.pipe(Effect.forkScoped));
+
+          yield* Effect.raceFirst(
+            Effect.forEach(
+              lanes,
+              (lane) =>
+                Effect.gen(function* () {
+                  const settlement = yield* host.awaitSettlement(lane.receipt!);
+
+                  lane.observedAt = yield* stamp(`settlement.observed.${lane.label}`);
+                  yield* check(
+                    settlement.outcome === "completed",
+                    "Fairness lane did not complete",
+                  );
+                }),
+              { concurrency: 5, discard: true },
+            ),
+            Fiber.join(pool).pipe(
+              Effect.andThen(
+                Effect.fail(
+                  BenchmarkError.make({ message: "Worker pool exited before all settlements" }),
+                ),
+              ),
+            ),
+          );
+          yield* Fiber.interrupt(pool);
+        }),
+      );
+      const totalMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+      yield* progress.phase("verification");
+      yield* check(
+        attemptsOpened === 5 &&
+          attemptsClosed === 5 &&
+          activeAttempts === 0 &&
+          maxAttempts <= concurrency &&
+          toolsOpened === 16 &&
+          toolsClosed === 16 &&
+          activeTools === 0 &&
+          maxTools <= concurrency * 2 &&
+          providers === 9 &&
+          streamsClosed === providers,
+        "Fairness work, worker bounds, or resource finalizers changed",
+      );
+      for (const lane of lanes) {
+        const log = yield* store.export(ThreadExportRequest.make({ threadId: lane.threadId }));
+        const payloads = log.records.map(({ record }) => record.payload);
+
+        const inputs = payloads.filter((payload) => payload._tag === "UserInputRecorded");
+        const starts = payloads.filter((payload) => payload._tag === "RunStarted");
+        const completions = payloads.filter((payload) => payload._tag === "RunCompleted");
+        const settlements = payloads.filter((payload) => payload._tag === "SubmissionSettled");
+        const runStarted = starts[0];
+        const runCompleted = completions[0];
+        const settlement = settlements[0];
+
+        if (
+          starts.length !== 1 ||
+          completions.length !== 1 ||
+          settlements.length !== 1 ||
+          runStarted === undefined ||
+          runCompleted === undefined ||
+          settlement === undefined
+        )
+          return yield* BenchmarkError.make({
+            message:
+              "Fairness lane did not retain exactly one started/completed Run and Settlement",
+          });
+
+        const output = yield* Schema.decodeUnknownEffect(FairnessOutput)(runCompleted.output);
+        const settledOutput = yield* Schema.decodeUnknownEffect(FairnessOutput)(settlement.result);
+
+        const snapshot = yield* ledger.loadRecoverySnapshot(
+          RecoverySnapshotRequest.make({ submissionId: lane.receipt!.submissionId }),
+        );
+
+        yield* check(
+          lane.maxActive === 1 &&
+            lane.active === 0 &&
+            lane.attemptAt >= lane.requestAt &&
+            lane.providerAt >= lane.attemptAt &&
+            lane.observedAt >= lane.providerAt &&
+            lane.closedAt >= lane.attemptAt &&
+            lane.toolCalls === (lane.busy ? 4 : 0) &&
+            inputs.length === 1 &&
+            inputs[0]?.submissionId === lane.receipt!.submissionId &&
+            inputs[0]?.runId === runStarted.runId &&
+            runCompleted.runId === runStarted.runId &&
+            settlement.runId === runStarted.runId &&
+            settlement.outcome === "completed" &&
+            output.answer === lane.label &&
+            settledOutput.answer === lane.label &&
+            lane.claimedSubmissionId === lane.receipt!.submissionId &&
+            settlement.submissionId === lane.receipt!.submissionId &&
+            snapshot.ownership === undefined &&
+            snapshot.reservation?.finalized === true &&
+            snapshot.hostSubmissionId === undefined,
+          "Fairness lane identity, canonical work, finalization, or timestamp mismatch",
+        );
+      }
+
+      return {
+        totalMs,
+        metrics: lanes.flatMap((lane) => [
+          { name: `${lane.label}.admission`, value: lane.acceptedAt - lane.requestAt },
+          { name: `${lane.label}.requestToAttempt`, value: lane.attemptAt - lane.requestAt },
+          { name: `${lane.label}.requestToProvider`, value: lane.providerAt - lane.requestAt },
+          {
+            name: `${lane.label}.requestToObservedSettlement`,
+            value: lane.observedAt - lane.requestAt,
+          },
+          { name: `${lane.label}.attemptLifetime`, value: lane.closedAt - lane.attemptAt },
+          { name: `${lane.label}.settlementObservedAt`, value: lane.observedAt },
+        ]),
+        counters: [
+          { name: "maxActiveAttempts", value: maxAttempts },
+          { name: "attemptsOpened", value: attemptsOpened },
+          { name: "attemptFinalizers", value: attemptsClosed },
+          { name: "maxActiveTools", value: maxTools },
+          { name: "toolsOpened", value: toolsOpened },
+          { name: "toolFinalizers", value: toolsClosed },
+          { name: "providers", value: providers },
+          { name: "streamFinalizers", value: streamsClosed },
+          { name: "shortAdmissionActiveAttempts", value: shortAdmissionActiveAttempts },
+          { name: "shortAdmissionActiveTools", value: shortAdmissionActiveTools },
+          ...lanes.map((lane) => ({
+            name: `${lane.label}.maxActiveAttempts`,
+            value: lane.maxActive,
+          })),
+          ...lanes.map((lane) => ({
+            name: `${lane.label}.queueSequence`,
+            value: lane.receipt!.queueSequence,
+          })),
+        ],
+      } satisfies DiagnosticResult;
+    }).pipe(Effect.provide(hostLayer), Effect.scoped);
+
+    yield* check(
+      modelsOpened === 5 && modelsClosed === modelsOpened,
+      "Host model resources did not close",
+    );
+
+    return {
+      ...result,
+      counters: [
+        ...result.counters,
+        { name: "modelsOpened", value: modelsOpened },
+        { name: "modelFinalizers", value: modelsClosed },
+      ],
+    } satisfies DiagnosticResult;
+  },
+  Effect.scoped,
+  Effect.mapError((cause) => BenchmarkError.make({ message: "Fairness diagnostic failed", cause })),
+);

--- a/examples/runtime-benchmark/src/diagnostic-ledger.ts
+++ b/examples/runtime-benchmark/src/diagnostic-ledger.ts
@@ -1,0 +1,629 @@
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { AgentId, ThreadId } from "@effect-agent/core/Identifiers";
+import { ContextCompactor } from "@effect-agent/engine/ContextCompactor";
+import { NodeDurableAgentRuntime } from "@effect-agent/platform-node/NodeDurableAgentRuntime";
+import { ScriptedModel } from "@effect-agent/testing/ScriptedModel";
+import { digestJson } from "@effect-agent/thread/Digest";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import {
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ProducerId,
+  RecordEnvelope,
+  SubmissionSettledRecord,
+} from "@effect-agent/thread/Records";
+import {
+  AdmissionRequest,
+  ClaimRequest,
+  IdempotencyKey,
+  MarkReadyRequest,
+  Principal,
+  SettlementFinalization,
+  SettlementReservation,
+  SubmissionLedger,
+  submissionSettlementId,
+  submissionSettlementRecordId,
+} from "@effect-agent/thread/SubmissionLedger";
+import type { Settlement } from "@effect-agent/thread/SubmissionLedger";
+import type { SubmissionStatus } from "@effect-agent/thread/SubmissionStatus";
+import {
+  Clock,
+  Context,
+  DateTime,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Schema,
+  Stream,
+} from "effect";
+import { Agent } from "effect-agent";
+import { Model, Toolkit } from "effect/unstable/ai";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+import { CurrentTransformer, type Statement } from "effect/unstable/sql/Statement";
+
+import { BenchmarkError, check } from "./contracts.js";
+import { ledgerCases } from "./diagnostic-cases.js";
+import {
+  DiagnosticProgress,
+  type DiagnosticCase,
+  type DiagnosticResult,
+} from "./diagnostic-contracts.js";
+import {
+  nodeMonotonicNanos,
+  writerOverlap,
+  WriterOptions,
+  WriterResult,
+} from "./diagnostic-writer.js";
+
+export { ledgerCases } from "./diagnostic-cases.js";
+
+/** Test-only scheduling input; real diagnostic cases observe immediately after the go signal. */
+export const DiagnosticLedgerWaitForWriterRelease = Context.Reference(
+  "runtime-benchmark/DiagnosticLedgerWaitForWriterRelease",
+  { defaultValue: () => false },
+);
+
+const digest = Digest.make("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+const deploymentId = DeploymentId.make("ledger-diagnostic");
+const producerId = ProducerId.make("ledger-diagnostic");
+const principal = Principal.make("ledger-diagnostic");
+const seedThread = ThreadId.make("ledger-seed");
+
+const agent = Agent.make("ledger-diagnostic", {
+  input: Schema.String,
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: "Answer the question.",
+  toolkit: Toolkit.empty,
+  policy: { maxTurns: 1, maxDuration: "5 seconds" },
+});
+
+const host = (filename: string) =>
+  NodeDurableAgentRuntime.layer({ filename, deploymentId, producerId, busyTimeout: 5_000 }).pipe(
+    Layer.provide(ContextCompactor.layerRollover),
+  );
+
+const admit = Effect.fn("diagnostic.ledger.admit")(function* (index: number) {
+  const ledger = yield* SubmissionLedger;
+
+  return yield* ledger.admit(
+    AdmissionRequest.make({
+      threadId: seedThread,
+      principal,
+      idempotencyKey: IdempotencyKey.make(`seed-${index}`),
+      agentId: AgentId.make("ledger-diagnostic"),
+      agentDigests: definitions,
+      deploymentId,
+      inputPayload: "fixture",
+      inputDigest: yield* digestJson("fixture"),
+    }),
+  );
+});
+
+/** Public adapter seed, deliberately independent of canonical history size. */
+const reserve = Effect.fn("diagnostic.ledger.reserve")(function* (index: number) {
+  const ledger = yield* SubmissionLedger;
+  const admitted = yield* admit(index);
+
+  yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+  const claim = yield* ledger.claim(ClaimRequest.make({ threadId: seedThread, producerId }));
+
+  if (Option.isNone(claim))
+    return yield* BenchmarkError.make({ message: "Ledger seed claim missing" });
+  const settlementId = submissionSettlementId(admitted.submissionId);
+
+  const record = RecordEnvelope.make({
+    recordId: submissionSettlementRecordId(admitted.submissionId),
+    family: "thread",
+    schemaVersion: 1,
+    createdAt: DateTime.makeUnsafe(1),
+    deploymentId,
+    payload: yield* Schema.decodeUnknownEffect(SubmissionSettledRecord)({
+      _tag: "SubmissionSettled",
+      submissionId: admitted.submissionId,
+      receiptId: admitted.receiptId,
+      settlementId,
+      outcome: "aborted",
+    }),
+  });
+
+  yield* ledger.reserveSettlement(
+    SettlementReservation.make({
+      submissionId: admitted.submissionId,
+      ownershipToken: claim.value.ownershipToken,
+      settlementId,
+      outcome: "aborted",
+      record,
+      recordDigest: yield* digestJson(yield* Schema.encodeEffect(RecordEnvelope)(record)),
+    }),
+  );
+
+  return SettlementFinalization.make({ submissionId: admitted.submissionId, settlementId });
+});
+
+const seed = Effect.fn("diagnostic.ledger.seed")(function* (settled: number, unfinished: number) {
+  const ledger = yield* SubmissionLedger;
+  const progress = yield* DiagnosticProgress;
+
+  for (let index = 0; index < settled; index++) {
+    yield* ledger.finalizeSettlement(yield* reserve(index));
+    if (index === 0) yield* progress.mark({ name: "seed.firstSettlement.committed", elapsedMs: 0 });
+  }
+  for (let index = settled; index < settled + unfinished; index++) yield* admit(index);
+  yield* check(
+    (yield* Stream.runCollect(ledger.scanNonterminal)).length === unfinished,
+    "Seed unfinished count mismatch",
+  );
+});
+
+const makeSeeds = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "diagnostic-ledger-seeds-" });
+  const templates = new Map<string, string>();
+  let attempts = 0;
+
+  const copy = Effect.fn("diagnostic.ledger.copySeed")(function* (
+    settled: number,
+    unfinished: number,
+    destination: string,
+  ) {
+    yield* check(
+      (settled === 8192 && unfinished === 16) || (settled === 0 && unfinished === 768),
+      "Unsupported ledger seed",
+    );
+    const key = `${settled}-${unfinished}`;
+    let source = templates.get(key);
+    let seedSetupMs = 0;
+
+    if (source === undefined) {
+      // A failed initialization can leave committed rows. Never retry against that file.
+      const candidate = `${directory}/${key}-${attempts++}.sqlite`;
+      const started = yield* Clock.monotonicTimeNanos;
+
+      yield* seed(settled, unfinished).pipe(Effect.provide(host(candidate)), Effect.scoped);
+      yield* check(
+        !(yield* fs.exists(`${candidate}-wal`)) && !(yield* fs.exists(`${candidate}-shm`)),
+        "Ledger template still owns SQLite sidecars",
+      );
+      seedSetupMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+      templates.set(key, candidate);
+      source = candidate;
+    }
+    yield* fs.copyFile(source, destination);
+
+    return seedSetupMs;
+  });
+
+  return { copy };
+});
+
+/** Provide once around the worker, not around each sample. Only closed database files are reused. */
+export class DiagnosticLedgerSeeds extends Context.Service<
+  DiagnosticLedgerSeeds,
+  Effect.Success<typeof makeSeeds>
+>()("runtime-benchmark/DiagnosticLedgerSeeds") {
+  static readonly layer = Layer.effect(DiagnosticLedgerSeeds, makeSeeds);
+}
+
+type Query = ReturnType<Statement<unknown>["compile"]>;
+
+const inspectQueries = Effect.fn("diagnostic.ledger.inspectQueries")(function* (
+  queries: ReadonlyArray<Query>,
+  started: bigint,
+) {
+  const sql = yield* SqlClient;
+  const progress = yield* DiagnosticProgress;
+  let indexedPlans = 0;
+  let searchedPlans = 0;
+  let sortedPlans = 0;
+
+  for (const [index, [query, parameters]] of queries.entries()) {
+    if (!query.includes("queue_sequence") || !query.includes("LIMIT")) continue;
+    const plans = yield* sql.unsafe<{ detail: string }>(`EXPLAIN QUERY PLAN ${query}`, parameters);
+
+    for (const [part, { detail }] of plans.entries()) {
+      indexedPlans += Number(detail.includes("effect_agent_submissions_nonterminal"));
+      searchedPlans += Number(detail.includes("SEARCH"));
+      sortedPlans += Number(detail.includes("TEMP B-TREE"));
+      for (let offset = 0; offset < detail.length; offset += 64)
+        yield* progress.mark({
+          name: `plan.${index}.${part}.${offset}.${detail.slice(offset, offset + 64)}`,
+          elapsedMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+        });
+    }
+  }
+
+  // Statement transformation observes adapter work, not the driver's BEGIN/COMMIT commands.
+  return [
+    { name: "sqlStatements", value: queries.length },
+    {
+      name: "sqlWriteStatements",
+      value: queries.filter(([query]) => /^\s*(INSERT|UPDATE|DELETE)/i.test(query)).length,
+    },
+    { name: "indexedPlans", value: indexedPlans },
+    { name: "searchedPlans", value: searchedPlans },
+    { name: "sortedPlans", value: sortedPlans },
+  ];
+});
+
+const scanCase = Effect.fn("diagnostic.ledger.scan")(function* (
+  workload: DiagnosticCase,
+  setupStarted: bigint,
+  seedSetupMs: number,
+) {
+  const progress = yield* DiagnosticProgress;
+  const ledger = yield* SubmissionLedger;
+  const queries: Array<Query> = [];
+  const setupMs = Number((yield* Clock.monotonicTimeNanos) - setupStarted) / 1e6;
+
+  yield* progress.phase("operation");
+  const started = yield* Clock.monotonicTimeNanos;
+
+  const rows = yield* Stream.runCollect(ledger.scanNonterminal).pipe(
+    Effect.provideService(CurrentTransformer, (statement) =>
+      Effect.sync(() => {
+        queries.push(statement.compile());
+
+        return statement;
+      }),
+    ),
+  );
+
+  const totalMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+  yield* progress.phase("verification");
+  yield* check(
+    rows.length === workload.parameters.unfinished &&
+      rows.every(
+        (row, index) =>
+          row.threadId === seedThread &&
+          row.queueSequence === (workload.parameters.settled ?? 0) + index + 1,
+      ),
+    "Scan lost FIFO rows or included settled rows",
+  );
+
+  return {
+    totalMs,
+    metrics: [
+      { name: "scanNonterminal", value: totalMs },
+      { name: "setup", value: setupMs },
+      { name: "seedSetup", value: seedSetupMs },
+    ],
+    counters: [
+      { name: "unfinished", value: rows.length },
+      { name: "settled", value: workload.parameters.settled ?? 0 },
+      ...(yield* inspectQueries(queries, started)),
+    ],
+  } satisfies DiagnosticResult;
+});
+
+const settledCase = Effect.fn("diagnostic.ledger.settled")(function* (
+  workload: DiagnosticCase,
+  filename: string,
+  setupStarted: bigint,
+) {
+  const progress = yield* DiagnosticProgress;
+  const ledger = yield* SubmissionLedger;
+  const runtime = yield* DurableAgentRuntime;
+  const fs = yield* FileSystem.FileSystem;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const mode = workload.parameters.mode;
+  let request: SettlementFinalization;
+  let modelCalls = 0;
+  let modelFinalizers = 0;
+
+  const model = ScriptedModel.layer([
+    {
+      _tag: "Stream",
+      termination: { _tag: "Complete" },
+      parts: [
+        { type: "text-start", id: "answer" },
+        { type: "text-delta", id: "answer", delta: '{"answer":"done"}' },
+        { type: "text-end", id: "answer" },
+        { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+      ],
+      assertRequest: () =>
+        Effect.sync(() => {
+          modelCalls++;
+        }),
+      onStreamFinalize: Effect.sync(() => {
+        modelFinalizers++;
+      }),
+    },
+  ]).pipe(
+    Layer.provideMerge(
+      Layer.mergeAll(
+        Layer.succeed(Model.ProviderName, "scripted"),
+        Layer.succeed(Model.ModelName, "ledger-diagnostic"),
+      ),
+    ),
+  );
+
+  const receipt =
+    mode === 1
+      ? undefined
+      : yield* Effect.gen(function* () {
+          const receipt = yield* runtime.submit({ definition: agent }, "Answer", {
+            threadId: ThreadId.make("healthy"),
+            principal,
+            idempotencyKey: IdempotencyKey.make("healthy"),
+            definitions,
+          });
+
+          yield* runtime.processThread({ definition: agent, model }, receipt.threadId);
+
+          return receipt;
+        });
+
+  if (receipt === undefined) request = yield* reserve(0);
+  else
+    request = SettlementFinalization.make({
+      submissionId: receipt.submissionId,
+      settlementId: submissionSettlementId(receipt.submissionId),
+    });
+  const original = receipt === undefined ? undefined : yield* runtime.awaitSettlement(receipt);
+
+  yield* check(
+    original === undefined || original.outcome === "completed",
+    "Runtime seed did not settle",
+  );
+  yield* check(
+    modelCalls === (mode === 1 ? 0 : 1) && modelFinalizers === modelCalls,
+    "Runtime seed model work or finalization mismatch",
+  );
+  const holdMs = workload.parameters.holdMs ?? -1;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "diagnostic-ledger-writer-" });
+  let writer: ChildProcessSpawner.ChildProcessHandle | undefined;
+  let operationStarted = 0n;
+
+  yield* Effect.addFinalizer(() =>
+    Effect.gen(function* () {
+      if (writer === undefined) return;
+      yield* check(!(yield* writer.isRunning), "External writer survived its Scope");
+      yield* progress.mark({
+        name: "writer.scope.closed",
+        elapsedMs:
+          operationStarted === 0n
+            ? 0
+            : Number((yield* Clock.monotonicTimeNanos) - operationStarted) / 1e6,
+      });
+    }).pipe(Effect.orDie),
+  );
+  if (holdMs >= 0) {
+    const options = yield* Schema.decodeUnknownEffect(WriterOptions)({
+      filename,
+      directory,
+      holdMs,
+    });
+
+    writer = yield* spawner.spawn(
+      ChildProcess.make(
+        process.execPath,
+        [
+          fileURLToPath(
+            new URL(
+              import.meta.url.endsWith(".ts") ? "./diagnostic-writer.ts" : "./diagnostic-writer.js",
+              import.meta.url,
+            ),
+          ),
+        ],
+        {
+          env: {
+            RUNTIME_DIAGNOSTIC_WRITER: yield* Schema.encodeEffect(
+              Schema.fromJsonString(WriterOptions),
+            )(options),
+            NODE_NO_WARNINGS: "1",
+          },
+          extendEnv: true,
+          stdin: "ignore",
+          stdout: "ignore",
+          stderr: "pipe",
+        },
+      ),
+    );
+  }
+  if (writer !== undefined) {
+    const activeWriter = writer;
+
+    yield* Effect.gen(function* () {
+      while (!(yield* fs.exists(`${directory}/ready`))) {
+        if (!(yield* activeWriter.isRunning)) {
+          const stderr = yield* activeWriter.stderr.pipe(Stream.decodeText(), Stream.mkString);
+
+          return yield* BenchmarkError.make({
+            message: `External SQLite writer exited before acquiring lock: ${stderr}`,
+          });
+        }
+        yield* Effect.sleep("1 millis");
+      }
+    }).pipe(Effect.timeout("5 seconds"));
+    yield* progress.mark({ name: "writer.acquired", elapsedMs: 0 });
+  }
+  const setupMs = Number((yield* Clock.monotonicTimeNanos) - setupStarted) / 1e6;
+
+  yield* progress.phase("operation");
+  if (writer !== undefined) yield* fs.writeFileString(`${directory}/go`, "go");
+  if (writer !== undefined && (yield* DiagnosticLedgerWaitForWriterRelease)) yield* writer.exitCode;
+  const queries: Array<Query> = [];
+  const durations: Array<number> = [];
+  const observations: Array<Settlement | SubmissionStatus> = [];
+
+  const observerIntervals: Array<{
+    readonly startedNanos: bigint;
+    readonly finishedNanos: bigint;
+  }> = [];
+
+  const started = yield* Clock.monotonicTimeNanos;
+
+  operationStarted = started;
+
+  for (let index = 0; index < (workload.parameters.repeats ?? 1); index++) {
+    const callStarted = yield* Clock.monotonicTimeNanos;
+    const startedNanos = yield* nodeMonotonicNanos;
+
+    const observation = yield* Effect.gen(function* () {
+      return mode === 3 && receipt !== undefined
+        ? yield* runtime.submissionStatus(receipt)
+        : yield* ledger.finalizeSettlement(request);
+    }).pipe(
+      Effect.provideService(CurrentTransformer, (statement) =>
+        Effect.sync(() => {
+          queries.push(statement.compile());
+
+          return statement;
+        }),
+      ),
+    );
+
+    const finishedNanos = yield* nodeMonotonicNanos;
+
+    durations.push(Number((yield* Clock.monotonicTimeNanos) - callStarted) / 1e6);
+    observerIntervals.push({ startedNanos, finishedNanos });
+    observations.push(observation);
+  }
+  const totalMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+  yield* progress.phase("verification");
+  for (const observation of observations) {
+    if ("_tag" in observation && observation._tag !== "settled")
+      return yield* BenchmarkError.make({ message: "Settled runtime observation became pending" });
+    const settlement = "_tag" in observation ? observation.settlement : observation;
+
+    yield* check(
+      settlement.submissionId === request.submissionId &&
+        settlement.settlementId === request.settlementId &&
+        settlement.outcome === (mode === 1 ? "aborted" : "completed") &&
+        (original === undefined ||
+          (settlement.receiptId === original.receiptId &&
+            DateTime.toEpochMillis(settlement.settledAt) ===
+              DateTime.toEpochMillis(original.settledAt))),
+      "Observation changed authoritative settlement",
+    );
+  }
+  let heldMs = 0;
+  let lockMs = 0;
+  let overlapMs = 0;
+  let observationsWithWriterOverlap = 0;
+  let observationsStartingWithWriter = 0;
+  let observationsFinishedWhileHeld = 0;
+
+  if (writer !== undefined) {
+    const stderr = yield* writer.stderr.pipe(Stream.decodeText(), Stream.mkString);
+
+    yield* check((yield* writer.exitCode) === 0, `External SQLite writer failed: ${stderr}`);
+
+    const result = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WriterResult))(
+      yield* fs.readFileString(`${directory}/result.json`),
+    );
+
+    heldMs = result.heldMs;
+    lockMs = result.lockMs;
+
+    // Exact timestamps remain available even when the requested hold window missed the call.
+    const rawBoundaries = [
+      ["writer.acquired", result.acquiredNanos],
+      ["writer.releaseStarted", result.releaseStartedNanos],
+      ["writer.released", result.releasedNanos],
+      ...observerIntervals.flatMap(
+        (interval, index) =>
+          [
+            [`observer.${index}.started`, interval.startedNanos],
+            [`observer.${index}.finished`, interval.finishedNanos],
+          ] as const,
+      ),
+    ] as const;
+
+    for (const [boundary, nanos] of rawBoundaries)
+      yield* progress.mark({
+        name: `node-hrtime.${boundary}.${nanos}`,
+        elapsedMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+      });
+    for (const interval of observerIntervals) {
+      const overlap = writerOverlap(result, interval);
+
+      overlapMs += overlap.overlapMs;
+      observationsWithWriterOverlap += Number(overlap.overlapMs > 0);
+      observationsStartingWithWriter += Number(overlap.heldAtStart);
+      observationsFinishedWhileHeld += Number(overlap.finishedWhileHeld);
+    }
+    yield* check(!(yield* writer.isRunning), "External writer remains running");
+    yield* progress.mark({
+      name: "writer.closed",
+      elapsedMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+    });
+  }
+  // A real subsequent write proves release, outside the observation clock.
+  yield* admit(1);
+
+  return {
+    totalMs,
+    metrics: [
+      { name: "setup", value: setupMs },
+      { name: "writerHold", value: heldMs },
+      { name: "writerLock", value: lockMs },
+      { name: "writerObserverOverlap", value: overlapMs },
+      ...durations.map((value, index) => ({ name: `observation.${index}`, value })),
+    ],
+    counters: [
+      { name: "observations", value: durations.length },
+      { name: "writers", value: Number(writer !== undefined) },
+      { name: "observationsWithWriterOverlap", value: observationsWithWriterOverlap },
+      { name: "observationsStartingWithWriter", value: observationsStartingWithWriter },
+      { name: "observationsFinishedWhileHeld", value: observationsFinishedWhileHeld },
+      {
+        name: "noWriterOverlap",
+        value: Number(writer !== undefined && observationsWithWriterOverlap === 0),
+      },
+      { name: "seedModelCalls", value: modelCalls },
+      { name: "seedModelFinalizers", value: modelFinalizers },
+      ...(yield* inspectQueries(queries, started)),
+    ],
+  } satisfies DiagnosticResult;
+});
+
+export const runLedgerCase = Effect.fn("diagnostic.runLedgerCase")(function* (
+  workload: DiagnosticCase,
+) {
+  const expected = ledgerCases.find(({ name }) => name === workload.name);
+
+  yield* check(
+    expected !== undefined &&
+      workload.family === "ledger" &&
+      Object.keys(expected.parameters).length === Object.keys(workload.parameters).length &&
+      Object.entries(expected.parameters).every(
+        ([key, value]) => workload.parameters[key] === value,
+      ),
+    "Unknown or modified ledger diagnostic case",
+  );
+  const progress = yield* DiagnosticProgress;
+  const fs = yield* FileSystem.FileSystem;
+  const seeds = yield* DiagnosticLedgerSeeds;
+
+  yield* progress.phase("setup");
+  const setupStarted = yield* Clock.monotonicTimeNanos;
+
+  return yield* Effect.gen(function* () {
+    const directory = yield* fs.makeTempDirectoryScoped({ prefix: "diagnostic-ledger-sample-" });
+    const filename = `${directory}/thread.sqlite`;
+
+    const seedSetupMs =
+      workload.parameters.mode === 0
+        ? yield* seeds.copy(
+            workload.parameters.settled ?? 0,
+            workload.parameters.unfinished ?? 0,
+            filename,
+          )
+        : 0;
+
+    return yield* (
+      workload.parameters.mode === 0
+        ? scanCase(workload, setupStarted, seedSetupMs)
+        : settledCase(workload, filename, setupStarted)
+    ).pipe(Effect.provide(host(filename)));
+  }).pipe(Effect.scoped);
+});

--- a/examples/runtime-benchmark/src/diagnostic-policy.ts
+++ b/examples/runtime-benchmark/src/diagnostic-policy.ts
@@ -1,0 +1,407 @@
+import { ModelCallContext } from "@effect-agent/engine/ContextWindow";
+import { RunContextPreparation, RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import {
+  ScriptedModel,
+  type ScriptedTurnInput,
+  type ScriptedStreamPart,
+} from "@effect-agent/testing/ScriptedModel";
+import { Clock, Context, Effect, Layer, Schema } from "effect";
+import { Agent, AgentRuntime } from "effect-agent";
+import { IdGenerator } from "effect-agent/IdGenerator";
+import { ThreadHistory } from "effect-agent/ThreadHistory";
+import { AiError, type LanguageModel, Model, Tool, Toolkit } from "effect/unstable/ai";
+
+import { BenchmarkError, check } from "./contracts.js";
+import { policyCases } from "./diagnostic-cases.js";
+import {
+  DiagnosticProgress,
+  type DiagnosticCase,
+  type DiagnosticResult,
+} from "./diagnostic-contracts.js";
+
+export { policyCases } from "./diagnostic-cases.js";
+
+const parameters = Schema.Struct({ index: Schema.Natural });
+
+const work = Tool.make("diagnostic_work", {
+  parameters,
+  success: Schema.Natural,
+  needsApproval: true,
+});
+
+const toolkit = Toolkit.make(work);
+
+const definition = Agent.make("diagnostic-policy", {
+  input: Schema.String,
+  output: Schema.Struct({ answer: Schema.String }),
+  instructions: "Perform the declared work and answer.",
+  toolkit,
+  policy: { maxTurns: 6, maxToolCalls: 32, maxDuration: "20 seconds", toolConcurrency: 4 },
+});
+
+const context = ModelCallContext.make({
+  contextCapacity: 100_000,
+  outputReserveTokens: 1_000,
+  uncountedOverheadTokens: 0,
+});
+
+const delay = (milliseconds: number) =>
+  milliseconds === 0 ? Effect.void : Effect.sleep(milliseconds);
+
+/** Controlled public hook delays diagnose scheduling; they are not provider latency estimates. */
+export const runPolicyCase = Effect.fn("diagnostic.policy")(function* (workload: DiagnosticCase) {
+  const selected = policyCases.find((candidate) => candidate.name === workload.name);
+
+  if (selected === undefined || workload.family !== "policy")
+    return yield* BenchmarkError.make({ message: "Unknown policy diagnostic case" });
+  yield* check(
+    Object.keys(workload.parameters).length === Object.keys(selected.parameters).length &&
+      Object.entries(selected.parameters).every(
+        ([key, value]) => workload.parameters[key] === value,
+      ),
+    "Policy diagnostic parameters differ from the named fixture",
+  );
+  const rounds = selected.parameters.rounds ?? 0;
+  const authorizationMs = selected.parameters.authorizationMs ?? 0;
+  const modelAcquisitionMs = selected.parameters.modelAcquisitionMs ?? 0;
+  const progress = yield* DiagnosticProgress;
+
+  yield* progress.phase("setup");
+  let started = 0n;
+  let providers = 0;
+  let streamsClosed = 0;
+  let approvals = 0;
+  let authorizations = 0;
+  let authorizationFinalizers = 0;
+  let activeAuthorizations = 0;
+  let handlers = 0;
+  let handlerFinalizers = 0;
+  let activeHandlers = 0;
+  let maxHandlers = 0;
+  let modelsOpened = 0;
+  let modelsReady = 0;
+  let modelsClosed = 0;
+  let activeModels = 0;
+  let preparationMs = 0;
+  let acquisitionMs = 0;
+  let authorizationSumMs = 0;
+  let waitMaxMs = 0;
+  let firstProviderMs = 0;
+  const authorizedAt = new Map<number, number>();
+  const authorizationPhases = Array.from({ length: rounds }, () => ({ start: -1, end: 0 }));
+  const handlerPhases = Array.from({ length: rounds }, () => ({ start: -1, end: 0 }));
+
+  const stamp = Effect.fn("diagnostic.policyMark")(function* (name: string) {
+    const evidence = yield* DiagnosticProgress;
+    const elapsedMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+    yield* evidence.mark({ name, elapsedMs });
+
+    return elapsedMs;
+  });
+
+  const modelAndHandlers = Layer.unwrap(
+    Effect.gen(function* () {
+      const evidence = yield* DiagnosticProgress;
+
+      const parts = (turn: number): ReadonlyArray<ScriptedStreamPart> =>
+        turn < rounds
+          ? [
+              ...Array.from({ length: 8 }, (_, index) => ({
+                type: "tool-call" as const,
+                id: `call-${turn * 8 + index}`,
+                name: "diagnostic_work",
+                params: { index: turn * 8 + index },
+                providerExecuted: false,
+              })),
+              {
+                type: "finish",
+                reason: "tool-calls",
+                usage: { inputTokens: {}, outputTokens: {} },
+              },
+            ]
+          : [
+              { type: "text-start", id: "answer" },
+              { type: "text-delta", id: "answer", delta: '{"answer":"done"}' },
+              { type: "text-end", id: "answer" },
+              { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+            ];
+
+      const turns: ReadonlyArray<ScriptedTurnInput> = Array.from(
+        { length: rounds + 1 },
+        (_, turn) => ({
+          _tag: "Stream",
+          parts: parts(turn),
+          termination: { _tag: "Complete" },
+          assertRequest: (request) =>
+            Effect.gen(function* () {
+              const at = yield* stamp(`provider:${turn + 1}`);
+
+              if (providers === 0) firstProviderMs = at;
+              providers++;
+              yield* check(
+                modelsReady === turn + 1 && activeModels === 1,
+                "Provider entered before its model was ready",
+              );
+
+              const results = request.prompt.content
+                .filter((message) => message.role === "tool")
+                .flatMap((message) => message.content)
+                .filter((part) => part.type === "tool-result");
+
+              yield* check(
+                results.length === turn * 8 &&
+                  results.every(
+                    (part, index) =>
+                      !part.isFailure && part.id === `call-${index}` && part.result === index,
+                  ),
+                "Provider lost, reordered, or duplicated successful tool results",
+              );
+            }).pipe(
+              Effect.provideService(DiagnosticProgress, evidence),
+              Effect.mapError((cause) =>
+                AiError.AiError.make({
+                  module: "runtime-diagnostics",
+                  method: "policy.assertRequest",
+                  reason: AiError.UnknownError.make({ description: cause.message }),
+                }),
+              ),
+            ),
+          onStreamFinalize: Effect.sync(() => {
+            streamsClosed++;
+          }),
+        }),
+      );
+
+      const handlersLayer = toolkit.toLayer({
+        diagnostic_work: ({ index }) =>
+          Effect.acquireUseRelease(
+            Effect.gen(function* () {
+              const round = Math.floor(index / 8);
+
+              yield* check(
+                authorizationFinalizers === (round + 1) * 8 &&
+                  approvals === (round + 1) * 8 &&
+                  activeAuthorizations === 0,
+                "A handler started before the complete batch was approved and authorized",
+              );
+              const at = yield* stamp(`handler:start:${index}`);
+              const authorized = authorizedAt.get(index);
+
+              yield* check(authorized !== undefined, "Handler lacked successful authorization");
+              waitMaxMs = Math.max(waitMaxMs, at - (authorized ?? at));
+              const phase = handlerPhases[round];
+
+              if (phase !== undefined && phase.start < 0) phase.start = at;
+              handlers++;
+              activeHandlers++;
+              maxHandlers = Math.max(maxHandlers, activeHandlers);
+            }),
+            () => Effect.sleep(20).pipe(Effect.as(index)),
+            () =>
+              Effect.gen(function* () {
+                activeHandlers--;
+                handlerFinalizers++;
+                const phase = handlerPhases[Math.floor(index / 8)];
+                const at = yield* stamp(`handler:end:${index}`);
+
+                if (phase !== undefined) phase.end = at;
+              }).pipe(Effect.orDie),
+          ).pipe(Effect.provideService(DiagnosticProgress, evidence), Effect.orDie),
+      });
+
+      return Layer.mergeAll(
+        ScriptedModel.layer(turns),
+        handlersLayer,
+        Layer.succeed(Model.ProviderName, "scripted"),
+        Layer.succeed(Model.ModelName, "diagnostic-policy"),
+      );
+    }),
+  );
+
+  const hooks = Layer.effectContext(
+    Effect.gen(function* () {
+      const evidence = yield* DiagnosticProgress;
+
+      const captured = Layer.succeedContext(
+        yield* Effect.context<LanguageModel.LanguageModel | Model.ProviderName | Model.ModelName>(),
+      );
+
+      const preparation = RunContextPreparation.of({
+        hook: {
+          prepare: (request) =>
+            Effect.gen(function* () {
+              const before = yield* stamp(`prepare:start:${request.turn}`);
+
+              yield* check(
+                activeModels === 0 && modelsClosed === request.turn - 1,
+                "Previous model layer did not close before preparation",
+              );
+
+              const acquisition = Layer.effectDiscard(
+                Effect.gen(function* () {
+                  yield* Effect.acquireRelease(
+                    Effect.sync(() => {
+                      modelsOpened++;
+                      activeModels++;
+                    }),
+                    () =>
+                      Effect.gen(function* () {
+                        activeModels--;
+                        modelsClosed++;
+                        yield* stamp(`model:close:${request.turn}`);
+                      }).pipe(Effect.orDie),
+                  );
+                  const opened = yield* stamp(`model:open:${request.turn}`);
+
+                  yield* delay(modelAcquisitionMs);
+                  modelsReady++;
+                  acquisitionMs += (yield* stamp(`model:ready:${request.turn}`)) - opened;
+                }).pipe(Effect.provideService(DiagnosticProgress, evidence), Effect.orDie),
+              );
+
+              preparationMs += (yield* stamp(`prepare:end:${request.turn}`)) - before;
+
+              return {
+                prompt: request.source,
+                modelCall: { model: Layer.merge(captured, acquisition), context },
+              };
+            }).pipe(Effect.provideService(DiagnosticProgress, evidence), Effect.orDie),
+        },
+      });
+
+      const authorization = RunToolAuthorization.of({
+        authorize: (request) =>
+          Effect.acquireUseRelease(
+            Effect.gen(function* () {
+              const decoded = yield* Schema.decodeUnknownEffect(parameters)(
+                request.call.parameters,
+              );
+
+              yield* check(
+                decoded.index === authorizations &&
+                  approvals === (Math.floor(decoded.index / 8) + 1) * 8 &&
+                  activeAuthorizations === 0 &&
+                  authorizations === authorizationFinalizers,
+                "Authorization Effects did not run and finalize in declaration order",
+              );
+              authorizations++;
+              activeAuthorizations++;
+              const at = yield* stamp(`authorize:start:${decoded.index}`);
+              const phase = authorizationPhases[Math.floor(decoded.index / 8)];
+
+              if (phase !== undefined && phase.start < 0) phase.start = at;
+
+              return { index: decoded.index, at };
+            }),
+            () => delay(authorizationMs).pipe(Effect.as({ _tag: "allowed" as const })),
+            ({ index, at }) =>
+              Effect.gen(function* () {
+                activeAuthorizations--;
+                authorizationFinalizers++;
+                const ended = yield* stamp(`authorize:end:${index}`);
+
+                authorizationSumMs += ended - at;
+                authorizedAt.set(index, ended);
+                const phase = authorizationPhases[Math.floor(index / 8)];
+
+                if (phase !== undefined) phase.end = ended;
+              }).pipe(Effect.orDie),
+          ).pipe(Effect.provideService(DiagnosticProgress, evidence), Effect.orDie),
+      });
+
+      return Context.make(RunContextPreparation, preparation).pipe(
+        Context.add(RunToolAuthorization, authorization),
+      );
+    }),
+  );
+
+  const app = hooks.pipe(
+    Layer.provideMerge(modelAndHandlers),
+    Layer.provideMerge(Layer.merge(IdGenerator.layer, ThreadHistory.layerTransient)),
+  );
+
+  return yield* Effect.gen(function* () {
+    const scripted = yield* ScriptedModel;
+
+    yield* progress.phase("operation");
+    started = yield* Clock.monotonicTimeNanos;
+
+    const result = yield* AgentRuntime.run(definition, "Do the work", {
+      approval: {
+        request: () =>
+          Effect.sync(() => {
+            approvals++;
+
+            return { _tag: "approved" as const };
+          }),
+      },
+    });
+
+    const totalMs = Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+    yield* progress.phase("verification");
+    yield* scripted.assertExhausted;
+    yield* check(
+      result.output.answer === "done" && result.turns === rounds + 1,
+      "Policy run did not return the expected answer/turn count",
+    );
+    yield* check(
+      providers === rounds + 1 &&
+        streamsClosed === providers &&
+        modelsOpened === providers &&
+        modelsReady === providers &&
+        modelsClosed === providers &&
+        activeModels === 0,
+      "Policy model call or finalizer counts changed",
+    );
+    yield* check(
+      approvals === rounds * 8 &&
+        authorizations === approvals &&
+        authorizationFinalizers === approvals &&
+        handlers === approvals &&
+        handlerFinalizers === approvals &&
+        activeHandlers === 0 &&
+        activeAuthorizations === 0 &&
+        maxHandlers > 1 &&
+        maxHandlers <= 4,
+      "Policy authorization, handler, concurrency, or finalizer counts changed",
+    );
+
+    return {
+      totalMs,
+      metrics: [
+        { name: "firstProvider", value: firstProviderMs },
+        { name: "preparationSum", value: preparationMs },
+        { name: "modelAcquisitionSum", value: acquisitionMs },
+        { name: "authorizationSum", value: authorizationSumMs },
+        {
+          name: "authorizationPhasesSum",
+          value: authorizationPhases.reduce((sum, phase) => sum + phase.end - phase.start, 0),
+        },
+        {
+          name: "handlerPhasesSum",
+          value: handlerPhases.reduce((sum, phase) => sum + phase.end - phase.start, 0),
+        },
+        { name: "postAuthorizationWaitMax", value: waitMaxMs },
+      ],
+      counters: [
+        { name: "providers", value: providers },
+        { name: "streamFinalizers", value: streamsClosed },
+        { name: "approvals", value: approvals },
+        { name: "authorizations", value: authorizations },
+        { name: "authorizationFinalizers", value: authorizationFinalizers },
+        { name: "handlers", value: handlers },
+        { name: "handlerFinalizers", value: handlerFinalizers },
+        { name: "maxConcurrentHandlers", value: maxHandlers },
+        { name: "modelsOpened", value: modelsOpened },
+        { name: "modelsReady", value: modelsReady },
+        { name: "modelsClosed", value: modelsClosed },
+      ],
+    } satisfies DiagnosticResult;
+  }).pipe(
+    Effect.provide(app),
+    Effect.scoped,
+    Effect.mapError((cause) => BenchmarkError.make({ message: "Policy diagnostic failed", cause })),
+  );
+});

--- a/examples/runtime-benchmark/src/diagnostic-worker.ts
+++ b/examples/runtime-benchmark/src/diagnostic-worker.ts
@@ -1,0 +1,195 @@
+import process from "node:process";
+
+import { NodeCrypto, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Cause, Clock, Config, Context, Effect, Exit, FileSystem, Layer, Schema } from "effect";
+
+import { BenchmarkError, check } from "./contracts.js";
+import { runCapabilityCase } from "./diagnostic-capabilities.js";
+import { diagnosticCases } from "./diagnostic-cases.js";
+import {
+  completeDiagnosticBatch,
+  DIAGNOSTIC_VERSION,
+  DiagnosticCase,
+  DiagnosticMark,
+  DiagnosticProgress,
+  DiagnosticResult,
+  DiagnosticWorkerOptions,
+  DiagnosticWorkerReport,
+  MAX_DIAGNOSTIC_MARKS,
+  type DiagnosticActive,
+  type DiagnosticSample,
+} from "./diagnostic-contracts.js";
+import { runFairnessCase } from "./diagnostic-fairness.js";
+import { DiagnosticLedgerSeeds, runLedgerCase } from "./diagnostic-ledger.js";
+import { runPolicyCase } from "./diagnostic-policy.js";
+import { writeEvidence } from "./evidence.js";
+
+export { diagnosticCases } from "./diagnostic-cases.js";
+
+const runDiagnosticCase = Effect.fn("diagnostic.runCase")(function* (workload: DiagnosticCase) {
+  if (workload.family === "policy") return yield* runPolicyCase(workload);
+  if (workload.family === "ledger") return yield* runLedgerCase(workload);
+  if (workload.family === "fairness") return yield* runFairnessCase(workload);
+
+  return yield* runCapabilityCase(workload);
+});
+
+export class DiagnosticRunner extends Context.Service<
+  DiagnosticRunner,
+  { readonly run: typeof runDiagnosticCase }
+>()("runtime-benchmark/DiagnosticRunner") {
+  static readonly layer = Layer.succeed(DiagnosticRunner, { run: runDiagnosticCase });
+}
+
+export const runDiagnosticWorker = Effect.fn("diagnostic.runWorker")(function* (
+  options: DiagnosticWorkerOptions,
+) {
+  const runner = yield* DiagnosticRunner;
+  const samples: Array<DiagnosticSample> = [];
+  let active: DiagnosticActive | null = null;
+  let failure: string | null = null;
+
+  const report = (): DiagnosticWorkerReport => ({
+    fixture: DIAGNOSTIC_VERSION,
+    runtime: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    active,
+    failure,
+    samples,
+  });
+
+  const persist = Effect.gen(function* () {
+    yield* writeEvidence(
+      options.output,
+      yield* Schema.encodeEffect(Schema.fromJsonString(DiagnosticWorkerReport))(report()),
+    );
+  }).pipe(
+    Effect.mapError((cause) =>
+      BenchmarkError.make({ message: "Cannot persist diagnostic evidence", cause }),
+    ),
+  );
+
+  yield* Effect.gen(function* () {
+    yield* persist;
+    yield* Schema.decodeUnknownEffect(Schema.Array(DiagnosticCase).check(Schema.isMaxLength(64)))(
+      diagnosticCases,
+    );
+    yield* check(
+      new Set(diagnosticCases.map(({ name }) => name)).size === diagnosticCases.length,
+      "Diagnostic case names must be unique",
+    );
+
+    for (let ordinal = 0; ordinal < options.warmups + options.samples; ordinal++) {
+      const ordered = ordinal % 2 === 0 ? diagnosticCases : [...diagnosticCases].reverse();
+
+      for (const workload of ordered) {
+        const started = yield* Clock.monotonicTimeNanos;
+        const marks: Array<DiagnosticMark> = [];
+
+        active = {
+          case: workload.name,
+          ordinal,
+          warmup: ordinal < options.warmups,
+          phase: "setup",
+          elapsedMs: 0,
+          marks,
+        };
+        yield* persist;
+
+        // Each sample's evidence service owns its bounded mark buffer and phase persistence.
+        const progressLayer = Layer.effect(
+          DiagnosticProgress,
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+
+            return DiagnosticProgress.of({
+              phase: Effect.fn("diagnostic.phase")(function* (phase) {
+                active = {
+                  case: workload.name,
+                  ordinal,
+                  warmup: ordinal < options.warmups,
+                  phase,
+                  elapsedMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+                  marks,
+                };
+                yield* persist.pipe(Effect.provideService(FileSystem.FileSystem, fs));
+              }),
+              mark: Effect.fn("diagnostic.mark")(function* (mark) {
+                yield* check(
+                  marks.length < MAX_DIAGNOSTIC_MARKS,
+                  "Diagnostic phase mark limit exceeded",
+                );
+
+                const validated = yield* Schema.decodeUnknownEffect(DiagnosticMark)(mark).pipe(
+                  Effect.mapError((cause) =>
+                    BenchmarkError.make({ message: "Invalid diagnostic mark", cause }),
+                  ),
+                );
+
+                marks.push(validated);
+              }),
+            });
+          }),
+        );
+
+        yield* Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const result = yield* restore(
+              runner
+                .run(workload)
+                .pipe(
+                  Effect.flatMap(Schema.decodeUnknownEffect(DiagnosticResult)),
+                  Effect.provide(progressLayer),
+                  Effect.timeout(options.timeoutMs),
+                ),
+            ).pipe(Effect.exit);
+
+            samples.push({
+              case: workload.name,
+              ordinal,
+              warmup: ordinal < options.warmups,
+              attemptMs: Number((yield* Clock.monotonicTimeNanos) - started) / 1e6,
+              phase: active?.phase ?? "setup",
+              result: Exit.isSuccess(result) ? result.value : null,
+              marks,
+              status: Exit.isSuccess(result) ? "passed" : "failed",
+              failure: Exit.isFailure(result) ? Cause.pretty(result.cause).slice(0, 8_192) : null,
+            });
+            active = null;
+            yield* persist;
+            if (Exit.isFailure(result) && Cause.hasInterrupts(result.cause))
+              return yield* Effect.failCause(result.cause);
+          }),
+        );
+      }
+    }
+    yield* check(
+      completeDiagnosticBatch(report(), options, diagnosticCases),
+      "Diagnostic correctness failed; inspect retained samples",
+    );
+  }).pipe(
+    Effect.onExit((exit) => {
+      if (Exit.isFailure(exit)) failure = Cause.pretty(exit.cause).slice(0, 8_192);
+
+      return persist;
+    }),
+  );
+});
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Effect.gen(function* () {
+      const options = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(DiagnosticWorkerOptions),
+      )(yield* Config.string("RUNTIME_DIAGNOSTIC_OPTIONS"));
+
+      yield* runDiagnosticWorker(options);
+    }).pipe(
+      Effect.provide(
+        Layer.merge(DiagnosticRunner.layer, DiagnosticLedgerSeeds.layer).pipe(
+          Layer.provideMerge(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+        ),
+      ),
+    ),
+  );

--- a/examples/runtime-benchmark/src/diagnostic-writer.ts
+++ b/examples/runtime-benchmark/src/diagnostic-writer.ts
@@ -1,0 +1,126 @@
+import { hrtime } from "node:process";
+import { DatabaseSync } from "node:sqlite";
+
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Config, Effect, FileSystem, Schema } from "effect";
+
+/** Private subprocess protocol. The observer never releases a lock on its own event loop. */
+export const WriterOptions = Schema.Struct({
+  filename: Schema.String,
+  directory: Schema.String,
+  holdMs: Schema.Literals([0, 25, 100]),
+});
+
+const Millis = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0));
+
+/** Both processes use the same Node executable and host/kernel monotonic clock, never performance.now. */
+export const nodeMonotonicNanos = Effect.sync(() => hrtime.bigint());
+
+export const WriterResult = Schema.Struct({
+  clock: Schema.Literal("node-hrtime-same-host"),
+  acquiredNanos: Schema.BigIntFromString,
+  releaseStartedNanos: Schema.BigIntFromString,
+  releasedNanos: Schema.BigIntFromString,
+  heldMs: Millis,
+  lockMs: Millis,
+}).check(
+  Schema.makeFilter(
+    (result) =>
+      result.acquiredNanos <= result.releaseStartedNanos &&
+      result.releaseStartedNanos <= result.releasedNanos,
+  ),
+);
+
+/** Conservative overlap: the lock is definitely held between these two boundary readings. */
+export const writerOverlap = (
+  writer: typeof WriterResult.Type,
+  observer: { readonly startedNanos: bigint; readonly finishedNanos: bigint },
+) => {
+  const start =
+    writer.acquiredNanos > observer.startedNanos ? writer.acquiredNanos : observer.startedNanos;
+
+  const end =
+    writer.releaseStartedNanos < observer.finishedNanos
+      ? writer.releaseStartedNanos
+      : observer.finishedNanos;
+
+  return {
+    overlapMs: end > start ? Number(end - start) / 1e6 : 0,
+    heldAtStart:
+      writer.acquiredNanos <= observer.startedNanos &&
+      observer.startedNanos < writer.releaseStartedNanos,
+    finishedWhileHeld:
+      writer.acquiredNanos < observer.finishedNanos &&
+      observer.finishedNanos < writer.releaseStartedNanos,
+  };
+};
+
+class WriterError extends Schema.TaggedError<WriterError>()("WriterError", {
+  cause: Schema.Defect(),
+}) {}
+
+export const runWriter = Effect.fn("diagnostic.writer")(function* (
+  options: typeof WriterOptions.Type,
+) {
+  const fs = yield* FileSystem.FileSystem;
+
+  // Foreign SQLite boundary: this process owns the connection and the entire transaction.
+  const database = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => new DatabaseSync(options.filename),
+      catch: (cause) => WriterError.make({ cause }),
+    }),
+    (connection) => Effect.sync(() => connection.close()),
+  );
+
+  let acquired = 0n;
+  let started = 0n;
+  let releaseStarted = 0n;
+  let released = 0n;
+
+  yield* Effect.gen(function* () {
+    yield* Effect.acquireRelease(
+      Effect.try({
+        try: () => database.exec("BEGIN IMMEDIATE"),
+        catch: (cause) => WriterError.make({ cause }),
+      }),
+      () =>
+        Effect.sync(() => {
+          releaseStarted = hrtime.bigint();
+          database.exec("ROLLBACK");
+          released = hrtime.bigint();
+        }),
+    );
+    acquired = yield* nodeMonotonicNanos;
+    yield* fs.writeFileString(`${options.directory}/ready`, "ready");
+    while (!(yield* fs.exists(`${options.directory}/go`))) yield* Effect.sleep("1 millis");
+    started = yield* nodeMonotonicNanos;
+    yield* Effect.sleep(options.holdMs);
+  }).pipe(Effect.scoped);
+  // heldMs excludes readiness/gating; lockMs includes that setup. Both end after rollback.
+  const heldMs = Number(released - started) / 1e6;
+  const lockMs = Number(released - acquired) / 1e6;
+
+  yield* fs.writeFileString(
+    `${options.directory}/result.json`,
+    yield* Schema.encodeEffect(Schema.fromJsonString(WriterResult))({
+      clock: "node-hrtime-same-host",
+      acquiredNanos: acquired,
+      releaseStartedNanos: releaseStarted,
+      releasedNanos: released,
+      heldMs,
+      lockMs,
+    }),
+  );
+});
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Effect.gen(function* () {
+      const options = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(WriterOptions))(
+        yield* Config.string("RUNTIME_DIAGNOSTIC_WRITER"),
+      );
+
+      yield* runWriter(options);
+    }).pipe(Effect.scoped, Effect.timeout("10 seconds"), Effect.provide(NodeServices.layer)),
+  );

--- a/examples/runtime-benchmark/test/diagnostic-capabilities.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-capabilities.test.ts
@@ -1,0 +1,252 @@
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { expect, it } from "vite-plus/test";
+
+import { BenchmarkError } from "../src/contracts.ts";
+import {
+  capabilityCases,
+  DiagnosticFault,
+  runCapabilityCase,
+} from "../src/diagnostic-capabilities.ts";
+import {
+  DiagnosticProgress,
+  DiagnosticResult,
+  type DiagnosticMark,
+  type DiagnosticPhase,
+} from "../src/diagnostic-contracts.ts";
+
+const services = Layer.merge(NodeServices.layer, NodeCrypto.layer);
+const silent = DiagnosticProgress.of({ phase: () => Effect.void, mark: () => Effect.void });
+
+it.each(capabilityCases)(
+  "validates completed work and owned finalizers in $name",
+  async (workload) => {
+    const phases: Array<DiagnosticPhase> = [];
+    const marks: Array<DiagnosticMark> = [];
+
+    const result = await Effect.runPromise(
+      runCapabilityCase(workload).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          phase: (phase) =>
+            Effect.sync(() => {
+              phases.push(phase);
+            }),
+          mark: (mark) =>
+            Effect.sync(() => {
+              marks.push(mark);
+            }),
+        }),
+        Effect.provide(services),
+      ),
+    );
+
+    expect(Schema.is(DiagnosticResult)(result)).toBe(true);
+    expect(phases).toEqual(["setup", "operation", "verification"]);
+    expect(new Set(result.counters.map(({ name }) => name)).size).toBe(result.counters.length);
+    expect(marks.length).toBeLessThanOrEqual(512);
+    expect(marks.every((mark) => mark.elapsedMs >= 0)).toBe(true);
+  },
+  30_000,
+);
+
+it("rejects a changed fixture inventory before starting work", async () => {
+  const workload = capabilityCases[0]!;
+
+  const result = await Effect.runPromiseExit(
+    runCapabilityCase({ ...workload, parameters: { prefix: 1_000_000 } }).pipe(
+      Effect.provideService(DiagnosticProgress, silent),
+      Effect.provide(services),
+    ),
+  );
+
+  expect(Exit.isFailure(result)).toBe(true);
+  expect(Exit.isFailure(result) ? Cause.pretty(result.cause) : "").toContain("Unknown or modified");
+});
+
+it("propagates a failed progress boundary without reporting a successful sample", async () => {
+  const result = await Effect.runPromiseExit(
+    runCapabilityCase(capabilityCases[0]!).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        ...silent,
+        phase: (phase) =>
+          phase === "operation"
+            ? Effect.fail(BenchmarkError.make({ message: "progress write failed" }))
+            : Effect.void,
+      }),
+      Effect.provide(services),
+    ),
+  );
+
+  expect(Exit.isFailure(result)).toBe(true);
+  expect(Exit.isFailure(result) ? Cause.pretty(result.cause) : "").toContain(
+    "progress write failed",
+  );
+});
+
+it("allows interruption at the operation boundary and a subsequent fresh sample", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+
+      const fiber = yield* runCapabilityCase(capabilityCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          ...silent,
+          phase: (phase) =>
+            phase === "operation"
+              ? Deferred.succeed(entered, undefined).pipe(Effect.andThen(Effect.never))
+              : Effect.void,
+        }),
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(fiber);
+      const interrupted = yield* Fiber.await(fiber);
+
+      expect(Exit.isFailure(interrupted)).toBe(true);
+
+      const next = yield* runCapabilityCase(capabilityCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, silent),
+      );
+
+      expect(next.counters.find(({ name }) => name === "committedMessages")?.value).toBe(256);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+const ownedCases = [
+  {
+    name: "memory-run-recall",
+    stop: "memory.readerIO.complete",
+    finalized: "memory.reader.finalized",
+    count: 1,
+  },
+  {
+    name: "remembering-run-on",
+    stop: "remember.foreground.complete",
+    finalized: "remember.extract.finalized.previous",
+    count: 1,
+  },
+  {
+    name: "mcp-in-process-http-on",
+    stop: "mcp.call.begin.0",
+    finalized: "mcp.session.closed",
+    count: 1,
+  },
+  {
+    name: "subagent-run-on",
+    stop: "subagent.queued.ready",
+    finalized: "subagent.release.end.",
+    count: 2,
+  },
+] as const;
+
+it.each(ownedCases)(
+  "closes acquired resources when $name is interrupted",
+  async (sample) => {
+    const marks: Array<DiagnosticMark> = [];
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>();
+        const workload = capabilityCases.find(({ name }) => name === sample.name)!;
+
+        const fiber = yield* runCapabilityCase(workload).pipe(
+          Effect.provideService(DiagnosticProgress, {
+            phase: () => Effect.void,
+            mark: (mark) =>
+              Effect.gen(function* () {
+                marks.push(mark);
+                if (mark.name === sample.stop) {
+                  yield* Deferred.succeed(entered, undefined);
+
+                  return yield* Effect.never;
+                }
+              }),
+          }),
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(entered).pipe(Effect.timeout("5 seconds"));
+        yield* Fiber.interrupt(fiber);
+        const exit = yield* Fiber.await(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      }).pipe(Effect.scoped, Effect.provide(services)),
+    );
+    expect(marks.filter((mark) => mark.name.startsWith(sample.finalized))).toHaveLength(
+      sample.count,
+    );
+  },
+  10_000,
+);
+
+it.each(
+  ownedCases.flatMap((sample) =>
+    ["failure", "defect", "timeout"].map((mode) => ({ ...sample, mode })),
+  ),
+)(
+  "closes acquired resources on $mode in $name",
+  async (sample) => {
+    const marks: Array<DiagnosticMark> = [];
+    const workload = capabilityCases.find(({ name }) => name === sample.name)!;
+
+    const exit = await Effect.runPromiseExit(
+      runCapabilityCase(workload).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          phase: () => Effect.void,
+          mark: (mark) =>
+            Effect.gen(function* () {
+              marks.push(mark);
+              if (mark.name !== sample.stop) return;
+              if (sample.mode === "defect") return yield* Effect.die("diagnostic injected defect");
+              if (sample.mode === "timeout")
+                return yield* Effect.never.pipe(
+                  Effect.timeout("10 millis"),
+                  Effect.mapError(() =>
+                    BenchmarkError.make({ message: "diagnostic injected timeout" }),
+                  ),
+                );
+
+              return yield* BenchmarkError.make({ message: "diagnostic injected failure" });
+            }),
+        }),
+        Effect.provide(services),
+        Effect.timeout("5 seconds"),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(marks.some((mark) => mark.name === sample.stop)).toBe(true);
+    expect(marks.filter((mark) => mark.name.startsWith(sample.finalized))).toHaveLength(
+      sample.count,
+    );
+  },
+  10_000,
+);
+
+it.each(["mcp-malformed-discovery", "mcp-call-failure"] as const)(
+  "fails closed and ends the real HTTP session for %s",
+  async (fault) => {
+    const marks: Array<DiagnosticMark> = [];
+    const workload = capabilityCases.find(({ name }) => name === "mcp-in-process-http-on")!;
+
+    const exit = await Effect.runPromiseExit(
+      runCapabilityCase(workload).pipe(
+        Effect.provideService(DiagnosticFault, fault),
+        Effect.provideService(DiagnosticProgress, {
+          phase: () => Effect.void,
+          mark: (mark) =>
+            Effect.sync(() => {
+              marks.push(mark);
+            }),
+        }),
+        Effect.provide(services),
+        Effect.timeout("5 seconds"),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(marks.filter(({ name }) => name === "mcp.session.closed")).toHaveLength(1);
+  },
+);

--- a/examples/runtime-benchmark/test/diagnostic-fairness.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-fairness.test.ts
@@ -1,0 +1,389 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { NodeDurableHost } from "@effect-agent/platform-node/NodeDurableHost";
+import { ScriptedModel } from "@effect-agent/testing/ScriptedModel";
+import { digestDefinitions } from "@effect-agent/thread/Digest";
+import { DefinitionDigestInput } from "@effect-agent/thread/Records";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import { ThreadExportRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Cause, Deferred, Effect, Exit, Fiber, FileSystem, Layer, Path, Schema } from "effect";
+import { Agent } from "effect-agent";
+import { Model, Toolkit } from "effect/unstable/ai";
+import { expect, expectTypeOf, it } from "vite-plus/test";
+
+import { BenchmarkError } from "../src/contracts.js";
+import {
+  DiagnosticProgress,
+  DiagnosticResult,
+  type DiagnosticMark,
+} from "../src/diagnostic-contracts.js";
+import { fairnessCases, runFairnessCase } from "../src/diagnostic-fairness.js";
+
+const silent = DiagnosticProgress.of({ phase: () => Effect.void, mark: () => Effect.void });
+
+it.each(fairnessCases)(
+  "checks public workers, independent lanes and finalizers in $name",
+  async (workload) => {
+    const marks: Array<DiagnosticMark> = [];
+    const phases: Array<string> = [];
+
+    const result = await Effect.runPromise(
+      runFairnessCase(workload).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          phase: (phase) =>
+            Effect.sync(() => {
+              phases.push(phase);
+            }),
+          mark: (mark) =>
+            Effect.sync(() => {
+              marks.push(mark);
+            }),
+        }),
+        Effect.provide(NodeServices.layer),
+        Effect.timeout("15 seconds"),
+      ),
+    );
+
+    const counters = Object.fromEntries(result.counters.map(({ name, value }) => [name, value]));
+
+    expect(Schema.is(DiagnosticResult)(result)).toBe(true);
+    expect(phases).toEqual(["setup", "operation", "verification"]);
+    expect(marks.length).toBeLessThanOrEqual(512);
+    expect(counters).toMatchObject({
+      attemptsOpened: 5,
+      attemptFinalizers: 5,
+      toolsOpened: 16,
+      toolFinalizers: 16,
+      providers: 9,
+      streamFinalizers: 9,
+      modelsOpened: 5,
+      modelFinalizers: 5,
+    });
+    expect(counters.maxActiveAttempts).toBeLessThanOrEqual(workload.parameters.workerConcurrency!);
+    expect(counters.maxActiveTools).toBeLessThanOrEqual(workload.parameters.workerConcurrency! * 2);
+    for (const label of ["busy0", "busy1", "busy2", "busy3", "short"]) {
+      expect(counters[`${label}.maxActiveAttempts`]).toBe(1);
+      expect(marks.filter(({ name }) => name === `request.${label}`)).toHaveLength(1);
+      expect(marks.filter(({ name }) => name === `attempt.open.${label}`)).toHaveLength(1);
+      expect(marks.filter(({ name }) => name === `settlement.observed.${label}`)).toHaveLength(1);
+      expect(
+        result.metrics.find(({ name }) => name === `${label}.requestToAttempt`)?.value,
+      ).toBeGreaterThanOrEqual(0);
+    }
+    if (workload.parameters.warmArrival === 1) {
+      expect(counters.shortAdmissionActiveAttempts).toBeGreaterThan(0);
+      expect(counters.shortAdmissionActiveTools).toBeGreaterThan(0);
+    } else {
+      expect(counters.shortAdmissionActiveAttempts).toBe(0);
+      expect(counters.shortAdmissionActiveTools).toBe(0);
+    }
+  },
+  20_000,
+);
+
+it("rejects altered workloads before acquiring host resources", async () => {
+  const marks: Array<DiagnosticMark> = [];
+
+  const result = await Effect.runPromiseExit(
+    runFairnessCase({
+      ...fairnessCases[0]!,
+      parameters: { workerConcurrency: 999 },
+    }).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        ...silent,
+        mark: (mark) =>
+          Effect.sync(() => {
+            marks.push(mark);
+          }),
+      }),
+      Effect.provide(NodeServices.layer),
+    ),
+  );
+
+  expect(Exit.isFailure(result)).toBe(true);
+  expect(marks).toEqual([]);
+});
+
+const assertReleased = (marks: ReadonlyArray<string>) => {
+  for (const resource of ["attempt", "tool", "model"]) {
+    const opened = marks
+      .filter((name) => name.startsWith(`${resource}.open.`))
+      .map((name) => name.slice(`${resource}.open.`.length))
+      .sort();
+
+    const closed = marks
+      .filter((name) => name.startsWith(`${resource}.closed.`))
+      .map((name) => name.slice(`${resource}.closed.`.length))
+      .sort();
+
+    expect(opened.length).toBeGreaterThan(0);
+    expect(closed).toEqual(opened);
+  }
+};
+
+it.each(["typed hook failure converted to defect", "defect"] as const)(
+  "preserves the original %s and releases active resources",
+  async (mode) => {
+    const marks: Array<string> = [];
+    const injected = BenchmarkError.make({ message: `original ${mode}` });
+
+    const result = await Effect.runPromiseExit(
+      runFairnessCase(fairnessCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          ...silent,
+          mark: ({ name }) =>
+            Effect.gen(function* () {
+              marks.push(name);
+              if (name !== "tool.open.busy0.0") return;
+
+              // The diagnostic Tool has no typed failure channel: its boundary deliberately
+              // uses orDie. Verify that conversion retains the original hook error object.
+              return yield* mode === "typed hook failure converted to defect"
+                ? Effect.fail(injected)
+                : Effect.die(injected);
+            }),
+        }),
+        Effect.provide(NodeServices.layer),
+        Effect.timeout("10 seconds"),
+      ),
+    );
+
+    const cause = Exit.isFailure(result) ? result.cause : Cause.empty;
+    const defects = cause.reasons.filter(Cause.isDieReason).map(({ defect }) => defect);
+
+    expect(defects[0]).toBe(injected);
+    expect(Cause.hasFails(cause)).toBe(false);
+    assertReleased(marks);
+  },
+  15_000,
+);
+
+it("preserves a typed verification failure after closing worker resources", async () => {
+  const marks: Array<string> = [];
+  const injected = BenchmarkError.make({ message: "original verification failure" });
+
+  const result = await Effect.runPromiseExit(
+    runFairnessCase(fairnessCases[0]!).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        phase: (phase) => (phase === "verification" ? Effect.fail(injected) : Effect.void),
+        mark: ({ name }) =>
+          Effect.sync(() => {
+            marks.push(name);
+          }),
+      }),
+      Effect.provide(NodeServices.layer),
+      Effect.timeout("10 seconds"),
+    ),
+  );
+
+  const cause = Exit.isFailure(result) ? result.cause : Cause.empty;
+  const errors = cause.reasons.filter(Cause.isFailReason).map(({ error }) => error);
+  const original = errors[0];
+
+  expect(errors).toHaveLength(1);
+  expect(Schema.is(BenchmarkError)(original) ? original.cause : undefined).toBe(injected);
+  expect(Cause.hasDies(cause)).toBe(false);
+  expect(Cause.hasInterrupts(cause)).toBe(false);
+  assertReleased(marks);
+}, 15_000);
+
+it("an enclosing timeout interrupts active work and returns that exact timeout after finalizers", async () => {
+  const marks: Array<string> = [];
+  const deadline = new Cause.TimeoutError();
+
+  const result = await Effect.runPromiseExit(
+    runFairnessCase(fairnessCases[0]!).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        ...silent,
+        mark: ({ name }) =>
+          Effect.gen(function* () {
+            marks.push(name);
+            if (name === "tool.open.busy0.0") return yield* Effect.never;
+          }),
+      }),
+      Effect.provide(NodeServices.layer),
+      Effect.timeoutOrElse({ duration: "1 second", orElse: () => Effect.fail(deadline) }),
+      // A hung finalizer must fail with a different TimeoutError, never satisfy this assertion.
+      Effect.timeout("10 seconds"),
+    ),
+  );
+
+  const cause = Exit.isFailure(result) ? result.cause : Cause.empty;
+  const errors = cause.reasons.filter(Cause.isFailReason).map(({ error }) => error);
+
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toBe(deadline);
+  expect(Cause.isTimeoutError(errors[0])).toBe(true);
+  expect(Cause.hasDies(cause)).toBe(false);
+  assertReleased(marks);
+}, 15_000);
+
+it("joins scoped worker cancellation and finalizes the interrupted tool", async () => {
+  const marks: Array<string> = [];
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+
+      const fiber = yield* runFairnessCase(fairnessCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          ...silent,
+          mark: ({ name }) =>
+            Effect.gen(function* () {
+              marks.push(name);
+              if (name === "tool.open.busy0.0") {
+                yield* Deferred.succeed(entered, undefined);
+
+                return yield* Effect.never;
+              }
+            }),
+        }),
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(entered).pipe(Effect.timeout("5 seconds"));
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+
+      expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(true);
+      expect(Exit.isFailure(exit) && Cause.hasFails(exit.cause)).toBe(false);
+      expect(Exit.isFailure(exit) && Cause.hasDies(exit.cause)).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer), Effect.timeout("10 seconds")),
+  );
+  assertReleased(marks);
+}, 15_000);
+
+it("preserves FIFO for two queued inputs joining one public-host Run", async () => {
+  let attempts = 0;
+  let finalized = 0;
+  let requests = 0;
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "fairness-fifo-" });
+
+      const definition = Agent.make("fairness-fifo", {
+        input: Schema.String,
+        output: Schema.String,
+        toolkit: Toolkit.empty,
+        instructions: "Answer both inputs.",
+        policy: { maxTurns: 2, maxDuration: "10 seconds" },
+      });
+
+      const model = Layer.mergeAll(
+        ScriptedModel.layer([
+          {
+            _tag: "Stream",
+            termination: { _tag: "Complete" },
+            parts: [
+              { type: "text-start", id: "answer" },
+              { type: "text-delta", id: "answer", delta: '"done"' },
+              { type: "text-end", id: "answer" },
+              { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+            ],
+            assertRequest: (request) =>
+              Effect.sync(() => {
+                requests++;
+
+                const users = request.prompt.content
+                  .filter((message) => message.role === "user")
+                  .flatMap((message) => message.content)
+                  .filter((part) => part.type === "text")
+                  .map((part) => part.text);
+
+                expect(users.filter((text) => text === '"first"' || text === '"second"')).toEqual([
+                  '"first"',
+                  '"second"',
+                ]);
+              }),
+          },
+        ]),
+        Layer.succeed(Model.ProviderName, "scripted"),
+        Layer.succeed(Model.ModelName, "fifo"),
+      );
+
+      const agent = Agent.withModel(definition, model);
+
+      const definitions = DefinitionDigestInput.make({
+        agent: "fifo-v1",
+        model: "fifo-v1",
+        tools: [],
+      });
+
+      const digests = yield* digestDefinitions(definitions).pipe(Effect.provide(NodeCrypto.layer));
+
+      const layer = NodeDurableHost.layerRegistered(
+        [
+          {
+            agent,
+            definitions,
+            attemptLayer: () =>
+              Layer.effectDiscard(
+                Effect.acquireRelease(
+                  Effect.sync(() => {
+                    attempts++;
+                  }),
+                  () =>
+                    Effect.sync(() => {
+                      finalized++;
+                    }),
+                ),
+              ),
+          },
+        ],
+        {
+          filename: path.join(directory, "fifo.sqlite"),
+          deploymentId: "fifo",
+          producerId: "fifo",
+          workerConcurrency: 1,
+        },
+      );
+
+      yield* Effect.gen(function* () {
+        const host = yield* NodeDurableHost;
+        const store = yield* ThreadStore;
+        const threadId = ThreadId.make("fifo-thread");
+
+        const receipts = yield* Effect.forEach(["first", "second"], (input) =>
+          host.submit(agent, input, {
+            threadId,
+            principal: Principal.make("fifo"),
+            idempotencyKey: IdempotencyKey.make(input),
+            definitions: digests,
+          }),
+        );
+
+        expect(receipts[1]!.queueSequence).toBe(receipts[0]!.queueSequence + 1);
+        const worker = yield* host.runResolvedWorkers.pipe(Effect.forkScoped);
+
+        const settlements = yield* Effect.raceFirst(
+          Effect.forEach(receipts, host.awaitSettlement, { concurrency: 2 }),
+          Fiber.join(worker).pipe(Effect.andThen(Effect.die("FIFO worker exited early"))),
+        );
+
+        yield* Fiber.interrupt(worker);
+        const log = yield* store.export(ThreadExportRequest.make({ threadId }));
+        const payloads = log.records.map(({ record }) => record.payload);
+
+        expect(settlements.map(({ outcome }) => outcome)).toEqual(["completed", "completed"]);
+        expect(
+          payloads
+            .filter((payload) => payload._tag === "UserInputRecorded")
+            .map(({ submissionId }) => submissionId),
+        ).toEqual(receipts.map(({ submissionId }) => submissionId));
+        expect(payloads.filter((payload) => payload._tag === "RunStarted")).toHaveLength(1);
+        expect(payloads.filter((payload) => payload._tag === "SubmissionSettled")).toHaveLength(2);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer), Effect.timeout("10 seconds")),
+  );
+  expect({ attempts, finalized, requests }).toEqual({ attempts: 1, finalized: 1, requests: 1 });
+}, 15_000);
+
+it("keeps platform services and typed fixture failure visible", () => {
+  expectTypeOf<Effect.Services<ReturnType<typeof runFairnessCase>>>().toEqualTypeOf<
+    DiagnosticProgress | FileSystem.FileSystem | Path.Path
+  >();
+  expectTypeOf<Effect.Error<ReturnType<typeof runFairnessCase>>>().toEqualTypeOf<BenchmarkError>();
+});

--- a/examples/runtime-benchmark/test/diagnostic-infrastructure.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-infrastructure.test.ts
@@ -1,0 +1,291 @@
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Deferred, Effect, Exit, Fiber, FileSystem, Layer, Schema } from "effect";
+import { expect, it } from "vite-plus/test";
+
+import {
+  compareDiagnostics,
+  DiagnosticReport,
+  renderDiagnosticReport,
+} from "../../../scripts/runtime-diagnostics.ts";
+import { BenchmarkError } from "../src/contracts.ts";
+import {
+  completeDiagnosticBatch,
+  DIAGNOSTIC_SIZES,
+  DiagnosticProgress,
+  DiagnosticWorkerReport,
+  MAX_DIAGNOSTIC_MARKS,
+  type DiagnosticWorkerOptions,
+} from "../src/diagnostic-contracts.ts";
+import { DiagnosticLedgerSeeds } from "../src/diagnostic-ledger.ts";
+import {
+  diagnosticCases,
+  DiagnosticRunner,
+  runDiagnosticWorker,
+} from "../src/diagnostic-worker.ts";
+
+const services = DiagnosticLedgerSeeds.layer.pipe(
+  Layer.provideMerge(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+);
+
+const passed = Effect.gen(function* () {
+  const progress = yield* DiagnosticProgress;
+
+  yield* progress.phase("operation");
+  yield* progress.mark({ name: "work", elapsedMs: 0 });
+  yield* progress.phase("verification");
+
+  return { totalMs: 0, metrics: [], counters: [] };
+});
+
+it("runs every case, alternates case order, and rejects incomplete result matrices", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+
+      const options: DiagnosticWorkerOptions = {
+        output: `${directory}/worker.json`,
+        warmups: 1,
+        samples: 1,
+        timeoutMs: 1_000,
+      };
+
+      yield* runDiagnosticWorker(options).pipe(
+        Effect.provideService(DiagnosticRunner, { run: () => passed }),
+      );
+
+      const report = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(DiagnosticWorkerReport),
+      )(yield* fs.readFileString(options.output));
+
+      expect(DIAGNOSTIC_SIZES).toEqual({ cohorts: 2, warmups: 2, samples: 5 });
+      expect(completeDiagnosticBatch(report, options, diagnosticCases)).toBe(true);
+      expect(report.samples.slice(0, diagnosticCases.length).map(({ case: name }) => name)).toEqual(
+        diagnosticCases.map(({ name }) => name),
+      );
+      expect(report.samples.slice(diagnosticCases.length).map(({ case: name }) => name)).toEqual(
+        [...diagnosticCases].reverse().map(({ name }) => name),
+      );
+      expect(
+        completeDiagnosticBatch(
+          { ...report, samples: report.samples.slice(1) },
+          options,
+          diagnosticCases,
+        ),
+      ).toBe(false);
+      expect(
+        completeDiagnosticBatch(
+          { ...report, samples: [...report.samples.slice(1), report.samples[1]!] },
+          options,
+          diagnosticCases,
+        ),
+      ).toBe(false);
+      expect(
+        completeDiagnosticBatch(
+          { ...report, samples: report.samples.map((sample) => ({ ...sample, result: null })) },
+          options,
+          diagnosticCases,
+        ),
+      ).toBe(false);
+      expect(
+        completeDiagnosticBatch(
+          {
+            ...report,
+            samples: report.samples.map((sample) => ({ ...sample, phase: "operation" })),
+          },
+          options,
+          diagnosticCases,
+        ),
+      ).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it.each(["failure", "defect", "timeout"] as const)(
+  "retains a sample %s and its finalized phase before later successes",
+  async (kind) => {
+    let closed = false;
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped();
+
+        const options: DiagnosticWorkerOptions = {
+          output: `${directory}/worker.json`,
+          warmups: 0,
+          samples: 1,
+          timeoutMs: 10,
+        };
+
+        const result = yield* runDiagnosticWorker(options).pipe(
+          Effect.provideService(DiagnosticRunner, {
+            run: (workload) =>
+              workload.name !== diagnosticCases[0]!.name
+                ? passed
+                : Effect.gen(function* () {
+                    const progress = yield* DiagnosticProgress;
+
+                    yield* progress.phase("operation");
+                    yield* Effect.acquireRelease(Effect.void, () =>
+                      Effect.sync(() => {
+                        closed = true;
+                      }),
+                    );
+                    yield* progress.mark({ name: "entered", elapsedMs: 0 });
+                    if (kind === "failure")
+                      return yield* BenchmarkError.make({ message: "expected fixture failure" });
+                    if (kind === "defect") return yield* Effect.die("fixture defect");
+
+                    return yield* Effect.never;
+                  }).pipe(Effect.scoped),
+          }),
+          Effect.exit,
+        );
+
+        const report = yield* Schema.decodeUnknownEffect(
+          Schema.fromJsonString(DiagnosticWorkerReport),
+        )(yield* fs.readFileString(options.output));
+
+        expect(Exit.isFailure(result)).toBe(true);
+        expect(closed).toBe(true);
+        expect(report.samples[0]).toMatchObject({
+          status: "failed",
+          phase: "operation",
+          result: null,
+          marks: [{ name: "entered", elapsedMs: 0 }],
+        });
+        expect(report.samples.at(-1)?.status).toBe("passed");
+        expect(completeDiagnosticBatch(report, options, diagnosticCases)).toBe(false);
+      }).pipe(Effect.scoped, Effect.provide(services)),
+    );
+  },
+);
+
+it("retains interrupted sample evidence and closes resources", async () => {
+  let closed = false;
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const entered = yield* Deferred.make<void>();
+
+      const options: DiagnosticWorkerOptions = {
+        output: `${directory}/worker.json`,
+        warmups: 0,
+        samples: 1,
+        timeoutMs: 1_000,
+      };
+
+      const fiber = yield* Effect.forkChild(
+        runDiagnosticWorker(options).pipe(
+          Effect.provideService(DiagnosticRunner, {
+            run: () =>
+              Effect.gen(function* () {
+                const progress = yield* DiagnosticProgress;
+
+                yield* progress.phase("operation");
+                yield* Effect.acquireRelease(Effect.void, () =>
+                  Effect.sync(() => {
+                    closed = true;
+                  }),
+                );
+                yield* progress.mark({ name: "waiting", elapsedMs: 0 });
+                yield* Deferred.succeed(entered, undefined);
+
+                return yield* Effect.never;
+              }).pipe(Effect.scoped),
+          }),
+        ),
+      );
+
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(fiber);
+
+      const report = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(DiagnosticWorkerReport),
+      )(yield* fs.readFileString(options.output));
+
+      expect(closed).toBe(true);
+      expect(report.failure).not.toBeNull();
+      expect(report.samples).toHaveLength(1);
+      expect(report.samples[0]?.marks).toEqual([{ name: "waiting", elapsedMs: 0 }]);
+      expect(report.samples[0]?.status).toBe("failed");
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("bounds phase marks and preserves the accepted prefix", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+
+      const options: DiagnosticWorkerOptions = {
+        output: `${directory}/worker.json`,
+        warmups: 0,
+        samples: 1,
+        timeoutMs: 1_000,
+      };
+
+      yield* runDiagnosticWorker(options).pipe(
+        Effect.provideService(DiagnosticRunner, {
+          run: (workload) =>
+            workload.name !== diagnosticCases[0]!.name
+              ? passed
+              : Effect.gen(function* () {
+                  const progress = yield* DiagnosticProgress;
+
+                  for (let index = 0; index <= MAX_DIAGNOSTIC_MARKS; index++)
+                    yield* progress.mark({ name: `mark-${index}`, elapsedMs: index });
+
+                  return { totalMs: 0, metrics: [], counters: [] };
+                }),
+        }),
+        Effect.exit,
+      );
+
+      const report = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(DiagnosticWorkerReport),
+      )(yield* fs.readFileString(options.output));
+
+      expect(report.samples[0]?.status).toBe("failed");
+      expect(report.samples[0]?.marks).toHaveLength(MAX_DIAGNOSTIC_MARKS);
+      expect(report.samples[0]?.marks.at(-1)?.name).toBe(`mark-${MAX_DIAGNOSTIC_MARKS - 1}`);
+      expect(report.samples[0]?.failure).toContain("mark limit exceeded");
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});
+
+it("retains controller setup failure and refuses to overwrite the evidence", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped();
+
+      const options = {
+        root: directory,
+        base: directory,
+        output: `${directory}/report`,
+        requireClean: false,
+      };
+
+      yield* compareDiagnostics(options).pipe(Effect.exit);
+      const text = yield* fs.readFileString(`${options.output}/report.json`);
+
+      const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(DiagnosticReport))(
+        text,
+      );
+
+      expect(report.phase).toBe("setup");
+      expect(report.failure).toContain("require clean");
+      expect(report.batches).toEqual([]);
+      expect(renderDiagnosticReport(report)).toContain("0/4 complete");
+      const second = yield* compareDiagnostics(options).pipe(Effect.exit);
+
+      expect(Exit.isFailure(second)).toBe(true);
+      expect(yield* fs.readFileString(`${options.output}/report.json`)).toBe(text);
+    }).pipe(Effect.scoped, Effect.provide(services)),
+  );
+});

--- a/examples/runtime-benchmark/test/diagnostic-ledger.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-ledger.test.ts
@@ -1,0 +1,217 @@
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { expect, it } from "vite-plus/test";
+
+import { BenchmarkError } from "../src/contracts.ts";
+import {
+  DiagnosticProgress,
+  DiagnosticResult,
+  type DiagnosticMark,
+} from "../src/diagnostic-contracts.ts";
+import {
+  DiagnosticLedgerSeeds,
+  DiagnosticLedgerWaitForWriterRelease,
+  ledgerCases,
+  runLedgerCase,
+} from "../src/diagnostic-ledger.ts";
+import { writerOverlap, WriterResult } from "../src/diagnostic-writer.ts";
+
+const services = DiagnosticLedgerSeeds.layer.pipe(
+  Layer.provideMerge(Layer.merge(NodeServices.layer, NodeCrypto.layer)),
+);
+
+const silent = DiagnosticProgress.of({ phase: () => Effect.void, mark: () => Effect.void });
+
+it("retries after a committed seed failure, measures all public workloads, and reuses only the closed successful seed", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      let committed = false;
+
+      const failed = yield* runLedgerCase(ledgerCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, {
+          ...silent,
+          mark: (mark) =>
+            Effect.gen(function* () {
+              if (mark.name !== "seed.firstSettlement.committed") return;
+              committed = true;
+
+              return yield* BenchmarkError.make({
+                message: "fail after first committed settlement",
+              });
+            }),
+        }),
+        Effect.exit,
+      );
+
+      expect(committed).toBe(true);
+      expect(Exit.isFailure(failed)).toBe(true);
+      expect(Exit.isFailure(failed) ? Cause.pretty(failed.cause) : "").toContain(
+        "fail after first committed settlement",
+      );
+
+      for (const workload of ledgerCases) {
+        const marks: Array<DiagnosticMark> = [];
+
+        const result = yield* runLedgerCase(workload).pipe(
+          Effect.provideService(DiagnosticProgress, {
+            ...silent,
+            mark: (mark) =>
+              Effect.sync(() => {
+                marks.push(mark);
+              }),
+          }),
+        );
+
+        expect(Schema.is(DiagnosticResult)(result)).toBe(true);
+        expect(result.metrics.find(({ name }) => name === "setup")?.value).toBeGreaterThan(0);
+
+        const counters = Object.fromEntries(
+          result.counters.map(({ name, value }) => [name, value]),
+        );
+
+        if (workload.parameters.mode === 0) {
+          expect(counters.unfinished).toBe(workload.parameters.unfinished);
+          expect(counters.sqlStatements).toBe(
+            Math.floor(workload.parameters.unfinished! / 256) + 1,
+          );
+          expect(counters.indexedPlans).toBe(counters.sqlStatements);
+          expect(counters.sortedPlans).toBe(0);
+          expect(marks.some(({ name }) => name.startsWith("plan."))).toBe(true);
+        } else {
+          expect(counters.observations).toBe(workload.parameters.repeats);
+          expect(counters.sqlStatements).toBeGreaterThanOrEqual(counters.observations!);
+          if (workload.parameters.mode === 1) {
+            expect(counters.sqlWriteStatements).toBe(3);
+            expect(counters.sqlStatements).toBe(6);
+          } else if (workload.parameters.mode === 2)
+            expect(counters.sqlStatements).toBe(counters.observations);
+          if (workload.parameters.holdMs! >= 0) {
+            expect(marks.filter(({ name }) => name === "writer.scope.closed")).toHaveLength(1);
+            expect(
+              result.metrics.find(({ name }) => name === "writerHold")?.value,
+            ).toBeGreaterThanOrEqual(workload.parameters.holdMs! * 0.8);
+            expect(counters.noWriterOverlap).toBe(
+              Number(counters.observationsWithWriterOverlap === 0),
+            );
+            expect(marks.filter(({ name }) => name.startsWith("node-hrtime."))).toHaveLength(5);
+          }
+        }
+      }
+
+      const second = yield* runLedgerCase(ledgerCases[0]!).pipe(
+        Effect.provideService(DiagnosticProgress, silent),
+      );
+
+      expect(second.metrics.find(({ name }) => name === "seedSetup")?.value).toBe(0);
+    }).pipe(Effect.scoped, Effect.provide(services), Effect.timeout("100 seconds")),
+  );
+}, 110_000);
+
+it("rejects modified inventory without creating a seed", async () => {
+  const result = await Effect.runPromiseExit(
+    runLedgerCase({ ...ledgerCases[0]!, parameters: { settled: 1_000_000 } }).pipe(
+      Effect.provideService(DiagnosticProgress, silent),
+      Effect.provide(services),
+    ),
+  );
+
+  expect(Exit.isFailure(result)).toBe(true);
+  expect(Exit.isFailure(result) ? Cause.pretty(result.cause) : "").toContain("Unknown or modified");
+});
+
+it.each([
+  { started: 5, finished: 15, overlap: 5, heldAtStart: false, finishedWhileHeld: true },
+  { started: 12, finished: 18, overlap: 6, heldAtStart: true, finishedWhileHeld: true },
+  { started: 15, finished: 25, overlap: 5, heldAtStart: true, finishedWhileHeld: false },
+  { started: 21, finished: 30, overlap: 0, heldAtStart: false, finishedWhileHeld: false },
+  { started: 0, finished: 10, overlap: 0, heldAtStart: false, finishedWhileHeld: false },
+])(
+  "classifies the complete observer interval $started–$finished without requiring release before completion",
+  (sample) => {
+    const writer = Schema.decodeUnknownSync(WriterResult)({
+      clock: "node-hrtime-same-host",
+      acquiredNanos: "10000000",
+      releaseStartedNanos: "20000000",
+      releasedNanos: "21000000",
+      heldMs: 11,
+      lockMs: 11,
+    });
+
+    expect(
+      writerOverlap(writer, {
+        startedNanos: BigInt(sample.started) * 1_000_000n,
+        finishedNanos: BigInt(sample.finished) * 1_000_000n,
+      }),
+    ).toEqual({
+      overlapMs: sample.overlap,
+      heldAtStart: sample.heldAtStart,
+      finishedWhileHeld: sample.finishedWhileHeld,
+    });
+  },
+);
+
+it("retains a successful sample with an explicitly missed writer window", async () => {
+  const workload = ledgerCases.find(({ name }) => name === "ledger-replay-writer-25")!;
+
+  const result = await Effect.runPromise(
+    runLedgerCase(workload).pipe(
+      Effect.provideService(DiagnosticLedgerWaitForWriterRelease, true),
+      Effect.provideService(DiagnosticProgress, silent),
+      Effect.provide(services),
+    ),
+  );
+
+  expect(Schema.is(DiagnosticResult)(result)).toBe(true);
+  expect(result.metrics.find(({ name }) => name === "writerObserverOverlap")?.value).toBe(0);
+  expect(result.counters.find(({ name }) => name === "noWriterOverlap")?.value).toBe(1);
+  expect(result.counters.find(({ name }) => name === "observationsStartingWithWriter")?.value).toBe(
+    0,
+  );
+  expect(result.counters.find(({ name }) => name === "observations")?.value).toBe(1);
+}, 10_000);
+
+it.each(["failure", "defect", "timeout", "interrupt"] as const)(
+  "closes the external writer after observer %s",
+  async (mode) => {
+    const marks: Array<DiagnosticMark> = [];
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>();
+        const workload = ledgerCases.find(({ name }) => name === "ledger-replay-writer-100")!;
+
+        const operation = runLedgerCase(workload).pipe(
+          Effect.provideService(DiagnosticProgress, {
+            ...silent,
+            mark: (mark) =>
+              Effect.gen(function* () {
+                marks.push(mark);
+                if (mark.name !== "writer.acquired") return;
+                yield* Deferred.succeed(entered, undefined);
+                if (mode === "failure")
+                  return yield* BenchmarkError.make({ message: "expected observer failure" });
+                if (mode === "defect") return yield* Effect.die("expected observer defect");
+                if (mode === "timeout")
+                  return yield* Effect.never.pipe(
+                    Effect.timeout("5 millis"),
+                    Effect.mapError(() =>
+                      BenchmarkError.make({ message: "expected observer timeout" }),
+                    ),
+                  );
+
+                return yield* Effect.never;
+              }),
+          }),
+        );
+
+        const fiber = yield* operation.pipe(Effect.forkChild);
+
+        yield* Deferred.await(entered);
+        if (mode === "interrupt") yield* Fiber.interrupt(fiber);
+        expect(Exit.isFailure(yield* Fiber.await(fiber))).toBe(true);
+      }).pipe(Effect.scoped, Effect.provide(services), Effect.timeout("10 seconds")),
+    );
+    expect(marks.filter(({ name }) => name === "writer.scope.closed")).toHaveLength(1);
+  },
+  15_000,
+);

--- a/examples/runtime-benchmark/test/diagnostic-policy.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-policy.test.ts
@@ -1,0 +1,137 @@
+import { Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { expect, expectTypeOf, it } from "vite-plus/test";
+
+import { BenchmarkError } from "../src/contracts.ts";
+import {
+  DiagnosticProgress,
+  DiagnosticResult,
+  MAX_DIAGNOSTIC_MARKS,
+  type DiagnosticMark,
+} from "../src/diagnostic-contracts.ts";
+import { policyCases, runPolicyCase } from "../src/diagnostic-policy.ts";
+
+it.each(policyCases)("validates the public policy workload $name", async (workload) => {
+  const marks: Array<DiagnosticMark> = [];
+  const phases: Array<string> = [];
+
+  const result = await Effect.runPromise(
+    runPolicyCase(workload).pipe(
+      Effect.provide(
+        Layer.succeed(DiagnosticProgress, {
+          phase: (phase) =>
+            Effect.sync(() => {
+              phases.push(phase);
+            }),
+          mark: (mark) =>
+            Effect.sync(() => {
+              marks.push(mark);
+            }),
+        }),
+      ),
+    ),
+  );
+
+  const rounds = workload.parameters.rounds!;
+
+  expect(Schema.is(DiagnosticResult)(result)).toBe(true);
+  expect(phases).toEqual(["setup", "operation", "verification"]);
+  expect(Object.fromEntries(result.counters.map(({ name, value }) => [name, value]))).toMatchObject(
+    {
+      providers: rounds + 1,
+      streamFinalizers: rounds + 1,
+      approvals: rounds * 8,
+      authorizations: rounds * 8,
+      authorizationFinalizers: rounds * 8,
+      handlers: rounds * 8,
+      handlerFinalizers: rounds * 8,
+      modelsOpened: rounds + 1,
+      modelsReady: rounds + 1,
+      modelsClosed: rounds + 1,
+    },
+  );
+  expect(marks.length).toBeLessThanOrEqual(MAX_DIAGNOSTIC_MARKS);
+  expect(marks.findIndex(({ name }) => name === "authorize:end:7")).toBeLessThan(
+    marks.findIndex(({ name }) => name === "handler:start:0"),
+  );
+  expect(marks.filter(({ name }) => name.startsWith("provider:")).length).toBe(rounds + 1);
+});
+
+it("rejects unknown policy cases", async () => {
+  const failure = await Effect.runPromise(
+    runPolicyCase({ name: "unknown", family: "policy", parameters: {} }).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        phase: () => Effect.void,
+        mark: () => Effect.void,
+      }),
+      Effect.flip,
+    ),
+  );
+
+  expect(failure).toBeInstanceOf(BenchmarkError);
+});
+
+it.each(["authorize:start:0", "model:open:1"])(
+  "closes the active model on interruption at %s without starting handlers",
+  async (boundary) => {
+    const marks: Array<string> = [];
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>();
+
+        const workload = policyCases.find(
+          (workload) =>
+            workload.parameters.authorizationMs === 20 &&
+            workload.parameters.modelAcquisitionMs === 20,
+        )!;
+
+        const fiber = yield* Effect.forkChild(
+          runPolicyCase(workload).pipe(
+            Effect.provideService(DiagnosticProgress, {
+              phase: () => Effect.void,
+              mark: ({ name }) =>
+                Effect.gen(function* () {
+                  marks.push(name);
+                  if (name === boundary) yield* Deferred.succeed(entered, undefined);
+                }),
+            }),
+          ),
+        );
+
+        yield* Deferred.await(entered);
+        yield* Fiber.interrupt(fiber);
+      }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
+    );
+    expect(marks).toContain("model:close:1");
+    expect(marks.some((name) => name.startsWith("handler:start:"))).toBe(false);
+  },
+);
+
+it("closes the acquired model when phase recording fails", async () => {
+  const marks: Array<string> = [];
+
+  const result = await Effect.runPromiseExit(
+    runPolicyCase(policyCases[0]!).pipe(
+      Effect.provideService(DiagnosticProgress, {
+        phase: () => Effect.void,
+        mark: ({ name }) =>
+          Effect.gen(function* () {
+            marks.push(name);
+            if (name === "model:open:1")
+              return yield* BenchmarkError.make({ message: "evidence failed" });
+          }),
+      }),
+    ),
+  );
+
+  expect(Exit.isFailure(result)).toBe(true);
+  expect(marks).toContain("model:close:1");
+  expect(marks.some((name) => name.startsWith("provider:"))).toBe(false);
+});
+
+it("exposes diagnostic progress and typed fixture failure", () => {
+  expectTypeOf<
+    Effect.Services<ReturnType<typeof runPolicyCase>>
+  >().toEqualTypeOf<DiagnosticProgress>();
+  expectTypeOf<Effect.Error<ReturnType<typeof runPolicyCase>>>().toEqualTypeOf<BenchmarkError>();
+});

--- a/packages/capabilities/src/EphemeralThreads.ts
+++ b/packages/capabilities/src/EphemeralThreads.ts
@@ -288,20 +288,68 @@ export const EphemeralThreadsLive = Layer.effect(
               }
               const timestamp = DateTime.toUtc(DateTime.makeUnsafe(yield* Clock.currentTimeMillis));
 
-              let snapshot = current;
-              let next = threads;
+              if (incoming.length === currentEncoded.length) return [current, threads] as const;
+
+              const messages = [...current.messages];
+              let contentBytes = current.contentBytes;
+              let storeBytes = totalStoreBytes(threads);
+              let nextSequence = current.nextSequence;
 
               for (const entry of incoming.slice(currentEncoded.length)) {
-                [snapshot, next] = yield* appendEncoded(
-                  next,
-                  snapshot,
-                  ThreadAppend.make({ runId: historyRunId, message: entry.message }),
-                  entry.encoded,
-                  timestamp,
+                const append = ThreadAppend.make({ runId: historyRunId, message: entry.message });
+
+                // Preserve append's first failing bound and observed value without publishing
+                // intermediate snapshots or rescanning the store for each suffix message.
+                if (messages.length >= MAX_THREAD_MESSAGES) {
+                  return yield* ThreadLimitExceeded.make({
+                    threadId,
+                    limit: "messages",
+                    limitValue: MAX_THREAD_MESSAGES,
+                    observedValue: messages.length + 1,
+                  });
+                }
+                const messageBytes = utf8ByteLength(entry.encoded);
+
+                contentBytes += messageBytes;
+                if (contentBytes > MAX_THREAD_CONTENT_BYTES) {
+                  return yield* ThreadLimitExceeded.make({
+                    threadId,
+                    limit: "content-bytes",
+                    limitValue: MAX_THREAD_CONTENT_BYTES,
+                    observedValue: contentBytes,
+                  });
+                }
+                storeBytes += messageBytes;
+                if (storeBytes > MAX_EPHEMERAL_CONTENT_BYTES) {
+                  return yield* ThreadLimitExceeded.make({
+                    threadId,
+                    limit: "store-content-bytes",
+                    limitValue: MAX_EPHEMERAL_CONTENT_BYTES,
+                    observedValue: storeBytes,
+                  });
+                }
+                messages.push(
+                  ThreadMessage.make({
+                    threadId,
+                    sequence: nextSequence,
+                    ...(append.runId === undefined ? {} : { runId: append.runId }),
+                    message: append.message,
+                    encodedBytes: messageBytes,
+                    timestamp,
+                  }),
                 );
+                nextSequence += 1;
               }
 
-              return [snapshot, next] as const;
+              const snapshot = ThreadSnapshot.make({
+                version: current.version,
+                threadId,
+                nextSequence,
+                contentBytes,
+                messages,
+              });
+
+              return [snapshot, new Map(threads).set(threadId, snapshot)] as const;
             }),
           );
         },

--- a/packages/capabilities/test/capabilities.test.ts
+++ b/packages/capabilities/test/capabilities.test.ts
@@ -26,9 +26,9 @@ import {
 } from "@effect-agent/capabilities/Commands";
 import {
   ThreadAppend,
+  ThreadEncodingError,
   ThreadExport,
   ThreadHistoryDiverged,
-  ThreadLimitExceeded,
   type ThreadNotFound,
   ThreadSnapshot,
   EphemeralThreads,
@@ -62,7 +62,18 @@ import { AgentId, ThreadId, RunId, ToolCallId, TurnId } from "@effect-agent/core
 import { RunStarted, TextDelta } from "@effect-agent/core/RunEvent";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Clock, Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
+import {
+  Cause,
+  Clock,
+  Context,
+  DateTime,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Schema,
+} from "effect";
 import { TestClock } from "effect/testing";
 import { Prompt, Response, Tool, Toolkit } from "effect/unstable/ai";
 import * as McpSchema from "effect/unstable/ai/McpSchema";
@@ -84,6 +95,12 @@ const textMessage = (role: "system" | "user" | "assistant", content: string): Pr
 
   return message;
 };
+
+const encodedMessageBytes = Effect.fn(function* (message: Prompt.Message) {
+  return new TextEncoder().encode(
+    JSON.stringify(yield* Schema.encodeEffect(Prompt.Message)(message)),
+  ).byteLength;
+});
 
 const approvalDraft = (
   requestId: string,
@@ -275,13 +292,432 @@ describe("capability contracts", () => {
         ...threadPrompt(base).content,
         textMessage("assistant", "a".repeat(3 * 1024 * 1024)),
         textMessage("assistant", "b".repeat(3 * 1024 * 1024)),
+        textMessage("assistant", "not reached"),
       ]);
+
+      const firstOverflow =
+        base.contentBytes +
+        (yield* encodedMessageBytes(oversized.content[1]!)) +
+        (yield* encodedMessageBytes(oversized.content[2]!));
 
       const error = yield* threads.recordHistory(threadId, runId, oversized).pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(ThreadLimitExceeded);
+      expect(error).toMatchObject({
+        _tag: "ThreadLimitExceeded",
+        limit: "content-bytes",
+        limitValue: 4 * 1024 * 1024,
+        observedValue: firstOverflow,
+      });
       expect(yield* threads.snapshot(threadId)).toEqual(base);
     }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "records equal-by-value native histories with one timestamp and contiguous sequences",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+
+        const rich = () => [
+          Prompt.userMessage({
+            options: { provider: { nested: ["é", { enabled: true }] } },
+            content: [
+              Prompt.filePart({
+                mediaType: "application/octet-stream",
+                data: new Uint8Array([1, 2, 3]),
+              }),
+              Prompt.filePart({
+                mediaType: "image/png",
+                data: new URL("https://example.test/image"),
+              }),
+            ],
+          }),
+          Prompt.assistantMessage({
+            content: [
+              Prompt.reasoningPart({ text: "Reasoning α" }),
+              Prompt.toolCallPart({
+                id: "native-call",
+                name: "search",
+                params: { query: "東京" },
+                providerExecuted: false,
+              }),
+              Prompt.toolResultPart({
+                id: "native-call",
+                name: "search",
+                isFailure: false,
+                result: { nested: ["found", 3] },
+                providerExecuted: false,
+              }),
+            ],
+          }),
+        ];
+
+        yield* threads.create(threadId);
+        const base = yield* threads.recordHistory(threadId, runId, Prompt.fromMessages(rich()));
+        const suffix = [textMessage("user", "次"), textMessage("assistant", "réponse")];
+        const nextRunId = RunId.make("next-native-run");
+        const history = Prompt.fromMessages([...rich(), ...suffix]);
+        const clock = yield* Clock.Clock;
+
+        const snapshot = yield* threads.recordHistory(threadId, nextRunId, history).pipe(
+          Effect.provideService(Clock.Clock, {
+            ...clock,
+            currentTimeMillis: Effect.succeed(1234),
+          }),
+        );
+
+        expect(snapshot.messages.map((entry) => entry.sequence)).toEqual([0, 1, 2, 3]);
+        expect(snapshot.messages.map((entry) => entry.runId)).toEqual([
+          runId,
+          runId,
+          nextRunId,
+          nextRunId,
+        ]);
+        expect(snapshot.messages.slice(2).map((entry) => entry.timestamp)).toEqual([
+          at(1234),
+          at(1234),
+        ]);
+        expect(snapshot.nextSequence).toBe(4);
+        expect(snapshot.contentBytes).toBe(
+          base.contentBytes +
+            (yield* encodedMessageBytes(suffix[0]!)) +
+            (yield* encodedMessageBytes(suffix[1]!)),
+        );
+        expect(yield* Schema.encodeEffect(Prompt.Prompt)(threadPrompt(snapshot))).toEqual(
+          yield* Schema.encodeEffect(Prompt.Prompt)(history),
+        );
+        expect(yield* threads.recordHistory(threadId, nextRunId, history)).toEqual(snapshot);
+        expect(base.messages).toHaveLength(2);
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "rechecks mutable native file data and nested options against current stored values",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+
+        const makeMessage = () => {
+          const bytes = new Uint8Array([1, 2, 3]);
+          const url = new URL("https://example.test/old");
+          const options = { provider: { value: "old" } };
+
+          const message = Prompt.userMessage({
+            options,
+            content: [
+              Prompt.filePart({ mediaType: "application/octet-stream", data: bytes }),
+              Prompt.filePart({ mediaType: "image/png", data: url }),
+            ],
+          });
+
+          return { bytes, url, options, message };
+        };
+
+        const original = makeMessage();
+        const stale = makeMessage();
+
+        yield* threads.create(threadId);
+
+        const base = yield* threads.append(
+          threadId,
+          ThreadAppend.make({ message: original.message }),
+        );
+
+        original.bytes[0] = 9;
+        original.url.pathname = "/new";
+        original.options.provider.value = "new";
+        expect(
+          yield* Schema.encodeEffect(Prompt.Prompt)(
+            threadPrompt(yield* threads.snapshot(threadId)),
+          ),
+        ).toEqual(
+          yield* Schema.encodeEffect(Prompt.Prompt)(Prompt.fromMessages([original.message])),
+        );
+
+        const rejected = yield* threads
+          .recordHistory(threadId, runId, Prompt.fromMessages([stale.message]))
+          .pipe(Effect.flip);
+
+        expect(rejected).toBeInstanceOf(ThreadHistoryDiverged);
+
+        const snapshot = yield* threads.recordHistory(
+          threadId,
+          runId,
+          Prompt.fromMessages([original.message, textMessage("assistant", "new suffix")]),
+        );
+
+        expect(snapshot.nextSequence).toBe(2);
+        expect(base.messages).toHaveLength(1);
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "validates incoming messages before lookup or divergence and revalidates stored messages",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+        const options = { provider: { value: 0 } };
+        const message = Prompt.systemMessage({ content: "official", options });
+
+        const invalid = Prompt.systemMessage({
+          content: "invalid",
+          options: { provider: { value: Number.NaN } },
+        });
+
+        yield* threads.create(threadId);
+        const base = yield* threads.append(threadId, ThreadAppend.make({ message }));
+
+        const missing = yield* threads
+          .recordHistory(ThreadId.make("missing-history"), runId, Prompt.fromMessages([invalid]))
+          .pipe(Effect.flip);
+
+        const rewritten = yield* threads
+          .recordHistory(
+            threadId,
+            runId,
+            Prompt.fromMessages([textMessage("user", "rewritten"), invalid]),
+          )
+          .pipe(Effect.flip);
+
+        expect(missing).toBeInstanceOf(ThreadEncodingError);
+        expect(rewritten).toBeInstanceOf(ThreadEncodingError);
+        expect(yield* threads.snapshot(threadId)).toEqual(base);
+        options.provider.value = Number.NaN;
+
+        const stored = yield* threads
+          .recordHistory(
+            threadId,
+            runId,
+            Prompt.fromMessages([
+              Prompt.systemMessage({ content: "official", options: { provider: { value: 0 } } }),
+            ]),
+          )
+          .pipe(Effect.flip);
+
+        expect(stored).toBeInstanceOf(ThreadEncodingError);
+        options.provider.value = 0;
+        expect(yield* threads.snapshot(threadId)).toEqual(base);
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "reports the first message-count overflow before byte limits and rolls back the suffix",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+        const small = textMessage("system", "x");
+
+        yield* threads.create(threadId);
+        const baseHistory = Prompt.fromMessages(Array.from({ length: 1_023 }, () => small));
+        const base = yield* threads.recordHistory(threadId, runId, baseHistory);
+
+        const error = yield* threads
+          .recordHistory(
+            threadId,
+            runId,
+            Prompt.fromMessages([
+              ...baseHistory.content,
+              small,
+              textMessage("system", "x".repeat(4 * 1024 * 1024)),
+              small,
+            ]),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toMatchObject({
+          _tag: "ThreadLimitExceeded",
+          limit: "messages",
+          limitValue: 1_024,
+          observedValue: 1_025,
+        });
+        expect(yield* threads.snapshot(threadId)).toEqual(base);
+
+        const full = yield* threads.recordHistory(
+          threadId,
+          runId,
+          Prompt.fromMessages([...baseHistory.content, small]),
+        );
+
+        expect(full.nextSequence).toBe(1_024);
+        expect(full.contentBytes).toBe(base.contentBytes + (yield* encodedMessageBytes(small)));
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "rolls back store-byte overflow and admits only one concurrent suffix at shared capacity",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+        const mib = 1024 * 1024;
+        const overhead = yield* encodedMessageBytes(Prompt.systemMessage({ content: "" }));
+
+        const sized = (bytes: number) =>
+          Prompt.systemMessage({ content: "x".repeat(bytes - overhead) });
+
+        const fullMessage = sized(4 * mib);
+
+        for (let index = 0; index < 16; index++) {
+          const id = ThreadId.make(`full-history-${index}`);
+
+          yield* threads.create(id);
+          yield* threads.append(
+            id,
+            ThreadAppend.make({ message: index < 15 ? fullMessage : sized(3 * mib) }),
+          );
+        }
+        const otherId = ThreadId.make("other-history");
+        const base = yield* threads.create(threadId);
+        const otherBase = yield* threads.create(otherId);
+
+        const rejected = yield* threads
+          .recordHistory(
+            threadId,
+            runId,
+            Prompt.fromMessages([sized(mib / 2), sized(mib), sized(mib)]),
+          )
+          .pipe(Effect.flip);
+
+        expect(rejected).toMatchObject({
+          _tag: "ThreadLimitExceeded",
+          limit: "store-content-bytes",
+          limitValue: 64 * mib,
+          observedValue: 64 * mib + mib / 2,
+        });
+        expect(yield* threads.snapshot(threadId)).toEqual(base);
+        expect(yield* threads.snapshot(otherId)).toEqual(otherBase);
+        const history = Prompt.fromMessages([sized(mib)]);
+
+        const outcomes = yield* Effect.all(
+          [threadId, otherId].map((id) =>
+            threads.recordHistory(id, runId, history).pipe(Effect.exit),
+          ),
+          { concurrency: 2 },
+        );
+
+        expect(outcomes.filter(Exit.isSuccess)).toHaveLength(1);
+        expect(outcomes.filter(Exit.isFailure)).toHaveLength(1);
+        for (const outcome of outcomes) {
+          if (Exit.isFailure(outcome))
+            expect(Cause.findErrorOption(outcome.cause)).toMatchObject({
+              _tag: "Some",
+              value: {
+                _tag: "ThreadLimitExceeded",
+                limit: "store-content-bytes",
+                observedValue: 65 * mib,
+              },
+            });
+        }
+
+        const snapshots = yield* Effect.all([
+          threads.snapshot(threadId),
+          threads.snapshot(otherId),
+        ]);
+
+        expect(snapshots.map((snapshot) => snapshot.contentBytes).sort((a, b) => a - b)).toEqual([
+          0,
+          mib,
+        ]);
+        expect(snapshots.map((snapshot) => snapshot.nextSequence).sort()).toEqual([0, 1]);
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect(
+    "releases a failed or interrupted history transaction without publishing its suffix",
+    () =>
+      Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+
+        yield* threads.create(threadId);
+
+        const base = yield* threads.append(
+          threadId,
+          ThreadAppend.make({ message: textMessage("user", "base") }),
+        );
+
+        const history = Prompt.fromMessages([
+          ...threadPrompt(base).content,
+          textMessage("assistant", "suffix"),
+        ]);
+
+        const clock = yield* Clock.Clock;
+
+        for (const failure of ["interruption", "timeout", "defect"] as const) {
+          const entered = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          let finalized = false;
+
+          const timestamp = Effect.acquireUseRelease(
+            Effect.void,
+            () =>
+              Deferred.succeed(entered, undefined).pipe(
+                Effect.andThen(Deferred.await(release)),
+                Effect.andThen(Effect.die("timestamp defect")),
+              ),
+            () =>
+              Effect.sync(() => {
+                finalized = true;
+              }),
+          );
+
+          const record = threads
+            .recordHistory(threadId, runId, history)
+            .pipe(Effect.provideService(Clock.Clock, { ...clock, currentTimeMillis: timestamp }));
+
+          const fiber = yield* (
+            failure === "timeout" ? record.pipe(Effect.timeout("1 second")) : record
+          ).pipe(Effect.forkChild);
+
+          yield* Deferred.await(entered);
+          if (failure === "interruption") yield* Fiber.interrupt(fiber);
+          else if (failure === "timeout") yield* TestClock.adjust("1 second");
+          else yield* Deferred.succeed(release, undefined);
+          const exit = yield* Fiber.await(fiber);
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            if (failure === "interruption") expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+            else if (failure === "defect") expect(Cause.hasDies(exit.cause)).toBe(true);
+            else
+              expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+                _tag: "Some",
+                value: { _tag: "TimeoutError" },
+              });
+          }
+          expect(finalized).toBe(true);
+          expect(yield* threads.snapshot(threadId)).toEqual(base);
+        }
+        const committed = yield* threads.recordHistory(threadId, runId, history);
+
+        expect(committed.nextSequence).toBe(2);
+        expect(committed.messages).toHaveLength(2);
+      }).pipe(Effect.provide(EphemeralThreadsLive)),
+  );
+
+  it.effect("starts each ephemeral store Scope with fresh thread and byte state", () =>
+    Effect.gen(function* () {
+      yield* Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+
+        yield* threads.create(threadId);
+        yield* threads.recordHistory(
+          threadId,
+          runId,
+          Prompt.fromMessages([textMessage("user", "old scope")]),
+        );
+      }).pipe(Effect.provide(EphemeralThreadsLive), Effect.scoped);
+
+      yield* Effect.gen(function* () {
+        const threads = yield* EphemeralThreads;
+        const missing = yield* threads.snapshot(threadId).pipe(Effect.flip);
+
+        expect(missing._tag).toBe("ThreadNotFound");
+        expect(yield* threads.create(threadId)).toMatchObject({
+          nextSequence: 0,
+          contentBytes: 0,
+          messages: [],
+        });
+      }).pipe(Effect.provide(EphemeralThreadsLive), Effect.scoped);
+    }),
   );
 
   it.effect(

--- a/packages/storage-cloudflare/src/DoSubmissionLedger.ts
+++ b/packages/storage-cloudflare/src/DoSubmissionLedger.ts
@@ -1888,6 +1888,76 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
     return reserved;
   });
 
+  const validateFinalization = Effect.fn("DoSubmissionLedger.validateFinalization")(function* (
+    validated: SettlementFinalization,
+    reservation: Option.Option<ReservationRow>,
+  ) {
+    const operation = "ledger finalize settlement";
+
+    if (Option.isNone(reservation)) {
+      return yield* LedgerError.make({
+        operation,
+        message: `No settlement reservation exists for submission ${validated.submissionId}.`,
+      });
+    }
+    if (reservation.value.settlement_id !== validated.settlementId) {
+      return yield* SettlementConflict.make({
+        submissionId: validated.submissionId,
+        existingOutcome: reservation.value.outcome,
+      });
+    }
+
+    const reservationRecord = yield* decodeRecordEnvelopeText(reservation.value.record_json).pipe(
+      Effect.mapError((error) =>
+        corruptionFailure(
+          operation,
+          "effect_agent_settlement_reservations",
+          validated.submissionId,
+          error.message,
+        ),
+      ),
+    );
+
+    const settlementFailure = settlementFailureFromRecord(reservationRecord);
+
+    if ((reservation.value.outcome === "failed") !== (settlementFailure !== undefined)) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        "The reserved outcome and canonical failure diagnostic disagree.",
+      );
+    }
+
+    return { reservation: reservation.value, settlementFailure };
+  });
+
+  const replayFinalization = Effect.fn("DoSubmissionLedger.replayFinalization")(function* (
+    validated: SettlementFinalization,
+    submission: SubmissionRow,
+    { reservation, settlementFailure }: Effect.Success<ReturnType<typeof validateFinalization>>,
+  ) {
+    const operation = "ledger finalize settlement";
+
+    if (reservation.finalized_at === null) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        "A settled Submission's reservation carries no finalization timestamp.",
+      );
+    }
+
+    return yield* decodeSettlement({
+      submissionId: validated.submissionId,
+      settlementId: validated.settlementId,
+      receiptId: submission.receipt_id,
+      outcome: reservation.outcome,
+      ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
+      settledAt: reservation.finalized_at,
+    }).pipe(Effect.mapError(internalFailure(operation)));
+  });
+
   const finalizeSettlement: SubmissionLedger["Service"]["finalizeSettlement"] = Effect.fn(
     "DoSubmissionLedger.finalizeSettlement",
   )(function* (request: SettlementFinalization) {
@@ -1899,73 +1969,74 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
 
     yield* hitFailpoint("ledger:finalize-settlement:before", operation);
 
+    // A single statement captures the settled row and its immutable reservation together.
+    // A miss does not authorize finalization: the write path re-reads under its transaction.
+    const replayRows = yield* sql<Record<string, unknown>>`
+      SELECT submission.*, reservation.settlement_id, reservation.outcome,
+        reservation.record_id, reservation.record_json, reservation.record_digest,
+        reservation.reserved_at, reservation.finalized_at
+      FROM effect_agent_submissions AS submission
+      INNER JOIN effect_agent_settlement_reservations AS reservation
+        ON reservation.submission_id = submission.submission_id
+      WHERE submission.submission_id = ${validated.submissionId} AND submission.state = 'settled'
+    `.pipe(Effect.mapError(sqlFailure(operation)));
+
+    if (replayRows.length > 1) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_submissions",
+        validated.submissionId,
+        "A submission primary key returned more than one row.",
+      );
+    }
+    const replayRow = replayRows[0];
+
+    if (replayRow !== undefined) {
+      const reservations = yield* decodeRows(
+        Schema.Array(ReservationRow),
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        replayRows,
+      ).pipe(Effect.mapError(internalFailure(operation)));
+
+      const state = yield* validateFinalization(validated, Option.fromUndefinedOr(reservations[0]));
+
+      const submission = yield* Schema.decodeUnknownEffect(SubmissionRow)(replayRow).pipe(
+        Effect.mapError((error) =>
+          corruptionFailure(
+            operation,
+            "effect_agent_submissions",
+            validated.submissionId,
+            error.message,
+          ),
+        ),
+      );
+
+      const settlement = yield* replayFinalization(validated, submission, state);
+
+      yield* hitFailpoint("ledger:finalize-settlement:after", operation);
+
+      return settlement;
+    }
+
     const settlement = yield* inWriteTransaction(
       operation,
       Effect.gen(function* () {
-        const reservation = yield* readReservation(operation, validated.submissionId);
-
-        if (Option.isNone(reservation)) {
-          return yield* LedgerError.make({
-            operation,
-            message: `No settlement reservation exists for submission ${validated.submissionId}.`,
-          });
-        }
-        if (reservation.value.settlement_id !== validated.settlementId) {
-          return yield* SettlementConflict.make({
-            submissionId: validated.submissionId,
-            existingOutcome: reservation.value.outcome,
-          });
-        }
-
-        const reservationRecord = yield* decodeRecordEnvelopeText(
-          reservation.value.record_json,
-        ).pipe(
-          Effect.mapError((error) =>
-            corruptionFailure(
-              operation,
-              "effect_agent_settlement_reservations",
-              validated.submissionId,
-              error.message,
-            ),
-          ),
+        const state = yield* validateFinalization(
+          validated,
+          yield* readReservation(operation, validated.submissionId),
         );
 
-        const settlementFailure = settlementFailureFromRecord(reservationRecord);
-
-        if ((reservation.value.outcome === "failed") !== (settlementFailure !== undefined)) {
-          return yield* corruptionFailure(
-            operation,
-            "effect_agent_settlement_reservations",
-            validated.submissionId,
-            "The reserved outcome and canonical failure diagnostic disagree.",
-          );
-        }
+        const { reservation, settlementFailure } = state;
         const submission = yield* requireSubmission(operation, validated.submissionId);
 
-        if (submission.state === "settled") {
-          if (reservation.value.finalized_at === null) {
-            return yield* corruptionFailure(
-              operation,
-              "effect_agent_settlement_reservations",
-              validated.submissionId,
-              "A settled Submission's reservation carries no finalization timestamp.",
-            );
-          }
-
-          return yield* decodeSettlement({
-            submissionId: validated.submissionId,
-            settlementId: validated.settlementId,
-            receiptId: submission.receipt_id,
-            outcome: reservation.value.outcome,
-            ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
-            settledAt: reservation.value.finalized_at,
-          }).pipe(Effect.mapError(internalFailure(operation)));
-        }
+        if (submission.state === "settled")
+          return yield* replayFinalization(validated, submission, state);
         const now = yield* currentInstant;
 
         yield* sql`
           UPDATE effect_agent_submissions
-          SET state = 'settled', settled_outcome = ${reservation.value.outcome}
+          SET state = 'settled', settled_outcome = ${reservation.outcome}
           WHERE submission_id = ${validated.submissionId}
         `.pipe(Effect.mapError(sqlFailure(operation)));
         yield* sql`
@@ -1982,7 +2053,7 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
           submissionId: validated.submissionId,
           settlementId: validated.settlementId,
           receiptId: submission.receipt_id,
-          outcome: reservation.value.outcome,
+          outcome: reservation.outcome,
           ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
           settledAt: now.iso,
         }).pipe(Effect.mapError(internalFailure(operation)));
@@ -3158,13 +3229,7 @@ const makeServices = Effect.fn("DoSubmissionLedger.makeServices")(function* () {
           SELECT ${sql.literal(SUBMISSION_COLUMNS)}
           FROM effect_agent_submissions
           WHERE state <> 'settled'
-            AND (
-              thread_id > ${cursor.threadId}
-              OR (
-                thread_id = ${cursor.threadId}
-                AND queue_sequence > ${cursor.queueSequence}
-              )
-            )
+            AND (thread_id, queue_sequence) > (${cursor.threadId}, ${cursor.queueSequence})
           ORDER BY thread_id ASC, queue_sequence ASC
           LIMIT ${SCAN_PAGE_SIZE}
         `

--- a/packages/storage-cloudflare/src/internal/do-journal.ts
+++ b/packages/storage-cloudflare/src/internal/do-journal.ts
@@ -25,7 +25,7 @@ import {
   type DoStorageFailpointLocation,
 } from "../DoStorageError.ts";
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
-import { CurrentDoStorageVersion, doMigrations } from "./migrations.ts";
+import { CurrentDoStorageVersion, createNonterminalIndex, doMigrations } from "./migrations.ts";
 import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 /**
@@ -349,11 +349,11 @@ const predecessorColumns = {
 } as const;
 
 const checkPredecessorLayout = Effect.fn("DoJournal.checkPredecessorLayout")(function* (
-  version: 3 | 4,
+  version: 3 | 4 | 5,
 ) {
   const sql = yield* SqlClient.SqlClient;
 
-  const expectedColumns =
+  const messageColumns =
     version === 3
       ? predecessorColumns
       : {
@@ -372,6 +372,20 @@ const checkPredecessorLayout = Effect.fn("DoJournal.checkPredecessorLayout")(fun
             "record_json",
           ],
         };
+
+  const expectedColumns = {
+    ...messageColumns,
+    ...(version === 5
+      ? {
+          effect_agent_recovery_checkpoints: [
+            "thread_id",
+            "through_sequence",
+            "tail_digest",
+            "checkpoint_json",
+          ],
+        }
+      : {}),
+  };
 
   for (const [table, expected] of Object.entries(expectedColumns)) {
     const columns = yield* decodeRows(
@@ -486,7 +500,12 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
       versionRows,
     );
 
-    if (version.value === "2" || version.value === "3" || version.value === "4") {
+    if (
+      version.value === "2" ||
+      version.value === "3" ||
+      version.value === "4" ||
+      version.value === "5"
+    ) {
       yield* sql
         .withTransaction(
           Effect.gen(function* () {
@@ -498,7 +517,10 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
               return;
             if (
               current.length !== 1 ||
-              (current[0].value !== "2" && current[0].value !== "3" && current[0].value !== "4")
+              (current[0].value !== "2" &&
+                current[0].value !== "3" &&
+                current[0].value !== "4" &&
+                current[0].value !== "5")
             )
               return yield* DoStorageCompatibilityError.make({
                 actualVersion: -1,
@@ -524,12 +546,23 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
             const recoveryTables =
               yield* sql`SELECT name FROM sqlite_master WHERE type='table' AND name='effect_agent_recovery_checkpoints'`;
 
-            if (recoveryTables.length !== 0)
+            if (recoveryTables.length !== (current[0].value === "5" ? 1 : 0))
               return yield* DoStorageCompatibilityError.make({
                 actualVersion: Number(current[0].value),
                 supportedVersion: CurrentDoStorageVersion,
                 message:
-                  "The predecessor already contains recovery checkpoint storage; refusing ambiguous data without mutation.",
+                  "The predecessor recovery checkpoint storage does not match its version; refusing ambiguous data without mutation.",
+              });
+
+            const indexes =
+              yield* sql`SELECT name FROM sqlite_master WHERE name='effect_agent_submissions_nonterminal'`;
+
+            if (indexes.length !== 0)
+              return yield* DoStorageCompatibilityError.make({
+                actualVersion: Number(current[0].value),
+                supportedVersion: CurrentDoStorageVersion,
+                message:
+                  "The predecessor already contains the nonterminal index; refusing ambiguous storage without mutation.",
               });
             if (current[0].value === "2") {
               yield* checkV2ThreadLayout();
@@ -545,7 +578,8 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
             }
             if (current[0].value === "3") yield* checkPredecessorLayout(3);
             if (current[0].value === "4") yield* checkPredecessorLayout(4);
-            if (current[0].value !== "4") {
+            if (current[0].value === "5") yield* checkPredecessorLayout(5);
+            if (current[0].value === "2" || current[0].value === "3") {
               yield* failpoint("upgrade:before-mutation");
               yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
               yield* failpoint("upgrade:after-mutation");
@@ -556,11 +590,16 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
               yield* createMessageDeliveryTables;
               yield* failpoint("upgrade:after-mutation");
             }
+            if (current[0].value !== "5") {
+              yield* failpoint("upgrade:before-mutation");
+              yield* createRecoveryCheckpointTable;
+              yield* failpoint("upgrade:after-mutation");
+            }
             yield* failpoint("upgrade:before-mutation");
-            yield* createRecoveryCheckpointTable;
+            yield* createNonterminalIndex;
             yield* failpoint("upgrade:after-mutation");
             yield* failpoint("upgrade:before-version");
-            yield* sql`UPDATE effect_agent_meta SET value='5' WHERE key='storage_version'`;
+            yield* sql`UPDATE effect_agent_meta SET value='6' WHERE key='storage_version'`;
             yield* failpoint("upgrade:after-version");
           }),
         )
@@ -590,7 +629,7 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
         message:
           `The Durable Object uses unsupported storage version ${version.value}; ` +
           `this build supports exactly version ${CurrentDoStorageVersion}. ` +
-          "Only supported v2, v3 and v4 can be upgraded automatically. Keep the original store and use a compatible library version.",
+          "Only supported v2, v3, v4 and v5 can be upgraded automatically. Keep the original store and use a compatible library version.",
       });
     }
   }
@@ -598,8 +637,9 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
   const requiredRows = yield* sql<Record<string, unknown>>`
     SELECT name
     FROM sqlite_master
-    WHERE type = 'table'
+    WHERE (type = 'table'
       AND name IN ${sql.in([...REQUIRED_TABLES, "effect_agent_message_deliveries", "effect_agent_recovery_checkpoints"])}
+    ) OR (type = 'index' AND name = 'effect_agent_submissions_nonterminal')
     ORDER BY name
   `.pipe(Effect.mapError(storageError("verify storage tables")));
 
@@ -610,12 +650,12 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
     requiredRows,
   );
 
-  if (required.length !== REQUIRED_TABLES.length + 2) {
+  if (required.length !== REQUIRED_TABLES.length + 3) {
     return yield* DoStorageCompatibilityError.make({
       actualVersion: CurrentDoStorageVersion,
       supportedVersion: CurrentDoStorageVersion,
       message:
-        "The Durable Object claims the current format but is missing required tables. Retain the original store for inspection.",
+        "The Durable Object claims the current format but is missing required tables or its nonterminal index. Retain the original store for inspection.",
     });
   }
 

--- a/packages/storage-cloudflare/src/internal/migrations.ts
+++ b/packages/storage-cloudflare/src/internal/migrations.ts
@@ -6,7 +6,15 @@ import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
 import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 /** The current storage version recorded in `effect_agent_meta`. */
-export const CurrentDoStorageVersion = 5;
+export const CurrentDoStorageVersion = 6;
+
+/** Index only outstanding obligations, ordered by the recovery scan's stable cursor. */
+export const createNonterminalIndex = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`CREATE INDEX effect_agent_submissions_nonterminal ON effect_agent_submissions (thread_id, queue_sequence) WHERE state <> 'settled'`
+    .withoutTransform;
+});
 
 /**
  * The Thread Durable Object schema shares its thread and ledger tables with Node/SQLite.
@@ -257,6 +265,7 @@ export const doMigrations = SqliteMigrator.fromRecord({
       )
     `.withoutTransform;
 
+    yield* createNonterminalIndex;
     yield* createMessageDeliveryTables;
     yield* createRecoveryCheckpointTable;
     yield* sql`

--- a/packages/storage-cloudflare/test/do-ledger-reads.test.ts
+++ b/packages/storage-cloudflare/test/do-ledger-reads.test.ts
@@ -1,0 +1,121 @@
+import { SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { BrowserCrypto } from "@effect/platform-browser";
+import { SqliteClient } from "@effect/sql-sqlite-do";
+import { Effect, Layer, type Crypto } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ledgerReadCases,
+  reserveReadFixture,
+} from "../../../test/fixtures/ledger-read-contracts.ts";
+import { DoStorageFailpointError } from "../src/DoStorageError.ts";
+import { DoStorageFailpoint } from "../src/DoStorageFailpoint.ts";
+import { submissionLedgerLayer } from "../src/DoSubmissionLedger.ts";
+import { storageConfigLayer } from "../src/DoThreadStore.ts";
+import { withThreadStorage } from "./harness.ts";
+
+let nextId = 0;
+
+const withFixture = <A, E>(
+  effect: Effect.Effect<A, E, SubmissionLedger | SqlClient.SqlClient | Crypto.Crypto>,
+  options?: {
+    readonly transaction?: () => void;
+    readonly failpoint?: (point: string) => Effect.Effect<void, DoStorageFailpointError>;
+  },
+) =>
+  withThreadStorage(`ledger-reads-${nextId++}`, (storage) =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      const observed = new Proxy(sql, {
+        get(target, key, receiver) {
+          if (key === "withTransaction")
+            return <A, E, R>(body: Effect.Effect<A, E, R>) =>
+              Effect.sync(() => options?.transaction?.()).pipe(
+                Effect.andThen(sql.withTransaction(body)),
+              );
+
+          return Reflect.get(target, key, receiver);
+        },
+      });
+
+      const deps = Layer.mergeAll(
+        Layer.succeed(SqlClient.SqlClient)(observed),
+        storageConfigLayer({ storage }),
+        BrowserCrypto.layer,
+        options?.failpoint === undefined
+          ? DoStorageFailpoint.layer
+          : Layer.succeed(DoStorageFailpoint)({ hit: options.failpoint }),
+      );
+
+      return yield* effect.pipe(
+        Effect.provide(submissionLedgerLayer.pipe(Layer.provideMerge(deps))),
+      );
+    }).pipe(Effect.provide(SqliteClient.layer({ storage }))),
+  );
+
+describe("Durable Object ledger read contracts", () => {
+  for (const test of ledgerReadCases) it(test.name, () => withFixture(test.run));
+
+  it("uses no storage transaction for settled replay and preserves active finalization", () => {
+    let transactions = 0;
+
+    return withFixture(
+      Effect.gen(function* () {
+        const ledger = yield* SubmissionLedger;
+        const request = yield* reserveReadFixture("transaction-budget");
+
+        transactions = 0;
+        yield* ledger.finalizeSettlement(request);
+        expect(transactions).toBe(1);
+        transactions = 0;
+        yield* ledger.finalizeSettlement(request);
+        expect(transactions).toBe(0);
+      }),
+      {
+        transaction: () => {
+          transactions++;
+        },
+      },
+    );
+  });
+
+  for (const point of [
+    "ledger:finalize-settlement:before",
+    "ledger:finalize-settlement:after",
+  ] as const) {
+    it(`preserves ${point} on already settled replay`, () => {
+      let armed = false;
+      let hits = 0;
+
+      return withFixture(
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const request = yield* reserveReadFixture(point);
+          const settled = yield* ledger.finalizeSettlement(request);
+
+          armed = true;
+          expect(yield* ledger.finalizeSettlement(request).pipe(Effect.result)).toMatchObject({
+            _tag: "Failure",
+            failure: {
+              _tag: "LedgerError",
+              cause: { _tag: "DoStorageFailpointError", location: point },
+            },
+          });
+          expect(hits).toBe(1);
+          armed = false;
+          expect(yield* ledger.finalizeSettlement(request)).toEqual(settled);
+        }),
+        {
+          failpoint: (location) => {
+            if (!armed || location !== point) return Effect.void;
+            hits++;
+
+            return DoStorageFailpointError.make({ location: point });
+          },
+        },
+      );
+    });
+  }
+});

--- a/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
+++ b/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
@@ -165,6 +165,7 @@ describe("unpatched v2 native storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClientService.SqlClient;
 
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
             yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`UPDATE effect_agent_meta SET value='4' WHERE key='storage_version'`;
             const before = yield* snapshotStore;
@@ -180,7 +181,7 @@ describe("unpatched v2 native storage upgrade", () => {
             yield* assertPreserved("thread");
             expect(
               yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
-            ).toEqual([{ value: "5" }]);
+            ).toEqual([{ value: "6" }]);
             expect(yield* sql`SELECT * FROM effect_agent_recovery_checkpoints`).toEqual([]);
             const upgraded = yield* snapshotStore;
 
@@ -198,6 +199,7 @@ describe("unpatched v2 native storage upgrade", () => {
         yield* open;
         const sql = yield* SqlClientService.SqlClient;
 
+        yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
         yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
         yield* sql`ALTER TABLE effect_agent_submissions RENAME COLUMN message_admission_json TO malformed_column`;
         yield* sql`UPDATE effect_agent_meta SET value='4' WHERE key='storage_version'`;
@@ -226,6 +228,7 @@ describe("unpatched v2 native storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClientService.SqlClient;
 
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
             yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`DROP TABLE effect_agent_message_deliveries`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
@@ -264,6 +267,7 @@ describe("unpatched v2 native storage upgrade", () => {
           yield* open;
           const sql = yield* SqlClientService.SqlClient;
 
+          yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
           yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
           yield* sql`DROP TABLE effect_agent_message_deliveries`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
@@ -279,7 +283,7 @@ describe("unpatched v2 native storage upgrade", () => {
           yield* assertPreserved("thread");
           expect(
             yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
-          ).toEqual([{ value: "5" }]);
+          ).toEqual([{ value: "6" }]);
           expect(yield* sql`SELECT * FROM effect_agent_message_deliveries`).toEqual([]);
         }),
       (point) => (armed && point === "upgrade:after-version" ? "failure" : undefined),
@@ -300,7 +304,7 @@ describe("unpatched v2 native storage upgrade", () => {
           if (store === "thread") {
             expect(
               yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
-            ).toEqual([{ value: "5" }]);
+            ).toEqual([{ value: "6" }]);
             expect(yield* sql`SELECT * FROM effect_agent_child_settlements`).toEqual([
               {
                 parent_submission_id: "parent",
@@ -393,6 +397,119 @@ describe("unpatched v2 native storage upgrade", () => {
         expect(failure).toMatchObject({
           _tag: "Failure",
           failure: { _tag: "SubscriptionError", reason: "corrupt" },
+        });
+        expect(yield* snapshotStore).toEqual(before);
+      }),
+    ));
+});
+
+describe("nonterminal index upgrade", () => {
+  for (const point of [
+    "upgrade:before-mutation",
+    "upgrade:after-mutation",
+    "upgrade:before-version",
+    "upgrade:after-version",
+  ] as const) {
+    for (const mode of ["failure", "interrupt", "defect"] as const) {
+      it(`preserves v5 rows and recovery checkpoints atomically at ${point} (${mode})`, () => {
+        let armed = false;
+
+        return fixture(
+          "thread",
+          (open) =>
+            Effect.gen(function* () {
+              yield* open;
+              const sql = yield* SqlClientService.SqlClient;
+
+              yield* sql`INSERT INTO effect_agent_recovery_checkpoints (thread_id, through_sequence, tail_digest, checkpoint_json) SELECT thread_id, tail_sequence, tail_digest, '{"retained":true}' FROM effect_agent_threads LIMIT 1`;
+              yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
+              yield* sql`UPDATE effect_agent_meta SET value='5' WHERE key='storage_version'`;
+              const before = yield* snapshotStore;
+
+              armed = true;
+              expect(Exit.isFailure(yield* open.pipe(Effect.exit))).toBe(true);
+              expect(yield* snapshotStore).toEqual(before);
+              expect(
+                yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
+              ).toEqual([{ value: "5" }]);
+              armed = false;
+              yield* open;
+              const after = yield* snapshotStore;
+
+              for (const [table, rows] of Object.entries(before.contents)) {
+                if (table !== "effect_agent_meta") expect(after.contents[table]).toEqual(rows);
+              }
+              expect(
+                after.definitions.filter(
+                  (entry) => entry.name !== "effect_agent_submissions_nonterminal",
+                ),
+              ).toEqual(before.definitions);
+              expect(
+                after.definitions.find(
+                  (entry) => entry.name === "effect_agent_submissions_nonterminal",
+                )?.sql,
+              ).toContain("WHERE state <> 'settled'");
+              expect(
+                yield* sql`SELECT value FROM effect_agent_meta WHERE key='storage_version'`,
+              ).toEqual([{ value: "6" }]);
+              yield* open;
+              expect(yield* snapshotStore).toEqual(after);
+            }),
+          (location) => (armed && location === point ? mode : undefined),
+        );
+      });
+    }
+  }
+
+  for (const [table, column] of [
+    ["effect_agent_submissions", "queue_sequence"],
+    ["effect_agent_recovery_checkpoints", "checkpoint_json"],
+  ] as const) {
+    it(`rejects malformed v5 ${table} before any mutation`, () => {
+      let armed = false;
+      let mutations = 0;
+
+      return fixture(
+        "thread",
+        (open) =>
+          Effect.gen(function* () {
+            yield* open;
+            const sql = yield* SqlClientService.SqlClient;
+
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
+            yield* sql`UPDATE effect_agent_meta SET value='5' WHERE key='storage_version'`;
+            yield* sql.unsafe(`ALTER TABLE ${table} RENAME COLUMN ${column} TO malformed_column`);
+            const before = yield* snapshotStore;
+
+            armed = true;
+            expect(yield* open.pipe(Effect.result)).toMatchObject({
+              _tag: "Failure",
+              failure: { _tag: "DoStorageCompatibilityError", actualVersion: 5 },
+            });
+            expect(mutations).toBe(0);
+            expect(yield* snapshotStore).toEqual(before);
+          }),
+        (location) => {
+          if (armed && location === "upgrade:before-mutation") mutations++;
+
+          return undefined;
+        },
+      );
+    });
+  }
+
+  it("rejects a predecessor with a conflicting index without mutation", () =>
+    fixture("thread", (open) =>
+      Effect.gen(function* () {
+        yield* open;
+        const sql = yield* SqlClientService.SqlClient;
+
+        yield* sql`UPDATE effect_agent_meta SET value='5' WHERE key='storage_version'`;
+        const before = yield* snapshotStore;
+
+        expect(yield* open.pipe(Effect.result)).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "DoStorageCompatibilityError", actualVersion: 5 },
         });
         expect(yield* snapshotStore).toEqual(before);
       }),

--- a/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
+++ b/packages/storage-sqlite/src/SqliteSubmissionLedger.ts
@@ -1816,6 +1816,76 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
     return reserved;
   });
 
+  const validateFinalization = Effect.fn("SqliteSubmissionLedger.validateFinalization")(function* (
+    validated: SettlementFinalization,
+    reservation: Option.Option<ReservationRow>,
+  ) {
+    const operation = "ledger finalize settlement";
+
+    if (Option.isNone(reservation)) {
+      return yield* LedgerError.make({
+        operation,
+        message: `No settlement reservation exists for submission ${validated.submissionId}.`,
+      });
+    }
+    if (reservation.value.settlement_id !== validated.settlementId) {
+      return yield* SettlementConflict.make({
+        submissionId: validated.submissionId,
+        existingOutcome: reservation.value.outcome,
+      });
+    }
+
+    const reservationRecord = yield* decodeRecordEnvelopeText(reservation.value.record_json).pipe(
+      Effect.mapError((error) =>
+        corruptionFailure(
+          operation,
+          "effect_agent_settlement_reservations",
+          validated.submissionId,
+          error.message,
+        ),
+      ),
+    );
+
+    const settlementFailure = settlementFailureFromRecord(reservationRecord);
+
+    if ((reservation.value.outcome === "failed") !== (settlementFailure !== undefined)) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        "The reserved outcome and canonical failure diagnostic disagree.",
+      );
+    }
+
+    return { reservation: reservation.value, settlementFailure };
+  });
+
+  const replayFinalization = Effect.fn("SqliteSubmissionLedger.replayFinalization")(function* (
+    validated: SettlementFinalization,
+    submission: SubmissionRow,
+    { reservation, settlementFailure }: Effect.Success<ReturnType<typeof validateFinalization>>,
+  ) {
+    const operation = "ledger finalize settlement";
+
+    if (reservation.finalized_at === null) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        "A settled Submission's reservation carries no finalization timestamp.",
+      );
+    }
+
+    return yield* decodeSettlement({
+      submissionId: validated.submissionId,
+      settlementId: validated.settlementId,
+      receiptId: submission.receipt_id,
+      outcome: reservation.outcome,
+      ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
+      settledAt: reservation.finalized_at,
+    }).pipe(Effect.mapError(internalFailure(operation)));
+  });
+
   const finalizeSettlement: SubmissionLedger["Service"]["finalizeSettlement"] = Effect.fn(
     "SqliteSubmissionLedger.finalizeSettlement",
   )(function* (request: SettlementFinalization) {
@@ -1827,73 +1897,74 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
 
     yield* hitFailpoint("ledger:finalize-settlement:before", operation);
 
+    // A single statement captures the settled row and its immutable reservation together.
+    // A miss does not authorize finalization: the write path re-reads under its transaction.
+    const replayRows = yield* sql<Record<string, unknown>>`
+      SELECT submission.*, reservation.settlement_id, reservation.outcome,
+        reservation.record_id, reservation.record_json, reservation.record_digest,
+        reservation.reserved_at, reservation.finalized_at
+      FROM effect_agent_submissions AS submission
+      INNER JOIN effect_agent_settlement_reservations AS reservation
+        ON reservation.submission_id = submission.submission_id
+      WHERE submission.submission_id = ${validated.submissionId} AND submission.state = 'settled'
+    `.pipe(Effect.mapError(sqlFailure(operation)));
+
+    if (replayRows.length > 1) {
+      return yield* corruptionFailure(
+        operation,
+        "effect_agent_submissions",
+        validated.submissionId,
+        "A submission primary key returned more than one row.",
+      );
+    }
+    const replayRow = replayRows[0];
+
+    if (replayRow !== undefined) {
+      const reservations = yield* decodeRows(
+        Schema.Array(ReservationRow),
+        "effect_agent_settlement_reservations",
+        validated.submissionId,
+        replayRows,
+      ).pipe(Effect.mapError(internalFailure(operation)));
+
+      const state = yield* validateFinalization(validated, Option.fromUndefinedOr(reservations[0]));
+
+      const submission = yield* Schema.decodeUnknownEffect(SubmissionRow)(replayRow).pipe(
+        Effect.mapError((error) =>
+          corruptionFailure(
+            operation,
+            "effect_agent_submissions",
+            validated.submissionId,
+            error.message,
+          ),
+        ),
+      );
+
+      const settlement = yield* replayFinalization(validated, submission, state);
+
+      yield* hitFailpoint("ledger:finalize-settlement:after", operation);
+
+      return settlement;
+    }
+
     const settlement = yield* inWriteTransaction(
       operation,
       Effect.gen(function* () {
-        const reservation = yield* readReservation(operation, validated.submissionId);
-
-        if (Option.isNone(reservation)) {
-          return yield* LedgerError.make({
-            operation,
-            message: `No settlement reservation exists for submission ${validated.submissionId}.`,
-          });
-        }
-        if (reservation.value.settlement_id !== validated.settlementId) {
-          return yield* SettlementConflict.make({
-            submissionId: validated.submissionId,
-            existingOutcome: reservation.value.outcome,
-          });
-        }
-
-        const reservationRecord = yield* decodeRecordEnvelopeText(
-          reservation.value.record_json,
-        ).pipe(
-          Effect.mapError((error) =>
-            corruptionFailure(
-              operation,
-              "effect_agent_settlement_reservations",
-              validated.submissionId,
-              error.message,
-            ),
-          ),
+        const state = yield* validateFinalization(
+          validated,
+          yield* readReservation(operation, validated.submissionId),
         );
 
-        const settlementFailure = settlementFailureFromRecord(reservationRecord);
-
-        if ((reservation.value.outcome === "failed") !== (settlementFailure !== undefined)) {
-          return yield* corruptionFailure(
-            operation,
-            "effect_agent_settlement_reservations",
-            validated.submissionId,
-            "The reserved outcome and canonical failure diagnostic disagree.",
-          );
-        }
+        const { reservation, settlementFailure } = state;
         const submission = yield* requireSubmission(operation, validated.submissionId);
 
-        if (submission.state === "settled") {
-          if (reservation.value.finalized_at === null) {
-            return yield* corruptionFailure(
-              operation,
-              "effect_agent_settlement_reservations",
-              validated.submissionId,
-              "A settled Submission's reservation carries no finalization timestamp.",
-            );
-          }
-
-          return yield* decodeSettlement({
-            submissionId: validated.submissionId,
-            settlementId: validated.settlementId,
-            receiptId: submission.receipt_id,
-            outcome: reservation.value.outcome,
-            ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
-            settledAt: reservation.value.finalized_at,
-          }).pipe(Effect.mapError(internalFailure(operation)));
-        }
+        if (submission.state === "settled")
+          return yield* replayFinalization(validated, submission, state);
         const now = yield* currentInstant;
 
         yield* sql`
           UPDATE effect_agent_submissions
-          SET state = 'settled', settled_outcome = ${reservation.value.outcome}
+          SET state = 'settled', settled_outcome = ${reservation.outcome}
           WHERE submission_id = ${validated.submissionId}
         `.pipe(Effect.mapError(sqlFailure(operation)));
         yield* sql`
@@ -1910,7 +1981,7 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
           submissionId: validated.submissionId,
           settlementId: validated.settlementId,
           receiptId: submission.receipt_id,
-          outcome: reservation.value.outcome,
+          outcome: reservation.outcome,
           ...(settlementFailure === undefined ? {} : { failure: settlementFailure }),
           settledAt: now.iso,
         }).pipe(Effect.mapError(internalFailure(operation)));
@@ -3051,13 +3122,7 @@ const makeServices = Effect.fn("SqliteSubmissionLedger.makeServices")(function* 
           SELECT ${sql.literal(SUBMISSION_COLUMNS)}
           FROM effect_agent_submissions
           WHERE state <> 'settled'
-            AND (
-              thread_id > ${cursor.threadId}
-              OR (
-                thread_id = ${cursor.threadId}
-                AND queue_sequence > ${cursor.queueSequence}
-              )
-            )
+            AND (thread_id, queue_sequence) > (${cursor.threadId}, ${cursor.queueSequence})
           ORDER BY thread_id ASC, queue_sequence ASC
           LIMIT ${SCAN_PAGE_SIZE}
         `

--- a/packages/storage-sqlite/src/internal/migrations.ts
+++ b/packages/storage-sqlite/src/internal/migrations.ts
@@ -5,7 +5,15 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
 import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
-export const CurrentSqliteStorageVersion = 10;
+export const CurrentSqliteStorageVersion = 11;
+
+/** Index only outstanding obligations, ordered by the recovery scan's stable cursor. */
+export const createNonterminalIndex = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`CREATE INDEX effect_agent_submissions_nonterminal ON effect_agent_submissions (thread_id, queue_sequence) WHERE state <> 'settled'`
+    .withoutTransform;
+});
 
 /** Initialize empty storage with the complete current schema. */
 export const sqliteMigrations = SqliteMigrator.fromRecord({
@@ -336,8 +344,9 @@ export const sqliteMigrations = SqliteMigrator.fromRecord({
       .withoutTransform;
     yield* sql`CREATE INDEX effect_agent_subscription_deliveries_registration ON effect_agent_subscription_deliveries (tenant_id, source_address, owner_id, subscription_id, delivery_key)`
       .withoutTransform;
+    yield* createNonterminalIndex;
     yield* createMessageDeliveryTables;
     yield* createRecoveryCheckpointTable;
-    yield* sql`PRAGMA user_version = 10`.withoutTransform;
+    yield* sql`PRAGMA user_version = 11`.withoutTransform;
   }),
 });

--- a/packages/storage-sqlite/src/internal/sqlite-journal.ts
+++ b/packages/storage-sqlite/src/internal/sqlite-journal.ts
@@ -37,7 +37,11 @@ import {
 } from "../SqliteStorageError.ts";
 import { SqliteStorageFailpoint } from "../SqliteStorageFailpoint.ts";
 import { createMessageDeliveryTables } from "./message-delivery-schema.ts";
-import { CurrentSqliteStorageVersion, sqliteMigrations } from "./migrations.ts";
+import {
+  CurrentSqliteStorageVersion,
+  createNonterminalIndex,
+  sqliteMigrations,
+} from "./migrations.ts";
 import { createRecoveryCheckpointTable } from "./recovery-checkpoint-schema.ts";
 
 const BoundedStoredText = Schema.String.check(Schema.isMaxLength(16 * 1024 * 1024));
@@ -381,11 +385,11 @@ const predecessorColumns = {
 } as const;
 
 const checkPredecessorLayout = Effect.fn("SqliteJournal.checkPredecessorLayout")(function* (
-  version: 8 | 9,
+  version: 8 | 9 | 10,
 ) {
   const sql = yield* SqlClient.SqlClient;
 
-  const expectedColumns =
+  const messageColumns =
     version === 8
       ? predecessorColumns
       : {
@@ -404,6 +408,20 @@ const checkPredecessorLayout = Effect.fn("SqliteJournal.checkPredecessorLayout")
             "record_json",
           ],
         };
+
+  const expectedColumns = {
+    ...messageColumns,
+    ...(version === 10
+      ? {
+          effect_agent_recovery_checkpoints: [
+            "thread_id",
+            "through_sequence",
+            "tail_digest",
+            "checkpoint_json",
+          ],
+        }
+      : {}),
+  };
 
   for (const [table, expected] of Object.entries(expectedColumns)) {
     const columns = yield* decodeRows(
@@ -472,6 +490,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     version.user_version !== 7 &&
     version.user_version !== 8 &&
     version.user_version !== 9 &&
+    version.user_version !== 10 &&
     version.user_version !== CurrentSqliteStorageVersion
   ) {
     return yield* SqliteStorageCompatibilityError.make({
@@ -480,11 +499,16 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
       message:
         `The SQLite file uses unsupported storage version ${version.user_version}; ` +
         `this build supports exactly version ${CurrentSqliteStorageVersion}. ` +
-        "Only supported v7, v8 and v9 can be upgraded automatically. Keep the original file and use a compatible library version.",
+        "Only supported v7, v8, v9 and v10 can be upgraded automatically. Keep the original file and use a compatible library version.",
     });
   }
 
-  if (version.user_version === 7 || version.user_version === 8 || version.user_version === 9) {
+  if (
+    version.user_version === 7 ||
+    version.user_version === 8 ||
+    version.user_version === 9 ||
+    version.user_version === 10
+  ) {
     yield* sql
       .withTransaction(
         Effect.gen(function* () {
@@ -496,7 +520,8 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
             current.length !== 1 ||
             (current[0].user_version !== 7 &&
               current[0].user_version !== 8 &&
-              current[0].user_version !== 9)
+              current[0].user_version !== 9 &&
+              current[0].user_version !== 10)
           )
             return yield* SqliteStorageCompatibilityError.make({
               actualVersion: -1,
@@ -524,12 +549,23 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
           const recoveryTables =
             yield* sql`SELECT name FROM sqlite_master WHERE type='table' AND name='effect_agent_recovery_checkpoints'`;
 
-          if (recoveryTables.length !== 0)
+          if (recoveryTables.length !== (current[0].user_version === 10 ? 1 : 0))
             return yield* SqliteStorageCompatibilityError.make({
               actualVersion: current[0].user_version,
               supportedVersion: CurrentSqliteStorageVersion,
               message:
-                "The predecessor already contains recovery checkpoint storage; refusing ambiguous data without mutation.",
+                "The predecessor recovery checkpoint storage does not match its version; refusing ambiguous data without mutation.",
+            });
+
+          const indexes =
+            yield* sql`SELECT name FROM sqlite_master WHERE name='effect_agent_submissions_nonterminal'`;
+
+          if (indexes.length !== 0)
+            return yield* SqliteStorageCompatibilityError.make({
+              actualVersion: current[0].user_version,
+              supportedVersion: CurrentSqliteStorageVersion,
+              message:
+                "The predecessor already contains the nonterminal index; refusing ambiguous storage without mutation.",
             });
           if (current[0].user_version === 7) {
             yield* checkV2ThreadLayout();
@@ -561,9 +597,13 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
               }),
             );
           }
-          if (current[0].user_version === 8 || current[0].user_version === 9)
+          if (
+            current[0].user_version === 8 ||
+            current[0].user_version === 9 ||
+            current[0].user_version === 10
+          )
             yield* checkPredecessorLayout(current[0].user_version);
-          if (current[0].user_version !== 9) {
+          if (current[0].user_version === 7 || current[0].user_version === 8) {
             yield* failpoint("upgrade:before-mutation");
             yield* sql`ALTER TABLE effect_agent_submissions ADD COLUMN worker_admission_json TEXT`;
             yield* failpoint("upgrade:after-mutation");
@@ -574,11 +614,16 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
             yield* createMessageDeliveryTables;
             yield* failpoint("upgrade:after-mutation");
           }
+          if (current[0].user_version !== 10) {
+            yield* failpoint("upgrade:before-mutation");
+            yield* createRecoveryCheckpointTable;
+            yield* failpoint("upgrade:after-mutation");
+          }
           yield* failpoint("upgrade:before-mutation");
-          yield* createRecoveryCheckpointTable;
+          yield* createNonterminalIndex;
           yield* failpoint("upgrade:after-mutation");
           yield* failpoint("upgrade:before-version");
-          yield* sql`PRAGMA user_version = 10`;
+          yield* sql`PRAGMA user_version = 11`;
           yield* failpoint("upgrade:after-version");
         }),
       )
@@ -655,7 +700,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
   const requiredRows = yield* sql<Record<string, unknown>>`
     SELECT name
     FROM sqlite_master
-    WHERE type = 'table'
+    WHERE (type = 'table'
       AND name IN (
         'effect_agent_threads',
         'effect_agent_canonical_batches',
@@ -671,7 +716,7 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
         'effect_agent_schedules',
         'effect_agent_message_deliveries',
         'effect_agent_recovery_checkpoints'
-      )
+      )) OR (type = 'index' AND name = 'effect_agent_submissions_nonterminal')
     ORDER BY name
   `.pipe(Effect.mapError(storageError("verify storage tables")));
 
@@ -682,12 +727,12 @@ export const initializeSqliteJournal = Effect.fn("SqliteJournal.initialize")(fun
     requiredRows,
   );
 
-  if (required.length !== 14) {
+  if (required.length !== 15) {
     return yield* SqliteStorageCompatibilityError.make({
       actualVersion: CurrentSqliteStorageVersion,
       supportedVersion: CurrentSqliteStorageVersion,
       message:
-        "The SQLite file claims the current format but is missing required tables. Retain the original store for inspection.",
+        "The SQLite file claims the current format but is missing required tables or its nonterminal index. Retain the original store for inspection.",
     });
   }
 

--- a/packages/storage-sqlite/test/sqlite-ledger-reads.test.ts
+++ b/packages/storage-sqlite/test/sqlite-ledger-reads.test.ts
@@ -1,0 +1,160 @@
+import { SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import { NodeCrypto, NodeFileSystem } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, type Crypto } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import {
+  ledgerReadCases,
+  reserveReadFixture,
+} from "../../../test/fixtures/ledger-read-contracts.ts";
+import { SqliteStorageFailpointError } from "../src/SqliteStorageError.ts";
+import { SqliteStorageFailpoint } from "../src/SqliteStorageFailpoint.ts";
+import { submissionLedgerLayer } from "../src/SqliteSubmissionLedger.ts";
+import { storageConfigLayer } from "../src/SqliteThreadStore.ts";
+
+const withFixture = <A, E>(
+  effect: Effect.Effect<A, E, SubmissionLedger | SqlClient.SqlClient | Crypto.Crypto>,
+  options?: {
+    readonly reserved?: () => void;
+    readonly failpoint?: (point: string) => Effect.Effect<void, SqliteStorageFailpointError>;
+  },
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "ledger-reads-" });
+      const filename = `${directory}/state.sqlite`;
+
+      return yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+
+        const observed = new Proxy(sql, {
+          get(target, key, receiver) {
+            if (key === "reserve")
+              return sql.reserve.pipe(Effect.tap(() => Effect.sync(() => options?.reserved?.())));
+
+            return Reflect.get(target, key, receiver);
+          },
+        });
+
+        const deps = Layer.mergeAll(
+          Layer.succeed(SqlClient.SqlClient)(observed),
+          storageConfigLayer({ filename, busyTimeout: 0 }),
+          NodeCrypto.layer,
+          options?.failpoint === undefined
+            ? SqliteStorageFailpoint.layer
+            : Layer.succeed(SqliteStorageFailpoint)({ hit: options.failpoint }),
+        );
+
+        return yield* effect.pipe(
+          Effect.provide(submissionLedgerLayer.pipe(Layer.provideMerge(deps))),
+        );
+      }).pipe(Effect.provide(SqliteClient.layer({ filename })));
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer));
+
+describe("SQLite ledger read contracts", () => {
+  for (const test of ledgerReadCases) it.effect(test.name, () => withFixture(test.run));
+
+  it.effect("replays finalized state while another connection holds BEGIN IMMEDIATE", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "ledger-read-lock-" });
+        const filename = `${directory}/state.sqlite`;
+
+        const deps = Layer.mergeAll(
+          SqliteClient.layer({ filename }),
+          storageConfigLayer({ filename, busyTimeout: 0 }),
+          NodeCrypto.layer,
+          SqliteStorageFailpoint.layer,
+        );
+
+        yield* Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const request = yield* reserveReadFixture("lock-reader");
+          const settled = yield* ledger.finalizeSettlement(request);
+
+          yield* Effect.gen(function* () {
+            const writer = yield* SqlClient.SqlClient;
+
+            yield* Effect.acquireRelease(writer`BEGIN IMMEDIATE`, () =>
+              writer`ROLLBACK`.pipe(Effect.orDie),
+            );
+            yield* writer`UPDATE effect_agent_settlement_reservations SET finalized_at='2040-01-01T00:00:00.000Z' WHERE submission_id=${request.submissionId}`;
+            expect(yield* ledger.finalizeSettlement(request)).toEqual(settled);
+          }).pipe(Effect.scoped, Effect.provide(SqliteClient.layer({ filename })));
+          expect(yield* ledger.finalizeSettlement(request)).toEqual(settled);
+          // The subsequent genuine finalization must still acquire and release the writer.
+          yield* ledger.finalizeSettlement(yield* reserveReadFixture("after-lock"));
+        }).pipe(Effect.provide(submissionLedgerLayer.pipe(Layer.provideMerge(deps))));
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  );
+
+  it.effect(
+    "adds one read probe to active finalization and takes no writer reservation on replay",
+    () => {
+      let reservations = 0;
+
+      return withFixture(
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const request = yield* reserveReadFixture("writer-budget");
+
+          reservations = 0;
+          yield* ledger.finalizeSettlement(request);
+          expect(reservations).toBe(1);
+          reservations = 0;
+          yield* ledger.finalizeSettlement(request);
+          expect(reservations).toBe(0);
+        }),
+        {
+          reserved: () => {
+            reservations++;
+          },
+        },
+      );
+    },
+  );
+
+  for (const point of [
+    "ledger:finalize-settlement:before",
+    "ledger:finalize-settlement:after",
+  ] as const) {
+    it.effect(`preserves ${point} on already settled replay`, () => {
+      let armed = false;
+      let hits = 0;
+
+      return withFixture(
+        Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const request = yield* reserveReadFixture(point);
+          const settled = yield* ledger.finalizeSettlement(request);
+
+          armed = true;
+          expect(yield* ledger.finalizeSettlement(request).pipe(Effect.result)).toMatchObject({
+            _tag: "Failure",
+            failure: {
+              _tag: "LedgerError",
+              cause: { _tag: "SqliteStorageFailpointError", location: point },
+            },
+          });
+          expect(hits).toBe(1);
+          armed = false;
+          expect(yield* ledger.finalizeSettlement(request)).toEqual(settled);
+        }),
+        {
+          failpoint: (location) => {
+            if (!armed || location !== point) return Effect.void;
+            hits++;
+
+            return SqliteStorageFailpointError.make({ location: point });
+          },
+        },
+      );
+    });
+  }
+});

--- a/packages/storage-sqlite/test/sqlite-storage-upgrade.test.ts
+++ b/packages/storage-sqlite/test/sqlite-storage-upgrade.test.ts
@@ -92,6 +92,7 @@ describe("supported beta50 storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClient.SqlClient;
 
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
             yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`PRAGMA user_version = 9`;
             const before = yield* snapshotStore;
@@ -103,7 +104,7 @@ describe("supported beta50 storage upgrade", () => {
             armed = false;
             yield* open;
             yield* assertPreserved("sqlite");
-            expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
+            expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 11 }]);
             expect(yield* sql`SELECT * FROM effect_agent_recovery_checkpoints`).toEqual([]);
             const upgraded = yield* snapshotStore;
 
@@ -124,6 +125,7 @@ describe("supported beta50 storage upgrade", () => {
         yield* open;
         const sql = yield* SqlClient.SqlClient;
 
+        yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
         yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
         yield* sql`ALTER TABLE effect_agent_submissions RENAME COLUMN message_admission_json TO malformed_column`;
         yield* sql`PRAGMA user_version = 9`;
@@ -152,6 +154,7 @@ describe("supported beta50 storage upgrade", () => {
             yield* open;
             const sql = yield* SqlClient.SqlClient;
 
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
             yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
             yield* sql`DROP TABLE effect_agent_message_deliveries`;
             yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
@@ -186,6 +189,7 @@ describe("supported beta50 storage upgrade", () => {
           yield* open;
           const sql = yield* SqlClient.SqlClient;
 
+          yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
           yield* sql`DROP TABLE effect_agent_recovery_checkpoints`;
           yield* sql`DROP TABLE effect_agent_message_deliveries`;
           yield* sql`ALTER TABLE effect_agent_submissions DROP COLUMN worker_admission_json`;
@@ -200,7 +204,7 @@ describe("supported beta50 storage upgrade", () => {
           armed = false;
           yield* open;
           yield* assertPreserved("sqlite");
-          expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
+          expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 11 }]);
           expect(yield* sql`SELECT * FROM effect_agent_message_deliveries`).toEqual([]);
         }),
       (location) =>
@@ -234,7 +238,7 @@ describe("supported beta50 storage upgrade", () => {
         );
         const sql = yield* SqlClient.SqlClient;
 
-        expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
+        expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 11 }]);
       }),
     ),
   );
@@ -316,5 +320,123 @@ describe("supported beta50 storage upgrade", () => {
           expect(yield* snapshotStore).toEqual(before);
         }),
       ),
+  );
+});
+
+describe("nonterminal index upgrade", () => {
+  for (const point of [
+    "upgrade:before-mutation",
+    "upgrade:after-mutation",
+    "upgrade:before-version",
+    "upgrade:after-version",
+  ] as const) {
+    for (const mode of ["failure", "interrupt", "defect"] as const) {
+      it.effect(
+        `preserves v10 rows and recovery checkpoints atomically at ${point} (${mode})`,
+        () => {
+          let armed = false;
+
+          return withFixture(
+            (open) =>
+              Effect.gen(function* () {
+                yield* open;
+                const sql = yield* SqlClient.SqlClient;
+
+                yield* sql`INSERT INTO effect_agent_recovery_checkpoints (thread_id, through_sequence, tail_digest, checkpoint_json) SELECT thread_id, tail_sequence, tail_digest, '{"retained":true}' FROM effect_agent_threads LIMIT 1`;
+                yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
+                yield* sql`PRAGMA user_version = 10`;
+                const before = yield* snapshotStore;
+
+                armed = true;
+                expect(Exit.isFailure(yield* open.pipe(Effect.exit))).toBe(true);
+                expect(yield* snapshotStore).toEqual(before);
+                expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 10 }]);
+                armed = false;
+                yield* open;
+                const after = yield* snapshotStore;
+
+                for (const [table, rows] of Object.entries(before.contents)) {
+                  if (table !== "effect_agent_meta") expect(after.contents[table]).toEqual(rows);
+                }
+                expect(
+                  after.definitions.filter(
+                    (entry) => entry.name !== "effect_agent_submissions_nonterminal",
+                  ),
+                ).toEqual(before.definitions);
+                expect(
+                  after.definitions.find(
+                    (entry) => entry.name === "effect_agent_submissions_nonterminal",
+                  )?.sql,
+                ).toContain("WHERE state <> 'settled'");
+                expect(yield* sql`PRAGMA user_version`).toEqual([{ user_version: 11 }]);
+                yield* open;
+                expect(yield* snapshotStore).toEqual(after);
+              }),
+            (location) =>
+              armed && location === point
+                ? mode === "interrupt"
+                  ? Effect.interrupt
+                  : mode === "defect"
+                    ? Effect.die("upgrade defect")
+                    : SqliteStorageFailpointError.make({ location })
+                : Effect.void,
+          );
+        },
+      );
+    }
+  }
+
+  for (const [table, column] of [
+    ["effect_agent_submissions", "queue_sequence"],
+    ["effect_agent_recovery_checkpoints", "checkpoint_json"],
+  ] as const) {
+    it.effect(`rejects malformed v10 ${table} before any mutation`, () => {
+      let armed = false;
+      let mutations = 0;
+
+      return withFixture(
+        (open) =>
+          Effect.gen(function* () {
+            yield* open;
+            const sql = yield* SqlClient.SqlClient;
+
+            yield* sql`DROP INDEX effect_agent_submissions_nonterminal`;
+            yield* sql`PRAGMA user_version = 10`;
+            yield* sql.unsafe(`ALTER TABLE ${table} RENAME COLUMN ${column} TO malformed_column`);
+            const before = yield* snapshotStore;
+
+            armed = true;
+            expect(yield* open.pipe(Effect.result)).toMatchObject({
+              _tag: "Failure",
+              failure: { _tag: "SqliteStorageCompatibilityError", actualVersion: 10 },
+            });
+            expect(mutations).toBe(0);
+            expect(yield* snapshotStore).toEqual(before);
+          }),
+        (location) => {
+          if (armed && location === "upgrade:before-mutation") mutations++;
+
+          return Effect.void;
+        },
+      );
+    });
+  }
+
+  it.effect("rejects a predecessor with a conflicting index without mutation", () =>
+    withFixture((open) =>
+      Effect.gen(function* () {
+        yield* open;
+        const sql = yield* SqlClient.SqlClient;
+
+        yield* sql`PRAGMA user_version = 10`;
+        const before = yield* snapshotStore;
+
+        expect(yield* open.pipe(Effect.result)).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "SqliteStorageCompatibilityError", actualVersion: 10 },
+        });
+        expect(yield* snapshotStore).toEqual(before);
+      }),
+    ),
   );
 });

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -144,7 +144,7 @@ export const subprocess = Effect.fn("benchmark.subprocess")(function* (
 }, Effect.scoped);
 
 /** Copy only public dist artifacts; external dependencies resolve from this revision's install. */
-const stageCheckout = Effect.fn("benchmark.stageCheckout")(function* (
+export const stageCheckout = Effect.fn("benchmark.stageCheckout")(function* (
   root: string,
   role: Revision["role"],
   fixtures: string,

--- a/scripts/runtime-diagnostics.ts
+++ b/scripts/runtime-diagnostics.ts
@@ -1,0 +1,403 @@
+import { createHash } from "node:crypto";
+import { arch, cpus, platform, release, totalmem } from "node:os";
+
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Cause, Clock, Console, Effect, Exit, FileSystem, Path, Schema } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { build, version as esbuildVersion } from "esbuild";
+
+import { BenchmarkError, check, summary } from "../examples/runtime-benchmark/src/contracts.ts";
+import { diagnosticCases } from "../examples/runtime-benchmark/src/diagnostic-cases.ts";
+import {
+  completeDiagnosticBatch,
+  DIAGNOSTIC_SIZES,
+  DIAGNOSTIC_VERSION,
+  DiagnosticCase,
+  DiagnosticWorkerOptions,
+  DiagnosticWorkerReport,
+} from "../examples/runtime-benchmark/src/diagnostic-contracts.ts";
+import { writeEvidence } from "../examples/runtime-benchmark/src/evidence.ts";
+import { withPublishManifests } from "./release-publish.ts";
+import { stageCheckout, subprocess } from "./runtime-benchmark.ts";
+
+const Role = Schema.Literals(["base", "head"]);
+const Hash = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/));
+
+const Revision = Schema.Struct({
+  role: Role,
+  revision: Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/)),
+  dirty: Schema.Boolean,
+  lockfileSha256: Hash,
+  builtArtifactsSha256: Hash,
+  effect: Schema.String,
+});
+
+const ActiveBatch = Schema.Struct({ role: Role, cohort: Schema.Natural });
+
+const Batch = Schema.Struct({
+  ...ActiveBatch.fields,
+  subprocessMs: Schema.Finite,
+  exitCode: Schema.Int,
+  complete: Schema.Boolean,
+  report: Schema.NullOr(DiagnosticWorkerReport),
+  failure: Schema.NullOr(Schema.String),
+});
+
+export const DiagnosticReport = Schema.Struct({
+  fixture: Schema.Literal(DIAGNOSTIC_VERSION),
+  fixtureSha256: Schema.NullOr(Hash),
+  transpiler: Schema.String,
+  environment: Schema.Struct({
+    node: Schema.String,
+    platform: Schema.String,
+    release: Schema.String,
+    architecture: Schema.String,
+    cpu: Schema.String,
+    cpuCount: Schema.Natural,
+    memoryBytes: Schema.Natural,
+  }),
+  settings: Schema.Struct({
+    cohorts: Schema.Literal(2),
+    warmups: Schema.Literal(2),
+    samples: Schema.Literal(5),
+    production: Schema.Literal(true),
+    execution: Schema.Literal("unbundled published ESM"),
+    timingGate: Schema.Literal("informational elapsed wall time"),
+  }),
+  cases: Schema.Array(DiagnosticCase).check(Schema.isMaxLength(64)),
+  revisions: Schema.Array(Revision).check(Schema.isMaxLength(2)),
+  batches: Schema.Array(Batch).check(Schema.isMaxLength(4)),
+  activeBatch: Schema.NullOr(ActiveBatch),
+  phase: Schema.Literals(["setup", "comparison", "complete"]),
+  failure: Schema.NullOr(Schema.String),
+});
+
+export type DiagnosticReport = typeof DiagnosticReport.Type;
+
+export const renderDiagnosticReport = (report: DiagnosticReport): string => {
+  const lines = [
+    "Manual public-package diagnostics. Elapsed wall milliseconds, median [Q1–Q3]; marks are inclusive. No CPU or provider latency claim.",
+    "",
+    `Status: ${report.phase}; ${report.batches.filter((batch) => batch.complete && batch.exitCode === 0).length}/4 complete batches.`,
+    ...(report.failure === null ? [] : [`Failure: ${report.failure}`]),
+    "",
+    "| Case / metric | Base | Head |",
+    "| --- | ---: | ---: |",
+  ];
+
+  for (const workload of report.cases) {
+    const samples = (role: "base" | "head") =>
+      report.batches
+        .filter((batch) => batch.role === role && batch.complete && batch.exitCode === 0)
+        .flatMap((batch) => batch.report?.samples ?? [])
+        .filter(
+          (sample) => sample.case === workload.name && !sample.warmup && sample.status === "passed",
+        )
+        .flatMap((sample) => (sample.result === null ? [] : [sample.result]));
+
+    const base = samples("base");
+    const head = samples("head");
+
+    const names = [
+      ...new Set([...base, ...head].flatMap((result) => result.metrics.map(({ name }) => name))),
+    ];
+
+    const format = (values: ReadonlyArray<number>) => {
+      const stats = summary(values);
+
+      return stats.count === 0
+        ? "n/a"
+        : `${stats.median.toFixed(2)} [${stats.q1.toFixed(2)}–${stats.q3.toFixed(2)}] (n=${stats.count})`;
+    };
+
+    lines.push(
+      `| ${workload.name} / total | ${format(base.map(({ totalMs }) => totalMs))} | ${format(head.map(({ totalMs }) => totalMs))} |`,
+    );
+    for (const name of names) {
+      const values = (results: typeof base) =>
+        results.flatMap((result) =>
+          result.metrics.filter((metric) => metric.name === name).map(({ value }) => value),
+        );
+
+      lines.push(
+        `| ${workload.name} / ${name} | ${format(values(base))} | ${format(values(head))} |`,
+      );
+    }
+  }
+
+  return lines.join("\n") + "\n";
+};
+
+export const compareDiagnostics = Effect.fn("diagnostic.compare")(function* (options: {
+  root: string;
+  base: string;
+  output: string;
+  requireClean: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = path.resolve(options.root);
+  const output = path.resolve(options.output);
+
+  yield* fs.makeDirectory(output, { recursive: true });
+  yield* check(
+    !(yield* fs.exists(path.join(output, "report.json"))),
+    "Output already contains a report; choose a new --out-dir",
+  );
+
+  const report: { -readonly [K in keyof DiagnosticReport]: DiagnosticReport[K] } = {
+    fixture: DIAGNOSTIC_VERSION,
+    fixtureSha256: null,
+    transpiler: `esbuild ${esbuildVersion} (fixture syntax only; no bundling)`,
+    environment: {
+      node: "unknown",
+      platform: platform(),
+      release: release(),
+      architecture: arch(),
+      cpu: cpus()[0]?.model ?? "unknown",
+      cpuCount: cpus().length,
+      memoryBytes: totalmem(),
+    },
+    settings: {
+      ...DIAGNOSTIC_SIZES,
+      production: true,
+      execution: "unbundled published ESM",
+      timingGate: "informational elapsed wall time",
+    },
+    cases: diagnosticCases,
+    revisions: [],
+    batches: [],
+    activeBatch: null,
+    phase: "setup",
+    failure: null,
+  };
+
+  const persist = Effect.gen(function* () {
+    yield* writeEvidence(
+      path.join(output, "report.json"),
+      yield* Schema.encodeEffect(Schema.fromJsonString(DiagnosticReport))(report),
+    );
+    yield* writeEvidence(path.join(output, "report.md"), renderDiagnosticReport(report));
+  });
+
+  yield* Effect.gen(function* () {
+    yield* persist;
+    yield* check(options.requireClean, "Diagnostics require clean exact-commit checkouts");
+    const node = yield* subprocess("node", ["--version"], root);
+
+    report.environment = { ...report.environment, node: node.stdout.trim() };
+    yield* check(
+      node.exitCode === 0 && report.environment.node.startsWith("v24."),
+      "Diagnostics require Node 24",
+    );
+    const fixtures = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-diagnostic-fixture-" });
+    const source = path.join(root, "examples/runtime-benchmark/src");
+
+    yield* Effect.tryPromise({
+      try: () =>
+        build({
+          entryPoints: [
+            "contracts.ts",
+            "evidence.ts",
+            "diagnostic-contracts.ts",
+            "diagnostic-cases.ts",
+            "diagnostic-worker.ts",
+            "diagnostic-policy.ts",
+            "diagnostic-capabilities.ts",
+            "diagnostic-ledger.ts",
+            "diagnostic-writer.ts",
+            "diagnostic-fairness.ts",
+          ].map((file) => path.join(source, file)),
+          outdir: fixtures,
+          bundle: false,
+          platform: "node",
+          format: "esm",
+          target: "node24",
+          sourcemap: false,
+          minify: false,
+          logLevel: "silent",
+        }),
+      catch: (cause) =>
+        BenchmarkError.make({ message: "Cannot transpile diagnostic fixtures", cause }),
+    });
+
+    const bytes = yield* Effect.forEach((yield* fs.readDirectory(fixtures)).sort(), (file) =>
+      fs.readFileString(path.join(fixtures, file)).pipe(Effect.map((text) => `${file}\n${text}`)),
+    );
+
+    report.fixtureSha256 = createHash("sha256").update(bytes.join("\n")).digest("hex");
+    yield* fs.copy(fixtures, path.join(output, "fixture"));
+    const base = yield* stageCheckout(path.resolve(options.base), "base", fixtures);
+    const head = yield* stageCheckout(root, "head", fixtures);
+    const stages = [base, head];
+
+    report.revisions = yield* Effect.forEach(stages, (stage) =>
+      Schema.decodeUnknownEffect(Revision)(stage.revision),
+    );
+    yield* check(
+      report.revisions.every((revision) => !revision.dirty),
+      "Diagnostics require clean exact-commit checkouts",
+    );
+
+    const measure = Effect.gen(function* () {
+      yield* check(
+        new Set(report.cases.map(({ name }) => name)).size === report.cases.length,
+        "Diagnostic case names must be unique",
+      );
+      report.phase = "comparison";
+      yield* persist;
+      for (let cohort = 0; cohort < DIAGNOSTIC_SIZES.cohorts; cohort++)
+        for (const stage of cohort === 0 ? stages : [...stages].reverse()) {
+          const role = yield* Schema.decodeUnknownEffect(Role)(stage.revision.role);
+          const name = `${cohort}-${role}`;
+          const filename = path.join(output, `${name}.json`);
+
+          const workerOptions: DiagnosticWorkerOptions = {
+            output: filename,
+            warmups: DIAGNOSTIC_SIZES.warmups,
+            samples: DIAGNOSTIC_SIZES.samples,
+            timeoutMs: 120_000,
+          };
+
+          report.activeBatch = { cohort, role };
+          yield* persist;
+          yield* Console.error(`Measuring diagnostics ${name}`);
+          yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const started = yield* Clock.monotonicTimeNanos;
+
+              const child = yield* restore(
+                subprocess(
+                  "node",
+                  [path.join(stage.stage, "fixture/diagnostic-worker.js")],
+                  stage.stage,
+                  {
+                    NODE_ENV: "production",
+                    RUNTIME_DIAGNOSTIC_OPTIONS: yield* Schema.encodeEffect(
+                      Schema.fromJsonString(DiagnosticWorkerOptions),
+                    )(workerOptions),
+                  },
+                  path.join(output, `${name}.log`),
+                ).pipe(Effect.timeout("5 minutes")),
+              ).pipe(Effect.exit);
+
+              const subprocessMs = Exit.isSuccess(child)
+                ? child.value.subprocessMs
+                : Number((yield* Clock.monotonicTimeNanos) - started) / 1e6;
+
+              const decoded = yield* Effect.gen(function* () {
+                yield* check(
+                  yield* fs.exists(filename),
+                  "Diagnostic worker did not produce a report",
+                );
+                const stat = yield* fs.stat(filename);
+
+                yield* check(
+                  stat.size <= 16n * 1024n * 1024n,
+                  "Diagnostic worker report exceeds 16 MiB",
+                );
+
+                return yield* Schema.decodeUnknownEffect(
+                  Schema.fromJsonString(DiagnosticWorkerReport),
+                )(yield* fs.readFileString(filename));
+              }).pipe(Effect.exit);
+
+              const worker = Exit.isSuccess(decoded) ? decoded.value : null;
+              const exitCode = Exit.isSuccess(child) ? child.value.exitCode : -1;
+
+              const complete =
+                worker !== null &&
+                completeDiagnosticBatch(worker, workerOptions, report.cases) &&
+                worker.runtime === report.environment.node &&
+                worker.platform === report.environment.platform &&
+                worker.architecture === report.environment.architecture;
+
+              report.batches = [
+                ...report.batches,
+                {
+                  role,
+                  cohort,
+                  subprocessMs,
+                  exitCode,
+                  complete,
+                  report: worker,
+                  failure: Exit.isFailure(child)
+                    ? Cause.pretty(child.cause).slice(0, 8_192)
+                    : Exit.isFailure(decoded)
+                      ? Cause.pretty(decoded.cause).slice(0, 8_192)
+                      : exitCode !== 0
+                        ? child.value.stderr.slice(0, 8_192)
+                        : !complete
+                          ? "Incomplete work or mismatched worker environment"
+                          : null,
+                },
+              ];
+              report.activeBatch = null;
+              yield* persist;
+              if (Exit.isFailure(child) && Cause.hasInterrupts(child.cause))
+                return yield* Effect.failCause(child.cause);
+            }),
+          );
+        }
+    });
+
+    yield* withPublishManifests(base.stage, () => withPublishManifests(head.stage, () => measure));
+    yield* check(
+      report.batches.length === 4 &&
+        report.batches.every((batch) => batch.complete && batch.exitCode === 0),
+      "Diagnostic correctness failed; inspect all retained samples and failures",
+    );
+    report.phase = "complete";
+  }).pipe(
+    Effect.timeout("19 minutes"),
+    Effect.onExit((exit) => {
+      if (Exit.isFailure(exit)) report.failure = Cause.pretty(exit.cause).slice(0, 8_192);
+
+      return persist;
+    }),
+  );
+  yield* Console.log(renderDiagnosticReport(report));
+
+  return report;
+}, Effect.scoped);
+
+export const command = Command.make(
+  "runtime-diagnostics",
+  {
+    base: Flag.string("base-dir").pipe(
+      Flag.withDescription(
+        "Clean exact base checkout with its own installed lockfile and public packages built.",
+      ),
+    ),
+    output: Flag.string("out-dir").pipe(
+      Flag.withDefault(".performance-report"),
+      Flag.withDescription("New artifact directory; previous reports are never overwritten."),
+    ),
+    requireClean: Flag.boolean("require-clean").pipe(
+      Flag.withDefault(true),
+      Flag.withDescription("Required: diagnostics reject modified checkouts."),
+    ),
+  },
+  Effect.fn(function* ({ base, output, requireClean }) {
+    const path = yield* Path.Path;
+
+    const root = path.resolve(
+      path.dirname(yield* path.fromFileUrl(new URL(import.meta.url))),
+      "..",
+    );
+
+    yield* compareDiagnostics({ root, base, output, requireClean });
+  }),
+).pipe(
+  Command.withDescription(
+    "Manual deterministic public-package diagnostics; two alternating base/head cohorts, ten measured samples per case. No network model calls.",
+  ),
+);
+
+if (import.meta.main)
+  NodeRuntime.runMain(
+    Command.run(command, { version: DIAGNOSTIC_VERSION }).pipe(
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    ),
+  );

--- a/test/fixtures/ledger-read-contracts.ts
+++ b/test/fixtures/ledger-read-contracts.ts
@@ -1,0 +1,400 @@
+import { digestJson } from "@effect-agent/thread/Digest";
+import {
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ProducerId,
+  RecordEnvelope,
+  SubmissionSettledRecord,
+  type SettlementOutcome,
+} from "@effect-agent/thread/Records";
+import {
+  AbortCommand,
+  AdmissionRequest,
+  ClaimRequest,
+  LedgerError,
+  MarkReadyRequest,
+  OwnershipToken,
+  SettlementConflict,
+  SettlementFinalization,
+  SettlementReservation,
+  SubmissionLedger,
+  SubmissionLookupById,
+  submissionSettlementId,
+  submissionSettlementRecordId,
+  type SubmissionSnapshot,
+} from "@effect-agent/thread/SubmissionLedger";
+import { Cause, DateTime, Effect, Exit, Option, Schema, Stream } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { CurrentTransformer, type Statement } from "effect/unstable/sql/Statement";
+import { expect } from "vite-plus/test";
+
+const digest = Schema.decodeSync(Digest)("a".repeat(64));
+const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+const producerId = ProducerId.make("ledger-read-test");
+const deploymentId = DeploymentId.make("ledger-read-test");
+
+export const admitReadFixture = Effect.fn("LedgerReadFixture.admit")(function* (
+  threadId: string,
+  key: string,
+) {
+  const ledger = yield* SubmissionLedger;
+
+  return yield* ledger.admit(
+    yield* Schema.decodeUnknownEffect(AdmissionRequest)({
+      threadId,
+      principal: "ledger-read-test",
+      idempotencyKey: key,
+      agentId: "ledger-read-test",
+      agentDigests: definitions,
+      deploymentId,
+      inputPayload: null,
+      inputDigest: digest,
+    }),
+  );
+});
+
+const reserve = Effect.fn("LedgerReadFixture.reserve")(function* (
+  submission: Pick<SubmissionSnapshot, "submissionId" | "receiptId">,
+  ownershipToken: OwnershipToken,
+  outcome: SettlementOutcome,
+) {
+  const ledger = yield* SubmissionLedger;
+  const settlementId = submissionSettlementId(submission.submissionId);
+
+  const payload = yield* Schema.decodeUnknownEffect(SubmissionSettledRecord)({
+    _tag: "SubmissionSettled",
+    submissionId: submission.submissionId,
+    settlementId,
+    receiptId: submission.receiptId,
+    outcome,
+    ...(outcome === "failed"
+      ? { result: { errorTag: "FixtureFailure", message: "Fixture failed" } }
+      : {}),
+  });
+
+  const record = RecordEnvelope.make({
+    recordId: submissionSettlementRecordId(submission.submissionId),
+    family: "thread",
+    schemaVersion: 1,
+    createdAt: DateTime.makeUnsafe(1),
+    deploymentId,
+    payload,
+  });
+
+  const recordDigest = yield* digestJson(yield* Schema.encodeEffect(RecordEnvelope)(record));
+
+  yield* ledger.reserveSettlement(
+    SettlementReservation.make({
+      submissionId: submission.submissionId,
+      ownershipToken,
+      settlementId,
+      outcome,
+      record,
+      recordDigest,
+    }),
+  );
+
+  return SettlementFinalization.make({ submissionId: submission.submissionId, settlementId });
+});
+
+/** Adapter fixture: reservation precedes finalization; runtime canonical append is outside this suite. */
+export const reserveReadFixture = Effect.fn("LedgerReadFixture.prepare")(function* (
+  key: string,
+  outcome: SettlementOutcome = "completed",
+) {
+  const ledger = yield* SubmissionLedger;
+  const admitted = yield* admitReadFixture(key, key);
+
+  yield* ledger.markReady(MarkReadyRequest.make({ submissionId: admitted.submissionId }));
+
+  const claim = yield* ledger.claim(
+    ClaimRequest.make({ threadId: AdmissionRequest.fields.threadId.make(key), producerId }),
+  );
+
+  if (Option.isNone(claim)) return yield* Effect.die("Fixture lane did not become claimable");
+
+  return yield* reserve(admitted, claim.value.ownershipToken, outcome);
+});
+
+const abortQueued = Effect.fn("LedgerReadFixture.abortQueued")(function* (submissionId: string) {
+  const ledger = yield* SubmissionLedger;
+
+  const submission = yield* ledger.lookup(
+    SubmissionLookupById.make({
+      submissionId: SubmissionLookupById.fields.submissionId.make(submissionId),
+    }),
+  );
+
+  if (Option.isNone(submission)) return yield* Effect.die("Missing scan fixture submission");
+  yield* ledger.requestAbort(
+    AbortCommand.make({
+      submissionId: submission.value.submissionId,
+      author: "ledger-read-test",
+      reason: "queued abort",
+    }),
+  );
+
+  return yield* ledger.finalizeSettlement(
+    yield* reserve(submission.value, OwnershipToken.make("unused-queued-abort"), "aborted"),
+  );
+});
+
+/** Synthetic scan rows isolate retained ledger growth; they do not represent a canonical settlement protocol. */
+export const seedScan = Effect.fn("LedgerReadFixture.seedScan")(function* (
+  count: number,
+  settledPrefix: number = 0,
+  gaps = false,
+) {
+  const sql = yield* SqlClient.SqlClient;
+
+  const encodedDefinitions = yield* Schema.encodeEffect(Schema.fromJsonString(DefinitionDigests))(
+    definitions,
+  );
+
+  yield* sql`
+    WITH RECURSIVE positions(n) AS (SELECT 0 UNION ALL SELECT n + 1 FROM positions WHERE n + 1 < ${count})
+    INSERT INTO effect_agent_submissions (
+      submission_id, thread_id, queue_sequence, principal, idempotency_key,
+      agent_id, agent_digests_json, deployment_id, input_json, input_digest,
+      receipt_id, state, settled_outcome, created_at, ready_at
+    )
+    SELECT 'scan-' || n, 'scan-lane', n + 1, 'ledger-read-test', 'scan-' || n,
+      'ledger-read-test', ${encodedDefinitions}, ${deploymentId}, 'null', ${digest},
+      'receipt-scan-' || n,
+      CASE WHEN n < ${settledPrefix} OR (${gaps ? 1 : 0} = 1 AND n % 7 = 0) THEN 'settled' ELSE 'ready' END,
+      CASE WHEN n < ${settledPrefix} OR (${gaps ? 1 : 0} = 1 AND n % 7 = 0) THEN 'completed' ELSE NULL END,
+      '1970-01-01T00:00:00.001Z', '1970-01-01T00:00:00.001Z'
+    FROM positions
+  `;
+});
+
+type CompiledQuery = ReturnType<Statement<unknown>["compile"]>;
+
+export const observeQueries = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const queries: Array<CompiledQuery> = [];
+
+    const result = yield* effect.pipe(
+      Effect.provideService(CurrentTransformer, (statement) =>
+        Effect.sync(() => {
+          queries.push(statement.compile());
+
+          return statement;
+        }),
+      ),
+    );
+
+    return { result, queries };
+  });
+
+const assertIndexedScan = Effect.fn("LedgerReadFixture.assertIndexedScan")(function* (
+  queries: ReadonlyArray<CompiledQuery>,
+) {
+  const sql = yield* SqlClient.SqlClient;
+
+  for (const [index, [query, parameters]] of queries.entries()) {
+    const plan = yield* sql.unsafe<{ detail: string }>(`EXPLAIN QUERY PLAN ${query}`, parameters);
+
+    expect(plan.some(({ detail }) => detail.includes("effect_agent_submissions_nonterminal"))).toBe(
+      true,
+    );
+    expect(plan.some(({ detail }) => detail.includes("TEMP B-TREE"))).toBe(false);
+    if (index > 0)
+      expect(
+        plan.some(
+          ({ detail }) =>
+            detail.includes("SEARCH") && detail.includes("effect_agent_submissions_nonterminal"),
+        ),
+      ).toBe(true);
+  }
+});
+
+export const ledgerReadCases = [
+  {
+    name: "scans more than two pages in FIFO order through a partial index and cursor seeks",
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+
+      yield* seedScan(900, 0, true);
+      const { result, queries } = yield* observeQueries(Stream.runCollect(ledger.scanNonterminal));
+      const expected = Array.from({ length: 900 }, (_, n) => n).filter((n) => n % 7 !== 0);
+
+      expect(result.map(({ submissionId }) => submissionId)).toEqual(
+        expected.map((n) => `scan-${n}`),
+      );
+      expect(result.map(({ queueSequence }) => queueSequence)).toEqual(expected.map((n) => n + 1));
+      expect(queries).toHaveLength(4);
+      yield* assertIndexedScan(queries);
+    }),
+  },
+  {
+    name: "skips a large settled prefix with one indexed page",
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+
+      yield* seedScan(2064, 2048);
+      const { result, queries } = yield* observeQueries(Stream.runCollect(ledger.scanNonterminal));
+
+      expect(result.map(({ submissionId }) => submissionId)).toEqual(
+        Array.from({ length: 16 }, (_, n) => `scan-${2048 + n}`),
+      );
+      expect(queries).toHaveLength(1);
+      yield* assertIndexedScan(queries);
+    }),
+  },
+  {
+    name: "keeps cursor order during settlement and observes earlier admissions on the next scan",
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+
+      yield* seedScan(770);
+      let count = 0;
+      let earlier: string | undefined;
+      let later: string | undefined;
+
+      const result = yield* Stream.runCollect(
+        ledger.scanNonterminal.pipe(
+          Stream.tap(() =>
+            Effect.gen(function* () {
+              count++;
+              if (count !== 256) return;
+              yield* abortQueued("scan-0");
+              yield* abortQueued("scan-514");
+              earlier = (yield* admitReadFixture("a-before-cursor", "earlier")).submissionId;
+              later = (yield* admitReadFixture("z-after-cursor", "later")).submissionId;
+            }),
+          ),
+        ),
+      );
+
+      expect(result.map(({ submissionId }) => submissionId)).toEqual([
+        ...Array.from({ length: 770 }, (_, n) => `scan-${n}`).filter((id) => id !== "scan-514"),
+        later,
+      ]);
+      const next = yield* Stream.runCollect(ledger.scanNonterminal);
+
+      expect(next.map(({ submissionId }) => submissionId)).toEqual([
+        earlier,
+        ...Array.from({ length: 770 }, (_, n) => `scan-${n}`).filter(
+          (id) => id !== "scan-0" && id !== "scan-514",
+        ),
+        later,
+      ]);
+    }),
+  },
+  ...(["completed", "failed", "aborted"] as const).map((outcome) => ({
+    name: `replays ${outcome} settlement in one read with unchanged timestamp and diagnostics`,
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+      const request = yield* reserveReadFixture(`settlement-${outcome}`, outcome);
+      const active = yield* observeQueries(ledger.finalizeSettlement(request));
+
+      // One probe, the two original reads and three original mutations; BEGIN/COMMIT are driver-owned.
+      expect(active.queries).toHaveLength(6);
+      expect(active.result.outcome).toBe(outcome);
+      for (let i = 0; i < 3; i++) {
+        const replay = yield* observeQueries(ledger.finalizeSettlement(request));
+
+        expect(replay.result).toEqual(active.result);
+        expect(replay.queries).toHaveLength(1);
+        expect(replay.queries[0]?.[0].trimStart().startsWith("SELECT")).toBe(true);
+      }
+      expect(active.result.failure).toEqual(
+        outcome === "failed"
+          ? { errorTag: "FixtureFailure", message: "Fixture failed" }
+          : undefined,
+      );
+
+      const conflict = yield* ledger
+        .finalizeSettlement(
+          SettlementFinalization.make({
+            ...request,
+            settlementId: SettlementFinalization.fields.settlementId.make("conflicting-settlement"),
+          }),
+        )
+        .pipe(Effect.result);
+
+      expect(conflict).toMatchObject({
+        _tag: "Failure",
+        failure: SettlementConflict.make({
+          submissionId: request.submissionId,
+          existingOutcome: outcome,
+        }),
+      });
+    }),
+  })),
+  ...(["record", "timestamp", "failure", "missing"] as const).map((corruption) => ({
+    name: `preserves typed ${corruption} failure without repairing settled storage`,
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+      const sql = yield* SqlClient.SqlClient;
+      const request = yield* reserveReadFixture(`corrupt-${corruption}`);
+
+      yield* ledger.finalizeSettlement(request);
+      switch (corruption) {
+        case "record":
+          yield* sql`UPDATE effect_agent_settlement_reservations SET record_json='{}' WHERE submission_id=${request.submissionId}`;
+          break;
+        case "timestamp":
+          yield* sql`UPDATE effect_agent_settlement_reservations SET finalized_at=NULL WHERE submission_id=${request.submissionId}`;
+          break;
+        case "failure":
+          yield* sql`UPDATE effect_agent_settlement_reservations SET outcome='failed' WHERE submission_id=${request.submissionId}`;
+          break;
+        case "missing":
+          yield* sql`DELETE FROM effect_agent_settlement_reservations WHERE submission_id=${request.submissionId}`;
+          break;
+      }
+
+      const before =
+        yield* sql`SELECT * FROM effect_agent_settlement_reservations WHERE submission_id=${request.submissionId}`;
+
+      const result = yield* ledger.finalizeSettlement(request).pipe(Effect.result);
+
+      expect(result).toMatchObject({ _tag: "Failure", failure: { _tag: "LedgerError" } });
+      if (result._tag === "Failure") {
+        expect(Schema.is(LedgerError)(result.failure)).toBe(true);
+        if (corruption !== "missing")
+          expect(result.failure).toMatchObject({
+            cause: { _tag: expect.stringMatching(/StorageCorruptionError$/) },
+          });
+      }
+      expect(
+        yield* sql`SELECT * FROM effect_agent_settlement_reservations WHERE submission_id=${request.submissionId}`,
+      ).toEqual(before);
+      expect(
+        yield* sql`SELECT state FROM effect_agent_submissions WHERE submission_id=${request.submissionId}`,
+      ).toEqual([{ state: "settled" }]);
+    }),
+  })),
+  ...(["failure", "defect", "interruption"] as const).map((mode) => ({
+    name: `releases a ${mode} during the settled read and permits later mutations`,
+    run: Effect.gen(function* () {
+      const ledger = yield* SubmissionLedger;
+      const sql = yield* SqlClient.SqlClient;
+      const request = yield* reserveReadFixture(`cleanup-${mode}`);
+      const settled = yield* ledger.finalizeSettlement(request);
+
+      const result = yield* ledger.finalizeSettlement(request).pipe(
+        Effect.provideService(CurrentTransformer, () =>
+          mode === "failure"
+            ? Effect.succeed(sql`SELECT * FROM effect_agent_missing_read_fixture`)
+            : mode === "defect"
+              ? Effect.die("read defect")
+              : Effect.interrupt,
+        ),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(result)).toBe(true);
+      if (Exit.isFailure(result)) {
+        if (mode === "failure") expect(Cause.hasFails(result.cause)).toBe(true);
+        if (mode === "defect") expect(Cause.hasDies(result.cause)).toBe(true);
+        if (mode === "interruption") expect(Cause.hasInterrupts(result.cause)).toBe(true);
+      }
+      expect(yield* ledger.finalizeSettlement(request)).toEqual(settled);
+      yield* admitReadFixture(`after-${mode}`, "after");
+    }),
+  })),
+];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -170,6 +170,10 @@ export default defineConfig({
         cache: false,
         command: "bun scripts/runtime-benchmark.ts",
       },
+      "perf:diagnose": {
+        cache: false,
+        command: "bun scripts/runtime-diagnostics.ts",
+      },
       "perf:cloudflare": {
         cache: false,
         command: "bun examples/context-continuity-eval/src/performance-main.ts",


### PR DESCRIPTION
Settled finalization replay now reads its validated submission/reservation pair without opening a write transaction. Active or incomplete state still follows the existing repair protocol. Both SQL adapters use a partial unfinished-submission index and tuple cursor, installed by narrow atomic upgrades. Ephemeral history updates scan aggregate bytes once and publish one immutable suffix update while preserving fresh Schema encoding of caller-owned values.

A manual diagnostic profile adds 45 bounded policy, history, memory, MCP, subagent, ledger-contention, and worker-fairness cases. It preserves setup/operation boundaries, actual writer overlap, scoped finalizers, and failures. Ordinary PR coverage and worker defaults remain unchanged.

Validation at `fc77740a8c03d26c98a44977bd365b32f712a347`:

- Full local `VITEST_MAX_WORKERS=2 vp run --concurrency-limit 2 ready`: 3,339 passed, seven skipped. Hosted CI, bundle checks, ordinary runtime comparison, and full-diff automated review passed with no actionable findings.
- [Public-package diagnostics](https://github.com/danieljvdm/effect-agent/actions/runs/34296212918): four alternating batches, 45 cases, all 1,260 raw samples passed; ten measured samples per case/revision. Exact base `9c98161d5a1026f2dc3d0fb395ea4a0bf6323fdd`, Node 24.20.0, Linux x64 AMD EPYC 9V74. Artifact retains identities, medians/spread, raw marks and finalizers.

| Operation | Base median | Candidate median | Result |
| --- | ---: | ---: | --- |
| History, 64-message suffix | 6.67 ms | 4.33 ms | 35.1% lower |
| History, 64-thread store | 7.02 ms | 4.21 ms | 40.1% lower |
| History, 768 + 256 messages | 40.11 ms | 14.03 ms | 65.0% lower |
| Sparse ledger, 8,192 settled + 16 unfinished | 4.18 ms | 1.20 ms | 71.3% lower; indexed query |
| Healthy settled replay, 32 calls | 11.59 ms | 7.29 ms | Explicit SQL statements 64 to 32 |
| Active finalization | 1.12 ms | 1.26 ms | 0.137 ms / 12.2% slower; one extra read |

All 168 raw writer samples had verified lock overlap. At requested 25/100 ms holds, all ten candidate replay/status observations per cell finished while the independent writer still held its transaction; zero baseline calls did. Runtime status still loads its recovery snapshot. Counts exclude driver BEGIN/COMMIT, and partial indexes add write maintenance.

Complete history-hook Runs, policy preparation, optional capabilities, and head-versus-base worker fairness show no additional demonstrated optimization. Policy `postAuthorizationWaitMax` measures each handler from its own authorization completion, including later serial authorizations; it is not isolated semaphore cost. MCP uses an in-process HTTP responder; remembering uses a bounded local protocol fixture. No CPU, billing, or general whole-library speedup is claimed.

Regression coverage includes both adapter contracts, upgrade fault boundaries, corruption/incomplete state, held external writers, sparse/dense pagination and actual query plans, mutable history payloads and atomic capacity failure, capability lifetimes, authorization ordering, canonical per-thread outputs/FIFO, and exact failure/timeout/interruption causes. Review also caught and fixed failed-seed reuse and unverified writer-overlap evidence. Encoding caches were rejected because accepted nested Prompt values remain mutable; scheduling/default changes were rejected without demonstrated benefit.
