### PR TITLE
fix(benchmark): report failed checkpoint settlements

### DIFF
--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -89,6 +89,9 @@ normalized provider callback. It does not use ModelStarted events. `totalMs` end
 completion or durable settlement; it includes the operation's correctness checks where those
 checks are inline. Every sample uses a new finite script, verifies exhaustion, and counts model
 stream finalizers. The first recovery attempt is verified before its counters are reset.
+If that attempt misses the expected checkpoint fault, its diagnostic includes bounded returned
+settlement outcomes/failures and the observed compaction/checkpoint phase. A successful worker
+Effect can return a failed settlement; it does not by itself prove a successful Attempt.
 `checkpointCreationMs` separately measures native checkpoint construction and persistence from
 `compaction:after-canonical-append` through `checkpoint:after-save`, before injecting the fault.
 It includes checkpoint scans/encoding/save but excludes the already committed compaction append

--- a/examples/runtime-benchmark/src/fixture.ts
+++ b/examples/runtime-benchmark/src/fixture.ts
@@ -36,6 +36,7 @@ import {
   IdempotencyKey,
   MarkReadyRequest,
   Principal,
+  type Settlement,
   SettlementFinalization,
   SettlementReservation,
   SubmissionLedger,
@@ -106,6 +107,47 @@ const ambientModel = Layer.effectContext(
 );
 
 const binding = { definition: agent, model: ambientModel };
+
+/** A completed worker Effect can return failed Settlements; retain those bounded diagnostics. */
+export const assertCheckpointFault = Effect.fn("benchmark.assertCheckpointFault")(function* <E>(
+  attempt: Exit.Exit<ReadonlyArray<Settlement>, E>,
+  phase: {
+    readonly compactionCommitted: boolean;
+    readonly checkpointCreationMs: number | null;
+  },
+) {
+  const fault = Exit.isFailure(attempt) ? Cause.findErrorOption(attempt.cause) : Option.none();
+
+  if (
+    Option.isSome(fault) &&
+    Schema.is(DurableRuntimeFailpointError)(fault.value) &&
+    fault.value.location === "checkpoint:after-save"
+  )
+    return;
+
+  const outcome = Exit.isFailure(attempt)
+    ? Cause.pretty(attempt.cause)
+    : JSON.stringify({
+        settlementCount: attempt.value.length,
+        // This fixture admits one Submission. Bound unexpected drain results and error text too.
+        settlements: attempt.value.slice(0, 8).map((settlement) => ({
+          submissionId: settlement.submissionId.slice(0, 256),
+          outcome: settlement.outcome,
+          ...(settlement.failure === undefined
+            ? {}
+            : {
+                failure: {
+                  errorTag: settlement.failure.errorTag.slice(0, 256),
+                  message: settlement.failure.message.slice(0, 1_024),
+                },
+              }),
+        })),
+      });
+
+  return yield* BenchmarkError.make({
+    message: `Expected checkpoint fault was not observed: ${outcome}; checkpoint phase: ${JSON.stringify(phase)}`,
+  });
+});
 
 const finalParts = (answer: string, chunks: number): ReadonlyArray<ScriptedStreamPart> => {
   const text = JSON.stringify({ answer });
@@ -677,16 +719,10 @@ export const runSample = Effect.fn("benchmark.runSample")(function* (
           yield* submit;
           const attempt = yield* runtime.processThread(binding, threadId).pipe(Effect.exit);
 
-          const fault = Exit.isFailure(attempt)
-            ? Cause.findErrorOption(attempt.cause)
-            : Option.none();
-
-          yield* check(
-            Option.isSome(fault) &&
-              fault.value._tag === "DurableRuntimeFailpointError" &&
-              fault.value.location === "checkpoint:after-save",
-            `Expected checkpoint fault was not observed: ${Exit.isFailure(attempt) ? Cause.pretty(attempt.cause) : "attempt succeeded"}`,
-          );
+          yield* assertCheckpointFault(attempt, {
+            compactionCommitted: checkpointStarted !== undefined,
+            checkpointCreationMs,
+          });
           const store = yield* ThreadStore;
 
           const checkpoint =

--- a/examples/runtime-benchmark/test/fixture.test.ts
+++ b/examples/runtime-benchmark/test/fixture.test.ts
@@ -1,5 +1,13 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { NodeDurableAgentRuntime } from "@effect-agent/platform-node/NodeDurableAgentRuntime";
+import { ScriptedModel } from "@effect-agent/testing/ScriptedModel";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import { DeploymentId, DefinitionDigests, Digest, ProducerId } from "@effect-agent/thread/Records";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
 import { NodeCrypto, NodeServices } from "@effect/platform-node";
-import { Effect, Layer } from "effect";
+import { Effect, Exit, FileSystem, Layer, Schema } from "effect";
+import { Agent } from "effect-agent";
+import { Model, Toolkit } from "effect/unstable/ai";
 import { expect, it } from "vite-plus/test";
 
 import {
@@ -11,8 +19,89 @@ import {
   type WorkerReport,
 } from "../src/contracts.ts";
 import { BenchmarkProgress } from "../src/evidence.ts";
-import { runSample, SeedInitializerLive } from "../src/fixture.ts";
+import { assertCheckpointFault, runSample, SeedInitializerLive } from "../src/fixture.ts";
 import { SeedTemplates } from "../src/seeds.ts";
+
+it("reports failed durable Settlements even when processThread succeeds", async () => {
+  let finalized = 0;
+
+  const agent = Agent.make("checkpoint-diagnostic", {
+    input: Schema.String,
+    output: Schema.String,
+    instructions: "Return the answer.",
+    toolkit: Toolkit.empty,
+  });
+
+  const digest = Schema.decodeSync(Digest)("b".repeat(64));
+  const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
+
+  const model = Layer.mergeAll(
+    ScriptedModel.layer([
+      {
+        _tag: "Stream",
+        parts: [],
+        termination: { _tag: "Fail", description: "diagnostic provider unavailable" },
+        onStreamFinalize: Effect.sync(() => {
+          finalized++;
+        }),
+      },
+    ]),
+    Layer.succeed(Model.ProviderName, "scripted"),
+    Layer.succeed(Model.ModelName, "checkpoint-diagnostic"),
+  );
+
+  const { attempt, diagnostic } = await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "checkpoint-diagnostic-" });
+
+      return yield* Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+
+        const receipt = yield* runtime.submit({ definition: agent }, "Answer", {
+          threadId: ThreadId.make("checkpoint-diagnostic"),
+          principal: Principal.make("checkpoint-diagnostic"),
+          idempotencyKey: IdempotencyKey.make("checkpoint-diagnostic"),
+          definitions,
+        });
+
+        const attempt = yield* runtime
+          .processThread({ definition: agent, model }, receipt.threadId)
+          .pipe(Effect.exit);
+
+        const diagnostic = yield* assertCheckpointFault(attempt, {
+          compactionCommitted: false,
+          checkpointCreationMs: null,
+        }).pipe(Effect.flip);
+
+        return { attempt, diagnostic };
+      }).pipe(
+        Effect.provide(
+          NodeDurableAgentRuntime.layer({
+            filename: `${directory}/thread.sqlite`,
+            deploymentId: DeploymentId.make("checkpoint-diagnostic"),
+            producerId: ProducerId.make("checkpoint-diagnostic"),
+          }),
+        ),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  expect(Exit.isSuccess(attempt)).toBe(true);
+  const settlements = Exit.isSuccess(attempt) ? attempt.value : [];
+
+  expect(settlements).toHaveLength(1);
+  expect(settlements[0]?.outcome).toBe("failed");
+  expect(settlements[0]?.failure?.errorTag).toBe("AiError");
+  expect(settlements[0]?.failure?.message).toContain("diagnostic provider unavailable");
+  expect(diagnostic._tag).toBe("BenchmarkError");
+  expect(diagnostic.message).toContain('"outcome":"failed"');
+  expect(diagnostic.message).toContain("AiError");
+  expect(diagnostic.message).toContain("diagnostic provider unavailable");
+  expect(diagnostic.message).toContain('"compactionCommitted":false');
+  expect(diagnostic.message).toContain('"checkpointCreationMs":null');
+  expect(finalized).toBe(1);
+});
 
 it.each(casesFor("smoke"))(
   "validates equivalent completed work in $name",


### PR DESCRIPTION
A checkpoint benchmark attempt can return successfully from `processThread` with a failed durable settlement. The fixture previously discarded that result and reported only “attempt succeeded,” hiding the reason its expected checkpoint fault was absent.

Report the returned settlement count, bounded outcome/error details, and observed compaction/checkpoint phase when that assertion fails. A regression uses the real Node durable runtime with a scripted provider failure, verifies the failed `AiError` settlement despite Effect success, and verifies the model stream finalizer. The guide explains the distinction.

Validation: all 18 fixture tests, package type checking, lint and formatting pass. Full `VITEST_MAX_WORKERS=2 vp run --concurrency-limit 2 ready` passed: 3,374 tests passed, seven skipped, all 82 tasks completed with zero cache hits. Workloads, timing boundaries, fixture contract, sample budgets and production defaults are unchanged; exact fixture bytes receive their normal new hash.

The [earlier manual archive](https://github.com/danieljvdm/effect-agent/actions/runs/34295761592) remains incomplete. This improves future diagnostics; it does not recover missing settlement outcomes, prove the previous checkpoint failure cause, fix ledger seed timeouts, or establish a 100k speedup.
