### PR TITLE
feat: report run and delegated model usage

### DIFF
--- a/.changeset/report-run-usage-on-completion.md
+++ b/.changeset/report-run-usage-on-completion.md
@@ -1,0 +1,7 @@
+---
+"@effect-agent/capabilities": patch
+"@effect-agent/engine": patch
+"@effect-agent/core": patch
+---
+
+Report cumulative Run spend on `RunCompleted`, `SubagentCompleted` and the agent result. A parent could not account for delegated work before this: a child is a separate Run, so the parent's `RunBudgetHook` never observed its model calls, and no other seam carried the totals back. The new `usage` field is optional so records written before it still decode.

--- a/.changeset/report-run-usage-on-completion.md
+++ b/.changeset/report-run-usage-on-completion.md
@@ -2,6 +2,7 @@
 "@effect-agent/capabilities": patch
 "@effect-agent/engine": patch
 "@effect-agent/core": patch
+"@effect-agent/thread": patch
 ---
 
-Report cumulative Run spend on `RunCompleted`, `SubagentCompleted` and the agent result. A parent could not account for delegated work before this: a child is a separate Run, so the parent's `RunBudgetHook` never observed its model calls, and no other seam carried the totals back. The new `usage` field is optional so records written before it still decode.
+Expose observed model usage and estimated cost on Run results, child projections, and terminal reports while preserving unknown coverage. Report nested attached-child usage separately and retain verified child totals across durable joins and recovery.

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -244,6 +244,32 @@ durable Submission with an explicit persisted command. See
 
 ## Provider usage and cost evidence
 
+`AgentRuntime.run` results and `RunCompleted` carry optional `usage` and `delegatedUsage` totals.
+`usage` covers this Run's own model calls, including compaction; `delegatedUsage` covers its
+attached children and their attached descendants. These sets are disjoint. Add them once with
+`Usage.sumRunTotals` when a combined report is needed; do not also add child event totals.
+Background workers have independent lifetimes and are excluded.
+
+Each total retains `usageStatus`, `pricingStatus`, and `unobservedModelCalls`. Missing legacy
+fields mean unknown. A numeric zero is only meaningful alongside its coverage: absent provider
+usage or pricing is not a free call. Costs are host estimates. Flat totals do not retain the
+per-model, cache, or reasoning breakdown; durable `usageSummary` retains that richer evidence.
+
+Expected-failure and suspended Run events include the usage observed at that boundary. For a detached Run,
+`handle.usageReport` provides a snapshot even if `handle.await` fails or is interrupted. Read it
+after execution settles, or after closing its owning Scope, to include finalization accounting:
+
+```ts
+const outcome = yield * Effect.exit(handle.await);
+const report = yield * handle.usageReport;
+```
+
+Reading a live report does not wait for execution. It cannot quantify an in-flight request until
+usage arrives, and interruption without usage leaves an unobserved call. If aggregated descendant
+totals exceed safe-integer capacity, their coverage becomes unknown rather than changing the
+Run's outcome or reporting a rounded value. Reports are observations, not billing receipts:
+retry/recovery and event replay require consumers to deduplicate by logical Run/child identity.
+
 A cost estimator receives the configured binding name in `request.model` and the actual
 provider-reported identity in `request.response`. Use the latter for response-sensitive pricing.
 `request.finishMetadata` carries native Effect AI finish metadata only during estimation; the

--- a/docs/guide/run-agents.md
+++ b/docs/guide/run-agents.md
@@ -244,31 +244,13 @@ durable Submission with an explicit persisted command. See
 
 ## Provider usage and cost evidence
 
-`AgentRuntime.run` results and `RunCompleted` carry optional `usage` and `delegatedUsage` totals.
-`usage` covers this Run's own model calls, including compaction; `delegatedUsage` covers its
-attached children and their attached descendants. These sets are disjoint. Add them once with
-`Usage.sumRunTotals` when a combined report is needed; do not also add child event totals.
-Background workers have independent lifetimes and are excluded.
+`AgentRuntime` results and `RunCompleted` expose optional `usage` (own calls, including compaction) and
+`delegatedUsage` (all attached descendants). Combine them once with `Usage.sumRunTotals`;
+background workers are excluded. Child events repeat cumulative totals, so deduplicate by Run ID.
 
-Each total retains `usageStatus`, `pricingStatus`, and `unobservedModelCalls`. Missing legacy
-fields mean unknown. A numeric zero is only meaningful alongside its coverage: absent provider
-usage or pricing is not a free call. Costs are host estimates. Flat totals do not retain the
-per-model, cache, or reasoning breakdown; durable `usageSummary` retains that richer evidence.
-
-Expected-failure and suspended Run events include the usage observed at that boundary. For a detached Run,
-`handle.usageReport` provides a snapshot even if `handle.await` fails or is interrupted. Read it
-after execution settles, or after closing its owning Scope, to include finalization accounting:
-
-```ts
-const outcome = yield * Effect.exit(handle.await);
-const report = yield * handle.usageReport;
-```
-
-Reading a live report does not wait for execution. It cannot quantify an in-flight request until
-usage arrives, and interruption without usage leaves an unobserved call. If aggregated descendant
-totals exceed safe-integer capacity, their coverage becomes unknown rather than changing the
-Run's outcome or reporting a rounded value. Reports are observations, not billing receipts:
-retry/recovery and event replay require consumers to deduplicate by logical Run/child identity.
+For failed or interrupted Runs, read `handle.usageReport` after `handle.await` settles or its
+owning Scope closes. Earlier reads are live snapshots and may omit in-flight usage. Durable
+settlements retain their richer per-model `usageSummary` for the Run's own calls.
 
 A cost estimator receives the configured binding name in `request.model` and the actual
 provider-reported identity in `request.response`. Use the latter for response-sensitive pricing.
@@ -276,7 +258,7 @@ provider-reported identity in `request.response`. Use the latter for response-se
 engine never persists provider HTTP details or raw metadata in accounting records. A summarizer
 uses the same estimator with `purpose: "summary"`.
 
-Calls retain `usageStatus` and `pricingStatus`. Missing legacy status is unknown, and a numeric
+Calls and Run totals retain `usageStatus` and `pricingStatus`. Missing legacy status is unknown, and a numeric
 zero without an estimate is not evidence of free execution. Run summaries distinguish complete,
 partial, and unknown coverage; `unobservedModelCalls` counts observed calls without retained accounting,
 which are excluded from numeric token and call totals. A canonical `ModelResponseInterrupted`

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -51,6 +51,29 @@ Set `failure` and `mapChildFailure` for application-specific errors. These custo
 are independent. Missing mappings validate the default value against the selected Schema and
 fail with `SubagentProjectionFailure` if it does not fit.
 
