### PR TITLE
fix(engine): recover mixed completion tool batches

### DIFF
--- a/.changeset/correct-mixed-completion.md
+++ b/.changeset/correct-mixed-completion.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/engine": patch
+---
+
+Let agents correct mixed completion-tool batches before application tools execute, within existing run budgets. Preserve failed call diagnostics and durable recovery without replaying rejected tools.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -183,6 +183,23 @@ tool and completion must use the named tool. Without it, valid final assistant J
 complete the run. [Exhaustion policy](../concepts/budgets#exhaustion-final-answer-or-failure)
 controls the last available turn.
 
+Completion tools must run alone, after any other needed tool results arrive. When a model mixes
+a completion tool with other application calls, the engine rejects the entire batch before any
+handler starts and returns one `ModelProtocolError` result per call. The next ordinary turn can
+correct the declaration. Each rejected call counts toward `maxToolCalls` and
+`repeatedFailureLimit`; model usage, turns, cost, and duration remain charged to the same run.
+There is no separate retry allowance. A batch of three rejected calls can therefore exhaust the
+default repeated-failure limit immediately. Budget exhaustion still controls finalization, and an
+invalid finalization batch fails without another correction.
+
+This correction also applies to `completionFromTools`. Batches containing provider-executed tools,
+context rollover, or invalid declarations recovered as pending work still fail: provider tools
+may already have run, and pending durable calls cannot safely be treated as unexecuted. Completed
+rejections are retained atomically with their failed results and survive recovery without replay.
+Ordinary valid tool batches keep their configured concurrency. `ToolCallFailed` events identify
+each rejected call by name and ID; turn events show correction attempts and the terminal run event
+reports their outcome.
+
 `completion` decides how a run finishes. `runDisposition` labels its successful output for
 durable readers.
 

--- a/packages/core/src/Agent.ts
+++ b/packages/core/src/Agent.ts
@@ -47,7 +47,12 @@ export interface CompletionProjectionInput<Parameters = unknown, Result = unknow
   readonly result: Result;
 }
 
