### PR TITLE
feat(code-mode): allow authorized writes and bounded parallel calls

### DIFF
--- a/.changeset/code-mode-parallel-writes.md
+++ b/.changeset/code-mode-parallel-writes.md
@@ -1,0 +1,11 @@
+---
+"@effect-agent/capabilities": patch
+"@effect-agent/engine": patch
+"@effect-agent/sandbox": patch
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/testing": patch
+---
+
+Allow authorized writes and bounded concurrent tool calls in Code Mode, with individual outcome reports after partial failure or interruption. Classify generated programs as uncertain to prevent automatic replay after ownership loss.
+
+BEHAVIOR CHANGE: Host Tool authorization now checks inner calls; policies must allow the selected Tools explicitly.

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -160,7 +160,10 @@ the exhaustion marker for the parent's result projection.
 ## Programmatic calls and Code Mode
 
 Code Mode checks and reserves `maxToolCalls` before each inner handler. Exhaustion becomes that
-call's outcome. The turn boundary then enforces the combined declared and programmatic count.
+call's outcome. Reservations are serialized across concurrent calls and never refunded after
+admission. The turn boundary then enforces the combined declared and programmatic count.
+`CodeExecutionLimits.maxHostCallConcurrency` independently bounds inner calls per pass (default 4,
+maximum 64); the outer `toolConcurrency` still bounds simultaneous generated programs.
 
 ## Sizing guidance
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -220,7 +220,8 @@ Use `BrowserTools` as the agent's toolkit and provide `browserToolsLive(credenti
 it. Use `WebCapture.makeScrape` for grouped selector results or `WebCapture.makeExtract` for
 Schema-validated extraction. Extraction also needs the adapter's explicit Workers AI authorization
 and accounting policy. Capture Tools have uncertain external outcomes because page rendering can
-execute JavaScript; they are not eligible for Code Mode's read-only allowlist.
+execute JavaScript. Code Mode can expose them through its authorized Tool allowlist; their resource
+policies still apply.
 
 `CloudflareBrowserRest.layer` accepts the same optional `workersAi` policy as the Worker
 constructor. It preserves schema decoding requirements and leaves `HttpClient` injectable.
@@ -507,8 +508,9 @@ completion, suspension, failure, or interruption. A replacement Attempt builds f
 Keep fallible browser acquisition in `session.get`, not Layer construction. No additional browser
 Durable Object or persisted browser-session record is needed.
 
-Credential Tools are ordinary effectful Tools. Do not mark them readonly/idempotent or expose them
-through the read-only Code Mode bridge. The existing prepared/settled journal governs recovery:
+Credential Tools are ordinary effectful Tools. Do not mark them readonly or idempotent. Host
+resource authorization still applies to brokered calls. The existing prepared/settled journal
+governs recovery; Code Mode treats the entire generated program as uncertain:
 an unresolved mutation is never automatically replayed after ownership loss. Old refs fail in a
 replacement Attempt; the application/operator must reconcile an uncertain external outcome.
 

--- a/docs/guide/code-mode.md
+++ b/docs/guide/code-mode.md
@@ -7,7 +7,7 @@ description: Let an agent run one bounded JavaScript program through an explicit
 
 Code Mode gives an agent one Effect AI Tool for a small JavaScript program. The program can call a
 fixed set of application Tools through named globals, then return one JSON value. It fits questions
