### PR TITLE
fix(perf): compare the latest release with main

### DIFF
--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -9,11 +9,12 @@ permissions: {}
 
 jobs:
   comment:
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: read
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -35,10 +36,9 @@ jobs:
               if (!stat.isFile() || stat.size > limit) throw new Error('Invalid performance artifact');
               return fs.readFileSync(file, 'utf8');
             };
-            const number = read('pr-number.txt', 20).trim();
-            if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error('Invalid PR number');
             const report = JSON.parse(read('report.json', 3000000));
             if (report.fixture !== 'runtime-v3' || report.profile !== 'pr' ||
+                !/^effect-agent@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(report.baselineTag) ||
                 report.activeBatch !== null || report.failure !== null ||
                 report.settings?.batches !== 3 || report.settings?.warmupsPerBatch !== 2 || report.settings?.samplesPerBatch !== 3 ||
                 report.settings?.production !== true || report.settings?.execution !== 'unbundled published ESM' ||
@@ -55,14 +55,33 @@ jobs:
                   !/^[a-f0-9]{64}$/.test(revision(role).builtArtifactsSha256)) throw new Error('Invalid revision');
             }
             const run = context.payload.workflow_run;
-            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: Number(number) });
-            if (pr.state !== 'open' || pr.head.sha !== run.head_sha || pr.head.sha !== revision('head').revision ||
-                pr.head.repo?.id !== run.head_repository.id || pr.base.sha !== revision('base').revision ||
-                pr.base.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
-            const med = values => {
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            const { data: main } = await github.rest.git.getRef({ ...context.repo, ref: 'heads/main' });
+            if (run.event !== 'push' || run.head_branch !== 'main' || run.head_repository.full_name !== repository ||
+                run.head_sha !== revision('head').revision || main.object.sha !== revision('head').revision) return;
+            // Re-resolve release identity using trusted API data. A newer release
+            // or moved tag makes the completed comparison stale.
+            const releases = await github.paginate(github.rest.repos.listReleases, { ...context.repo, per_page: 100 });
+            const latest = releases.filter(release => !release.draft && release.published_at &&
+              /^effect-agent@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(release.tag_name))
+              .sort((a, b) => b.published_at.localeCompare(a.published_at) || b.id - a.id)[0];
+            if (!latest || latest.tag_name !== report.baselineTag) return;
+            const { data: tag } = await github.rest.git.getRef({ ...context.repo, ref: `tags/${latest.tag_name}` });
+            let object = tag.object;
+            for (let depth = 0; object.type === 'tag' && depth < 10; depth++) {
+              const { data } = await github.rest.git.getTag({ ...context.repo, tag_sha: object.sha });
+              object = data.object;
+            }
+            if (object.type !== 'commit' || object.sha !== revision('base').revision) return;
+            const identical = revision('base').builtArtifactsSha256 === revision('head').builtArtifactsSha256 &&
+              revision('base').lockfileSha256 === revision('head').lockfileSha256;
+            const summarize = values => {
               values.sort((a, b) => a - b);
-              const i = (values.length - 1) / 2;
-              return (values[Math.floor(i)] + values[Math.ceil(i)]) / 2;
+              const quantile = p => {
+                const i = (values.length - 1) * p, lower = Math.floor(i);
+                return values[lower] + (values[Math.ceil(i)] - values[lower]) * (i - lower);
+              };
+              return { median: quantile(0.5), q1: quantile(0.25), q3: quantile(0.75) };
             };
             const expected = ['small-run', 'small-stream', ...[1,64,1024,4096].map(n => `stream-64k-${n}`),
               'history-65536', 'history-1048576', 'parallel-tools-8', 'tool-rounds-4',
@@ -99,15 +118,28 @@ jobs:
             }
             const rows = expected.map(name => {
               const values = role => samples.filter(s => s.name === name && s.role === role).map(s => s.ms);
-              const base = med(values('base')), head = med(values('head'));
-              const change = before => before === 0 ? 'n/a' : `${((head / before - 1) * 100).toFixed(1)}%`;
-              return `| ${name} | ${base.toFixed(2)} | ${head.toFixed(2)} | ${change(base)} |`;
+              const base = summarize(values('base')), head = summarize(values('head'));
+              const format = value => `${value.median.toFixed(2)} [${value.q1.toFixed(2)}–${value.q3.toFixed(2)}]`;
+              const change = identical || base.median === 0 ? 'n/a' : `${((head.median / base.median - 1) * 100).toFixed(1)}%`;
+              return `| ${name} | ${format(base)} | ${format(head)} | ${change} |`;
             });
             const marker = '<!-- effect-agent:runtime-performance -->';
-            const body = `${marker}\n### Runtime performance\n\n` +
-              'Informational medians in milliseconds, nine samples per workload and revision. Same fixture bytes and Node runtime; separate lockfiles and public builds.\n\n' +
-              '| Workload | Base | Head | Head/base |\n| --- | ---: | ---: | ---: |\n' + rows.join('\n') +
-              `\n\n[Raw samples, spread, cold process totals, failures, environment, and exact revisions](${run.html_url}) for \`${run.head_sha.slice(0,12)}\`. Timing deltas are not a merge threshold.`;
+            const repoUrl = `https://github.com/${repository}`;
+            const body = `${marker}\n### Runtime performance: latest release → main\n\n` +
+              `Release: [\`${report.baselineTag}\`](${repoUrl}/releases/tag/${encodeURIComponent(report.baselineTag)}) (\`${revision('base').revision.slice(0,12)}\`). ` +
+              `Main: [\`${revision('head').revision.slice(0,12)}\`](${repoUrl}/commit/${revision('head').revision}).\n\n` +
+              'Operation median [Q1–Q3] in milliseconds; nine samples per workload and revision across three worker processes. Same fixture bytes and Node runtime; separate lockfiles and public builds.\n\n' +
+              (identical ? '**Identical built JavaScript and lockfiles. Timing differences do not establish a code regression; percentage changes are suppressed.**\n\n' : '') +
+              '| Workload | Latest release | Main | Change |\n| --- | ---: | ---: | ---: |\n' + rows.join('\n') +
+              `\n\n[Raw samples, cold process totals, failures, environment, and exact revisions](${run.html_url}). ` +
+              'Sample spread is not a confidence interval. Timing deltas are observations, not established regressions or a merge threshold; runner and process variability have not been calibrated.';
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              ...context.repo, state: 'open', base: 'main', head: `${context.repo.owner}:changeset-release/main`, per_page: 100,
+            });
+            const pr = pulls.find(pr => pr.state === 'open' && pr.head.ref === 'changeset-release/main' &&
+              pr.head.repo?.full_name === repository && pr.base.ref === 'main' &&
+              pr.base.repo.full_name === repository && pr.base.sha === revision('head').revision);
+            if (!pr) return;
             const comments = await github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 });
             const previous = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
             if (previous) await github.rest.issues.updateComment({ ...context.repo, comment_id: previous.id, body });

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,24 +1,21 @@
 name: Runtime performance
 
 on:
