### PR TITLE
refactor(examples): namespace the Cloudflare orchestration host

### DIFF
--- a/examples/durable-orchestration/README.md
+++ b/examples/durable-orchestration/README.md
@@ -73,6 +73,8 @@ storage when changing models; existing registrations retain their original model
 The Worker exports a SQLite Durable Object class and includes its first migration in
 [wrangler.jsonc](wrangler.jsonc). Each Thread has its own Object; persisted alarms drive
 accepted work and message delivery. There is no process-local worker loop to keep alive.
+The example's [CloudflareHost](src/CloudflareHost.ts) module exposes `make` and `layer`;
+`CloudflareHost.make` extends `ThreadObject.make` with the demo's `command` and `status` RPCs.
 The host supplies Effect `Config` from Worker vars and secrets, so the same model configuration
 used on Node reads `OPENAI_API_KEY` and `OPENAI_MODEL` without an environment adapter. An unset
 or empty `OPENAI_MODEL` uses the default; a missing or empty API key refuses initialization.

--- a/examples/durable-orchestration/src/CloudflareHost.ts
+++ b/examples/durable-orchestration/src/CloudflareHost.ts
@@ -6,14 +6,14 @@ import { DurableObject, type WorkerEnvironment } from "effect-cf";
 import { authority, handlers, registrations, rootThread, type Models } from "./agents.ts";
 import { Command, CommandResult, execute, Snapshot, snapshot } from "./application.ts";
 
-export const threadLayer = (models: Models, modelVersion: string) =>
+export const layer = (models: Models, modelVersion: string) =>
   ThreadObject.layer(registrations(models, modelVersion)).pipe(
     Layer.provide([authority, handlers(models)]),
   );
 
-type ApplicationLayer = ReturnType<typeof threadLayer>;
+type ApplicationLayer = ReturnType<typeof layer>;
 
-export const makeOrchestrationThread = <E>(
+export const make = <E>(
   application: Layer.Layer<
     Layer.Success<ApplicationLayer>,
     E,

--- a/examples/durable-orchestration/src/cloudflare.ts
+++ b/examples/durable-orchestration/src/cloudflare.ts
@@ -1,9 +1,9 @@
 import { Effect, Layer } from "effect";
 
-import { makeOrchestrationThread, threadLayer } from "./cloudflare-host.ts";
+import * as CloudflareHost from "./CloudflareHost.ts";
 import { openAiModels } from "./openai.ts";
 
-export { default } from "./cloudflare-host.ts";
+export { default } from "./CloudflareHost.ts";
 
 declare global {
   namespace Cloudflare {
@@ -16,8 +16,10 @@ declare global {
   }
 }
 
-export class OrchestrationThread extends makeOrchestrationThread(
+export class OrchestrationThread extends CloudflareHost.make(
   Layer.unwrap(
-    Effect.map(openAiModels, ({ models, modelVersion }) => threadLayer(models, modelVersion)),
+    Effect.map(openAiModels, ({ models, modelVersion }) =>
+      CloudflareHost.layer(models, modelVersion),
+    ),
   ),
 ) {}

--- a/examples/durable-orchestration/test/fixtures/cloudflare.ts
+++ b/examples/durable-orchestration/test/fixtures/cloudflare.ts
@@ -1,8 +1,8 @@
-import { makeOrchestrationThread, threadLayer } from "../../src/cloudflare-host.ts";
+import * as CloudflareHost from "../../src/CloudflareHost.ts";
 import { models } from "./models.ts";
 
-export { default } from "../../src/cloudflare-host.ts";
+export { default } from "../../src/CloudflareHost.ts";
 
-export class OrchestrationThread extends makeOrchestrationThread(
-  threadLayer(models, "scripted-v1"),
+export class OrchestrationThread extends CloudflareHost.make(
+  CloudflareHost.layer(models, "scripted-v1"),
 ) {}


### PR DESCRIPTION
The orchestration example's flat `makeOrchestrationThread` and `threadLayer` helpers obscure the repository's namespaced API convention. Rename the local module to `CloudflareHost.ts`, expose `make` and `layer`, and use namespace imports in the live entrypoint and test fixture.

Before, in the test fixture:

```ts
import { makeOrchestrationThread, threadLayer } from "../../src/cloudflare-host.ts";

export class OrchestrationThread extends makeOrchestrationThread(
  threadLayer(models, "scripted-v1"),
) {}
```

After:

```ts
import * as CloudflareHost from "../../src/CloudflareHost.ts";

export class OrchestrationThread extends CloudflareHost.make(
  CloudflareHost.layer(models, "scripted-v1"),
) {}
```

`CloudflareHost.make` is an example-local extension of the public `ThreadObject.make`, adding the demo's `command` and `status` RPCs. This only changes local module names and imports; the exported Durable Object class, deployment identity, and runtime behavior stay the same.

Validation: `vp run ready` passed, including all six orchestration tests and the Worker dry-run build. Existing behavioral tests cover both Node and workerd; no new tests are needed for the rename.