-that need a bounded query followed by filtering, aggregation, or calculation.
+that need authorized reads and writes, overlapping independent I/O, and a compact answer.
 
 The [Cloudflare warehouse example](https://github.com/danieljvdm/effect-agent/tree/main/examples/code-mode-cloudflare)
 answers invoice questions this way:
@@ -22,7 +22,7 @@ const code = `async () => {
 ```
 
 `warehouse` is not a database client. It is a generated global that routes through the runtime's
-Tool broker to an application-owned Tool handler. The handler decides what the program can read.
+Tool broker to an application-owned Tool handler. The handler decides which resources the program may read or change.
 
 ## Build an analyst
 
@@ -147,9 +147,13 @@ at construction, capturing the services used by inner calls. Handler constructio
 remaining service requirements stay visible. The runtime supplies its own Tool broker.
 For a custom executor, provide it and the selected handlers directly to `codeMode.handlers`.
 
-Code Mode accepts only Tools annotated `readonly` and without approval requirements. That annotation
-does not make a database connection read-only. Enforce resource and tenant access inside handlers;
-use a read-only database identity where available. The warehouse example's Durable Object uses an
+Code Mode accepts read and mutation Tools without additional approval requirements. The broker
+retains parameter and result schemas, visibility, inherited grants, host action-time authorization,
+and run budgets. `RunToolAuthorization` receives each inner call with its `programmatic` parent
+identity before reservation and execution. Approving the outer Tool does not authorize its inner calls. Already
+authorized calls require no additional approval round trip; Tools declaring `needsApproval` remain
+unsupported and fail closed. Enforce resource and tenant access inside handlers. For read-only
+workloads, use a read-only database identity where available. The warehouse example's Durable Object uses an
 application SQL allowlist because its SQLite authorizer blocks `PRAGMA query_only`. That scanner is
 a demo boundary.
 
@@ -214,7 +218,7 @@ cannot enumerate hidden methods. If grants or host policy hide an allowlisted me
 `includeDeclarations` is still true, the runtime refuses the configuration before its full
 description can leak. Use generic shared descriptions and `includeDeclarations: false` for that
 case. Default eager Code Mode behavior remains available when the full allowlist is eligible.
-Readonly, approval, budget and handler authorization constraints continue to apply.
+Approval, budget and handler authorization constraints continue to apply.
 
 ## Program results and limits
 
@@ -223,9 +227,26 @@ async function expression, runs once with no arguments, and returns JSON. `conso
 returns with the result. Expected inner Tool failures reject the Promise with a JSON failure
 envelope, which generated code can catch and handle.
 
-The Tool broker rejects calls outside the construction-time allowlist. Inner calls are strictly
-sequential. The executor enforces source, wall-clock, log, result, host-call, and per-host-call
-byte limits. Code Mode applies `maxEgressBytes` after optional redaction to the result, logs, and
+The Tool broker rejects calls outside the construction-time allowlist. Use `Promise.all` for
+independent calls and `await` for actual dependencies:
+
+```js
+async () => {
+  const project = await tools.createProject({ name: "Launch" });
+  const tasks = await Promise.all(
+    ["Design", "Build", "Ship"].map((title) => tools.createTask({ projectId: project.id, title })),
+  );
+  return { projectId: project.id, tasksCreated: tasks.length };
+};
+```
+
+Set `limits.maxHostCallConcurrency` from 1 through 64 (default 4). Both the executor and broker
+bound active calls; waiting calls stay in Effect structured concurrency. Independent results return
+when ready, without waiting for earlier calls. `toolConcurrency` limits outer Tool Calls, so several
+simultaneous Code Mode passes can each use their inner concurrency allowance. Set it to 1 when the
+inner bound should also be the run's bound.
+
+The executor enforces source, wall-clock, log, result, host-call, and per-host-call byte limits. Code Mode applies `maxEgressBytes` after optional redaction to the result, logs, and
 thrown value visible to the model. The agent policy's `maxToolCalls` also includes brokered inner
 calls. See [Budgets & bounded autonomy](../concepts/budgets#programmatic-calls-and-code-mode).
 
@@ -236,6 +257,29 @@ result and logs before the aggregate model-visible byte limit.
 Its required services remain in the Code Mode handler Layer's requirements and are captured when
 that Layer is built. Temporary redactor resources close with each invocation. The redactor must
 be total: defects and interruption retain their Effect semantics.
+
+## Partial outcomes
+
+Writes are not transactional. A rejected `Promise.all` ends the program and interrupts outstanding
+calls; completed writes remain completed. Await every call the result depends on, and use
+`Promise.allSettled` when independent failures should not stop the remaining work.
+
+A `CodeModeFailure` includes invocation-ordered `calls` with `succeeded`, `failed`, `uncertain`, or
+`not-started` status. A confirmed failure does not imply rollback. A started call without a confirmed
+outcome is uncertain and must be reconciled with the application before retrying. Calls that cannot
+fit the output budget are counted in `omittedCalls`; do not assume an omitted call never ran.
+Evidence takes priority over logs and thrown values when the budget is tight.
+
+Set `onPassExit` to receive the full ephemeral report after executor fibers and resources close,
+including timeout, defect, and interruption. The host callback's Effect service requirements remain
+visible in the handler Layer. Reports contain tool names and statuses, without copying arguments or
+results. Existing programmatic Tool spans retain per-call timing and execution identity. No inner
+Canonical Records or program checkpoints are created; a process loss also loses these local reports.
+
+The outer Tool is always `uncertain` and `Tool.Readonly` is false. Under a durable host, an unresolved
+program enters the ordinary unknown-outcome protocol; it is never automatically replayed, even if
+its selected Tools happen to be readonly or idempotent. Recovery of a complete JavaScript program
+requires separate checkpoint/resume semantics.
 
 ## Run generated code on Cloudflare
 
@@ -296,5 +340,5 @@ allowed handler should access a particular tenant, table, account, or secret.
 
 [Sandbox execution](./sandbox) covers trusted local commands. Its local adapter is unisolated and
 does not implement the `CodeExecutor` required here. [Browser tools](./browser) cover page capture,
-crawl, and interactive passes; browser capture has uncertain external effects and cannot be added
-to Code Mode's readonly allowlist.
+crawl, and interactive passes. Tools with uncertain external effects still require application
+resource authorization when exposed through Code Mode.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -19,7 +19,7 @@ Effect AI provides models, tools, and provider integrations. Effect Agent uses t
 - [Context management](./context-management) to prune and summarize long threads.
 - [Subagents](../concepts/durability#attached-subagents) for delegation with explicit permissions and budgets.
 - [Thread history](./threads) across runs.
-- [Code Mode](./code-mode) for generated JavaScript that queries application data through read-only tools.
+- [Code Mode](./code-mode) for generated JavaScript that reads and changes application data through authorized tools.
 - [Sandbox execution](./sandbox) and [browser tools](./browser) for process output, rendered pages,
   crawling, and scoped browser interaction.
 

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -248,7 +248,10 @@ a tool call.
 
 ## Authorize tool calls
 
-Use `RunToolAuthorization` to decide whether a model-declared application tool call may execute.
+Use `RunToolAuthorization` to decide whether a native or programmatic application tool call may execute.
+Code Mode invokes the same policy for each inner call before reserving its budget or starting its
+handler. The request includes `programmatic.parentToolCallId` and `programmatic.sequenceIndex`;
+allowing the outer execution Tool does not grant permission to its inner Tools.
 This policy permits only the `search` tool:
 
 ```ts twoslash
@@ -287,9 +290,10 @@ Omitting both the service and per-run hook allows calls without this additional 
 protected resources. Authenticate callers and authorize runtime operations as described in
 [operations](./operations#authorization-and-isolation).
 
-This hook does not authorize provider-executed calls or [Code Mode](./code-mode)'s inner programmatic calls.
-The Code Mode broker restricts inner calls to its allowlisted toolkit; enforce resource access
-inside those handlers.
+This hook does not authorize provider-executed calls. A denied [Code Mode](./code-mode) inner call
+returns a catchable `ProgrammaticToolAuthorizationDenied` outcome without consuming execution budget;
+other independent calls may already have completed. The broker also restricts calls to the eligible
+allowlist. Keep resource access checks inside handlers as appropriate for the application.
 
 ## Handle uncertain external effects {#durability}
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -100,7 +100,7 @@ implementations.
 | Delegate to another agent                  | [Subagents](../guide/subagents)                                   | Targets, bindings, permissions, budgets                                  |
 | Schedule new input                         | [Scheduling](../guide/operations#scheduled-input)                 | Owner policy, registered inputs, driver                                  |
 | React to external events                   | [Subscriptions](../guide/operations#event-subscriptions)          | Authenticated source, preparation, authorization                         |
-| Run generated JavaScript                   | [Code Mode](../guide/code-mode)                                   | Read-only tools and an isolated executor                                 |
+| Run generated JavaScript                   | [Code Mode](../guide/code-mode)                                   | Authorized tools and an isolated executor                                |
 | Run trusted local commands                 | [Sandbox execution](../guide/sandbox)                             | Executable, environment, output and time limits                          |
 | Capture, crawl, or interact with pages     | [Browser tools](../guide/browser)                                 | Browser binding or credentials, target policy                            |
 | Call tools on an MCP server                | [MCP servers](../guide/tools#mcp)                                 | Transport, `HttpClient` or process spawner, bounds                       |
@@ -159,7 +159,7 @@ MCP, redaction, and subagents to the engine.
 Optional `indexMemorySource` and `querySemanticMemory` use upstream
 Effect AI `EmbeddingModel` with an application-selected index and authoritative reader. See
 [semantic retrieval](../guide/context-management#semantic-memory). [`CodeMode.make`](../guide/code-mode) exposes generated
-JavaScript execution over an explicit read-only Tool allowlist. `WebCapture.make`,
+JavaScript execution over an explicit authorized Tool allowlist with bounded parallel calls. `WebCapture.make`,
 `WebCapture.makeScrape`, and `WebCapture.makeExtract` expose a supplied `PageCapture` service as tools.
 Capture calls have uncertain external outcomes;
 extraction retains its schema's service requirements.

--- a/examples/code-mode-cloudflare/README.md
+++ b/examples/code-mode-cloudflare/README.md
@@ -123,3 +123,27 @@ binding.
 See Cloudflare's [Dynamic Workers guide](https://developers.cloudflare.com/dynamic-workers/getting-started/)
 for Worker Loader setup. This example runs in deployment class E and makes no durable-execution
 claim. Without `OPENAI_API_KEY` the Worker runs the deterministic scripted profile.
+
+## Compare native calls and Code Mode
+
+Run the local, credential-free benchmark with no other builds or tests running:
+
+```sh
+vp run -F @effect-agent/example-code-mode-cloudflare benchmark
+```
+
+The benchmark uses real Miniflare/workerd Dynamic Workers and a scripted Effect AI model. It
+compares native calls, sequential Code Mode, and concurrent Code Mode for independent customer /
+invoice reads and project creation followed by three task writes. Each model request and Tool I/O
+waits 20 ms. Every answer must consume the actual results; assertions check dependencies, model
+round trips, observed concurrency, call counts, and completed finalizers. Ordinary tests run one
+correctness sample of each combination; the explicit benchmark retains two warmups and 20 samples
+per combination in rotating mode order.
+
+`/tmp/code-mode-benchmark.json` contains all samples and end-to-end p50/p95 latency, model calls,
+and observed Tool concurrency. Set `CODE_MODE_BENCHMARK_OUT` to change the output path. The Node
+monotonic timer starts before dispatch and ends after the complete JSON reply has been consumed,
+including runtime acquisition, generated-worker startup, tools, and final model response. The host
+is warm; every Code Mode pass creates a fresh Dynamic Worker. These are local scripted measurements,
+not live-provider or deployed Cloudflare latency. Partial failure, timeout, interruption, and
+unknown-outcome recovery are covered by framework regression tests.

--- a/examples/code-mode-cloudflare/test/benchmark-contract.ts
+++ b/examples/code-mode-cloudflare/test/benchmark-contract.ts
@@ -1,0 +1,12 @@
+import { Schema } from "effect";
+
+export const Mode = Schema.Literals(["native", "sequential", "concurrent"]);
+export const Workload = Schema.Literals(["reads", "writes"]);
+
+export const BenchmarkResult = Schema.Struct({
+  answer: Schema.Json,
+  modelCalls: Schema.Natural,
+  toolCalls: Schema.Natural,
+  peakConcurrency: Schema.Natural,
+  activeAfterRun: Schema.Natural,
+});

--- a/examples/code-mode-cloudflare/test/benchmark-worker.ts
+++ b/examples/code-mode-cloudflare/test/benchmark-worker.ts
@@ -1,0 +1,284 @@
+import * as CodeMode from "@effect-agent/capabilities/CodeMode";
+import * as Agent from "@effect-agent/core/Agent";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import { RunContextPreparationPassthrough } from "@effect-agent/engine/RunOptions";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { dynamicWorkerCodeExecutorLayer } from "@effect-agent/platform-cloudflare/CloudflareCodeMode";
+import { CodeExecutionLimits } from "@effect-agent/sandbox/CodeExecutor";
+import { Duration, Effect, Layer, Schema, Stream } from "effect";
+import {
+  LanguageModel,
+  Model,
+  Tool,
+  Toolkit,
+  type Response as AiResponse,
+} from "effect/unstable/ai";
+
+import { Mode, Workload } from "./benchmark-contract.ts";
+
+const Project = Tool.make("createProject", {
+  parameters: Schema.Struct({ name: Schema.String }),
+  success: Schema.Struct({ id: Schema.String }),
+});
+
+const Task = Tool.make("createTask", {
+  parameters: Schema.Struct({ projectId: Schema.String, title: Schema.String }),
+  success: Schema.Struct({ title: Schema.String }),
+});
+
+const Customer = Tool.make("getCustomer", {
+  parameters: Schema.Struct({ id: Schema.String }),
+  success: Schema.Struct({ name: Schema.String }),
+});
+
+const Invoices = Tool.make("listInvoices", {
+  parameters: Schema.Struct({ customerId: Schema.String }),
+  success: Schema.Array(Schema.Struct({ paid: Schema.Boolean, amountCents: Schema.Int })),
+});
+
+const native = Toolkit.make(Project, Task, Customer, Invoices);
+const titles = ["Design", "Build", "Ship"];
+const usage = { inputTokens: {}, outputTokens: {} };
+
+const toolCall = (id: string, name: string, params: Schema.Json): AiResponse.StreamPartEncoded => ({
+  type: "tool-call",
+  id,
+  name,
+  params,
+});
+
+const benchmark = Effect.fn("benchmark")(function* (
+  mode: typeof Mode.Type,
+  workload: typeof Workload.Type,
+  loader: WorkerLoader,
+) {
+  let active = 0;
+  let peakConcurrency = 0;
+  let toolCalls = 0;
+  let modelCalls = 0;
+  let projectCreated = false;
+
+  const io = <A>(result: () => A) =>
+    Effect.gen(function* () {
+      active++;
+      toolCalls++;
+      peakConcurrency = Math.max(peakConcurrency, active);
+      yield* Effect.sleep("20 millis");
+
+      return result();
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          active--;
+        }),
+      ),
+    );
+
+  const handlers = native.toLayer({
+    createProject: () =>
+      io(() => {
+        projectCreated = true;
+
+        return { id: "launch" };
+      }),
+    createTask: ({ projectId, title }) =>
+      io(() => {
+        if (!projectCreated || projectId !== "launch")
+          throw new Error("Task ran before its project");
+
+        return { title };
+      }),
+    getCustomer: () => io(() => ({ name: "Acme" })),
+    listInvoices: () =>
+      io(() => [
+        { paid: false, amountCents: 1_200 },
+        { paid: true, amountCents: 700 },
+        { paid: false, amountCents: 800 },
+      ]),
+  });
+
+  const codeMode = CodeMode.make("run_code", {
+    description: "Perform the workload and return its compact answer",
+    tools: {
+      tools: {
+        createProject: Project,
+        createTask: Task,
+        getCustomer: Customer,
+        listInvoices: Invoices,
+      },
+    },
+    limits: CodeExecutionLimits.make({
+      maxSourceBytes: 16_384,
+      maxWallTime: Duration.seconds(10),
+      maxLogBytes: 1_024,
+      maxResultBytes: 16_384,
+      maxHostCalls: 8,
+      maxHostCallConcurrency: mode === "sequential" ? 1 : 3,
+      maxHostCallArgumentBytes: 1_024,
+      maxHostCallResultBytes: 16_384,
+    }),
+  });
+
+  const code =
+    workload === "writes"
+      ? `async () => {
+    const project = await tools.createProject({ name: "Launch" });
+    const tasks = ${
+      mode === "sequential"
+        ? '[await tools.createTask({ projectId: project.id, title: "Design" }), await tools.createTask({ projectId: project.id, title: "Build" }), await tools.createTask({ projectId: project.id, title: "Ship" })]'
+        : 'await Promise.all(["Design", "Build", "Ship"].map(title => tools.createTask({ projectId: project.id, title })))'
+    };
+    return { projectId: project.id, tasksCreated: tasks.length };
+  }`
+      : `async () => {
+    const [customer, invoices] = ${
+      mode === "sequential"
+        ? '[await tools.getCustomer({ id: "acme" }), await tools.listInvoices({ customerId: "acme" })]'
+        : 'await Promise.all([tools.getCustomer({ id: "acme" }), tools.listInvoices({ customerId: "acme" })])'
+    };
+    return { customer: customer.name, unpaidCents: invoices.filter(i => !i.paid).reduce((sum, i) => sum + i.amountCents, 0) };
+  }`;
+
+  const model = Model.make(
+    "scripted",
+    "20ms-model",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: ({ prompt }) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const turn = modelCalls++;
+
+              yield* Effect.sleep("20 millis");
+
+              const results = prompt.content
+                .filter((message) => message.role === "tool")
+                .flatMap((message) => message.content)
+                .filter((part) => part.type === "tool-result");
+
+              if (results.some((result) => result.isFailure))
+                return yield* Effect.die("Workload tool failed");
+              let calls: ReadonlyArray<AiResponse.StreamPartEncoded> | undefined;
+
+              if (turn === 0) {
+                calls =
+                  mode !== "native"
+                    ? [toolCall("program", "run_code", { code })]
+                    : workload === "writes"
+                      ? [toolCall("project", "createProject", { name: "Launch" })]
+                      : [
+                          toolCall("customer", "getCustomer", { id: "acme" }),
+                          toolCall("invoices", "listInvoices", { customerId: "acme" }),
+                        ];
+              } else if (mode === "native" && workload === "writes" && turn === 1) {
+                const project = Schema.decodeUnknownSync(Project.successSchema)(
+                  results.find((r) => r.name === "createProject")?.result,
+                );
+
+                calls = titles.map((title) =>
+                  toolCall(title, "createTask", { projectId: project.id, title }),
+                );
+              }
+              if (calls !== undefined)
+                return Stream.fromIterable<AiResponse.StreamPartEncoded>([
+                  ...calls,
+                  { type: "finish", reason: "tool-calls", usage },
+                ]);
+              let answer: Schema.Json;
+
+              if (mode !== "native") {
+                answer = Schema.decodeUnknownSync(CodeMode.CodeModeSuccess)(
+                  results[0]?.result,
+                ).result;
+              } else if (workload === "writes") {
+                const project = Schema.decodeUnknownSync(Project.successSchema)(
+                  results.find((r) => r.name === "createProject")?.result,
+                );
+
+                const tasks = results
+                  .filter((r) => r.name === "createTask")
+                  .map((r) => Schema.decodeUnknownSync(Task.successSchema)(r.result));
+
+                answer = { projectId: project.id, tasksCreated: tasks.length };
+              } else {
+                const customer = Schema.decodeUnknownSync(Customer.successSchema)(
+                  results.find((r) => r.name === "getCustomer")?.result,
+                );
+
+                const invoices = Schema.decodeUnknownSync(Invoices.successSchema)(
+                  results.find((r) => r.name === "listInvoices")?.result,
+                );
+
+                answer = {
+                  customer: customer.name,
+                  unpaidCents: invoices
+                    .filter((i) => !i.paid)
+                    .reduce((sum, i) => sum + i.amountCents, 0),
+                };
+              }
+
+              return Stream.fromIterable<AiResponse.StreamPartEncoded>([
+                { type: "text-start", id: "answer" },
+                { type: "text-delta", id: "answer", delta: JSON.stringify(answer) },
+                { type: "text-end", id: "answer" },
+                { type: "finish", reason: "stop", usage },
+              ]);
+            }),
+          ),
+      }),
+    ),
+  );
+
+  const definition = Agent.make("benchmark", {
+    input: Schema.String,
+    output: Schema.Json,
+    instructions: "Execute and summarize.",
+    toolkit: mode === "native" ? native : Toolkit.make(codeMode.tool),
+    policy: { maxTurns: 3, maxToolCalls: 8, maxDuration: "15 seconds", toolConcurrency: 3 },
+  });
+
+  const services = Layer.merge(
+    handlers,
+    codeMode.handlers.pipe(Layer.provide([handlers, dynamicWorkerCodeExecutorLayer({ loader })])),
+  );
+
+  const result = yield* AgentRuntime.run(Agent.withModel(definition, model), workload).pipe(
+    Effect.provide(services),
+    Effect.provide([
+      IdGenerator.layer,
+      ThreadHistory.layerTransient,
+      RunContextPreparationPassthrough,
+    ]),
+    Effect.scoped,
+  );
+
+  return { answer: result.output, modelCalls, toolCalls, peakConcurrency, activeAfterRun: active };
+});
+
+export default {
+  async fetch(request: Request, env: { readonly LOADER: WorkerLoader }): Promise<Response> {
+    const url = new URL(request.url);
+
+    const program = Effect.gen(function* () {
+      const mode = yield* Schema.decodeUnknownEffect(Mode)(url.searchParams.get("mode"));
+
+      const workload = yield* Schema.decodeUnknownEffect(Workload)(
+        url.searchParams.get("workload"),
+      );
+
+      return yield* benchmark(mode, workload, env.LOADER);
+    });
+
+    return await Effect.runPromise(
+      program.pipe(
+        Effect.map((result) => Response.json(result)),
+        Effect.catchCause((cause) =>
+          Effect.succeed(Response.json({ failure: String(cause) }, { status: 500 })),
+        ),
+      ),
+    );
+  },
+};