-  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       profile:
-        description: Scripted profile (diagnostic runs manual base/head probes)
+        description: Latest published release versus main (diagnostic runs phase probes)
         type: choice
         options: [pr, extended, archive, diagnostic]
-        default: extended
-      base_sha:
-        description: Exact 40-character comparison base SHA
-        type: string
-        required: true
+        default: pr
 
 permissions:
   contents: read
 
 concurrency:
-  group: runtime-performance-${{ github.ref }}
+  group: runtime-performance-main
   cancel-in-progress: true
 
 env:
@@ -29,22 +26,42 @@ jobs:
   compare:
     name: Compare scripted runtime
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ (github.event_name == 'pull_request' || inputs.profile == 'diagnostic') && 30 || 180 }}
+    timeout-minutes: ${{ (github.event_name == 'push' || inputs.profile == 'pr' || inputs.profile == 'diagnostic') && 30 || 180 }}
     steps:
+      - name: Resolve latest published release and main
+        id: comparison
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea9 # v7
+        with:
+          script: |
+            if (context.ref !== 'refs/heads/main') throw new Error('Run this comparison on main');
+            // /releases/latest excludes prereleases. Use the umbrella package's
+            // publication timestamp, not tag creation order or a sibling package.
+            const releases = await github.paginate(github.rest.repos.listReleases, { ...context.repo, per_page: 100 });
+            const latest = releases.filter(release => !release.draft && release.published_at &&
+              /^effect-agent@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(release.tag_name))
+              .sort((a, b) => b.published_at.localeCompare(a.published_at) || b.id - a.id)[0];
+            if (!latest) throw new Error('No published effect-agent release found');
+            const { data: tag } = await github.rest.git.getRef({ ...context.repo, ref: `tags/${latest.tag_name}` });
+            let object = tag.object;
+            for (let depth = 0; object.type === 'tag' && depth < 10; depth++) {
+              const { data } = await github.rest.git.getTag({ ...context.repo, tag_sha: object.sha });
+              object = data.object;
+            }
+            if (object.type !== 'commit' || !/^[a-f0-9]{40}$/.test(object.sha) ||
+                !/^[a-f0-9]{40}$/.test(context.sha)) throw new Error('Invalid comparison commit');
+            core.setOutput('base_sha', object.sha);
+            core.setOutput('base_tag', latest.tag_name);
+            core.setOutput('head_sha', context.sha);
+            core.info(`Comparing ${latest.tag_name} (${object.sha}) to main (${context.sha})`);
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ steps.comparison.outputs.head_sha }}
           persist-credentials: false
 
