### PR TITLE
fix(perf): compare scripted runtime Base and Head only

### DIFF
--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -38,24 +38,22 @@ jobs:
             const number = read('pr-number.txt', 20).trim();
             if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error('Invalid PR number');
             const report = JSON.parse(read('report.json', 3000000));
-            if (report.fixture !== 'runtime-v2' || report.profile !== 'pr' ||
-                report.referenceVersion !== 'audit-beta67-node24-v1' ||
+            if (report.fixture !== 'runtime-v3' || report.profile !== 'pr' ||
                 report.activeBatch !== null || report.failure !== null ||
                 report.settings?.batches !== 3 || report.settings?.warmupsPerBatch !== 2 || report.settings?.samplesPerBatch !== 3 ||
                 report.settings?.production !== true || report.settings?.execution !== 'unbundled published ESM' ||
                 report.environment?.node !== 'v24.20.0' ||
                 !/^[a-f0-9]{64}$/.test(report.fixtureSha256) ||
-                !Array.isArray(report.revisions) || report.revisions.length !== 3 ||
-                !Array.isArray(report.batches) || report.batches.length !== 18) {
+                !Array.isArray(report.revisions) || report.revisions.length !== 2 ||
+                !Array.isArray(report.batches) || report.batches.length !== 12) {
               throw new Error('Invalid report contract');
             }
             const revision = role => report.revisions.find(value => value.role === role);
-            for (const role of ['base', 'head', 'reference']) {
+            for (const role of ['base', 'head']) {
               if (!/^[a-f0-9]{40}$/.test(revision(role)?.revision) || revision(role).dirty !== false ||
                   !/^[a-f0-9]{64}$/.test(revision(role).lockfileSha256) ||
                   !/^[a-f0-9]{64}$/.test(revision(role).builtArtifactsSha256)) throw new Error('Invalid revision');
             }
-            if (revision('reference').revision !== '596cffba70716b1211ac02de949c4d0f31734b2f') throw new Error('Unexpected reference');
             const run = context.payload.workflow_run;
             const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: Number(number) });
             if (pr.state !== 'open' || pr.head.sha !== run.head_sha || pr.head.sha !== revision('head').revision ||
@@ -73,7 +71,7 @@ jobs:
             const identities = new Set();
             for (const batch of report.batches) {
               const key = `${batch.role}:${batch.cohort}:${batch.cold}`;
-              if (!['base','head','reference'].includes(batch.role) || ![0,1,2].includes(batch.cohort) ||
+              if (!['base','head'].includes(batch.role) || ![0,1,2].includes(batch.cohort) ||
                   typeof batch.cold !== 'boolean' || identities.has(key) || batch.exitCode !== 0 || batch.complete !== true ||
                   batch.failure !== null || !Number.isFinite(batch.subprocessMs) || batch.subprocessMs < 0 ||
                   batch.report?.fixture !== report.fixture || batch.report?.profile !== report.profile ||
@@ -101,15 +99,15 @@ jobs:
             }
             const rows = expected.map(name => {
               const values = role => samples.filter(s => s.name === name && s.role === role).map(s => s.ms);
-              const base = med(values('base')), head = med(values('head')), reference = med(values('reference'));
+              const base = med(values('base')), head = med(values('head'));
               const change = before => before === 0 ? 'n/a' : `${((head / before - 1) * 100).toFixed(1)}%`;
-              return `| ${name} | ${base.toFixed(2)} | ${head.toFixed(2)} | ${reference.toFixed(2)} | ${change(base)} | ${change(reference)} |`;
+              return `| ${name} | ${base.toFixed(2)} | ${head.toFixed(2)} | ${change(base)} |`;
             });
             const marker = '<!-- effect-agent:runtime-performance -->';
             const body = `${marker}\n### Runtime performance\n\n` +
               'Informational medians in milliseconds, nine samples per workload and revision. Same fixture bytes and Node runtime; separate lockfiles and public builds.\n\n' +
-              '| Workload | Base | Head | Reference | Head/base | Head/reference |\n| --- | ---: | ---: | ---: | ---: | ---: |\n' + rows.join('\n') +
-              `\n\n[Raw samples, spread, cold process totals, failures, environment, and immutable reference](${run.html_url}) for \`${run.head_sha.slice(0,12)}\`. Timing deltas are not a merge threshold.`;
+              '| Workload | Base | Head | Head/base |\n| --- | ---: | ---: | ---: |\n' + rows.join('\n') +
+              `\n\n[Raw samples, spread, cold process totals, failures, environment, and exact revisions](${run.html_url}) for \`${run.head_sha.slice(0,12)}\`. Timing deltas are not a merge threshold.`;
             const comments = await github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 });
             const previous = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
             if (previous) await github.rest.issues.updateComment({ ...context.repo, comment_id: previous.id, body });

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -48,15 +48,6 @@ jobs:
           path: .performance-base
           persist-credentials: false
 
-      # Immutable audited beta67 release, rerun on this machine rather than
-      # comparing historical stopwatch values from another runner.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
-        with:
-          ref: 596cffba70716b1211ac02de949c4d0f31734b2f
-          path: .performance-reference
-          persist-credentials: false
-
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.20.0
@@ -74,11 +65,6 @@ jobs:
         working-directory: .performance-base
         run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
 
-      - name: Install immutable reference dependencies
-        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
-        working-directory: .performance-reference
-        run: ../node_modules/.bin/vp install --frozen-lockfile --ignore-scripts
-
       - name: Build candidate public packages
         run: |
           ./node_modules/.bin/vp run patch:tsgo
@@ -86,13 +72,6 @@ jobs:
 
       - name: Build base public packages
         working-directory: .performance-base
-        run: |
-          ./node_modules/.bin/vp run patch:tsgo
-          ./node_modules/.bin/vp run --no-cache -F './packages/*' build
-
-      - name: Build reference public packages
-        if: github.event_name != 'workflow_dispatch' || inputs.profile != 'diagnostic'
-        working-directory: .performance-reference
         run: |
           ./node_modules/.bin/vp run patch:tsgo
           ./node_modules/.bin/vp run --no-cache -F './packages/*' build
@@ -108,13 +87,11 @@ jobs:
         env:
           PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || inputs.profile }}
         run: |