+## Account for delegated work
+
+`SubagentCompleted` reports the child's own `usage` and its separate `delegatedUsage` for attached
+descendants. Failed and interrupted child observations retain the usage known at termination;
+a failed output validation does not erase the model call. The parent's result reports its own
+usage separately from the entire attached subtree. Observing both a completion and a join does
+not add another charge: reports are cumulative snapshots keyed by child Run ID.
+
+`projectResult` receives the same optional `usage` and `delegatedUsage` fields in its context,
+alongside `budgetExhausted`. A host can record accounting without including it in model-visible
+Tool output. `SubagentRuntime.layer` also accepts `child.budget` for live per-child deltas and
+`child.estimateCostMicrousd` for pricing; the reservation observer composes with that budget hook.
+
+Durable delegation carries verified settlement usage in `SubagentJoined` and into `projectResult`.
+The canonical join retains both totals atomically with the Tool result, and replacement Attempts
+restore child reports by Run ID. Earlier joins without accounting remain unknown; reservations
+are not substituted for measured spend. Durable Run settlements retain their existing own-Run
+`usageSummary`; child accounting is available from their canonical joins. Background worker
+accounting remains independent of the launching Run.
+
+Keep the completeness markers when exporting or combining totals. Unknown usage or pricing may
+contain numeric zeros; see [usage and cost evidence](run-agents.md#provider-usage-and-cost-evidence).
+
 ## Define the child
 
 The child is an ordinary agent. Give it a narrow task and the tools that task needs.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -51,28 +51,10 @@ Set `failure` and `mapChildFailure` for application-specific errors. These custo
 are independent. Missing mappings validate the default value against the selected Schema and
 fail with `SubagentProjectionFailure` if it does not fit.
 
-## Account for delegated work
-
-`SubagentCompleted` reports the child's own `usage` and its separate `delegatedUsage` for attached
-descendants. Failed and interrupted child observations retain the usage known at termination;
-a failed output validation does not erase the model call. The parent's result reports its own
-usage separately from the entire attached subtree. Observing both a completion and a join does
-not add another charge: reports are cumulative snapshots keyed by child Run ID.
-
-`projectResult` receives the same optional `usage` and `delegatedUsage` fields in its context,
-alongside `budgetExhausted`. A host can record accounting without including it in model-visible
-Tool output. `SubagentRuntime.layer` also accepts `child.budget` for live per-child deltas and
-`child.estimateCostMicrousd` for pricing; the reservation observer composes with that budget hook.
-
-Durable delegation carries verified settlement usage in `SubagentJoined` and into `projectResult`.
-The canonical join retains both totals atomically with the Tool result, and replacement Attempts
-restore child reports by Run ID. Earlier joins without accounting remain unknown; reservations
-are not substituted for measured spend. Durable Run settlements retain their existing own-Run
-`usageSummary`; child accounting is available from their canonical joins. Background worker
-accounting remains independent of the launching Run.
-
-Keep the completeness markers when exporting or combining totals. Unknown usage or pricing may
-contain numeric zeros; see [usage and cost evidence](run-agents.md#provider-usage-and-cost-evidence).
+Child terminal events and the `projectResult` context expose `usage` and `delegatedUsage`.
+Durable joins preserve verified totals across recovery; see [usage accounting](run-agents.md#provider-usage-and-cost-evidence).
+For live child deltas or pricing, pass `child.budget` or `child.estimateCostMicrousd` to
+`SubagentRuntime.layer`.
 
 ## Define the child
 

--- a/packages/capabilities/src/Subagent.ts
+++ b/packages/capabilities/src/Subagent.ts
@@ -14,6 +14,7 @@ import {
   SubagentGrant,
   SubagentReservationAmounts,
 } from "@effect-agent/core/SubagentContract";
+import { type RunTotals, RunUsageReport, unknownRunTotals } from "@effect-agent/core/Usage";
 import {
   type AgentRuntimeFailure,
   type AgentRuntimeRequirements,
@@ -41,7 +42,7 @@ import {
 } from "@effect-agent/engine/RunOptions";
 import { type ThreadHistory } from "@effect-agent/engine/ThreadHistory";
 import type { Layer } from "effect";
-import { Clock, Duration, Effect, Option, Ref, Schema } from "effect";
+import { Cause, Clock, Duration, Effect, Exit, Option, Ref, Schema, Scope } from "effect";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import type {
@@ -112,6 +113,9 @@ export type SubagentPrepareContext = {
  */
 export interface SubagentResultContext {
   readonly budgetExhausted: boolean;
+  /** Own and disjoint attached-descendant usage; absent only for legacy/custom hosts. */
+  readonly usage?: RunTotals;
+  readonly delegatedUsage?: RunTotals;
 }
 
 /** Default delegation result, preserving partial-output information. */
@@ -1545,26 +1549,32 @@ const layer = <
 
       yield* Ref.set(startedAt, yield* Clock.currentTimeMillis);
 
-      const child = yield* spawner.spawn<
-        TargetInput,
-        TargetOutput,
-        TargetInstructions,
-        TargetTools,
-        Provider,
-        ModelProvides,
-        ModelRequires,
-        never,
-        HookRequirements,
-        InstructionError,
-        InstructionRequirements,
-        undefined,
-        InputPromptValue
-      >(
-        { ...childBinding, definition: { ...childBinding.definition, policy: childPolicy } },
-        encodedInput,
-        { delegationId: delegation.delegationId, parentToolCallId: toolCallId },
-        childOptions,
-      );
+      const childScope = yield* Scope.make();
+
+      yield* Effect.addFinalizer((exit) => Scope.close(childScope, exit));
+
+      const child = yield* spawner
+        .spawn<
+          TargetInput,
+          TargetOutput,
+          TargetInstructions,
+          TargetTools,
+          Provider,
+          ModelProvides,
+          ModelRequires,
+          never,
+          HookRequirements,
+          InstructionError,
+          InstructionRequirements,
+          undefined,
+          InputPromptValue
+        >(
+          { ...childBinding, definition: { ...childBinding.definition, policy: childPolicy } },
+          encodedInput,
+          { delegationId: delegation.delegationId, parentToolCallId: toolCallId },
+          childOptions,
+        )
+        .pipe(Scope.provide(childScope));
 
       const payload: SubagentEventBasePayload = {
         toolCallId,
@@ -1586,12 +1596,16 @@ const layer = <
       const joined = Effect.gen(function* () {
         const result = yield* child.await.pipe(
           Effect.catch((childFailure) =>
-            emit({
-              _tag: "SubagentFailed",
-              ...payload,
-              errorTag: errorTagOf(childFailure),
-              message: boundedEventText(errorMessageOf(childFailure)),
-            }).pipe(
+            child.usageReport.pipe(
+              Effect.flatMap((report) =>
+                emit({
+                  _tag: "SubagentFailed",
+                  ...payload,
+                  ...report,
+                  errorTag: errorTagOf(childFailure),
+                  message: boundedEventText(errorMessageOf(childFailure)),
+                }),
+              ),
               Effect.andThen(
                 Effect.fail(
                   options.mapChildFailure === undefined
@@ -1607,46 +1621,63 @@ const layer = <
           ),
           Effect.timeoutOrElse({
             duration: Duration.millis(allocation.durationMillis),
-            orElse: () =>
-              emit({
-                _tag: "SubagentFailed",
-                ...payload,
-                errorTag: "SubagentBudgetExhausted",
-                message: `Attached child exceeded its ${allocation.durationMillis}ms delegation duration budget`,
-              }).pipe(
-                Effect.andThen(
-                  Effect.fail(
-                    SubagentBudgetExhausted.make({
-                      parentRunId,
-                      dimension: "duration",
-                      limitValue: allocation.durationMillis,
-                      observedValue: allocation.durationMillis,
+            orElse: () => Effect.succeed(undefined),
+          }),
+          Effect.tapCause((cause) =>
+            Cause.hasDies(cause)
+              ? child.usageReport.pipe(
+                  Effect.flatMap((report) =>
+                    emit({
+                      _tag: "SubagentFailed",
+                      ...payload,
+                      ...report,
+                      errorTag: "Defect",
+                      message: "The child Run ended with a defect",
                     }),
                   ),
-                ),
-              ),
-          }),
+                  Effect.ignore,
+                )
+              : Effect.void,
+          ),
         );
+
+        if (result === undefined) {
+          // Choose the timeout before interrupting the child; otherwise its interrupted await
+          // can win the timeout race and replace the typed delegation failure.
+          yield* Scope.close(childScope, Exit.void);
+          const report = yield* child.usageReport;
+
+          yield* emit({
+            _tag: "SubagentFailed",
+            ...payload,
+            ...report,
+            errorTag: "SubagentBudgetExhausted",
+            message: `Attached child exceeded its ${allocation.durationMillis}ms delegation duration budget`,
+          });
+
+          return yield* SubagentBudgetExhausted.make({
+            parentRunId,
+            dimension: "duration",
+            limitValue: allocation.durationMillis,
+            observedValue: allocation.durationMillis,
+          });
+        }
+        const report = yield* child.usageReport;
 
         yield* emit({
           _tag: "SubagentCompleted",
           ...payload,
+          ...report,
           turns: result.turns,
           finishReason: result.finishReason,
-          // A child that settled through graceful budget exhaustion (RUN-025)
-          // stays a success; the marker keeps the degradation observable to
-          // the parent without leaking any child transcript.
           ...(result.exhausted !== undefined ? { exhausted: result.exhausted } : {}),
-          // Travels verbatim from the child's own terminal event: without it a parent cannot
-          // account for delegated work, because the child is a separate Run and the parent's
-          // budget hook never sees its model calls.
-          ...(result.usage !== undefined ? { usage: result.usage } : {}),
         });
 
         const projected = yield* delegation.projectResult(
           result.output,
           {
             budgetExhausted: result.finishReason === "budget-exhausted",
+            ...report,
           },
           parameters,
         );
@@ -1670,6 +1701,7 @@ const layer = <
           yield* emit({
             _tag: "SubagentFailed",
             ...payload,
+            ...report,
             errorTag: "SubagentBudgetExhausted",
             message: `Projected child result of ${resultBytes} bytes exceeds the ${policy.maxResultBytes}-byte delegation budget`,
           });
@@ -1681,23 +1713,27 @@ const layer = <
             observedValue: resultBytes,
           });
         }
-        yield* emit({ _tag: "SubagentJoined", ...payload });
+        yield* emit({ _tag: "SubagentJoined", ...payload, ...report });
 
         return projected;
       });
 
-      // Interruption stays interruption: record the
-      // bounded lifecycle event best-effort, then let the closing handler
-      // scope interrupt and join the child and settle the reservation.
+      // Join the interrupted child before observing its final usage. Keep the original
+      // interruption even when the closing parent can no longer accept lifecycle events.
       return yield* joined.pipe(
         Effect.onInterrupt(() =>
-          sink
-            .emit({
-              _tag: "SubagentInterrupted",
-              ...payload,
-              reason: "Parent Run interrupted the attached child before it settled",
-            })
-            .pipe(Effect.ignore),
+          Scope.close(childScope, Exit.void).pipe(
+            Effect.andThen(child.usageReport),
+            Effect.flatMap((report) =>
+              sink.emit({
+                _tag: "SubagentInterrupted",
+                ...payload,
+                ...report,
+                reason: "Parent Run interrupted the attached child before it settled",
+              }),
+            ),
+            Effect.ignore,
+          ),
         ),
       );
     });
@@ -1838,6 +1874,11 @@ const layer = <
             depth,
           };
 
+          const report = RunUsageReport.make({
+            usage: status.usage ?? unknownRunTotals(),
+            delegatedUsage: status.delegatedUsage ?? unknownRunTotals(),
+          });
+
           // Every terminal projection of a settled child — success or typed
           // failure — goes through ONE atomic join (SUB-019): the coordinator
           // appends `SubagentJoined` + the parent `ToolCallSettled` in one
@@ -1851,6 +1892,7 @@ const layer = <
             emit({
               _tag: "SubagentFailed",
               ...payload,
+              ...report,
               errorTag: errorTagOf(failure),
               message: boundedEventText(errorMessageOf(failure)),
             }).pipe(
@@ -1919,6 +1961,7 @@ const layer = <
               decoded,
               {
                 budgetExhausted: status.finishReason === "budget-exhausted",
+                ...report,
               },
               parameters,
             )
@@ -1968,7 +2011,7 @@ const layer = <
               encodedAccounting: conservativeAccounting,
             }),
           );
-          yield* emit({ _tag: "SubagentJoined", ...payload });
+          yield* emit({ _tag: "SubagentJoined", ...payload, ...report });
 
           return projected;
         }

--- a/packages/capabilities/src/Subagent.ts
+++ b/packages/capabilities/src/Subagent.ts
@@ -1637,6 +1637,10 @@ const layer = <
           // stays a success; the marker keeps the degradation observable to
           // the parent without leaking any child transcript.
           ...(result.exhausted !== undefined ? { exhausted: result.exhausted } : {}),
+          // Travels verbatim from the child's own terminal event: without it a parent cannot
+          // account for delegated work, because the child is a separate Run and the parent's
+          // budget hook never sees its model calls.
+          ...(result.usage !== undefined ? { usage: result.usage } : {}),
         });
 
         const projected = yield* delegation.projectResult(

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -3902,10 +3902,8 @@ layer(TestServices)("Subagent usage accounting", (it) => {
       ),
     );
 
-  it.effect("reports exact known child totals and supports the existing child budget hook", () =>
+  it.effect("reports priced child totals on completion and the detached handle", () =>
     Effect.gen(function* () {
-      const deltas: number[] = [];
-
       const childLayer = SubagentRuntime.layer(
         researchDelegation,
         Agent.withModel(childDefinition, reviewModel('{"answer":"ok"}')),
@@ -3913,13 +3911,6 @@ layer(TestServices)("Subagent usage accounting", (it) => {
           mapChildFailure,
           child: {
             estimateCostMicrousd: () => Effect.succeed(17),
-            budget: {
-              guard: (effect) => effect,
-              consume: (delta) =>
-                Effect.sync(() => {
-                  deltas.push(delta.inputTokens);
-                }),
-            },
           },
         },
       );
@@ -3928,7 +3919,12 @@ layer(TestServices)("Subagent usage accounting", (it) => {
         Effect.provide(childLayer),
       );
 
-      yield* handle.await;
+      const infallibleReport: Assert<
+        Equal<typeof handle.usageReport, Effect.Effect<RunUsageReport>>
+      > = true;
+
+      expect(infallibleReport).toBe(true);
+      const result = yield* handle.await;
       const events = yield* handle.events;
 
       expect(findEvent(events, "SubagentCompleted")?.usage).toMatchObject({
@@ -3939,7 +3935,6 @@ layer(TestServices)("Subagent usage accounting", (it) => {
         usageStatus: "partial",
         pricingStatus: "complete",
       });
-      const result = yield* handle.await;
 
       expect(result.usage?.modelCalls).toBe(2);
       expect(result.delegatedUsage).toEqual(findEvent(events, "SubagentCompleted")?.usage);
@@ -3947,25 +3942,6 @@ layer(TestServices)("Subagent usage accounting", (it) => {
         usage: result.usage,
         delegatedUsage: result.delegatedUsage,
       });
-      expect(deltas).toEqual([12]);
-    }),
-  );
-
-  it.effect("preserves unknown usage and pricing instead of reporting unqualified zero", () =>
-    Effect.gen(function* () {
-      const childLayer = researchLayer(
-        Agent.withModel(childDefinition, answeringModel("review-unknown", '{"answer":"ok"}')),
-      );
-
-      const handle = yield* AgentRuntime.start(parent(), { mission: "review" }).pipe(
-        Effect.provide(childLayer),
-      );
-
-      yield* handle.await;
-      const events = yield* handle.events;
-      const usage = findEvent(events, "SubagentCompleted")?.usage;
-
-      expect(usage).toMatchObject({ usageStatus: "unknown", pricingStatus: "unknown" });
     }),
   );
 
@@ -3980,18 +3956,12 @@ layer(TestServices)("Subagent usage accounting", (it) => {
         },
       );
 
-      const events: RunEvent[] = [];
-
-      yield* AgentRuntime.stream(parent(), { mission: "review" }).pipe(
-        Stream.tap((event) =>
-          Effect.sync(() => {
-            events.push(event);
-          }),
-        ),
-        Stream.runDrain,
+      const handle = yield* AgentRuntime.start(parent(), { mission: "review" }).pipe(
         Effect.provide(childLayer),
-        Effect.exit,
       );
+
+      expect(yield* Effect.flip(handle.await)).toBeInstanceOf(ResearchDelegationFailed);
+      const events = yield* handle.events;
       const failed = findEvent(events, "SubagentFailed");
 
       expect(failed).toMatchObject({
@@ -4086,11 +4056,6 @@ layer(TestServices)("Subagent usage accounting", (it) => {
           Scope.provide(scope),
         );
 
-        const infallibleReport: Assert<
-          Equal<typeof handle.usageReport, Effect.Effect<RunUsageReport>>
-        > = true;
-
-        expect(infallibleReport).toBe(true);
         yield* Deferred.await(ready);
         if (ending === "interrupt") yield* Scope.close(scope, Exit.void);
         if (ending === "timeout") yield* TestClock.adjust("10 seconds");
@@ -4171,22 +4136,8 @@ layer(TestServices)("Subagent usage accounting", (it) => {
         });
 
         const result = yield* AgentRuntime.run(
-          Agent.withModel(
-            Agent.make("accounting-parent", {
-              input: Schema.String,
-              output: Schema.String,
-              instructions: "Delegate",
-              toolkit: Toolkit.make(delegation.tool),
-              policy: parentPolicy,
-            }),
-            delegatingModel(
-              "accounting-parent",
-              "delegate_research",
-              [{ id: "call-1", params: { topic: "x" } }],
-              '"done"',
-            ),
-          ),
-          "input",
+          durableParent("accounting-parent", "x"),
+          { mission: "x" },
           {
             subagent,
             resumeUsage: {

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -30,6 +30,8 @@ import {
 import { IdGenerator } from "@effect-agent/core/IdGenerator";
 import { type RunEvent } from "@effect-agent/core/RunEvent";
 import { DelegationTool, SubagentDelegationCaps } from "@effect-agent/core/SubagentContract";
+import type { RunUsageReport } from "@effect-agent/core/Usage";
+import { RunTotals, emptyRunTotals } from "@effect-agent/core/Usage";
 import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import {
   type SubagentDurability,
@@ -62,6 +64,7 @@ import {
   Option,
   Ref,
   Schema,
+  Scope,
   Stream,
 } from "effect";
 import { TestClock } from "effect/testing";
@@ -437,12 +440,19 @@ layer(TestServices)("SubagentRuntime S1 attached delegation", (it) => {
 
       expect(requested?.childRunId).toBe(joined?.childRunId);
       expect(findEvent(events, "SubagentCompleted")).toMatchObject({ turns: 1 });
-      // The parent's own budget hook never sees the child's model calls, so this event is the
-      // only place a host can learn what a delegation cost.
+      // Completion reports preserve uncertainty when this fixture reports no token usage.
       const childUsage = findEvent(events, "SubagentCompleted")?.usage;
 
       expect(childUsage).toBeDefined();
-      expect(childUsage?.modelCalls).toBeGreaterThan(0);
+      expect(childUsage).toMatchObject({
+        modelCalls: 1,
+        inputTokens: 0,
+        outputTokens: 0,
+        costMicrousd: 0,
+        usageStatus: "unknown",
+        pricingStatus: "unknown",
+      });
+      expect(result.delegatedUsage).toEqual(childUsage);
 
       // The parent Tool result is the projected, Schema-encoded value.
       expect(findEvent(events, "ToolCallSucceeded")).toMatchObject({
@@ -1212,6 +1222,8 @@ layer(TestServices)("SubagentRuntime S1 attached delegation", (it) => {
         ).pipe(Effect.provide(middleLive));
 
         expect(result.output).toBe("root");
+        expect(result.usage?.modelCalls).toBe(2);
+        expect(result.delegatedUsage?.modelCalls).toBe(3);
         const reservations = yield* SubagentReservations;
         const snapshot = yield* reservations.parentSnapshot(runId);
 
@@ -3854,3 +3866,362 @@ const countingProbingChildBinding = (invocations: Ref.Ref<number>) =>
       ),
     ),
   );
+
+layer(TestServices)("Subagent usage accounting", (it) => {
+  const reviewModel = (answer: string) =>
+    Model.make(
+      "scripted",
+      "review-child",
+      Layer.effect(
+        LanguageModel.LanguageModel,
+        LanguageModel.make({
+          generateText: () => Effect.succeed([]),
+          streamText: () =>
+            Stream.fromIterable<Response.StreamPartEncoded>([
+              { type: "text-start", id: "a" },
+              { type: "text-delta", id: "a", delta: answer },
+              { type: "text-end", id: "a" },
+              {
+                type: "finish",
+                reason: "stop",
+                usage: { inputTokens: { total: 12 }, outputTokens: { total: 3 } },
+              },
+            ]),
+        }),
+      ),
+    );
+
+  const parent = () =>
+    Agent.withModel(
+      coordinatorDefinition,
+      delegatingModel(
+        "review-parent",
+        "delegate_research",
+        [{ id: "review-call", params: { topic: "review" } }],
+        '{"report":"done"}',
+      ),
+    );
+
+  it.effect("reports exact known child totals and supports the existing child budget hook", () =>
+    Effect.gen(function* () {
+      const deltas: number[] = [];
+
+      const childLayer = SubagentRuntime.layer(
+        researchDelegation,
+        Agent.withModel(childDefinition, reviewModel('{"answer":"ok"}')),
+        {
+          mapChildFailure,
+          child: {
+            estimateCostMicrousd: () => Effect.succeed(17),
+            budget: {
+              guard: (effect) => effect,
+              consume: (delta) =>
+                Effect.sync(() => {
+                  deltas.push(delta.inputTokens);
+                }),
+            },
+          },
+        },
+      );
+
+      const handle = yield* AgentRuntime.start(parent(), { mission: "review" }).pipe(
+        Effect.provide(childLayer),
+      );
+
+      yield* handle.await;
+      const events = yield* handle.events;
+
+      expect(findEvent(events, "SubagentCompleted")?.usage).toMatchObject({
+        modelCalls: 1,
+        inputTokens: 12,
+        outputTokens: 3,
+        costMicrousd: 17,
+        usageStatus: "partial",
+        pricingStatus: "complete",
+      });
+      const result = yield* handle.await;
+
+      expect(result.usage?.modelCalls).toBe(2);
+      expect(result.delegatedUsage).toEqual(findEvent(events, "SubagentCompleted")?.usage);
+      expect(yield* handle.usageReport).toMatchObject({
+        usage: result.usage,
+        delegatedUsage: result.delegatedUsage,
+      });
+      expect(deltas).toEqual([12]);
+    }),
+  );
+
+  it.effect("preserves unknown usage and pricing instead of reporting unqualified zero", () =>
+    Effect.gen(function* () {
+      const childLayer = researchLayer(
+        Agent.withModel(childDefinition, answeringModel("review-unknown", '{"answer":"ok"}')),
+      );
+
+      const handle = yield* AgentRuntime.start(parent(), { mission: "review" }).pipe(
+        Effect.provide(childLayer),
+      );
+
+      yield* handle.await;
+      const events = yield* handle.events;
+      const usage = findEvent(events, "SubagentCompleted")?.usage;
+
+      expect(usage).toMatchObject({ usageStatus: "unknown", pricingStatus: "unknown" });
+    }),
+  );
+
+  it.effect("reports consumed child usage when output validation fails", () =>
+    Effect.gen(function* () {
+      const childLayer = SubagentRuntime.layer(
+        researchDelegation,
+        Agent.withModel(childDefinition, reviewModel("invalid json")),
+        {
+          mapChildFailure,
+          child: { estimateCostMicrousd: () => Effect.succeed(17) },
+        },
+      );
+
+      const events: RunEvent[] = [];
+
+      yield* AgentRuntime.stream(parent(), { mission: "review" }).pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.provide(childLayer),
+        Effect.exit,
+      );
+      const failed = findEvent(events, "SubagentFailed");
+
+      expect(failed).toMatchObject({
+        usage: { modelCalls: 1, inputTokens: 12, outputTokens: 3, costMicrousd: 17 },
+      });
+    }),
+  );
+  for (const ending of ["defect", "timeout", "interrupt"] as const) {
+    it.effect(`retains child spend and closes resources after ${ending}`, () =>
+      Effect.gen(function* () {
+        const ready = yield* Deferred.make<void>();
+        const finalized = yield* Ref.make(false);
+        const turn = yield* Ref.make(0);
+
+        const progressTools = Toolkit.make(
+          Tool.make("progress", {
+            parameters: Schema.Struct({}),
+            success: Schema.String,
+          }),
+        );
+
+        const target = Agent.make("accounting-child", {
+          input: ChildInput,
+          output: ChildOutput,
+          instructions: "Make progress, then answer.",
+          toolkit: progressTools,
+          policy: childPolicy,
+        });
+
+        const delegation = Subagent.define("delegate_research", {
+          description: "Research",
+          target,
+          parameters: ResearchParams,
+          success: ResearchFindings,
+          failure: ResearchDelegationFailed,
+          policy: researchPolicy,
+          prepareInput: ({ topic }) => Effect.succeed({ question: topic }),
+          projectResult: (output) => Effect.succeed({ summary: output.answer }),
+        });
+
+        const childModel = Model.make(
+          "scripted",
+          `accounting-${ending}`,
+          Layer.effect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: () => Effect.succeed([]),
+              streamText: () =>
+                Stream.unwrap(
+                  Effect.gen(function* () {
+                    if ((yield* Ref.getAndUpdate(turn, (value) => value + 1)) === 0) {
+                      return Stream.fromIterable<Response.StreamPartEncoded>([
+                        {
+                          type: "tool-call",
+                          id: "progress-1",
+                          name: "progress",
+                          params: {},
+                          providerExecuted: false,
+                        },
+                        {
+                          type: "finish",
+                          reason: "tool-calls",
+                          usage: { inputTokens: { total: 12 }, outputTokens: { total: 3 } },
+                        },
+                      ]);
+                    }
+
+                    return Stream.unwrap(
+                      Deferred.succeed(ready, undefined).pipe(
+                        Effect.as(
+                          ending === "defect" ? Stream.die("child-defect-sentinel") : Stream.never,
+                        ),
+                      ),
+                    ).pipe(Stream.ensuring(Ref.set(finalized, true)));
+                  }),
+                ),
+            }),
+          ),
+        );
+
+        const scope = yield* Scope.make();
+
+        yield* Effect.addFinalizer((exit) => Scope.close(scope, exit));
+
+        const childLayer = SubagentRuntime.layer(delegation, Agent.withModel(target, childModel), {
+          mapChildFailure,
+          child: { estimateCostMicrousd: () => Effect.succeed(17) },
+        }).pipe(Layer.provide(progressTools.toLayer({ progress: () => Effect.succeed("done") })));
+
+        const handle = yield* AgentRuntime.start(parent(), { mission: "review" }).pipe(
+          Effect.provide(childLayer),
+          Scope.provide(scope),
+        );
+
+        const infallibleReport: Assert<
+          Equal<typeof handle.usageReport, Effect.Effect<RunUsageReport>>
+        > = true;
+
+        expect(infallibleReport).toBe(true);
+        yield* Deferred.await(ready);
+        if (ending === "interrupt") yield* Scope.close(scope, Exit.void);
+        if (ending === "timeout") yield* TestClock.adjust("10 seconds");
+        const exit = yield* Effect.exit(handle.await);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isSuccess(exit)) return;
+        if (ending === "defect") expect(Cause.hasDies(exit.cause)).toBe(true);
+        if (ending === "interrupt") expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+        if (ending === "timeout") expect(failureFrom(exit)).toBeInstanceOf(SubagentBudgetExhausted);
+        expect(yield* Ref.get(finalized)).toBe(true);
+        const report = yield* handle.usageReport;
+
+        expect(report.delegatedUsage).toMatchObject({
+          modelCalls: 1,
+          inputTokens: 12,
+          outputTokens: 3,
+          costMicrousd: 17,
+        });
+        if (ending !== "interrupt") {
+          const events = yield* handle.events;
+
+          expect(findEvent(events, "SubagentFailed")?.usage).toEqual(report.delegatedUsage);
+        }
+      }),
+    );
+  }
+
+  it.effect(
+    "passes a verified durable child's accounting into projection and counts a repeated report once",
+    () =>
+      Effect.gen(function* () {
+        const child = durableChildIdentity("accounting");
+
+        const usage = RunTotals.make({
+          ...emptyRunTotals(),
+          modelCalls: 2,
+          inputTokens: 100,
+          outputTokens: 25,
+          costMicrousd: 17,
+        });
+
+        const delegatedUsage = RunTotals.make({
+          ...emptyRunTotals(),
+          modelCalls: 1,
+          inputTokens: 10,
+          outputTokens: 5,
+          costMicrousd: 3,
+        });
+
+        let projected: RunTotals | undefined;
+
+        const delegation = Subagent.define("delegate_research", {
+          description: "Research",
+          target: childDefinition,
+          parameters: ResearchParams,
+          success: ResearchFindings,
+          failure: ResearchDelegationFailed,
+          policy: researchPolicy,
+          prepareInput: ({ topic }) => Effect.succeed({ question: topic }),
+          projectResult: (output, context) =>
+            Effect.sync(() => {
+              projected = context.usage;
+
+              return { summary: output.answer };
+            }),
+        });
+
+        const subagent = scriptedDurableHook({
+          establish: () => ({
+            _tag: "settled",
+            ...child,
+            outcome: "completed",
+            encodedResult: { answer: "done" },
+            usage,
+            delegatedUsage,
+          }),
+        });
+
+        const result = yield* AgentRuntime.run(
+          Agent.withModel(
+            Agent.make("accounting-parent", {
+              input: Schema.String,
+              output: Schema.String,
+              instructions: "Delegate",
+              toolkit: Toolkit.make(delegation.tool),
+              policy: parentPolicy,
+            }),
+            delegatingModel(
+              "accounting-parent",
+              "delegate_research",
+              [{ id: "call-1", params: { topic: "x" } }],
+              '"done"',
+            ),
+          ),
+          "input",
+          {
+            subagent,
+            resumeUsage: {
+              committedTurns: 0,
+              toolCalls: 0,
+              programmaticToolCalls: 0,
+              consecutiveToolFailures: 0,
+              finalizationUsed: false,
+              modelCalls: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              lastInputTokens: 0,
+              lastOutputTokens: 0,
+              costMicrousd: 0,
+              usageStatus: "complete",
+              pricingStatus: "complete",
+              children: [{ runId: child.childRunId, report: { usage, delegatedUsage } }],
+            },
+          },
+        ).pipe(
+          Effect.provide(
+            SubagentRuntime.layer(
+              delegation,
+              Agent.withModel(childDefinition, reviewModel('{"answer":"unused"}')),
+            ),
+          ),
+        );
+
+        expect(projected).toEqual(usage);
+        expect(result.delegatedUsage).toMatchObject({
+          modelCalls: 3,
+          inputTokens: 110,
+          outputTokens: 30,
+          costMicrousd: 20,
+        });
+      }),
+  );
+});

--- a/packages/capabilities/test/subagent.test.ts
+++ b/packages/capabilities/test/subagent.test.ts
@@ -437,6 +437,12 @@ layer(TestServices)("SubagentRuntime S1 attached delegation", (it) => {
 
       expect(requested?.childRunId).toBe(joined?.childRunId);
       expect(findEvent(events, "SubagentCompleted")).toMatchObject({ turns: 1 });
+      // The parent's own budget hook never sees the child's model calls, so this event is the
+      // only place a host can learn what a delegation cost.
+      const childUsage = findEvent(events, "SubagentCompleted")?.usage;
+
+      expect(childUsage).toBeDefined();
+      expect(childUsage?.modelCalls).toBeGreaterThan(0);
 
       // The parent Tool result is the projected, Schema-encoded value.
       expect(findEvent(events, "ToolCallSucceeded")).toMatchObject({

--- a/packages/core/src/RunEvent.ts
+++ b/packages/core/src/RunEvent.ts
@@ -192,8 +192,9 @@ const RunCompletedFields = Schema.Struct({
   turns: Schema.Int.check(Schema.isGreaterThan(0)),
   finishReason: CompletionFinishReason,
   exhausted: Schema.optionalKey(ExhaustedLimit),
-  /** Cumulative spend for the Run. Optional so records written before this field still decode. */
+  /** Own Run usage, excluding attached descendants. Missing legacy reports are unknown. */
   usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
 }).check(
   Schema.makeFilter((event) => validateCompletionMetadata(event)),
   Schema.makeFilter((event) =>
@@ -226,6 +227,8 @@ export class RunCompleted extends Schema.TaggedClass<RunCompleted>()(
 /** Terminal event for a run that failed with an expected error. */
 export class RunFailed extends Schema.TaggedClass<RunFailed>()("RunFailed", {
   ...RunEventBase,
+  usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
   errorTag: Schema.NonEmptyString,
   message: Schema.String,
 }) {}
@@ -239,6 +242,8 @@ export class RunInterrupted extends Schema.TaggedClass<RunInterrupted>()("RunInt
 /** Terminal event for a run awaiting resumable external input. */
 export class RunSuspended extends Schema.TaggedClass<RunSuspended>()("RunSuspended", {
   ...RunEventBase,
+  usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
   reason: Schema.String,
 }) {}
 
@@ -287,18 +292,18 @@ export class SubagentCompleted extends Schema.TaggedClass<SubagentCompleted>()(
     finishReason: CompletionFinishReason,
     exhausted: Schema.optionalKey(ExhaustedLimit),
     /**
-     * What the child spent, travelling verbatim from its own terminal event.
-     *
-     * Without it a parent cannot account for delegated work at all: the child is a separate Run, so
-     * a parent's `RunBudgetHook` never sees its calls.
+     * The child's own observed usage. Delegated usage covers its attached descendants separately.
      */
     usage: Schema.optionalKey(RunTotals),
+    delegatedUsage: Schema.optionalKey(RunTotals),
   }).check(Schema.makeFilter((event) => validateCompletionMetadata(event))),
 ) {}
 
 /** Records the child run's expected terminal failure using safe, serializable diagnostics. */
 export class SubagentFailed extends Schema.TaggedClass<SubagentFailed>()("SubagentFailed", {
   ...SubagentEventBase,
+  usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
   errorTag: Schema.NonEmptyString,
   message: SubagentText,
 }) {}
@@ -308,15 +313,18 @@ export class SubagentInterrupted extends Schema.TaggedClass<SubagentInterrupted>
   "SubagentInterrupted",
   {
     ...SubagentEventBase,
+    usage: Schema.optionalKey(RunTotals),
+    delegatedUsage: Schema.optionalKey(RunTotals),
     reason: SubagentText,
   },
 ) {}
 
 /** Records that the child's terminal outcome was joined into its parent delegation Tool Call. */
-export class SubagentJoined extends Schema.TaggedClass<SubagentJoined>()(
-  "SubagentJoined",
-  SubagentEventBase,
-) {}
+export class SubagentJoined extends Schema.TaggedClass<SubagentJoined>()("SubagentJoined", {
+  ...SubagentEventBase,
+  usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
+}) {}
 
 /** Versioned union of stable semantic run events, excluding raw provider chunks. */
 export const RunEvent = Schema.Union([

--- a/packages/core/src/RunEvent.ts
+++ b/packages/core/src/RunEvent.ts
@@ -3,6 +3,7 @@ import { Schema } from "effect";
 import { AgentId, ThreadId, DelegationId, RunId, ToolCallId, TurnId } from "./Identifiers.ts";
 import { DelegationDepth } from "./SubagentContract.ts";
 import { Selection } from "./ToolExposure.ts";
+import { RunTotals } from "./Usage.ts";
 
 const RunEventBase = {
   eventVersion: Schema.Literal(1),
@@ -191,6 +192,8 @@ const RunCompletedFields = Schema.Struct({
   turns: Schema.Int.check(Schema.isGreaterThan(0)),
   finishReason: CompletionFinishReason,
   exhausted: Schema.optionalKey(ExhaustedLimit),
+  /** Cumulative spend for the Run. Optional so records written before this field still decode. */
+  usage: Schema.optionalKey(RunTotals),
 }).check(
   Schema.makeFilter((event) => validateCompletionMetadata(event)),
   Schema.makeFilter((event) =>
@@ -283,6 +286,13 @@ export class SubagentCompleted extends Schema.TaggedClass<SubagentCompleted>()(
     turns: Schema.Int.check(Schema.isGreaterThan(0)),
     finishReason: CompletionFinishReason,
     exhausted: Schema.optionalKey(ExhaustedLimit),
+    /**
+     * What the child spent, travelling verbatim from its own terminal event.
+     *
+     * Without it a parent cannot account for delegated work at all: the child is a separate Run, so
+     * a parent's `RunBudgetHook` never sees its calls.
+     */
+    usage: Schema.optionalKey(RunTotals),
   }).check(Schema.makeFilter((event) => validateCompletionMetadata(event))),
 ) {}
 

--- a/packages/core/src/Usage.ts
+++ b/packages/core/src/Usage.ts
@@ -69,6 +69,20 @@ export class ModelCallUsage extends Schema.Class<ModelCallUsage>(
   costMicrousd: Schema.Natural,
 }) {}
 
+/**
+ * Cumulative spend for one Run, without per-model attribution.
+ *
+ * The ephemeral runtime tracks running totals to enforce `tokenBudget`, but it does not retain the
+ * per-pricing-identity groups a `RunUsageSummary` carries, so this is what it can report honestly.
+ * Durable settlements keep using `RunUsageSummary`.
+ */
+export class RunTotals extends Schema.Class<RunTotals>("@effect-agent/core/RunTotals")({
+  modelCalls: Schema.Natural,
+  inputTokens: Schema.Natural,
+  outputTokens: Schema.Natural,
+  costMicrousd: Schema.Natural,
+}) {}
+
 /** Settlement-sized aggregate for calls sharing one pricing identity. */
 export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
   "@effect-agent/core/ModelUsageGroup",

--- a/packages/core/src/Usage.ts
+++ b/packages/core/src/Usage.ts
@@ -1,5 +1,7 @@
 import { Effect, Schema } from "effect";
 
+import { RunId } from "./Identifiers.ts";
+
 const UsageIdentity = Schema.NonEmptyString.check(Schema.isMaxLength(256));
 
 /** Bounded provider response identity. Request configuration is not response evidence. */
@@ -70,18 +72,53 @@ export class ModelCallUsage extends Schema.Class<ModelCallUsage>(
 }) {}
 
 /**
- * Cumulative spend for one Run, without per-model attribution.
- *
- * The ephemeral runtime tracks running totals to enforce `tokenBudget`, but it does not retain the
- * per-pricing-identity groups a `RunUsageSummary` carries, so this is what it can report honestly.
- * Durable settlements keep using `RunUsageSummary`.
+ * Observed model usage and estimated cost, without per-model attribution.
+ * Numeric zero with unknown coverage never establishes free execution. Missing legacy
+ * statuses mean unknown. Unobserved calls are excluded from the numeric call/token totals.
  */
 export class RunTotals extends Schema.Class<RunTotals>("@effect-agent/core/RunTotals")({
   modelCalls: Schema.Natural,
   inputTokens: Schema.Natural,
   outputTokens: Schema.Natural,
   costMicrousd: Schema.Natural,
+  usageStatus: Schema.optionalKey(UsageCompleteness),
+  pricingStatus: Schema.optionalKey(UsageCompleteness),
+  unobservedModelCalls: Schema.optionalKey(Schema.Natural),
 }) {}
+
+/** Own Run usage and disjoint attached-descendant usage. Add each component once. */
+export class RunUsageReport extends Schema.Class<RunUsageReport>(
+  "@effect-agent/core/RunUsageReport",
+)({
+  usage: RunTotals,
+  delegatedUsage: RunTotals,
+}) {}
+
+/** A verified child report retained across durable parent Attempts. */
+export class ChildRunUsage extends Schema.Class<ChildRunUsage>("@effect-agent/core/ChildRunUsage")({
+  runId: RunId,
+  report: RunUsageReport,
+}) {}
+
+/** Known absence of observed work. */
+export const emptyRunTotals = (): RunTotals =>
+  RunTotals.make({
+    modelCalls: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    costMicrousd: 0,
+    usageStatus: "complete",
+    pricingStatus: "complete",
+    unobservedModelCalls: 0,
+  });
+
+/** No accounting evidence, including legacy child reports. This is not known zero spend. */
+export const unknownRunTotals = (): RunTotals =>
+  RunTotals.make({
+    ...emptyRunTotals(),
+    usageStatus: "unknown",
+    pricingStatus: "unknown",
+  });
 
 /** Settlement-sized aggregate for calls sharing one pricing identity. */
 export class ModelUsageGroup extends Schema.Class<ModelUsageGroup>(
@@ -224,6 +261,81 @@ const checkedAdd = (
         }),
       );
 };
+
+/** Combine disjoint totals, retaining uncertainty and rejecting numeric overflow. */
+export const sumRunTotals = Effect.fn("sumRunTotals")(function* (
+  contributions: ReadonlyArray<RunTotals>,
+): Effect.fn.Return<RunTotals, UsageAggregationError> {
+  let modelCalls = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let costMicrousd = 0;
+  let unobservedModelCalls = 0;
+  const usageStatuses: Array<typeof UsageCompleteness.Type> = [];
+  const pricingStatuses: Array<typeof UsageCompleteness.Type> = [];
+
+  for (const contribution of contributions) {
+    const value = yield* Schema.decodeUnknownEffect(RunTotals)(contribution).pipe(
+      Effect.mapError(
+        () => new UsageAggregationError({ field: "totals", message: "Invalid Run totals" }),
+      ),
+    );
+
+    modelCalls = yield* checkedAdd("modelCalls", modelCalls, value.modelCalls);
+    inputTokens = yield* checkedAdd("inputTokens", inputTokens, value.inputTokens);
+    outputTokens = yield* checkedAdd("outputTokens", outputTokens, value.outputTokens);
+    costMicrousd = yield* checkedAdd("costMicrousd", costMicrousd, value.costMicrousd);
+    unobservedModelCalls = yield* checkedAdd(
+      "unobservedModelCalls",
+      unobservedModelCalls,
+      value.unobservedModelCalls ?? 0,
+    );
+    // Known empty contributions are identities; unknown empty contributions are evidence gaps.
+    if (
+      value.modelCalls > 0 ||
+      (value.unobservedModelCalls ?? 0) > 0 ||
+      value.usageStatus !== "complete"
+    ) {
+      usageStatuses.push(value.usageStatus ?? "unknown");
+    }
+    if (
+      value.modelCalls > 0 ||
+      (value.unobservedModelCalls ?? 0) > 0 ||
+      value.pricingStatus !== "complete"
+    ) {
+      pricingStatuses.push(value.pricingStatus ?? "unknown");
+    }
+  }
+
+  const coverage = (statuses: ReadonlyArray<typeof UsageCompleteness.Type>) =>
+    statuses.every((status) => status === "complete")
+      ? ("complete" as const)
+      : statuses.every((status) => status === "unknown")
+        ? ("unknown" as const)
+        : ("partial" as const);
+
+  return RunTotals.make({
+    modelCalls,
+    inputTokens,
+    outputTokens,
+    costMicrousd,
+    unobservedModelCalls,
+    usageStatus: coverage(usageStatuses),
+    pricingStatus: coverage(pricingStatuses),
+  });
+});
+
+/** Flatten a canonical settlement summary without discarding its coverage markers. */
+export const runTotalsFromSummary = (summary: RunUsageSummary): RunTotals =>
+  RunTotals.make({
+    modelCalls: summary.modelCalls,
+    inputTokens: summary.inputTokens.total,
+    outputTokens: summary.outputTokens.total,
+    costMicrousd: summary.costMicrousd,
+    usageStatus: summary.usageStatus ?? "unknown",
+    pricingStatus: summary.pricingStatus ?? "unknown",
+    unobservedModelCalls: summary.unobservedModelCalls ?? 0,
+  });
 
 /**
  * Deterministically aggregate canonical per-call usage without making cached tokens free.

--- a/packages/core/test/provider-usage.test.ts
+++ b/packages/core/test/provider-usage.test.ts
@@ -4,7 +4,6 @@ import {
   emptyRunTotals,
   unknownRunTotals,
   sumRunTotals,
-  runTotalsFromSummary,
   RunUsageSummary,
   summarizeModelUsage,
   UsageAggregationError,
@@ -215,7 +214,8 @@ it("combines disjoint Run totals without converting unknown or legacy evidence i
         usageStatus: "unknown",
         pricingStatus: "unknown",
       });
-      const combined = yield* sumRunTotals([known, unknownRunTotals(), legacy]);
+      expect((yield* sumRunTotals([known, unknownRunTotals()])).pricingStatus).toBe("partial");
+      const combined = yield* sumRunTotals([known, legacy]);
 
       expect(combined).toMatchObject({
         modelCalls: 3,
@@ -225,10 +225,7 @@ it("combines disjoint Run totals without converting unknown or legacy evidence i
         usageStatus: "partial",
         pricingStatus: "partial",
       });
-      expect(yield* sumRunTotals([legacy, unknownRunTotals(), known])).toEqual(combined);
-      expect(Schema.decodeUnknownSync(RunTotals)(Schema.encodeSync(RunTotals)(combined))).toEqual(
-        combined,
-      );
+      expect(yield* sumRunTotals([legacy, known])).toEqual(combined);
       expectTypeOf(sumRunTotals([known])).toEqualTypeOf<
         Effect.Effect<RunTotals, UsageAggregationError>
       >();
@@ -239,23 +236,5 @@ it("combines disjoint Run totals without converting unknown or legacy evidence i
       ]).pipe(Effect.flip);
 
       expect(overflow).toMatchObject({ _tag: "UsageAggregationError", field: "inputTokens" });
-
-      const summary = yield* summarizeModelUsage([
-        ModelCallUsage.make({
-          provider: "test",
-          model: "model",
-          inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
-          outputTokens: { total: 0, text: 0, reasoning: 0 },
-          costMicrousd: 0,
-          usageStatus: "unknown",
-          pricingStatus: "unknown",
-        }),
-      ]);
-
-      expect(runTotalsFromSummary(summary)).toMatchObject({
-        modelCalls: 1,
-        usageStatus: "unknown",
-        pricingStatus: "unknown",
-      });
     }),
   ));

--- a/packages/core/test/provider-usage.test.ts
+++ b/packages/core/test/provider-usage.test.ts
@@ -1,5 +1,10 @@
 import {
   ModelCallUsage,
+  RunTotals,
+  emptyRunTotals,
+  unknownRunTotals,
+  sumRunTotals,
+  runTotalsFromSummary,
   RunUsageSummary,
   summarizeModelUsage,
   UsageAggregationError,
@@ -184,5 +189,73 @@ it("rejects invalid seeds and seeded usage overflow through the typed error chan
       expect((yield* summarizeModelUsage([zero], callLimit).pipe(Effect.flip)).field).toBe(
         "modelCalls",
       );
+    }),
+  ));
+
+it("combines disjoint Run totals without converting unknown or legacy evidence into free work", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const known = RunTotals.make({
+        ...emptyRunTotals(),
+        modelCalls: 2,
+        inputTokens: 12,
+        outputTokens: 3,
+        costMicrousd: 17,
+      });
+
+      const legacy = Schema.decodeUnknownSync(RunTotals)({
+        modelCalls: 1,
+        inputTokens: 0,
+        outputTokens: 0,
+        costMicrousd: 0,
+      });
+
+      expect(yield* sumRunTotals([emptyRunTotals(), known])).toEqual(known);
+      expect(yield* sumRunTotals([legacy])).toMatchObject({
+        usageStatus: "unknown",
+        pricingStatus: "unknown",
+      });
+      const combined = yield* sumRunTotals([known, unknownRunTotals(), legacy]);
+
+      expect(combined).toMatchObject({
+        modelCalls: 3,
+        inputTokens: 12,
+        outputTokens: 3,
+        costMicrousd: 17,
+        usageStatus: "partial",
+        pricingStatus: "partial",
+      });
+      expect(yield* sumRunTotals([legacy, unknownRunTotals(), known])).toEqual(combined);
+      expect(Schema.decodeUnknownSync(RunTotals)(Schema.encodeSync(RunTotals)(combined))).toEqual(
+        combined,
+      );
+      expectTypeOf(sumRunTotals([known])).toEqualTypeOf<
+        Effect.Effect<RunTotals, UsageAggregationError>
+      >();
+
+      const overflow = yield* sumRunTotals([
+        RunTotals.make({ ...known, inputTokens: Number.MAX_SAFE_INTEGER }),
+        known,
+      ]).pipe(Effect.flip);
+
+      expect(overflow).toMatchObject({ _tag: "UsageAggregationError", field: "inputTokens" });
+
+      const summary = yield* summarizeModelUsage([
+        ModelCallUsage.make({
+          provider: "test",
+          model: "model",
+          inputTokens: { total: 0, uncached: 0, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 0, text: 0, reasoning: 0 },
+          costMicrousd: 0,
+          usageStatus: "unknown",
+          pricingStatus: "unknown",
+        }),
+      ]);
+
+      expect(runTotalsFromSummary(summary)).toMatchObject({
+        modelCalls: 1,
+        usageStatus: "unknown",
+        pricingStatus: "unknown",
+      });
     }),
   ));

--- a/packages/engine/src/RunEventSink.ts
+++ b/packages/engine/src/RunEventSink.ts
@@ -6,6 +6,7 @@ import {
   type ToolCallId,
 } from "@effect-agent/core/Identifiers";
 import { type DelegationDepth } from "@effect-agent/core/SubagentContract";
+import { type RunTotals } from "@effect-agent/core/Usage";
 import { Context, Schema } from "effect";
 import type { Effect } from "effect";
 
@@ -49,6 +50,8 @@ export interface SubagentCompletedPayload extends SubagentEventBasePayload {
   readonly finishReason: "completed" | "model-stop" | "budget-exhausted";
   /** Dimension that bound when the child settled budget-exhausted (the RUN-021 grant-flow marker). */
   readonly exhausted?: "tokens" | "tool-calls" | "turns" | undefined;
+  /** What the child spent, so a parent can account for delegated work. */
+  readonly usage?: RunTotals | undefined;
 }
 
 /** Pre-base payload for the core `SubagentFailed` event; `message` is at most 4096 characters. */

--- a/packages/engine/src/RunEventSink.ts
+++ b/packages/engine/src/RunEventSink.ts
@@ -52,11 +52,14 @@ export interface SubagentCompletedPayload extends SubagentEventBasePayload {
   readonly exhausted?: "tokens" | "tool-calls" | "turns" | undefined;
   /** What the child spent, so a parent can account for delegated work. */
   readonly usage?: RunTotals | undefined;
+  readonly delegatedUsage?: RunTotals | undefined;
 }
 
 /** Pre-base payload for the core `SubagentFailed` event; `message` is at most 4096 characters. */
 export interface SubagentFailedPayload extends SubagentEventBasePayload {
   readonly _tag: "SubagentFailed";
+  readonly usage?: RunTotals | undefined;
+  readonly delegatedUsage?: RunTotals | undefined;
   readonly errorTag: string;
   readonly message: string;
 }
@@ -64,12 +67,16 @@ export interface SubagentFailedPayload extends SubagentEventBasePayload {
 /** Pre-base payload for the core `SubagentInterrupted` event; `reason` is at most 4096 characters. */
 export interface SubagentInterruptedPayload extends SubagentEventBasePayload {
   readonly _tag: "SubagentInterrupted";
+  readonly usage?: RunTotals | undefined;
+  readonly delegatedUsage?: RunTotals | undefined;
   readonly reason: string;
 }
 
 /** Pre-base payload for the core `SubagentJoined` event. */
 export interface SubagentJoinedPayload extends SubagentEventBasePayload {
   readonly _tag: "SubagentJoined";
+  readonly usage?: RunTotals | undefined;
+  readonly delegatedUsage?: RunTotals | undefined;
 }
 
 /**

--- a/packages/engine/src/RunOptions.ts
+++ b/packages/engine/src/RunOptions.ts
@@ -22,7 +22,12 @@ import {
 } from "@effect-agent/core/SubagentContract";
 import type { Snapshot } from "@effect-agent/core/ToolExposure";
 import { Selection } from "@effect-agent/core/ToolExposure";
-import { type ModelCallUsage } from "@effect-agent/core/Usage";
+import {
+  ChildRunUsage,
+  UsageCompleteness,
+  type RunTotals,
+  type ModelCallUsage,
+} from "@effect-agent/core/Usage";
 import type { WorkerBudgetScope } from "@effect-agent/core/Worker";
 import { type Cause, Effect, Context, type DateTime, Layer, Schema } from "effect";
 import type { LanguageModel, Model, Prompt, Response } from "effect/unstable/ai";
@@ -654,6 +659,9 @@ export interface ChildEstablishWaiting extends RunSubagentChildIdentity {
  */
 export interface ChildEstablishSettled extends RunSubagentChildIdentity {
   readonly _tag: "settled";
+  /** Verified canonical usage; absence denotes legacy or unavailable evidence. */
+  readonly usage?: RunTotals;
+  readonly delegatedUsage?: RunTotals;
   readonly outcome: "completed" | "failed" | "aborted";
   readonly encodedResult: unknown;
   /**
@@ -762,6 +770,11 @@ export const RunResumeUsageSchema = Schema.Struct({
   lastInputTokens: Schema.Natural,
   lastOutputTokens: Schema.Natural,
   costMicrousd: Schema.Natural,
+  usageStatus: Schema.optionalKey(UsageCompleteness),
+  pricingStatus: Schema.optionalKey(UsageCompleteness),
+  unobservedModelCalls: Schema.optionalKey(Schema.Natural),
+  /** Verified direct-child reports, deduplicated by Run ID across Attempts. */
+  children: Schema.optionalKey(Schema.Array(ChildRunUsage)),
 }).check(
   Schema.makeFilter(
     (usage) =>

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -79,6 +79,7 @@ import {
   ModelCallUsage,
   ModelResponseIdentity,
   OutputTokenUsage,
+  RunTotals,
 } from "@effect-agent/core/Usage";
 import type { WorkerBudgetScope } from "@effect-agent/core/Worker";
 import type { Take } from "effect";
@@ -336,6 +337,8 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
     exhausted: Schema.optionalKey(Schema.Literals(["tokens", "tool-calls", "turns"])),
     /** Schema-encoded application disposition declared for an ordinary completed Run. */
     runDisposition: Schema.optionalKey(Schema.Json),
+    /** Cumulative spend for the Run, as reported on its terminal event. */
+    usage: Schema.optionalKey(RunTotals),
   }).check(
     Schema.makeFilter(
       (result) =>
@@ -348,6 +351,20 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
       },
     ),
   );
+
+/** The Run's cumulative spend, as the terminal events report it. */
+const runTotalsOf = (context: {
+  readonly modelCalls: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly costMicrousd: number;
+}): RunTotals =>
+  RunTotals.make({
+    modelCalls: context.modelCalls,
+    inputTokens: context.inputTokens,
+    outputTokens: context.outputTokens,
+    costMicrousd: context.costMicrousd,
+  });
 
 /** Decoded terminal value produced by reducing a completed agent event stream. */
 export type AgentResult<Output> = ReturnType<
@@ -1436,6 +1453,7 @@ const stampSubagentEvent = Effect.fn("AgentRuntime.stampSubagentEvent")(function
         turns: payload.turns,
         finishReason: payload.finishReason,
         ...(payload.exhausted !== undefined ? { exhausted: payload.exhausted } : {}),
+        ...(payload.usage !== undefined ? { usage: payload.usage } : {}),
       });
     }
     case "SubagentFailed": {
@@ -6185,6 +6203,7 @@ const makeTurn = <
                                   turns: turn,
                                   finishReason: "budget-exhausted",
                                   exhausted: "tokens",
+                                  usage: runTotalsOf(context),
                                 }),
                               ),
                             ),
@@ -6310,6 +6329,7 @@ const makeTurn = <
                     ...(finalAnswerOnly && context.exhaustedDimension !== undefined
                       ? { exhausted: context.exhaustedDimension }
                       : {}),
+                    usage: runTotalsOf(context),
                   }),
                 ),
               );
@@ -6703,6 +6723,7 @@ const toolBatchContinuation = <
               turns: turn,
               finishReason: exhausted === undefined ? "completed" : "budget-exhausted",
               ...(exhausted === undefined ? {} : { exhausted }),
+              usage: runTotalsOf(context),
             }),
           ),
         );
@@ -7933,6 +7954,7 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
             finishReason: completed.finishReason,
             ...(completed.exhausted !== undefined ? { exhausted: completed.exhausted } : {}),
             ...(runDisposition === undefined ? {} : { runDisposition: completed.runDisposition }),
+            ...(completed.usage === undefined ? {} : { usage: completed.usage }),
           };
         }),
       ),