-/** One application Tool whose successful canonical result can complete its owning Agent. */
+/**
+ * One application Tool whose successful singleton result can complete its owning Agent.
+ * Mixed, wholly unexecuted application batches are rejected with failed Tool results so the
+ * model can correct them within ordinary Run budgets. Provider-containing and invalid pending
+ * resumed batches fail closed; the completion designation never permits side-effect replay.
+ */
 export interface CompletionToolDeclaration<
   Parameters = unknown,
   Result = unknown,

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -1344,11 +1344,11 @@ const makeToolFailedEvent = Effect.fn("AgentRuntime.makeToolFailedEvent")(functi
 });
 
 /**
- * Settle an over-budget declared Tool batch without starting any handler
- * (RUN-018): every open application call is marked settled in the trace with
- * the encoded policy failure as its model-visible result, flagged
- * `budgetRejected` so it is exempt from repeated-failure folding, and one
- * `ToolCallFailed` is emitted per call with no `ToolCallStarted` (the
+ * Settle a rejected Tool batch without starting any handler: every open
+ * application call receives the encoded failure as its model-visible result.
+ * Only budget rejections (RUN-018) are exempt from repeated-failure folding;
+ * correctable model declarations count as ordinary failed calls. Emit one
+ * `ToolCallFailed` per call with no `ToolCallStarted` (the
  * approval-denied precedent). The caller hands the trace to
  * `toolBatchContinuation`, so the synthetic results advance history through
  * the ordinary tool message and — under a durable coordinator that never saw
@@ -1359,13 +1359,15 @@ const settleRejectedBatch = Effect.fn("AgentRuntime.settleRejectedBatch")(functi
   context: RunContext,
   turnId: TurnId,
   trace: TurnTrace,
-  policyError: AgentPolicyError,
+  error: AgentPolicyError | ModelProtocolError,
   alreadySettled?: ReadonlySet<string>,
 ): Effect.fn.Return<ReadonlyArray<RunEvent>, ModelProtocolError> {
+  const budgetRejected = error._tag === "AgentPolicyError" ? true : undefined;
+
   const encodedResult = {
-    _tag: policyError._tag,
-    limit: policyError.limit,
-    message: policyError.message,
+    _tag: error._tag,
+    ...(error._tag === "AgentPolicyError" ? { limit: error.limit } : {}),
+    message: error.message,
   };
 
   const events: Array<RunEvent> = [];
@@ -1380,9 +1382,9 @@ const settleRejectedBatch = Effect.fn("AgentRuntime.settleRejectedBatch")(functi
       name: call.name,
       encodedResult,
       isFailure: true,
-      budgetRejected: true,
+      ...(budgetRejected === undefined ? {} : { budgetRejected }),
     };
-    events.push(yield* makeToolFailedEvent(context, turnId, call, policyError, true));
+    events.push(yield* makeToolFailedEvent(context, turnId, call, error, budgetRejected));
   }
 
   return events;
@@ -5954,14 +5956,19 @@ const makeTurn = <
             );
           }
 
-          if ((declaresCompletion || declaresActionCompletion) && trace.toolCalls.size !== 1) {
-            return failRunEventStream(
-              ModelProtocolError.make({
-                message: declaresCompletion
-                  ? `Completion Tool ${completionTool} must be the only Tool Call in its batch`
-                  : "An action completion Tool must be the only Tool Call in its batch",
-              }),
-            );
+          const completionBatchError =
+            (declaresCompletion || declaresActionCompletion) && trace.toolCalls.size !== 1
+              ? ModelProtocolError.make({
+                  message: declaresCompletion
+                    ? `Completion Tool ${completionTool} must be the only Tool Call in its batch`
+                    : "An action completion Tool must be the only Tool Call in its batch",
+                })
+              : undefined;
+
+          // Provider calls may already have executed. Finalization cannot grant
+          // another correction turn. Neither case is a safe batch rejection.
+          if (completionBatchError !== undefined && (hasProviderCalls || finalAnswerOnly)) {
+            return failRunEventStream(completionBatchError);
           }
 
           const completionBatch =
@@ -6310,30 +6317,41 @@ const makeTurn = <
                 }),
               );
             }
-            // RUN-018: the over-budget batch never executes a handler and is
+
+            // RUN-018: a rejected batch never executes a handler and is
             // never durably declared — it settles synthetically through the
             // ordinary batch continuation, so the model sees one failed
-            // result per rejected call and the next Turn is final-answer
-            // constrained. `commitResponse` is deliberately skipped: with no
-            // response commit the Turn stays on the single-batch canonical
+            // result per rejected call. Budget exhaustion constrains the next
+            // Turn; a mixed completion declaration can be corrected within
+            // the remaining budgets. `commitResponse` is deliberately skipped:
+            // without it the Turn stays on the single-batch canonical
             // commit shape and recovery replays it like any no-tool Turn. The
             // rejected Turn's usage is still charged via
             // `afterValidatedResponse` because the Run continues.
-            if (
+            const batchRejection =
               overToolBudget &&
               trace.applicationToolCalls.length > 0 &&
               !(completionBatch && policy.onExhaustion === "final-answer")
-            ) {
+                ? AgentPolicyError.make({
+                    limit: "tool-calls",
+                    message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
+                  })
+                : completionBatchError === undefined
+                  ? undefined
+                  : ModelProtocolError.make({
+                      message:
+                        `${completionBatchError.message}. The entire batch was rejected before execution; none of its tools ran. ` +
+                        "Request any needed ordinary tools first, wait for their results, then call a completion tool alone.",
+                    });
+
+            if (batchRejection !== undefined) {
               return afterValidatedResponse(
                 Effect.gen(function* () {
                   const rejection = yield* settleRejectedBatch(
                     context,
                     turnId,
                     trace,
-                    AgentPolicyError.make({
-                      limit: "tool-calls",
-                      message: `Tool Call budget exhausted: this Run's ${bounds.maxToolCalls} Tool Call limit was reached, so this call was rejected without executing. Do not request more tools; produce your final answer now from the information you already have.`,
-                    }),
+                    batchRejection,
                   );
 
                   return Stream.fromIterable(rejection).pipe(

--- a/packages/engine/src/internal/output-contract.ts
+++ b/packages/engine/src/internal/output-contract.ts
@@ -64,7 +64,7 @@ const contractDirective = (definition: Agent.AnyDefinition): string =>
       "before or after the JSON."
     : `Final output contract: when the task is complete without calling the "${definition.completion.tool}" completion Tool, the final assistant message must be only ` +
       "JSON that is valid against this JSON Schema — no prose, no Markdown code fences, nothing " +
-      `before or after the JSON. When calling the "${definition.completion.tool}" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool's parameter schema instead. The engine projects the successful completion Tool result into the Agent output.`;
+      `before or after the JSON. When calling the "${definition.completion.tool}" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool's parameter schema instead. Call it alone, after receiving any other Tool results. The engine projects the successful completion Tool result into the Agent output.`;
 
 const requiredCompletionDirective = (tool: string, hasAlternatives: boolean): string =>
   `Final output contract: ${hasAlternatives ? "otherwise complete" : "complete only"} by calling the required completion Tool ${JSON.stringify(tool)} ` +
@@ -100,7 +100,7 @@ const renderOutputSchemaContract = (definition: Agent.AnyDefinition): OutputCont
         "An empty reply is valid only when allowed by the output Schema and the task instructions." +
         (definition.completion === undefined
           ? ""
-          : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead; the engine projects its successful result into the Agent output.`),
+          : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead and call it alone, after receiving any other Tool results; the engine projects its successful result into the Agent output.`),
     );
   }
   try {

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -89,6 +89,39 @@ const model = Model.make(
   ),
 );
 
+it("preserves completion correction failures and services in run and stream composition", () => {
+  const completing = Agent.make("typed-completion", {
+    input: Schema.String,
+    output: Schema.String,
+    instructions: "Look up the answer and complete alone.",
+    toolkit,
+    completion: { tool: "lookup", required: true, project: ({ result }) => result },
+  });
+
+  const binding = Agent.withModel(completing, model);
+
+  const options = {
+    beforeTurn: () => TurnHost.pipe(Effect.andThen(Effect.fail(new TurnHostError()))),
+  };
+
+  const run = AgentRuntime.run(binding, "question", options);
+  const stream = AgentRuntime.stream(binding, "question", options);
+
+  expectTypeOf<Effect.Error<typeof run>>().toEqualTypeOf<
+    AgentRuntimeFailure<typeof completing, TurnHostError>
+  >();
+  expectTypeOf<Stream.Error<typeof stream>>().toEqualTypeOf<Effect.Error<typeof run>>();
+  expectTypeOf<Effect.Services<typeof run>>().toEqualTypeOf<
+    | ThreadHistory
+    | IdGenerator
+    | ProviderClient
+    | Catalog
+    | Tool.HandlersFor<typeof toolkit.tools>
+    | TurnHost
+  >();
+  expectTypeOf<Stream.Services<typeof stream>>().toEqualTypeOf<Effect.Services<typeof run>>();
+});
+
 it("preserves encoded input, output, failures and every unsatisfied service", () => {
   const input = { city: "Lisbon", days: "2" };
   const bufferLimits: RunBufferLimits = { maxToolProgressBytes: 1_024 };

--- a/packages/engine/test/completion-correction.test.ts
+++ b/packages/engine/test/completion-correction.test.ts
@@ -1,0 +1,557 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { type AgentPolicyInput } from "@effect-agent/core/AgentPolicy";
+import { RunId, ThreadId, TurnId } from "@effect-agent/core/Identifiers";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { type RunEvent } from "@effect-agent/core/RunEvent";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
+import {
+  RunContextPreparationPassthrough,
+  type RunUsageDelta,
+} from "@effect-agent/engine/RunOptions";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { expect, layer } from "@effect/vitest";
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Stream,
+} from "effect";
+import { TestClock } from "effect/testing";
+import {
+  AiError,
+  LanguageModel,
+  Model,
+  type Prompt,
+  type Response,
+  Tool,
+  Toolkit,
+} from "effect/unstable/ai";
+
+const tools = Toolkit.make(
+  Tool.make("search", {
+    parameters: Schema.Struct({ query: Schema.String }),
+    success: Schema.String,
+  }),
+  Tool.make("complete", {
+    parameters: Schema.Struct({ answer: Schema.String }),
+    success: Schema.String,
+  }),
+);
+
+const definition = (
+  kind: "required" | "optional" | "action" = "required",
+  policy: Partial<AgentPolicyInput> = {},
+) =>
+  Agent.make("completion-correction", {
+    input: Schema.String,
+    output: Schema.String,
+    instructions: "Research before completing.",
+    toolkit: tools,
+    completion:
+      kind === "action"
+        ? undefined
+        : {
+            tool: "complete",
+            required: kind === "required",
+            project: ({ result }) => result,
+          },
+    completionFromTools:
+      kind === "action"
+        ? [
+            {
+              tool: "complete",
+              project: ({ result }) => Option.some(result),
+            },
+          ]
+        : undefined,
+    policy: {
+      maxTurns: 5,
+      maxToolCalls: 10,
+      maxDuration: "30 seconds",
+      toolConcurrency: 2,
+      ...policy,
+    },
+  });
+
+const call = (
+  id: string,
+  name: string,
+  params: Schema.Json,
+  providerExecuted = false,
+): Response.StreamPartEncoded => ({
+  type: "tool-call",
+  id,
+  name,
+  params,
+  providerExecuted,
+});
+
+const finish: Response.StreamPartEncoded = {
+  type: "finish",
+  reason: "tool-calls",
+  usage: { inputTokens: { total: 10 }, outputTokens: { total: 5 } },
+};
+
+const mixed = [
+  call("premature", "complete", { answer: "unresearched" }),
+  call("rejected-search", "search", { query: "Tahoe" }),
+  finish,
+];
+
+const complete = [call("final", "complete", { answer: "researched" }), finish];
+
+const scriptedModel = (responses: ReadonlyArray<ReadonlyArray<Response.StreamPartEncoded>>) => {
+  const prompts: Array<Prompt.Prompt> = [];
+
+  const model = Model.make(
+    "scripted",
+    "completion-correction",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: (request) => {
+          const index = prompts.length;
+
+          prompts.push(request.prompt);
+
+          return Stream.fromIterable(responses[Math.min(index, responses.length - 1)] ?? []);
+        },
+      }),
+    ),
+  );
+
+  return { model, prompts };
+};
+
+const identifiers = Layer.succeed(IdGenerator, {
+  nextThreadId: Effect.succeed(ThreadId.make("correction-thread")),
+  nextRunId: Effect.succeed(RunId.make("correction-run")),
+  nextTurnId: Effect.succeed(TurnId.make("correction-turn")),
+});
+
+layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient, RunContextPreparationPassthrough))(
+  "mixed completion correction",
+  (it) => {
+    for (const kind of ["required", "optional", "action"] as const) {
+      it.effect.each(["run", "stream"] as const)(
+        `${kind} completion corrects before any handler starts through %s`,
+        (mode) =>
+          Effect.gen(function* () {
+            const { model, prompts } = scriptedModel([
+              mixed,
+              [
+                call("research-1", "search", { query: "Tahoe" }),
+                call("research-2", "search", { query: "dates" }),
+                finish,
+              ],
+              complete,
+            ]);
+
+            const starts: Array<string> = [];
+            const usage: Array<RunUsageDelta> = [];
+            const agent = Agent.withModel(definition(kind), model);
+
+            const options = {
+              budget: {
+                guard: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+                consume: (delta: RunUsageDelta) =>
+                  Effect.sync(() => {
+                    usage.push(delta);
+                  }),
+              },
+            };
+
+            const handlers = tools.toLayer({
+              search: ({ query }) =>
+                Effect.sync(() => {
+                  starts.push(query);
+
+                  return `found ${query}`;
+                }),
+              complete: ({ answer }) =>
+                Effect.sync(() => {
+                  starts.push(answer);
+
+                  return answer;
+                }),
+            });
+
+            if (mode === "run") {
+              const result = yield* AgentRuntime.run(agent, "travel", options).pipe(
+                Effect.provide(handlers),
+              );
+
+              expect(result.output).toBe("researched");
+            } else {
+              const events = yield* AgentRuntime.stream(agent, "travel", options).pipe(
+                Stream.runCollect,
+                Effect.provide(handlers),
+              );
+
+              const failures = events.filter((event) => event._tag === "ToolCallFailed");
+
+              expect(
+                failures.map(({ toolCallId, toolName, errorTag, budgetRejected }) => ({
+                  toolCallId,
+                  toolName,
+                  errorTag,
+                  budgetRejected,
+                })),
+              ).toEqual([
+                {
+                  toolCallId: "premature",
+                  toolName: "complete",
+                  errorTag: "ModelProtocolError",
+                  budgetRejected: undefined,
+                },
+                {
+                  toolCallId: "rejected-search",
+                  toolName: "search",
+                  errorTag: "ModelProtocolError",
+                  budgetRejected: undefined,
+                },
+              ]);
+              expect(
+                events
+                  .filter((event) => event._tag === "ToolCallStarted")
+                  .map((event) => event.toolCallId),
+              ).toEqual(["research-1", "research-2", "final"]);
+              expect(events.at(-1)).toMatchObject({
+                _tag: "RunCompleted",
+                output: "researched",
+                turns: 3,
+              });
+            }
+
+            expect(starts).toEqual(["Tahoe", "dates", "researched"]);
+            expect(prompts).toHaveLength(3);
+
+            const results = prompts[1]?.content.flatMap((message) =>
+              message.role === "tool" ? message.content : [],
+            );
+
+            expect(results).toMatchObject([
+              {
+                id: "premature",
+                name: "complete",
+                isFailure: true,
+                result: {
+                  _tag: "ModelProtocolError",
+                  message: expect.stringContaining("none of its tools ran"),
+                },
+              },
+              {
+                id: "rejected-search",
+                name: "search",
+                isFailure: true,
+                result: { _tag: "ModelProtocolError" },
+              },
+            ]);
+            expect(
+              usage
+                .filter((delta) => delta.modelCalls > 0)
+                .map((delta) => [delta.toolCalls, delta.inputTokens, delta.outputTokens]),
+            ).toEqual([
+              [2, 10, 5],
+              [2, 10, 5],
+              [1, 10, 5],
+            ]);
+          }),
+      );
+    }
+
+    it.effect.each([
+      {
+        name: "repeated failures",
+        policy: {},
+        requests: 2,
+        tag: "AgentPolicyError",
+        limit: "repeated-failures",
+      },
+      {
+        name: "strict turns",
+        policy: { maxTurns: 1, onExhaustion: "fail" },
+        requests: 1,
+        tag: "AgentPolicyError",
+        limit: "turns",
+      },
+      {
+        name: "finalization",
+        policy: { maxTurns: 1, repeatedFailureLimit: 0 },
+        requests: 2,
+        tag: "ModelProtocolError",
+      },
+      {
+        name: "strict calls",
+        policy: { maxToolCalls: 1, onExhaustion: "fail" },
+        requests: 1,
+        tag: "AgentPolicyError",
+        limit: "tool-calls",
+      },
+      {
+        name: "exhausted calls",
+        policy: { maxToolCalls: 1 },
+        requests: 2,
+        tag: "ModelProtocolError",
+      },
+      {
+        name: "strict tokens",
+        policy: { tokenBudget: 1_000, completionReserveTokens: 0, onExhaustion: "fail" },
+        requests: 1,
+        tag: "AgentPolicyError",
+        limit: "tokens",
+      },
+      {
+        name: "exhausted tokens",
+        policy: { tokenBudget: 1_000, completionReserveTokens: 0 },
+        requests: 2,
+        tag: "ModelProtocolError",
+      },
+      {
+        name: "cost",
+        policy: { costBudgetMicrousd: 0 },
+        requests: 1,
+        tag: "AgentPolicyError",
+        limit: "cost",
+      },
+    ] satisfies ReadonlyArray<{
+      name: string;
+      policy: Partial<AgentPolicyInput>;
+      requests: number;
+      tag: string;
+      limit?: string;
+    }>)("respects $name without executing or falsely completing", (scenario) =>
+      Effect.gen(function* () {
+        const response = scenario.name.includes("tokens")
+          ? [
+              ...mixed.slice(0, -1),
+              {
+                type: "finish" as const,
+                reason: "tool-calls" as const,
+                usage: { inputTokens: { total: 900 }, outputTokens: { total: 200 } },
+              },
+            ]
+          : mixed;
+
+        const { model, prompts } = scriptedModel([response]);
+        const events: Array<RunEvent> = [];
+
+        const exit = yield* AgentRuntime.stream(
+          Agent.withModel(definition("required", scenario.policy), model),
+          "travel",
+          scenario.name === "cost" ? { estimateCostMicrousd: () => Effect.succeed(1) } : {},
+        ).pipe(
+          Stream.tap((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Stream.runDrain,
+          Effect.provide(
+            tools.toLayer({
+              search: () => Effect.die("must not execute"),
+              complete: () => Effect.die("must not execute"),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit))
+          expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+            _tag: "Some",
+            value: {
+              _tag: scenario.tag,
+              ...("limit" in scenario ? { limit: scenario.limit } : {}),
+            },
+          });
+        expect(prompts).toHaveLength(scenario.requests);
+        expect(
+          events.some((event) => event._tag === "RunCompleted" || event._tag === "ToolCallStarted"),
+        ).toBe(false);
+      }),
+    );
+
+    it.effect.each([false, true])(
+      "refuses mixed provider batches with terminal result=%s",
+      (settled) =>
+        Effect.gen(function* () {
+          const { model, prompts } = scriptedModel([
+            [
+              call("provider-search", "search", { query: "Tahoe" }, true),
+              ...(settled
+                ? [
+                    {
+                      type: "tool-result" as const,
+                      id: "provider-search",
+                      name: "search",
+                      result: "found",
+                      isFailure: false,
+                      providerExecuted: true,
+                    },
+                  ]
+                : []),
+              call("premature", "complete", { answer: "unresearched" }),
+              finish,
+            ],
+            complete,
+          ]);
+
+          const exit = yield* AgentRuntime.run(Agent.withModel(definition(), model), "travel").pipe(
+            Effect.provide(
+              tools.toLayer({
+                search: () => Effect.die("provider calls never invoke handlers"),
+                complete: () => Effect.die("must not execute"),
+              }),
+            ),
+            Effect.exit,
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit))
+            expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+              _tag: "Some",
+              value: { _tag: "ModelProtocolError" },
+            });
+          expect(prompts).toHaveLength(1);
+        }),
+    );
+
+    it.effect.each([false, true])(
+      "refuses a canonically declared mixed resume with settled calls=%s",
+      (settled) =>
+        Effect.gen(function* () {
+          const { model, prompts } = scriptedModel([complete]);
+
+          const exit = yield* AgentRuntime.run(Agent.withModel(definition(), model), "travel", {
+            resume: {
+              turn: 1,
+              turnId: TurnId.make("resumed"),
+              calls: [
+                { id: "premature", name: "complete", params: { answer: "unresearched" } },
+                { id: "search", name: "search", params: { query: "Tahoe" } },
+              ],
+              settled: settled
+                ? [{ id: "search", result: "already happened", isFailure: false }]
+                : [],
+            },
+          }).pipe(
+            Effect.provide(
+              tools.toLayer({
+                search: () => Effect.die("must not replay"),
+                complete: () => Effect.die("must not execute"),
+              }),
+            ),
+            Effect.exit,
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit))
+            expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+              _tag: "Some",
+              value: { _tag: "ModelProtocolError" },
+            });
+          expect(prompts).toHaveLength(0);
+        }),
+    );
+
+    it.effect.each(["failure", "defect", "timeout", "interruption"] as const)(
+      "retains %s semantics and releases the corrective model request",
+      (outcome) =>
+        Effect.gen(function* () {
+          const entered = yield* Deferred.make<void>();
+          const closed = yield* Deferred.make<void>();
+          let requests = 0;
+
+          const nativeError = AiError.make({
+            module: "test",
+            method: "streamText",
+            reason: new AiError.InvalidRequestError({ description: "corrective request failed" }),
+          });
+
+          const defect = new Error("corrective request defect");
+
+          const model = Model.make(
+            "scripted",
+            "correction-lifecycle",
+            Layer.effect(
+              LanguageModel.LanguageModel,
+              LanguageModel.make({
+                generateText: () => Effect.succeed([]),
+                streamText: () =>
+                  requests++ === 0
+                    ? Stream.fromIterable(mixed)
+                    : Stream.unwrap(
+                        Effect.gen(function* () {
+                          yield* Effect.addFinalizer(() => Deferred.succeed(closed, undefined));
+                          yield* Deferred.succeed(entered, undefined);
+
+                          return outcome === "failure"
+                            ? Stream.fail(nativeError)
+                            : outcome === "defect"
+                              ? Stream.die(defect)
+                              : Stream.never;
+                        }),
+                      ),
+              }),
+            ),
+          );
+
+          const events: Array<RunEvent> = [];
+
+          const fiber = yield* AgentRuntime.stream(
+            Agent.withModel(definition(), model),
+            "travel",
+          ).pipe(
+            Stream.tap((event) =>
+              Effect.sync(() => {
+                events.push(event);
+              }),
+            ),
+            Stream.runDrain,
+            Effect.provide(
+              tools.toLayer({
+                search: () => Effect.die("must not execute"),
+                complete: () => Effect.die("must not execute"),
+              }),
+            ),
+            Effect.forkChild,
+          );
+
+          yield* Deferred.await(entered);
+          if (outcome === "timeout") yield* TestClock.adjust("31 seconds");
+          if (outcome === "interruption") yield* Fiber.interrupt(fiber);
+          const exit = yield* Fiber.await(fiber);
+
+          yield* Deferred.await(closed);
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            if (outcome === "defect")
+              expect(Cause.findDefect(exit.cause)).toEqual(Result.succeed(defect));
+            else if (outcome === "interruption") expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+            else
+              expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+                _tag: "Some",
+                value:
+                  outcome === "failure"
+                    ? nativeError
+                    : { _tag: "AgentPolicyError", limit: "duration" },
+              });
+          }
+          expect(requests).toBe(2);
+          expect(
+            events.some(
+              (event) => event._tag === "RunCompleted" || event._tag === "ToolCallStarted",
+            ),
+          ).toBe(false);
+        }),
+    );
+  },
+);

--- a/packages/engine/test/context-economics.test.ts
+++ b/packages/engine/test/context-economics.test.ts
@@ -1232,8 +1232,7 @@ layer(testLayer)("context economics — bounding, tracking, status, exhaustion",
         );
 
         expect(yield* Ref.get(starts)).toBe(0);
-        if (boundary === "mixed" || boundary === "turns")
-          expect(failureFrom(result)).toBeInstanceOf(ModelProtocolError);
+        if (boundary === "turns") expect(failureFrom(result)).toBeInstanceOf(ModelProtocolError);
         else {
           expect(Exit.isSuccess(result)).toBe(true);
           if (Exit.isSuccess(result)) expect(result.value.output).toBe("No action performed.");
@@ -2030,7 +2029,7 @@ layer(testLayer)("context economics — bounding, tracking, status, exhaustion",
       }),
   );
 
-  it.effect("RUN-032: a completion Tool must be the singleton declared batch", () =>
+  it.effect("RUN-032: repeated mixed completion batches fail without executing tools", () =>
     Effect.gen(function* () {
       const mixedToolkit = Toolkit.make(PostMessageTool, SearchTool);
       const handlerStarts = yield* Ref.make(0);
@@ -2088,8 +2087,11 @@ layer(testLayer)("context economics — bounding, tracking, status, exhaustion",
         question: "deliver",
       }).pipe(Effect.provide(toolLayer), Effect.exit);
 
-      expect(failureFrom(exit)).toBeInstanceOf(ModelProtocolError);
-      expect(requests).toHaveLength(1);
+      expect(failureFrom(exit)).toMatchObject({
+        _tag: "AgentPolicyError",
+        limit: "repeated-failures",
+      });
+      expect(requests).toHaveLength(2);
       expect(yield* Ref.get(handlerStarts)).toBe(0);
     }),
   );

--- a/packages/engine/test/output-contract.test.ts
+++ b/packages/engine/test/output-contract.test.ts
@@ -472,7 +472,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
         expect(contracts[0]?.split("\n\n")[0]).toBe(
           'Final output contract: when the task is complete without calling the "deliver_reply" completion Tool, the final assistant message must be only ' +
             "JSON that is valid against this JSON Schema — no prose, no Markdown code fences, nothing " +
-            'before or after the JSON. When calling the "deliver_reply" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool\'s parameter schema instead. The engine projects the successful completion Tool result into the Agent output.',
+            'before or after the JSON. When calling the "deliver_reply" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool\'s parameter schema instead. Call it alone, after receiving any other Tool results. The engine projects the successful completion Tool result into the Agent output.',
         );
         expect(contracts[0]).toContain('"itemCount"');
         expect(histories.length).toBeGreaterThan(0);

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -1999,6 +1999,195 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
       }),
   );
 
+  for (const scenario of [
+    { name: "rejected batch", location: "turn:after-canonical-append", repeated: false },
+    { name: "corrected declaration", location: "turn:after-response-append", repeated: false },
+    { name: "corrected result", location: "turn:after-results-append", repeated: false },
+    { name: "repeated rejection", location: "turn:after-canonical-append", repeated: true },
+  ] satisfies ReadonlyArray<{
+    name: string;
+    location: DurableRuntimeFailpointLocation;
+    repeated: boolean;
+  }>) {
+    it.effect(
+      `mixed completion recovery preserves ${scenario.name} without duplicate effects`,
+      () =>
+        Effect.gen(function* () {
+          const runtime = yield* DurableAgentRuntime;
+
+          const Search = Tool.make("search", {
+            parameters: Schema.Struct({}),
+            success: Schema.String,
+          });
+
+          const Deliver = Tool.make("deliver", {
+            parameters: Schema.Struct({ message: Schema.String }),
+            success: Schema.String,
+          });
+
+          const tools = Toolkit.make(Search, Deliver);
+
+          const definition = Agent.make("durable-completion-correction", {
+            input: Schema.String,
+            output: Schema.String,
+            instructions: "Research, then deliver alone.",
+            toolkit: tools,
+            completion: { tool: "deliver", required: true, project: ({ result }) => result },
+            policy: {
+              maxTurns: 5,
+              maxToolCalls: 8,
+              maxDuration: "30 seconds",
+              repeatedFailureLimit: 3,
+            },
+          });
+
+          const scripted = yield* makeScriptedModel((turn) =>
+            turn === 0 || scenario.repeated
+              ? [
+                  {
+                    type: "tool-call",
+                    id: `premature-${turn}`,
+                    name: "deliver",
+                    params: { message: "premature" },
+                    providerExecuted: false,
+                  },
+                  {
+                    type: "tool-call",
+                    id: `rejected-${turn}`,
+                    name: "search",
+                    params: {},
+                    providerExecuted: false,
+                  },
+                  {
+                    type: "finish",
+                    reason: "tool-calls",
+                    usage: { inputTokens: { total: 10 }, outputTokens: { total: 5 } },
+                  },
+                ]
+              : turn === 1
+                ? [
+                    {
+                      type: "tool-call",
+                      id: "research",
+                      name: "search",
+                      params: {},
+                      providerExecuted: false,
+                    },
+                    {
+                      type: "finish",
+                      reason: "tool-calls",
+                      usage: { inputTokens: { total: 20 }, outputTokens: { total: 10 } },
+                    },
+                  ]
+                : [
+                    {
+                      type: "tool-call",
+                      id: "final",
+                      name: "deliver",
+                      params: { message: "researched" },
+                      providerExecuted: false,
+                    },
+                    {
+                      type: "finish",
+                      reason: "tool-calls",
+                      usage: { inputTokens: { total: 30 }, outputTokens: { total: 15 } },
+                    },
+                  ],
+          );
+
+          const starts: Array<string> = [];
+
+          const toolLayer = tools.toLayer({
+            search: () =>
+              Effect.sync(() => {
+                starts.push("search");
+
+                return "found";
+              }),
+            deliver: ({ message }) =>
+              Effect.sync(() => {
+                starts.push(message);
+
+                return message;
+              }),
+          });
+
+          const agent = Agent.withModel(definition, scripted.model);
+          const thread = `correction-${scenario.name}`;
+
+          const receipt = yield* runtime.submit(
+            agent,
+            "travel",
+            submitOptions(thread, "correction"),
+          );
+
+          yield* armFailpoint(scenario.location);
+
+          const crashed = yield* runtime
+            .processThread(agent, decodeThreadId(thread))
+            .pipe(Effect.provide(toolLayer), Effect.exit);
+
+          expect(failureTag(crashed)).toBe("DurableRuntimeFailpointError");
+          yield* clearFailpoint;
+
+          const before = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+          expect(
+            before.filter((payload) => payload._tag === "ToolCallSettled").slice(0, 2),
+          ).toMatchObject([
+            {
+              toolCallId: "premature-0",
+              toolName: "deliver",
+              isFailure: true,
+              result: { _tag: "ModelProtocolError" },
+            },
+            {
+              toolCallId: "rejected-0",
+              toolName: "search",
+              isFailure: true,
+              result: { _tag: "ModelProtocolError" },
+            },
+          ]);
+          expect(
+            before.some(
+              (payload) =>
+                payload._tag === "ToolCallPrepared" &&
+                (payload.toolCallId === "premature-0" || payload.toolCallId === "rejected-0"),
+            ),
+          ).toBe(false);
+          expect(before.some((payload) => payload._tag === "RunCompleted")).toBe(false);
+          expect(starts).toEqual(
+            scenario.location === "turn:after-results-append" ? ["search"] : [],
+          );
+
+          yield* runtime
+            .processThread(agent, decodeThreadId(thread))
+            .pipe(Effect.provide(toolLayer));
+          const settlement = yield* runtime.awaitSettlement(receipt);
+
+          expect(settlement.outcome).toBe(scenario.repeated ? "failed" : "completed");
+          expect(starts).toEqual(scenario.repeated ? [] : ["search", "researched"]);
+          expect(scripted.prompts).toHaveLength(scenario.repeated ? 2 : 3);
+          const correctionPrompt = JSON.stringify(scripted.prompts[1]);
+
+          expect(correctionPrompt).toContain("none of its tools ran");
+          expect(correctionPrompt).toContain("premature-0");
+          const after = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
+
+          expect(after.filter((payload) => payload._tag === "RunCompleted")).toHaveLength(
+            scenario.repeated ? 0 : 1,
+          );
+          expect(after.filter((payload) => payload._tag === "SubmissionSettled")).toHaveLength(1);
+          expect(after.filter((payload) => payload._tag === "ModelResponseRecorded")).toHaveLength(
+            scenario.repeated ? 2 : 3,
+          );
+          expect(after.find((payload) => payload._tag === "SubmissionSettled")).toMatchObject({
+            result: scenario.repeated ? { errorTag: "AgentPolicyError" } : "researched",
+          });
+        }),
+    );
+  }
+
   it.effect("RUN-029 invalid disposition selection settles failed without disposition", () =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;


### PR DESCRIPTION
When a model calls a completion tool alongside another tool, the engine currently fails the run before application handlers execute. Reject the whole application batch with one failed result per call, then let the next ordinary turn correct the declaration within the existing run budgets.

Illustrative correction:

```text
search + complete → reject both without execution → search → complete alone
```

Reuse the existing rejected-batch settlement and atomic turn commit. Each rejected call counts toward the tool-call and repeated-failure limits; model usage, turns, cost, and duration remain charged to the same run. Required, optional, and action completion tools retain singleton terminal semantics, and ordinary batches retain their concurrency. Optional completion instructions now state the singleton rule explicitly.

Batches containing provider-executed tools, context rollover, invalid pending resumed declarations, and invalid finalization calls still fail safely. The engine cannot treat potentially executed work as an unexecuted batch. Retrying the entire run could repeat earlier side effects, while disabling parallel calls would restrict valid ordinary batches; correction stays at the existing pre-execution boundary.

Validation: `vp run --no-cache ready` passed all 82 tasks, including static checks, tests, package builds, documentation/link validation, and the Action build. Regression coverage exercises correction through run and stream, budget exhaustion, provider boundaries, failure/defect/timeout/interruption finalizers, and crash recovery after rejection, corrected declaration, and corrected results. It also verifies that the failure limit survives recovery and rejected tools never execute. Includes documentation and a patch changeset.
