### PR TITLE
feat: expose tool failure modes and handling diagnostics

### DIFF
--- a/.changeset/clear-tool-failure-routing.md
+++ b/.changeset/clear-tool-failure-routing.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/core": patch
+"@effect-agent/engine": patch
+---
+
+Expose native tool failure modes through `Agent.inspectTools` and distinguish propagated failures from returned results in tool events, spans, and logs. Clarify when declared tool failures end a run and when the model or programmatic caller receives them.

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -203,6 +203,11 @@ per-run hooks.
 A tool may fail and the model may still complete the run. Install `toolFailureObserverLayer` from
 `@effect-agent/engine` to report such failures.
 
+This observer covers failures contained as results, including programmatic broker outcomes. It does
+not duplicate model-declared failures that propagate through the run's Effect error channel, or
+defects and interruptions. Use [`ToolCallFailed.failureHandling` and tool telemetry](./tools#failure-remains-failure)
+to distinguish returned failures from propagated ones, and handle the run's Effect exit separately.
+
 ```ts
 import { toolFailureObserverLayer } from "@effect-agent/engine/RunOptions";
 import { Effect, ErrorReporter } from "effect";

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -210,8 +210,68 @@ declaration order. The model never sees a partial batch.
 
 ## Keep tool failures typed {#failure-remains-failure}
 
-The default `failureMode: "error"` keeps a declared tool failure in the Effect error channel. Use
-`failureMode: "return"` when the model should receive that declared failure as a tool result.
+The default `failureMode: "error"` keeps a declared tool failure in the Effect error channel and
+fails the run. Declaring a `failure` Schema does not opt into recovery. Choose `failureMode: "return"`
+when the model should receive the failure as a tool result and decide what to do next:
+
+```ts twoslash
+import { Agent } from "effect-agent";
+import { Effect, Schema } from "effect";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+class SearchUnavailable extends Schema.TaggedError<SearchUnavailable>()("SearchUnavailable", {
+  message: Schema.String,
+}) {}
+
+const Search = Tool.make("search", {
+  parameters: Schema.Struct({ query: Schema.String }),
+  success: Schema.Array(Schema.String),
+  failure: SearchUnavailable,
+  failureMode: "return",
+});
+const tools = Toolkit.make(Search);
+const ToolsLive = tools.toLayer({
+  search: () => Effect.fail(SearchUnavailable.make({ message: "Try another source." })),
+});
+const researcher = Agent.make("researcher", {
+  input: Schema.String,
+  output: Schema.String,
+  instructions: "Search, then answer. Try another source if search is unavailable.",
+  toolkit: tools,
+});
+
+Agent.inspectTools(researcher);
+// [{ name: "search", failureMode: "return", requiresHandler: true }]
+```
+
+`Agent.inspectTools` accepts a Definition or Binding and reads its registered native toolkit without
+starting a run or acquiring services. It includes tools outside the current exposure. Provider-executed
+tools have `requiresHandler: false`; their results do not pass through a local handler's failure mode.
+
+Inspect configuration and execution separately. A handler can catch its own errors, the programmatic
+broker can contain an error-channel failure, and Subagent containment has its own policy. A returned
+failure may still be followed by a run failure from a sibling, a repeated-failure limit, or another budget.
+
+| Failure boundary                              | Behavior                                                                                                       |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Declared handler error, `"error"`             | Propagates the original typed error and fails the model-declared call's run.                                   |
+| Declared handler error, `"return"`            | Encodes a failed tool result for the model; the loop may continue.                                             |
+| Handler defect or interruption                | Stays a defect or interruption under either mode.                                                              |
+| Invalid result encoding                       | Still fails even with `"return"`.                                                                              |
+| Invalid parameters, unknown or unexposed tool | Rejected before handler execution. Effect Agent's model/preflight validation remains strict under either mode. |
+
+`ToolCallFailed.failureMode` reports the native configuration when known. Its `failureHandling` reports
+the actual route: `propagated` or `returned-to-model`. Older events may omit these fields; absence means
+unknown. `returned-to-model` records the result path; delivery still requires the complete batch to
+commit and another model call. A failure event terminates that call, not necessarily the run. Use the
+run's terminal event and Effect exit to determine the overall outcome.
+
+Application tool spans and terminal logs carry `effect_agent.tool.failure_mode` and, on failure,
+`effect_agent.tool.failure_handling`. Programmatic calls use `returned-to-caller` when the broker
+returns a failure outcome, including a captured error-channel failure. A propagated defect is still
+`propagated`. These attributes contain no error payloads. Interruption alone emits no terminal tool
+failure log or failure-handling classification. Returned failures can also be reported through the
+[recovered tool failure observer](./run-agents#observe-recovered-tool-failures).
 
 Represent an expected empty result as success with `Option.none` or an empty collection.
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -136,6 +136,8 @@ Provider clients, storage, hosts, sandbox adapters, and testing remain separate 
 Agent definitions and bindings, schemas, identifiers, errors, and run events. Shared memory
 contracts and `Memory.recall` compose host-selected readers without a storage or platform dependency.
 Start with `Agent`, `AgentPolicy`, and `IdGenerator`.
+Use [`Agent.inspectTools`](../guide/tools#failure-remains-failure) to inspect registered native tool
+failure modes without acquiring handlers or model services.
 
 ### `@effect-agent/engine`
 

--- a/packages/core/src/Agent.ts
+++ b/packages/core/src/Agent.ts
@@ -1,6 +1,13 @@
 import type { Effect, Layer, Option, Schema } from "effect";
 import * as S from "effect/Schema";
-import type { AiError, LanguageModel, Model, Prompt, Tool, Toolkit } from "effect/unstable/ai";
+import {
+  type AiError,
+  type LanguageModel,
+  type Model,
+  type Prompt,
+  Tool,
+  type Toolkit,
+} from "effect/unstable/ai";
 
 import type { AgentInputError, AgentOutputError, AgentRunDispositionError } from "./AgentError.ts";
 import { AgentPolicy, type AgentPolicyInput } from "./AgentPolicy.ts";
@@ -202,6 +209,35 @@ export interface Any {
   readonly definition: AnyDefinition;
   readonly model?: unknown;
 }
+
+/** Native Tool configuration for inspection; it does not predict an invocation's outcome. */
+export const ToolInspection = S.Struct({
+  name: S.String,
+  failureMode: S.Literals(["error", "return"]),
+  /** False for provider-executed Tools, whose results do not pass through local handlers. */
+  requiresHandler: S.Boolean,
+});
+
+export type ToolInspection = typeof ToolInspection.Type;
+
+/**
+ * Inspect registered native Tools in declaration order without acquiring handlers or a Model.
+ * This is the full Definition toolkit, before run-specific visibility or exposure filtering.
+ * `failureMode` is Effect AI's configured mode, including its `"error"` default. Handler-level
+ * recovery, programmatic invocation and Subagent containment can change where failures go;
+ * consult execution diagnostics for the actual route. No arguments, results or services are read.
+ */
+export const inspectTools = (agent: AnyDefinition | Any): ReadonlyArray<ToolInspection> => {
+  const definition = "definition" in agent ? agent.definition : agent;
+
+  return Object.values(definition.toolkit.tools).map((tool) =>
+    ToolInspection.make({
+      name: tool.name,
+      failureMode: tool.failureMode,
+      requiresHandler: !Tool.isProviderDefined(tool) || tool.requiresHandler,
+    }),
+  );
+};
 
 type DefinitionOf<AgentValue extends AnyDefinition | Any> = AgentValue extends {
   readonly definition: infer DefinitionValue extends AnyDefinition;

--- a/packages/core/src/RunEvent.ts
+++ b/packages/core/src/RunEvent.ts
@@ -80,6 +80,20 @@ export class ToolCallSucceeded extends Schema.TaggedClass<ToolCallSucceeded>()(
   },
 ) {}
 
+/**
+ * How this boundary handled a failed invocation, independently of its native failure mode.
+ * `returned-to-model` records the result path; delivery still requires the complete batch to
+ * commit and a later model call. A sibling, policy or later operation can still fail the Run.
+ * This classification never implies that side effects were rolled back.
+ */
+export const ToolFailureHandling = Schema.Literals([
+  "propagated",
+  "returned-to-model",
+  "returned-to-caller",
+]);
+
+export type ToolFailureHandling = typeof ToolFailureHandling.Type;
+
 /** Records a terminal Tool Call failure using safe, serializable diagnostics. */
 export class ToolCallFailed extends Schema.TaggedClass<ToolCallFailed>()("ToolCallFailed", {
   ...RunEventBase,
@@ -88,6 +102,10 @@ export class ToolCallFailed extends Schema.TaggedClass<ToolCallFailed>()("ToolCa
   errorTag: Schema.NonEmptyString,
   message: Schema.String,
   providerExecuted: Schema.Boolean,
+  /** Native configuration when a local Tool is known; absent on provider results and old events. */
+  failureMode: Schema.optionalKey(Schema.Literals(["error", "return"])),
+  /** Actual route at this boundary. Absence on older events means unknown, never recoverable. */
+  failureHandling: Schema.optionalKey(ToolFailureHandling),
   /** Synthetic policy rejection; no handler ran and the failure streak is unchanged. */
   budgetRejected: Schema.optionalKey(Schema.Literal(true)),
 }) {}

--- a/packages/core/test/agent-types.test.ts
+++ b/packages/core/test/agent-types.test.ts
@@ -262,6 +262,39 @@ type ContextOverflowInAgentErrorProof = Assert<
 >;
 
 describe("Agent type inference", () => {
+  it("inspects native failure modes without resolving handlers or the model", () => {
+    const toolkit = Toolkit.make(
+      SearchAvailability,
+      Tool.make("recoverable", { failure: AvailabilityFailure, failureMode: "return" }),
+      Tool.dynamic("dynamic", { failureMode: "return" }),
+      Tool.providerDefined({ id: "test.search", customName: "hosted", providerName: "search" })(
+        undefined,
+      ),
+    );
+
+    const inspected = Agent.make("inspect-tools", {
+      input: Schema.String,
+      output: Schema.String,
+      instructions: "Inspect only.",
+      toolkit,
+      toolExposure: { initialToolNames: ["recoverable"] },
+    });
+
+    const expected = [
+      { name: "search_availability", failureMode: "error", requiresHandler: true },
+      { name: "recoverable", failureMode: "return", requiresHandler: true },
+      { name: "dynamic", failureMode: "return", requiresHandler: true },
+      { name: "hosted", failureMode: "error", requiresHandler: false },
+    ];
+
+    expect(Agent.inspectTools(inspected)).toEqual(expected);
+    expect(Agent.inspectTools(Agent.withModel(inspected, model))).toEqual(expected);
+    expect(
+      Schema.encodeSync(Schema.Array(Agent.ToolInspection))(Agent.inspectTools(inspected)),
+    ).toEqual(expected);
+    expect(inspected.toolkit).toBe(toolkit);
+  });
+
   it("separates immutable definition from model binding", () => {
     const requirementsProof: RequirementsProof = true;
     const definitionRequirementsProof: DefinitionRequirementsProof = true;

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -405,6 +405,16 @@ describe("core schemas", () => {
       _tag: "ToolCallFailed",
       toolCallId: "search-1",
     });
+    expect(Schema.encodeSync(RunEvent)(Schema.decodeSync(RunEvent)(event))).toEqual(event);
+    const diagnostic = { ...event, failureMode: "return", failureHandling: "propagated" } as const;
+
+    expect(Schema.encodeSync(RunEvent)(Schema.decodeSync(RunEvent)(diagnostic))).toEqual(
+      diagnostic,
+    );
+    expect(() => Schema.decodeUnknownSync(RunEvent)({ ...event, failureMode: "retry" })).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(RunEvent)({ ...event, failureHandling: "recoverable" }),
+    ).toThrow();
     expect(() =>
       Schema.decodeUnknownSync(RunEvent)({
         ...event,

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -51,6 +51,7 @@ import {
   TextDelta,
   ToolCallDeclared,
   ToolCallFailed,
+  type ToolFailureHandling,
   type RunEvent,
   ToolCallStarted,
   ToolCallSucceeded,
@@ -1327,9 +1328,11 @@ const makeToolFailedEvent = Effect.fn("AgentRuntime.makeToolFailedEvent")(functi
   turnId: TurnId,
   call: Response.ToolCallPart<string, unknown>,
   error: unknown,
+  failureHandling: "propagated" | "returned-to-model",
   budgetRejected?: true,
 ): Effect.fn.Return<RunEvent, ModelProtocolError> {
   const toolCallId = yield* decodeToolCallId(call.id);
+  const tools = context.definition.toolkit.tools;
 
   return ToolCallFailed.make({
     ...(yield* eventBase(context)),
@@ -1339,6 +1342,8 @@ const makeToolFailedEvent = Effect.fn("AgentRuntime.makeToolFailedEvent")(functi
     errorTag: errorTag(error),
     message: errorMessage(error),
     providerExecuted: false,
+    failureHandling,
+    ...(Object.hasOwn(tools, call.name) ? { failureMode: tools[call.name].failureMode } : {}),
     ...(budgetRejected === undefined ? {} : { budgetRejected }),
   });
 });
@@ -1384,7 +1389,9 @@ const settleRejectedBatch = Effect.fn("AgentRuntime.settleRejectedBatch")(functi
       isFailure: true,
       ...(budgetRejected === undefined ? {} : { budgetRejected }),
     };
-    events.push(yield* makeToolFailedEvent(context, turnId, call, error, budgetRejected));
+    events.push(
+      yield* makeToolFailedEvent(context, turnId, call, error, "returned-to-model", budgetRejected),
+    );
   }
 
   return events;
@@ -1578,6 +1585,8 @@ const preflightApproval = <Tools extends Record<string, Tool.Any>, HookError, Ho
                   errorTag: denied._tag,
                   message: denied.message,
                   providerExecuted: false,
+                  failureMode: prepared.tool.failureMode,
+                  failureHandling: "propagated",
                 });
 
                 return Stream.fromIterable<RunEvent>([requested, failed]).pipe(
@@ -1667,6 +1676,8 @@ const preflightToolAuthorization = <HookError, HookRequirements>(
                 errorTag: denied._tag,
                 message: denied.message,
                 providerExecuted: false,
+                failureMode: context.definition.toolkit.tools[call.toolName].failureMode,
+                failureHandling: "propagated",
               }),
             ),
           ).pipe(Stream.concat(Stream.fail(denied)));
@@ -1696,6 +1707,7 @@ interface ToolTelemetryDescriptor {
   readonly toolName: string;
   readonly executionClass: ReturnType<typeof getToolExecutionClass>;
   readonly invocationKind: "model" | "programmatic";
+  readonly failureMode: Tool.FailureMode;
   readonly parentToolCallId?: ToolCallId | undefined;
   readonly sequenceIndex?: number | undefined;
 }
@@ -1716,6 +1728,7 @@ const toolTelemetryAttributes = (descriptor: ToolTelemetryDescriptor) => ({
   "gen_ai.conversation.id": descriptor.context.threadId,
   "effect_agent.tool.execution_class": descriptor.executionClass,
   "effect_agent.tool.invocation_kind": descriptor.invocationKind,
+  "effect_agent.tool.failure_mode": descriptor.failureMode,
   ...(descriptor.parentToolCallId === undefined
     ? {}
     : {
@@ -1740,8 +1753,14 @@ const terminalToolTelemetry = (
   descriptor: ToolTelemetryDescriptor,
   outcome: ToolTelemetryOutcome,
   failureMarker?: ToolSpanFailure,
+  failureHandling?: ToolFailureHandling,
 ): Effect.Effect<void> =>
-  annotateToolSpanTerminalOutcome(outcome, failureMarker).pipe(
+  annotateToolSpanTerminalOutcome(
+    outcome,
+    failureMarker,
+    failureHandling,
+    descriptor.failureMode,
+  ).pipe(
     Effect.andThen(
       (outcome === "success"
         ? Effect.logInfo("agent tool execution completed")
@@ -1750,6 +1769,9 @@ const terminalToolTelemetry = (
         Effect.annotateLogs({
           ...toolTelemetryAttributes(descriptor),
           "effect_agent.tool.outcome": outcome,
+          ...(failureHandling === undefined
+            ? {}
+            : { "effect_agent.tool.failure_handling": failureHandling }),
           toolExecutionClass: descriptor.executionClass,
           toolOutcome: outcome,
         }),
@@ -1810,6 +1832,7 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
     toolName: call.name,
     executionClass,
     invocationKind: "model",
+    failureMode: prepared.tool.failureMode,
   };
 
   const toolSpanFailure = ToolSpanFailure.marker();
@@ -1828,18 +1851,25 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
   let propagatedFailure: Cause.Cause<ToolExecutionError> | undefined;
   let failureObservation: ModelToolFailure | undefined;
 
-  const terminalTelemetry = (outcome: ToolTelemetryOutcome) =>
+  const terminalTelemetry = (
+    outcome: ToolTelemetryOutcome,
+    failureHandling?: ToolFailureHandling,
+  ) =>
     terminalToolTelemetry(
       telemetryDescriptor,
       outcome,
       outcome === "failure" ? toolSpanFailure : undefined,
+      failureHandling,
     );
 
-  const isolatedTerminalTelemetry = (outcome: "success" | "failure") =>
+  const isolatedTerminalTelemetry = (
+    outcome: "success" | "failure",
+    failureHandling?: ToolFailureHandling,
+  ) =>
     // Measurement is derivative: a broken Logger/Tracer must never change the Tool event or make
     // an already-completed external side effect eligible for recovery. Non-interrupt Causes reach
     // Effect's owned reporter boundary; external interruption remains interruption.
-    isolateToolDerivative(terminalTelemetry(outcome));
+    isolateToolDerivative(terminalTelemetry(outcome, failureHandling));
 
   /**
    * The authoritative event reaches the downstream Run stream before derivative work starts.
@@ -1850,8 +1880,9 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
     event: Effect.Effect<RunEvent, EventError>,
     outcome: "success" | "failure",
     failSpan: boolean,
+    failureHandling?: ToolFailureHandling,
   ): Stream.Stream<RunEvent, EventError | ToolSpanFailure> => {
-    const telemetry = isolatedTerminalTelemetry(outcome);
+    const telemetry = isolatedTerminalTelemetry(outcome, failureHandling);
 
     const after =
       observer === undefined
@@ -1999,6 +2030,8 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
               errorTag: errorTag(result.result),
               message: errorMessage(result.result),
               providerExecuted: false,
+              failureMode: prepared.tool.failureMode,
+              failureHandling: "returned-to-model",
             })
           : ToolCallSucceeded.make({
               ...(yield* eventBase(context)),
@@ -2046,6 +2079,7 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
           commitTerminalResult,
           terminalOutcome ?? "failure",
           terminalOutcome === "failure",
+          terminalOutcome === "failure" ? "returned-to-model" : undefined,
         ),
       ),
     );
@@ -2059,7 +2093,7 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
     propagatedFailure = cause;
 
     return terminalEventThenAfter(
-      makeToolFailedEvent(context, turnId, call, Cause.squash(cause)).pipe(
+      makeToolFailedEvent(context, turnId, call, Cause.squash(cause), "propagated").pipe(
         Effect.tap(() =>
           Effect.sync(() => {
             trace.finalToolResultIds.add(call.id);
@@ -2069,6 +2103,7 @@ const executePreparedToolCall = <Tools extends Record<string, Tool.Any>>(
       ),
       "failure",
       true,
+      "propagated",
     );
   };
 
@@ -3383,7 +3418,12 @@ const stampProviderResultEvent = (
       case "ToolCallSucceeded":
         return ToolCallSucceeded.make({ ...base, turnId, ...payload });
       case "ToolCallFailed":
-        return ToolCallFailed.make({ ...base, turnId, ...payload });
+        return ToolCallFailed.make({
+          ...base,
+          turnId,
+          ...payload,
+          failureHandling: "returned-to-model",
+        });
     }
   });
 
@@ -8261,9 +8301,9 @@ const measureProgrammaticToolCall = <R>(
           }
           propagatedFailure = exit.cause;
 
-          return isolateToolDerivative(terminalToolTelemetry(descriptor, "failure", marker)).pipe(
-            Effect.andThen(Effect.fail(marker)),
-          );
+          return isolateToolDerivative(
+            terminalToolTelemetry(descriptor, "failure", marker, "propagated"),
+          ).pipe(Effect.andThen(Effect.fail(marker)));
         }
 
         terminalResult = exit.value;
@@ -8272,7 +8312,12 @@ const measureProgrammaticToolCall = <R>(
           exit.value._tag === "ProgrammaticCallSuccess" ? "success" : "failure";
 
         return isolateToolDerivative(
-          terminalToolTelemetry(descriptor, outcome, outcome === "failure" ? marker : undefined),
+          terminalToolTelemetry(
+            descriptor,
+            outcome,
+            outcome === "failure" ? marker : undefined,
+            outcome === "failure" ? "returned-to-caller" : undefined,
+          ),
         ).pipe(
           Effect.andThen(outcome === "failure" ? Effect.fail(marker) : Effect.succeed(exit.value)),
         );
@@ -8675,6 +8720,7 @@ const makeToolBrokerService = Effect.fnUntraced(function* <HookError, HookRequir
               toolName: input.toolName,
               executionClass,
               invocationKind: "programmatic",
+              failureMode: tool.failureMode,
               parentToolCallId: binding.outerToolCallId,
               sequenceIndex: index,
             };

--- a/packages/engine/src/internal/tool-telemetry.ts
+++ b/packages/engine/src/internal/tool-telemetry.ts
@@ -1,3 +1,4 @@
+import type { ToolFailureHandling } from "@effect-agent/core/RunEvent";
 import {
   Cause,
   Context,
@@ -10,7 +11,7 @@ import {
   Stream,
   Tracer,
 } from "effect";
-import { AiError } from "effect/unstable/ai";
+import { AiError, type Tool } from "effect/unstable/ai";
 
 import { isolateToolDerivative } from "./tool-derivative.ts";
 
@@ -42,6 +43,8 @@ const terminalOutcomeTokens = new WeakMap<
   {
     readonly outcome: "success" | "failure";
     readonly failureMarker: ToolSpanFailure | undefined;
+    readonly failureHandling: ToolFailureHandling | undefined;
+    readonly failureMode: Tool.FailureMode | undefined;
   }
 >();
 
@@ -49,10 +52,12 @@ const terminalOutcomeTokens = new WeakMap<
 export const annotateToolSpanTerminalOutcome = (
   outcome: "success" | "failure",
   failureMarker?: ToolSpanFailure,
+  failureHandling?: ToolFailureHandling,
+  failureMode?: Tool.FailureMode,
 ): Effect.Effect<void> => {
   const token = {};
 
-  terminalOutcomeTokens.set(token, { outcome, failureMarker });
+  terminalOutcomeTokens.set(token, { outcome, failureMarker, failureHandling, failureMode });
 
   return Effect.annotateCurrentSpan({
     "effect_agent.tool.outcome": outcome,
@@ -135,6 +140,8 @@ class IsolatedToolSpan implements Tracer.Span {
   readonly #recordDefect: (defect: unknown) => void;
   #terminalOutcome: "success" | "failure" | undefined;
   #terminalFailure: ToolSpanFailure | undefined;
+  #terminalFailureHandling: ToolFailureHandling | undefined;
+  #terminalFailureMode: Tool.FailureMode | undefined;
 
   constructor(
     delegate: Tracer.Span,
@@ -187,6 +194,21 @@ class IsolatedToolSpan implements Tracer.Span {
         this.#recordDefect(defect);
       }
     }
+    for (const [key, value] of [
+      ["effect_agent.tool.failure_mode", this.#terminalFailureMode],
+      ["effect_agent.tool.failure_handling", this.#terminalFailureHandling],
+    ] as const) {
+      if (value !== undefined) {
+        this.attributes.set(key, value);
+        try {
+          this.#delegate.attribute(key, value);
+        } catch (defect) {
+          this.#recordDefect(defect);
+        }
+      } else if (key === "effect_agent.tool.failure_handling") {
+        this.attributes.delete(key);
+      }
+    }
     try {
       this.#delegate.end(endTime, exportedExit);
     } catch (defect) {
@@ -202,11 +224,15 @@ class IsolatedToolSpan implements Tracer.Span {
         if (terminal !== undefined) {
           this.#terminalOutcome = terminal.outcome;
           this.#terminalFailure = terminal.failureMarker;
+          this.#terminalFailureHandling = terminal.failureHandling;
+          this.#terminalFailureMode = terminal.failureMode;
         }
       }
 
       return;
     }
+    // Only the authenticated terminal token may classify a failure's route.
+    if (key === "effect_agent.tool.failure_handling") return;
     this.attributes.set(key, value);
     try {
       this.#delegate.attribute(key, value);

--- a/packages/engine/test/agent-api-types.test.ts
+++ b/packages/engine/test/agent-api-types.test.ts
@@ -42,6 +42,33 @@ const Lookup = Tool.make("lookup", {
 
 const toolkit = Toolkit.make(Lookup);
 
+it("keeps native failure-mode error and service inference unchanged by inspection", () => {
+  const returned = Tool.make("lookup", {
+    parameters: Lookup.parametersSchema,
+    success: Lookup.successSchema,
+    failure: ToolError,
+    failureMode: "return",
+    dependencies: [Catalog],
+  });
+
+  const base = { input: Schema.String, output: Schema.String, instructions: "Look up." };
+  const fatal = Agent.make("fatal", { ...base, toolkit });
+  const recoverable = Agent.make("recoverable", { ...base, toolkit: Toolkit.make(returned) });
+
+  expectTypeOf(Agent.inspectTools(fatal)).toEqualTypeOf<ReadonlyArray<Agent.ToolInspection>>();
+  expectTypeOf(Agent.inspectTools(recoverable)).toEqualTypeOf<
+    ReadonlyArray<Agent.ToolInspection>
+  >();
+  const fatalRun = AgentRuntime.run(fatal, "go");
+  const returnedRun = AgentRuntime.run(recoverable, "go");
+
+  expectTypeOf<Extract<Effect.Error<typeof fatalRun>, ToolError>>().toEqualTypeOf<ToolError>();
+  expectTypeOf<Extract<Effect.Error<typeof returnedRun>, ToolError>>().toEqualTypeOf<never>();
+  expectTypeOf<Effect.Services<typeof returnedRun>>().toEqualTypeOf<
+    Effect.Services<typeof fatalRun>
+  >();
+});
+
 const Input = Schema.Struct({
   city: Schema.String,
   days: Schema.NumberFromString.pipe(

--- a/packages/engine/test/agent-runtime.test.ts
+++ b/packages/engine/test/agent-runtime.test.ts
@@ -889,6 +889,11 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(events.filter((event) => event._tag === "ToolCallSucceeded")).toHaveLength(1);
       expect(events.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(1);
 
+      expect(events.find((event) => event._tag === "ToolCallFailed")).toMatchObject({
+        failureMode: "return",
+        failureHandling: "returned-to-model",
+      });
+
       const toolSpans = spans
         .filter((span) => span.name.startsWith("execute_tool "))
         .toSorted((left, right) => left.name.localeCompare(right.name));
@@ -927,6 +932,8 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
         "gen_ai.conversation.id": "thread-1",
         "effect_agent.tool.execution_class": "uncertain",
         "effect_agent.tool.outcome": "failure",
+        "effect_agent.tool.failure_mode": "return",
+        "effect_agent.tool.failure_handling": "returned-to-model",
         agentId: "tool-observability",
         threadId: "thread-1",
         runId: "run-1",
@@ -1271,6 +1278,8 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
         toolCallId: "fail-early-1",
         toolName: "fail_early",
         providerExecuted: false,
+        failureMode: "return",
+        failureHandling: "returned-to-model",
       });
 
       const terminalLogs = logs.filter(
@@ -1280,6 +1289,8 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(terminalLogs).toHaveLength(1);
       expect(terminalLogs[0]?.annotations).toMatchObject({
         "effect_agent.tool.outcome": "failure",
+        "effect_agent.tool.failure_mode": "return",
+        "effect_agent.tool.failure_handling": "returned-to-model",
         toolName: "fail_early",
         toolOutcome: "failure",
       });
@@ -1288,6 +1299,7 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
 
       expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
         "effect_agent.tool.outcome": "failure",
+        "effect_agent.tool.failure_handling": "returned-to-model",
       });
       if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
         throw new Error("Expected the early-closed returned Tool failure span to end failed");
@@ -1520,6 +1532,8 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
                   annotateToolSpanTerminalOutcome(
                     outcome,
                     outcome === "failure" ? failureMarker : undefined,
+                    outcome === "failure" ? "returned-to-model" : undefined,
+                    "return",
                   ).pipe(
                     Effect.andThen(
                       Effect.flatMap(Effect.currentSpan, (span) =>
@@ -1530,6 +1544,8 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
                             "effect_agent.tool.outcome",
                             outcome === "success" ? "failure" : "success",
                           );
+                          span.attribute("effect_agent.tool.failure_handling", "propagated");
+                          span.attribute("effect_agent.tool.failure_mode", "error");
                         }),
                       ),
                     ),
@@ -1566,7 +1582,11 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
 
         expect(Object.fromEntries(span?.attributes ?? [])).toMatchObject({
           "effect_agent.tool.outcome": outcome,
+          "effect_agent.tool.failure_mode": "return",
         });
+        expect(span?.attributes.get("effect_agent.tool.failure_handling")).toBe(
+          outcome === "failure" ? "returned-to-model" : undefined,
+        );
         if (span?.status._tag !== "Ended") throw new Error("Expected the Tool span to end");
         expect(Exit.isSuccess(span.status.exit)).toBe(outcome === "success");
         if (outcome === "failure") {
@@ -3868,6 +3888,13 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
       expect(observed.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(1);
       const span = spans.find((candidate) => candidate.name === "execute_tool fail");
 
+      expect(observed.find((event) => event._tag === "ToolCallFailed")).toMatchObject({
+        failureMode: "error",
+        failureHandling: "propagated",
+      });
+      expect(span?.attributes.get("effect_agent.tool.failure_mode")).toBe("error");
+      expect(span?.attributes.get("effect_agent.tool.failure_handling")).toBe("propagated");
+
       expect(span?.attributes.get("effect_agent.tool.outcome")).toBe("failure");
       expect(span?.status._tag).toBe("Ended");
       if (span?.status._tag !== "Ended" || !Exit.isFailure(span.status.exit)) {
@@ -4832,6 +4859,7 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
         const Defect = Tool.make("defect", {
           parameters: Schema.Struct({}),
           success: Schema.String,
+          failureMode: "return",
         });
 
         const tools = Toolkit.make(Defect);
@@ -4886,6 +4914,10 @@ layer(testLayer)("RUN-001 Phase 1 AgentRuntime", (it) => {
         expect(Cause.squash(exit.cause)).toBe(defect);
         expect(yield* Deferred.isDone(finalized)).toBe(true);
         expect(observed.filter((event) => event._tag === "ToolCallFailed")).toHaveLength(1);
+        expect(observed.find((event) => event._tag === "ToolCallFailed")).toMatchObject({
+          failureMode: "return",
+          failureHandling: "propagated",
+        });
         expect(observed.some((event) => event._tag === "RunFailed")).toBe(false);
       }),
   );

--- a/packages/engine/test/tool-broker.test.ts
+++ b/packages/engine/test/tool-broker.test.ts
@@ -687,7 +687,13 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
         failureMode: "return",
       }).annotate(ToolExecutionClass, "readonly");
 
-      const innerToolkit = Toolkit.make(ObservedQuery, ObservedFailure);
+      const ObservedError = Tool.make("observed_error", {
+        parameters: ObservedFailure.parametersSchema,
+        success: ObservedFailure.successSchema,
+        failure: QueryFailure,
+      });
+
+      const innerToolkit = Toolkit.make(ObservedQuery, ObservedFailure, ObservedError);
 
       return Effect.gen(function* () {
         const outcomes = yield* Ref.make<ReadonlyArray<ProgrammaticCallOutcome>>([]);
@@ -698,6 +704,7 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
             observed_query: () =>
               Effect.succeed({ rows: [1] }).pipe(Effect.withSpan("host.programmatic.query")),
             observed_failure: () => Effect.fail(QueryFailure.make({ message: failureSecret })),
+            observed_error: () => Effect.fail(QueryFailure.make({ message: failureSecret })),
           }),
           program: (pass) =>
             Effect.gen(function* () {
@@ -711,7 +718,12 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
                 encodedArguments: { sql: argumentSecret },
               });
 
-              yield* Ref.set(outcomes, [success, failure]);
+              const error = yield* pass.invoke({
+                toolName: "observed_error",
+                encodedArguments: { sql: argumentSecret },
+              });
+
+              yield* Ref.set(outcomes, [success, failure, error]);
 
               return null;
             }),
@@ -723,6 +735,7 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
         expect(yield* Ref.get(outcomes)).toMatchObject([
           { _tag: "ProgrammaticCallSuccess", index: 0 },
           { _tag: "ProgrammaticCallFailure", index: 1 },
+          { _tag: "ProgrammaticCallError", index: 2 },
         ]);
 
         const programmaticSpans = spans.filter(
@@ -732,11 +745,12 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
         expect(programmaticSpans.map((span) => span.name)).toEqual([
           "execute_tool observed_query",
           "execute_tool observed_failure",
+          "execute_tool observed_error",
         ]);
         expect(spans.some((span) => span.name === "AgentRuntime.programmaticTool")).toBe(false);
         expect(spans.some((span) => span.name === "AgentRuntime.toolkit.handle")).toBe(false);
 
-        const [successSpan, failureSpan] = programmaticSpans;
+        const [successSpan, failureSpan, errorSpan] = programmaticSpans;
 
         expect(Object.fromEntries(successSpan?.attributes ?? [])).toMatchObject({
           "gen_ai.operation.name": "execute_tool",
@@ -747,6 +761,7 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
           "effect_agent.tool.execution_class": "readonly",
           "effect_agent.tool.invocation_kind": "programmatic",
           "effect_agent.tool.outcome": "success",
+          "effect_agent.tool.failure_mode": "error",
           "effect_agent.tool.parent_call.id": "orchestrate-1",
           "effect_agent.tool.sequence_index": 0,
           toolCallId: "orchestrate-1#0",
@@ -758,8 +773,16 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
           "gen_ai.tool.name": "observed_failure",
           "gen_ai.tool.call.id": "orchestrate-1#1",
           "effect_agent.tool.outcome": "failure",
+          "effect_agent.tool.failure_mode": "return",
+          "effect_agent.tool.failure_handling": "returned-to-caller",
           "effect_agent.tool.sequence_index": 1,
           toolCallId: "orchestrate-1#1",
+        });
+        expect(successSpan?.attributes.has("effect_agent.tool.failure_handling")).toBe(false);
+        expect(Object.fromEntries(errorSpan?.attributes ?? [])).toMatchObject({
+          "gen_ai.tool.name": "observed_error",
+          "effect_agent.tool.failure_mode": "error",
+          "effect_agent.tool.failure_handling": "returned-to-caller",
         });
         if (successSpan?.status._tag !== "Ended" || failureSpan?.status._tag !== "Ended") {
           throw new Error("Expected both programmatic Tool spans to end");
@@ -792,6 +815,8 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
             outcome: annotations.toolOutcome,
             toolCallId: annotations.toolCallId,
             toolName: annotations.toolName,
+            failureMode: annotations["effect_agent.tool.failure_mode"],
+            failureHandling: annotations["effect_agent.tool.failure_handling"],
           })),
         ).toEqual([
           {
@@ -799,12 +824,24 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
             outcome: "success",
             toolCallId: "orchestrate-1#0",
             toolName: "observed_query",
+            failureMode: "error",
+            failureHandling: undefined,
           },
           {
             message: "agent tool execution failed",
             outcome: "failure",
             toolCallId: "orchestrate-1#1",
             toolName: "observed_failure",
+            failureMode: "return",
+            failureHandling: "returned-to-caller",
+          },
+          {
+            message: "agent tool execution failed",
+            outcome: "failure",
+            toolCallId: "orchestrate-1#2",
+            toolName: "observed_error",
+            failureMode: "error",
+            failureHandling: "returned-to-caller",
           },
         ]);
 
@@ -1243,6 +1280,62 @@ layer(testLayer)("RUN-016 programmatic Tool broker", (it) => {
       expect(yield* Ref.get(invocations)).toBe(0);
     }),
   );
+
+  for (const failureKind of ["defect", "interruption"] as const) {
+    it.effect(`keeps a programmatic ${failureKind} distinct from a returned failure`, () =>
+      Effect.gen(function* () {
+        const spans: Array<Tracer.NativeSpan> = [];
+        let finalized = 0;
+        const defect = new Error("programmatic handler defect");
+
+        const innerToolkit = Toolkit.make(
+          Tool.make("inner", {
+            parameters: Schema.Struct({}),
+            success: Schema.String,
+            failureMode: "return",
+          }),
+        );
+
+        const tracer = Tracer.make({
+          span(options) {
+            const span = new Tracer.NativeSpan(options);
+
+            spans.push(span);
+
+            return span;
+          },
+        });
+
+        const exit = yield* runOrchestrated({
+          innerToolkit,
+          innerHandlers: innerToolkit.toLayer({
+            inner: () =>
+              (failureKind === "defect" ? Effect.die(defect) : Effect.interrupt).pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    finalized += 1;
+                  }),
+                ),
+              ),
+          }),
+          program: (pass) =>
+            pass.invoke({ toolName: "inner", encodedArguments: {} }).pipe(Effect.as(null)),
+        }).pipe(Effect.provideService(Tracer.Tracer, tracer), Effect.exit);
+
+        if (Exit.isSuccess(exit)) throw new Error("Expected a propagated handler Cause");
+        if (failureKind === "defect") expect(Cause.squash(exit.cause)).toBe(defect);
+        else expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+        expect(finalized).toBe(1);
+        const span = spans.find((candidate) => candidate.name === "execute_tool inner");
+
+        expect(span?.status._tag).toBe("Ended");
+        expect(span?.attributes.get("effect_agent.tool.failure_mode")).toBe("return");
+        expect(span?.attributes.get("effect_agent.tool.failure_handling")).toBe(
+          failureKind === "defect" ? "propagated" : undefined,
+        );
+      }),
+    );
+  }
 
   it.effect("RUN-016 a typed handler failure stays typed in the outcome", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
Effect's default `failureMode: "error"` can end an agent run even when a tool declares a failure schema. Tool failure events and telemetry previously did not distinguish these propagated failures from failures returned as results.

Add `Agent.inspectTools` for inspecting the native configuration of a Definition or Binding without acquiring handlers or a model:

```ts
import { Agent } from "effect-agent";
import { Schema } from "effect";
import { Tool, Toolkit } from "effect/unstable/ai";

const agent = Agent.make("lookup", {
  input: Schema.String,
  output: Schema.String,
  instructions: "Look up the answer.",
  toolkit: Toolkit.make(Tool.make("lookup", {
    success: Schema.String,
    failure: Schema.String,
    failureMode: "return",
  })),
});

Agent.inspectTools(agent);
// [{ name: "lookup", failureMode: "return", requiresHandler: true }]
```

`ToolCallFailed` gains optional `failureMode` and `failureHandling` fields. Application tool spans and terminal logs expose the same distinction through `effect_agent.tool.failure_mode` and `effect_agent.tool.failure_handling`: `propagated`, `returned-to-model`, or `returned-to-caller` for broker outcomes. Older events remain decodable with an unknown route.

The configured mode is not a fatal/recoverable boolean: a defect can propagate under `"return"`, and the broker can contain a typed failure under `"error"`. `returned-to-model` identifies the result path; delivery still requires the complete batch to commit and another model call. Preserve native failure behavior and error/service inference, and document the observer's scope and strict preflight validation.

Validation: `vp run ready` passed, including the full test suite, package checks, documentation examples, and builds. Focused coverage also passed all 196 tests across inspection, schema compatibility, runtime diagnostics, broker outcomes, and failure observers; explicit core/engine type checks passed.

Related upstream documentation PR: [Effect-TS/effect#8156](https://github.com/Effect-TS/effect/pull/8156).