-      - name: Validate manual base identity
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          BASE_SHA: ${{ inputs.base_sha }}
-        run: '[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]'
-
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.event.pull_request.base.sha || inputs.base_sha }}
+          ref: ${{ steps.comparison.outputs.base_sha }}
           path: .performance-base
           persist-credentials: false
 
@@ -77,7 +94,7 @@ jobs:
           ./node_modules/.bin/vp run --no-cache -F './packages/*' build
 
       - name: Compare sequential cohorts
-        timeout-minutes: ${{ (github.event_name == 'pull_request' || inputs.profile == 'diagnostic') && 20 || 165 }}
+        timeout-minutes: ${{ (github.event_name == 'push' || inputs.profile == 'pr' || inputs.profile == 'diagnostic') && 20 || 165 }}
         # The controller stops at 19m (PR) / 160m (larger profiles), leaving time
         # for bounded child termination and atomic failure evidence before this outer limit.
         # Older releases do not ignore these known declaration artifacts emitted
@@ -85,22 +102,24 @@ jobs:
         # The subsequent --require-clean check rejects every other modification.
         shell: bash
         env:
-          PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || inputs.profile }}
+          PROFILE: ${{ github.event_name == 'push' && 'pr' || inputs.profile }}
+          BASE_TAG: ${{ steps.comparison.outputs.base_tag }}
         run: |
           rm -f .performance-base/test/fixtures/checkpoints.d.ts .performance-base/test/fixtures/storage-upgrade.d.ts .performance-base/test/fixtures/storage-v2.d.ts
           if [ "$PROFILE" = diagnostic ]; then
             ./node_modules/.bin/vp run --no-cache perf:diagnose --base-dir .performance-base --require-clean
           else
-            ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --profile "$PROFILE" --require-clean
+            ./node_modules/.bin/vp run --no-cache perf:compare --base-dir .performance-base --base-tag "$BASE_TAG" --profile "$PROFILE" --require-clean
           fi
 
       - name: Preserve run identity and readable evidence
         if: always()
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_TAG: ${{ steps.comparison.outputs.base_tag }}
+          MAIN_SHA: ${{ steps.comparison.outputs.head_sha }}
         run: |
           mkdir -p .performance-report
-          echo "$PR_NUMBER" > .performance-report/pr-number.txt
+          printf 'Latest published release: %s. Main: %s.\n\n' "$BASE_TAG" "$MAIN_SHA" >> "$GITHUB_STEP_SUMMARY"
           if test -f .performance-report/report.md; then cat .performance-report/report.md >> "$GITHUB_STEP_SUMMARY"; fi
 
       - name: Upload all samples and failures

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -28,14 +28,25 @@ measurement. `perf:compare` always bypasses task caching. `--help` describes the
 The cleanup lines remove only declaration artifacts emitted by older package builds in those
 disposable checkouts. Every other modified or untracked file fails clean-checkout validation.
 
