### PR TITLE
fix(engine): allow completion alongside hosted tool results

### DIFF
--- a/.changeset/quiet-hosted-completion.md
+++ b/.changeset/quiet-hosted-completion.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+"@effect-agent/thread": patch
+---
+
+Allow completion alongside terminal provider tool results during execution and recovery. Preserve hosted results when correcting mixed application completion calls, and keep provider work charged to run budgets.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -166,15 +166,19 @@ effects into named Steps. The handler may be re-entered after interruption.
 
 **Completion Tool**
 
-The single Definition-designated Tool whose successful singleton call projects through the Agent
-output Schema and completes the Run immediately. It remains an ordinary external side effect for
-authorization and durability; the designation adds terminal semantics, not exactly-once execution.
+The single Definition-designated Tool whose successful call, as the sole application Tool Call,
+projects through the Agent output Schema and completes the Run immediately. It remains an ordinary
+external side effect for authorization and durability; the designation adds terminal semantics,
+not exactly-once execution.
+Provider-executed calls may accompany it only with recorded terminal results and still count toward
+Run budgets.
 
 **Action completion**
 
 An optional Definition-owned projection from an ordinary action Tool's successful canonical result
-to Agent output. The Tool runs alone and receives no completion-budget exemption. The pure
-projector may decline completion when the whole request remains unfinished.
+to Agent output. The Tool is the sole application call, may accompany terminal provider results,
+and receives no completion-budget exemption. The pure projector may decline completion when the
+whole request remains unfinished.
 
 **Step**  
 A deterministically named sub-operation within one Durable Tool Call. Its result is

--- a/docs/concepts/runtime-model.md
+++ b/docs/concepts/runtime-model.md
@@ -113,7 +113,7 @@ maximum charge before the request.
 | Stop condition                                 | Runtime behavior                                                                               |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Valid final output                             | Decode through the output Schema and complete when no queued input continues the run           |
-| Successful designated completion tool          | Project its singleton result through the output Schema and complete immediately                |
+| Successful designated completion tool          | Project its sole application result through the output Schema and complete immediately         |
 | Turn, tool call, or token exhaustion           | Follow `onExhaustion`: fail, or produce a constrained final answer with at most one grace turn |
 | Duration, cost, or repeated tool failure limit | Fail with a typed policy error                                                                 |
 | Abort or interruption                          | End the current execution; durable ownership loss may leave work for a replacement attempt     |

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -183,18 +183,23 @@ tool and completion must use the named tool. Without it, valid final assistant J
 complete the run. [Exhaustion policy](../concepts/budgets#exhaustion-final-answer-or-failure)
 controls the last available turn.
 
-Completion tools must run alone, after any other needed tool results arrive. When a model mixes
-a completion tool with other application calls, the engine rejects the entire batch before any
-handler starts and returns one `ModelProtocolError` result per call. The next ordinary turn can
-correct the declaration. Each rejected call counts toward `maxToolCalls` and
+A completion tool must be the only application call, after any other needed application tool
+results arrive. Completed provider work, such as hosted web search with a terminal result, may
+appear in the same response and still counts toward run budgets. When a model mixes a completion
+tool with other application calls, the engine rejects those application calls before any handler
+starts and returns one `ModelProtocolError` result per rejected call. Provider results are retained.
+The next ordinary turn can correct the declaration. Each rejected call counts toward `maxToolCalls` and
 `repeatedFailureLimit`; model usage, turns, cost, and duration remain charged to the same run.
 There is no separate retry allowance. A batch of three rejected calls can therefore exhaust the
 default repeated-failure limit immediately. Budget exhaustion still controls finalization, and an
 invalid finalization batch fails without another correction.
 
-This correction also applies to `completionFromTools`. Batches containing provider-executed tools,
-context rollover, or invalid declarations recovered as pending work still fail: provider tools
-may already have run, and pending durable calls cannot safely be treated as unexecuted. Completed
+This correction also applies to `completionFromTools`. Provider calls without terminal results,
+context rollover mixed with other calls, and invalid application batches recovered as pending work
+still fail: pending durable calls cannot safely be treated as unexecuted. Recovery permits one
+completion call alongside recorded terminal provider results, using recorded application results
+when available and never replaying an uncertain ordinary side effect. Finalization after budget
+exhaustion still permits only the advertised completion tool, with no provider calls. Completed
 rejections are retained atomically with their failed results and survive recovery without replay.
 Ordinary valid tool batches keep their configured concurrency. `ToolCallFailed` events identify
 each rejected call by name and ID; turn events show correction attempts and the terminal run event

--- a/packages/core/src/Agent.ts
+++ b/packages/core/src/Agent.ts
@@ -48,10 +48,12 @@ export interface CompletionProjectionInput<Parameters = unknown, Result = unknow
 }
 
 /**
- * One application Tool whose successful singleton result can complete its owning Agent.
+ * One application Tool whose successful result can complete its owning Agent when it is the
+ * only application call. Provider-executed calls may accompany it only with terminal results.
  * Mixed, wholly unexecuted application batches are rejected with failed Tool results so the
- * model can correct them within ordinary Run budgets. Provider-containing and invalid pending
- * resumed batches fail closed; the completion designation never permits side-effect replay.
+ * model can correct them within ordinary Run budgets; completed provider results are retained.
+ * Missing provider results and invalid pending resumed batches fail closed. The completion
+ * designation never permits side-effect replay.
  */
 export interface CompletionToolDeclaration<
   Parameters = unknown,