-          for checkout in .performance-base .performance-reference; do
-            rm -f "$checkout/test/fixtures/checkpoints.d.ts" "$checkout/test/fixtures/storage-upgrade.d.ts" "$checkout/test/fixtures/storage-v2.d.ts"
-          done
+          rm -f .performance-base/test/fixtures/checkpoints.d.ts .performance-base/test/fixtures/storage-upgrade.d.ts .performance-base/test/fixtures/storage-v2.d.ts
           if [ "$PROFILE" = diagnostic ]; then
             ./node_modules/.bin/vp run --no-cache perf:diagnose --base-dir .performance-base --require-clean
           else
-            ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --reference-dir .performance-reference --profile "$PROFILE" --require-clean
+            ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --profile "$PROFILE" --require-clean
           fi
 
       - name: Preserve run identity and readable evidence

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ packages/*/src/**/*.d.ts
 scripts/*.d.ts
 test/fixtures/*.d.ts
 .performance-base/
-.performance-reference/
 .performance-report/

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -361,8 +361,8 @@ The comment workflow becomes active after it is merged into the default branch.
 
 ## Runtime performance comparisons
 
-Pull requests run the **Runtime performance** workflow against the exact base, head, and retained
-release reference. The [scripted benchmark](../examples/runtime-benchmark/README.md) runs identical
+Pull requests run the **Runtime performance** workflow against the exact base and head commits.
+The [scripted benchmark](../examples/runtime-benchmark/README.md) runs identical
 fixture bytes against production builds and each revision's own lockfile on the same Node runtime.
 Run `vp run perf:compare --help` for local reproduction. Timing tasks bypass the task cache; keep
 other builds, tests, and benchmarks idle during measurement.

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -4,24 +4,21 @@ This leaf consumer measures public production packages with deterministic Effect
 It makes no provider requests. Correctness assertions fail the command; latency changes are
 informational until CI variance supports workload-specific relative and absolute thresholds.
 
-Run from the repository root with Node 24 and the repository's Bun/Vite+ toolchain. Prepare three
+Run from the repository root with Node 24 and the repository's Bun/Vite+ toolchain. Prepare two
 checkouts, install each checkout's own lockfile, and build before measuring:
 
 ```sh
 git worktree add --detach /tmp/effect-agent-base <exact-base-sha>
-git worktree add --detach /tmp/effect-agent-reference 596cffba70716b1211ac02de949c4d0f31734b2f
 vp install --frozen-lockfile
+vp run patch:tsgo
 vp run -F './packages/*' build
 cd /tmp/effect-agent-base
 vp install --frozen-lockfile
-vp run -F './packages/*' build
-rm -f test/fixtures/checkpoints.d.ts test/fixtures/storage-upgrade.d.ts test/fixtures/storage-v2.d.ts
-cd /tmp/effect-agent-reference
-vp install --frozen-lockfile
+vp run patch:tsgo
 vp run -F './packages/*' build
 rm -f test/fixtures/checkpoints.d.ts test/fixtures/storage-upgrade.d.ts test/fixtures/storage-v2.d.ts
 cd <candidate-checkout>
-vp run perf:compare --base-dir /tmp/effect-agent-base --reference-dir /tmp/effect-agent-reference --profile pr --out-dir /tmp/performance-001
+vp run perf:compare --base-dir /tmp/effect-agent-base --profile pr --out-dir /tmp/performance-001
 ```
 
 Use `--require-clean` for exact-commit evidence. A local dirty checkout is labeled in the report;
@@ -31,10 +28,12 @@ measurement. `perf:compare` always bypasses task caching. `--help` describes the
 The cleanup lines remove only declaration artifacts emitted by older package builds in those
 disposable checkouts. Every other modified or untracked file fails clean-checkout validation.
 
-The PR workflow uses exact PR base/head commits, an immutable release reference, Node 24.20.0,
-and sequential production builds. It runs three rotating cohorts (base/head/reference,
-head/reference/base, reference/base/head). Each warm cohort has two warmups and three measured
-samples per case: nine measured samples per revision. Workload order reverses between samples.
+The PR workflow uses exact PR base/head commits, Node 24.20.0, and sequential production builds.
+It runs three sequential cohorts (base/head, head/base, base/head). Each warm cohort retains two
+warmups and three measured samples per case: nine measured samples per revision. Alternating
+the order gives each revision a turn first; with three cohorts, Base runs first twice. Keeping
+three cohorts preserves the existing sample count and correctness coverage. Workload order
+reverses between samples. Each cohort also runs one cold process per revision.
 All warmups, measured samples, slow values, and failures remain in JSON artifacts. The trusted
 comment workflow validates artifact data and current PR identity without executing candidate code.
 
@@ -71,14 +70,14 @@ SQLite uses the production Node assembly and its default scheduling, lease, and 
 configuration; checkpoint cases additionally install the documented host rollover preparation.
 Database teardown and evidence reads are outside the warm-operation interval.
 
-Fixture `runtime-v2` builds worker-local seed templates through those same public adapter
+Fixture `runtime-v3` builds worker-local seed templates through those same public adapter
 operations, once per history/ledger size and revision. It closes the full seed runtime and rejects
 any remaining WAL or SHM sidecar before copying the database to each sample's fresh directory.
 Copies share no mutable database state. Fresh submission and checkpoint recovery can reuse the
 same retained-history seed; every recovery sample still constructs and saves its own checkpoint,
 injects the fault, closes the runtime, and resumes its own Submission. Templates are discarded
 when the worker closes and never cross a cohort or revision. This removes repeated fixture setup;
-it does not measure or change the cost of production mutations. The reference SHA is unchanged.
+it does not measure or change the cost of production mutations.
 
 The worker composes the seed initializer, scoped template cache, sample runner, and progress
 writer as Effect services. Sample arguments contain only workload data and timeout settings;
@@ -115,20 +114,26 @@ shutdown. These are labeled subprocess totals, not isolated import latency or a 
 startup claim. Warm cohorts live in separate long-running child processes.
 
 The fixture is transpiled once without bundling, then identical JavaScript bytes are copied to
-all three stages. Framework stages contain only public `dist` artifacts and npm-ready manifests;
+both stages. Framework stages contain only public `dist` artifacts and npm-ready manifests;
 they cannot resolve framework TypeScript source. External dependencies come from each revision's
 own installation. Reports identify exact commits, dirty state, lockfile hashes, built artifact
 hashes, fixture hash/version, runtime, operating system, CPU, memory, sample counts, median,
 interquartile range, and process failures. The artifact includes the exact transpiled fixture.
 
-The retained reference is `audit-beta67-node24-v1`, commit
-`596cffba70716b1211ac02de949c4d0f31734b2f`. It is rebuilt and rerun on the same machine as each
-candidate to expose gradual drift. Historical stopwatch numbers are never used as the baseline.
-To reset it, change the version and immutable SHA in `src/contracts.ts`, both workflow validators,
-and this guide together; explain the release selection and fixture/runtime change in the PR.
-Keep the previous artifacts. Incompatible historical APIs must fail clearly rather than silently
+The `runtime-v3` artifact contract contains only Base and Head; the trusted publisher rejects
+older three-revision reports. Comparison tables show Base, Head, and Head/base. Workloads,
+operation clocks, warmups, and measured samples per revision are unchanged from `runtime-v2`.
+Keep historical artifacts. Incompatible historical APIs must fail clearly rather than silently
 substituting source code or skipping cases. A new fixture changes the measurement definition and
 requires a version bump; report environment changes before interpreting across-run trends.
+
+The PR profile runs 12 child processes and 576 attempts: 19 cases × five warm attempts ×
+three cohorts × two revisions, plus six cold attempts. Millisecond operation medians do not
+represent CI duration: all attempts, warmups, seed creation, checkpoint preparation, assertions,
+cleanup, imports, and report writes take wall time. The worker-time table retains attempt and
+setup totals; setup is part of attempt time, so do not add them. Checkout/install/build precedes
+measurement. Removing a revision removes its work, but an exact CI speedup requires matched
+runs on comparable runners; the retained setup and verification costs remain outside operation medians.
 
 Read the full spread and raw samples before drawing a conclusion. Re-run a suspected regression
 with another matched cohort. Small-sample p95, local source timings, or differing provider workloads
@@ -150,8 +155,8 @@ Run this command from the candidate checkout, with no concurrent builds, tests, 
 vp run perf:diagnose --base-dir /tmp/effect-agent-base --require-clean --out-dir /tmp/diagnostic-001
 ```
 
-The manual workflow's `diagnostic` choice runs the same command and skips the immutable-reference
-checkout. Ordinary PRs still run the unchanged `runtime-v2` matrix and trusted report validator.
+The manual workflow's `diagnostic` choice runs the same command. Ordinary PRs run the
+`runtime-v3` matrix and trusted report validator.
 Diagnostics run base/head followed by head/base, with two warmups and five measured samples per
 cohort: ten measured samples per case and revision. They use the same production-package staging,
 published manifests, own-lockfile dependencies, built-artifact identities, and identical unbundled

--- a/examples/runtime-benchmark/src/contracts.ts
+++ b/examples/runtime-benchmark/src/contracts.ts
@@ -1,11 +1,6 @@
 import { Effect, Schema } from "effect";
 
-export const FIXTURE_VERSION = "runtime-v2";
-
-export const REFERENCE = {
-  version: "audit-beta67-node24-v1",
-  revision: "596cffba70716b1211ac02de949c4d0f31734b2f",
-} as const;
+export const FIXTURE_VERSION = "runtime-v3";
 
 export class BenchmarkError extends Schema.TaggedError<BenchmarkError>()("BenchmarkError", {
   message: Schema.String,

--- a/examples/runtime-benchmark/test/report.test.ts
+++ b/examples/runtime-benchmark/test/report.test.ts
@@ -1,8 +1,8 @@
+import { Schema } from "effect";
 import { expect, it } from "vite-plus/test";
 
-import type { PerformanceReport } from "../../../scripts/runtime-benchmark.ts";
-import { renderPerformanceReport } from "../../../scripts/runtime-benchmark.ts";
-import { FIXTURE_VERSION, REFERENCE } from "../src/contracts.ts";
+import { PerformanceReport, renderPerformanceReport } from "../../../scripts/runtime-benchmark.ts";
+import { FIXTURE_VERSION } from "../src/contracts.ts";
 
 it("reports and excludes an invalid batch even when its process exited successfully", () => {
   const report: typeof PerformanceReport.Type = {
@@ -10,7 +10,6 @@ it("reports and excludes an invalid batch even when its process exited successfu
     fixtureSha256: "fixture",
     transpiler: "test",
     profile: "smoke",
-    referenceVersion: REFERENCE.version,
     environment: {
       platform: "test",
       release: "test",
@@ -75,13 +74,24 @@ it("reports and excludes an invalid batch even when its process exited successfu
 
   const rendered = renderPerformanceReport(report);
 
-  expect(rendered).toContain("Invalid/incomplete batches: 1; processes recorded: 1/6");
+  expect(rendered).toContain(
+    "| Workload | Base | Head | Head/base |\n| --- | ---: | ---: | ---: |\n",
+  );
+  expect(rendered).not.toMatch(/reference/i);
+  expect(Schema.is(PerformanceReport)({ ...report, fixture: "runtime-v2" })).toBe(false);
+  expect(
+    Schema.is(PerformanceReport)({
+      ...report,
+      batches: [{ ...report.batches[0], role: "reference" }],
+    }),
+  ).toBe(false);
+  expect(rendered).toContain("Invalid/incomplete batches: 1; processes recorded: 1/4");
   expect(rendered).toContain("Worker runtime differs from the controller");
   expect(rendered).toContain("| small-run | n/a | n/a | n/a |");
 
   const interrupted = renderPerformanceReport({
     ...report,
-    activeBatch: { role: "reference", cohort: 0, cold: false },
+    activeBatch: { role: "base", cohort: 0, cold: false },
     failure: "TimeoutException: comparison deadline",
     batches: report.batches.map((batch) => ({
       ...batch,
@@ -102,7 +112,7 @@ it("reports and excludes an invalid batch even when its process exited successfu
     })),
   });
 
-  expect(interrupted).toContain("Interrupted active batch: reference/0/warm");
+  expect(interrupted).toContain("Interrupted active batch: base/0/warm");
   expect(interrupted).toContain("Comparison failure: TimeoutException: comparison deadline");
   expect(interrupted).toContain("settled-ledger-16:0 setup at 1200.00 ms");
 });

--- a/examples/runtime-benchmark/test/trusted-report.test.ts
+++ b/examples/runtime-benchmark/test/trusted-report.test.ts
@@ -4,7 +4,7 @@ import { runInNewContext } from "node:vm";
 import { expect, it } from "vite-plus/test";
 
 import type { PerformanceReport } from "../../../scripts/runtime-benchmark.ts";
-import { casesFor, FIXTURE_VERSION, REFERENCE } from "../src/contracts.ts";
+import { casesFor, FIXTURE_VERSION } from "../src/contracts.ts";
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] extends object ? Mutable<T[K]> : T[K] };
 type Report = Mutable<typeof PerformanceReport.Type>;
@@ -16,7 +16,6 @@ const makeReport = (): Report => ({
   fixtureSha256: "c".repeat(64),
   transpiler: "test",
   profile: "pr",
-  referenceVersion: REFERENCE.version,
   activeBatch: null,
   failure: null,
   environment: {
@@ -36,16 +35,16 @@ const makeReport = (): Report => ({
     execution: "unbundled published ESM",
     timingGate: "informational",
   },
-  revisions: (["base", "head", "reference"] as const).map((role) => ({
+  revisions: (["base", "head"] as const).map((role) => ({
     role,
-    revision: role === "base" ? base : role === "head" ? head : REFERENCE.revision,
+    revision: role === "base" ? base : head,
     dirty: false,
     lockfileSha256: "d".repeat(64),
     builtArtifactsSha256: "e".repeat(64),
     effect: "test",
   })),
   batches: [0, 1, 2].flatMap((cohort) =>
-    (["base", "head", "reference"] as const).flatMap((role) =>
+    (["base", "head"] as const).flatMap((role) =>
       [true, false].map((cold) => ({
         role,
         cohort,
@@ -96,7 +95,7 @@ const workflow = readFileSync(
 
 const script = workflow.split("          script: |\n")[1]!.replace(/^ {12}/gm, "");
 
-const publish = async (report: Report, currentHead = head) => {
+const publish = async (report: unknown, currentHead = head) => {
   const comments: string[] = [];
 
   const files: Record<string, string> = {
@@ -157,16 +156,88 @@ const publish = async (report: Report, currentHead = head) => {
   return comments;
 };
 
-it("publishes all 18 valid cohorts and rejects stale PR identity", async () => {
+it("publishes all 12 valid batches and rejects stale PR identity", async () => {
   const comments = await publish(makeReport());
 
   expect(comments).toHaveLength(1);
   expect(comments[0]).toContain("nine samples per workload and revision");
-  expect(comments[0]).toContain("| settled-ledger-2048 |");
+  expect(comments[0]).toContain(
+    "| Workload | Base | Head | Head/base |\n| --- | ---: | ---: | ---: |\n",
+  );
+  expect(comments[0]).toContain("| settled-ledger-2048 | 2.00 | 2.00 | 0.0% |");
+  expect(comments[0]).not.toMatch(/reference/i);
   expect(await publish(makeReport(), "f".repeat(40))).toEqual([]);
 });
 
+it("computes Head/base from measured warm samples only", async () => {
+  const report = makeReport();
+
+  for (const batch of report.batches) {
+    const worker = batch.report!;
+
+    batch.report = {
+      ...worker,
+      samples: worker.samples.map((sample) => ({
+        ...sample,
+        totalMs: batch.cold || sample.warmup ? 100 : batch.role === "base" ? 4 : 2,
+        attemptMs: 102,
+      })),
+    };
+  }
+
+  const comments = await publish(report);
+
+  expect(comments[0]).toContain("| small-run | 4.00 | 2.00 | -50.0% |");
+  expect(comments[0]).toContain("| settled-ledger-2048 | 4.00 | 2.00 | -50.0% |");
+});
+
+it("rejects historical contracts and reference roles before commenting", async () => {
+  const report = makeReport();
+
+  await expect(publish({ ...report, fixture: "runtime-v2" })).rejects.toThrow(
+    "Invalid report contract",
+  );
+  await expect(
+    publish({
+      ...report,
+      revisions: [...report.revisions, { ...report.revisions[0], role: "reference" }],
+    }),
+  ).rejects.toThrow("Invalid report contract");
+  await expect(
+    publish({
+      ...report,
+      revisions: [report.revisions[0], { ...report.revisions[1], role: "reference" }],
+    }),
+  ).rejects.toThrow("Invalid revision");
+  await expect(
+    publish({
+      ...report,
+      batches: report.batches.map((batch, index) =>
+        index === 0 ? { ...batch, role: "reference" } : batch,
+      ),
+    }),
+  ).rejects.toThrow("Invalid cohort");
+});
+
 const mutations: ReadonlyArray<readonly [string, (report: Report) => void]> = [
+  [
+    "missing revision",
+    (report) => {
+      report.revisions.pop();
+    },
+  ],
+  [
+    "duplicated revision",
+    (report) => {
+      report.revisions[1] = report.revisions[0]!;
+    },
+  ],
+  [
+    "reduced samples",
+    (report) => {
+      report.settings.samplesPerBatch = 2;
+    },
+  ],
   [
     "missing batch",
     (report) => {

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -14,7 +14,6 @@ import {
   completeBatch,
   FIXTURE_VERSION,
   Profile,
-  REFERENCE,
   summary,
   WorkerOptions,
   WorkerReport,
@@ -23,7 +22,7 @@ import { writeEvidence } from "../examples/runtime-benchmark/src/evidence.ts";
 import { PublishManifest, withPublishManifests } from "./release-publish.ts";
 
 const Revision = Schema.Struct({
-  role: Schema.Literals(["base", "head", "reference"]),
+  role: Schema.Literals(["base", "head"]),
   revision: Schema.String,
   dirty: Schema.Boolean,
   lockfileSha256: Schema.String,
@@ -51,7 +50,6 @@ export const PerformanceReport = Schema.Struct({
   fixtureSha256: Schema.String,
   transpiler: Schema.String,
   profile: Profile,
-  referenceVersion: Schema.Literal(REFERENCE.version),
   environment: Schema.Struct({
     platform: Schema.String,
     release: Schema.String,
@@ -228,10 +226,10 @@ export const stageCheckout = Effect.fn("benchmark.stageCheckout")(function* (
 
 export const renderPerformanceReport = (report: PerformanceReport): string => {
   const lines = [
-    "Timing is informational. Median [Q1–Q3] in milliseconds; every measured sample and outlier is retained.",
+    "Timing is informational. Operation median [Q1–Q3] in milliseconds; every measured sample and outlier is retained. Model-entry timings remain in raw samples.",
     "",
-    "| Workload | Base total | Head total | Reference total | Head/base | Head/reference | Head model entry |",
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Workload | Base | Head | Head/base |",
+    "| --- | ---: | ---: | ---: |",
   ];
 
   const format = (value: ReturnType<typeof summary>) =>
@@ -252,29 +250,20 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
 
     const base = summary(samples("base").map((sample) => sample.totalMs));
     const head = summary(samples("head").map((sample) => sample.totalMs));
-    const reference = summary(samples("reference").map((sample) => sample.totalMs));
-
-    const entry = summary(
-      samples("head").flatMap((sample) =>
-        sample.modelEntryMs === null ? [] : [sample.modelEntryMs],
-      ),
-    );
 
     const delta = (baseline: ReturnType<typeof summary>) =>
       baseline.count === 0 || head.count === 0 || baseline.median === 0
         ? "n/a"
         : `${((head.median / baseline.median - 1) * 100).toFixed(1)}%`;
 
-    lines.push(
-      `| ${workload.name} | ${format(base)} | ${format(head)} | ${format(reference)} | ${delta(base)} | ${delta(reference)} | ${format(entry)} |`,
-    );
+    lines.push(`| ${workload.name} | ${format(base)} | ${format(head)} | ${delta(base)} |`);
   }
   lines.push(
     "",
     "Inline checkpoint construction and save (outside recovery total):",
     "",
-    "| Workload | Base | Head | Reference |",
-    "| --- | ---: | ---: | ---: |",
+    "| Workload | Base | Head |",
+    "| --- | ---: | ---: |",
   );
   for (const workload of casesFor(report.profile).filter(
     (workload) => workload.kind === "recovery",
@@ -296,14 +285,14 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
       );
 
     lines.push(
-      `| ${workload.name} | ${format(checkpoints("base"))} | ${format(checkpoints("head"))} | ${format(checkpoints("reference"))} |`,
+      `| ${workload.name} | ${format(checkpoints("base"))} | ${format(checkpoints("head"))} |`,
     );
   }
   lines.push(
     "",
     "Cold subprocess totals include Node startup, imports, one small run, assertions, and process shutdown:",
   );
-  for (const role of ["base", "head", "reference"] as const)
+  for (const role of ["base", "head"] as const)
     lines.push(
       `${role}: ${format(summary(report.batches.filter((batch) => batch.role === role && batch.cold && batch.complete && batch.exitCode === 0).map((batch) => batch.subprocessMs)))}`,
     );
@@ -318,7 +307,7 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
   lines.push(
     "",
     `Correctness failures: ${failures.length}; failed subprocesses: ${failedProcesses}.`,
-    `Invalid/incomplete batches: ${incomplete.length}; processes recorded: ${report.batches.length}/${report.settings.batches * 6}. Incomplete batches are excluded from comparison summaries.`,
+    `Invalid/incomplete batches: ${incomplete.length}; processes recorded: ${report.batches.length}/${report.settings.batches * 4}. Incomplete batches are excluded from comparison summaries.`,
     ...(report.activeBatch === null
       ? []
       : [
@@ -329,7 +318,7 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
       (batch) =>
         `${batch.role}/${batch.cohort}/${batch.cold ? "cold" : "warm"}: ${(batch.failure ?? "Missing or invalid worker report").split("\n")[0]}`,
     ),
-    `Fixture ${report.fixture} (${report.fixtureSha256}); reference ${report.referenceVersion}.`,
+    `Fixture ${report.fixture} (${report.fixtureSha256}).`,
     `Node ${report.environment.node}; ${report.environment.platform}/${report.environment.architecture}; ${report.environment.cpu}.`,
     `Samples per workload/revision: ${report.settings.samplesPerBatch * report.settings.batches}; warmups: ${report.settings.warmupsPerBatch * report.settings.batches}.`,
   );
@@ -365,7 +354,6 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
 export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (options: {
   root: string;
   base: string;
-  reference: string;
   output: string;
   profile: Profile;
   requireClean: boolean;
@@ -411,13 +399,8 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
   // All compilation and staging finishes before any measurements start.
   const base = yield* stageCheckout(path.resolve(options.base), "base", fixtures);
   const head = yield* stageCheckout(root, "head", fixtures);
-  const reference = yield* stageCheckout(path.resolve(options.reference), "reference", fixtures);
-  const stages = [base, head, reference];
+  const stages = [base, head];
 
-  yield* check(
-    reference.revision.revision === REFERENCE.revision && !reference.revision.dirty,
-    `Reference must be clean immutable ${REFERENCE.revision} (${REFERENCE.version})`,
-  );
   if (options.requireClean)
     yield* check(
       stages.every((stage) => !stage.revision.dirty),
@@ -427,7 +410,7 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
 
   yield* check(
     node.exitCode === 0 && node.stdout.trim().startsWith("v24."),
-    `${FIXTURE_VERSION} requires Node 24; changing the runtime requires a versioned reference reset`,
+    `${FIXTURE_VERSION} requires Node 24; record runtime changes before comparing across runs`,
   );
 
   const sizes =
@@ -450,7 +433,6 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
     fixtureSha256: sha256(fixtureBytes.join("\n")),
     transpiler: `esbuild ${esbuildVersion} (fixture syntax only; no bundling)`,
     profile: options.profile,
-    referenceVersion: REFERENCE.version,
     environment: {
       platform: platform(),
       release: release(),
@@ -487,8 +469,9 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
   const measure = Effect.gen(function* () {
     yield* persist;
     for (let cohort = 0; cohort < sizes.batches; cohort++) {
-      // Rotate who goes first on the same runner; no concurrent builds, tests, or revisions.
-      const ordered = [...stages.slice(cohort % 3), ...stages.slice(0, cohort % 3)];
+      // Alternate base/head, head/base, base/head without reducing per-revision samples.
+      // Three cohorts necessarily give one revision the first slot twice. Keep measurements sequential.
+      const ordered = cohort % 2 === 0 ? stages : [...stages].reverse();
 
       for (const cold of [true, false])
         for (const stage of ordered) {
@@ -602,12 +585,10 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
     }),
   );
 
-  yield* withPublishManifests(base.stage, () =>
-    withPublishManifests(head.stage, () => withPublishManifests(reference.stage, () => measure)),
-  );
+  yield* withPublishManifests(base.stage, () => withPublishManifests(head.stage, () => measure));
   yield* Console.log(renderPerformanceReport(report));
   yield* check(
-    batches.length === sizes.batches * 6 &&
+    batches.length === sizes.batches * 4 &&
       batches.every((batch) => batch.exitCode === 0 && batch.complete),
     "Benchmark correctness failed; timings are informational but incomplete work is rejected",
   );
@@ -622,9 +603,6 @@ export const command = Command.make(
       Flag.withDescription(
         "Exact base checkout, installed with its lockfile and production packages built.",
       ),
-    ),
-    reference: Flag.string("reference-dir").pipe(
-      Flag.withDescription(`Clean built immutable reference ${REFERENCE.revision}.`),
     ),
     output: Flag.string("out-dir").pipe(
       Flag.withDefault(".performance-report"),
@@ -641,7 +619,7 @@ export const command = Command.make(
       Flag.withDescription("Reject modified or untracked files in any checkout (required by CI)."),
     ),
   },
-  Effect.fn(function* ({ base, reference, output, profile, requireClean }) {
+  Effect.fn(function* ({ base, output, profile, requireClean }) {
     const path = yield* Path.Path;
 
     const root = path.resolve(
@@ -649,11 +627,11 @@ export const command = Command.make(
       "..",
     );
 
-    yield* compareRuntime({ root, base, reference, output, profile, requireClean });
+    yield* compareRuntime({ root, base, output, profile, requireClean });
   }),
 ).pipe(
   Command.withDescription(
-    "Compare public built packages on one runner against PR base and a retained reference; no provider calls.",
+    "Compare public built packages on one runner for Base versus Head; no provider calls.",
   ),
 );
 


### PR DESCRIPTION
The scripted runtime benchmark now compares the exact PR Base and Head only. Remove the pinned beta67 checkout, install, build, staging, CLI argument, report field, trusted validation, comment columns, and reproduction instructions. The `runtime-v3` contract rejects historical three-revision reports; there is no optional reference mode.

Keep three cohorts, two warmups, and three measurements per workload/revision (nine measurements each). Order is Base/Head, Head/Base, Base/Head: each revision gets a turn first, with Base first twice because the cohort count is odd. This preserves sample counts and correctness coverage while reducing execution from 18 to 12 child processes and 864 to 576 attempts. Exact identities, independent lockfiles and public builds, identical fixture bytes, sequential measurement, cold evidence, first-model timing in raw samples, failure retention, and bounded cleanup remain intact. No additional runtime or fixture optimization is included.

In [the successful baseline run](https://github.com/danieljvdm/effect-agent/actions/runs/34380434074/job/102564153499) at `9bb82a32f58a2077682f7af104fc2c49f02a78fa`, the job took 9m39s: about 1m36s for setup/install/build and 7m59s for comparison. The raw artifact records 477.55s across 18 sequential processes and 864 attempts. Setup accounts for 370.41s of that time, including 248.18s in the 2,048-row ledger case. Setup is inside attempt time and outside the operation medians shown in the comment, which explains why millisecond rows take minutes overall.

The removed reference accounted for 150.08s of subprocess time plus about 28s of checkout/install/build in that run. The retained Base/Head work accounted for 327.47s of subprocess time, including 260.29s of setup. These are historical component costs, not a measured candidate speedup; exact hosted savings require matched runs. No contention or reduced assertions are used to shorten CI.

Validation: `vp run patch:tsgo`, `vp run --no-cache check`, and `vp run ready` passed (including all 143 runtime-benchmark tests, adapter/crash suites, public examples, docs, and Action build). CLI help exposes only Base/Head inputs and the removed `--reference-dir` fails parsing. A full `--profile pr --require-clean` run on macOS arm64 / Node 24.21.0 completed in 96.60s with 12/12 batches, 576/576 passing attempts, the expected sequential order, nine measured samples and six warmups per case/revision, and an empty scratch directory after scoped cleanup. This local duration is validation evidence, not a hosted before/after measurement.

The trusted comment workflow uses default-branch code, so its new contract takes effect after merge. Tests execute the exact new inline publisher without executing candidate artifacts.