--- a/packages/engine/src/internal/agent-runtime.ts
+++ b/packages/engine/src/internal/agent-runtime.ts
@@ -80,6 +80,11 @@ import {
   ModelResponseIdentity,
   OutputTokenUsage,
   RunTotals,
+  RunUsageReport,
+  emptyRunTotals,
+  unknownRunTotals,
+  sumRunTotals,
+  type UsageCompleteness,
 } from "@effect-agent/core/Usage";
 import type { WorkerBudgetScope } from "@effect-agent/core/Worker";
 import type { Take } from "effect";
@@ -339,6 +344,8 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
     runDisposition: Schema.optionalKey(Schema.Json),
     /** Cumulative spend for the Run, as reported on its terminal event. */
     usage: Schema.optionalKey(RunTotals),
+    /** Disjoint usage of attached descendants, including nested and failed children. */
+    delegatedUsage: Schema.optionalKey(RunTotals),
   }).check(
     Schema.makeFilter(
       (result) =>
@@ -352,19 +359,48 @@ export const AgentResultSchema = <Output extends Schema.Top>(output: Output) =>
     ),
   );
 
-/** The Run's cumulative spend, as the terminal events report it. */
-const runTotalsOf = (context: {
-  readonly modelCalls: number;
-  readonly inputTokens: number;
-  readonly outputTokens: number;
-  readonly costMicrousd: number;
-}): RunTotals =>
+/** Direct usage only: budget counters never absorb descendant consumption. */
+const runTotalsOf = (context: RunContext): RunTotals =>
   RunTotals.make({
     modelCalls: context.modelCalls,
     inputTokens: context.inputTokens,
     outputTokens: context.outputTokens,
     costMicrousd: context.costMicrousd,
+    usageStatus: context.usageStatus,
+    pricingStatus: context.pricingStatus,
+    unobservedModelCalls: context.unobservedModelCalls,
   });
