### PR TITLE
refactor(cloudflare): simplify application configuration

### DIFF
--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -15,8 +15,7 @@ bun add @effect-agent/platform-cloudflare@beta
 ```
 
 Also install `effect@4.0.0-rc.112`, `effect-cf@^0.40.0`, `@effect-agent/core@beta`,
-`@effect-agent/thread@beta`, `@effect/ai-openai@4.0.0-rc.112`, and
-`@effect/platform-browser@4.0.0-rc.112` for the examples below.
+`@effect-agent/thread@beta`, and `@effect/ai-openai@4.0.0-rc.112` for the examples below.
 Keep framework packages at one release and add your [model provider](../guide/getting-started#installation-and-compatibility).
 
 ## Create the thread object
@@ -25,16 +24,16 @@ Compose agent registrations and application services as a layer, then pass it to
 `ThreadObject.make`. This example expects `OPENAI_API_KEY` and a `THREADS` Durable
 Object namespace in the generated `Cloudflare.Env`.
 
-```ts
+```ts twoslash
+// @types: @cloudflare/workers-types
 import * as Agent from "@effect-agent/core/Agent";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
 import { DefinitionDigestInput } from "@effect-agent/thread/Records";
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
-import { Effect, Layer, Redacted, Schema } from "effect";
+import { Config, Layer, Schema } from "effect";
 import { Toolkit } from "effect/unstable/ai";
 import { FetchHttpClient } from "effect/unstable/http";
-import { WorkerEnvironment } from "effect-cf";
 
 const TravelPlanner = Agent.make("travel-planner", {
   input: Schema.Struct({ destination: Schema.String, days: Schema.Number }),
@@ -56,13 +55,9 @@ export const travelDefinitions = DefinitionDigestInput.make({
   tools: [],
 });
 
-const OpenAiLive = Layer.unwrap(
-  Effect.map(WorkerEnvironment, (env) =>
-    OpenAiClient.layer({ apiKey: Redacted.make(env.OPENAI_API_KEY) }).pipe(
-      Layer.provide(FetchHttpClient.layer),
-    ),
-  ),
-);
+const OpenAiLive = OpenAiClient.layerConfig({
+  apiKey: Config.redacted("OPENAI_API_KEY"),
+}).pipe(Layer.provide(FetchHttpClient.layer));
 
 const RuntimeLive = ThreadObject.layer([
   {
@@ -84,7 +79,10 @@ submitter passes `digestDefinitions(travelDefinitions)` through
 change. Version tool implementations and model configuration when they change.
 
 Application layers can use `WorkerEnvironment`, `DurableObjectState`,
-`ThreadObjectIdentity`, and Crypto. Use `Layer.unwrap` for configuration-dependent registrations.
+`ThreadObjectIdentity`, and Crypto. Scalar Worker vars and secrets are available through Effect
+`Config`: `ThreadObject.make` installs `effect-cf`'s environment config provider. Read secrets
+with `Config.redacted`, and use `WorkerEnvironment` for resource bindings such as R2 or Durable
+Object namespaces. Use `Layer.unwrap` when configuration selects registrations or services.
 The application is acquired once per Object instance and rebuilt after eviction. Keep initialization
 local and bounded. Eviction does not guarantee finalizers; acquire resources needing timely cleanup
 inside scoped operations or `options.eventLayer`. Each event runs a bounded recovery pass;
@@ -92,6 +90,53 @@ no worker loop is needed.
 
 Register the exported class as a SQLite Durable Object under `THREADS`.
 `ThreadObject.layer([])` registers no agents and refuses every agent identity.
+
+## Configure the binding
+
+```jsonc
+{
+  "name": "travel-planner",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-08-31",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [{ "name": "THREADS", "class_name": "TravelThread" }],
+  },
+  "exports": {
+    "TravelThread": { "type": "durable-object", "storage": "sqlite" },
+  },
+}
+```
+
+Match `THREADS` to `namespaceBinding` and `TravelThread` to the exported class.
+Enable `nodejs_compat` for the async context support used by `effect-cf`.
+See Cloudflare's [class configuration guide](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/)
+for Workers using the older `migrations` array.
+
+## Connect from your Worker
+
+```ts twoslash
+// @types: @cloudflare/workers-types
+import { CloudflareThreadClient } from "@effect-agent/platform-cloudflare/CloudflareThreadClient";
+import { type ThreadObjectRpc } from "@effect-agent/platform-cloudflare/CloudflareBindings";
+
+export const threadClientLayer = (env: { THREADS: DurableObjectNamespace<ThreadObjectRpc> }) =>
+  CloudflareThreadClient.layerFromBinding({ namespace: env.THREADS });
+```
+
+This constructor supplies the namespace and platform Crypto. Pass `rpcTracing: "THREADS"` only
+when the receiver also enables native RPC tracing. Keep `CloudflareThreadClient.layer` for
+custom Crypto or namespace composition, and `threadNamespaceLayer` for untyped environment lookup.
+
+In an authenticated handler, call `client.submit(agent, input, options)` with the thread ID,
+principal, idempotency key, and definition digests. Return its receipt after admission.
+
+Use `client.awaitSettlement(receipt)` for completion.
+For updates, call `readPage`, then `awaitProgress`, then read after the last received sequence.
+Scope progress waits so interruption cancels them remotely.
+Cancellation is best effort and waits at most one second for the remote reply, so a lost reply
+does not prevent local shutdown. The Object retains bounded cancellation hints for late retries.
+Expose these Effects through your application's HTTP or RPC API.
 
 ## Configure runtime services
 
@@ -179,53 +224,6 @@ across reconstruction. A projection deadline never gates approval publication or
 Backfill failures are reported after eligible canonical work, retaining the prearmed generation;
 interruption stops the event. Hooks return typed `ThreadProjectionError` failures, own scoped
 resources, and never write the alarm slot or call source mutation ports.
-
-## Configure the binding
-
-```jsonc
-{
-  "name": "travel-planner",
-  "main": "src/worker.ts",
-  "compatibility_date": "2026-08-31",
-  "compatibility_flags": ["nodejs_compat"],
-  "durable_objects": {
-    "bindings": [{ "name": "THREADS", "class_name": "TravelThread" }],
-  },
-  "exports": {
-    "TravelThread": { "type": "durable-object", "storage": "sqlite" },
-  },
-}
-```
-
-Match `THREADS` to `namespaceBinding` and `TravelThread` to the exported class.
-Enable `nodejs_compat` for the async context support used by `effect-cf`.
-See Cloudflare's [class configuration guide](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/)
-for Workers using the older `migrations` array.
-
-## Connect from your Worker
-
-```ts twoslash
-// @types: @cloudflare/workers-types
-import { CloudflareThreadClient } from "@effect-agent/platform-cloudflare/CloudflareThreadClient";
-import { type ThreadObjectRpc } from "@effect-agent/platform-cloudflare/CloudflareBindings";
-
-export const threadClientLayer = (env: { THREADS: DurableObjectNamespace<ThreadObjectRpc> }) =>
-  CloudflareThreadClient.layerFromBinding({ namespace: env.THREADS });
-```
-
-This constructor supplies the namespace and platform Crypto. Pass `rpcTracing: "THREADS"` only
-when the receiver also enables native RPC tracing. Keep `CloudflareThreadClient.layer` for
-custom Crypto or namespace composition, and `threadNamespaceLayer` for untyped environment lookup.
-
-In an authenticated handler, call `client.submit(agent, input, options)` with the thread ID,
-principal, idempotency key, and definition digests. Return its receipt after admission.
-
-Use `client.awaitSettlement(receipt)` for completion.
-For updates, call `readPage`, then `awaitProgress`, then read after the last received sequence.
-Scope progress waits so interruption cancels them remotely.
-Cancellation is best effort and waits at most one second for the remote reply, so a lost reply
-does not prevent local shutdown. The Object retains bounded cancellation hints for late retries.
-Expose these Effects through your application's HTTP or RPC API.
 
 ## Shared memory {#shared-memory}
 

--- a/examples/browser-run-worker-proof/README.md
+++ b/examples/browser-run-worker-proof/README.md
@@ -62,6 +62,10 @@ Required environment:
   to the temporary Worker after its deletion finalizer is registered;
 - `CLOUDFLARE_WORKERS_SUBDOMAIN`: the account's workers.dev subdomain without `.workers.dev`.
 
+Inside the Worker, `effect-cf` supplies Effect `Config` for `CLOUDFLARE_ACCOUNT_ID` and
+`BROWSER_RENDERING_API_TOKEN`; missing or empty values refuse initialization. `WorkerEnvironment`
+supplies the `BROWSER` resource binding.
+
 Run the proof from the repository root:
 
 ```sh