@@ -75,8 +77,9 @@ type CompletionToolFor<ToolkitValue extends Toolkit.Any, Output> = {
 /**
  * An ordinary action Tool whose canonical success may satisfy the whole request.
  * Projectors must be pure and deterministic: recovery re-evaluates them. None preserves
- * ordinary continuation; Some is validated as the Agent output. These Tools must run alone
- * and never receive the required completion Tool's exhaustion allowance.
+ * ordinary continuation; Some is validated as the Agent output. These Tools must be the sole
+ * application call; terminal provider results may accompany them. They never receive the
+ * required completion Tool's exhaustion allowance.
  */
 export interface CompletionFromToolDeclaration<
   Parameters = unknown,

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -5957,30 +5957,32 @@ const makeTurn = <
           }
 
           const completionBatchError =
-            (declaresCompletion || declaresActionCompletion) && trace.toolCalls.size !== 1
+            (declaresCompletion || declaresActionCompletion) &&
+            trace.applicationToolCalls.length !== 1
               ? ModelProtocolError.make({
                   message: declaresCompletion
-                    ? `Completion Tool ${completionTool} must be the only Tool Call in its batch`
-                    : "An action completion Tool must be the only Tool Call in its batch",
+                    ? `Completion Tool ${completionTool} must be the only application Tool Call in its batch`
+                    : "An action completion Tool must be the only application Tool Call in its batch",
                 })
               : undefined;
 