--- a/examples/code-mode-cloudflare/test/benchmark.test.ts
+++ b/examples/code-mode-cloudflare/test/benchmark.test.ts
@@ -1,0 +1,169 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { Schema } from "effect";
+import { build } from "esbuild";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
+import { afterAll, beforeAll, expect, it } from "vite-plus/test";
+
+import { BenchmarkResult, Mode, Workload } from "./benchmark-contract.ts";
+
+const Sample = Schema.Struct({
+  mode: Mode,
+  workload: Workload,
+  elapsedMs: Schema.Number,
+  warmup: Schema.Boolean,
+  result: BenchmarkResult,
+});
+
+type Sample = typeof Sample.Type;
+let runtime: Miniflare;
+let fixtureSha256 = "";
+
+beforeAll(async () => {
+  const bundled = await build({
+    entryPoints: [join(import.meta.dirname, "benchmark-worker.ts")],
+    bundle: true,
+    write: false,
+    format: "esm",
+    target: "es2022",
+    platform: "browser",
+    conditions: ["workerd", "worker", "browser"],
+    external: ["cloudflare:*", "node:*"],
+    logLevel: "silent",
+  });
+
+  const output = bundled.outputFiles[0];
+
+  if (output === undefined) throw new Error("Missing benchmark bundle");
+  fixtureSha256 = createHash("sha256").update(output.text).digest("hex");
+  runtime = new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script: output.text,
+      modulesRoot: "/",
+      compatibilityDate: "2025-05-01",
+      compatibilityFlags: ["nodejs_compat", "no_handle_cross_request_promise_resolution"],
+      workerLoaders: { LOADER: {} },
+    }),
+  );
+  await runtime.ready;
+}, 120_000);
+afterAll(async () => {
+  await runtime?.dispose();
+});
+
+const run = async (
+  mode: Sample["mode"],
+  workload: Sample["workload"],
+  warmup: boolean,
+): Promise<Sample> => {
+  const started = performance.now();
+
+  const response = await runtime.dispatchFetch(
+    `http://benchmark/?mode=${mode}&workload=${workload}`,
+  );
+
+  const payload: unknown = await response.json();
+  const elapsedMs = performance.now() - started;
+
+  if (response.status !== 200)
+    throw new Error(`Benchmark request failed: ${JSON.stringify(payload)}`);
+  const result = Schema.decodeUnknownSync(BenchmarkResult)(payload);
+
+  expect(result.answer).toEqual(
+    workload === "writes"
+      ? { projectId: "launch", tasksCreated: 3 }
+      : { customer: "Acme", unpaidCents: 2_000 },
+  );
+  expect(result.toolCalls).toBe(workload === "writes" ? 4 : 2);
+  expect(result.modelCalls).toBe(mode === "native" && workload === "writes" ? 3 : 2);
+  expect(result.peakConcurrency).toBe(mode === "sequential" ? 1 : workload === "writes" ? 3 : 2);
+  expect(result.activeAfterRun).toBe(0);
+
+  return { mode, workload, elapsedMs, warmup, result };
+};
+
+const modes = ["native", "sequential", "concurrent"] as const;
+const workloads = ["reads", "writes"] as const;
+
+it("executes equivalent native, sequential and concurrent workloads in workerd", async () => {
+  const samples: Array<Sample> = [];
+
+  for (const workload of workloads)
+    for (const mode of modes) samples.push(await run(mode, workload, true));
+  expect(samples).toHaveLength(6);
+}, 60_000);
+
+it.skipIf(process.env.CODE_MODE_BENCHMARK !== "1")(
+  "measures complete replies with matched model and I/O delays",
+  async () => {
+    const samples: Array<Sample> = [];
+
+    const failures: Array<{
+      readonly workload: string;
+      readonly mode: string;
+      readonly message: string;
+    }> = [];
+
+    try {
+      for (let iteration = -2; iteration < 20; iteration++) {
+        // Rotate execution order to reduce bias from warm caches and host drift.
+        const offset = (iteration + 2) % modes.length;
+        const order = [...modes.slice(offset), ...modes.slice(0, offset)];
+
+        for (const workload of workloads)
+          for (const mode of order)
+            try {
+              samples.push(await run(mode, workload, iteration < 0));
+            } catch (cause) {
+              failures.push({ workload, mode, message: String(cause) });
+              throw cause;
+            }
+      }
+      expect(samples).toHaveLength(132);
+    } finally {
+      const summary = workloads.flatMap((workload) =>
+        modes.map((mode) => {
+          const selected = samples.filter(
+            (s) => !s.warmup && s.workload === workload && s.mode === mode,
+          );
+
+          const sorted = selected.map((s) => s.elapsedMs).sort((a, b) => a - b);
+
+          return {
+            workload,
+            mode,
+            samples: sorted.length,
+            p50Ms: sorted[Math.ceil(sorted.length * 0.5) - 1],
+            p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
+            modelCalls: selected[0]?.result.modelCalls,
+            peakConcurrency: selected[0]?.result.peakConcurrency,
+          };
+        }),
+      );
+
+      const report = {
+        environment: { node: process.version, platform: process.platform, arch: process.arch },
+        clock: "Node performance.now: before dispatchFetch through fully consumed reply",
+        scope:
+          "local Miniflare/workerd; scripted model 20ms/request; tool I/O 20ms/call; fresh Dynamic Worker per Code Mode pass",
+        revision: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+        dirty: execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" }).length > 0,
+        fixtureSha256,
+        failures,
+        samples,
+        summary,
+      };
+
+      await writeFile(
+        process.env.CODE_MODE_BENCHMARK_OUT ?? "/tmp/code-mode-benchmark.json",
+        JSON.stringify(report, null, 2),
+      );
+      console.log(JSON.stringify(summary, null, 2));
+    }
+  },
+  120_000,
+);