--- a/examples/browser-run-worker-proof/src/worker.ts
+++ b/examples/browser-run-worker-proof/src/worker.ts
@@ -32,17 +32,7 @@ import {
   PageScreenshotRequest,
 } from "@effect-agent/sandbox/PageScreenshot";
 import { BrowserCrypto } from "@effect/platform-browser";
-import {
-  Config,
-  ConfigProvider,
-  Duration,
-  Effect,
-  Layer,
-  Option,
-  Redacted,
-  Schema,
-  Stream,
-} from "effect";
+import { Config, Duration, Effect, Layer, Option, Redacted, Schema, Stream } from "effect";
 import { Worker, WorkerEnvironment } from "effect-cf";
 import { Toolkit } from "effect/unstable/ai";
 import { FetchHttpClient } from "effect/unstable/http";
@@ -113,7 +103,7 @@ const proofLayer = Layer.unwrap(
     const lifecycleConfig = yield* Config.all({
       accountId: Config.string("CLOUDFLARE_ACCOUNT_ID"),
       apiToken: Config.redacted("BROWSER_RENDERING_API_TOKEN"),
-    }).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(env)));
+    });
 
     const quickActionLayer = browserQuickActionScreenshotLayer().pipe(
       Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser: env.BROWSER })),

--- a/examples/durable-orchestration/README.md
+++ b/examples/durable-orchestration/README.md
@@ -73,6 +73,9 @@ storage when changing models; existing registrations retain their original model
 The Worker exports a SQLite Durable Object class and includes its first migration in
 [wrangler.jsonc](wrangler.jsonc). Each Thread has its own Object; persisted alarms drive
 accepted work and message delivery. There is no process-local worker loop to keep alive.
