### PR TITLE
fix(cloudflare): deliver messages during source execution

### DIFF
--- a/.changeset/live-peer-message-delivery.md
+++ b/.changeset/live-peer-message-delivery.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Deliver messages created during an active Cloudflare source Run without waiting for that Run to finish.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -565,7 +565,9 @@ evidence is automatically deleted. Effect spans identify preparation, admission,
 operations; persisted failures contain bounded codes rather than raw application errors.
 
 Node's scoped delivery pump and Cloudflare's persisted alarms rediscover stored obligations even
-after both Runs settle and wake hints are lost. Progress still needs a functioning host and
+after both Runs settle and wake hints are lost. During an active Cloudflare maintenance pass,
+message delivery continues alongside source execution, so a message can reach its destination
+before the source Run finishes. Progress still needs a functioning host and
 available capacity. The complete [Node and Cloudflare orchestration example](https://github.com/danieljvdm/effect-agent/tree/main/examples/durable-orchestration)
 shows builders, attached scouts, later input, automatic reports, and peer request/reply using
 the same platform-independent declarations.

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -15,6 +15,7 @@ import {
   Clock,
   Context,
   DateTime,
+  Deferred,
   Effect,
   Exit,
   Fiber,
@@ -629,10 +630,37 @@ export class ThreadMaintenance extends Context.Service<
           }),
         );
 
-        // Run one bounded message wave beside source work. Slow destination admission or
-        // status RPCs cannot consume the source Attempt's execution window. Join before
-        // acknowledging the alarm so the final deadline includes all delivery mutations.
-        const delivery = yield* Effect.forkChild(messages.drain);
+        // Keep one bounded delivery wave active beside source work, including messages
+        // created after this pass starts. New writes invalidate the cached deadline; the
+        // wake scan bounds discovery even when this Object's native alarm is already running.
+        const stopDelivery = yield* Deferred.make<void>();
+
+        const delivery = yield* Effect.forkChild(
+          Effect.gen(function* () {
+            while (true) {
+              const stopping = yield* Deferred.isDone(stopDelivery);
+
+              yield* messages.drain;
+              if (stopping) return;
+
+              const next = yield* messages.pendingDeadline;
+              const now = yield* Clock.currentTimeMillis;
+
+              const delay = Option.isSome(next)
+                ? Math.min(config.wakeScanInterval, Math.max(1, next.value - now))
+                : config.wakeScanInterval;
+
+              yield* Effect.raceFirst(Deferred.await(stopDelivery), Effect.sleep(delay));
+            }
+          }),
+        );
+
+        // Complete the in-flight wave and one final drain before reading alarm deadlines.
+        // Failures still surface after source work; interruption supervises the child and
+        // leaves the prearmed generation available for durable recovery.
+        const finishDelivery = Deferred.succeed(stopDelivery, undefined).pipe(
+          Effect.andThen(Fiber.join(delivery)),
+        );
 
         // Capture derived-index failures until canonical work has had its turn. Interruption
         // still stops the event; ordinary failures and defects retain the prearmed generation.
@@ -653,7 +681,7 @@ export class ThreadMaintenance extends Context.Service<
         const pending = yield* publication.pendingDeadline;
 
         if (started._tag === "CaughtUp" || Option.isSome(pending)) {
-          yield* Fiber.join(delivery);
+          yield* finishDelivery;
           if (Exit.isFailure(projected)) return yield* Effect.failCause(projected.cause);
           yield* failpoint.hit("maintenance:finish:before");
 
@@ -708,7 +736,7 @@ export class ThreadMaintenance extends Context.Service<
         // soft deadline is reached; queued followers belong to a subsequent alarm.
         const settlement = yield* runtime.processThreadHead(identity.threadId, { yieldAfter });
 
-        yield* Fiber.join(delivery);
+        yield* finishDelivery;
         if (Exit.isFailure(projected)) return yield* Effect.failCause(projected.cause);
         // Observe residual state before acknowledging this exact pass-start generation.
         const remaining = yield* Stream.runCollect(ledger.scanNonterminal);

--- a/packages/platform-cloudflare/test/message-delivery.test.ts
+++ b/packages/platform-cloudflare/test/message-delivery.test.ts
@@ -10,6 +10,7 @@ import { CloudflareThreadClient } from "../src/CloudflareThreadClient.ts";
 import {
   decodeIdempotencyKey,
   decodeThreadId,
+  alarmAttemptHolds,
   maintenanceClocks,
   plannerDefinition,
   submitOptions,
@@ -130,6 +131,7 @@ const withThreads = (
             messageEvictions.delete(thread);
             messageDeliveryHolds.delete(thread);
             messageDeliveryResources.delete(thread);
+            alarmAttemptHolds.delete(thread);
           }
         }),
       );