+
+const usageReportOf = Effect.fn("AgentRuntime.usageReport")(function* (context: RunContext) {
+  const contributions: RunTotals[] = [];
+
+  for (const read of context.childUsage.values()) {
+    const report = yield* read;
+
+    contributions.push(report.usage, report.delegatedUsage);
+  }
+
+  // Observation must not change execution when a subtree exceeds numeric accounting capacity.
+  const delegatedUsage = yield* sumRunTotals(contributions).pipe(
+    Effect.catchTag("UsageAggregationError", () => Effect.succeed(unknownRunTotals())),
+  );
+
+  return RunUsageReport.make({ usage: runTotalsOf(context), delegatedUsage });
+});
+
+const noteIncompleteUsage = Effect.fn("AgentRuntime.noteIncompleteUsage")(function* (
+  context: RunContext,
+  turn: number,
+) {
+  const accounting = yield* ModelUsageAccounting;
+
+  context.unobservedModelCalls += 1;
+  context.usageStatus =
+    context.usageStatus === "unknown" || context.modelCalls === 0 ? "unknown" : "partial";
+  context.pricingStatus =
+    context.pricingStatus === "unknown" || context.modelCalls === 0 ? "unknown" : "partial";
+  yield* accounting.noteIncompleteUsage(turn);
+});
 
 /** Decoded terminal value produced by reducing a completed agent event stream. */
 export type AgentResult<Output> = ReturnType<