+The host supplies Effect `Config` from Worker vars and secrets, so the same model configuration
+used on Node reads `OPENAI_API_KEY` and `OPENAI_MODEL` without an environment adapter. An unset
+or empty `OPENAI_MODEL` uses the default; a missing or empty API key refuses initialization.
 
 ```sh
 cp examples/durable-orchestration/.dev.vars.example examples/durable-orchestration/.dev.vars

--- a/examples/durable-orchestration/src/cloudflare.ts
+++ b/examples/durable-orchestration/src/cloudflare.ts
@@ -1,5 +1,4 @@
-import { ConfigProvider, Effect, Layer } from "effect";
-import { WorkerEnvironment } from "effect-cf";
+import { Effect, Layer } from "effect";
 
 import { makeOrchestrationThread, threadLayer } from "./cloudflare-host.ts";
 import { openAiModels } from "./openai.ts";
@@ -19,20 +18,6 @@ declare global {
 
 export class OrchestrationThread extends makeOrchestrationThread(
   Layer.unwrap(
-    Effect.gen(function* () {
-      const env = yield* WorkerEnvironment;
-
-      const { models, modelVersion } = yield* openAiModels.pipe(
-        Effect.provideService(
-          ConfigProvider.ConfigProvider,
-          ConfigProvider.fromUnknown({
-            OPENAI_API_KEY: env.OPENAI_API_KEY,
-            OPENAI_MODEL: env.OPENAI_MODEL,
-          }),
-        ),
-      );
-
-      return threadLayer(models, modelVersion);
-    }),
+    Effect.map(openAiModels, ({ models, modelVersion }) => threadLayer(models, modelVersion)),
   ),
 ) {}

--- a/packages/platform-cloudflare/src/ThreadObject.ts
+++ b/packages/platform-cloudflare/src/ThreadObject.ts
@@ -842,6 +842,8 @@ export interface Class<EventServices = never> {
  * Export a composed application Layer as a native Durable Object class.
  * Bootstrap services are provided to the whole graph before it acquires, so application Layers
  * can yield effect-cf's WorkerEnvironment and DurableObjectState, derived identity, and Crypto.
+ * Effect Config reads scalar Worker vars and secrets through effect-cf's environment provider;
+ * WorkerEnvironment exposes resource bindings without a separate config Layer.
  * Application dependencies remain visible until Layer.provide satisfies them. effect-cf owns the
  * cached ManagedRuntime, native RPC methods, event scopes, and telemetry flushing.
  * Initialization is local and bounded inside the constructor gate. Cloudflare eviction does not

--- a/packages/platform-cloudflare/test/registrations.test.ts
+++ b/packages/platform-cloudflare/test/registrations.test.ts
@@ -100,6 +100,7 @@ describe("Cloudflare Agent registrations", () => {
       threadId: firstThread,
       producerId: `${PRODUCER_PREFIX}:${firstThread}`,
       rawEnvHasNamespace: true,
+      configuredLabel: "configured-by-worker",
       stateMatches: true,
     });
 
@@ -110,6 +111,7 @@ describe("Cloudflare Agent registrations", () => {
       threadId: secondThread,
       producerId: `${PRODUCER_PREFIX}:${secondThread}`,
       rawEnvHasNamespace: true,
+      configuredLabel: "configured-by-worker",
       stateMatches: true,
     });
     expect(secondProbe.incarnation).not.toBe(firstProbe.incarnation);

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -20,7 +20,7 @@ import * as ThreadObject from "@effect-agent/platform-cloudflare/ThreadObject";
 import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
 import { OperationDenied } from "@effect-agent/thread/OperationAuthorizer";
 import { ScheduleAuthorizer, ScheduleFailpoint } from "@effect-agent/thread/Schedule";
-import { Clock, Context, Crypto, Effect, Layer, Schema } from "effect";
+import { Clock, Config, Context, Crypto, Effect, Layer, Schema } from "effect";
 import { DurableObject, DurableObjectState, RpcTracing, WorkerEnvironment } from "effect-cf";
 import { OtlpExporter } from "effect/unstable/observability";
 
@@ -186,6 +186,7 @@ interface BindingSourceProbe {
   readonly threadId: string;
   readonly producerId: string;
   readonly rawEnvHasNamespace: boolean;
+  readonly configuredLabel: string;
 }
 
 let nextBindingSourceIncarnation = 0;
@@ -204,6 +205,7 @@ const registrationResourceLayer = Layer.effect(
     const { raw: ctx } = yield* DurableObjectState.DurableObjectState;
     const env = yield* WorkerEnvironment;
     const { threadId, producerId } = yield* ThreadObjectIdentity;
+    const configuredLabel = yield* Config.string("REGISTRATION_LABEL");
 
     yield* Crypto.Crypto;
     const previous = bindingSourceProbes.get(ctx);
@@ -214,6 +216,7 @@ const registrationResourceLayer = Layer.effect(
       threadId,
       producerId,
       rawEnvHasNamespace: env.DYNAMIC_BINDINGS !== undefined,
+      configuredLabel,
     });
 
     const resource = yield* Effect.acquireRelease(

--- a/packages/platform-cloudflare/vite.config.ts
+++ b/packages/platform-cloudflare/vite.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
             miniflare: {
               compatibilityDate: "2025-05-01",
               compatibilityFlags: ["nodejs_compat"],
+              bindings: { REGISTRATION_LABEL: "configured-by-worker" },
               durableObjects: {
                 THREADS: { className: "TestThreadObject", useSQLite: true },
                 PUBLICATIONS: { className: "PublicationThreadObject", useSQLite: true },


### PR DESCRIPTION
Cloudflare examples and the setup guide rebuild configuration that `effect-cf` already provides. Use native Effect `Config` for model and browser credentials, and put binding/client setup before optional runtime services. The main guide example is now type-checked.

OpenAI client setup in the guide, before:

```ts
const OpenAiLive = Layer.unwrap(
  Effect.map(WorkerEnvironment, (env) =>
    OpenAiClient.layer({ apiKey: Redacted.make(env.OPENAI_API_KEY) }).pipe(
      Layer.provide(FetchHttpClient.layer),
    ),
  ),
);
```

After:

```ts
const OpenAiLive = OpenAiClient.layerConfig({
  apiKey: Config.redacted("OPENAI_API_KEY"),
}).pipe(Layer.provide(FetchHttpClient.layer));
```

Configuration-dependent registrations in the orchestration example, before:

```ts
export class OrchestrationThread extends makeOrchestrationThread(
  Layer.unwrap(
    Effect.gen(function* () {
      const env = yield* WorkerEnvironment;

      const { models, modelVersion } = yield* openAiModels.pipe(
        Effect.provideService(
          ConfigProvider.ConfigProvider,
          ConfigProvider.fromUnknown({
            OPENAI_API_KEY: env.OPENAI_API_KEY,
            OPENAI_MODEL: env.OPENAI_MODEL,
          }),
        ),
      );

      return threadLayer(models, modelVersion);
    }),
  ),
) {}
```

After:

```ts
export class OrchestrationThread extends makeOrchestrationThread(
  Layer.unwrap(
    Effect.map(openAiModels, ({ models, modelVersion }) => threadLayer(models, modelVersion)),
  ),
) {}
```

Browser Run credentials inside the Worker application layer, before:

```ts
const env = yield* WorkerEnvironment;
const lifecycleConfig = yield* Config.all({
  accountId: Config.string("CLOUDFLARE_ACCOUNT_ID"),
  apiToken: Config.redacted("BROWSER_RENDERING_API_TOKEN"),
}).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(env)));
```

After:

```ts
const env = yield* WorkerEnvironment;
const lifecycleConfig = yield* Config.all({
  accountId: Config.string("CLOUDFLARE_ACCOUNT_ID"),
  apiToken: Config.redacted("BROWSER_RENDERING_API_TOKEN"),
});
```

`WorkerEnvironment` still supplies `env.BROWSER`. Both `Worker.make` and the native Durable Object host supply the configuration provider when acquiring application layers.

Empty Worker values follow native configuration semantics: an empty model name uses the default, while empty required credentials refuse initialization. Resource bindings remain available through `WorkerEnvironment`.

Validation: `vp run ready` exited successfully, including 510 Cloudflare tests, native application-configuration coverage, the guide build, and Worker dry-run builds. Cached `packages/testing` build output still contains TS4082 diagnostics for the unchanged `oxlint/plugin-exports.ts`.