@@ -140,6 +142,60 @@ const withThreads = (
   );
 
 describe("Thread Object message maintenance", () => {
+  // https://github.com/danieljvdm/effect-agent/commit/4ff21e2a4
+  it("delivers messages created during a running source Attempt before that Attempt finishes", () =>
+    withThreads(async (source, destination, now, advance) => {
+      await submit(source, "initial");
+      await drainAlarmsUntil(source, allSettled(source));
+
+      const entered = latch();
+      const release = latch();
+      let released = false;
+
+      alarmAttemptHolds.set(source, {
+        location: "claim:after-claim",
+        entered: Effect.sync(entered.resolve),
+        release: Effect.promise(() => release.promise),
+        finished: Effect.sync(() => {
+          released = true;
+        }),
+      });
+      await submit(source, "producing-message");
+      const running = runDurableObjectAlarm(stubFor(source));
+
+      try {
+        await entered.promise;
+        // Let the pass-start delivery wave finish before new outbound work exists.
+        await advance(100);
+        await enqueue(source, destination, now + 100);
+        await advance(100);
+        for (
+          let attempt = 0;
+          attempt < 200 && (await read(source))?.status === "pending";
+          attempt += 1
+        ) {
+          await Promise.resolve();
+        }
+        expect((await read(source))?.status).toBe("accepted");
+        expect(await laneRows(destination)).toHaveLength(1);
+        expect(await allSettled(source)()).toBe(false);
+        expect(released).toBe(false);
+      } finally {
+        release.resolve();
+        // Completion must stop the delivery fiber without another clock tick.
+        await running;
+      }
+      expect(released).toBe(true);
+      expect(await allSettled(source)()).toBe(true);
+      expect(await scheduledAlarm(source)).not.toBeNull();
+      await drainAlarmsUntil(destination, allSettled(destination));
+      await advance(20);
+      // The completed pass leaves future delivery work to its durable alarm.
+      expect((await read(source))?.status).toBe("accepted");
+      await runDurableObjectAlarm(stubFor(source));
+      expect((await read(source))?.status).toBe("processed");
+    }));
+
   it("settles ready source work while delivery is held and finalizes delivery on maintenance interruption", () =>
     withThreads(async (source, destination, now, advance) => {
       await submit(source, "initial");


### PR DESCRIPTION
Messages created after Cloudflare maintenance's first delivery wave could remain pending until the source Attempt finished. Keep delivery progressing alongside source execution in one supervised fiber, using the existing wake-scan interval and stored retry deadlines. Finish the active wave and a final drain before acknowledging the maintenance alarm.

The workerd regression holds a source Attempt open, inserts an outbound message, and verifies destination admission before releasing the source. It also verifies delivery polling ends with the pass and later processing resumes through the persisted alarm. Existing interruption and eviction recovery coverage remains in place. Includes a patch changeset and updates the subagent guide.

Validation:
- Regression reproduced the pending-message failure on the original implementation; all 5 message-delivery and 15 alarm tests pass with the fix.
- Full static checks and workspace type checks passed during `vp run ready`.
- The complete Cloudflare platform suite passes with `--maxWorkers=1 --no-file-parallelism`: 510 passed, 3 skipped. Package, documentation, and Action builds passed.
- The broad local test run had two Cloudflare runners exit with code 137 and one unrelated 10 ms diagnostic timeout. The diagnostic case passed in isolation. [CI on this commit](https://github.com/danieljvdm/effect-agent/actions/runs/34313335695) passed static checks, every test job including both Cloudflare suites, and the build.
