### PR TITLE
test(benchmark): stabilize diagnostic test deadlines

### DIFF
--- a/examples/runtime-benchmark/test/diagnostic-infrastructure.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-infrastructure.test.ts
@@ -1,5 +1,6 @@
 import { NodeCrypto, NodeServices } from "@effect/platform-node";
 import { Deferred, Effect, Exit, Fiber, FileSystem, Layer, Schema } from "effect";
+import { TestClock } from "effect/testing";
 import { expect, it } from "vite-plus/test";
 
 import {
@@ -110,6 +111,7 @@ it.each(["failure", "defect", "timeout"] as const)(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const directory = yield* fs.makeTempDirectoryScoped();
+        const entered = yield* Deferred.make<void>();
 
         const options: DiagnosticWorkerOptions = {
           output: `${directory}/worker.json`,
@@ -118,7 +120,7 @@ it.each(["failure", "defect", "timeout"] as const)(
           timeoutMs: 10,
         };
 
-        const result = yield* runDiagnosticWorker(options).pipe(
+        const fiber = yield* runDiagnosticWorker(options).pipe(
           Effect.provideService(DiagnosticRunner, {
             run: (workload) =>
               workload.name !== diagnosticCases[0]!.name
@@ -133,6 +135,7 @@ it.each(["failure", "defect", "timeout"] as const)(
                       }),
                     );
                     yield* progress.mark({ name: "entered", elapsedMs: 0 });
+                    yield* Deferred.succeed(entered, undefined);
                     if (kind === "failure")
                       return yield* BenchmarkError.make({ message: "expected fixture failure" });
                     if (kind === "defect") return yield* Effect.die("fixture defect");
@@ -140,8 +143,12 @@ it.each(["failure", "defect", "timeout"] as const)(
                     return yield* Effect.never;
                   }).pipe(Effect.scoped),
           }),
-          Effect.exit,
+          Effect.forkChild,
         );
+
+        yield* Deferred.await(entered);
+        if (kind === "timeout") yield* TestClock.adjust(options.timeoutMs);
+        const result = yield* Fiber.await(fiber);
 
         const report = yield* Schema.decodeUnknownEffect(
           Schema.fromJsonString(DiagnosticWorkerReport),
@@ -155,9 +162,19 @@ it.each(["failure", "defect", "timeout"] as const)(
           result: null,
           marks: [{ name: "entered", elapsedMs: 0 }],
         });
-        expect(report.samples.at(-1)?.status).toBe("passed");
+        expect(report.samples[0]?.failure).toContain(
+          kind === "failure"
+            ? "expected fixture failure"
+            : kind === "defect"
+              ? "fixture defect"
+              : "TimeoutError",
+        );
+        expect(report.samples).toHaveLength(diagnosticCases.length);
+        expect(report.samples.slice(1).map(({ status }) => status)).toEqual(
+          diagnosticCases.slice(1).map(() => "passed"),
+        );
         expect(completeDiagnosticBatch(report, options, diagnosticCases)).toBe(false);
-      }).pipe(Effect.scoped, Effect.provide(services)),
+      }).pipe(Effect.scoped, Effect.provide(Layer.merge(services, TestClock.layer()))),
     );
   },
 );

--- a/examples/runtime-benchmark/test/diagnostic-ledger.test.ts
+++ b/examples/runtime-benchmark/test/diagnostic-ledger.test.ts
@@ -23,6 +23,7 @@ const services = DiagnosticLedgerSeeds.layer.pipe(
 const silent = DiagnosticProgress.of({ phase: () => Effect.void, mark: () => Effect.void });
 
 it("retries after a committed seed failure, measures all public workloads, and reuses only the closed successful seed", async () => {
+  // The timeout covers both real SQLite seeds and every workload, including setup.
   await Effect.runPromise(
     Effect.gen(function* () {
       let committed = false;
@@ -103,9 +104,9 @@ it("retries after a committed seed failure, measures all public workloads, and r
       );
 
       expect(second.metrics.find(({ name }) => name === "seedSetup")?.value).toBe(0);
-    }).pipe(Effect.scoped, Effect.provide(services), Effect.timeout("100 seconds")),
+    }).pipe(Effect.scoped, Effect.provide(services), Effect.timeout("5 minutes")),
   );
-}, 110_000);
+}, 310_000);
 
 it("rejects modified inventory without creating a seed", async () => {
   const result = await Effect.runPromiseExit(


### PR DESCRIPTION
The diagnostic failure test gave successful samples only 10 ms, including filesystem evidence writes, making its success assertion depend on runner speed. The [workspace CI run](https://github.com/danieljvdm/effect-agent/actions/runs/34404624558/job/102644523362) also exhausted the ledger test's 100-second limit for seeding and executing the full workload inventory.

Drive the failure/defect/timeout coverage with `TestClock`, advancing the timeout only after the fixture enters its operation. Assert the intended failure and every later sample's success. Give the ledger test five minutes for its real SQLite seeds and full workload inventory; retain all workload and cleanup assertions.

Validation: `vp run ready` passed, including all 143 runtime-benchmark tests.
