### PR TITLE
fix(thread): persist shared acyclic provider values

### DIFF
--- a/.changeset/persist-shared-search-values.md
+++ b/.changeset/persist-shared-search-values.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Persist native provider web-search responses without rejecting valid JSON, while retaining cycle rejection and existing persistence limits.

--- a/packages/thread/src/Records.ts
+++ b/packages/thread/src/Records.ts
@@ -119,11 +119,14 @@ export const MAX_PERSISTED_JSON_BYTES = 1024 * 1024;
 const isJson = Schema.is(Schema.Json);
 
 const isPersistedJson = (input: unknown): input is Schema.Json => {
-  const pending: Array<{ readonly value: unknown; readonly depth: number }> = [
-    { value: input, depth: 0 },
-  ];
+  const pending: Array<
+    | { readonly _tag: "visit"; readonly value: unknown; readonly depth: number }
+    | { readonly _tag: "leave"; readonly value: object }
+  > = [{ _tag: "visit", value: input, depth: 0 }];
 
-  const visited = new WeakSet<object>();
+  // Only ancestors indicate a cycle. Shared acyclic values serialize once per occurrence,
+  // so revisit them and charge every occurrence against the same resource limits.
+  const ancestors = new WeakSet<object>();
   let nodes = 0;
   let textUnits = 0;
 
@@ -132,6 +135,10 @@ const isPersistedJson = (input: unknown): input is Schema.Json => {
       const current = pending.pop();
 
       if (current === undefined) return false;
+      if (current._tag === "leave") {
+        ancestors.delete(current.value);
+        continue;
+      }
       if (current.depth > MAX_PERSISTED_JSON_DEPTH || ++nodes > MAX_PERSISTED_JSON_NODES) {
         return false;
       }
@@ -148,8 +155,9 @@ const isPersistedJson = (input: unknown): input is Schema.Json => {
         if (textUnits > MAX_PERSISTED_JSON_BYTES) return false;
         continue;
       }
-      if (typeof value !== "object" || visited.has(value)) return false;
-      visited.add(value);
+      if (typeof value !== "object" || ancestors.has(value)) return false;
+      ancestors.add(value);
+      pending.push({ _tag: "leave", value });
 
       const entries = Array.isArray(value)
         ? Array.from(value, (entry, index) => [index, entry] as const)
@@ -159,7 +167,7 @@ const isPersistedJson = (input: unknown): input is Schema.Json => {
       for (const [key, entry] of entries) {
         textUnits += typeof key === "string" ? key.length : 0;
         if (textUnits > MAX_PERSISTED_JSON_BYTES) return false;
-        pending.push({ value: entry, depth: current.depth + 1 });
+        pending.push({ _tag: "visit", value: entry, depth: current.depth + 1 });
       }
     }
 

--- a/packages/thread/test/run-journal.test.ts
+++ b/packages/thread/test/run-journal.test.ts
@@ -1,9 +1,15 @@
+import * as Agent from "@effect-agent/core/Agent";
 import { ThreadId, SubmissionId, ToolCallId } from "@effect-agent/core/Identifiers";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
 import { Selection, Snapshot } from "@effect-agent/core/ToolExposure";
 import { summarizeModelUsage } from "@effect-agent/core/Usage";
+import * as AgentRuntime from "@effect-agent/engine/AgentRuntime";
 import { contextWindowId, contextWindowMessage } from "@effect-agent/engine/Compaction";
+import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
+import { digestCanonicalBatch, EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
 import {
   BatchId,
+  CanonicalBatch,
   CanonicalRecordEnvelope,
   CanonicalSequence,
   DeploymentId,
@@ -11,7 +17,6 @@ import {
   ProducerId,
   RecordEnvelope,
   RecordId,
-  type CanonicalBatch,
 } from "@effect-agent/thread/Records";
 import {
   childThreadIdFor,
@@ -42,8 +47,8 @@ import {
 } from "@effect-agent/thread/RunJournal";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it, layer } from "@effect/vitest";
-import { DateTime, Effect, Schema, Stream } from "effect";
-import { Prompt } from "effect/unstable/ai";
+import { DateTime, Effect, Layer, Ref, Schema, Stream } from "effect";
+import { LanguageModel, Model, Prompt, Tool, Toolkit, type Response } from "effect/unstable/ai";
 
 import { JournalCheckpointSeed } from "../src/internal/journal-checkpoint.ts";
 import { makeJournalMetadata } from "../src/internal/journal-metadata.ts";
@@ -200,6 +205,161 @@ const auditRecord = (
 
 describe("run journal batch split (plan §2.1)", () => {
   layer(NodeCrypto.layer)((it) => {
+    it.effect(
+      "journals native provider results after the engine freezes snapshot array prototypes",
+      () =>
+        Effect.gen(function* () {
+          const action = {
+            type: "search",
+            queries: ["Tahoe private hot tub"],
+            sources: [{ type: "url", url: "https://www.tahoegetaways.com/" }],
+          };
+
+          const actionSchema = Schema.Struct({
+            type: Schema.Literal("search"),
+            queries: Schema.Array(Schema.String),
+            sources: Schema.Array(
+              Schema.Struct({ type: Schema.Literal("url"), url: Schema.String }),
+            ),
+          });
+
+          const search = Tool.providerDefined({
+            id: "test.web_search",
+            customName: "HostedSearch",
+            providerName: "web_search",
+            parameters: Schema.Struct({ action: actionSchema }),
+            success: Schema.Struct({ action: actionSchema, status: Schema.String }),
+          })(undefined);
+
+          const definition = Agent.make("journal-provider-search", {
+            input: Schema.String,
+            output: Schema.String,
+            instructions: "Search once and answer as JSON.",
+            toolkit: Toolkit.make(search),
+            policy: { maxTurns: 1, maxToolCalls: 1, maxDuration: "30 seconds", toolConcurrency: 1 },
+          });
+
+          const parts: ReadonlyArray<Response.StreamPartEncoded> = [
+            {
+              type: "tool-call",
+              id: "search-1",
+              name: "HostedSearch",
+              params: { action },
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              id: "search-1",
+              name: "HostedSearch",
+              result: { action, status: "completed" },
+              providerExecuted: true,
+              isFailure: false,
+            },
+            { type: "text-start", id: "answer" },
+            { type: "text-delta", id: "answer", delta: '"Found a listing."' },
+            { type: "text-end", id: "answer" },
+            { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+          ];
+
+          const model = Model.make(
+            "scripted",
+            "journal-search",
+            Layer.effect(
+              LanguageModel.LanguageModel,
+              LanguageModel.make({
+                generateText: () => Effect.succeed([]),
+                streamText: () => Stream.fromIterable(parts),
+              }),
+            ),
+          );
+
+          const retained = yield* Ref.make(Prompt.empty);
+
+          yield* AgentRuntime.run(Agent.withModel(definition, model), "Find a listing", {
+            onHistory: (history) => Ref.set(retained, history),
+          }).pipe(Effect.provide([IdGenerator.layer, ThreadHistory.layerTransient]));
+          const history = yield* Ref.get(retained);
+
+          const providerResult = history.content.flatMap((message) =>
+            message.role === "assistant"
+              ? message.content.filter((part) => part.type === "tool-result")
+              : [],
+          )[0];
+
+          if (providerResult === undefined)
+            return yield* Effect.die("Expected the staged provider result");
+
+          const frozen = Schema.decodeUnknownSync(
+            Schema.Struct({
+              action: Schema.Struct({ queries: Schema.Unknown, sources: Schema.Unknown }),
+            }),
+          )(providerResult.result);
+
+          for (const array of [frozen.action.queries, frozen.action.sources]) {
+            expect(Array.isArray(array)).toBe(true);
+            expect(Object.getPrototypeOf(array)).toBeNull();
+            expect(Object.isFrozen(array)).toBe(true);
+          }
+          const batch = yield* turnResponseBatch(turnInput(history.content));
+
+          const plainBatch = yield* Schema.decodeUnknownEffect(
+            Schema.fromJsonString(CanonicalBatch),
+          )(JSON.stringify(Schema.encodeSync(CanonicalBatch)(batch)));
+
+          expect(yield* digestCanonicalBatch(EMPTY_TAIL_DIGEST, batch)).toBe(
+            yield* digestCanonicalBatch(EMPTY_TAIL_DIGEST, plainBatch),
+          );
+          const projected = yield* projectRunJournal(envelopesOf([batch]), RUN_ID);
+          const encoded = Schema.encodeSync(Prompt.Prompt)(projected.prompt);
+
+          expect(JSON.stringify(encoded)).toContain("https://www.tahoegetaways.com/");
+          expect(JSON.stringify(encoded)).toContain("Tahoe private hot tub");
+          const replayed = yield* Ref.make(false);
+
+          const replayModel = Model.make(
+            "scripted",
+            "journal-search-replay",
+            Layer.effect(
+              LanguageModel.LanguageModel,
+              LanguageModel.make({
+                generateText: () => Effect.succeed([]),
+                streamText: (request) =>
+                  Stream.unwrap(
+                    Effect.gen(function* () {
+                      const result = request.prompt.content.flatMap((message) =>
+                        message.role === "assistant"
+                          ? message.content.filter((part) => part.type === "tool-result")
+                          : [],
+                      )[0];
+
+                      expect(result).toMatchObject({
+                        providerExecuted: true,
+                        result: { action, status: "completed" },
+                      });
+                      yield* Ref.set(replayed, true);
+
+                      return Stream.fromIterable(
+                        parts.filter(
+                          (part) => part.type !== "tool-call" && part.type !== "tool-result",
+                        ),
+                      );
+                    }),
+                  ),
+              }),
+            ),
+          );
+
+          yield* AgentRuntime.run(
+            Agent.withModel(definition, replayModel),
+            "Use the previous search",
+            {
+              history: projected.prompt,
+            },
+          ).pipe(Effect.provide([IdGenerator.layer, ThreadHistory.layerTransient]));
+          expect(yield* Ref.get(replayed)).toBe(true);
+        }),
+    );
+
     it.effect("splits a tool Turn into response and results batches with stable identities", () =>
       Effect.gen(function* () {
         const response = yield* turnResponseBatch(turnInput(toolTurnAppended));

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -12,6 +12,7 @@ import {
   DefinitionDigests,
   Digest,
   MAX_PERSISTED_JSON_BYTES,
+  MAX_PERSISTED_JSON_COLLECTION_LENGTH,
   MAX_PERSISTED_JSON_DEPTH,
   PersistedJson,
   ProducerEpoch,
@@ -92,6 +93,7 @@ import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { NodeCrypto } from "@effect/platform-node";
 import { describe, expect, it, layer } from "@effect/vitest";
 import { Duration, Effect, Schema } from "effect";
+import { Prompt } from "effect/unstable/ai";
 
 import { historicalCheckpointJson } from "../../../test/fixtures/checkpoints.ts";
 
@@ -320,6 +322,103 @@ describe("thread canonical contracts", () => {
 
     cyclic.self = cyclic;
     expect(Schema.decodeUnknownExit(PersistedJson)(cyclic)._tag).toBe("Failure");
+  });
+
+  it.each([false, true])(
+    "persists native provider search Prompts with shared actions (frozen arrays: %s)",
+    (frozen) => {
+      // OpenAI emits the same action object in both provider-executed parts.
+      const action = {
+        type: "search",
+        queries: ["Tahoe private hot tub October"],
+        sources: [{ type: "url", url: "https://www.tahoegetaways.com/" }],
+      };
+
+      if (frozen) {
+        // Engine provider-result staging deliberately removes prototypes before freezing.
+        Object.setPrototypeOf(action.queries, null);
+        Object.setPrototypeOf(action.sources, null);
+        Object.freeze(action.queries);
+        Object.freeze(action.sources);
+      }
+
+      const prompt = Prompt.fromMessages([
+        Prompt.makeMessage("assistant", {
+          content: [
+            Prompt.makePart("tool-call", {
+              id: "ws_1",
+              name: "OpenAiWebSearch",
+              params: { action },
+              providerExecuted: true,
+            }),
+            Prompt.makePart("tool-result", {
+              id: "ws_1",
+              name: "OpenAiWebSearch",
+              result: { action, status: "completed" },
+              providerExecuted: true,
+              isFailure: false,
+            }),
+          ],
+        }),
+      ]);
+
+      const encoded = Schema.encodeSync(Prompt.Prompt)(prompt);
+      const actionPayload = Schema.Struct({ action: Schema.Unknown });
+
+      const call = Schema.decodeUnknownSync(Schema.Struct({ params: actionPayload }))(
+        encoded.content[0]?.content[0],
+      );
+
+      const result = Schema.decodeUnknownSync(Schema.Struct({ result: actionPayload }))(
+        encoded.content[0]?.content[1],
+      );
+
+      expect(call.params.action).toBe(action);
+      expect(result.result.action).toBe(action);
+      expect(Schema.is(Schema.toEncoded(Prompt.Prompt))(encoded)).toBe(true);
+      const persisted = Schema.decodeUnknownSync(PersistedJson)(encoded);
+
+      expect(Schema.decodeUnknownSync(Prompt.Prompt)(persisted)).toEqual(prompt);
+    },
+  );
+
+  it("accepts shared acyclic JSON while rejecting object and array ancestor cycles", () => {
+    const shared = { amenities: ["hot tub", "kitchen"] };
+    const dag = { first: shared, nested: { second: shared }, list: [shared, shared.amenities] };
+
+    expect(Schema.decodeUnknownSync(PersistedJson)(dag)).toEqual(dag);
+    const cycle: unknown[] = [];
+    const parent = { shared, cycle };
+
+    cycle.push(parent);
+    expect(Schema.decodeUnknownExit(PersistedJson)(parent)._tag).toBe("Failure");
+    expect(Schema.decodeUnknownExit(PersistedJson)(cycle)._tag).toBe("Failure");
+  });
+
+  it("charges every shared occurrence to traversal and byte limits", () => {
+    // Fifteen binary levels expand to 65,535 nodes despite containing only fifteen arrays.
+    let sharedTree: Schema.Json = null;
+
+    for (let level = 0; level < 15; level++) sharedTree = [sharedTree, sharedTree];
+    expect(Schema.decodeUnknownExit(PersistedJson)([sharedTree])._tag).toBe("Success");
+    expect(Schema.decodeUnknownExit(PersistedJson)([sharedTree, null])._tag).toBe("Failure");
+
+    const largeShared = { text: "x".repeat(MAX_PERSISTED_JSON_BYTES / 2) };
+
+    expect(Schema.decodeUnknownExit(PersistedJson)(largeShared)._tag).toBe("Success");
+    expect(Schema.decodeUnknownExit(PersistedJson)([largeShared, largeShared])._tag).toBe(
+      "Failure",
+    );
+    expect(
+      Schema.decodeUnknownExit(PersistedJson)(
+        Array(MAX_PERSISTED_JSON_COLLECTION_LENGTH).fill(null),
+      )._tag,
+    ).toBe("Success");
+    expect(
+      Schema.decodeUnknownExit(PersistedJson)(
+        Array(MAX_PERSISTED_JSON_COLLECTION_LENGTH + 1).fill(null),
+      )._tag,
+    ).toBe("Failure");
   });
 
   it("replays a checkpoint suffix equivalently to full replay", () => {


### PR DESCRIPTION
Persisted provider responses can reuse the same object in multiple places, such as a web-search action shared by its call and result. The persistence validator treated that sharing as a cycle and rejected otherwise valid JSON. Track only active ancestors when detecting cycles, and continue charging every occurrence against the existing traversal and size limits.

Regression coverage exercises shared objects and arrays, actual ancestor cycles, expanded resource limits, and native provider results through engine staging, journal persistence, and replay. No persisted format changes.

Extracted from the travel demo PR #427 so the fix can be reviewed and released independently. The demo will consume the published release.

Validation: `VITEST_MAX_WORKERS=2 vp run ready` passed, including static checks, workspace tests, package builds, and documentation validation.