-The PR workflow uses exact PR base/head commits, Node 24.20.0, and sequential production builds.
+The workflow runs on pushes to `main`, comparing the most recently published
+`effect-agent@…` release tag against the triggering `main` commit. It includes beta
+prereleases, excludes drafts and sibling-package/Action releases, and resolves the tag to
+an exact commit before checkout. It does not compare the Changesets version bump against
+its own parent. Manual dispatch must select `main` and uses the same release baseline;
+local `--base-dir` comparisons remain available for exact-revision investigations.
+Use `--base-tag effect-agent@<version>` to name the release in a local report.
+
+The workflow uses Node 24.20.0 and sequential production builds.
 It runs three sequential cohorts (base/head, head/base, base/head). Each warm cohort retains two
 warmups and three measured samples per case: nine measured samples per revision. Alternating
 the order gives each revision a turn first; with three cohorts, Base runs first twice. Keeping
 three cohorts preserves the existing sample count and correctness coverage. Workload order
 reverses between samples. Each cohort also runs one cold process per revision.
 All warmups, measured samples, slow values, and failures remain in JSON artifacts. The trusted
-comment workflow validates artifact data and current PR identity without executing candidate code.
+comment workflow validates artifact data, the current `main` commit, and the latest release
+tag's commit without executing candidate code. Successful push runs update the open Changesets
+release PR when one exists; every run retains its Actions summary and artifact. Superseded
+`main` commits, newer releases, and moved release tags cannot publish stale comments.
 
 `--profile smoke` exercises every workload family with one sample and 16 retained records;
 it checks the command, not statistical confidence. `extended` takes 30 samples per revision and
@@ -120,8 +131,15 @@ own installation. Reports identify exact commits, dirty state, lockfile hashes, 
 hashes, fixture hash/version, runtime, operating system, CPU, memory, sample counts, median,
 interquartile range, and process failures. The artifact includes the exact transpiled fixture.
 
-The `runtime-v3` artifact contract contains only Base and Head; the trusted publisher rejects
-older three-revision reports. Comparison tables show Base, Head, and Head/base. Workloads,
+The `runtime-v3` artifact contract contains only Base and Head, with `baselineTag` naming
+the release (null for an unlabeled local comparison). The trusted publisher rejects
+older three-revision reports. Release PR tables name Latest release, Main, and Change and
+link the exact tag and commits. Both the comment and artifact show medians and Q1–Q3 spread.
+The nine samples share three worker processes per revision; that spread is not a confidence
+interval, and runner/process variability has not been calibrated. Timing differences alone
+do not establish a regression. When built JavaScript and lockfile hashes match, reports
+explicitly identify identical builds and suppress percentage changes while preserving all
+timings and samples. Workloads,
 operation clocks, warmups, and measured samples per revision are unchanged from `runtime-v2`.
 Keep historical artifacts. Incompatible historical APIs must fail clearly rather than silently
 substituting source code or skipping cases. A new fixture changes the measurement definition and