--- a/examples/code-mode-cloudflare/vite.config.ts
+++ b/examples/code-mode-cloudflare/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig, type UserConfig } from "vite-plus";
 // retaining dependency file hashes. The lockfile covers dependency additions.
 const run: NonNullable<UserConfig["run"]> = {
   tasks: {
+    benchmark: {
+      command: "CODE_MODE_BENCHMARK=1 vitest run test/benchmark.test.ts",
+      cache: false,
+    },
     test: {
       command: "vitest run",
       input: [

--- a/packages/capabilities/src/CodeMode.ts
+++ b/packages/capabilities/src/CodeMode.ts
@@ -2,13 +2,13 @@ import {
   AdditionalToolCatalog,
   IncludesCatalogDocumentation,
 } from "@effect-agent/core/ToolExposure";
-import { getToolExecutionClass } from "@effect-agent/engine/DurableStep";
 import {
   type ToolBrokerConfigurationError,
   type ToolBrokerUnavailableError,
   ToolBroker,
   type ProgrammaticCallOutcome,
   type ToolBrokerPass,
+  ProgrammaticCallRecord,
 } from "@effect-agent/engine/ToolBroker";
 import { CurrentToolCatalog } from "@effect-agent/engine/ToolExposure";
 import {
@@ -24,7 +24,17 @@ import {
   type CodeHostCallResult,
 } from "@effect-agent/sandbox/CodeExecutor";
 import { NetworkDisabled } from "@effect-agent/sandbox/Sandbox";
-import { type Layer, Context, Duration, Effect, Option, Schema, type Scope } from "effect";
+import {
+  type Layer,
+  Cause,
+  Context,
+  Duration,
+  Effect,
+  Exit,
+  Option,
+  Schema,
+  type Scope,
+} from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import { utf8ByteLength } from "./internal/utf8.ts";
@@ -46,6 +56,14 @@ const BoundedErrorTag = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 const BoundedLogLine = Schema.String.check(Schema.isMaxLength(16 * 1024));
 const BoundedLogs = Schema.Array(BoundedLogLine).check(Schema.isMaxLength(4_096));
 const BoundedCode = Schema.NonEmptyString.check(Schema.isMaxLength(512 * 1024));
+
+/** A pass-local report, available to the host even when the caller interrupts execution. */
+export const CodeModePassReport = Schema.Struct({
+  status: Schema.Literals(["completed", "failed", "interrupted", "defect"]),
+  calls: Schema.Array(ProgrammaticCallRecord),
+});
+
+export type CodeModePassReport = typeof CodeModePassReport.Type;
 
 const encodedJsonByteLength = (value: unknown): number | undefined => {
   try {
@@ -85,6 +103,9 @@ export class CodeModeFailure extends Schema.TaggedError<CodeModeFailure>()("Code
   message: BoundedFailureText,
   logs: BoundedLogs,
   thrown: Schema.optionalKey(Schema.Json),
+  /** Invocation-ordered evidence that fits the egress budget. This is not a replay plan. */
+  calls: Schema.optionalKey(Schema.Array(ProgrammaticCallRecord)),
+  omittedCalls: Schema.optionalKey(Schema.Natural),
 }) {}
 
 /** A selective documentation request is invalid or cannot fit its declared byte budget. */
@@ -170,8 +191,7 @@ export interface CodeModeOptions<
   readonly includeDeclarations?: boolean | undefined;
   /**
    * Explicit allowlist: namespace name → method name → native Effect AI
-   * Tool. Every Tool must be annotated `readonly` (`ToolExecutionClass`) and
-   * must not require approval; construction fails closed otherwise.
+   * Tool. Reads and mutations are allowed; calls requiring additional approval fail closed.
    */
   readonly tools: Namespaces;
   /** Executor limits for one pass; a bounded default applies when omitted. */
@@ -181,6 +201,14 @@ export interface CodeModeOptions<
    * result, captured logs, and any thrown value (CAP-016). Default 65536.
    */
   readonly maxEgressBytes?: number | undefined;
+  /**
+   * Host-only ephemeral report after executor resources and invocation fibers close, including
+   * failure, defect, and interruption. It contains no arguments/results and is never a checkpoint.
+   * Keep this total callback bounded; its services are captured with the handler Layer.
+   */
+  readonly onPassExit?:
+    | ((report: CodeModePassReport) => Effect.Effect<void, never, RedactionRequirements>)
+    | undefined;
   /**
    * Optional aggregate redaction pass applied to the model-visible egress
    * before the byte budget. Its services are acquired with the handler Layer;
@@ -572,13 +600,6 @@ const make = <
           `Code Mode method ${namespace}.${method} is not a valid JavaScript identifier`,
         );
       }
-      const executionClass = getToolExecutionClass(tool);
-
-      if (executionClass !== "readonly") {
-        throw new Error(
-          `Code Mode rejects Tool ${tool.name} (${namespace}.${method}): its execution class is ${executionClass}; the first slice accepts only Tools annotated readonly (an unannotated Tool reads as uncertain)`,
-        );
-      }
       const approval = tool.needsApproval;
 
       if (approval !== undefined && approval !== false) {
@@ -674,7 +695,7 @@ const make = <
     options.description,
     "",
     "The `code` argument must be one JavaScript async function expression; the sandbox invokes it exactly once with no arguments. It runs isolated with no ambient network, filesystem, environment, or secrets. Return one JSON value. `console.log` output is captured within a bounded budget and returned alongside the result.",
-    "Namespace methods return Promises. An expected Tool failure rejects with a JSON envelope carrying a stable `_tag`; catch it to branch. Calls are strictly sequential — issue one host call at a time.",
+    "Namespace methods return Promises. An expected Tool failure rejects with a JSON envelope carrying a stable `_tag`; catch it to branch. Use Promise.all for independent calls; the host bounds concurrency. Await every call you need. Writes may complete before a failure: inspect call outcomes and never blindly retry a program.",
     ...(options.includeDeclarations === false
       ? []
       : ["", "Sandbox globals:", "```ts", declarations, "```"]),
@@ -687,8 +708,8 @@ const make = <
     failure: CodeModeFailure,
     failureMode: "return",
   })
-    .annotate(Tool.Readonly, true)
-    .annotate(ToolExecutionClassAnnotation, "readonly")
+    .annotate(Tool.Readonly, false)
+    .annotate(ToolExecutionClassAnnotation, "uncertain")
     .annotate(IncludesCatalogDocumentation, options.includeDeclarations !== false)
     .annotate(
       AdditionalToolCatalog,
@@ -911,18 +932,41 @@ const make = <
                 : [CodeExecutionNamespace.make({ name: namespace.name, methods: allowed })];
             });
 
+      let calls: ReadonlyArray<ProgrammaticCallRecord> = [];
+
       const execution = Effect.gen(function* () {
         const pass = yield* broker.openPass(withHandler, {
           maxResultBytes: limits.maxHostCallResultBytes,
+          concurrency: limits.maxHostCallConcurrency ?? 4,
         });
 
         const host = CodeExecutionHost.of({
           call: (hostCall) => routeHostCall(pass, hostCall, visiblePaths),
         });
 
-        return yield* executor
-          .execute(executionRequest(parameters.code, visibleNamespaces))
-          .pipe(Effect.provideService(CodeExecutionHost, host));
+        return yield* executor.execute(executionRequest(parameters.code, visibleNamespaces)).pipe(
+          Effect.provideService(CodeExecutionHost, host),
+          Effect.scoped,
+          Effect.onExit((exit) =>
+            Effect.gen(function* () {
+              calls = yield* pass.snapshot;
+              if (options.onPassExit !== undefined) {
+                yield* Effect.scoped(
+                  options.onPassExit({
+                    status: Exit.isSuccess(exit)
+                      ? "completed"
+                      : Cause.hasInterrupts(exit.cause)
+                        ? "interrupted"
+                        : Cause.hasDies(exit.cause)
+                          ? "defect"
+                          : "failed",
+                    calls,
+                  }),
+                ).pipe(Effect.provideContext(redactionServices));
+              }
+            }),
+          ),
+        );
       }).pipe(
         Effect.scoped,
         // The live engine broker is re-provided innermost so a Layer built
@@ -940,13 +984,50 @@ const make = <
         CodeExecutionError | ToolBrokerUnavailableError | ToolBrokerConfigurationError
       >;
 
-      const result = yield* execution.pipe(
-        Effect.catch((error) =>
-          failureEgress(error).pipe(Effect.flatMap((failure) => Effect.fail(failure))),
-        ),
-      );
+      return yield* execution.pipe(
+        Effect.catch((error) => failureEgress(error).pipe(Effect.flatMap(Effect.fail))),
+        Effect.flatMap(successEgress),
+        Effect.mapError((failure) => {
+          if (calls.length === 0) return failure;
 
-      return yield* successEgress(result);
+          const complete = CodeModeFailure.make({
+            errorTag: failure.errorTag,
+            message: failure.message,
+            logs: failure.logs,
+            ...(failure.thrown === undefined ? {} : { thrown: failure.thrown }),
+            calls,
+            omittedCalls: 0,
+          });
+
+          if ((encodedJsonByteLength(complete) ?? Infinity) <= maxEgressBytes) return complete;
+
+          // Evidence takes priority over logs and thrown values. Never silently omit calls.
+          const base = {
+            errorTag: failure.errorTag,
+            message: truncateToUtf8Bytes(failure.message, Math.min(256, maxEgressBytes / 4)),
+            logs: [],
+          };
+
+          const kept: Array<ProgrammaticCallRecord> = [];
+
+          for (const call of calls) {
+            const candidate = CodeModeFailure.make({
+              ...base,
+              calls: [...kept, call],
+              omittedCalls: calls.length - kept.length - 1,
+            });
+
+            if ((encodedJsonByteLength(candidate) ?? Infinity) > maxEgressBytes) break;
+            kept.push(call);
+          }
+
+          return CodeModeFailure.make({
+            ...base,
+            calls: kept,
+            omittedCalls: calls.length - kept.length,
+          });
+        }),
+      );
     });
 
     return { [name]: invoke } as unknown as Toolkit.HandlersFrom<CodeModeTools<Name>>;

--- a/packages/capabilities/test/code-mode.test.ts
+++ b/packages/capabilities/test/code-mode.test.ts
@@ -60,14 +60,14 @@ const ArraySchema = Tool.dynamic("array_schema", {
 }).annotate(ToolExecutionClass, "readonly");
 
 describe("CAP-014 CodeMode.make construction", () => {
-  it("builds a readonly-annotated Tool and encoded-side declarations", () => {
+  it("builds an uncertain Tool and encoded-side declarations", () => {
     const definition = CodeMode.make("run_javascript", {
       description: "Run JavaScript over the warehouse",
       tools: { warehouse: { query: Query } },
     });
 
-    expect(Context.get(definition.tool.annotations, Tool.Readonly)).toBe(true);
-    expect(Context.get(definition.tool.annotations, ToolExecutionClass)).toBe("readonly");
+    expect(Context.get(definition.tool.annotations, Tool.Readonly)).toBe(false);
+    expect(Context.get(definition.tool.annotations, ToolExecutionClass)).toBe("uncertain");
     expect(definition.tool.failureMode).toBe("return");
     expect(definition.declarations).toContain("declare const warehouse:");
     expect(definition.declarations).toContain("readonly sql: string");
@@ -78,13 +78,13 @@ describe("CAP-014 CodeMode.make construction", () => {
     expect(definition.namespaces[0]).toMatchObject({ name: "warehouse", methods: ["query"] });
   });
 
-  it("CAP-014 rejects a Tool that is not annotated readonly", () => {
+  it("allows an authorized mutating Tool without a readonly annotation", () => {
     expect(() =>
       CodeMode.make("run_javascript", {
         description: "d",
         tools: { ns: { call: Unannotated } },
       }),
-    ).toThrow(/uncertain/);
+    ).not.toThrow();
   });
 
   it("CAP-014 rejects an approval-requiring Tool at construction", () => {
@@ -710,6 +710,7 @@ it.effect("filters executor inventory and guessed calls using the live invocatio
       Effect.provideService(ToolBroker, {
         openPass: () =>
           Effect.succeed({
+            snapshot: Effect.succeed([]),
             invoke: () =>
               Ref.update(brokerCalls, (count) => count + 1).pipe(
                 Effect.as({
@@ -820,6 +821,24 @@ describe("Code Mode type proofs", () => {
 
     expect(requirements && toolRequirements && errors).toBe(true);
   });
+  it("captures report callback requirements without widening Tool errors or requirements", () => {
+    const reported = CodeMode.make("reported", {
+      description: "d",
+      tools: { ns: { call: Unannotated } },
+      onPassExit: () => Effect.asVoid(RedactionPolicy),
+    });
+
+    const requirements: Equal<
+      Extract<LayerContext<typeof reported.handlers>, RedactionPolicy>,
+      RedactionPolicy
+    > = true;
+
+    const errors: Equal<Layer.Error<typeof reported.handlers>, never> = true;
+    const toolRequirements: Equal<Tool.HandlerServices<typeof reported.tool>, ToolBroker> = true;
+
+    expect(requirements && errors && toolRequirements).toBe(true);
+  });
+
   it("pins the envelope failure, executor requirement, and budgeted success", () => {
     const failureProof: HandlerFailureIsEnvelope = true;
     const executorProof: RequiresExecutor = true;

--- a/packages/capabilities/test/web-capture.test.ts
+++ b/packages/capabilities/test/web-capture.test.ts
@@ -33,7 +33,7 @@ import { Context, Effect, Layer, Ref, Schema, SchemaGetter, Stream } from "effec
 import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 describe("WebCapture construction", () => {
-  it("classifies browser JavaScript as uncertain and excludes capture from readonly Code Mode", () => {
+  it("keeps browser JavaScript uncertain when included in Code Mode", () => {
     const definition = WebCapture.make("read_webpage", {
       description: "Read documentation pages.",
       urls: ["docs.example.com", "*.Effect.website"],
@@ -52,7 +52,7 @@ describe("WebCapture construction", () => {
         description: "Read a page through Code Mode",
         tools: { browser: { capture: definition.tool } },
       }),
-    ).toThrow(/uncertain/);
+    ).not.toThrow();
   });
 
   it("snapshots and freezes security-sensitive host and action policies", () => {

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -392,7 +392,7 @@ export type RunToolAuthorizationDecision =
   | { readonly _tag: "denied"; readonly reason: string };
 
 /**
- * Exact authority presented before one model-declared application Tool Handler may start.
+ * Exact authority presented before one application Tool Handler may start.
  *
  * `input` is the Agent Schema's encoded Run input. Durable coordinators replace it with the exact
  * canonical Submission input admitted for the logical Run on every Attempt.
@@ -406,9 +406,16 @@ export interface RunToolAuthorizationRequest {
   readonly turn: number;
   readonly input: unknown;
   readonly call: RunToolCallDescriptor;
+  /** Present for an ephemeral inner invocation; the outer Tool's approval grants no inner authority. */
+  readonly programmatic?:
+    | {
+        readonly parentToolCallId: ToolCallId;
+        readonly sequenceIndex: number;
+      }
+    | undefined;
 }
 
-/** Host policy invoked for each still-executable model-declared call in an application batch. */
+/** Host policy invoked before each executable native or programmatic application call. */
 export interface RunToolAuthorizationHook<Error = never, Requirements = never> {
   readonly authorize: (
     request: RunToolAuthorizationRequest,
@@ -442,7 +449,7 @@ export const RunContextPreparationPassthrough: Layer.Layer<RunContextPreparation
 )({});
 
 /**
- * Host action-time authority for model-declared application Tools. Implementations close over
+ * Host action-time authority for native and programmatic application Tools. Implementations close over
  * their dependencies at Layer construction and return a denial when execution is not authorized.
  * Durable coordinators capture this service once and retain it across replacement Attempts.
  * Ephemeral Runs also resolve this service at their Run boundary. A typed per-run
@@ -938,7 +945,9 @@ export interface RunOptions<HookError = never, HookRequirements = never> {
    * It invokes the policy for every still-executable call after complete-batch validation and approval, but
    * before durable preparation or any Handler permit. A resumed durable batch invokes it again
    * with the same canonical Run/Turn/input authority and Tool Call identity. Programmatic
-   * `ToolBroker` calls are outside this hook.
+   * `ToolBroker` calls invoke it after schema/visibility checks and before budget reservation or
+   * execution, with their parent identity in `programmatic`. Inner denials become catchable
+   * outcomes; other independent calls may already have completed.
    */
   readonly toolAuthorization?: RunToolAuthorizationHook<HookError, HookRequirements> | undefined;
   /**

--- a/packages/engine/src/ToolBroker.ts
+++ b/packages/engine/src/ToolBroker.ts
@@ -24,7 +24,7 @@ export interface ProgrammaticToolInput {
 /** The handler ran and settled with an owned JSON snapshot of its encoded success value. */
 export interface ProgrammaticCallSuccess {
   readonly _tag: "ProgrammaticCallSuccess";
-  /** Broker-owned zero-based index of this call within the pass (RUN-016). */
+  /** Broker-owned invocation index within the pass; rejected calls leave gaps. */
   readonly index: number;
   readonly encodedResult: unknown;
 }
@@ -42,7 +42,7 @@ export interface ProgrammaticCallFailure {
 
 /**
  * The call never produced a settled handler result: a broker preflight
- * rejected it (concurrency, budget, unknown Tool, approval-requiring Tool,
+ * rejected it (authorization, budget, unknown Tool, approval-requiring Tool,
  * invalid parameters), the handler failed in its typed error channel, or the
  * result failed encoding or the broker-owned size bound. `errorTag` and
  * `message` are the same bounded projection the direct path uses for
@@ -67,8 +67,24 @@ export type ProgrammaticCallOutcome =
   | ProgrammaticCallFailure
   | ProgrammaticCallError;
 
+/**
+ * Ephemeral execution evidence, ordered by invocation rather than completion. No arguments or
+ * results are copied into this diagnostic. A started call without a confirmed result is uncertain;
+ * a failed call is a confirmed failure, not a promise that external effects were rolled back.
+ */
+export const ProgrammaticCallRecord = Schema.Struct({
+  sequenceIndex: Schema.Natural,
+  toolName: Schema.String,
+  status: Schema.Literals(["not-started", "succeeded", "failed", "uncertain"]),
+  errorTag: Schema.optionalKey(Schema.String),
+});
+
+export type ProgrammaticCallRecord = typeof ProgrammaticCallRecord.Type;
+
 /** Broker-owned per-pass policy for results crossing back into the sandbox. */
 export interface ToolBrokerPassOptions {
+  /** Maximum active invocations in this pass, from one through 64. Defaults to four. */
+  readonly concurrency?: number | undefined;
   /**
    * Maximum UTF-8 byte size of one encoded success result at the sandbox
    * boundary. The returned value is decoded from the exact JSON representation
@@ -84,12 +100,14 @@ export interface ToolBrokerPassOptions {
 }
 
 /**
- * One open programmatic pass, bound to one outer Tool Call. Calls are
- * strictly sequential: an invocation issued while another from the same pass
- * is unsettled fails with a typed concurrency error outcome.
+ * One open programmatic pass, bound to one outer Tool Call. A finite Effect Semaphore bounds
+ * execution. The caller owns invocation fibers and must join or interrupt them before leaving
+ * its Scope. Results return as soon as they settle, without waiting for unrelated earlier calls.
  */
 export interface ToolBrokerPass {
   readonly invoke: (input: ProgrammaticToolInput) => Effect.Effect<ProgrammaticCallOutcome>;
+  /** Owned snapshot in invocation order, including interrupted and rejected calls. Never replay it. */
+  readonly snapshot: Effect.Effect<ReadonlyArray<ProgrammaticCallRecord>>;
 }
 
 /** The broker was used outside a live Tool batch; there is nothing to bind to. */

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -284,6 +284,7 @@ import {
   RunResumeUsageSchema,
   RunContextPreparation,
   RunToolAuthorization,
+  type RunToolAuthorizationHook,
   RunToolScheduling,
   type PreparedRunContext,
   type RunContextPreparationError,
@@ -439,6 +440,7 @@ type InterpreterRequirements<
   | ThreadHistory
   | ContextCompactor
   | ModelUsageAccounting
+  | ProgrammaticToolAuthorization
   | HookRequirements
   | InstructionRequirements;
 
@@ -2184,7 +2186,10 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
   | AgentChildPending
   | AiError.AiError
   | Tool.HandlerError<ToolUnion<Tools>>,
-  HookRequirements | ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
+  | HookRequirements
+  | ToolSpanTelemetry
+  | ProgrammaticToolAuthorization
+  | Tool.HandlerServices<ToolUnion<Tools>>
 > =>
   Stream.unwrap(
     Effect.gen(function* () {
@@ -2352,7 +2357,7 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
         Stream.Stream<
           RunEvent,
           ModelProtocolError | AiError.AiError | Tool.HandlerError<ToolUnion<Tools>>,
-          ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
+          ToolSpanTelemetry | ProgrammaticToolAuthorization | Tool.HandlerServices<ToolUnion<Tools>>
         >
       >((stream, group) => {
         const channels = group.map(
@@ -2377,7 +2382,6 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
                     turnId,
                     outerToolCallId: call.toolCallId,
                     turn,
-                    toolAuthorization: options.toolAuthorization,
                     maxToolCalls: brokerAccounting.maxToolCalls,
                     declaredToolCalls: brokerAccounting.declaredToolCalls,
                     budget: options.budget,
@@ -2457,7 +2461,7 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
       const settling: Stream.Stream<
         RunEvent,
         never,
-        ToolSpanTelemetry | Tool.HandlerServices<ToolUnion<Tools>>
+        ToolSpanTelemetry | ProgrammaticToolAuthorization | Tool.HandlerServices<ToolUnion<Tools>>
       > = handlers.pipe(
         Stream.provideService(RunEventSink, batchSink),
         Stream.provideService(SubagentDurability, batchSubagentDurability),
@@ -7277,6 +7281,27 @@ function streamWithCompletion<
           : { history: retained.prompt, onHistory: retained.stageHistory }),
       };
 
+      // Normalize the selected host policy at the Run boundary. Inner calls project typed
+      // override failures into broker outcomes; native calls retain their original E channel.
+      const programmaticAuthorization = Layer.effect(
+        ProgrammaticToolAuthorization,
+        Effect.gen(function* () {
+          const services = yield* Effect.context<HookRequirements>();
+          const selected = options.toolAuthorization;
+
+          return ProgrammaticToolAuthorization.of({
+            authorize: (request) =>
+              selected === undefined
+                ? Effect.succeed({ _tag: "allowed" })
+                : provideHookServices(selected.authorize(request), services).pipe(
+                    Effect.catchCauseFilter(Cause.findError, (error, cause) =>
+                      Effect.fail(new BrokerCallFailure(error, cause)),
+                    ),
+                  ),
+          });
+        }),
+      );
+
       const interpreted = Stream.unwrap(
         Effect.gen(function* () {
           const resumed =
@@ -7706,6 +7731,7 @@ function streamWithCompletion<
         AgentRuntimeFailure<typeof agent, HookError, InstructionError>,
         | AgentRuntimeRequirements<typeof agent, HookRequirements, InstructionRequirements>
         | ToolSpanTelemetry
+        | ProgrammaticToolAuthorization
         | ModelRequires
         | ModelUsageAccounting
       > = model === undefined ? finalized : finalized.pipe(Stream.provide(model, { local: true }));
@@ -7714,6 +7740,7 @@ function streamWithCompletion<
         // The engine composition boundary owns span-lifecycle isolation while preserving the host's
         // ambient Tracer/Logger configuration. Individual Tool executions consume this capability.
         Stream.provide(ToolSpanTelemetry.layer),
+        Stream.provide(programmaticAuthorization),
       );
 
       if (retained === undefined && onCompleted === undefined) return events;
@@ -8128,7 +8155,6 @@ interface ToolBrokerBinding<HookError, HookRequirements> {
   readonly turnId: TurnId;
   readonly outerToolCallId: ToolCallId;
   readonly turn: number;
-  readonly toolAuthorization: RunOptions<HookError, HookRequirements>["toolAuthorization"];
   readonly maxToolCalls: number;
   /** Model-declared Tool Calls committed through this batch (the outer call included). */
   readonly declaredToolCalls: number;
@@ -8148,13 +8174,19 @@ const programmaticOutcomeError = (
   message,
 });
 
-/** A handler's typed failure captured as a value so defects stay defects. */
-class BrokerHandlerFailure {
+/** A call's typed failure captured as a value so defects stay defects. */
+class BrokerCallFailure {
   constructor(
     readonly error: unknown,
     readonly cause: Cause.Cause<unknown>,
   ) {}
 }
+
+/** Run-owned authorization with typed override failures preserved for broker projection. */
+class ProgrammaticToolAuthorization extends Context.Service<
+  ProgrammaticToolAuthorization,
+  RunToolAuthorizationHook<BrokerCallFailure>
+>()("@effect-agent/engine/internal/ProgrammaticToolAuthorization") {}
 
 /**
  * Measure one started programmatic handler with the same canonical span semantics as a
@@ -8289,17 +8321,11 @@ interface LiveToolBroker {
  * handler is invoked. Inner calls produce no Run events and no Canonical
  * Records. Trusted applications may explicitly observe non-propagating failures (RUN-036).
  */
-const makeToolBrokerService = <HookError, HookRequirements>(
+const makeToolBrokerService = Effect.fnUntraced(function* <HookError, HookRequirements>(
   binding: ToolBrokerBinding<HookError, HookRequirements>,
-): Effect.Effect<LiveToolBroker, never, ToolSpanTelemetry> =>
-  Effect.map(ToolSpanTelemetry, (toolSpanTelemetry) =>
-    makeToolBrokerServiceWithTelemetry(binding, toolSpanTelemetry),
-  );
-
-const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
-  binding: ToolBrokerBinding<HookError, HookRequirements>,
-  toolSpanTelemetry: ToolSpanTelemetryService,
-): LiveToolBroker => {
+): Effect.fn.Return<LiveToolBroker, never, ToolSpanTelemetry | ProgrammaticToolAuthorization> {
+  const toolSpanTelemetry = yield* ToolSpanTelemetry;
+  const authorization = yield* ProgrammaticToolAuthorization;
   const lifecycle = { closed: false };
   const observer = binding.context.toolFailureObserver;
 
@@ -8469,27 +8495,24 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
             }
 
             const handleId = ToolCallId.make(`${binding.outerToolCallId}#${sequenceIndex}`);
-            const authorization = binding.toolAuthorization;
 
-            if (authorization !== undefined) {
-              const denied = yield* provideHookServices(
-                authorization.authorize({
-                  threadId: binding.context.threadId,
-                  runId: binding.context.runId,
-                  turnId: binding.turnId,
-                  turn: binding.turn,
-                  input: binding.context.input,
-                  programmatic: { parentToolCallId: binding.outerToolCallId, sequenceIndex },
-                  call: {
-                    toolCallId: handleId,
-                    toolName: input.toolName,
-                    parameters: input.encodedArguments,
-                    executionClass: getToolExecutionClass(tool),
-                    executionKind: getToolExecutionKind(tool.annotations),
-                  },
-                }),
-                binding.hookServices,
-              ).pipe(
+            const denied = yield* authorization
+              .authorize({
+                threadId: binding.context.threadId,
+                runId: binding.context.runId,
+                turnId: binding.turnId,
+                turn: binding.turn,
+                input: binding.context.input,
+                programmatic: { parentToolCallId: binding.outerToolCallId, sequenceIndex },
+                call: {
+                  toolCallId: handleId,
+                  toolName: input.toolName,
+                  parameters: input.encodedArguments,
+                  executionClass: getToolExecutionClass(tool),
+                  executionKind: getToolExecutionKind(tool.annotations),
+                },
+              })
+              .pipe(
                 Effect.flatMap((decision) =>
                   decision._tag === "allowed"
                     ? Effect.succeed(undefined)
@@ -8500,19 +8523,18 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
                         decision.reason,
                       ),
                 ),
-                Effect.catchCauseFilter(Cause.findError, (error, cause) =>
+                Effect.catch((failure) =>
                   preflightFailure(
                     input,
                     "infrastructure",
-                    errorTag(error),
-                    errorMessage(error),
-                    cause,
+                    errorTag(failure.error),
+                    errorMessage(failure.error),
+                    failure.cause,
                   ),
                 ),
               );
 
-              if (denied !== undefined) return denied;
-            }
+            if (denied !== undefined) return denied;
 
             // Serialize admission and durable reservation across outer handlers.
             // Once reserved, a slot is never refunded: ownership may be lost
@@ -8700,11 +8722,11 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
                   ),
                   Effect.map(() => undefined),
                   Effect.catchCauseFilter(Cause.findError, (error, cause) =>
-                    Effect.succeed(new BrokerHandlerFailure(error, cause)),
+                    Effect.succeed(new BrokerCallFailure(error, cause)),
                   ),
                 );
 
-                if (handlerFailed instanceof BrokerHandlerFailure) {
+                if (handlerFailed instanceof BrokerCallFailure) {
                   const tag = errorTag(handlerFailed.error);
 
                   if (observer !== undefined) {
@@ -8903,7 +8925,7 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
       lifecycle.closed = true;
     },
   };
-};
+});
 
 /**
  * Ephemeral pass-through `DurableStep` provided when `RunOptions.durability`

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -305,6 +305,7 @@ import {
   ToolBrokerConfigurationError,
   ToolBrokerUnavailableError,
   type ProgrammaticCallOutcome,
+  type ProgrammaticCallRecord,
   type ProgrammaticToolInput,
   type ToolBrokerPass,
   type ToolBrokerService,
@@ -2375,6 +2376,8 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
                     context,
                     turnId,
                     outerToolCallId: call.toolCallId,
+                    turn,
+                    toolAuthorization: options.toolAuthorization,
                     maxToolCalls: brokerAccounting.maxToolCalls,
                     declaredToolCalls: brokerAccounting.declaredToolCalls,
                     budget: options.budget,
@@ -8124,6 +8127,8 @@ interface ToolBrokerBinding<HookError, HookRequirements> {
   readonly context: RunContext;
   readonly turnId: TurnId;
   readonly outerToolCallId: ToolCallId;
+  readonly turn: number;
+  readonly toolAuthorization: RunOptions<HookError, HookRequirements>["toolAuthorization"];
   readonly maxToolCalls: number;
   /** Model-declared Tool Calls committed through this batch (the outer call included). */
   readonly declaredToolCalls: number;
@@ -8277,9 +8282,9 @@ interface LiveToolBroker {
 /**
  * Live per-outer-call `ToolBroker` (runtime spec §12.1; RUN-016, RUN-017).
  * The pass executes under the outer Tool Call's already-held scheduling
- * permit — invocations run inside the outer handler's fiber and acquire no
- * batch permit of their own. Calls are strictly sequential, indices are
- * allocated from broker-owned monotonic state exactly when a handler starts,
+ * permit — invocations run in caller-owned structured fibers and acquire a finite
+ * per-pass Semaphore, never the outer batch permit again. Execution indices are
+ * allocated in invocation order before preflight, with gaps for rejected calls,
  * and every started call consumes the Run's Tool-call budgets before its
  * handler is invoked. Inner calls produce no Run events and no Canonical
  * Records. Trusted applications may explicitly observe non-propagating failures (RUN-036).
@@ -8329,7 +8334,15 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
         // inside business execution can substitute them per invocation. The
         // same private-assertion contract as `provideHookServices` applies.
         const handlerServices = (yield* Effect.context<never>()) as Context.Context<unknown>;
-        const state = { nextIndex: 0, inFlight: false };
+        const concurrency = passOptions.concurrency ?? 4;
+
+        if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 64) {
+          return yield* ToolBrokerConfigurationError.make({
+            message: "concurrency must be an integer between 1 and 64",
+          });
+        }
+        const permits = yield* Semaphore.make(concurrency);
+        const records: Array<ProgrammaticCallRecord> = [];
 
         const preflightFailure = (
           input: ProgrammaticToolInput,
@@ -8360,7 +8373,10 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
           }).pipe(preflightObserver.permits.withPermits(1), Effect.as(outcome));
         };
 
-        const body = (input: ProgrammaticToolInput): Effect.Effect<ProgrammaticCallOutcome> =>
+        const body = (
+          input: ProgrammaticToolInput,
+          sequenceIndex: number,
+        ): Effect.Effect<ProgrammaticCallOutcome> =>
           Effect.gen(function* () {
             if (!hasTool(toolkit.tools, input.toolName)) {
               return yield* preflightFailure(
@@ -8452,6 +8468,52 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
               return invalidParameters;
             }
 
+            const handleId = ToolCallId.make(`${binding.outerToolCallId}#${sequenceIndex}`);
+            const authorization = binding.toolAuthorization;
+
+            if (authorization !== undefined) {
+              const denied = yield* provideHookServices(
+                authorization.authorize({
+                  threadId: binding.context.threadId,
+                  runId: binding.context.runId,
+                  turnId: binding.turnId,
+                  turn: binding.turn,
+                  input: binding.context.input,
+                  programmatic: { parentToolCallId: binding.outerToolCallId, sequenceIndex },
+                  call: {
+                    toolCallId: handleId,
+                    toolName: input.toolName,
+                    parameters: input.encodedArguments,
+                    executionClass: getToolExecutionClass(tool),
+                    executionKind: getToolExecutionKind(tool.annotations),
+                  },
+                }),
+                binding.hookServices,
+              ).pipe(
+                Effect.flatMap((decision) =>
+                  decision._tag === "allowed"
+                    ? Effect.succeed(undefined)
+                    : preflightFailure(
+                        input,
+                        "infrastructure",
+                        "ProgrammaticToolAuthorizationDenied",
+                        decision.reason,
+                      ),
+                ),
+                Effect.catchCauseFilter(Cause.findError, (error, cause) =>
+                  preflightFailure(
+                    input,
+                    "infrastructure",
+                    errorTag(error),
+                    errorMessage(error),
+                    cause,
+                  ),
+                ),
+              );
+
+              if (denied !== undefined) return denied;
+            }
+
             // Serialize admission and durable reservation across outer handlers.
             // Once reserved, a slot is never refunded: ownership may be lost
             // after the append but before the Handler starts.
@@ -8524,8 +8586,13 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
 
             if (rejected !== undefined) return rejected;
 
-            const index = state.nextIndex++;
-            const handleId = `${binding.outerToolCallId}#${index}`;
+            const index = sequenceIndex;
+
+            records[sequenceIndex] = {
+              sequenceIndex,
+              toolName: input.toolName,
+              status: "uncertain",
+            };
             const executionClass = getToolExecutionClass(tool);
             let failureObservation: ProgrammaticToolFailure | undefined;
 
@@ -8756,9 +8823,29 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
             // Fix the broker outcome and terminal telemetry before delivery. Interruption of an
             // observer cannot turn a settled inner failure into an interrupted Handler attempt.
             // This still runs inline under the outer call's permit, before pass.invoke returns.
+            const recorded = execution.pipe(
+              Effect.tap((outcome) =>
+                Effect.sync(() => {
+                  records[sequenceIndex] = {
+                    sequenceIndex,
+                    toolName: input.toolName,
+                    status:
+                      outcome._tag === "ProgrammaticCallSuccess"
+                        ? "succeeded"
+                        : outcome._tag === "ProgrammaticCallFailure"
+                          ? "failed"
+                          : "uncertain",
+                    ...(outcome._tag === "ProgrammaticCallError"
+                      ? { errorTag: outcome.errorTag }
+                      : {}),
+                  };
+                }),
+              ),
+            );
+
             return yield* observer === undefined
-              ? execution
-              : execution.pipe(
+              ? recorded
+              : recorded.pipe(
                   Effect.tap(() =>
                     failureObservation === undefined
                       ? Effect.void
@@ -8768,39 +8855,41 @@ const makeToolBrokerServiceWithTelemetry = <HookError, HookRequirements>(
           }).pipe(Effect.provideContext(handlerServices)) as Effect.Effect<ProgrammaticCallOutcome>;
 
         const pass: ToolBrokerPass = {
+          snapshot: Effect.sync(() => records.map((record) => ({ ...record }))),
           invoke: (input) =>
             Effect.suspend(() => {
-              // A pass retained past its outer Tool Call cannot execute
-              // Tools outside the batch's scheduling authority.
-              if (lifecycle.closed) {
-                return preflightFailure(
-                  input,
-                  "infrastructure",
-                  "ToolBrokerUnavailableError",
-                  "The outer Tool Call for this pass has already settled",
-                );
-              }
-              // Strict sequentiality (RUN-016): a call issued while another
-              // from this pass is unsettled fails typed without acquiring an
-              // identity or consuming budget; the rejection does not release
-              // the in-flight owner's claim.
-              if (state.inFlight) {
-                return preflightFailure(
-                  input,
-                  "infrastructure",
-                  "ProgrammaticCallConcurrencyError",
-                  `Host call ${input.toolName} was issued while another call from this pass is unsettled; in-program Tool calls are strictly sequential`,
-                );
-              }
-              state.inFlight = true;
+              const sequenceIndex = records.length;
 
-              return body(input).pipe(
-                Effect.ensuring(
-                  Effect.sync(() => {
-                    state.inFlight = false;
-                  }),
-                ),
-              );
+              records.push({ sequenceIndex, toolName: input.toolName, status: "not-started" });
+
+              // Check after acquiring the permit too: queued work cannot start after its owner exits.
+              return permits
+                .withPermit(
+                  Effect.suspend(() =>
+                    lifecycle.closed
+                      ? preflightFailure(
+                          input,
+                          "infrastructure",
+                          "ToolBrokerUnavailableError",
+                          "The outer Tool Call for this pass has already settled",
+                        )
+                      : body(input, sequenceIndex),
+                  ),
+                )
+                .pipe(
+                  Effect.tap((outcome) =>
+                    Effect.sync(() => {
+                      if (outcome._tag === "ProgrammaticCallError" && outcome.index === undefined) {
+                        records[sequenceIndex] = {
+                          sequenceIndex,
+                          toolName: input.toolName,
+                          status: "not-started",
+                          errorTag: outcome.errorTag,
+                        };
+                      }
+                    }),
+                  ),
+                );
             }),
         };
 

--- a/packages/engine/test/tool-broker.test.ts
+++ b/packages/engine/test/tool-broker.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@effect-agent/core/SubagentContract";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
-import { type RunOptions } from "@effect-agent/engine/RunOptions";
+import { type RunOptions, type RunToolAuthorizationRequest } from "@effect-agent/engine/RunOptions";
 import {
   ToolBroker,
   ToolBrokerConfigurationError,
@@ -494,6 +494,13 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
                     captured,
                     Option.getOrUndefined(Cause.findErrorOption(exit.cause)),
                   );
+                  for (const concurrency of [0, -1, 1.5, 65, NaN, Infinity]) {
+                    const error = yield* broker
+                      .openPass(inner, { maxResultBytes: 1024, concurrency })
+                      .pipe(Effect.flip, Effect.orDie);
+
+                    expect(error).toBeInstanceOf(ToolBrokerConfigurationError);
+                  }
 
                   return null;
                 }),
@@ -847,58 +854,192 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
     }),
   );
 
-  it.effect("RUN-016 a concurrent host call fails typed without consuming an identity", () =>
+  it.effect("authorizes each inner mutation before reserving budget or starting its handler", () =>
     Effect.gen(function* () {
-      const outcomes = yield* Ref.make<ReadonlyArray<ProgrammaticCallOutcome>>([]);
-      const started = yield* Deferred.make<void>();
-      const gate = yield* Deferred.make<void>();
       const innerToolkit = Toolkit.make(Query);
+      const requests: Array<RunToolAuthorizationRequest> = [];
+      const started: Array<string> = [];
 
       yield* runOrchestrated({
         innerToolkit,
+        agentPolicy: policy({ maxToolCalls: 2 }),
         innerHandlers: innerToolkit.toLayer({
-          query: () =>
-            Deferred.succeed(started, undefined).pipe(
-              Effect.andThen(Deferred.await(gate)),
-              Effect.as({ rows: [1] }),
+          query: ({ sql }) =>
+            Effect.sync(() => {
+              started.push(sql);
+
+              return { rows: [1] };
+            }),
+        }),
+        runOptions: {
+          toolAuthorization: {
+            authorize: (request) =>
+              Effect.sync(() => {
+                requests.push(request);
+
+                return request.programmatic?.sequenceIndex === 0
+                  ? { _tag: "denied" as const, reason: "No access to this write" }
+                  : { _tag: "allowed" as const };
+              }),
+          },
+        },
+        program: (pass) =>
+          Effect.gen(function* () {
+            const outcomes = yield* Effect.forEach(
+              ["denied", "allowed"],
+              (sql) => pass.invoke({ toolName: "query", encodedArguments: { sql } }),
+              { concurrency: 2 },
+            );
+
+            expect(outcomes).toMatchObject([
+              {
+                _tag: "ProgrammaticCallError",
+                index: undefined,
+                errorTag: "ProgrammaticToolAuthorizationDenied",
+              },
+              { _tag: "ProgrammaticCallSuccess", index: 1 },
+            ]);
+            expect((yield* pass.snapshot).map((call) => call.status)).toEqual([
+              "not-started",
+              "succeeded",
+            ]);
+
+            return null;
+          }),
+      });
+      expect(started).toEqual(["allowed"]);
+      expect(requests).toHaveLength(3);
+      expect(requests[2]).toMatchObject({
+        input: { question: "go" },
+        programmatic: { parentToolCallId: "orchestrate-1", sequenceIndex: 1 },
+        call: {
+          toolCallId: "orchestrate-1#1",
+          toolName: "query",
+          parameters: { sql: "allowed" },
+          executionClass: "uncertain",
+        },
+      });
+    }),
+  );
+
+  it.effect("bounds concurrent calls and records outcomes without delaying dependencies", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      const gate = yield* Deferred.make<void>();
+      const innerToolkit = Toolkit.make(Query);
+      const starts: Array<string> = [];
+      let active = 0;
+      let peak = 0;
+
+      yield* runOrchestrated({
+        innerToolkit,
+        passOptions: { maxResultBytes: 1024, concurrency: 2 },
+        innerHandlers: innerToolkit.toLayer({
+          query: ({ sql }) =>
+            Effect.gen(function* () {
+              starts.push(sql);
+              active++;
+              peak = Math.max(peak, active);
+              if (sql === "a") {
+                yield* Deferred.succeed(started, undefined);
+                yield* Deferred.await(gate);
+              }
+
+              return { rows: [1] };
+            }).pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  active--;
+                }),
+              ),
             ),
         }),
         program: (pass) =>
           Effect.gen(function* () {
-            const firstFiber = yield* pass
+            const first = yield* pass
               .invoke({ toolName: "query", encodedArguments: { sql: "a" } })
               .pipe(Effect.forkChild);
 
             yield* Deferred.await(started);
 
+            // b and its dependent c must finish while unrelated a is still blocked.
             const second = yield* pass.invoke({
               toolName: "query",
               encodedArguments: { sql: "b" },
             });
 
+            const third = yield* pass.invoke({ toolName: "query", encodedArguments: { sql: "c" } });
+
+            expect(second).toMatchObject({ _tag: "ProgrammaticCallSuccess", index: 1 });
+            expect(third).toMatchObject({ _tag: "ProgrammaticCallSuccess", index: 2 });
+            expect((yield* pass.snapshot).map((call) => call.status)).toEqual([
+              "uncertain",
+              "succeeded",
+              "succeeded",
+            ]);
             yield* Deferred.succeed(gate, undefined);
-            const first = yield* Fiber.join(firstFiber);
-
-            const third = yield* pass.invoke({
-              toolName: "query",
-              encodedArguments: { sql: "c" },
-            });
-
-            yield* Ref.set(outcomes, [first, second, third]);
+            yield* Fiber.join(first);
+            expect((yield* pass.snapshot).map((call) => call.sequenceIndex)).toEqual([0, 1, 2]);
 
             return null;
           }),
       });
-      const [first, second, third] = yield* Ref.get(outcomes);
+      expect(starts).toEqual(["a", "b", "c"]);
+      expect(peak).toBe(2);
+      expect(active).toBe(0);
+    }),
+  );
 
-      expect(first).toMatchObject({ _tag: "ProgrammaticCallSuccess", index: 0 });
-      expect(second).toMatchObject({
-        _tag: "ProgrammaticCallError",
-        index: undefined,
-        errorTag: "ProgrammaticCallConcurrencyError",
+  it.effect("interrupts active and queued calls without starting queued handlers", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      const innerToolkit = Toolkit.make(Query);
+      let starts = 0;
+      let finalized = 0;
+
+      yield* runOrchestrated({
+        innerToolkit,
+        passOptions: { maxResultBytes: 1024, concurrency: 1 },
+        innerHandlers: innerToolkit.toLayer({
+          query: () =>
+            Effect.gen(function* () {
+              starts++;
+              yield* Deferred.succeed(started, undefined);
+
+              return yield* Effect.never;
+            }).pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  finalized++;
+                }),
+              ),
+            ),
+        }),
+        program: (pass) =>
+          Effect.gen(function* () {
+            const first = yield* pass
+              .invoke({ toolName: "query", encodedArguments: { sql: "a" } })
+              .pipe(Effect.forkChild);
+
+            yield* Deferred.await(started);
+
+            const queued = yield* pass
+              .invoke({ toolName: "query", encodedArguments: { sql: "b" } })
+              .pipe(Effect.forkChild);
+
+            yield* Effect.yieldNow;
+            yield* Fiber.interrupt(queued);
+            yield* Fiber.interrupt(first);
+            expect(yield* pass.snapshot).toEqual([
+              { sequenceIndex: 0, toolName: "query", status: "uncertain" },
+              { sequenceIndex: 1, toolName: "query", status: "not-started" },
+            ]);
+
+            return null;
+          }),
       });
-      // The rejected call consumed no identity: the next sequential call gets index 1.
-      expect(third).toMatchObject({ _tag: "ProgrammaticCallSuccess", index: 1 });
+      expect(starts).toBe(1);
+      expect(finalized).toBe(1);
     }),
   );
 

--- a/packages/engine/test/tool-broker.test.ts
+++ b/packages/engine/test/tool-broker.test.ts
@@ -9,7 +9,11 @@ import {
 } from "@effect-agent/core/SubagentContract";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
-import { type RunOptions, type RunToolAuthorizationRequest } from "@effect-agent/engine/RunOptions";
+import {
+  RunToolAuthorization,
+  type RunOptions,
+  type RunToolAuthorizationRequest,
+} from "@effect-agent/engine/RunOptions";
 import {
   ToolBroker,
   ToolBrokerConfigurationError,
@@ -20,6 +24,7 @@ import {
 import { expect, layer } from "@effect/vitest";
 import {
   Cause,
+  Context,
   Deferred,
   Effect,
   Exit,
@@ -131,13 +136,17 @@ const orchestrateCall = (id: string): ReadonlyArray<Response.StreamPartEncoded> 
  * outcomes as its Tool success so the test observes exactly what generated
  * code would.
  */
-const runOrchestrated = <InnerTools extends Record<string, Tool.Any>>(options: {
+const runOrchestrated = <
+  InnerTools extends Record<string, Tool.Any>,
+  HookError = never,
+  HookRequirements = never,
+>(options: {
   readonly innerToolkit: Toolkit.Toolkit<InnerTools>;
   readonly innerHandlers: Layer.Layer<Tool.HandlersFor<InnerTools>, never, never>;
   readonly program: (pass: ToolBrokerPass) => Effect.Effect<unknown>;
   readonly passOptions?: ToolBrokerPassOptions;
   readonly agentPolicy?: AgentPolicy;
-  readonly runOptions?: RunOptions;
+  readonly runOptions?: RunOptions<HookError, HookRequirements>;
 }) =>
   Effect.gen(function* () {
     const Orchestrate = Tool.make("orchestrate", {
@@ -906,7 +915,11 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
 
             return null;
           }),
-      });
+      }).pipe(
+        Effect.provideService(RunToolAuthorization, {
+          authorize: () => Effect.die("The explicit override must replace the ambient policy"),
+        }),
+      );
       expect(started).toEqual(["allowed"]);
       expect(requests).toHaveLength(3);
       expect(requests[2]).toMatchObject({
@@ -921,6 +934,119 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
       });
     }),
   );
+
+  it.effect("uses the Run's ambient authorization despite an inner policy substitution", () =>
+    Effect.gen(function* () {
+      const innerToolkit = Toolkit.make(Query);
+      const requests: Array<RunToolAuthorizationRequest> = [];
+
+      yield* runOrchestrated({
+        innerToolkit,
+        innerHandlers: innerToolkit.toLayer({ query: () => Effect.die("Denied handler started") }),
+        program: (pass) =>
+          pass.invoke({ toolName: "query", encodedArguments: { sql: "denied" } }).pipe(
+            Effect.tap((outcome) =>
+              Effect.sync(() => {
+                expect(outcome).toMatchObject({
+                  _tag: "ProgrammaticCallError",
+                  errorTag: "ProgrammaticToolAuthorizationDenied",
+                });
+              }),
+            ),
+            Effect.provideService(RunToolAuthorization, {
+              authorize: () => Effect.succeed({ _tag: "allowed" }),
+            }),
+          ),
+      }).pipe(
+        Effect.provideService(RunToolAuthorization, {
+          authorize: (request) =>
+            Effect.sync(() => {
+              requests.push(request);
+
+              return request.programmatic === undefined
+                ? { _tag: "allowed" as const }
+                : { _tag: "denied" as const, reason: "Inner call denied" };
+            }),
+        }),
+      );
+      expect(requests.map((request) => request.call.toolName)).toEqual(["orchestrate", "query"]);
+    }),
+  );
+
+  for (const failureKind of ["typed", "defect", "interruption"] as const) {
+    it.effect(`preserves ${failureKind} authorization failures and Run-captured services`, () =>
+      Effect.gen(function* () {
+        class AuthorizationPolicy extends Context.Service<
+          AuthorizationPolicy,
+          { readonly message: string }
+        >()("test/AuthorizationPolicy") {}
+
+        const innerToolkit = Toolkit.make(Query);
+        const observed: Array<ProgrammaticCallOutcome> = [];
+
+        const run = runOrchestrated({
+          innerToolkit,
+          innerHandlers: innerToolkit.toLayer({
+            query: () => Effect.die("Denied handler started"),
+          }),
+          runOptions: {
+            toolAuthorization: {
+              authorize: (request) =>
+                Effect.gen(function* () {
+                  if (request.programmatic === undefined) return { _tag: "allowed" as const };
+                  const policy = yield* AuthorizationPolicy;
+
+                  if (failureKind === "defect") return yield* Effect.die(policy.message);
+                  if (failureKind === "interruption") return yield* Effect.interrupt;
+
+                  return yield* new QueryFailure({ message: policy.message });
+                }),
+            },
+          },
+          program: (pass) =>
+            pass.invoke({ toolName: "query", encodedArguments: { sql: "denied" } }).pipe(
+              Effect.tap((outcome) => Effect.sync(() => observed.push(outcome))),
+              Effect.provideService(AuthorizationPolicy, { message: "inner substitution" }),
+            ),
+        });
+
+        const requirement: AuthorizationPolicy extends Effect.Services<typeof run> ? true : false =
+          true;
+
+        const error: QueryFailure extends Effect.Error<typeof run> ? true : false = true;
+
+        const exit = yield* run.pipe(
+          Effect.provideService(AuthorizationPolicy, { message: "Run policy failure" }),
+          Effect.exit,
+        );
+
+        expect(requirement && error).toBe(true);
+        if (failureKind === "typed") {
+          expect(Exit.isSuccess(exit)).toBe(true);
+          expect(observed).toMatchObject([
+            {
+              _tag: "ProgrammaticCallError",
+              index: undefined,
+              errorTag: "QueryFailure",
+              message: "Run policy failure",
+            },
+          ]);
+        } else {
+          expect(observed).toEqual([]);
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            if (failureKind === "defect") {
+              expect(
+                exit.cause.reasons.filter(Cause.isDieReason).map((reason) => reason.defect),
+              ).toEqual(["Run policy failure"]);
+            } else {
+              expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+            }
+          }
+        }
+      }),
+    );
+  }
 
   it.effect("bounds concurrent calls and records outcomes without delaying dependencies", () =>
     Effect.gen(function* () {

--- a/packages/engine/test/tool-failure-observer.test.ts
+++ b/packages/engine/test/tool-failure-observer.test.ts
@@ -704,7 +704,6 @@ layer(testLayer)("RUN-036 trusted Tool failure observation", (it) => {
             const handler = yield* invoke(pass).pipe(Effect.forkChild);
 
             yield* Deferred.await(entered);
-            yield* burst([pass, pass, pass, pass], "ProgrammaticCallConcurrencyError");
             yield* Deferred.succeed(release, undefined);
             yield* Fiber.join(handler);
 
@@ -718,14 +717,11 @@ layer(testLayer)("RUN-036 trusted Tool failure observation", (it) => {
           "ToolBrokerUnavailableError",
         );
         expect(observations.map(({ tag }) => tag)).toEqual([
-          "ProgrammaticCallConcurrencyError",
-          "ProgrammaticCallConcurrencyError",
-          "ProgrammaticCallConcurrencyError",
           "ToolBrokerUnavailableError",
           "ToolBrokerUnavailableError",
           "ToolBrokerUnavailableError",
         ]);
-        expect({ peak, finalized }).toEqual({ peak: 1, finalized: 6 });
+        expect({ peak, finalized }).toEqual({ peak: 1, finalized: 3 });
         for (const observation of observations) {
           expect(observation).toMatchObject({
             _tag: "ProgrammaticPreflightFailure",

--- a/packages/platform-cloudflare/src/CloudflareCodeMode.ts
+++ b/packages/platform-cloudflare/src/CloudflareCodeMode.ts
@@ -565,7 +565,12 @@ const makeExecute = (
       }
     });
 
-    const server = yield* serveHostCalls.pipe(Effect.forkScoped);
+    const concurrency = request.limits.maxHostCallConcurrency ?? 4;
+
+    const server = yield* Effect.all(
+      Array.from({ length: concurrency }, () => serveHostCalls),
+      { concurrency, discard: true },
+    ).pipe(Effect.andThen(Effect.never), Effect.forkScoped);
 
     const dispatch = (hostCall: unknown): Promise<unknown> => {
       if (!passOpen) {

--- a/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
+++ b/packages/platform-cloudflare/test/code-mode/code-mode-executor.test.ts
@@ -112,4 +112,15 @@ describe("DEPLOY-011 Cloudflare Dynamic Worker CodeExecutor", () => {
     expect(response.ok).toBe(true);
     expect(await response.json()).toEqual({ tag: "success" });
   });
+  it("overlaps host calls and releases dependent work without waiting for earlier calls", async () => {
+    const response = await runtime.dispatchFetch("http://placeholder/concurrent-host-calls");
+
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toMatchObject({
+      outcome: { tag: "success", detail: { value: [0, 2] } },
+      completed: [1, 2, 0],
+      peak: 2,
+      active: 0,
+    });
+  }, 30_000);
 });

--- a/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
+++ b/packages/platform-cloudflare/test/code-mode/conformance-worker.ts
@@ -17,11 +17,13 @@ import {
   Cause,
   Context,
   Duration,
+  Deferred,
   Effect,
   Exit,
   ManagedRuntime,
   Option,
   Predicate,
+  Schema,
   type Layer,
 } from "effect";
 
@@ -382,6 +384,56 @@ const runDisposalRegression = Effect.gen(function* () {
   return { tag: "success" };
 });
 
+const runConcurrentRegression = (env: WorkerEnv) =>
+  Effect.gen(function* () {
+    const dependentFinished = yield* Deferred.make<void>();
+    let active = 0;
+    let peak = 0;
+    const completed: Array<number> = [];
+
+    const outcome = yield* runOutcome(
+      request(
+        `async () => {
+    const first = example.write({ id: 0 });
+    const second = (async () => {
+      await example.write({ id: 1 });
+      return await example.write({ id: 2 });
+    })();
+    return await Promise.all([first, second]);
+  }`,
+        {
+          namespaces: [CodeExecutionNamespace.make({ name: "example", methods: ["write"] })],
+          limits: CodeExecutionLimits.make({ ...baseLimits, maxHostCallConcurrency: 2 }),
+        },
+      ),
+      executorLayerFor(env),
+      {
+        call: (call) =>
+          Effect.gen(function* () {
+            const { id } = yield* Schema.decodeUnknownEffect(Schema.Struct({ id: Schema.Int }))(
+              call.argument,
+            ).pipe(Effect.orDie);
+
+            active++;
+            peak = Math.max(peak, active);
+            if (id === 0) yield* Deferred.await(dependentFinished);
+            completed.push(id);
+            if (id === 2) yield* Deferred.succeed(dependentFinished, undefined);
+
+            return CodeHostCallSuccess.make({ value: id });
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                active--;
+              }),
+            ),
+          ),
+      },
+    );
+
+    return { outcome, completed, peak, active };
+  });
+
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     try {
@@ -400,6 +452,9 @@ export default {
       }
       if (new URL(request.url).pathname === "/host-call-pass-scope") {
         return Response.json(await Effect.runPromise(runHostCallScopeRegression(env)));
+      }
+      if (new URL(request.url).pathname === "/concurrent-host-calls") {
+        return Response.json(await Effect.runPromise(runConcurrentRegression(env)));
       }
       if (new URL(request.url).pathname === "/total-disposal") {
         return Response.json(await Effect.runPromise(runDisposalRegression));

--- a/packages/sandbox/src/CodeExecutor.ts
+++ b/packages/sandbox/src/CodeExecutor.ts
@@ -120,6 +120,8 @@ export class CodeExecutionLimits extends Schema.Class<CodeExecutionLimits>("Code
   maxLogBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(1024 * 1024)),
   maxResultBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(4 * 1024 * 1024)),
   maxHostCalls: Schema.Natural.check(Schema.isLessThanOrEqualTo(10_000)),
+  /** Maximum active host calls per pass; defaults to four. Excess calls wait in Scope. */
+  maxHostCallConcurrency: Schema.optionalKey(PositiveInt.check(Schema.isLessThanOrEqualTo(64))),
   maxHostCallArgumentBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(1024 * 1024)),
   maxHostCallResultBytes: PositiveInt.check(Schema.isLessThanOrEqualTo(4 * 1024 * 1024)),
 }) {}

--- a/packages/sandbox/test/code-executor.test.ts
+++ b/packages/sandbox/test/code-executor.test.ts
@@ -142,4 +142,16 @@ describe("CAP-015 CodeExecutor schemas", () => {
       /Schema validation failed/,
     );
   });
+  it("accepts only finite bounded host concurrency", () => {
+    for (const maxHostCallConcurrency of [0, -1, 1.5, 65, NaN, Infinity]) {
+      expect(() => CodeExecutionLimits.make({ ...limits, maxHostCallConcurrency })).toThrow(
+        /Schema validation failed/,
+      );
+    }
+    for (const maxHostCallConcurrency of [1, 4, 64]) {
+      expect(
+        CodeExecutionLimits.make({ ...limits, maxHostCallConcurrency }).maxHostCallConcurrency,
+      ).toBe(maxHostCallConcurrency);
+    }
+  });
 });

--- a/packages/testing/src/CodeExecutorSubstitute.ts
+++ b/packages/testing/src/CodeExecutorSubstitute.ts
@@ -430,9 +430,14 @@ const executeInProcess: CodeExecutorExecute = Effect.fn("InProcessCodeExecutor.e
       }),
     );
 
-    const server = yield* serveHostCalls(host, queue, request.limits, capture, counter).pipe(
-      Effect.forkScoped,
-    );
+    const concurrency = request.limits.maxHostCallConcurrency ?? 4;
+
+    const server = yield* Effect.all(
+      Array.from({ length: concurrency }, () =>
+        serveHostCalls(host, queue, request.limits, capture, counter),
+      ),
+      { concurrency, discard: true },
+    ).pipe(Effect.andThen(Effect.never), Effect.forkScoped);
 
     const program = Effect.tryPromise({
       try: async () => {

--- a/packages/testing/test/code-mode-concurrency.test.ts
+++ b/packages/testing/test/code-mode-concurrency.test.ts
@@ -1,0 +1,363 @@
+import * as CodeMode from "@effect-agent/capabilities/CodeMode";
+import * as Agent from "@effect-agent/core/Agent";
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import { RunContextPreparationPassthrough } from "@effect-agent/engine/RunOptions";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { CodeExecutionLimits } from "@effect-agent/sandbox/CodeExecutor";
+import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
+import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
+import { inProcessCodeExecutorLayer } from "@effect-agent/testing/CodeExecutorSubstitute";
+import {
+  DurableAgentRuntime,
+  DurableRuntimeConfig,
+} from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeFailpoint } from "@effect-agent/thread/DurableFailpoint";
+import { DefinitionDigests, DeploymentId, Digest, ProducerId } from "@effect-agent/thread/Records";
+import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
+import { NodeCrypto } from "@effect/platform-node";
+import { expect, layer } from "@effect/vitest";
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, Schema, Stream } from "effect";
+import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
+
+class WriteFailure extends Schema.TaggedError<WriteFailure>()("WriteFailure", {}) {}
+
+const Write = Tool.make("write", {
+  parameters: Schema.Struct({ id: Schema.Int }),
+  success: Schema.Int,
+  failure: WriteFailure,
+  failureMode: "return",
+});
+
+const scenario = (
+  code: string,
+  handler: (id: number) => Effect.Effect<number, WriteFailure>,
+  options: { readonly wallMillis?: number; readonly maxEgressBytes?: number } = {},
+) => {
+  const reports: Array<CodeMode.CodeModePassReport> = [];
+  const results: Array<unknown> = [];
+
+  const mode = CodeMode.make("run_code", {
+    description: "Write the selected records",
+    tools: { tools: { write: Write } },
+    maxEgressBytes: options.maxEgressBytes,
+    limits: CodeExecutionLimits.make({
+      maxSourceBytes: 16_384,
+      maxWallTime: Duration.millis(options.wallMillis ?? 2_000),
+      maxLogBytes: 1_024,
+      maxResultBytes: 16_384,
+      maxHostCalls: 16,
+      maxHostCallArgumentBytes: 1_024,
+      maxHostCallResultBytes: 1_024,
+      maxHostCallConcurrency: 2,
+    }),
+    onPassExit: (report) =>
+      Effect.sync(() => {
+        reports.push(report);
+      }),
+  });
+
+  const definition = Agent.make("writes", {
+    input: Schema.String,
+    output: Schema.String,
+    instructions: "Run the program then finish.",
+    toolkit: Toolkit.make(mode.tool),
+    policy: { maxTurns: 2, maxToolCalls: 20, maxDuration: "5 seconds", toolConcurrency: 1 },
+  });
+
+  const usage = { inputTokens: {}, outputTokens: {} };
+
+  const model = Model.make(
+    "scripted",
+    "writes",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      Effect.gen(function* () {
+        let turn = 0;
+
+        return yield* LanguageModel.make({
+          generateText: () => Effect.succeed([]),
+          streamText: ({ prompt }) =>
+            Stream.unwrap(
+              Effect.sync(() => {
+                results.push(
+                  ...prompt.content
+                    .filter((m) => m.role === "tool")
+                    .flatMap((m) => m.content)
+                    .filter((p) => p.type === "tool-result")
+                    .map((p) => p.result),
+                );
+
+                const parts: ReadonlyArray<Response.StreamPartEncoded> =
+                  turn++ === 0
+                    ? [
+                        { type: "tool-call", id: "program", name: "run_code", params: { code } },
+                        { type: "finish", reason: "tool-calls", usage },
+                      ]
+                    : [
+                        { type: "text-start", id: "answer" },
+                        { type: "text-delta", id: "answer", delta: '"done"' },
+                        { type: "text-end", id: "answer" },
+                        { type: "finish", reason: "stop", usage },
+                      ];
+
+                return Stream.fromIterable(parts);
+              }),
+            ),
+        });
+      }),
+    ),
+  );
+
+  const handlers = mode.handlers.pipe(
+    Layer.provide([
+      Toolkit.make(Write).toLayer({ write: ({ id }) => handler(id) }),
+      inProcessCodeExecutorLayer,
+    ]),
+  );
+
+  const agent = Agent.withModel(definition, model);
+
+  return {
+    reports,
+    results,
+    agent,
+    handlers,
+    run: AgentRuntime.run(agent, "go").pipe(Effect.provide(handlers), Effect.scoped),
+  };
+};
+
+layer(
+  Layer.mergeAll(IdGenerator.layer, ThreadHistory.layerTransient, RunContextPreparationPassthrough),
+  { excludeTestServices: true },
+)("Code Mode writes and concurrency", (it) => {
+  it.effect(
+    "runs dependencies in order and independent writes with a finite concurrency limit",
+    () =>
+      Effect.gen(function* () {
+        const completed: Array<number> = [];
+        let active = 0;
+        let peak = 0;
+
+        const test = scenario(
+          `async () => {
+      const project = await tools.write({ id: 0 });
+      const tasks = await Promise.all([1, 2, 3, 4, 5].map(id => tools.write({ id })));
+      return { project, tasks };
+    }`,
+          (id) =>
+            Effect.gen(function* () {
+              if (id > 0) expect(completed).toContain(0);
+              active++;
+              peak = Math.max(peak, active);
+              yield* Effect.sleep("5 millis");
+              completed.push(id);
+
+              return id;
+            }).pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  active--;
+                }),
+              ),
+            ),
+        );
+
+        yield* test.run;
+        expect(peak).toBe(2);
+        expect(active).toBe(0);
+        expect(test.results[0]).toMatchObject({ result: { project: 0, tasks: [1, 2, 3, 4, 5] } });
+        expect(test.reports[0]?.calls.map((call) => call.status)).toEqual(
+          Array(6).fill("succeeded"),
+        );
+      }),
+  );
+
+  it.effect(
+    "reports completed writes, declared failures, and interrupted siblings in invocation order",
+    () =>
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        let finalized = false;
+
+        const test = scenario(
+          `async () => {
+      await tools.write({ id: 0 });
+      return await Promise.all([tools.write({ id: 1 }), tools.write({ id: 2 })]);
+    }`,
+          (id) =>
+            id === 0
+              ? Effect.succeed(id)
+              : id === 1
+                ? Deferred.succeed(started, undefined).pipe(
+                    Effect.andThen(Effect.never),
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        finalized = true;
+                      }),
+                    ),
+                  )
+                : Deferred.await(started).pipe(Effect.andThen(Effect.fail(new WriteFailure({})))),
+        );
+
+        yield* test.run;
+        expect(finalized).toBe(true);
+        expect(test.reports[0]?.status).toBe("failed");
+        expect(test.reports[0]?.calls.map((call) => call.status)).toEqual([
+          "succeeded",
+          "uncertain",
+          "failed",
+        ]);
+        expect(test.results[0]).toMatchObject({
+          _tag: "CodeModeFailure",
+          calls: test.reports[0]?.calls,
+          omittedCalls: 0,
+        });
+      }),
+  );
+
+  it.effect("preserves interruption and reports uncertain writes after finalization", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      let finalized = false;
+
+      const test = scenario(`async () => await tools.write({ id: 1 })`, () =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(
+            Effect.sync(() => {
+              finalized = true;
+            }),
+          ),
+        ),
+      );
+
+      const fiber = yield* test.run.pipe(Effect.forkChild);
+
+      yield* Deferred.await(started);
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+
+      expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(true);
+      expect(finalized).toBe(true);
+      expect(test.reports).toMatchObject([
+        { status: "interrupted", calls: [{ status: "uncertain" }] },
+      ]);
+    }),
+  );
+
+  it.effect("reports timeout without replaying or claiming a started write failed", () =>
+    Effect.gen(function* () {
+      let starts = 0;
+
+      const test = scenario(
+        `async () => await tools.write({ id: 1 })`,
+        () =>
+          Effect.sync(() => {
+            starts++;
+          }).pipe(Effect.andThen(Effect.never)),
+        { wallMillis: 30 },
+      );
+
+      yield* test.run;
+      expect(starts).toBe(1);
+      expect(test.results[0]).toMatchObject({
+        errorTag: "CodeExecutionTimeoutError",
+        calls: [{ status: "uncertain" }],
+      });
+    }),
+  );
+
+  it.effect("keeps defects as defects and reports their uncertain write", () =>
+    Effect.gen(function* () {
+      const test = scenario(`async () => await tools.write({ id: 1 })`, () =>
+        Effect.die("handler defect"),
+      );
+
+      const exit = yield* test.run.pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(test.reports).toMatchObject([{ status: "defect", calls: [{ status: "uncertain" }] }]);
+    }),
+  );
+
+  it.effect("bounds failure evidence and explicitly reports omitted calls", () =>
+    Effect.gen(function* () {
+      const test = scenario(
+        `async () => {
+      for (let id = 0; id < 8; id++) await tools.write({ id });
+      throw 'x'.repeat(2000);
+    }`,
+        Effect.succeed,
+        { maxEgressBytes: 256 },
+      );
+
+      yield* test.run;
+      const failure = Schema.decodeUnknownSync(CodeMode.CodeModeFailure)(test.results[0]);
+
+      expect(failure.omittedCalls).toBeGreaterThan(0);
+      expect(new TextEncoder().encode(JSON.stringify(failure)).byteLength).toBeLessThanOrEqual(256);
+      expect(test.reports[0]?.calls).toHaveLength(8);
+    }),
+  );
+  it.effect("does not replay a program interrupted after a write under durable recovery", () =>
+    Effect.gen(function* () {
+      let writes = 0;
+
+      const test = scenario(
+        `async () => {
+      await tools.write({ id: 0 });
+      return await tools.write({ id: 1 });
+    }`,
+        (id) => (id === 0 ? Effect.sync(() => ++writes) : Effect.interrupt),
+      );
+
+      const runtimeLayer = DurableAgentRuntime.layer.pipe(
+        Layer.provideMerge(
+          Layer.mergeAll(
+            MemoryThreadStoreLive,
+            MemorySubmissionLedgerLive,
+            WakeScheduler.layerNoop,
+            DurableRuntimeFailpoint.layer,
+            ToolReconciler.uncertain,
+            DurableRuntimeConfig.layer({
+              deploymentId: DeploymentId.make("code-mode"),
+              producerId: ProducerId.make("code-mode"),
+            }),
+          ),
+        ),
+        Layer.provide(NodeCrypto.layer),
+      );
+
+      yield* Effect.gen(function* () {
+        const runtime = yield* DurableAgentRuntime;
+        const threadId = ThreadId.make("interrupted-writes");
+        const digest = Digest.make("a".repeat(64));
+
+        const receipt = yield* runtime.submit(test.agent, "go", {
+          threadId,
+          principal: Principal.make("test"),
+          idempotencyKey: IdempotencyKey.make("write"),
+          definitions: DefinitionDigests.make({ agent: digest, model: digest, tools: digest }),
+        });
+
+        const killed = yield* runtime
+          .processThread(test.agent, threadId)
+          .pipe(Effect.provide(test.handlers), Effect.exit);
+
+        expect(Exit.isFailure(killed)).toBe(true);
+        expect(writes).toBe(1);
+        const reports = yield* runtime.runRecovery;
+
+        expect(
+          reports.find((report) => report.submissionId === receipt.submissionId)?.decision._tag,
+        ).toBe("MarkUnknown");
+        yield* runtime.processThread(test.agent, threadId).pipe(Effect.provide(test.handlers));
+        expect(writes).toBe(1);
+      }).pipe(Effect.provide(runtimeLayer), Effect.scoped);
+    }),
+  );
+});