-          // Provider calls may already have executed. Finalization cannot grant
-          // another correction turn. Neither case is a safe batch rejection.
-          if (completionBatchError !== undefined && (hasProviderCalls || finalAnswerOnly)) {
+          // Finalization cannot grant another correction turn. Completed provider work
+          // is retained separately; only unexecuted application calls can be rejected.
+          if (completionBatchError !== undefined && finalAnswerOnly) {
             return failRunEventStream(completionBatchError);
           }
 
-          const completionBatch =
-            declaresCompletion &&
-            trace.toolCalls.size === 1 &&
-            trace.applicationToolCalls.length === 1;
+          const completionBatch = declaresCompletion && trace.applicationToolCalls.length === 1;
 
           // Fail-closed (RUN-020): final-answer mode advertises either no
           // Tool or exactly the Definition-owned completion Tool. Any other
           // declaration is a protocol violation, never another rejection
           // round.
-          if (finalAnswerOnly && trace.toolCalls.size > 0 && !completionBatch) {
+          if (
+            finalAnswerOnly &&
+            trace.toolCalls.size > 0 &&
+            (hasProviderCalls || !completionBatch)
+          ) {
             return failRunEventStream(
               ModelProtocolError.make({
                 message:
@@ -6340,7 +6342,10 @@ const makeTurn = <
                   ? undefined
                   : ModelProtocolError.make({
                       message:
-                        `${completionBatchError.message}. The entire batch was rejected before execution; none of its tools ran. ` +
+                        `${completionBatchError.message}. ` +
+                        (hasProviderCalls
+                          ? "The application batch was rejected before execution; none of its application tools ran. Completed provider results are retained. "
+                          : "The entire batch was rejected before execution; none of its tools ran. ") +
                         "Request any needed ordinary tools first, wait for their results, then call a completion tool alone.",
                     });
 
@@ -6865,18 +6870,18 @@ const makeResumeTurn = <
         (actionCompletionCall !== undefined ||
           (completionTool !== undefined &&
             trace.applicationToolCalls.some((call) => call.name === completionTool))) &&
-        trace.toolCalls.size !== 1
+        trace.applicationToolCalls.length !== 1
       ) {
         return failRunEventStream(
           ModelProtocolError.make({
-            message: `Completion Tool ${completionTool} must be the only Tool Call in its batch`,
+            message: "A completion Tool must be the only application Tool Call in its batch",
           }),
         );
       }
 
       const completionBatch =
         completionTool !== undefined &&
-        trace.toolCalls.size === 1 &&
+        trace.applicationToolCalls.length === 1 &&
         trace.applicationToolCalls[0]?.name === completionTool;
 
       if (
@@ -6891,7 +6896,7 @@ const makeResumeTurn = <
         );
       }
 
-      if (context.finalizationUsed && !completionBatch) {
+      if (context.finalizationUsed && (!completionBatch || trace.toolCalls.size !== 1)) {
         return failRunEventStream(
           ModelProtocolError.make({
             message: "A resumed grace finalization may only execute the completion Tool",

--- a/packages/engine/src/internal/output-contract.ts
+++ b/packages/engine/src/internal/output-contract.ts
@@ -64,11 +64,11 @@ const contractDirective = (definition: Agent.AnyDefinition): string =>
       "before or after the JSON."
     : `Final output contract: when the task is complete without calling the "${definition.completion.tool}" completion Tool, the final assistant message must be only ` +
       "JSON that is valid against this JSON Schema — no prose, no Markdown code fences, nothing " +
-      `before or after the JSON. When calling the "${definition.completion.tool}" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool's parameter schema instead. Call it alone, after receiving any other Tool results. The engine projects the successful completion Tool result into the Agent output.`;
+      `before or after the JSON. When calling the "${definition.completion.tool}" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool's parameter schema instead. Call it as the sole application Tool Call, after receiving any other needed application Tool results. Completed provider Tool results may accompany it. The engine projects the successful completion Tool result into the Agent output.`;
 
 const requiredCompletionDirective = (tool: string, hasAlternatives: boolean): string =>
   `Final output contract: ${hasAlternatives ? "otherwise complete" : "complete only"} by calling the required completion Tool ${JSON.stringify(tool)} ` +
-  "as the sole Tool Call in its batch. Do not emit an ordinary final assistant text answer. " +
+  "as the sole application Tool Call in its batch. Completed provider Tool results may accompany it. Do not emit an ordinary final assistant text answer. " +
   "The Tool's canonical parameters and successful result are projected and validated as the Agent output.";
 
 /**
@@ -100,7 +100,7 @@ const renderOutputSchemaContract = (definition: Agent.AnyDefinition): OutputCont
         "An empty reply is valid only when allowed by the output Schema and the task instructions." +
         (definition.completion === undefined
           ? ""
-          : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead and call it alone, after receiving any other Tool results; the engine projects its successful result into the Agent output.`),
+          : ` When calling the "${definition.completion.tool}" completion Tool, follow its parameter schema instead and call it as the sole application Tool Call, after receiving any other needed application Tool results; completed provider Tool results may accompany it; the engine projects its successful result into the Agent output.`),
     );
   }
   try {
@@ -132,7 +132,7 @@ export const outputSchemaContract = (definition: Agent.AnyDefinition): OutputCon
     base._tag === "rendered" && alternatives.length > 0
       ? rendered(
           `The following action Tools may complete the Run from their successful canonical result: ${alternatives.map((declaration) => JSON.stringify(declaration.tool)).join(", ")}. ` +
-            "Call such a Tool alone, following its parameter schema. It may complete the Run only when it satisfies the whole request. " +
+            "Call such a Tool as the sole application Tool Call, following its parameter schema. Completed provider Tool results may accompany it. It may complete the Run only when it satisfies the whole request. " +
             "An incomplete or pending result continues the Run. These actions are unavailable during finalization after budget exhaustion.\n\n" +
             base.message,
         )

--- a/packages/engine/test/completion-correction.test.ts
+++ b/packages/engine/test/completion-correction.test.ts
@@ -106,6 +106,18 @@ const mixed = [
 
 const complete = [call("final", "complete", { answer: "researched" }), finish];
 
+const hostedSearch = [
+  call("provider-search", "search", { query: "Tahoe" }, true),
+  {
+    type: "tool-result",
+    id: "provider-search",
+    name: "search",
+    result: "found",
+    isFailure: false,
+    providerExecuted: true,
+  },
+] satisfies ReadonlyArray<Response.StreamPartEncoded>;
+
 const scriptedModel = (responses: ReadonlyArray<ReadonlyArray<Response.StreamPartEncoded>>) => {
   const prompts: Array<Prompt.Prompt> = [];
 
@@ -128,6 +140,20 @@ const scriptedModel = (responses: ReadonlyArray<ReadonlyArray<Response.StreamPar
   );
 
   return { model, prompts };
+};
+
+const resumeUsage = {
+  modelCalls: 1,
+  committedTurns: 1,
+  toolCalls: 2,
+  inputTokens: 10,
+  outputTokens: 5,
+  lastInputTokens: 10,
+  lastOutputTokens: 5,
+  costMicrousd: 0,
+  programmaticToolCalls: 0,
+  consecutiveToolFailures: 0,
+  finalizationUsed: false,
 };
 
 const identifiers = Layer.succeed(IdGenerator, {
@@ -379,35 +405,201 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient, RunContextPrepar
       }),
     );
 
-    it.effect.each([false, true])(
-      "refuses mixed provider batches with terminal result=%s",
-      (settled) =>
-        Effect.gen(function* () {
-          const { model, prompts } = scriptedModel([
-            [
-              call("provider-search", "search", { query: "Tahoe" }, true),
-              ...(settled
-                ? [
-                    {
-                      type: "tool-result" as const,
-                      id: "provider-search",
-                      name: "search",
-                      result: "found",
-                      isFailure: false,
-                      providerExecuted: true,
-                    },
-                  ]
-                : []),
-              call("premature", "complete", { answer: "unresearched" }),
-              finish,
-            ],
-            complete,
-          ]);
+    for (const kind of ["required", "optional", "action"] as const) {
+      it.effect.each(["live", "pending", "settled"] as const)(
+        `${kind} completion accepts terminal provider work during %s execution`,
+        (mode) =>
+          Effect.gen(function* () {
+            const { model, prompts } = scriptedModel([[...hostedSearch, ...complete]]);
+            let starts = 0;
+            const usage: Array<RunUsageDelta> = [];
 
-          const exit = yield* AgentRuntime.run(Agent.withModel(definition(), model), "travel").pipe(
+            const result = yield* AgentRuntime.run(
+              Agent.withModel(definition(kind), model),
+              "travel",
+              {
+                ...(mode === "live"
+                  ? {}
+                  : {
+                      resumeUsage,
+                      resume: {
+                        turn: 1,
+                        turnId: TurnId.make("resumed-provider"),
+                        calls: [
+                          {
+                            id: "provider-search",
+                            name: "search",
+                            params: { query: "Tahoe" },
+                            providerExecuted: true,
+                          },
+                          { id: "final", name: "complete", params: { answer: "researched" } },
+                        ],
+                        settled: [
+                          { id: "provider-search", result: "found", isFailure: false },
+                          ...(mode === "settled"
+                            ? [{ id: "final", result: "researched", isFailure: false }]
+                            : []),
+                        ],
+                      },
+                    }),
+                budget: {
+                  guard: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+                  consume: (delta: RunUsageDelta) =>
+                    Effect.sync(() => {
+                      usage.push(delta);
+                    }),
+                },
+              },
+            ).pipe(
+              Effect.provide(
+                tools.toLayer({
+                  search: () =>
+                    Effect.die("provider work must never invoke an application handler"),
+                  complete: ({ answer }) =>
+                    Effect.sync(() => {
+                      starts++;
+
+                      return answer;
+                    }),
+                }),
+              ),
+            );
+
+            expect(result.output).toBe("researched");
+            expect(starts).toBe(mode === "settled" ? 0 : 1);
+            expect(prompts).toHaveLength(mode === "live" ? 1 : 0);
+            expect(
+              usage.filter((delta) => delta.modelCalls > 0).map((delta) => delta.toolCalls),
+            ).toEqual(mode === "live" ? [2] : []);
+          }),
+      );
+
+      it.effect(
+        `${kind} completion corrects application calls while retaining hosted results`,
+        () =>
+          Effect.gen(function* () {
+            const { model, prompts } = scriptedModel([[...hostedSearch, ...mixed], complete]);
+            const starts: Array<string> = [];
+
+            const events = yield* AgentRuntime.stream(
+              Agent.withModel(definition(kind), model),
+              "travel",
+            ).pipe(
+              Stream.runCollect,
+              Effect.provide(
+                tools.toLayer({
+                  search: () => Effect.die("rejected and provider calls must not run"),
+                  complete: ({ answer }) =>
+                    Effect.sync(() => {
+                      starts.push(answer);
+
+                      return answer;
+                    }),
+                }),
+              ),
+            );
+
+            expect(starts).toEqual(["researched"]);
+            expect(events.at(-1)).toMatchObject({
+              _tag: "RunCompleted",
+              output: "researched",
+              turns: 2,
+            });
+            expect(
+              events
+                .filter((event) => event._tag === "ToolCallFailed")
+                .map((event) => event.toolCallId),
+            ).toEqual(["premature", "rejected-search"]);
+            expect(
+              prompts[1]?.content.flatMap((message) =>
+                message.role === "assistant" ? message.content : [],
+              ),
+            ).toContainEqual(
+              expect.objectContaining({
+                type: "tool-result",
+                id: "provider-search",
+                result: "found",
+                isFailure: false,
+                providerExecuted: true,
+              }),
+            );
+            expect(JSON.stringify(prompts[1])).toContain("none of its application tools ran");
+          }),
+      );
+    }
+
+    it.effect.each(["strict", "finalization"] as const)(
+      "counts provider calls and preserves the %s budget boundary",
+      (mode) =>
+        Effect.gen(function* () {
+          const { model } = scriptedModel([[...hostedSearch, ...complete]]);
+
+          const exit = yield* AgentRuntime.run(
+            Agent.withModel(
+              definition("required", {
+                maxToolCalls: 1,
+                onExhaustion: mode === "strict" ? "fail" : "final-answer",
+              }),
+              model,
+            ),
+            "travel",
+            mode === "finalization" ? { resumeUsage } : {},
+          ).pipe(
             Effect.provide(
               tools.toLayer({
-                search: () => Effect.die("provider calls never invoke handlers"),
+                search: () => Effect.die("must not replay"),
+                complete: () => Effect.die("must not execute beyond the allowed tool surface"),
+              }),
+            ),
+            Effect.exit,
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit))
+            expect(Cause.findErrorOption(exit.cause)).toMatchObject({
+              _tag: "Some",
+              value:
+                mode === "strict"
+                  ? { _tag: "AgentPolicyError", limit: "tool-calls" }
+                  : { _tag: "ModelProtocolError" },
+            });
+        }),
+    );
+
+    it.effect.each(["live", "resume"] as const)(
+      "refuses provider work without a terminal result during %s",
+      (mode) =>
+        Effect.gen(function* () {
+          const { model, prompts } = scriptedModel([
+            [call("provider-search", "search", { query: "Tahoe" }, true), ...complete],
+          ]);
+
+          const exit = yield* AgentRuntime.run(
+            Agent.withModel(definition(), model),
+            "travel",
+            mode === "live"
+              ? {}
+              : {
+                  resumeUsage,
+                  resume: {
+                    turn: 1,
+                    turnId: TurnId.make("missing-provider-result"),
+                    calls: [
+                      {
+                        id: "provider-search",
+                        name: "search",
+                        params: { query: "Tahoe" },
+                        providerExecuted: true,
+                      },
+                      { id: "final", name: "complete", params: { answer: "researched" } },
+                    ],
+                    settled: [],
+                  },
+                },
+          ).pipe(
+            Effect.provide(
+              tools.toLayer({
+                search: () => Effect.die("must not replay"),
                 complete: () => Effect.die("must not execute"),
               }),
             ),
@@ -420,7 +612,7 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient, RunContextPrepar
               _tag: "Some",
               value: { _tag: "ModelProtocolError" },
             });
-          expect(prompts).toHaveLength(1);
+          expect(prompts).toHaveLength(mode === "live" ? 1 : 0);
         }),
     );
 
@@ -431,6 +623,7 @@ layer(Layer.mergeAll(identifiers, ThreadHistory.layerTransient, RunContextPrepar
           const { model, prompts } = scriptedModel([complete]);
 
           const exit = yield* AgentRuntime.run(Agent.withModel(definition(), model), "travel", {
+            resumeUsage,
             resume: {
               turn: 1,
               turnId: TurnId.make("resumed"),

--- a/packages/engine/test/output-contract.test.ts
+++ b/packages/engine/test/output-contract.test.ts
@@ -472,7 +472,7 @@ layer(testLayer)("RUN-028 model-visible output contract", (it) => {
         expect(contracts[0]?.split("\n\n")[0]).toBe(
           'Final output contract: when the task is complete without calling the "deliver_reply" completion Tool, the final assistant message must be only ' +
             "JSON that is valid against this JSON Schema — no prose, no Markdown code fences, nothing " +
-            'before or after the JSON. When calling the "deliver_reply" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool\'s parameter schema instead. Call it alone, after receiving any other Tool results. The engine projects the successful completion Tool result into the Agent output.',
+            'before or after the JSON. When calling the "deliver_reply" completion Tool, never place this private Agent output JSON in any Tool argument; follow the Tool\'s parameter schema instead. Call it as the sole application Tool Call, after receiving any other needed application Tool results. Completed provider Tool results may accompany it. The engine projects the successful completion Tool result into the Agent output.',
         );
         expect(contracts[0]).toContain('"itemCount"');
         expect(histories.length).toBeGreaterThan(0);

--- a/packages/platform-node/test/worker-reports.test.ts
+++ b/packages/platform-node/test/worker-reports.test.ts
@@ -11,10 +11,23 @@ import { DefinitionDigestInput } from "@effect-agent/thread/Records";
 import { IdempotencyKey, Principal } from "@effect-agent/thread/SubmissionLedger";
 import { ThreadExportRequest, ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { WorkerHostAuthorizer } from "@effect-agent/thread/WorkerHost";
+import { OpenAiClient, OpenAiLanguageModel, OpenAiTool } from "@effect/ai-openai";
 import { NodeFileSystem } from "@effect/platform-node";
 import { expect, it } from "@effect/vitest";
-import { Context, Effect, Exit, FileSystem, Layer, Ref, Schema, Scope, Stream } from "effect";
-import { LanguageModel, Model, Toolkit, type Response } from "effect/unstable/ai";
+import {
+  Context,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Redacted,
+  Ref,
+  Schema,
+  Scope,
+  Stream,
+} from "effect";
+import { LanguageModel, Model, Tool, Toolkit, type Response } from "effect/unstable/ai";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 const principal = Schema.decodeSync(Principal)("report-owner");
 const sourceThreadId = Schema.decodeSync(ThreadId)("report-source");
@@ -52,15 +65,132 @@ const agent = (id: string) =>
     ),
   );
 
-it.live(
-  "recovers one frozen report for joined child inputs after both Node lanes restart",
-  () =>
+// Keep the real OpenAI encoder and SSE decoder; only the HTTP transport is synthetic.
+const hostedChild = () => {
+  let requests = 0;
+  let completions = 0;
+
+  const tools = Toolkit.make(
+    OpenAiTool.WebSearch({}),
+    Tool.make("finish_research", { parameters: output, success: output }),
+  );
+
+  const http = HttpClient.make((request) =>
+    Effect.sync(() => {
+      requests++;
+
+      const search = {
+        type: "web_search_call",
+        id: "search-1",
+        status: "completed",
+        action: { type: "search", query: "research", sources: [] },
+      };
+
+      const completion = {
+        type: "function_call",
+        id: "function-1",
+        call_id: "finish-1",
+        name: "finish_research",
+        arguments: JSON.stringify({ answer: "done" }),
+        status: "completed",
+      };
+
+      const response = { id: "response-1", model: "gpt-5.6-sol", created_at: 1, output: [] };
+
+      const events = [
+        { type: "response.created", response },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { ...search, status: "in_progress" },
+        },
+        { type: "response.output_item.done", output_index: 0, item: search },
+        { type: "response.output_item.added", output_index: 1, item: completion },
+        {
+          type: "response.function_call_arguments.done",
+          output_index: 1,
+          item_id: completion.id,
+          arguments: completion.arguments,
+        },
+        { type: "response.output_item.done", output_index: 1, item: completion },
+        {
+          type: "response.completed",
+          response: {
+            ...response,
+            output: [search, completion],
+            usage: {
+              input_tokens: 10,
+              output_tokens: 5,
+              total_tokens: 15,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ];
+
+      return HttpClientResponse.fromWeb(
+        request,
+        new globalThis.Response(
+          events
+            .map(
+              (event, sequence_number) =>
+                `data: ${JSON.stringify({ ...event, sequence_number })}\n\n`,
+            )
+            .join(""),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+    }),
+  );
+
+  const model = OpenAiLanguageModel.model("gpt-5.6-sol", { store: false }).pipe(
+    Layer.provide(
+      OpenAiClient.layer({ apiKey: Redacted.make("fixture-key") }).pipe(
+        Layer.provide(Layer.succeed(HttpClient.HttpClient, http)),
+      ),
+    ),
+  );
+
+  return {
+    agent: Agent.withModel(
+      Agent.make("report-child-agent", {
+        input,
+        output,
+        instructions: "Research, then finish.",
+        toolkit: tools,
+        completion: { tool: "finish_research", required: true, project: ({ result }) => result },
+        policy: { maxTurns: 2, maxToolCalls: 2, maxDuration: "1 minute" },
+      }),
+      model,
+    ),
+    handlers: tools.toLayer({
+      finish_research: (result) =>
+        Effect.sync(() => {
+          completions++;
+
+          return result;
+        }),
+    }),
+    requests: () => requests,
+    completions: () => completions,
+  };
+};
+
+it.live.each([
+  "turn:after-response-append",
+  "turn:after-results-append",
+  "worker:after-report-append",
+] as const)(
+  "recovers hosted search completion and one report for joined child inputs after %s and a Node restart",
+  (failpoint) =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const directory = yield* fs.makeTempDirectoryScoped({ prefix: "worker-report-" });
         const source = agent("report-source-agent");
-        const child = agent("report-child-agent");
+        const native = hostedChild();
+        const child = native.agent;
 
         const declaration = Subagent.make("research", {
           target: child.definition,
@@ -70,7 +200,7 @@ it.live(
             maxChildren: 8,
             maxConcurrency: 2,
             maxTurns: 2,
-            maxToolCalls: 1,
+            maxToolCalls: 2,
             maxDuration: "2 seconds",
           }),
         });
@@ -119,10 +249,10 @@ it.live(
           NodeHost.NodeDurableHost.layerRegistered(registrations, {
             ...options,
             runtimeFailpoint: (location) =>
-              location === "worker:after-report-append"
+              location === failpoint
                 ? DurableRuntimeFailpointError.make({ location })
                 : Effect.void,
-          }).pipe(Layer.provide(authority)),
+          }).pipe(Layer.provide(authority), Layer.provide(native.handlers)),
         ).pipe(Scope.provide(firstScope));
 
         const runtime = Context.get(first, DurableAgentRuntime);
@@ -156,7 +286,17 @@ it.live(
           { idempotencyKey: key("joined") },
         ).pipe(Effect.provideService(SubagentHost, host));
 
-        yield* runtime.processThreadResolved(started.worker.threadId).pipe(Effect.result);
+        const interrupted = yield* runtime
+          .processThreadResolved(started.worker.threadId)
+          .pipe(Effect.result);
+
+        expect(interrupted).toMatchObject({
+          _tag: "Failure",
+          failure:
+            failpoint === "worker:after-report-append"
+              ? { _tag: "LedgerError", operation: "worker-completion" }
+              : { _tag: "DurableRuntimeFailpointError", location: failpoint },
+        });
 
         const firstLog = yield* Context.get(first, ThreadStore).export(
           ThreadExportRequest.make({ threadId: started.worker.threadId }),
@@ -166,8 +306,10 @@ it.live(
           record.payload._tag === "WorkerReportPrepared" ? [record.payload] : [],
         );
 
-        expect(decisions).toHaveLength(1);
-        expect(yield* Ref.get(projected)).toBe(1);
+        expect(decisions).toHaveLength(failpoint === "worker:after-report-append" ? 1 : 0);
+        expect(yield* Ref.get(projected)).toBe(failpoint === "worker:after-report-append" ? 1 : 0);
+        expect(native.requests()).toBe(1);
+        expect(native.completions()).toBe(failpoint === "turn:after-response-append" ? 0 : 1);
         expect(
           (yield* Context.get(first, MessageDeliveryStore).list({
             ownerThreadId: started.worker.threadId,
@@ -178,7 +320,10 @@ it.live(
 
         // No live source Run or retained wake fiber survives this complete host restart.
         const second = yield* Layer.build(
-          NodeHost.layer(registrations, options).pipe(Layer.provide(authority)),
+          NodeHost.layer(registrations, options).pipe(
+            Layer.provide(authority),
+            Layer.provide(native.handlers),
+          ),
         );
 
         const reopened = Context.get(second, DurableAgentRuntime);
@@ -202,6 +347,18 @@ it.live(
         expect(firstResult.outcome).toBe("completed");
         expect(joinedResult.outcome).toBe("completed");
 
+        const childLog = yield* store.export(
+          ThreadExportRequest.make({ threadId: started.worker.threadId }),
+        );
+
+        const childSettlements = childLog.records.flatMap(({ record }) =>
+          record.payload._tag === "SubmissionSettled" ? [record.payload] : [],
+        );
+
+        const reports = childLog.records.flatMap(({ record }) =>
+          record.payload._tag === "WorkerReportPrepared" ? [record.payload] : [],
+        );
+
         const sourceLog = yield* store.export(
           ThreadExportRequest.make({ threadId: sourceThreadId }),
         );
@@ -211,7 +368,7 @@ it.live(
         );
 
         expect(inputs).toHaveLength(2);
-        expect(inputs[1]?.input).toEqual({ question: `report:${decisions[0]?.runId}:done` });
+        expect(inputs[1]?.input).toEqual({ question: `report:${reports[0]?.runId}:done` });
         expect(inputs[1]?.runId).not.toBe(inputs[0]?.runId);
 
         const settlements = sourceLog.records.flatMap(({ record }) =>
@@ -221,24 +378,22 @@ it.live(
         expect(settlements).toHaveLength(2);
         expect(settlements.every((settlement) => settlement.outcome === "completed")).toBe(true);
 
-        const childLog = yield* store.export(
-          ThreadExportRequest.make({ threadId: started.worker.threadId }),
-        );
-
-        const childSettlements = childLog.records.flatMap(({ record }) =>
-          record.payload._tag === "SubmissionSettled" ? [record.payload] : [],
-        );
-
+        expect(reports).toHaveLength(1);
         expect(childSettlements).toHaveLength(2);
         expect(childSettlements.map((settlement) => settlement.runId)).toEqual([
-          decisions[0]?.runId,
-          decisions[0]?.runId,
+          reports[0]?.runId,
+          reports[0]?.runId,
         ]);
+        if (decisions.length > 0) expect(reports).toEqual(decisions);
+        expect(native.requests()).toBe(1);
+        expect(native.completions()).toBe(1);
         expect(
-          childLog.records.flatMap(({ record }) =>
-            record.payload._tag === "WorkerReportPrepared" ? [record.payload] : [],
-          ),
-        ).toEqual(decisions);
+          childLog.records.filter(({ record }) => record.payload._tag === "RunCompleted"),
+        ).toHaveLength(1);
+        expect(
+          childLog.records.filter(({ record }) => record.payload._tag === "ModelResponseRecorded"),
+        ).toHaveLength(1);
+        expect(JSON.stringify(childLog)).toContain("OpenAiWebSearch");
         expect(yield* Ref.get(projected)).toBe(1);
         expect(
           (yield* deliveries.list({ ownerThreadId: started.worker.threadId, limit: 100 })).items,

--- a/packages/testing/test/durable-runtime.test.ts
+++ b/packages/testing/test/durable-runtime.test.ts
@@ -1614,7 +1614,26 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
       Effect.gen(function* () {
         const runtime = yield* DurableAgentRuntime;
         const fixture = makeReceiptCompletionFixture();
-        const scripted = yield* makeScriptedModel(() => receiptCreateParts);
+
+        const scripted = yield* makeScriptedModel(() => [
+          {
+            type: "tool-call",
+            id: "hosted-1",
+            name: "respond",
+            params: { answer: "found" },
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            id: "hosted-1",
+            name: "respond",
+            result: { answer: "found" },
+            isFailure: false,
+            providerExecuted: true,
+          },
+          ...receiptCreateParts,
+        ]);
+
         const agent = Agent.withModel(fixture.definition, scripted.model);
         const thread = "thread-receipt-recovered-result";
         const starts = yield* Ref.make(0);
@@ -1624,7 +1643,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
             Ref.update(starts, (count) => count + 1).pipe(
               Effect.as({ name: "Project", href: "/project/1", complete: true }),
             ),
-          respond: ({ answer }) => Effect.succeed({ answer }),
+          respond: () => Effect.die("Recorded provider work must not be replayed"),
         });
 
         const receipt = yield* runtime.submit(
@@ -2010,7 +2029,7 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
     repeated: boolean;
   }>) {
     it.effect(
-      `mixed completion recovery preserves ${scenario.name} without duplicate effects`,
+      `mixed completion recovery retains hosted results and preserves ${scenario.name} without duplicate effects`,
       () =>
         Effect.gen(function* () {
           const runtime = yield* DurableAgentRuntime;
@@ -2044,6 +2063,25 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           const scripted = yield* makeScriptedModel((turn) =>
             turn === 0 || scenario.repeated
               ? [
+                  ...(turn === 0
+                    ? ([
+                        {
+                          type: "tool-call",
+                          id: `hosted-${turn}`,
+                          name: "search",
+                          params: {},
+                          providerExecuted: true,
+                        },
+                        {
+                          type: "tool-result",
+                          id: `hosted-${turn}`,
+                          name: "search",
+                          result: "provider evidence",
+                          isFailure: false,
+                          providerExecuted: true,
+                        },
+                      ] as const)
+                    : []),
                   {
                     type: "tool-call",
                     id: `premature-${turn}`,
@@ -2170,7 +2208,8 @@ layer(testLayer)("DUR P4 DurableAgentRuntime", (it) => {
           expect(scripted.prompts).toHaveLength(scenario.repeated ? 2 : 3);
           const correctionPrompt = JSON.stringify(scripted.prompts[1]);
 
-          expect(correctionPrompt).toContain("none of its tools ran");
+          expect(correctionPrompt).toContain("none of its application tools ran");
+          expect(correctionPrompt).toContain("provider evidence");
           expect(correctionPrompt).toContain("premature-0");
           const after = (yield* readLog(thread)).map((envelope) => envelope.record.payload);
 
@@ -3656,8 +3695,8 @@ layer(corruptedCompletionTestLayer)("RUN-032 recovered completion validation", (
   );
 });
 
-layer(injectedProviderCallTestLayer)("RUN-032 recovered completion singleton validation", (it) => {
-  it.effect("rejects a completion marker mixed with a provider-executed Tool Call", () =>
+layer(injectedProviderCallTestLayer)("RUN-032 recovered completion provider validation", (it) => {
+  it.effect("rejects a completion marker whose provider call has no terminal result", () =>
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
 

--- a/packages/thread/src/Digest.ts
+++ b/packages/thread/src/Digest.ts
@@ -21,7 +21,7 @@ const canonicalJson = (value: Schema.Json): string => {
     return JSON.stringify(value);
   }
   if (Array.isArray<Schema.Json>(value)) {
-    return `[${value.map(canonicalJson).join(",")}]`;
+    return `[${globalThis.Array.from(value, canonicalJson).join(",")}]`;
   }
 
   const entries = Object.entries(value).sort(([left], [right]) =>

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -838,7 +838,6 @@ interface DeclaredApplicationCall {
 }
 
 interface DeclaredToolCalls {
-  readonly total: number;
   readonly application: Array<DeclaredApplicationCall>;
   readonly all: Array<DeclaredApplicationCall>;
   readonly providerResults: Array<Prompt.ToolResultPart>;
@@ -846,8 +845,8 @@ interface DeclaredToolCalls {
 
 /**
  * Pure inspection of every Tool Call declared in one canonical response. Provider-executed calls
- * count toward the batch singleton invariant even though only application calls enter the durable
- * prepared/settled protocol.
+ * retain their terminal results, while only application calls enter the durable prepared/settled
+ * protocol and completion singleton invariant.
  */
 const declaredToolCalls = Effect.fn("DurableAgentRuntime.declaredToolCalls")(
   (messages: PersistedJson): Effect.Effect<DeclaredToolCalls, RunJournalError> =>
@@ -858,8 +857,7 @@ const declaredToolCalls = Effect.fn("DurableAgentRuntime.declaredToolCalls")(
           cause,
         }),
       ),
-      Effect.map((prompt) => {
-        let total = 0;
+      Effect.flatMap((prompt) => {
         const application: Array<DeclaredApplicationCall> = [];
         const all: Array<DeclaredApplicationCall> = [];
         const providerResults: Array<Prompt.ToolResultPart> = [];
@@ -869,7 +867,6 @@ const declaredToolCalls = Effect.fn("DurableAgentRuntime.declaredToolCalls")(
           for (const part of message.content) {
             if (part.type === "tool-result" && part.providerExecuted) providerResults.push(part);
             if (part.type !== "tool-call") continue;
-            total += 1;
             all.push({
               id: part.id,
               name: part.name,
@@ -882,7 +879,33 @@ const declaredToolCalls = Effect.fn("DurableAgentRuntime.declaredToolCalls")(
           }
         }
 
-        return { total, application, all, providerResults };
+        const providerCalls = new Map(
+          all.filter((call) => call.providerExecuted).map((call) => [call.id, call]),
+        );
+
+        const resultIds = new Set<string>();
+
+        for (const result of providerResults) {
+          if (providerCalls.get(result.id)?.name !== result.name || resultIds.has(result.id)) {
+            return Effect.fail(
+              RunJournalError.make({
+                message: `Invalid canonical provider result ${result.id}`,
+              }),
+            );
+          }
+          resultIds.add(result.id);
+        }
+        for (const id of providerCalls.keys()) {
+          if (!resultIds.has(id)) {
+            return Effect.fail(
+              RunJournalError.make({
+                message: `Turn lacks canonical provider result for ${id}`,
+              }),
+            );
+          }
+        }
+
+        return Effect.succeed({ application, all, providerResults });
       }),
     ),
 );
@@ -1829,11 +1852,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       }
     }
 
+    const completionCall = declared.application[0];
+
     const projectSettledCompletion =
-      calls.length === 1 &&
-      calls[0] !== undefined &&
-      completionTools.includes(calls[0].name) &&
-      settled[0]?.isFailure === false &&
+      declared.application.length === 1 &&
+      completionCall !== undefined &&
+      completionTools.includes(completionCall.name) &&
+      settledByCallId.get(completionCall.id)?.isFailure === false &&
       !records.some(
         ({ record }) => record.payload._tag === "RunCompleted" && record.payload.runId === runId,
       );
@@ -4598,7 +4623,6 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 )?.record.payload;
 
           if (
-            declared.total !== 1 ||
             calls.length !== 1 ||
             call === undefined ||
             (call.name !== completion?.tool && actionCompletion === undefined) ||

--- a/packages/thread/src/Records.ts
+++ b/packages/thread/src/Records.ts
@@ -152,7 +152,7 @@ const isPersistedJson = (input: unknown): input is Schema.Json => {
       visited.add(value);
 
       const entries = Array.isArray(value)
-        ? value.map((entry, index) => [index, entry] as const)
+        ? Array.from(value, (entry, index) => [index, entry] as const)
         : Object.entries(value);
 
       if (entries.length > MAX_PERSISTED_JSON_COLLECTION_LENGTH) return false;

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -220,6 +220,22 @@ describe("thread canonical contracts", () => {
       }),
     );
 
+    it.effect("persists frozen provider arrays without changing their canonical digest", () =>
+      Effect.gen(function* () {
+        const sources = [{ type: "url", url: "https://example.com" }];
+
+        Object.setPrototypeOf(sources, null);
+        Object.freeze(sources);
+        const decoded = Schema.decodeUnknownSync(PersistedJson)({ action: { sources } });
+
+        expect(yield* digestJson(decoded)).toBe(
+          yield* digestJson({
+            action: { sources: [{ type: "url", url: "https://example.com" }] },
+          }),
+        );
+      }),
+    );
+
     it.effect("digests object keys by UTF-16 code units, independent of insertion order", () =>
       Effect.gen(function* () {
         const ordered = yield* digestJson({


### PR DESCRIPTION
An OpenAI response can contain completed hosted web search followed by an application completion call. The engine rejected this as a multi-tool completion batch, and durable recovery enforced the same restriction.

Allow completion as the sole application call alongside validated terminal provider results, including required, optional, and action completion. For example, `web_search (terminal result) + finish_research` now completes in one response and survives restart. Mixed application batches remain correctable without discarding hosted results. Missing provider results still fail closed, provider calls remain charged to budgets, and restricted finalization and uncertain side-effect replay rules are preserved.

Support frozen provider arrays without prototypes in persistence validation and canonical hashing; ordinary JSON retains the same digest. Update the completion contracts, guides, and package changeset.

Validation:

- `vp run ready` completed successfully, covering static checks, tests, builds, and docs.
- Regression coverage includes the real OpenAI SSE adapter with synthetic HTTP, SQLite host restarts after response/result/report appends, externally reconciled action completion, and one report delivery for joined child inputs.
- The build emits TS4082 declaration diagnostics from unchanged `oxlint/plugin-exports.ts`; the readiness command exits successfully.