--- a/examples/runtime-benchmark/test/release-baseline.test.ts
+++ b/examples/runtime-benchmark/test/release-baseline.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+
+import { expect, it } from "vite-plus/test";
+
+// Run the bootstrap that chooses the actual checkout SHAs, before dependencies exist.
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/performance.yml", import.meta.url),
+  "utf8",
+);
+
+const script = workflow
+  .split("          script: |\n")[1]!
+  .split("\n      - ")[0]!
+  .replace(/^ {12}/gm, "");
+
+const main = "a".repeat(40);
+const released = "b".repeat(40);
+
+const release = (tag_name: string, published_at: string | null, draft = false) => ({
+  id: 1,
+  tag_name,
+  published_at,
+  draft,
+  prerelease: true,
+});
+
+const resolve = async (
+  releases: ReturnType<typeof release>[],
+  options: { ref?: string; annotated?: boolean; badTag?: boolean } = {},
+) => {
+  const outputs: Record<string, string> = {};
+  const refs: string[] = [];
+
+  const execution: Promise<unknown> = runInNewContext(`(async () => { ${script} })()`, {
+    context: {
+      repo: { owner: "owner", repo: "repository" },
+      ref: options.ref ?? "refs/heads/main",
+      sha: main,
+    },
+    core: {
+      setOutput: (key: string, value: string) => {
+        outputs[key] = value;
+      },
+      info: () => {},
+    },
+    github: {
+      paginate: async () => releases,
+      rest: {
+        repos: { listReleases: "releases" },
+        git: {
+          getRef: async ({ ref }: { ref: string }) => {
+            refs.push(ref);
+
+            return {
+              data: {
+                object: {
+                  type: options.badTag ? "tree" : options.annotated ? "tag" : "commit",
+                  sha: released,
+                },
+              },
+            };
+          },
+          getTag: async () => ({ data: { object: { type: "commit", sha: released } } }),
+        },
+      },
+    },
+  });
+
+  await execution;
+
+  return { outputs, refs };
+};
+
+it.each([false, true])(
+  "compares the newest published umbrella beta tag to main (annotated: %s)",
+  async (annotated) => {
+    const result = await resolve(
+      [
+        release("effect-agent@0.1.0-beta.77", "2026-09-11T00:00:00Z", true),
+        release("action-v1", "2026-09-11T00:00:00Z"),
+        release("@effect-agent/engine@0.1.0-beta.77", "2026-09-11T00:00:00Z"),
+        release("effect-agent@0.1.0-beta.75", "2026-09-09T00:00:00Z"),
+        release("effect-agent@0.1.0-beta.76", "2026-09-10T00:00:00Z"),
+        release("effect-agent@0.1.0-beta.78", null),
+      ],
+      { annotated },
+    );
+
+    expect(result).toEqual({
+      outputs: { base_tag: "effect-agent@0.1.0-beta.76", base_sha: released, head_sha: main },
+      refs: ["tags/effect-agent@0.1.0-beta.76"],
+    });
+  },
+);
+
+it("fails clearly when no published release or usable commit exists", async () => {
+  await expect(resolve([])).rejects.toThrow("No published effect-agent release found");
+  const releases = [release("effect-agent@0.1.0-beta.76", "2026-09-10T00:00:00Z")];
+
+  await expect(resolve(releases, { badTag: true })).rejects.toThrow("Invalid comparison commit");
+  await expect(resolve(releases, { ref: "refs/heads/changeset-release/main" })).rejects.toThrow(
+    "Run this comparison on main",
+  );
+});

