### PR TITLE
fix: keep explicit tool pins within run authority

### DIFF
--- a/.changeset/eligible-common-tool-pins.md
+++ b/.changeset/eligible-common-tool-pins.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+---
+
+Keep explicit tool pins selected only while authorized, so disabling a common tool does not prevent other work. Omit unavailable optional completion tools from final-answer requests while preserving mandatory tool checks.

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -174,10 +174,12 @@ successful selection clears it. If a batch contains several successful selection
 declaration order wins, regardless of completion order. No selection takes effect midway through
 a batch. Failed results retain the previous selection; ordinary tool error behavior still applies.
 
-During working turns, discovery tools, explicit `PinnedTool` annotations, required completion and context
-rollover tools stay exposed. Pins count toward the limits and never override eligibility: an
-excluded required pin causes a typed refusal. Optional completion is available when the runtime
-enters its final answer turn; that turn may expose only the completion tool. The default exposure limits are 64 tools and 256 KiB of aggregate
+During working turns, eligible tools with explicit `PinnedTool` annotations stay exposed across
+selections. Host visibility and inherited grants may hide these common tools without failing the
+run. Discovery, required completion and context rollover tools are mandatory: excluding one causes
+a typed refusal. Exposed pins count toward the limits and never override eligibility. Optional
+completion is available in the final answer turn only when eligible; otherwise the model finishes
+with text. That turn may expose only the completion tool. The default exposure limits are 64 tools and 256 KiB of aggregate
 UTF-8 JSON declarations (names, descriptions and parameter schemas, including the current model's
 schema transformation). Exceeding a limit fails with `ModelProtocolError`; there is no silent
 eviction beyond replacement.

--- a/packages/core/src/ToolExposure.ts
+++ b/packages/core/src/ToolExposure.ts
@@ -48,7 +48,9 @@ export const DiscoveryTool = Context.Reference<boolean>(
   { defaultValue: () => false },
 );
 
-/** Remains exposed under selection, subject to host visibility and inherited grants. */
+/** Remains selected while eligible. Host visibility and inherited grants may hide an explicit
+ * pin without failing the Run; discovery, context rollover and required completion stay mandatory.
+ */
 export const PinnedTool = Context.Reference<boolean>("@effect-agent/core/ToolExposure/PinnedTool", {
   defaultValue: () => false,
 });

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -5113,7 +5113,13 @@ const makeTurn = <
             turn === bounds.maxTurns);
 
         return terminalToolChoiceOnly
-          ? agent.definition.completion === undefined
+          ? agent.definition.completion === undefined ||
+            (agent.definition.completion.required !== true &&
+              !catalog.some(
+                (entry) =>
+                  entry.kind === "native" &&
+                  entry.nativeToolName === agent.definition.completion?.tool,
+              ))
             ? "none"
             : agent.definition.completion.required === true
               ? { tool: agent.definition.completion.tool }