### PR DESCRIPTION
Code Mode previously rejected mutations and overlapping host calls. Allow selected read and write Tools, and run independent calls concurrently through scoped Effect workers and broker Semaphore permits. `limits.maxHostCallConcurrency` defaults to 4 and accepts 1–64 per pass; existing schemas, grants, visibility, and run budgets still apply.

**Behavior change:** host Tool authorization now checks every inner call before budget reservation or execution. Policies must explicitly allow those Tools; requests include the parent call identity and invocation index. Tools declaring additional approval requirements remain unsupported and fail closed.

Select and capture that policy once at the Run boundary. Brokers acquire the private `ProgrammaticToolAuthorization` service through Effect context; its adapter preserves typed override failures for broker outcomes without widening the public authorization service's error channel.

```mermaid
flowchart LR
  C[CodeMode] -->|generated program| E[CodeExecutor]
  E -->|bounded host calls| B[ToolBroker]
  B -->|authorize and reserve budget| H[Selected Tool handler]
  B -->|invocation-ordered outcome report| C
  R[Run boundary] -->|select policy and capture services| A[ProgrammaticToolAuthorization]
  B -.->|acquire from context| A
```

For example, with `createProject` and `createTask` exposed in the `tools` namespace:

```js
async () => {
  const project = await tools.createProject({ name: "Launch" });
  const tasks = await Promise.all(
    ["Design", "Build", "Ship"].map((title) =>
      tools.createTask({ projectId: project.id, title }),
    ),
  );
  return { projectId: project.id, tasksCreated: tasks.length };
}
```