--- a/examples/runtime-benchmark/test/report.test.ts
+++ b/examples/runtime-benchmark/test/report.test.ts
@@ -7,6 +7,7 @@ import { FIXTURE_VERSION } from "../src/contracts.ts";
 it("reports and excludes an invalid batch even when its process exited successfully", () => {
   const report: typeof PerformanceReport.Type = {
     fixture: FIXTURE_VERSION,
+    baselineTag: null,
     fixtureSha256: "fixture",
     transpiler: "test",
     profile: "smoke",

--- a/examples/runtime-benchmark/test/trusted-report.test.ts
+++ b/examples/runtime-benchmark/test/trusted-report.test.ts
@@ -4,15 +4,18 @@ import { runInNewContext } from "node:vm";
 import { expect, it } from "vite-plus/test";
 
 import type { PerformanceReport } from "../../../scripts/runtime-benchmark.ts";
+import { renderPerformanceReport } from "../../../scripts/runtime-benchmark.ts";
 import { casesFor, FIXTURE_VERSION } from "../src/contracts.ts";
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] extends object ? Mutable<T[K]> : T[K] };
 type Report = Mutable<typeof PerformanceReport.Type>;
 const head = "a".repeat(40);
 const base = "b".repeat(40);
+const baselineTag = "effect-agent@0.1.0-beta.76";
 
 const makeReport = (): Report => ({
   fixture: FIXTURE_VERSION,
+  baselineTag,
   fixtureSha256: "c".repeat(64),
   transpiler: "test",
   profile: "pr",
@@ -40,7 +43,7 @@ const makeReport = (): Report => ({
     revision: role === "base" ? base : head,
     dirty: false,
     lockfileSha256: "d".repeat(64),
-    builtArtifactsSha256: "e".repeat(64),
+    builtArtifactsSha256: (role === "base" ? "e" : "f").repeat(64),
     effect: "test",
   })),
   batches: [0, 1, 2].flatMap((cohort) =>
@@ -95,12 +98,22 @@ const workflow = readFileSync(
 
 const script = workflow.split("          script: |\n")[1]!.replace(/^ {12}/gm, "");
 
-const publish = async (report: unknown, currentHead = head) => {
+const publish = async (
+  report: unknown,
+  options: {
+    currentMain?: string;
+    releaseTag?: string;
+    releaseCommit?: string;
+    runHead?: string;
+    runRepository?: string;
+    annotatedTag?: boolean;
+    releasePr?: boolean;
+  } = {},
+) => {
   const comments: string[] = [];
 
   const files: Record<string, string> = {
     "runtime-performance/report.json": JSON.stringify(report),
-    "runtime-performance/pr-number.txt": "1",
   };
 
   const execution: Promise<unknown> = runInNewContext(`(async () => { ${script} })()`, {
@@ -119,26 +132,38 @@ const publish = async (report: unknown, currentHead = head) => {
       repo: { owner: "owner", repo: "repository" },
       payload: {
         workflow_run: {
-          head_sha: head,
-          head_repository: { id: 1 },
+          event: "push",
+          head_branch: "main",
+          head_sha: options.runHead ?? head,
+          head_repository: { full_name: options.runRepository ?? "owner/repository" },
           html_url: "https://example.test/run",
         },
       },
     },
     github: {
       rest: {
-        pulls: {
-          get: async () => ({
+        repos: { listReleases: "releases" },
+        git: {
+          getRef: async ({ ref }: { ref: string }) => ({
             data: {
-              number: 1,
-              state: "open",
-              head: { sha: currentHead, repo: { id: 1 } },
-              base: { sha: base, repo: { full_name: "owner/repository" } },
+              object: {
+                type: ref === "heads/main" || !options.annotatedTag ? "commit" : "tag",
+                sha:
+                  ref === "heads/main"
+                    ? (options.currentMain ?? head)
+                    : (options.releaseCommit ?? base),
+              },
             },
           }),
+          getTag: async () => ({
+            data: { object: { type: "commit", sha: options.releaseCommit ?? base } },
+          }),
+        },
+        pulls: {
+          list: "pulls",
         },
         issues: {
-          listComments: () => {},
+          listComments: "comments",
           createComment: async (value: { body: string }) => {
             comments.push(value.body);
           },
@@ -147,7 +172,39 @@ const publish = async (report: unknown, currentHead = head) => {
           },
         },
       },
-      paginate: async () => [],
+      paginate: async (endpoint: string) => {
+        if (endpoint === "releases")
+          return [
+            {
+              id: 1,
+              draft: false,
+              prerelease: true,
+              published_at: "2026-09-10T03:17:46Z",
+              tag_name: options.releaseTag ?? baselineTag,
+            },
+          ];
+        if (endpoint === "pulls")
+          return options.releasePr === false
+            ? []
+            : [
+                {
+                  number: 1,
+                  state: "open",
+                  head: {
+                    ref: "changeset-release/main",
+                    sha: "9".repeat(40),
+                    repo: { full_name: "owner/repository" },
+                  },
+                  base: {
+                    ref: "main",
+                    sha: options.currentMain ?? head,
+                    repo: { full_name: "owner/repository" },
+                  },
+                },
+              ];
+        if (endpoint === "comments") return [];
+        throw new Error("Unexpected GitHub endpoint");
+      },
     },
   });
 
@@ -156,17 +213,34 @@ const publish = async (report: unknown, currentHead = head) => {
   return comments;
 };
 
-it("publishes all 12 valid batches and rejects stale PR identity", async () => {
+it("publishes release versus main even though the release PR head is a version-only commit", async () => {
   const comments = await publish(makeReport());
 
   expect(comments).toHaveLength(1);
-  expect(comments[0]).toContain("nine samples per workload and revision");
   expect(comments[0]).toContain(
-    "| Workload | Base | Head | Head/base |\n| --- | ---: | ---: | ---: |\n",
+    "nine samples per workload and revision across three worker processes",
   );
-  expect(comments[0]).toContain("| settled-ledger-2048 | 2.00 | 2.00 | 0.0% |");
+  expect(comments[0]).toContain(baselineTag);
+  expect(comments[0]).toContain(`/commit/${head}`);
+  expect(comments[0]).toContain(
+    "| Workload | Latest release | Main | Change |\n| --- | ---: | ---: | ---: |\n",
+  );
+  expect(comments[0]).toContain(
+    "| settled-ledger-2048 | 2.00 [2.00–2.00] | 2.00 [2.00–2.00] | 0.0% |",
+  );
   expect(comments[0]).not.toMatch(/reference/i);
-  expect(await publish(makeReport(), "f".repeat(40))).toEqual([]);
+  expect(await publish(makeReport(), { annotatedTag: true })).toHaveLength(1);
+});
+
+it.each([
+  { currentMain: "f".repeat(40) },
+  { runHead: "f".repeat(40) },
+  { runRepository: "someone/fork" },
+  { releaseTag: "effect-agent@0.1.0-beta.77" },
+  { releaseCommit: "f".repeat(40) },
+  { releasePr: false },
+])("does not publish stale or unrelated comparison %j", async (options) => {
+  expect(await publish(makeReport(), options)).toEqual([]);
 });
 
 it("computes Head/base from measured warm samples only", async () => {
@@ -187,8 +261,37 @@ it("computes Head/base from measured warm samples only", async () => {
 
   const comments = await publish(report);
 
-  expect(comments[0]).toContain("| small-run | 4.00 | 2.00 | -50.0% |");
-  expect(comments[0]).toContain("| settled-ledger-2048 | 4.00 | 2.00 | -50.0% |");
+  expect(comments[0]).toContain("| small-run | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] | -50.0% |");
+  expect(comments[0]).toContain(
+    "| settled-ledger-2048 | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] | -50.0% |",
+  );
+});
+
+it("preserves slow samples and spread without claiming identical builds regressed", async () => {
+  const report = makeReport();
+
+  report.revisions[1]!.builtArtifactsSha256 = report.revisions[0]!.builtArtifactsSha256;
+  for (const batch of report.batches) {
+    const worker = batch.report!;
+
+    batch.report = {
+      ...worker,
+      samples: worker.samples.map((sample) => ({
+        ...sample,
+        totalMs: batch.role === "base" ? 2 : [2, 2, 3, 4, 100][sample.ordinal]!,
+        attemptMs: 102,
+      })),
+    };
+  }
+  const comments = await publish(report);
+
+  for (const output of [comments[0]!, renderPerformanceReport(report)]) {
+    expect(output).toContain("Identical built JavaScript and lockfiles");
+    expect(output).toContain("| small-run | 2.00 [2.00–2.00] | 4.00 [3.00–100.00] | n/a |");
+    expect(output).not.toContain("100.0%");
+  }
+  report.revisions[1]!.lockfileSha256 = "a".repeat(64);
+  expect((await publish(report))[0]).toContain("| 100.0% |");
 });
 
 it("rejects historical contracts and reference roles before commenting", async () => {
@@ -220,6 +323,12 @@ it("rejects historical contracts and reference roles before commenting", async (
 });
 
 const mutations: ReadonlyArray<readonly [string, (report: Report) => void]> = [
+  [
+    "invalid release tag",
+    (report) => {
+      report.baselineTag = "main";
+    },
+  ],
   [
     "missing revision",
     (report) => {

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -2,7 +2,18 @@ import { createHash } from "node:crypto";
 import { arch, cpus, platform, release, totalmem } from "node:os";
 
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Cause, Clock, Console, Effect, Exit, FileSystem, Path, Schema, Stream } from "effect";
+import {
+  Cause,
+  Clock,
+  Console,
+  Effect,
+  Exit,
+  FileSystem,
+  Option,
+  Path,
+  Schema,
+  Stream,
+} from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { build, version as esbuildVersion } from "esbuild";
@@ -47,6 +58,7 @@ type Batch = typeof Batch.Type;
 
 export const PerformanceReport = Schema.Struct({
   fixture: Schema.Literal(FIXTURE_VERSION),
+  baselineTag: Schema.NullOr(Schema.String),
   fixtureSha256: Schema.String,
   transpiler: Schema.String,
   profile: Profile,
@@ -225,8 +237,29 @@ export const stageCheckout = Effect.fn("benchmark.stageCheckout")(function* (
 });
 
 export const renderPerformanceReport = (report: PerformanceReport): string => {
+  const baseline = report.revisions.find((revision) => revision.role === "base");
+  const candidate = report.revisions.find((revision) => revision.role === "head");
+
+  const identical =
+    baseline !== undefined &&
+    candidate !== undefined &&
+    baseline.builtArtifactsSha256 === candidate.builtArtifactsSha256 &&
+    baseline.lockfileSha256 === candidate.lockfileSha256;
+
   const lines = [
+    ...(report.baselineTag === null
+      ? []
+      : [
+          `Base release: \`${report.baselineTag}\` (\`${baseline?.revision}\`). Head checkout: \`${candidate?.revision}\`.`,
+          "",
+        ]),
     "Timing is informational. Operation median [Q1–Q3] in milliseconds; every measured sample and outlier is retained. Model-entry timings remain in raw samples.",
+    "Samples share three worker processes per revision in the pr profile; their spread is not a confidence interval or a calibrated regression threshold.",
+    ...(identical
+      ? [
+          "Identical built JavaScript and lockfiles. Timing differences do not establish a code regression; percentage changes are suppressed.",
+        ]
+      : []),
     "",
     "| Workload | Base | Head | Head/base |",
     "| --- | ---: | ---: | ---: |",
@@ -252,7 +285,7 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
     const head = summary(samples("head").map((sample) => sample.totalMs));
 
     const delta = (baseline: ReturnType<typeof summary>) =>
-      baseline.count === 0 || head.count === 0 || baseline.median === 0
+      identical || baseline.count === 0 || head.count === 0 || baseline.median === 0
         ? "n/a"
         : `${((head.median / baseline.median - 1) * 100).toFixed(1)}%`;
 
@@ -357,6 +390,7 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
   output: string;
   profile: Profile;
   requireClean: boolean;
+  baselineTag: string | null;
 }) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -430,6 +464,7 @@ export const compareRuntime = Effect.fn("benchmark.compareRuntime")(function* (o
 
   const report: PerformanceReport = {
     fixture: FIXTURE_VERSION,
+    baselineTag: options.baselineTag,
     fixtureSha256: sha256(fixtureBytes.join("\n")),
     transpiler: `esbuild ${esbuildVersion} (fixture syntax only; no bundling)`,
     profile: options.profile,
@@ -604,6 +639,15 @@ export const command = Command.make(
         "Exact base checkout, installed with its lockfile and production packages built.",
       ),
     ),
+    baselineTag: Flag.string("base-tag").pipe(
+      Flag.withSchema(
+        Schema.String.check(Schema.isPattern(/^effect-agent@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)),
+      ),
+      Flag.withDescription(
+        "Published effect-agent release tag naming the base checkout in CI reports.",
+      ),
+      Flag.optional,
+    ),
     output: Flag.string("out-dir").pipe(
       Flag.withDefault(".performance-report"),
       Flag.withDescription("New artifact directory; existing reports are never overwritten."),
@@ -619,7 +663,7 @@ export const command = Command.make(
       Flag.withDescription("Reject modified or untracked files in any checkout (required by CI)."),
     ),
   },
-  Effect.fn(function* ({ base, output, profile, requireClean }) {
+  Effect.fn(function* ({ base, baselineTag, output, profile, requireClean }) {
     const path = yield* Path.Path;
 
     const root = path.resolve(
@@ -627,7 +671,14 @@ export const command = Command.make(
       "..",
     );
 
-    yield* compareRuntime({ root, base, output, profile, requireClean });
+    yield* compareRuntime({
+      root,
+      base,
+      baselineTag: Option.getOrNull(baselineTag),
+      output,
+      profile,
+      requireClean,
+    });
   }),
 ).pipe(
   Command.withDescription(


### PR DESCRIPTION
Release PR benchmarks compared a version-only Changesets commit with its parent, producing apparent regressions between identical runtime builds. Compare the latest published `effect-agent` release tag with the exact `main` commit instead, including beta releases and annotated tags. Automatic runs now follow pushes to `main`; manual dispatch on `main` uses the same release baseline.

Reports name the release and commit, show median and Q1–Q3 spread, and suppress percentage changes when compiled JavaScript and lockfile hashes match. The trusted publisher updates the open release PR only while both the main commit and release identity remain current. Raw samples and correctness checks are preserved.

Validation:

- `vp run ready` passed, including the 154-test runtime benchmark suite.
- A local smoke comparison against `effect-agent@0.1.0-beta.76` completed all four batches without correctness failures.
- The [hosted identical-commit control](https://github.com/danieljvdm/effect-agent/actions/runs/34437551013) compared `84d6684` with itself, retaining nine measured samples per workload and revision. Durable workloads still showed apparent changes from −23.8% to +13.5%; basic workloads stayed within approximately 2.4%.

Runner/process variability remains uncalibrated. This change corrects the comparison and reporting; it does not claim a runtime speedup or establish a timing regression threshold. The new automatic workflow takes effect after merge.