--- a/packages/engine/src/internal/tool-exposure.ts
+++ b/packages/engine/src/internal/tool-exposure.ts
@@ -154,9 +154,8 @@ export const exposureSnapshot = Effect.fn("ToolExposure.exposureSnapshot")(funct
   const native = entries.filter((entry) => entry.kind === "native").map((entry) => entry.tool);
   const progressive = definition.toolExposure !== undefined || selection !== undefined;
 
-  const pinned = Object.values(definition.toolkit.tools).filter(
+  const mandatory = Object.values(definition.toolkit.tools).filter(
     (tool) =>
-      Context.get(tool.annotations, PinnedTool) ||
       Context.get(tool.annotations, DiscoveryTool) ||
       Context.get(tool.annotations, ContextRolloverTool) ||
       (definition.completion?.required === true && definition.completion.tool === tool.name),
@@ -164,10 +163,17 @@ export const exposureSnapshot = Effect.fn("ToolExposure.exposureSnapshot")(funct
 
   if (
     progressive &&
-    pinned.some((tool) => !native.some((candidate) => candidate.name === tool.name))
+    mandatory.some((tool) => !native.some((candidate) => candidate.name === tool.name))
   ) {
-    return yield* invalid("A pinned Tool is excluded by host visibility or the inherited grant");
+    return yield* invalid("A mandatory Tool is excluded by host visibility or the inherited grant");
   }
+
+  // Explicit pins affect selection, never eligibility. Hosts may disable a common action
+  // without disabling the Run; protocol-required Tools still fail closed above.
+  const pinned = native.filter(
+    (tool) => Context.get(tool.annotations, PinnedTool) || mandatory.includes(tool),
+  );
+
   if (selection !== undefined) yield* validateSelection(selection, definition, entries, false);
   const selected = selection === undefined ? undefined : new Set(selection.toolNames);
 

--- a/packages/engine/test/tool-exposure.test.ts
+++ b/packages/engine/test/tool-exposure.test.ts
@@ -189,7 +189,7 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("native Tool ex
           ),
           "go",
           options,
-        ).pipe(Effect.provide(handlers), Effect.provide(visibility));
+        ).pipe(Effect.provide([handlers, visibility]));
 
         expect(result.output).toBe("done");
         expect(requests).toEqual([
@@ -202,7 +202,7 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("native Tool ex
           Agent.withModel(agent, scripted([[call("hidden", "status"), finish]], [])),
           "go",
           options,
-        ).pipe(Effect.provide(handlers), Effect.provide(visibility), Effect.exit);
+        ).pipe(Effect.provide([handlers, visibility]), Effect.exit);
 
         expect(Exit.isFailure(rejected)).toBe(true);
         expect(hiddenStarts).toBe(0);

--- a/packages/engine/test/tool-exposure.test.ts
+++ b/packages/engine/test/tool-exposure.test.ts
@@ -1,6 +1,7 @@
 import * as Agent from "@effect-agent/core/Agent";
 import { RunId, ThreadId, TurnId } from "@effect-agent/core/Identifiers";
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { SubagentGrant } from "@effect-agent/core/SubagentContract";
 import {
   AdditionalToolCatalog,
   DiscoveryTool,
@@ -10,6 +11,7 @@ import {
   Snapshot,
 } from "@effect-agent/core/ToolExposure";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import { ContextRolloverTool } from "@effect-agent/engine/ContextWindow";
 import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
 import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
 import { CurrentToolCatalog, RunToolVisibility } from "@effect-agent/engine/ToolExposure";
@@ -46,6 +48,7 @@ const done: ReadonlyArray<Response.StreamPartEncoded> = [
 const scripted = (
   responses: ReadonlyArray<ReadonlyArray<Response.StreamPartEncoded>>,
   requests: Array<ReadonlyArray<string>>,
+  choices?: Array<LanguageModel.ToolChoice<string>>,
 ) => {
   let index = 0;
 
@@ -58,6 +61,7 @@ const scripted = (
         generateText: () => Effect.succeed([]),
         streamText: (options) => {
           requests.push(options.tools.map((tool) => tool.name));
+          choices?.push(options.toolChoice);
 
           return Stream.fromIterable(responses[index++] ?? done);
         },
@@ -113,6 +117,147 @@ const failure = <E>(exit: Exit.Exit<unknown, E>) =>
   Exit.isFailure(exit) ? Option.getOrUndefined(Cause.findErrorOption(exit.cause)) : undefined;
 
 layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("native Tool exposure", (it) => {
+  for (const authority of ["host", "grant"] as const) {
+    it.effect(`keeps eligible pins across replacements while ${authority} hides another pin`, () =>
+      Effect.gen(function* () {
+        const native = Toolkit.make(Search, Read.annotate(PinnedTool, true), Write, Status);
+
+        const agent = Agent.make("eligible-pins", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Use authorized Tools.",
+          toolkit: native,
+          toolExposure: { maxTools: 3 },
+        });
+
+        const requests: Array<ReadonlyArray<string>> = [];
+        let hiddenStarts = 0;
+
+        const handlers = native.toLayer({
+          discover: ({ select }) =>
+            Effect.gen(function* () {
+              expect((yield* CurrentToolCatalog).entries.map((entry) => entry.tool.name)).toEqual([
+                "discover",
+                "read",
+                "write",
+              ]);
+
+              return { toolNames: select === "" ? [] : [select], padding: "" };
+            }),
+          read: () => Effect.succeed("read"),
+          write: () => Effect.succeed("write"),
+          status: () =>
+            Effect.sync(() => {
+              hiddenStarts++;
+
+              return "status";
+            }),
+        });
+
+        const options =
+          authority === "grant"
+            ? {
+                subagentGrant: SubagentGrant.make({
+                  allowedToolNames: ["discover", "read", "write"],
+                  maxDepth: 1,
+                }),
+                delegationDepth: 1,
+              }
+            : {};
+
+        const visibility = Layer.succeed(
+          RunToolVisibility,
+          authority === "host"
+            ? {
+                visible: ({ toolNames }) =>
+                  Effect.succeed(toolNames.filter((name) => name !== "status")),
+              }
+            : undefined,
+        );
+
+        const result = yield* AgentRuntime.run(
+          Agent.withModel(
+            agent,
+            scripted(
+              [
+                [call("select", "discover", { select: "write" }), finish],
+                [call("clear", "discover", { select: "" }), finish],
+                done,
+              ],
+              requests,
+            ),
+          ),
+          "go",
+          options,
+        ).pipe(Effect.provide(handlers), Effect.provide(visibility));
+
+        expect(result.output).toBe("done");
+        expect(requests).toEqual([
+          ["discover", "read"],
+          ["discover", "read", "write"],
+          ["discover", "read"],
+        ]);
+
+        const rejected = yield* AgentRuntime.run(
+          Agent.withModel(agent, scripted([[call("hidden", "status"), finish]], [])),
+          "go",
+          options,
+        ).pipe(Effect.provide(handlers), Effect.provide(visibility), Effect.exit);
+
+        expect(Exit.isFailure(rejected)).toBe(true);
+        expect(hiddenStarts).toBe(0);
+      }),
+    );
+  }
+
+  for (const mandatory of ["discovery", "rollover", "completion"] as const) {
+    it.effect(`refuses an unavailable mandatory ${mandatory} Tool before model dispatch`, () =>
+      Effect.gen(function* () {
+        const required =
+          mandatory === "discovery"
+            ? Search
+            : mandatory === "rollover"
+              ? Read.annotate(ContextRolloverTool, true)
+              : Read;
+
+        const native = Toolkit.make(required);
+
+        const agent = Agent.make("mandatory-tool", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Go.",
+          toolkit: native,
+          toolExposure: {},
+          ...(mandatory === "completion"
+            ? { completion: { tool: "read", required: true, project: () => "done" } }
+            : {}),
+        });
+
+        const requests: Array<ReadonlyArray<string>> = [];
+
+        const exit = yield* AgentRuntime.run(
+          Agent.withModel(agent, scripted([done], requests)),
+          "go",
+        ).pipe(
+          Effect.provideService(RunToolVisibility, { visible: () => Effect.succeed([]) }),
+          Effect.provide(
+            native.toLayer({
+              discover: () => Effect.die("Unavailable discovery must not execute"),
+              read: () => Effect.die("Unavailable mandatory Tool must not execute"),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(failure(exit)).toMatchObject({
+          _tag: "ModelProtocolError",
+          message: "A mandatory Tool is excluded by host visibility or the inherited grant",
+        });
+        expect(requests).toEqual([]);
+      }),
+    );
+  }
+
   it.effect(
     "replaces in declaration order, keeps pins, and projects before result truncation",
     () =>
@@ -600,6 +745,82 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient))("native Tool ex
       expect(staged[1]?.selection?.toolNames).toEqual(["read"]);
     }),
   );
+
+  for (const authority of ["host", "grant"] as const) {
+    it.effect(`finishes with text when ${authority} hides an optional completion Tool`, () =>
+      Effect.gen(function* () {
+        const Finish = Tool.make("finish", {
+          parameters: Schema.Struct({}),
+          success: Schema.String,
+        }).annotate(PinnedTool, true);
+
+        const native = Toolkit.make(Read, Finish);
+
+        const agent = Agent.make("hidden-optional-completion", {
+          input: Schema.String,
+          output: Schema.String,
+          instructions: "Read then answer.",
+          toolkit: native,
+          toolExposure: { initialToolNames: ["read"] },
+          policy: { maxTurns: 1, maxToolCalls: 5, onExhaustion: "final-answer" },
+          completion: { tool: "finish", project: ({ result }) => result },
+        });
+
+        const requests: Array<ReadonlyArray<string>> = [];
+        const choices: Array<LanguageModel.ToolChoice<string>> = [];
+        const staged: Array<Snapshot> = [];
+
+        const result = yield* AgentRuntime.run(
+          Agent.withModel(
+            agent,
+            scripted([[call("read-1", "read"), finish], done], requests, choices),
+          ),
+          "go",
+          {
+            ...(authority === "grant"
+              ? {
+                  subagentGrant: SubagentGrant.make({ allowedToolNames: ["read"], maxDepth: 1 }),
+                  delegationDepth: 1,
+                }
+              : {}),
+            durability: {
+              noteToolExposure: (_, snapshot) =>
+                Effect.sync(() => {
+                  staged.push(snapshot);
+                }),
+              commitResponse: () => Effect.void,
+              prepareToolCalls: () => Effect.void,
+              commitCompaction: () => Effect.void,
+              noteTurnUsage: () => Effect.void,
+              step: { lookup: () => Effect.succeed(Option.none()), commit: () => Effect.void },
+            },
+          },
+        ).pipe(
+          Effect.provideService(
+            RunToolVisibility,
+            authority === "host"
+              ? {
+                  visible: ({ toolNames }) =>
+                    Effect.succeed(toolNames.filter((name) => name !== "finish")),
+                }
+              : undefined,
+          ),
+          Effect.provide(
+            native.toLayer({
+              read: () => Effect.succeed("read"),
+              finish: () => Effect.die("Hidden optional completion must not execute"),
+            }),
+          ),
+        );
+
+        expect(result.output).toBe("done");
+        expect(result.finishReason).toBe("budget-exhausted");
+        expect(requests).toEqual([["read"], ["read"]]);
+        expect(choices).toEqual(["auto", "none"]);
+        expect(staged.map((snapshot) => snapshot.exposedToolNames)).toEqual(requests);
+      }),
+    );
+  }
 
   it.effect("keeps legacy eager completion free of opt-in exposure bounds", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
Progressive tool exposure currently rejects a run before model dispatch when host visibility or an inherited grant hides any explicitly pinned tool. This blocked a consumer preview request: disabling delegation hid pinned `delegate_persona_work`, so an unrelated project-creation request failed with zero model calls.

Explicit pins now keep common tools selected only while eligible. Discovery, context rollover, and required completion remain mandatory and fail closed when hidden. A hidden optional completion no longer becomes an invalid final-answer tool choice; the model can finish with text.

For example, pinning `CreateProject` keeps it available after discovery replacements for an authorized caller. Denying that operation removes it from both the model and dispatch while allowing other work to continue. This avoids per-admission toolkit variants or consumer-maintained selection state; merely moving common actions into the initial selection would lose them on the next discovery replacement.

Seven new regressions cover host and inherited-grant filtering, replacement/clear behavior, blocked hidden-tool dispatch, mandatory tools, and final-answer exposure snapshots. The focused exposure, output-contract, and API type suites pass all 44 tests. Full `vp run ready` and patched, uncached static checks pass. CI static checks, builds, and every test suite pass.
