### PR TITLE
fix(worker): distinguish pending delivery from storage failures

### DIFF
--- a/.changeset/retained-worker-delivery.md
+++ b/.changeset/retained-worker-delivery.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/thread": patch
+---
+
+Distinguish durably retained worker input from storage failures with `WorkerError` reason `delivery-pending`. Treat this outcome as pending delivery, preserve the original idempotency key, and wait for a Receipt before reporting destination acceptance.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -421,6 +421,14 @@ input. `Subagent.followUp` submits more declared parameters to that same Thread.
 Effects; acceptance does not wait for the child to finish. Programmatic calls require an
 explicit, stable `IdempotencyKey`. A model tool derives its key from its actual invocation.
 
+If another delivery attempt owns the claim, `start` and `followUp` can fail with
+`WorkerError` reason `delivery-pending`. This confirms that the exact input is durably retained;
+it does not confirm destination acceptance or that the child started. The host's existing
+delivery recovery owns progress. Preserve the same parameters and idempotency key when
+reconciling instead of launching replacement work. Conclusive refusal retains its specific
+reason, while a recorded retry failure or a storage exception still reports `storage`.
+These operations add no waiting or polling for a competing claim.
+
 ```ts
 const Research = Subagent.make("research", { target: researcher });
 const tools = Subagent.background(Research, {

--- a/packages/core/src/Worker.ts
+++ b/packages/core/src/Worker.ts
@@ -80,7 +80,11 @@ export const WorkerHistoryEntry = Schema.Struct({
 
 export type WorkerHistoryEntry = typeof WorkerHistoryEntry.Type;
 
-/** Closed host-boundary failures. Infrastructure diagnostics remain in host telemetry. */
+/**
+ * Closed host-boundary failures. Infrastructure diagnostics remain in host telemetry.
+ * `delivery-pending` confirms retained input, not destination acceptance or execution.
+ * Keep the same idempotency key and parameters when reconciling; never launch a replacement.
+ */
 export class WorkerError extends Schema.TaggedError<WorkerError>()("WorkerError", {
   operation: Schema.Literals([
     "context",
@@ -100,6 +104,7 @@ export class WorkerError extends Schema.TaggedError<WorkerError>()("WorkerError"
     "idempotency-conflict",
     "capacity",
     "not-found",
+    "delivery-pending",
     "storage",
     "corrupt",
     "unavailable",

--- a/packages/platform-node/test/background-workers.test.ts
+++ b/packages/platform-node/test/background-workers.test.ts
@@ -6,13 +6,33 @@ import { WorkerError } from "@effect-agent/core/Worker";
 import { SubagentHost } from "@effect-agent/engine/SubagentHost";
 import * as NodeHost from "@effect-agent/platform-node/NodeDurableHost";
 import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import {
+  MessageDeliveryFailpoint,
+  MessageDeliveryFailpointError,
+  MessageDeliveryStore,
+} from "@effect-agent/thread/MessageDelivery";
 import { DefinitionDigestInput } from "@effect-agent/thread/Records";
 import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
 import { ThreadExportRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
-import { WorkerHostAuthorizer } from "@effect-agent/thread/WorkerHost";
+import { WorkerConcurrencyResolver, WorkerHostAuthorizer } from "@effect-agent/thread/WorkerHost";
 import { NodeFileSystem } from "@effect/platform-node";
 import { expect, it } from "@effect/vitest";
-import { Context, Effect, Exit, Fiber, FileSystem, Layer, Schema, Scope, Stream } from "effect";
+import {
+  Clock,
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Scope,
+  Stream,
+  Tracer,
+} from "effect";
 import { TestClock } from "effect/testing";
 import { LanguageModel, Model, Toolkit, type Response } from "effect/unstable/ai";
 
@@ -28,7 +48,7 @@ const parts: ReadonlyArray<Response.StreamPartEncoded> = [
   { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
 ];
 
-const agent = (id: string) =>
+const agent = (id: string, beforeReply: Effect.Effect<void> = Effect.void) =>
   Agent.withModel(
     Agent.make(id, {
       input: Schema.Struct({ question: Schema.String }),
@@ -44,7 +64,7 @@ const agent = (id: string) =>
         LanguageModel.LanguageModel,
         LanguageModel.make({
           generateText: () => Effect.succeed([]),
-          streamText: () => Stream.fromIterable(parts),
+          streamText: () => Stream.unwrap(beforeReply.pipe(Effect.as(Stream.fromIterable(parts)))),
         }),
       ),
     ),
@@ -96,6 +116,357 @@ const untilSettled = (
 
     return yield* Effect.die("Worker receipt did not settle");
   });
+
+// Regression: https://github.com/danieljvdm/effect-agent/blob/4c417d98e8cc790c42ab4200a54a0548fe32e6e3/packages/thread/src/internal/worker-host.ts#L1645-L1691
+for (const completion of ["released", "interrupted"] as const) {
+  it.effect(
+    `reports retained worker delivery while another admission owns its ${completion} claim`,
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const directory = yield* fs.makeTempDirectoryScoped({ prefix: "worker-admission-" });
+          const claimed = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          let claims = 0;
+          let admissions = 0;
+          let modelCalls = 0;
+          let finalized = 0;
+          let starts = 0;
+          let driverPasses = 0;
+
+          const tracer = Tracer.make({
+            span: (options) => {
+              if (options.name === "WorkerHost.start") starts++;
+              if (options.name === "MessageDelivery.process") driverPasses++;
+
+              return new Tracer.NativeSpan(options);
+            },
+          });
+
+          const child = agent(
+            "admission-target",
+            Effect.sync(() => {
+              modelCalls++;
+            }),
+          );
+
+          const research = Subagent.make("research", {
+            target: child.definition,
+            policy: declaration.policy,
+          });
+
+          const context = yield* Layer.build(
+            NodeHost.NodeDurableHost.layerRegistered(
+              [
+                { agent: source, definitions },
+                { agent: child, definitions },
+              ],
+              {
+                filename: `${directory}/runtime.sqlite`,
+                deploymentId: "admission-v1",
+                producerId: "admission-node",
+                runtimeFailpoint: (location) =>
+                  Effect.sync(() => {
+                    if (location === "submit:after-admit") admissions++;
+                  }),
+              },
+            ).pipe(
+              Layer.provide(authority),
+              Layer.provide(
+                Layer.succeed(MessageDeliveryFailpoint, {
+                  hit: (point) =>
+                    Effect.gen(function* () {
+                      if (point !== "message-delivery:claim:after") return;
+                      claims++;
+                      if (claims !== 1) return;
+                      yield* Deferred.succeed(claimed, undefined);
+                      yield* Deferred.await(release).pipe(
+                        Effect.ensuring(
+                          Effect.sync(() => {
+                            finalized++;
+                          }),
+                        ),
+                      );
+                    }),
+                }),
+              ),
+            ),
+          );
+
+          const runtime = Context.get(context, DurableAgentRuntime);
+          const store = Context.get(context, MessageDeliveryStore);
+          const history = Context.get(context, ThreadStore);
+
+          const sourceReceipt = yield* runtime.submitRegistered(
+            source,
+            { question: "prepare" },
+            {
+              threadId: sourceThreadId,
+              principal,
+              idempotencyKey: key("source"),
+            },
+          );
+
+          yield* runtime.processThreadResolved(sourceThreadId);
+          expect((yield* runtime.awaitSettlement(sourceReceipt)).outcome).toBe("completed");
+          admissions = 0;
+          const facet = yield* runtime.workerHost({ sourceThreadId, principal });
+
+          const start = withFacet(
+            facet,
+            Subagent.start(
+              research,
+              { question: "once" },
+              {
+                idempotencyKey: key("held-claim"),
+              },
+            ),
+          ).pipe(Effect.withTracer(tracer), Effect.withTracerEnabled(true));
+
+          const first = yield* start.pipe(Effect.forkChild);
+
+          yield* Deferred.await(claimed);
+          const retained = (yield* store.list({ ownerThreadId: sourceThreadId, limit: 10 })).items;
+
+          expect(retained).toHaveLength(1);
+          expect(retained[0]).toMatchObject({ status: "pending", receipt: null });
+          expect(retained[0]!.leaseUntilMillis).toBeGreaterThan(yield* Clock.currentTimeMillis);
+          const clockStart = yield* Clock.currentTimeMillis;
+          const wallStart = performance.now();
+
+          const competing = yield* Effect.all([start, start, start].map(Effect.result), {
+            concurrency: 3,
+          });
+
+          const wallMillis = performance.now() - wallStart;
+          const clockMillis = (yield* Clock.currentTimeMillis) - clockStart;
+
+          expect(claims).toBe(1);
+          expect(admissions).toBe(0);
+          expect(modelCalls).toBe(0);
+          expect(clockMillis).toBe(0);
+          if (completion === "interrupted") {
+            yield* Fiber.interrupt(first);
+            expect(Exit.hasInterrupts(yield* Fiber.await(first))).toBe(true);
+            yield* TestClock.adjust("31 seconds");
+          } else {
+            yield* Deferred.succeed(release, undefined);
+          }
+          const started = yield* completion === "interrupted" ? start : Fiber.join(first);
+          const replay = yield* start;
+
+          expect(replay).toEqual(started);
+          expect(admissions).toBe(1);
+          expect(claims).toBe(completion === "interrupted" ? 2 : 1);
+          expect(starts).toBe(completion === "interrupted" ? 6 : 5);
+          expect(driverPasses).toBe(completion === "interrupted" ? 5 : 4);
+          expect(finalized).toBe(1);
+          yield* runtime.processThreadResolved(started.worker.threadId);
+          expect((yield* runtime.awaitSettlement(started.receipt)).outcome).toBe("completed");
+          expect(modelCalls).toBe(1);
+
+          const sourceLog = yield* history.export(
+            ThreadExportRequest.make({ threadId: sourceThreadId }),
+          );
+
+          const childLog = yield* history.export(
+            ThreadExportRequest.make({ threadId: started.worker.threadId }),
+          );
+
+          expect(
+            sourceLog.records.filter(
+              ({ record }) => record.payload._tag === "WorkerInputRequested",
+            ),
+          ).toHaveLength(1);
+          expect(
+            childLog.records.filter(({ record }) => record.payload._tag === "UserInputRecorded"),
+          ).toHaveLength(1);
+
+          const outcomes = competing.map((result) =>
+            Result.isFailure(result)
+              ? result.failure._tag === "WorkerError"
+                ? result.failure.reason
+                : result.failure._tag
+              : "started",
+          );
+
+          console.info(
+            "Pending worker delivery admission",
+            JSON.stringify({
+              outcomes,
+              completion,
+              wallMillis,
+              clockMillis,
+              claims,
+              admissions,
+              modelCalls,
+              finalized,
+              starts,
+              driverPasses,
+            }),
+          );
+          expect(outcomes).toEqual(["delivery-pending", "delivery-pending", "delivery-pending"]);
+        }),
+      ).pipe(Effect.provide(NodeFileSystem.layer)),
+    15_000,
+  );
+}
+
+// The same delivery path must retain refusal and actual failure diagnostics.
+it.effect(
+  "keeps refusal, storage failure, defect and timeout distinct from retained delivery",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "worker-admission-errors-" });
+        let mode: "retry" | "refuse" | "storage" | "defect" | "timeout" = "retry";
+        let claims = 0;
+        let timeoutsFinalized = 0;
+        const timeoutEntered = yield* Deferred.make<void>();
+
+        const context = yield* Layer.build(
+          NodeHost.NodeDurableHost.layerRegistered(
+            [
+              { agent: source, definitions },
+              { agent: target, definitions },
+            ],
+            {
+              filename: `${directory}/runtime.sqlite`,
+              deploymentId: "errors-v1",
+              producerId: "errors-node",
+            },
+          ).pipe(
+            Layer.provide(authority),
+            Layer.provide(
+              Layer.succeed(WorkerConcurrencyResolver, {
+                resolve: () =>
+                  Effect.suspend(() => {
+                    if (mode === "retry")
+                      return WorkerError.make({ operation: "start", reason: "unavailable" });
+                    if (mode === "timeout")
+                      return Deferred.succeed(timeoutEntered, undefined).pipe(
+                        Effect.andThen(Effect.never),
+                        Effect.ensuring(
+                          Effect.sync(() => {
+                            timeoutsFinalized++;
+                          }),
+                        ),
+                      );
+
+                    return Effect.succeed(Option.some({ maxActiveWorkersPerSource: 0 }));
+                  }),
+              }),
+            ),
+            Layer.provide(
+              Layer.succeed(MessageDeliveryFailpoint, {
+                hit: (point) =>
+                  Effect.suspend(() => {
+                    if (point !== "message-delivery:claim:before") return Effect.void;
+                    claims++;
+                    if (mode === "storage") return MessageDeliveryFailpointError.make({ point });
+                    if (mode === "defect") return Effect.die("injected delivery defect");
+
+                    return Effect.void;
+                  }),
+              }),
+            ),
+          ),
+        );
+
+        const runtime = Context.get(context, DurableAgentRuntime);
+        const deliveries = Context.get(context, MessageDeliveryStore);
+
+        yield* runtime.submitRegistered(
+          source,
+          { question: "prepare" },
+          {
+            threadId: sourceThreadId,
+            principal,
+            idempotencyKey: key("source"),
+          },
+        );
+        yield* runtime.processThreadResolved(sourceThreadId);
+        const facet = yield* runtime.workerHost({ sourceThreadId, principal });
+
+        const start = (id: string) =>
+          withFacet(
+            facet,
+            Subagent.start(declaration, { question: id }, { idempotencyKey: key(id) }),
+          );
+
+        expect(yield* start("retry").pipe(Effect.flip)).toMatchObject({
+          _tag: "WorkerError",
+          reason: "storage",
+        });
+        expect(yield* start("retry").pipe(Effect.flip)).toMatchObject({
+          _tag: "WorkerError",
+          reason: "storage",
+        });
+        expect(claims).toBe(1);
+        expect(
+          (yield* deliveries.list({ ownerThreadId: sourceThreadId, limit: 10 })).items[0],
+        ).toMatchObject({
+          status: "pending",
+          receipt: null,
+          retry: { lastFailure: "storage" },
+        });
+        mode = "refuse";
+        yield* TestClock.adjust("1 second");
+        expect(yield* start("retry").pipe(Effect.flip)).toMatchObject({
+          _tag: "WorkerError",
+          reason: "capacity",
+        });
+        expect(yield* start("retry").pipe(Effect.flip)).toMatchObject({
+          _tag: "WorkerError",
+          reason: "capacity",
+        });
+        expect(claims).toBe(2);
+        expect(
+          (yield* deliveries.list({ ownerThreadId: sourceThreadId, limit: 10 })).items[0],
+        ).toMatchObject({
+          status: "refused",
+          receipt: null,
+          refusal: "worker-capacity",
+        });
+        mode = "storage";
+        expect(yield* start("storage").pipe(Effect.flip)).toMatchObject({
+          _tag: "WorkerError",
+          reason: "storage",
+        });
+        mode = "defect";
+        expect(Exit.hasDies(yield* start("defect").pipe(Effect.exit))).toBe(true);
+        mode = "timeout";
+        const waiting = yield* start("timeout").pipe(Effect.result, Effect.forkChild);
+
+        yield* Deferred.await(timeoutEntered);
+        yield* TestClock.adjust("30 seconds");
+        expect(yield* Fiber.join(waiting)).toMatchObject({
+          _tag: "Failure",
+          failure: { reason: "storage" },
+        });
+        expect(timeoutsFinalized).toBe(1);
+
+        const retained = (yield* deliveries.list({ ownerThreadId: sourceThreadId, limit: 10 }))
+          .items;
+
+        expect(retained.find((row) => row.retry.lastFailure === "timeout")).toMatchObject({
+          status: "pending",
+          receipt: null,
+        });
+
+        const sourceLog = yield* Context.get(context, ThreadStore).export(
+          ThreadExportRequest.make({ threadId: sourceThreadId }),
+        );
+
+        expect(
+          sourceLog.records.filter(({ record }) => record.payload._tag === "WorkerInputRequested"),
+        ).toHaveLength(0);
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  15_000,
+);
 
 it.effect(
   "retains worker ownership across a Node restart and accepts another input after both agents settle",

--- a/packages/thread/src/internal/worker-host.ts
+++ b/packages/thread/src/internal/worker-host.ts
@@ -1688,7 +1688,14 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
         );
       }
 
-      return yield* failure(operation, "storage");
+      // A live claim or a future delivery deadline is not a storage failure. Keep the
+      // receipt-only success contract: retention alone does not mean the child started.
+      return yield* failure(
+        operation,
+        processed.status === "pending" && processed.retry.lastFailure === null
+          ? "delivery-pending"
+          : "storage",
+      );
     });
 
     const messageIdFor = (parts: ReadonlyArray<string>) =>


### PR DESCRIPTION
When a worker input is retained while another delivery attempt holds its claim, `start` or `followUp` currently returns `WorkerError` with reason `storage` even when no storage operation failed. This change reports `delivery-pending` when the delivery is pending and has no recorded retry failure. Successful admission still requires a receipt; known retry failures, storage errors and conclusive refusals keep their existing outcomes.

Illustrative boundary result for a retained start request:

```ts
new WorkerError({ operation: "start", reason: "delivery-pending" })
```

Callers should describe this as saved input awaiting delivery, retain the original parameters and idempotency key, and leave progress to existing host recovery. It does not mean the child was accepted or started. No new waiting, polling, retry loop, durable write, or ownership mechanism is added.

The added error literal requires compatible producer and consumer `WorkerError` decoders. Deploy it through a published package release containing both the updated schema and host behavior; older closed-union decoders reject the new literal.

A real SQLite host/driver fixture held a claim and issued three concurrent same-key starts, then released or interrupted the owner. Five fresh processes per revision used identical measured fixture bytes on base `8023db1` and the candidate:

| Observation | Base | Candidate |
| --- | --- | --- |
| 30 retained competing outcomes | `storage` | `delivery-pending` |
| Child admissions / model calls per case | 1 / 1 | 1 / 1 |
| Released-claim median (range), ms | 8.075 (7.377–9.020) | 7.731 (7.247–8.121) |
| Interrupted-claim median (range), ms | 6.425 (5.881–6.454) | 5.800 (5.714–6.522) |

These local timings establish no latency improvement or hosted-race reproduction. Driver passes, claims and source/destination admission counts are unchanged. Lease advancement for interrupted recovery occurs outside the timed region. Regression coverage includes receipt-only success, release/interruption/replay, refusal, retry failure, typed driver failure, defect and timeout/finalizer behavior. A later public comment and diagnostic-label cleanup changes no assertion or measured interval.

Validation: 45 focused tests passed. Final `vp run ready` passed on unchanged publication bytes in 72.347 seconds, reusing 66/82 task results and rerunning the changed Node suite. The earlier uncached passing gate took 170.933 seconds. The command retains nonfatal lint warnings and packaging TS4082 diagnostics at `oxlint/plugin-exports.ts:167`; this PR does not suppress them or claim diagnostic-free builds.