Successful execution returns the project ID and `tasksCreated: 3`. If a call fails, completed writes remain completed. Bounded `CodeModeFailure.calls` evidence distinguishes succeeded, failed, uncertain, and not-started calls; `omittedCalls` identifies truncated evidence. The optional `onPassExit` callback receives the full ephemeral report after executor resources close, including interruption and defects.

The outer Tool is always uncertain, so ownership loss cannot automatically replay a partially completed program. Inferring whole-program idempotency from individual Tools would be unsafe; checkpoint/resume remains a separate concern. Reports add no inner canonical records and do not survive process loss.

Validation: `vp run ready` passed, including adapter/conformance suites, type checks, public examples, builds, and documentation checks. Regression coverage includes ambient policy and typed override precedence, captured authorization services, denial without budget consumption, bounded concurrency, dependent-call progress, partial failure, timeout, interruption, defects, finalizers, output limits, and durable recovery without replay. The commit hook passed without changing the validated tree.

The local workerd benchmark used 2 warmups and 20 measured samples per combination, rotating mode order, with 20 ms scripted model requests and 20 ms Tool I/O. Timing covers dispatch through the fully consumed reply, including a fresh Dynamic Worker for each Code Mode pass. All answers, model-call counts, concurrency bounds, and finalizers passed.

| Workload | Mode | p50 (ms) | p95 (ms) | Model calls | Peak Tool concurrency |
| --- | --- | ---: | ---: | ---: | ---: |
| Independent reads | Native | 77.0 | 80.7 | 2 | 2 |
| Independent reads | Sequential Code Mode | 104.4 | 109.8 | 2 | 1 |
| Independent reads | Concurrent Code Mode | 81.3 | 85.9 | 2 | 2 |
| Project + three tasks | Native | 127.2 | 140.1 | 3 | 3 |
| Project + three tasks | Sequential Code Mode | 148.8 | 157.0 | 2 | 1 |
| Project + three tasks | Concurrent Code Mode | 105.8 | 111.6 | 2 | 3 |

These measurements were collected for the implementation tree committed as `18f96441`, on macOS arm64 with Node 24.21.0; the subsequent authorization service refactor has not been remeasured. They describe local scripted execution, not live-provider or deployed Cloudflare latency. Reproduce with `vp run -F @effect-agent/example-code-mode-cloudflare benchmark`; the command writes all samples and environment metadata to `/tmp/code-mode-benchmark.json`.
