### PR TITLE
feat(cloudflare): add authorized exact-key memory reads

### DIFF
--- a/.agents/skills/open-pull-request/.dev-kit-origin.json
+++ b/.agents/skills/open-pull-request/.dev-kit-origin.json
@@ -2,9 +2,9 @@
   "version": 1,
   "selector": "open-pull-request",
   "name": "open-pull-request",
-  "baseDigest": "sha256:606a824df786efb1e52cf8d4bf0a1478db227e50c78821548086d2b60f17bc14",
+  "baseDigest": "sha256:a1b0041cfe16270a703d8bc0164c7154e9c8ee9d1ce317dc50ed6719abcf7cb5",
   "source": {
     "type": "bundled",
-    "version": "1.0.2"
+    "version": "2.0.1"
   }
 }

--- a/.agents/skills/open-pull-request/SKILL.md
+++ b/.agents/skills/open-pull-request/SKILL.md
@@ -5,9 +5,15 @@ description: Prepare, open, update, or land pull requests with concise explanati
 
 # Pull requests
 
-Lead with the concrete problem and resulting behavior. Give reviewers the
-context needed to assess the final change; simple changes need only a brief
-summary and relevant validation.
+Lead with the concrete problem and resulting behavior. Describe the final
+aggregate diff, omitting intermediate commits, abandoned approaches, and work
+session history unless they explain a relevant tradeoff. Simple changes need
+only a brief summary; complex or high-risk changes can justify more context.
+
+Keep test and validation reporting out of PR bodies: no dedicated sections,
+checklists, or lists of commands run. Still perform required checks and disclose
+material risks or limitations; include validation details only when required by
+higher-priority instructions.
 
 This is a public library. Keep descriptions self-contained and follow any
 required PR template. Omit private tracker links and issue IDs, including Linear
@@ -17,6 +23,7 @@ evidence unless the user explicitly requests them.
 
 - Ownership, data flow, or API changes: [diagrams and examples](references/explanation.md).
 - UI or other visible behavior: [capture and publish evidence](references/evidence.md).