@@ -482,6 +518,11 @@ interface RunContext {
   readonly durationDeadlineMillis: number;
   history: Prompt.Prompt;
   modelCalls: number;
+  usageStatus: typeof UsageCompleteness.Type;
+  pricingStatus: typeof UsageCompleteness.Type;
+  unobservedModelCalls: number;
+  readonly childUsage: Map<RunId, Effect.Effect<RunUsageReport>>;
+  readonly liveChildren: Set<RunId>;
   consecutiveToolFailures: number;
   inputTokens: number;
   outputTokens: number;
@@ -1298,9 +1339,10 @@ const decodeResumeUsage = Effect.fn("AgentRuntime.decodeResumeUsage")((input: un
           throw new TypeError("Run resume usage must be an object");
         }
 
-        const read = (key: keyof RunResumeUsage): unknown => {
+        const read = (key: keyof RunResumeUsage, optional = false): unknown => {
           const descriptor = Object.getOwnPropertyDescriptor(input, key);
 
+          if (descriptor === undefined && optional) return undefined;
           if (descriptor === undefined || !("value" in descriptor)) {
             throw new TypeError(`Run resume usage ${key} must be an own data property`);
           }
@@ -1308,7 +1350,14 @@ const decodeResumeUsage = Effect.fn("AgentRuntime.decodeResumeUsage")((input: un
           return descriptor.value;
         };
 
+        const optional = Object.fromEntries(
+          (["usageStatus", "pricingStatus", "unobservedModelCalls", "children"] as const)
+            .map((key) => [key, read(key, true)])
+            .filter(([, value]) => value !== undefined),
+        );
+
         return {
+          ...optional,
           modelCalls: read("modelCalls"),
           inputTokens: read("inputTokens"),
           outputTokens: read("outputTokens"),
@@ -1437,6 +1486,16 @@ const stampSubagentEvent = Effect.fn("AgentRuntime.stampSubagentEvent")(function
     depth: payload.depth,
   };
 
+  const report =
+    "usage" in payload
+      ? {
+          ...(payload.usage === undefined ? {} : { usage: payload.usage }),
+          ...(payload.delegatedUsage === undefined
+            ? {}
+            : { delegatedUsage: payload.delegatedUsage }),
+        }
+      : {};
+
   switch (payload._tag) {
     case "SubagentRequested": {
       return SubagentRequested.make(shared);
@@ -1453,21 +1512,22 @@ const stampSubagentEvent = Effect.fn("AgentRuntime.stampSubagentEvent")(function
         turns: payload.turns,
         finishReason: payload.finishReason,
         ...(payload.exhausted !== undefined ? { exhausted: payload.exhausted } : {}),
-        ...(payload.usage !== undefined ? { usage: payload.usage } : {}),
+        ...report,
       });
     }
     case "SubagentFailed": {
       return SubagentFailed.make({
         ...shared,
+        ...report,
         errorTag: payload.errorTag,
         message: payload.message,
       });
     }
     case "SubagentInterrupted": {
-      return SubagentInterrupted.make({ ...shared, reason: payload.reason });
+      return SubagentInterrupted.make({ ...shared, ...report, reason: payload.reason });
     }
     case "SubagentJoined": {
-      return SubagentJoined.make(shared);
+      return SubagentJoined.make({ ...shared, ...report });
     }
   }
 });
@@ -2492,7 +2552,33 @@ const executeToolBatch = <Tools extends Record<string, Tool.Any>, HookError, Hoo
           Queue.offer(sinkQueue, payload).pipe(
             Effect.flatMap((accepted) =>
               accepted
-                ? Effect.void
+                ? Effect.sync(() => {
+                    if (context.liveChildren.has(payload.childRunId)) return;
+                    if ("usage" in payload && payload.usage !== undefined) {
+                      context.childUsage.set(
+                        payload.childRunId,
+                        Effect.succeed(
+                          RunUsageReport.make({
+                            usage: payload.usage,
+                            delegatedUsage: payload.delegatedUsage ?? unknownRunTotals(),
+                          }),
+                        ),
+                      );
+                    } else if (
+                      payload._tag === "SubagentStarted" &&
+                      !context.childUsage.has(payload.childRunId)
+                    ) {
+                      context.childUsage.set(
+                        payload.childRunId,
+                        Effect.succeed(
+                          RunUsageReport.make({
+                            usage: unknownRunTotals(),
+                            delegatedUsage: unknownRunTotals(),
+                          }),
+                        ),
+                      );
+                    }
+                  })
                 : Effect.fail(
                     RunEventSinkClosedError.make({
                       message: `Subagent event ${payload._tag} was emitted after its Tool batch settled`,
@@ -3138,6 +3224,18 @@ const consumeUsage = <AgentValue extends Agent.Any, HookError, HookRequirements>
         message: "Cumulative model cost exceeds safe-integer accounting capacity",
       });
     }
+    const firstObserved = context.modelCalls === 0 && context.unobservedModelCalls === 0;
+
+    const combineStatus = (
+      prior: typeof UsageCompleteness.Type,
+      next: typeof UsageCompleteness.Type,
+    ) => (firstObserved && prior === "complete" ? next : prior === next ? prior : "partial");
+
+    context.usageStatus = combineStatus(context.usageStatus, modelUsage.usageStatus ?? "unknown");
+    context.pricingStatus = combineStatus(
+      context.pricingStatus,
+      pricingStatus === "estimated" ? "complete" : "unknown",
+    );
     context.modelCalls = modelCalls;
     context.inputTokens = cumulativeInputTokens;
     context.outputTokens = cumulativeOutputTokens;
@@ -3550,7 +3648,6 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
   | Model.ModelName
 > =>
   Effect.gen(function* () {
-    const usageAccounting = yield* ModelUsageAccounting;
     const state = context.compaction;
     const events: Array<RunEvent> = [];
     const messages = source.content;
@@ -3791,7 +3888,7 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
         );
 
         if (summaryUsage === undefined) {
-          yield* usageAccounting.noteIncompleteUsage(turn);
+          yield* noteIncompleteUsage(context, turn);
           if (Exit.isFailure(summaryExit)) return yield* Effect.failCause(summaryExit.cause);
           if (!summaryFinished)
             return yield* ModelProtocolError.make({
@@ -3810,7 +3907,7 @@ const compactContext = <AgentValue extends Agent.Any, HookError, HookRequirement
         }).pipe(
           Effect.tapCause(() =>
             summaryUsage !== undefined && context.modelCalls === priorSummaryModelCalls
-              ? usageAccounting.noteIncompleteUsage(turn)
+              ? noteIncompleteUsage(context, turn)
               : Effect.void,
           ),
           Effect.ensuring(
@@ -4939,7 +5036,6 @@ const makeTurn = <
 > =>
   Stream.unwrap(
     Effect.gen(function* () {
-      const usageAccounting = yield* ModelUsageAccounting;
       const policy = agent.definition.policy;
       const bounds = effectiveRunBounds(policy, options);
 
@@ -5694,7 +5790,7 @@ const makeTurn = <
             withCallModel,
             Effect.tapCause(() =>
               context.modelCalls === priorModelCalls
-                ? usageAccounting.noteIncompleteUsage(turn)
+                ? noteIncompleteUsage(context, turn)
                 : Effect.void,
             ),
           );
@@ -5706,7 +5802,7 @@ const makeTurn = <
         if (trace.usageConsumed) return;
         trace.usageConsumed = true;
         if (trace.usage === undefined) {
-          return yield* usageAccounting.noteIncompleteUsage(turn);
+          return yield* noteIncompleteUsage(context, turn);
         }
         yield* consumeTurnUsage(0).pipe(Effect.exit);
       });
@@ -6194,6 +6290,8 @@ const makeTurn = <
                         if (Option.isSome(output)) {
                           yield* advanceHistory(context, historyWithResponse(), options);
 
+                          const completionUsage = yield* usageReportOf(context);
+
                           return emitThen(
                             Stream.fromEffect(
                               Effect.map(eventBase(context), (base) =>
@@ -6203,7 +6301,7 @@ const makeTurn = <
                                   turns: turn,
                                   finishReason: "budget-exhausted",
                                   exhausted: "tokens",
-                                  usage: runTotalsOf(context),
+                                  ...completionUsage,
                                 }),
                               ),
                             ),
@@ -6315,6 +6413,8 @@ const makeTurn = <
                   ? undefined
                   : yield* encodeRunDisposition(agent, output.decoded);
 
+              const completionUsage = yield* usageReportOf(context);
+
               return Stream.fromEffect(
                 Effect.map(eventBase(context), (base) =>
                   RunCompleted.make({
@@ -6329,7 +6429,7 @@ const makeTurn = <
                     ...(finalAnswerOnly && context.exhaustedDimension !== undefined
                       ? { exhausted: context.exhaustedDimension }
                       : {}),
-                    usage: runTotalsOf(context),
+                    ...completionUsage,
                   }),
                 ),
               );
@@ -6714,6 +6814,8 @@ const toolBatchContinuation = <
             ? undefined
             : yield* encodeRunDisposition(agent, output.decoded);
 
+        const completionUsage = yield* usageReportOf(context);
+
         return Stream.fromEffect(
           Effect.map(eventBase(context), (base) =>
             RunCompleted.make({
@@ -6723,7 +6825,7 @@ const toolBatchContinuation = <
               turns: turn,
               finishReason: exhausted === undefined ? "completed" : "budget-exhausted",
               ...(exhausted === undefined ? {} : { exhausted }),
-              usage: runTotalsOf(context),
+              ...completionUsage,
             }),
           ),
         );
@@ -7231,6 +7333,7 @@ function streamWithCompletion<
   onCompleted?: (
     completed: RunCompleted,
   ) => Effect.Effect<void, CompletionError, CompletionRequirements>,
+  onUsage?: (read: Effect.Effect<RunUsageReport>) => void,
 ): Stream.Stream<
   RunEvent,
   AgentRuntimeFailure<A, H> | CompletionError,
@@ -7288,6 +7391,7 @@ function streamWithCompletion<
   onCompleted?: (
     completed: RunCompleted,
   ) => Effect.Effect<void, CompletionError, CompletionRequirements>,
+  onUsage?: (read: Effect.Effect<RunUsageReport>) => void,
 ) {
   const agent: RuntimeProgram<
     InputSchema,
@@ -7470,6 +7574,18 @@ function streamWithCompletion<
             // canonical response records so token budgets and the compaction
             // trigger keep accounting across ownership changes.
             modelCalls: resumeUsage?.modelCalls ?? 0,
+            usageStatus:
+              resumeUsage?.usageStatus ?? (resumeUsage === undefined ? "complete" : "unknown"),
+            pricingStatus:
+              resumeUsage?.pricingStatus ?? (resumeUsage === undefined ? "complete" : "unknown"),
+            unobservedModelCalls: resumeUsage?.unobservedModelCalls ?? 0,
+            childUsage: new Map(
+              (resumeUsage?.children ?? []).map((child) => [
+                child.runId,
+                Effect.succeed(child.report),
+              ]),
+            ),
+            liveChildren: new Set(),
             consecutiveToolFailures: resumeUsage?.consecutiveToolFailures ?? 0,
             inputTokens: resumeUsage?.inputTokens ?? 0,
             outputTokens: resumeUsage?.outputTokens ?? 0,
@@ -7495,6 +7611,8 @@ function streamWithCompletion<
             finalizationUsed: resumeUsage?.finalizationUsed ?? false,
             policyReservations: yield* Semaphore.make(1),
           };
+
+          onUsage?.(usageReportOf(context));
 
           // Restored totals can already breach the token budget (runtime spec §9):
           // the resumed Attempt must never issue an unconstrained external call.
@@ -7728,6 +7846,10 @@ function streamWithCompletion<
               options.subagentGrant,
               options.subagentBudget,
               options.subagentBudgetScope,
+              (childRunId, read) => {
+                context.liveChildren.add(childRunId);
+                context.childUsage.set(childRunId, read);
+              },
             ),
           ).pipe(
             Context.add(ContextWindow, {
@@ -7780,11 +7902,13 @@ function streamWithCompletion<
                     return RunSuspended.make({
                       ...(yield* terminalEventBase(context)),
                       reason: error.message,
+                      ...(yield* usageReportOf(context)),
                     });
                   }
 
                   return RunFailed.make({
                     ...(yield* terminalEventBase(context)),
+                    ...(yield* usageReportOf(context)),
                     errorTag: errorTag(error),
                     message: errorMessage(error),
                   });
@@ -7867,6 +7991,8 @@ function streamWithCompletion<
                       threadId: terminal.threadId,
                       runId: terminal.runId,
                       agentId: terminal.agentId,
+                      usage: terminal.usage,
+                      delegatedUsage: terminal.delegatedUsage,
                       sequence: terminal.sequence,
                       timestamp: terminal.timestamp,
                       errorTag: errorTag(error),
@@ -7955,6 +8081,9 @@ const reduceRunEvents = <AgentValue extends Agent.Any, Error, Requirements>(
             ...(completed.exhausted !== undefined ? { exhausted: completed.exhausted } : {}),
             ...(runDisposition === undefined ? {} : { runDisposition: completed.runDisposition }),
             ...(completed.usage === undefined ? {} : { usage: completed.usage }),
+            ...(completed.delegatedUsage === undefined
+              ? {}
+              : { delegatedUsage: completed.delegatedUsage }),
           };
         }),
       ),
@@ -7994,6 +8123,9 @@ export interface DetachedRun<Output, Error> {
   readonly await: Effect.Effect<AgentResult<Output>, Error>;
   readonly events: Effect.Effect<ReadonlyArray<RunEvent>>;
   readonly observe: Stream.Stream<RunEvent>;
+  /** Snapshot of observed usage, also available after failure, defect, or interruption. Read after
+   * await settles (or the owning Scope closes) for a final report. In-flight work may be unpriced. */
+  readonly usageReport: Effect.Effect<RunUsageReport>;
 }
 
 const startProgram = Effect.fn("AgentRuntime.start")(function* <A extends Agent.Any, E, R, H, HR>(
@@ -8001,6 +8133,7 @@ const startProgram = Effect.fn("AgentRuntime.start")(function* <A extends Agent.
   events: (
     options: RunOptions<H, HR>,
     onCompleted: CompletionValidator<A>,
+    onUsage: (read: Effect.Effect<RunUsageReport>) => void,
   ) => Stream.Stream<RunEvent, E, R>,
   options: RunOptions<H, HR>,
 ) {
@@ -8038,8 +8171,14 @@ const startProgram = Effect.fn("AgentRuntime.start")(function* <A extends Agent.
 
   yield* Effect.addFinalizer(() => PubSub.shutdown(pubsub));
 
+  let readUsage = Effect.succeed(
+    RunUsageReport.make({ usage: emptyRunTotals(), delegatedUsage: emptyRunTotals() }),
+  );
+
   const execution = reduceRunEvents(agent, (onCompleted) =>
-    events(executionOptions, onCompleted).pipe(
+    events(executionOptions, onCompleted, (read) => {
+      readUsage = read;
+    }).pipe(
       Stream.tap((event) =>
         Effect.suspend(() => {
           captured.push(event);
@@ -8048,7 +8187,18 @@ const startProgram = Effect.fn("AgentRuntime.start")(function* <A extends Agent.
         }),
       ),
     ),
-  ).pipe(Effect.ensuring(PubSub.publish(pubsub, Exit.void)));
+  ).pipe(
+    Effect.onExit(() =>
+      Effect.suspend(() => readUsage).pipe(
+        Effect.flatMap((report) =>
+          Effect.sync(() => {
+            readUsage = Effect.succeed(report);
+          }),
+        ),
+      ),
+    ),
+    Effect.ensuring(PubSub.publish(pubsub, Exit.void)),
+  );
 
   const fiber = yield* execution.pipe(Effect.forkScoped);
 
@@ -8056,6 +8206,7 @@ const startProgram = Effect.fn("AgentRuntime.start")(function* <A extends Agent.
     await: Fiber.join(fiber),
     events: Fiber.await(fiber).pipe(Effect.andThen(Effect.sync(() => captured.slice()))),
     observe: Stream.fromPubSubTake(pubsub),
+    usageReport: Effect.suspend(() => readUsage),
   };
 });
 
@@ -8161,8 +8312,8 @@ function startUnknown<H = never, R = never>(
 
   return startProgram(
     program,
-    (executionOptions, onCompleted) =>
-      streamWithCompletion(agent, input, executionOptions, onCompleted).pipe(
+    (executionOptions, onCompleted, onUsage) =>
+      streamWithCompletion(agent, input, executionOptions, onCompleted, onUsage).pipe(
         Stream.provide(ModelUsageAccounting.layerEphemeral),
       ),
     options,
@@ -9417,6 +9568,7 @@ const spawnWithParent = (
   depth: number,
   history: ThreadHistory["Service"],
   preparation: RunContextPreparation["Service"],
+  onChild: (runId: RunId, read: Effect.Effect<RunUsageReport>) => void,
 ) =>
   Effect.fn("AgentSpawner.spawn")(function* <
     InputSchema extends Schema.Top,
@@ -9489,6 +9641,8 @@ const spawnWithParent = (
         Context.make(ThreadHistory, history).pipe(Context.add(RunContextPreparation, preparation)),
       ),
     );
+
+    onChild(runId, child.usageReport);
 
     return {
       ...child,
@@ -9614,6 +9768,7 @@ const makeAgentSpawner = (
   grant?: SubagentGrant,
   budget?: SubagentBudgetReservation,
   budgetScope?: WorkerBudgetScope,
+  onChild: (runId: RunId, read: Effect.Effect<RunUsageReport>) => void = () => {},
 ): AgentSpawnerService => ({
   ...(grant === undefined ? {} : { grant }),
   ...(budget === undefined ? {} : { budget }),
@@ -9621,7 +9776,7 @@ const makeAgentSpawner = (
   policy,
   depth,
   parent,
-  spawn: spawnWithParent(parent, depth, history, preparation),
+  spawn: spawnWithParent(parent, depth, history, preparation, onChild),
 });
 
 /** Bound applied to the rendered defect message of `withTerminalDefectEvent` (SEC-013). */

--- a/packages/testing/test/travel-planner-subagents-durable.test.ts
+++ b/packages/testing/test/travel-planner-subagents-durable.test.ts
@@ -1,7 +1,6 @@
 import { SubagentDurableAccounting } from "@effect-agent/capabilities/Subagent";
 import { ThreadId, ToolCallId, type SubmissionId } from "@effect-agent/core/Identifiers";
 import { SubagentReservationAmounts } from "@effect-agent/core/SubagentContract";
-import { runTotalsFromSummary, emptyRunTotals } from "@effect-agent/core/Usage";
 import {
   NodeDurableAgentRuntime,
   type NodeDurableAgentRuntimeOptions,
@@ -529,13 +528,22 @@ describe("TEST-014 S2 durable Travel Planner Subagent delegation (DN)", () => {
 
               expect(payloadsOf(log, "SubagentJoined")).toHaveLength(1);
               const joined = payloadsOf(log, "SubagentJoined")[0]?.record.payload;
-              const childUsage = childSettlements[0]?.usageSummary;
 
-              if (joined?._tag !== "SubagentJoined" || childUsage === undefined)
-                throw new Error("Expected canonical child usage");
-              expect(joined.usage).toEqual(runTotalsFromSummary(childUsage));
-              expect(joined.usage?.modelCalls).toBe(2);
-              expect(joined.delegatedUsage).toEqual(emptyRunTotals());
+              expect(joined).toMatchObject({
+                usage: {
+                  modelCalls: 2,
+                  inputTokens: 192,
+                  outputTokens: 128,
+                  costMicrousd: 0,
+                  usageStatus: "partial",
+                  pricingStatus: "unknown",
+                },
+                delegatedUsage: {
+                  modelCalls: 0,
+                  usageStatus: "complete",
+                  pricingStatus: "complete",
+                },
+              });
 
               const reservations = yield* childReservations(receipt.submissionId);
 

--- a/packages/testing/test/travel-planner-subagents-durable.test.ts
+++ b/packages/testing/test/travel-planner-subagents-durable.test.ts
@@ -1,6 +1,7 @@
 import { SubagentDurableAccounting } from "@effect-agent/capabilities/Subagent";
 import { ThreadId, ToolCallId, type SubmissionId } from "@effect-agent/core/Identifiers";
 import { SubagentReservationAmounts } from "@effect-agent/core/SubagentContract";
+import { runTotalsFromSummary, emptyRunTotals } from "@effect-agent/core/Usage";
 import {
   NodeDurableAgentRuntime,
   type NodeDurableAgentRuntimeOptions,
@@ -486,6 +487,7 @@ describe("TEST-014 S2 durable Travel Planner Subagent delegation (DN)", () => {
       withTemporaryDirectory((directory) =>
         Effect.gen(function* () {
           const locations = [
+            "subagent:before-join-append",
             "subagent:after-join-append",
             "subagent:after-release-pending",
             "subagent:after-release",
@@ -526,6 +528,15 @@ describe("TEST-014 S2 durable Travel Planner Subagent delegation (DN)", () => {
               const log = yield* readLog(receipt.threadId);
 
               expect(payloadsOf(log, "SubagentJoined")).toHaveLength(1);
+              const joined = payloadsOf(log, "SubagentJoined")[0]?.record.payload;
+              const childUsage = childSettlements[0]?.usageSummary;
+
+              if (joined?._tag !== "SubagentJoined" || childUsage === undefined)
+                throw new Error("Expected canonical child usage");
+              expect(joined.usage).toEqual(runTotalsFromSummary(childUsage));
+              expect(joined.usage?.modelCalls).toBe(2);
+              expect(joined.delegatedUsage).toEqual(emptyRunTotals());
+
               const reservations = yield* childReservations(receipt.submissionId);
 
               expect(reservations.map((row) => row.status)).toEqual(["released"]);

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -31,6 +31,12 @@ import {
   InputTokenUsage,
   ModelUsageGroup,
   RunUsageSummary,
+  ChildRunUsage,
+  RunUsageReport,
+  emptyRunTotals,
+  unknownRunTotals,
+  runTotalsFromSummary,
+  sumRunTotals,
   summarizeModelUsage,
   OutputTokenUsage,
 } from "@effect-agent/core/Usage";
@@ -486,6 +492,20 @@ const subagentRecordsOf = (
 
   return { requested, started, joined, preparedNames };
 };
+
+/** Joined reports are canonical snapshots, keyed by child Run so replay cannot double charge. */
+const childUsageReportsOf = (state: SubagentCallRecords): ReadonlyArray<ChildRunUsage> =>
+  [...state.started.entries()].map(([toolCallId, child]) => {
+    const joined = state.joined.get(toolCallId);
+
+    return ChildRunUsage.make({
+      runId: child.childRunId,
+      report: RunUsageReport.make({
+        usage: joined?.usage ?? unknownRunTotals(),
+        delegatedUsage: joined?.delegatedUsage ?? unknownRunTotals(),
+      }),
+    });
+  });
 
 /** Deterministic batch identity of one Thread's initial `ThreadCreated` append. */
 export const threadCreatedBatchId = (threadId: ThreadId): BatchId =>
@@ -3192,6 +3212,25 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
     readonly childRecords: ReadonlyArray<CanonicalRecordEnvelope>;
   }
 
+  const verifiedChildUsage = Effect.fn("DurableAgentRuntime.verifiedChildUsage")(function* (
+    verified: VerifiedChildSettlement,
+    childRunId: RunId,
+  ) {
+    const reports = childUsageReportsOf(subagentRecordsOf(verified.childRecords, childRunId));
+
+    const delegatedUsage = yield* sumRunTotals(
+      reports.flatMap(({ report }) => [report.usage, report.delegatedUsage]),
+    ).pipe(Effect.catchTag("UsageAggregationError", () => Effect.succeed(unknownRunTotals())));
+
+    return RunUsageReport.make({
+      usage:
+        verified.settlement.usageSummary === undefined
+          ? unknownRunTotals()
+          : runTotalsFromSummary(verified.settlement.usageSummary),
+      delegatedUsage,
+    });
+  });
+
   type ChildVerification =
     | { readonly _tag: "verified"; readonly value: VerifiedChildSettlement }
     | { readonly _tag: "mismatch"; readonly message: string };
@@ -3433,6 +3472,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
       }).pipe(Effect.orDie);
       const childRunId = runIdForSubmission(childSubmissionId);
 
+      yield* hit("subagent:before-join-append");
+
       const joinedPayload = SubagentJoined.make({
         runId,
         toolCallId,
@@ -3442,6 +3483,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         childResultDigest: yield* withCrypto(digestJson(verified.settlement.result ?? null)),
         projectedResultDigest: yield* withCrypto(digestJson(boundedResult)),
         usageSummary: yield* childUsageSummaryOf(verified.childRecords, childRunId),
+        ...(yield* verifiedChildUsage(verified, childRunId)),
         reservationId: reservation.reservationId,
         finalAccounting,
       });
@@ -6177,6 +6219,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               ...identity,
               outcome: verification.value.outcome,
               encodedResult: verification.value.encodedResult,
+              ...(yield* verifiedChildUsage(verification.value, startedPayload.childRunId)),
               // The child Settlement's honest exhaustion marker (RUN-018)
               // rides to the parent handler so the delegation can surface a
               // budget-truncated partial to the orchestrator (SUB-034).
@@ -6257,6 +6300,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                 });
               }
 
+              yield* hit("subagent:before-join-append");
+
               const joinedPayload = SubagentJoined.make({
                 runId,
                 toolCallId,
@@ -6271,6 +6316,7 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
                   verified.childRecords,
                   startedPayload.childRunId,
                 ),
+                ...(yield* verifiedChildUsage(verified, startedPayload.childRunId)),
                 reservationId: requestedPayload.reservationId,
                 finalAccounting: accounting,
               });
@@ -6410,7 +6456,19 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
         ...(config.estimateCostMicrousd === undefined
           ? {}
           : { estimateCostMicrousd: config.estimateCostMicrousd }),
-        resumeUsage: { ...journal.usage, ...journal.policyUsage },
+        resumeUsage: {
+          ...journal.usage,
+          ...journal.policyUsage,
+          ...(journal.usage.modelCalls === 0 &&
+          (journal.usage.unobservedModelCalls ?? 0) === 0 &&
+          !records.some(
+            ({ record }) =>
+              record.payload._tag === "ModelResponseInterrupted" && record.payload.runId === runId,
+          )
+            ? emptyRunTotals()
+            : runTotalsFromSummary(yield* currentUsageSummary())),
+          children: childUsageReportsOf(subagentState),
+        },
         ...(journal.contextWindowId === undefined
           ? {}
           : { initialContextWindowId: journal.contextWindowId }),

--- a/packages/thread/src/DurableFailpoint.ts
+++ b/packages/thread/src/DurableFailpoint.ts
@@ -49,6 +49,7 @@ export const DurableRuntimeFailpointLocation = Schema.Literals([
   "subagent:after-sibling-settle",
   "subagent:after-suspend",
   "subagent:after-child-abort-intent",
+  "subagent:before-join-append",
   "subagent:after-join-append",
   "subagent:after-release-pending",
   "subagent:after-release",

--- a/packages/thread/src/Records.ts
+++ b/packages/thread/src/Records.ts
@@ -24,7 +24,7 @@ import {
   ToolExecutionKind,
 } from "@effect-agent/core/SubagentContract";
 import { Selection, Snapshot } from "@effect-agent/core/ToolExposure";
-import { ModelCallUsage, RunUsageSummary } from "@effect-agent/core/Usage";
+import { ModelCallUsage, RunUsageSummary, RunTotals } from "@effect-agent/core/Usage";
 import { WorkerBudgetScope, WorkerRef, WorkerSource } from "@effect-agent/core/Worker";
 import { ContextHandoff } from "@effect-agent/engine/ContextWindow";
 import { Schema } from "effect";
@@ -729,6 +729,8 @@ export class SubagentJoined extends Schema.TaggedClass<SubagentJoined>(
   childResultDigest: Digest,
   projectedResultDigest: Digest,
   usageSummary: PersistedJson,
+  usage: Schema.optionalKey(RunTotals),
+  delegatedUsage: Schema.optionalKey(RunTotals),
   reservationId: BoundedName,
   finalAccounting: PersistedJson,
 }) {}


### PR DESCRIPTION
Delegated model work was absent from parent accounting. Expose each Run's own observed `usage` and a separate `delegatedUsage` for its entire attached subtree, including work consumed before failure, timeout, defect, or interruption.

Keep usage/pricing completeness and unobserved-call counts alongside the numbers, so unavailable evidence does not become an apparently free call. `RunTotals` stays flat because ephemeral execution does not retain per-model groups; durable settlements keep their richer `RunUsageSummary`. Optional fields preserve decoding of earlier records.

```mermaid
flowchart LR
  Child[Attached child reports] --> Reports[Reports keyed by child Run ID]
  Join[Verified canonical durable joins] --> Reports
  Reports --> Delegated[Parent delegatedUsage]
  Own[Parent model calls] --> Usage[Parent usage]
```

`DetachedRun.usageReport` remains readable after any outcome. Within an existing scoped Effect, with a binding, input, and options supplied by the host:

```ts
const handle = yield* AgentRuntime.start(binding, input, options);
const outcome = yield* Effect.exit(handle.await);
const report = yield* handle.usageReport;
const combined = yield* Usage.sumRunTotals([report.usage, report.delegatedUsage]);
```

The two totals are disjoint; do not also add child event totals. Durable joins persist verified child reports atomically with the Tool result, and recovery restores them by child Run ID. Background workers retain independent accounting. Costs remain estimates and missing usage remains unknown.

Child projection context now receives both totals. The existing `SubagentRuntimeOptions.child.budget` hook already supports live child deltas and continues to compose with reservation accounting.

Regression coverage includes exact totals, unknown coverage, nested children, validation failures, defects, timeouts, interruption/finalizers, aggregation overflow, and replay before/after canonical joins without counting a child twice.

`vp run ready` passed: static/package checks, 3,525 passing tests (8 skipped), and all package, example, documentation, and action builds. Static checks retain the existing 231 warnings with no errors.