+- Performance claims: [baseline and candidate comparisons](references/explanation.md#performance-claims).
 - Commits, publication, readiness, or landing: [PR workflow](references/publication.md).
 
 Reuse verification and captures for unchanged inputs. Include limitations or

--- a/.agents/skills/open-pull-request/references/evidence.md
+++ b/.agents/skills/open-pull-request/references/evidence.md
@@ -5,7 +5,12 @@ verification and reuse it for the PR. A screenshot is the default; use a short
 video when the sequence matters, such as an agent exchange or animation. Both
 are rarely needed. Nonvisual changes need no screenshots or recordings.
 
-Use existing capture tools; load `playwright-cli` when available for browser capture. Keep
+For changes to existing visible behavior, prefer a before/after table with
+published captures when the comparison helps reviewers see the change. Use the
+same viewport, fixture data, and interaction state for both captures. A new
+feature can use a final-state capture without a contrived before image.
+
+Use existing capture tools; load `playwright-cli` for browser capture. Keep
 recordings focused, usually under 30 seconds, without changing product timing.
 Use safe fixture data and review the image or whole clip once for correctness
 and private content. Treat published assets as public; unreviewed media stays
@@ -17,13 +22,6 @@ Use the repository's existing media publisher when available. Otherwise inspect
 that capability when authenticated access allows it. Do not assume a particular
 publisher script exists in every consumer repository.
 
-If no approved publisher or supported attachment tool is available, report the
-exact local path. Do not add a publisher as part of opening a PR.
-
 Use the returned link or Markdown in the PR. Keep originals until publication succeeds;
 if it fails, report the exact local path. Never extract browser cookies, expose
 credentials in arguments, create asset branches, or invent an upload service.
-
-Include nonvisual evidence only when it adds to the diff and CI. Mention
-validation commands for unusual checks, checks CI cannot run, or results that
-explain the behavior.

--- a/.agents/skills/open-pull-request/references/explanation.md
+++ b/.agents/skills/open-pull-request/references/explanation.md
@@ -17,6 +17,13 @@ Use fenced Mermaid and code blocks directly in the PR. A call tree or pseudocode
 can replace a chart when it explains the change more clearly. Match diagrams
 and examples to the final implementation, use safe fixture data, and distinguish
 illustrative or expected output from output actually observed during validation.
-Mark omitted context and schematic examples clearly.
 Include both a chart and an API example when they answer different review
 questions, not just to fill sections.
+
+## Performance claims
+
+Support performance claims with a before/after table comparing the target-branch
+baseline and PR candidate. Identify the revisions, workload, measurement
+conditions, units, and relevant variability so reviewers can interpret the
+comparison. Report measured results; label estimates and avoid claiming gains
+without a comparable baseline.

--- a/.agents/skills/open-pull-request/references/publication.md
+++ b/.agents/skills/open-pull-request/references/publication.md
@@ -3,21 +3,15 @@
 Check authenticated push access to the target repository before publication.
 Use the existing branch and review workflow. For an already verified change:
 
-1. Read repository contribution instructions and any required PR template.
-   Check the base, full branch diff, and working tree for accidental changes. Reuse
+1. Check the base, branch diff, and working tree for accidental changes. Reuse
    review, validation, and evidence already completed for unchanged inputs;
-   `AGENTS.md` owns required checks. Validate the final branch state, including
-   commit-hook changes, and ground claims in the diff, CI, or verified artifacts.
-2. Use Conventional Commits for commits and the title:
-   `type(scope): imperative summary`. Follow repository conventions, omit an
-   unhelpful scope, and keep commits focused. Commit and push the intended
-   changes, preserving unrelated work. Rewrite only your own unshared commits;
-   get approval before rewriting user-authored or published history.
+   `AGENTS.md` owns required checks.
+2. Use Conventional Commits for commits and the title. Commit and push the
+   intended changes, preserving unrelated work and published history.
 3. Open or update the PR with the short body, useful diagrams or API examples,
    and existing evidence. With `gh`, use `--body-file` for multiline text.
-4. Read back base/head, title, body, links, attached artifacts, and check status
-   once with `gh pr view`, then return the URL. Report pending or failed checks
-   accurately. No GitHub browser inspection or wait for CI is required to open it.
+4. Read back base/head, title, and body once with `gh pr view`, then return the
+   URL. No GitHub browser inspection or wait for CI is required to open it.
 
 Follow `AGENTS.md` for merge approval and required checks; opening a PR does
 not authorize merging it.

--- a/.changeset/authorized-cloudflare-memory-reads.md
+++ b/.changeset/authorized-cloudflare-memory-reads.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Add authorized, bounded exact-key current document reads through `CloudflareMemoryClient.get`, returning explicit absence or withdrawal tombstones while preserving typed access, storage, and transport failures.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -377,6 +377,32 @@ make an RPC. Applications that provide that service once through their Effect La
 `CloudflareMemoryClient.make(access, principal)` instead. Both return the same Effect-native client
 with the same validation and budgets.
 
+When the host already knows the document key, use `client.get(key)` with a `MemoryKey` in the
+bound namespace. The [compiling example](https://github.com/danieljvdm/effect-agent/blob/main/packages/platform-cloudflare/examples/memory.ts)
+reads `project-profile` directly. It sends one `Get` owner request and returns a schema-validated
+`MemoryDocument` with its current `source.revision`, or `null` only when the key is absent.
+A withdrawn key returns `WithdrawnMemoryDocument`, containing its terminal revision and no content.
+There is no extraction, job draining, embedding, candidate search, index refresh, rendering, or
+background readiness wait on this path.
+
+The owner invokes `MemoryOwnerAuthorizer` for the exact key, namespace, authenticated principal,
+and scope before reading, including for absent and withdrawn documents. It also denies active
+documents whose `scopes` omit the bound scope. Key or scope possession never grants access.
+For source-dependent memories, the application's owner authorizer must preserve its source authority
+and provenance checks; a current document revision does not prove that its original evidence remains
+authorized or current. These checks remain application-owned and are not replaced by `get`.
+
+Reads begun after an acknowledged write see that revision or a later one through the same SQLite
+owner. Reads after withdrawal return the tombstone; an already captured read may finish. The adapter
+must fail with `MemoryStorageError` if it cannot provide a current view. Denied access, expired
+deadlines, unavailable owners, invalid wire data, and exceeded budgets remain typed failures,
+never `null`. Both client and owner enforce `MemoryRpcLimits`: encoded request and response bytes,
+encoded document `maxSourceBytes`, and `timeoutMillis`. Storage row limits bound local reads before
+wire encoding. An interrupted caller stops waiting; the owner's own deadline finalizes its work.
+The `CloudflareMemoryClient.get` span measures the client operation without adding document text,
+keys, principals, or scopes as span attributes. Measure application authentication and rendering
+separately; this adapter operation alone does not establish a 100–200 ms complete lookup target.
+
 Access and document scopes share the `MemoryScope` brand from core. Clients and owner authorizers
 use the existing `Principal` brand from thread. Decode external values with their Effect Schemas
 after authentication; `.make` is suitable for trusted constants. Scopes are nonempty strings of at

--- a/examples/cloudflare-memory/README.md
+++ b/examples/cloudflare-memory/README.md
@@ -19,12 +19,18 @@ The measurement command does not deploy, delete, or change account configuration
 Worker and its DO namespaces afterward. Ordinary builds use only `wrangler deploy --dry-run`.
 
 The bounded workload covers 1, 4, 8, and 16 distinct 1024-byte sources, plus 128 candidates over
-16 sources. Two Thread callers alternate, at concurrency 1 and 4. Five independent memory owners
+16 sources. The `get` case reads one known 1024-byte current document directly through the public
+client, with no candidates, search, or rendering. Two Thread callers alternate, at concurrency 1 and 4. Six independent memory owners
 permit a first request after inactivity for each case. Every sample, payload size, error, and timeout
 is retained; warm p50/p95/p99 are reported in milliseconds. Egress-colo probes run after measurement.
 They describe observed routing, not guaranteed physical owner placement.
 
 Source-validation RPC time is separate from final recall rendering and full HTTP elapsed time.
+For `get`, `validationRpcMillis` measures the direct adapter round trip and
+`fullRecallMillis` retains the report's existing field name for the complete read and result checks.
+These timings include the synthetic owner's fixed authorization policy, but exclude production
+application authentication, source authority lookups, and rendering. They do not establish a
+100–200 ms complete application lookup target.
 Embedding/search are deliberately absent, so this benchmark makes no claim about their latency.
 Worker clocks advance on I/O; zero rendering intervals are not evidence of zero CPU cost.
 One first-after-inactivity sample per case cannot establish cold-start percentiles, and inactivity

--- a/examples/cloudflare-memory/src/contracts.ts
+++ b/examples/cloudflare-memory/src/contracts.ts
@@ -13,11 +13,13 @@ export const Projects = MemoryNamespace.define({
   identity: Schema.String,
 });
 
-export const BenchmarkCase = Schema.Literals(["1", "4", "8", "16", "duplicates"]);
+export const BenchmarkCase = Schema.Literals(["get", "1", "4", "8", "16", "duplicates"]);
 export type BenchmarkCase = typeof BenchmarkCase.Type;
 export const cases = BenchmarkCase.literals;
 export const memoryScope = MemoryScope.make("benchmark");
-export const sourceCount = (name: BenchmarkCase) => (name === "duplicates" ? 16 : Number(name));
+
+export const sourceCount = (name: BenchmarkCase) =>
+  name === "get" ? 1 : name === "duplicates" ? 16 : Number(name);
 
 export const limits = MemoryRecallLimits.make({
   maxSources: 16,

--- a/examples/cloudflare-memory/src/measure.ts
+++ b/examples/cloudflare-memory/src/measure.ts
@@ -159,7 +159,7 @@ export const command = Command.make(
       yield* request("sample", name, "b", Sample);
     }
     yield* Console.error(
-      `Seeded five isolated memory owners; waiting ${options.inactivity}s before first-after-inactivity samples.`,
+      `Seeded ${cases.length} isolated memory owners; waiting ${options.inactivity}s before first-after-inactivity samples.`,
     );
     yield* Effect.sleep(options.inactivity * 1000);
     for (const name of cases) {
@@ -212,6 +212,8 @@ export const command = Command.make(
       cohorts,
       placements,
       notes: [
+        "The get case reads one exact current 1024-byte document in one owner RPC, with zero candidates and no rendering. validationRpc measures the get round trip; fullRecall retains the existing field name and measures the complete read and result checks for this case.",
+        "Adapter timings include the synthetic owner's fixed authorization policy; production application authentication, source authority checks and rendering are not measured. This does not establish a 100–200 ms complete lookup target.",
         "Synthetic 1024-byte source texts; normal cases use 64-byte excerpts; duplicate-heavy uses 128 candidates over 16 sources.",
         "validationRpc measures Thread-to-Memory round trip plus validation, excluding candidate preparation and final rendering; fullRecall adds final rendering. HTTP includes caller activation and ingress.",
         "No embedding or search runs in this source-validation benchmark. Their latency is not measured or inferred.",

--- a/examples/cloudflare-memory/src/worker.ts
+++ b/examples/cloudflare-memory/src/worker.ts
@@ -107,13 +107,28 @@ export class BenchmarkThread extends ThreadObject.make(ThreadObject.layer([]), {
       Effect.gen(function* () {
         name = yield* Schema.decodeUnknownEffect(BenchmarkCase)(name);
         const client = yield* memoryClient(name);
-        const lookup = candidates(name);
+        const lookup = name === "get" ? null : candidates(name);
+        const key = command(name, 0).key;
         let validatedBytes = 0;
         let renderedBytes = 0;
         let validationRpcMillis = 0;
         const start = yield* Clock.currentTimeMillis;
 
         const result = yield* Effect.gen(function* () {
+          if (lookup === null) {
+            const document = yield* client.get(key);
+
+            validationRpcMillis = (yield* Clock.currentTimeMillis) - start;
+            if (
+              document?._tag !== "ActiveMemoryDocument" ||
+              document.source.revision !== "1" ||
+              document.content.text !== "source-0: ".padEnd(1024, "x")
+            )
+              return yield* MemoryRpcError.make({ reason: "protocol" });
+            validatedBytes = memoryWireBytes(JSON.stringify(document));
+
+            return;
+          }
           const current = yield* client.revalidate(lookup, limits);
 
           validationRpcMillis = (yield* Clock.currentTimeMillis) - start;
@@ -132,9 +147,9 @@ export class BenchmarkThread extends ThreadObject.make(ThreadObject.layer([]), {
         return yield* Schema.encodeEffect(Sample)({
           case: name,
           sourceCount: sourceCount(name),
-          candidateCount: lookup._tag === "Found" ? lookup.passages.length : 0,
+          candidateCount: lookup?._tag === "Found" ? lookup.passages.length : 0,
           corpusTextBytes: sourceCount(name) * 1024,
-          candidateBytes: memoryWireBytes(JSON.stringify(lookup)),
+          candidateBytes: lookup === null ? 0 : memoryWireBytes(JSON.stringify(lookup)),
           validatedBytes,
           renderedBytes,
           validationRpcMillis,

--- a/examples/cloudflare-memory/test/restart.test.ts
+++ b/examples/cloudflare-memory/test/restart.test.ts
@@ -76,6 +76,7 @@ it(
 
           expect(denied.status).toBe(401);
           expect((yield* request(runtime, "seed?case=4&caller=a")).status).toBe(200);
+          expect((yield* request(runtime, "seed?case=get&caller=a")).status).toBe(200);
         }).pipe(Effect.scoped);
         yield* Effect.gen(function* () {
           const runtime = yield* open(script, directory);
@@ -90,6 +91,22 @@ it(
             corpusTextBytes: 4096,
           });
           expect(sample.renderedBytes).toBeGreaterThan(0);
+          const direct = yield* request(runtime, "sample?case=get&caller=b");
+
+          const directSample = yield* Schema.decodeUnknownEffect(Sample)(
+            yield* Effect.promise(() => direct.json()),
+          );
+
+          expect(directSample).toMatchObject({
+            case: "get",
+            status: "ok",
+            sourceCount: 1,
+            candidateCount: 0,
+            candidateBytes: 0,
+            corpusTextBytes: 1024,
+            renderedBytes: 0,
+          });
+          expect(directSample.validatedBytes).toBeGreaterThan(1024);
           // Re-ingestion uses the original null expected revision and must resolve receipts.
           expect((yield* request(runtime, "seed?case=4&caller=a")).status).toBe(200);
         }).pipe(Effect.scoped);

--- a/packages/platform-cloudflare/examples/memory.ts
+++ b/packages/platform-cloudflare/examples/memory.ts
@@ -2,7 +2,11 @@ import * as MemoryNamespace from "@effect-agent/core/MemoryNamespace";
 import { type MemoryLookup, type MemoryRecallLimits } from "@effect-agent/core/MemoryReference";
 import { MemoryAccess } from "@effect-agent/core/MemoryRevalidation";
 import { type MemoryWrite } from "@effect-agent/core/MemoryStore";
-import { MemoryScope } from "@effect-agent/core/MemoryStore";
+import { MemoryKey, MemoryScope } from "@effect-agent/core/MemoryStore";
+import {
+  MemoryObject,
+  CloudflareMemoryClient,
+} from "@effect-agent/platform-cloudflare/CloudflareMemory";
 import {
   MemoryOwnerAuthorizer,
   MemoryOwnerIdentity,
@@ -10,8 +14,6 @@ import {
 } from "@effect-agent/storage-cloudflare/MemoryProtocol";
 import { Principal } from "@effect-agent/thread/SubmissionLedger";
 import { Effect, Layer, Schema } from "effect";
-
-import { MemoryObject, CloudflareMemoryClient } from "../src/CloudflareMemory.ts";
 
 export const Projects = MemoryNamespace.define({
   name: "application/projects",
@@ -37,6 +39,17 @@ const authorizer = Layer.effect(
 );
 
 export class ProjectMemory extends MemoryObject.make(authorizer) {}
+
+/** Host-authenticated access; add source authority checks to the owner policy when required. */
+export const readProjectMemory = Effect.fn("example.readProjectMemory")(function* (
+  access: MemoryAccess<ReturnType<typeof Projects.make>>,
+  principal: Principal,
+) {
+  const memory = yield* CloudflareMemoryClient.make(access, principal);
+
+  // One owner request. Null is absent; a withdrawn document is an explicit tombstone.
+  return yield* memory.get(MemoryKey.make({ namespace: access.namespace, id: "project-profile" }));
+});
 
 /** Called by any authorized Thread or ingestion job, not by the framework automatically. */
 export const correctProjectMemory = Effect.fn("example.correctProjectMemory")(function* (

--- a/packages/platform-cloudflare/src/CloudflareMemory.ts
+++ b/packages/platform-cloudflare/src/CloudflareMemory.ts
@@ -6,6 +6,7 @@ import { MemoryAccess } from "@effect-agent/core/MemoryRevalidation";
 import {
   type MemoryReader,
   type MemoryWrite,
+  MemoryKey,
   MemoryDocument,
   MemoryMutationFailpoint,
   MemoryStorageError,
@@ -164,6 +165,52 @@ const makeMemoryClient = Effect.fn("CloudflareMemoryClient.make")(function* <
     }).pipe((effect) => withinDeadline(effect, validated.timeoutMillis));
   });
 
+  /**
+   * Read one exact current document in one owner RPC. Null means absent; withdrawals return
+   * tombstones. Denial, unavailable storage and deadlines fail typed, never become absence.
+   * Reads begun after an acknowledged write observe it or a later revision. The owner checks
+   * exact-key authority and active document scopes; source-dependent provenance policy remains
+   * application-owned. No extraction, job draining, embedding, discovery or rendering occurs.
+   */
+  const get = Effect.fn("CloudflareMemoryClient.get")(function* (key: MemoryKey<Namespace>) {
+    const decodedKey = yield* Schema.decodeUnknownEffect(MemoryKey.Wire)(key).pipe(
+      Effect.mapError(() => MemoryRpcError.make({ reason: "protocol" })),
+    );
+
+    if (!MemoryNamespace.equals(decodedKey.namespace, bound.namespace))
+      return yield* MemoryRpcError.make({ reason: "denied" });
+
+    return yield* Effect.gen(function* () {
+      const response = yield* call({
+        _tag: "Get",
+        version: 1,
+        access: bound,
+        principal,
+        key: decodedKey,
+        deadlineMillis: (yield* Clock.currentTimeMillis) + validated.timeoutMillis,
+      });
+
+      if (
+        response._tag !== "Document" ||
+        !MemoryNamespace.equals(response.key.namespace, bound.namespace) ||
+        response.key.id !== decodedKey.id
+      )
+        return yield* MemoryRpcError.make({ reason: "protocol" });
+      if (response.document === null) return null;
+      if (
+        response.document.key.id !== decodedKey.id ||
+        response.document.source.id !== decodedKey.id ||
+        (response.document._tag === "ActiveMemoryDocument" &&
+          !response.document.scopes.includes(bound.scope))
+      )
+        return yield* MemoryRpcError.make({ reason: "protocol" });
+
+      yield* encodeMemoryWire(MemoryDocument.Wire, response.document, validated.maxSourceBytes);
+
+      return yield* MemoryDocument.restore(access.namespace, response.document);
+    }).pipe((effect) => withinDeadline(effect, validated.timeoutMillis));
+  });
+
   const revalidateSemantic = Effect.fn("CloudflareMemoryClient.revalidateSemantic")(function* (
     found: MemoryIndexSearch<Namespace>,
     profile: SemanticMemoryProfile,
@@ -206,7 +253,7 @@ const makeMemoryClient = Effect.fn("CloudflareMemoryClient.make")(function* <
     );
   });
 
-  return { recall, revalidate, revalidateSemantic, change };
+  return { get, recall, revalidate, revalidateSemantic, change };
 });
 
 export const CloudflareMemoryClient = {

--- a/packages/platform-cloudflare/test/memory-fixtures.ts
+++ b/packages/platform-cloudflare/test/memory-fixtures.ts
@@ -16,6 +16,7 @@ import {
   MemoryOwnerAuthorizer,
   MemoryOwnerIdentity,
   MemoryRpcError,
+  type MemoryOwnerRequest,
 } from "@effect-agent/storage-cloudflare/MemoryProtocol";
 import { Principal } from "@effect-agent/thread/SubmissionLedger";
 import { Clock, Deferred, Effect, Layer, Schema } from "effect";
@@ -91,6 +92,9 @@ export const memoryCandidates = (ids: ReadonlyArray<string>): MemoryLookup => ({
 });
 
 export const memoryCalls = new Map<string, number>();
+export const memoryRequests = new Map<string, Array<MemoryOwnerRequest>>();
+export const memoryReplies = new Map<string, string>();
+export const memoryDeniedSources = new Map<string, ReadonlySet<string>>();
 
 export const memoryFaults = new Map<
   string,
@@ -110,6 +114,10 @@ export const memoryAuthorizer = Layer.effect(
 
     return {
       authorize: Effect.fn("test.memory.authorize")(function* (request) {
+        const requests = memoryRequests.get(namespace.address) ?? [];
+
+        requests.push(request);
+        memoryRequests.set(namespace.address, requests);
         if (request.principal === "defect") return yield* Effect.die("authorization defect");
         if (request.principal === "slow") {
           return yield* Effect.acquireUseRelease(
@@ -128,6 +136,11 @@ export const memoryAuthorizer = Layer.effect(
           );
         }
         if (request.principal !== memoryPrincipal || request.access.scope !== memoryScope)
+          return yield* MemoryRpcError.make({ reason: "denied" });
+        if (
+          request._tag === "Get" &&
+          memoryDeniedSources.get(namespace.address)?.has(request.key.id)
+        )
           return yield* MemoryRpcError.make({ reason: "denied" });
       }),
     };

--- a/packages/platform-cloudflare/test/memory-get.test.ts
+++ b/packages/platform-cloudflare/test/memory-get.test.ts
@@ -1,0 +1,418 @@
+import type { MemoryDocument } from "@effect-agent/core/MemoryStore";
+import {
+  MemoryKey,
+  MemoryReader,
+  MemoryScope,
+  MemoryStorageError,
+  MemoryWriter,
+} from "@effect-agent/core/MemoryStore";
+import { CloudflareMemoryClient } from "@effect-agent/platform-cloudflare/CloudflareMemory";
+import { doMemoryStoreLayer } from "@effect-agent/storage-cloudflare/DoMemoryStore";
+import {
+  defaultMemoryRpcLimits,
+  encodeMemoryWire,
+  handleMemoryOwnerRequest,
+  MemoryOwnerAuthorizer,
+  MemoryOwnerIdentity,
+  MemoryOwnerRequest,
+  MemoryOwnerResponse,
+  type MemoryOwnerFailure,
+} from "@effect-agent/storage-cloudflare/MemoryProtocol";
+import { Principal } from "@effect-agent/thread/SubmissionLedger";
+import { env, runInDurableObject } from "cloudflare:test";
+import { Clock, Deferred, Effect, Fiber, Schema } from "effect";
+import { TestClock } from "effect/testing";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+
+import {
+  memoryAccess,
+  memoryCalls,
+  memoryClocks,
+  memoryDeniedSources,
+  memoryPrincipal,
+  MemoryProjects,
+  memoryPut,
+  memoryReplies,
+  memoryRequests,
+  slowFinished,
+  slowStarted,
+} from "./memory-fixtures.ts";
+
+let counter = 0;
+const project = () => `memory-get-${counter++}`;
+const stub = (name: string) => env.MEMORIES.getByName(MemoryProjects.make(name).address);
+
+const client = (name: string, principal = memoryPrincipal, timeoutMillis = 1000) =>
+  CloudflareMemoryClient.fromBinding(env.MEMORIES, {
+    access: memoryAccess(name),
+    principal,
+    rpcLimits: { ...defaultMemoryRpcLimits, timeoutMillis },
+  });
+
+const decode = Schema.decodeSync(Schema.fromJsonString(MemoryOwnerResponse));
+
+describe("CloudflareMemoryClient.get", () => {
+  it("reads the current revision, absence, and terminal withdrawal in one request each", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const address = MemoryProjects.make(name).address;
+        const memory = yield* client(name);
+        const write = memoryPut(name, "known");
+        const read = memory.get(write.key);
+
+        expectTypeOf<Effect.Success<typeof read>>().toEqualTypeOf<MemoryDocument<
+          ReturnType<typeof MemoryProjects.make>
+        > | null>();
+        expectTypeOf<Effect.Error<typeof read>>().toEqualTypeOf<MemoryOwnerFailure>();
+        expectTypeOf<Effect.Services<typeof read>>().toEqualTypeOf<never>();
+        expect(yield* read).toBeNull();
+        const first = yield* memory.change(write);
+        const before = memoryCalls.get(address) ?? 0;
+
+        expect(yield* read).toEqual(first);
+        expect(memoryCalls.get(address)).toBe(before + 1);
+        expect(memoryRequests.get(address)?.at(-1)).toMatchObject({ _tag: "Get", key: write.key });
+
+        const corrected = yield* memory.change(memoryPut(name, "known", "correct", "1", "new"));
+
+        expect(yield* read).toEqual(corrected);
+
+        const withdrawn = yield* memory.change({
+          _tag: "Withdraw",
+          key: write.key,
+          operationId: "withdraw",
+          expectedRevision: "2",
+          reason: "removed",
+        });
+
+        expect(yield* read).toEqual(withdrawn);
+        // An old write receipt still replays exactly without restoring the current head.
+        expect(yield* memory.change(write)).toEqual(first);
+        expect(yield* read).toEqual(withdrawn);
+        expect(memoryRequests.get(address)?.map((request) => request._tag)).not.toContain(
+          "Revalidate",
+        );
+        expect(memoryRequests.get(address)?.map((request) => request._tag)).not.toContain(
+          "RevalidateSemantic",
+        );
+      }),
+    ));
+
+  it("authorizes the exact key, principal and scope even for missing or withdrawn sources", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const memory = yield* client(name);
+        const write = memoryPut(name, "known");
+
+        yield* memory.change(write);
+        const untrusted = yield* client(name, Principal.make("untrusted"));
+
+        expect(yield* untrusted.get(write.key).pipe(Effect.flip)).toMatchObject({
+          reason: "denied",
+        });
+
+        const foreignScope = yield* CloudflareMemoryClient.fromBinding(env.MEMORIES, {
+          access: { ...memoryAccess(name), scope: MemoryScope.make("foreign") },
+          principal: memoryPrincipal,
+        });
+
+        expect(yield* foreignScope.get(write.key).pipe(Effect.flip)).toMatchObject({
+          reason: "denied",
+        });
+        expect(
+          yield* memory.get(memoryPut(project(), "known").key).pipe(Effect.flip),
+        ).toMatchObject({ reason: "denied" });
+
+        memoryDeniedSources.set(MemoryProjects.make(name).address, new Set(["known", "missing"]));
+        expect(yield* memory.get(write.key).pipe(Effect.flip)).toMatchObject({ reason: "denied" });
+        expect(yield* memory.get({ ...write.key, id: "missing" }).pipe(Effect.flip)).toMatchObject({
+          reason: "denied",
+        });
+        yield* memory.change({
+          _tag: "Withdraw",
+          key: write.key,
+          operationId: "withdraw",
+          expectedRevision: "1",
+          reason: "removed",
+        });
+        expect(yield* memory.get(write.key).pipe(Effect.flip)).toMatchObject({ reason: "denied" });
+
+        const revoked = memoryPut(name, "revoked");
+
+        yield* memory.change(revoked);
+        yield* memory.change({
+          ...revoked,
+          operationId: "revoke-scope",
+          expectedRevision: "1",
+          scopes: [],
+        });
+        expect(yield* memory.get(revoked.key).pipe(Effect.flip)).toMatchObject({
+          reason: "denied",
+        });
+      }),
+    ));
+
+  it("rejects malformed keys, mismatched owner namespaces, expired requests and byte overflows", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const key = memoryPut(name, "known").key;
+
+        const request: MemoryOwnerRequest = {
+          _tag: "Get",
+          version: 1,
+          access: memoryAccess(name),
+          principal: memoryPrincipal,
+          key,
+          deadlineMillis: (yield* Clock.currentTimeMillis) + 1000,
+        };
+
+        for (const id of ["", "x".repeat(1025)]) {
+          const raw = JSON.stringify({ ...request, key: { ...key, id } });
+
+          expect(decode(yield* Effect.promise(() => stub(name).memory(raw)))).toMatchObject({
+            failure: { reason: "protocol" },
+          });
+        }
+        const foreign = JSON.stringify({ ...request, key: memoryPut(project(), "known").key });
+
+        expect(decode(yield* Effect.promise(() => stub(name).memory(foreign)))).toMatchObject({
+          failure: { reason: "denied" },
+        });
+        expect(
+          decode(
+            yield* Effect.promise(() =>
+              stub(name).memory(JSON.stringify({ ...request, deadlineMillis: 0 })),
+            ),
+          ),
+        ).toMatchObject({ failure: { reason: "timeout" } });
+        expect(
+          decode(yield* Effect.promise(() => stub(name).memory("x".repeat(1_048_577)))),
+        ).toMatchObject({ failure: { reason: "budget" } });
+
+        const memory = yield* client(name);
+
+        yield* memory.change(memoryPut(name, "known"));
+        for (const bound of ["maxRequestBytes", "maxResponseBytes", "maxSourceBytes"] as const) {
+          const limited = yield* CloudflareMemoryClient.fromBinding(env.MEMORIES, {
+            access: memoryAccess(name),
+            principal: memoryPrincipal,
+            rpcLimits: { ...defaultMemoryRpcLimits, [bound]: 256 },
+          });
+
+          expect(yield* limited.get(key).pipe(Effect.flip)).toMatchObject({ reason: "budget" });
+        }
+      }),
+    ));
+
+  it("validates reply envelopes, exact identity and document schemas before exposing a result", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const memory = yield* client(name);
+        const document = yield* memory.change(memoryPut(name, "known"));
+
+        const response = {
+          _tag: "Document",
+          access: memoryAccess(name),
+          key: document.key,
+          document,
+        };
+
+        const address = MemoryProjects.make(name).address;
+
+        yield* Effect.addFinalizer(() => Effect.sync(() => memoryReplies.delete(address)));
+        for (const malformed of [
+          { ...response, _tag: "Lookup", lookup: { _tag: "NoMatch" } },
+          { ...response, access: memoryAccess(project()) },
+          { ...response, access: { ...response.access, scope: "foreign" } },
+          { ...response, key: { ...document.key, id: "other" }, document: null },
+          { ...response, key: memoryPut(project(), "known").key, document: null },
+          { ...response, document: { ...document, generation: 0 } },
+          { ...response, document: { ...document, key: { ...document.key, id: "other" } } },
+          { ...response, document: { ...document, source: { ...document.source, id: "other" } } },
+          { ...response, document: { ...document, scopes: [] } },
+        ]) {
+          memoryReplies.set(address, JSON.stringify(malformed));
+          expect(yield* memory.get(document.key).pipe(Effect.flip)).toMatchObject({
+            reason: "protocol",
+          });
+        }
+        memoryReplies.set(
+          address,
+          JSON.stringify({
+            ...response,
+            document: { ...document, key: memoryPut(project(), "known").key },
+          }),
+        );
+        expect(yield* memory.get(document.key).pipe(Effect.flip)).toMatchObject({
+          _tag: "MemoryStorageError",
+          reason: "corrupt",
+        });
+      }).pipe(Effect.scoped),
+    ));
+
+  it("performs one local read without writing, enforces owner limits and preserves typed read failures", async () => {
+    const name = project();
+
+    await runInDurableObject(stub(name), (_instance, state) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const reader = yield* MemoryReader;
+          const writer = yield* MemoryWriter;
+          const document = yield* writer.change(memoryPut(name, "known"));
+
+          const request: MemoryOwnerRequest = {
+            _tag: "Get",
+            version: 1,
+            access: memoryAccess(name),
+            principal: memoryPrincipal,
+            key: document.key,
+            deadlineMillis: (yield* Clock.currentTimeMillis) + 1000,
+          };
+
+          const encoded = yield* encodeMemoryWire(MemoryOwnerRequest, request, 1_048_576);
+          let reads = 0;
+
+          const counted = MemoryReader.fromAdapter({
+            get: (key) =>
+              Effect.suspend(() => {
+                reads++;
+
+                return reader.get(key);
+              }),
+          });
+
+          const before = state.storage.sql
+            .exec("SELECT * FROM effect_agent_memory_usage_v1")
+            .toArray();
+
+          expect(
+            decode(
+              yield* handleMemoryOwnerRequest(encoded).pipe(
+                Effect.provideService(MemoryReader, counted),
+                Effect.provideService(MemoryWriter, {
+                  change: () => Effect.die("read must not write"),
+                }),
+              ),
+            ),
+          ).toMatchObject({ _tag: "Document", document });
+          expect(reads).toBe(1);
+          expect(
+            state.storage.sql.exec("SELECT * FROM effect_agent_memory_usage_v1").toArray(),
+          ).toEqual(before);
+          for (const bound of ["maxResponseBytes", "maxSourceBytes"] as const) {
+            expect(
+              decode(
+                yield* handleMemoryOwnerRequest(encoded, {
+                  ...defaultMemoryRpcLimits,
+                  [bound]: 256,
+                }),
+              ),
+            ).toMatchObject({ failure: { reason: "budget" } });
+          }
+
+          const unavailable = MemoryStorageError.make({
+            operation: "current read",
+            reason: "unavailable",
+          });
+
+          expect(
+            decode(
+              yield* handleMemoryOwnerRequest(encoded).pipe(
+                Effect.provideService(MemoryReader, { get: () => Effect.fail(unavailable) }),
+              ),
+            ),
+          ).toMatchObject({ failure: unavailable });
+          const other = yield* writer.change(memoryPut(name, "other"));
+
+          expect(
+            decode(
+              yield* handleMemoryOwnerRequest(encoded).pipe(
+                Effect.provideService(
+                  MemoryReader,
+                  MemoryReader.fromAdapter({ get: () => Effect.succeed(other) }),
+                ),
+              ),
+            ),
+          ).toMatchObject({ failure: { _tag: "MemoryStorageError", reason: "corrupt" } });
+          state.storage.sql.exec(
+            "UPDATE effect_agent_memory_documents_v1 SET document_json = '{}' WHERE source_id = 'known'",
+          );
+        }).pipe(
+          Effect.provideService(MemoryOwnerIdentity, { namespace: MemoryProjects.make(name) }),
+          Effect.provideService(MemoryOwnerAuthorizer, { authorize: () => Effect.void }),
+          Effect.provide(doMemoryStoreLayer(state.storage)),
+        ),
+      ),
+    );
+
+    const failure = await Effect.runPromise(
+      Effect.gen(function* () {
+        const memory = yield* client(name);
+
+        return yield* memory.get(memoryPut(name, "known").key).pipe(Effect.flip);
+      }),
+    );
+
+    expect(failure).toMatchObject({ _tag: "MemoryStorageError", reason: "corrupt" });
+  });
+
+  it("fails closed on owner defects", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const memory = yield* client(name, Principal.make("defect"));
+
+        expect(yield* memory.get(memoryPut(name, "known").key).pipe(Effect.flip)).toMatchObject({
+          reason: "unavailable",
+        });
+      }),
+    ));
+
+  it("finalizes authorization after timeout or caller interruption", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const name = project();
+        const address = MemoryProjects.make(name).address;
+
+        memoryClocks.set(address, yield* Clock.Clock);
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            memoryClocks.delete(address);
+            slowStarted.delete(address);
+            slowFinished.delete(address);
+          }),
+        );
+        const memory = yield* client(name, Principal.make("slow"), 100);
+
+        for (const interrupt of [true, false]) {
+          const started = yield* Deferred.make<void>();
+          const finished = yield* Deferred.make<void>();
+
+          slowStarted.set(address, started);
+          slowFinished.set(address, finished);
+
+          const pending = yield* memory
+            .get(MemoryKey.make({ namespace: MemoryProjects.make(name), id: "known" }))
+            .pipe(Effect.result, Effect.forkChild);
+
+          yield* Deferred.await(started);
+          if (interrupt) yield* Fiber.interrupt(pending);
+          expect(yield* Deferred.isDone(finished)).toBe(false);
+          yield* TestClock.adjust("100 millis");
+          yield* Deferred.await(finished);
+          if (!interrupt)
+            expect(yield* Fiber.join(pending)).toMatchObject({
+              _tag: "Failure",
+              failure: { reason: "timeout" },
+            });
+        }
+        const normal = yield* client(name);
+
+        expect(yield* normal.get(memoryPut(name, "known").key)).toBeNull();
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+    ));
+});

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -56,6 +56,7 @@ import {
   memoryAuthorizer,
   memoryFailpoints,
   memoryCalls,
+  memoryReplies,
   memoryAccess,
   memoryPrincipal,
   memoryRecallLimits,
@@ -85,6 +86,10 @@ export class TestMemoryObject extends MemoryObject.make(memoryAuthorizer, {
     const name = this.ctx.id.name ?? "";
 
     memoryCalls.set(name, (memoryCalls.get(name) ?? 0) + 1);
+
+    const reply = memoryReplies.get(name);
+
+    if (reply !== undefined) return Promise.resolve(reply);
 
     return super.memory(encoded);
   }

--- a/packages/storage-cloudflare/src/MemoryProtocol.ts
+++ b/packages/storage-cloudflare/src/MemoryProtocol.ts
@@ -5,8 +5,9 @@ import {
   MemoryRecallLimits,
 } from "@effect-agent/core/MemoryReference";
 import { MemoryAccess, revalidateMemoryLookup } from "@effect-agent/core/MemoryRevalidation";
-import { type MemoryReader } from "@effect-agent/core/MemoryStore";
 import {
+  MemoryKey,
+  MemoryReader,
   MemoryConflict,
   MemoryDocument,
   MemoryMutationFailure,
@@ -68,6 +69,8 @@ const RevalidateRequest = Schema.TaggedStruct("Revalidate", {
 
 const ChangeRequest = Schema.TaggedStruct("Change", { ...RequestFields, write: MemoryWrite.Wire });
 
+const GetRequest = Schema.TaggedStruct("Get", { ...RequestFields, key: MemoryKey.Wire });
+
 const SemanticRequest: Schema.TaggedStruct<
   "RevalidateSemantic",
   typeof RequestFields & {
@@ -83,8 +86,8 @@ const SemanticRequest: Schema.TaggedStruct<
 });
 
 export const MemoryOwnerRequest: Schema.Union<
-  [typeof RevalidateRequest, typeof ChangeRequest, typeof SemanticRequest]
-> = Schema.Union([RevalidateRequest, ChangeRequest, SemanticRequest]);
+  [typeof RevalidateRequest, typeof ChangeRequest, typeof SemanticRequest, typeof GetRequest]
+> = Schema.Union([RevalidateRequest, ChangeRequest, SemanticRequest, GetRequest]);
 
 export type MemoryOwnerRequest = typeof MemoryOwnerRequest.Type;
 
@@ -102,16 +105,52 @@ export const MemoryOwnerFailure = Schema.Union([
 
 export type MemoryOwnerFailure = typeof MemoryOwnerFailure.Type;
 
-export const MemoryOwnerResponse = Schema.Union([
-  Schema.TaggedStruct("Lookup", { access: MemoryAccess.Wire, lookup: MemoryLookup }),
-  Schema.TaggedStruct("Changed", { access: MemoryAccess.Wire, document: MemoryDocument.Wire }),
-  Schema.TaggedStruct("Semantic", { access: MemoryAccess.Wire, result: SemanticCandidateResult }),
-  Schema.TaggedStruct("Failed", { failure: MemoryOwnerFailure }),
+const LookupResponse = Schema.TaggedStruct("Lookup", {
+  access: MemoryAccess.Wire,
+  lookup: MemoryLookup,
+});
+
+const ChangedResponse = Schema.TaggedStruct("Changed", {
+  access: MemoryAccess.Wire,
+  document: MemoryDocument.Wire,
+});
+
+const SemanticResponse = Schema.TaggedStruct("Semantic", {
+  access: MemoryAccess.Wire,
+  result: SemanticCandidateResult,
+});
+
+const DocumentResponse = Schema.TaggedStruct("Document", {
+  access: MemoryAccess.Wire,
+  key: MemoryKey.Wire,
+  document: Schema.NullOr(MemoryDocument.Wire),
+});
+
+const FailedResponse = Schema.TaggedStruct("Failed", { failure: MemoryOwnerFailure });
+
+export const MemoryOwnerResponse: Schema.Union<
+  [
+    typeof LookupResponse,
+    typeof ChangedResponse,
+    typeof SemanticResponse,
+    typeof DocumentResponse,
+    typeof FailedResponse,
+  ]
+> = Schema.Union([
+  LookupResponse,
+  ChangedResponse,
+  SemanticResponse,
+  DocumentResponse,
+  FailedResponse,
 ]);
 
 export type MemoryOwnerResponse = typeof MemoryOwnerResponse.Type;
 
-/** Fail-closed application policy. Authorize the namespace, principal, scope, and full command. */
+/**
+ * Fail-closed application policy. Authorize the namespace, principal, scope, and full command.
+ * Get requires exact-key authority, including application source/provenance checks where needed.
+ * Possession of a key or scope is not authorization, including for absent or withdrawn documents.
+ */
 export class MemoryOwnerAuthorizer extends Context.Service<
   MemoryOwnerAuthorizer,
   {
@@ -161,7 +200,7 @@ export const encodeMemoryWire = Effect.fn("encodeMemoryWire")(function* <A, I>(
   return encoded;
 });
 
-/** One local read per distinct candidate source, with no per-document network calls. */
+/** One local read for Get, or per distinct candidate source. No discovery or background work. */
 export const handleMemoryOwnerRequest = Effect.fn("MemoryOwner.handleRequest")(function* (
   raw: unknown,
   limits: MemoryRpcLimits = defaultMemoryRpcLimits,
@@ -183,6 +222,7 @@ export const handleMemoryOwnerRequest = Effect.fn("MemoryOwner.handleRequest")(f
 
     if (
       !MemoryNamespace.equals(namespace, request.access.namespace) ||
+      (request._tag === "Get" && !MemoryNamespace.equals(namespace, request.key.namespace)) ||
       (request._tag === "Change" &&
         !MemoryNamespace.equals(namespace, request.write.key.namespace)) ||
       (request._tag === "RevalidateSemantic" &&
@@ -207,6 +247,30 @@ export const handleMemoryOwnerRequest = Effect.fn("MemoryOwner.handleRequest")(f
       const authorizer = yield* MemoryOwnerAuthorizer;
 
       yield* authorizer.authorize(request);
+      if (request._tag === "Get") {
+        const reader = yield* MemoryReader;
+        const current = yield* reader.get(request.key);
+
+        const document =
+          current === null ? null : yield* MemoryDocument.restore(namespace, current);
+
+        if (document !== null) {
+          if (document.key.id !== request.key.id || document.source.id !== request.key.id)
+            return yield* MemoryStorageError.make({
+              operation: "validate memory read identity",
+              reason: "corrupt",
+            });
+          if (
+            document._tag === "ActiveMemoryDocument" &&
+            !document.scopes.includes(request.access.scope)
+          )
+            return yield* MemoryRpcError.make({ reason: "denied" });
+
+          yield* encodeMemoryWire(MemoryDocument.Wire, document, limits.maxSourceBytes);
+        }
+
+        return { _tag: "Document", access: request.access, key: request.key, document };
+      }
       if (request._tag === "Change") {
         const writer = yield* MemoryWriter;
 


### PR DESCRIPTION
Add `CloudflareMemoryClient.get(key)` for authorized reads of a known memory document in one owner request, without recall candidates or semantic search.

With host-authenticated `access` and `principal`:

```ts
const memory = yield* CloudflareMemoryClient.fromBinding(env.MEMORIES, {
  access,
  principal,
});
const document = yield* memory.get(
  MemoryKey.make({ namespace: access.namespace, id: "project-profile" }),
);
```

Returns the current document, a withdrawal tombstone, or `null` for absence. Authorization, storage, timeout, and payload-limit failures remain typed errors. Application source-authority checks still apply.

Also refresh the repository's PR skill to Dev Kit 2.0.1, keeping descriptions concise and validation reporting out of PR bodies.
