### PR TITLE
fix(thread): retain worker authority across root agent upgrades

### DIFF
--- a/.changeset/retain-upgraded-worker-authority.md
+++ b/.changeset/retain-upgraded-worker-authority.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Allow an explicitly admitted root Agent upgrade to start background workers and receive their reports in an existing conversation. Preserve existing worker lineage and reject unregistered upgrade bindings.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -264,6 +264,14 @@ Inspection, listing, observation, and cancellation do not require resolving a so
 Keep retained binding versions available; a policy resolver cannot repair ambiguous historical
 definition identities or reconstruct a missing capture.
 
+A root conversation can admit a new registered Agent ID after an application upgrade. When
+an explicit owner Submission selects that Agent, worker creation and reporting use its exact
+retained binding, while the original `ThreadCreated` record stays unchanged. An unregistered
+Agent/digest pair is rejected. Existing workers retain their original lineage and reporting
+binding when the upgraded root sends follow-ups; worker and attached child Agent IDs cannot
+be replaced this way. Without an explicit owner Submission, programmatic hosts continue to
+use the thread's original Agent.
+
 Captured source reporting uses the initial owner binding and stores its existing reporting intent
 in the worker origin. A later input from another source revision does not replace that projection;
 terminal preparation validates the original owner retained by the first worker input reservation.

--- a/packages/testing/test/certification-sqlite.test.ts
+++ b/packages/testing/test/certification-sqlite.test.ts
@@ -90,79 +90,77 @@ const certified = Effect.gen(function* () {
 });
 
 describe("TEST-004 STORE-010 adapter certification — storage-sqlite (DN)", () => {
-  it.effect(
-    "distinguishes executed-check success from complete real-loss certification",
-    () =>
+  // Each verdict exercises the full SQLite certification independently. Keep its timeout
+  // per case so disk latency across four sweeps cannot consume one shared test budget.
+  it.effect.each([
+    {
+      name: "missing",
+      crashLever: undefined,
+      ok: true,
+      full: false,
+      status: "not-exercised",
+    },
+    {
+      name: "empty",
+      crashLever: Effect.succeed([]),
+      ok: true,
+      full: false,
+      status: "not-exercised",
+    },
+    {
+      name: "passed",
+      crashLever: Effect.succeed([
+        CertificationCaseResult.make({
+          suite: "real-loss",
+          name: "supplied lever result",
+          status: "passed",
+        }),
+      ]),
+      ok: true,
+      full: true,
+      status: "exercised",
+    },
+    {
+      name: "failed",
+      crashLever: Effect.succeed([
+        CertificationCaseResult.make({
+          suite: "real-loss",
+          name: "supplied lever result",
+          status: "failed",
+        }),
+      ]),
+      ok: false,
+      full: false,
+      status: "exercised",
+    },
+  ])(
+    "distinguishes executed-check success from complete real-loss certification: $name lever",
+    (row) =>
       Effect.gen(function* () {
-        const rows = [
-          {
-            name: "missing",
-            crashLever: undefined,
-            ok: true,
-            full: false,
-            status: "not-exercised",
-          },
-          {
-            name: "empty",
-            crashLever: Effect.succeed([]),
-            ok: true,
-            full: false,
-            status: "not-exercised",
-          },
-          {
-            name: "passed",
-            crashLever: Effect.succeed([
-              CertificationCaseResult.make({
-                suite: "real-loss",
-                name: "supplied lever result",
-                status: "passed",
-              }),
-            ]),
-            ok: true,
-            full: true,
-            status: "exercised",
-          },
-          {
-            name: "failed",
-            crashLever: Effect.succeed([
-              CertificationCaseResult.make({
-                suite: "real-loss",
-                name: "supplied lever result",
-                status: "failed",
-              }),
-            ]),
-            ok: false,
-            full: false,
-            status: "exercised",
-          },
-        ];
+        const report = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
 
-        for (const row of rows) {
-          const report = yield* Effect.scoped(
-            Effect.gen(function* () {
-              const fs = yield* FileSystem.FileSystem;
+            const directory = yield* fs.makeTempDirectoryScoped({
+              prefix: "certification-verdict-",
+            });
 
-              const directory = yield* fs.makeTempDirectoryScoped({
-                prefix: "certification-verdict-",
-              });
+            const adapters = combinedAdapters(`${directory}/test.sqlite`);
 
-              const adapters = combinedAdapters(`${directory}/test.sqlite`);
+            return yield* certifyDurableAdapters({
+              adapter: { name: row.name },
+              submissionLedger: adapters,
+              threadStore: adapters,
+              crashLever: row.crashLever,
+            });
+          }),
+        );
 
-              return yield* certifyDurableAdapters({
-                adapter: { name: row.name },
-                submissionLedger: adapters,
-                threadStore: adapters,
-                crashLever: row.crashLever,
-              });
-            }),
-          );
-
-          expect({
-            ok: report.ok,
-            full: report.fullyCertified,
-            status: report.tier3.status,
-          }).toEqual({ ok: row.ok, full: row.full, status: row.status });
-        }
+        expect({
+          ok: report.ok,
+          full: report.fullyCertified,
+          status: report.tier3.status,
+        }).toEqual({ ok: row.ok, full: row.full, status: row.status });
       }).pipe(Effect.provide([NodeFileSystem.layer, NodeCrypto.layer])),
     300_000,
   );

--- a/packages/thread/src/internal/worker-host.ts
+++ b/packages/thread/src/internal/worker-host.ts
@@ -410,7 +410,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       if (
         Option.isNone(submission) ||
         submission.value.threadId !== threadId ||
-        submission.value.agentId !== created.agentId
+        (nested && submission.value.agentId !== created.agentId)
       )
         return yield* failure("start", "denied");
       ownerSubmission = submission.value;
@@ -472,7 +472,13 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
     const selectedBinding = ownerBinding ?? binding;
 
-    if (selectedBinding === undefined) return yield* failure("start", "declaration-unavailable");
+    const changedRootAgent =
+      ownerSubmission !== undefined && ownerSubmission.agentId !== created.agentId;
+
+    // A root conversation may admit a new registered Agent after deployment.
+    // Its immutable owner input selects authority; child lineage never changes.
+    if (selectedBinding === undefined || (changedRootAgent && ownerBinding === undefined))
+      return yield* failure("start", "declaration-unavailable");
 
     const selected = yield* deps.policyResolver.resolveSource({
       threadId,
@@ -483,7 +489,9 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
     if (Option.isSome(selected) && ownerSubmission !== undefined && ownerBinding === undefined)
       return yield* failure("start", "declaration-unavailable");
-    const effectiveBinding = Option.isSome(selected) ? selectedBinding : binding;
+
+    const effectiveBinding =
+      Option.isSome(selected) || changedRootAgent ? selectedBinding : binding;
 
     if (effectiveBinding === undefined) return yield* failure("start", "declaration-unavailable");
 
@@ -724,8 +732,7 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
       }
       const first = current.records[0]?.record.payload;
 
-      if (first?._tag !== "ThreadCreated" || first.agentId !== origin.source.agentId)
-        return yield* failure("start", "denied");
+      if (first?._tag !== "ThreadCreated") return yield* failure("start", "denied");
 
       const own = rows.filter(
         (row) => row.admission.origin.worker.threadId === origin.worker.threadId,
@@ -737,6 +744,11 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
 
       const prior = origins.get(origin.worker.threadId);
 
+      if (
+        prior === undefined &&
+        (source.submission?.agentId ?? first.agentId) !== origin.source.agentId
+      )
+        return yield* failure("start", "denied");
       if (prior !== undefined && !sameOrigin(prior, origin))
         return yield* failure("start", "worker-mismatch");
       if (prior === undefined && admission.messageId !== origin.firstMessageId)
@@ -2106,10 +2118,20 @@ export const makeWorkerRuntime = Effect.fn("WorkerHost.make")(function* (
           ? attached
           : undefined;
 
+    const selected =
+      request.sourceSubmissionId === undefined
+        ? undefined
+        : yield* sourceAuthority(sourceThreadId, request.sourceSubmissionId);
+
     return facet(
       {
-        source: { _tag: "programmatic", threadId: sourceThreadId, agentId: created.agentId },
-        policy: retained?.policy ?? resolved.definition.policy,
+        source: {
+          _tag: "programmatic",
+          threadId: sourceThreadId,
+          agentId: selected?.submission?.agentId ?? created.agentId,
+        },
+        policy:
+          retained?.policy ?? selected?.binding?.definition.policy ?? resolved.definition.policy,
         depth:
           origin?._tag === "WorkerOriginRecorded"
             ? origin.origin.depth

--- a/packages/thread/test/worker-host.test.ts
+++ b/packages/thread/test/worker-host.test.ts
@@ -610,6 +610,125 @@ const harness = Effect.fn("workerHostHarness")(function* (
 });
 
 layer(NodeCrypto.layer)((it) => {
+  it.effect("uses an admitted root Agent upgrade for workers without changing child lineage", () =>
+    Effect.gen(function* () {
+      const upgraded = Agent.make("upgraded-source-agent", {
+        input: sourceAgent.input,
+        output: sourceAgent.output,
+        instructions: "Delegate and receive research reports",
+        toolkit: Toolkit.empty,
+        policy: sourceAgent.policy,
+      });
+
+      const upgradedDigests = DefinitionDigests.make({
+        ...definitions,
+        agent: Schema.decodeSync(Digest)("d".repeat(64)),
+      });
+
+      const ownerId = Schema.decodeSync(SubmissionId)("upgraded-owner");
+
+      const owner = SubmissionSnapshot.make({
+        submissionId: ownerId,
+        threadId: sourceId,
+        queueSequence: Schema.decodeSync(QueueSequence)(1),
+        principal,
+        idempotencyKey: Schema.decodeSync(IdempotencyKey)("upgraded-owner"),
+        agentId: upgraded.id,
+        agentDigests: upgradedDigests,
+        deploymentId: Schema.decodeSync(DeploymentId)("test"),
+        inputPayload: "research this existing conversation",
+        inputDigest: digest,
+        receiptId: Schema.decodeSync(ReceiptId)("upgraded-owner"),
+        state: "ready",
+        createdAt: DateTime.makeUnsafe(0),
+      });
+
+      const h = yield* harness({
+        sourceRevisions: [
+          {
+            definition: upgraded,
+            digests: upgradedDigests,
+            reporting: [reportWith(() => Effect.succeed({ encodedInput: "upgraded findings" }))],
+          },
+        ],
+      });
+
+      const legacy = yield* h.host.start(request("legacy-worker"));
+
+      yield* h.settle(legacy.receipt);
+      h.submissions.set(ownerId, owner);
+
+      const host = yield* h.runtime.acquire({
+        sourceThreadId: sourceId,
+        principal,
+        sourceSubmissionId: ownerId,
+      });
+
+      const followUp = yield* host.followUp({
+        worker: legacy.worker,
+        target,
+        idempotencyKey: Schema.decodeSync(IdempotencyKey)("upgraded-follow-up"),
+        encodedInput: { text: "continue existing work" },
+        encodedParameters: { note: "continue existing work" },
+      });
+
+      expect(h.submissions.get(followUp.submissionId)?.workerAdmission?.origin).toEqual(
+        h.submissions.get(legacy.receipt.submissionId)?.workerAdmission?.origin,
+      );
+      yield* h.settle(followUp);
+      const started = yield* host.start(request("upgraded-scout"));
+      const child = h.submissions.get(started.receipt.submissionId)!;
+
+      expect(child.workerAdmission?.origin.source.agentId).toBe(upgraded.id);
+      expect(child.workerAdmission?.origin.reporting?.sourceDigests).toEqual(upgradedDigests);
+      yield* h.settle(started.receipt);
+      expect(
+        [...h.deliveries.values()]
+          .filter((row) => row.envelope.threadId === sourceId)
+          .map((row) => row.envelope),
+      ).toEqual([
+        expect.objectContaining({
+          agentId: upgraded.id,
+          definitions: upgradedDigests,
+          input: "upgraded findings",
+        }),
+      ]);
+      expect(h.logs.get(sourceId)?.[0]?.record.payload).toEqual(
+        ThreadCreated.make({ agentId: sourceAgent.id, definitions }),
+      );
+
+      // An exact registered owner is required; a different digest cannot fall back
+      // to the ThreadCreated agent or create a new canonical worker reservation.
+      const count = h.logs.get(sourceId)?.length;
+
+      h.submissions.set(ownerId, SubmissionSnapshot.make({ ...owner, agentDigests: definitions }));
+      expect((yield* host.start(request("unregistered-upgrade")).pipe(Effect.flip)).reason).toBe(
+        "declaration-unavailable",
+      );
+      expect(h.logs.get(sourceId)?.length).toBe(count);
+      h.submissions.set(
+        ownerId,
+        SubmissionSnapshot.make({ ...owner, threadId: started.worker.threadId }),
+      );
+      expect((yield* host.start(request("wrong-source")).pipe(Effect.flip)).reason).toBe("denied");
+
+      // Root upgrades cannot be used to replace a worker's admitted target Agent.
+      h.submissions.set(
+        child.submissionId,
+        SubmissionSnapshot.make({ ...child, agentId: upgraded.id, agentDigests: upgradedDigests }),
+      );
+      expect(
+        (yield* h.runtime
+          .acquire({
+            sourceThreadId: started.worker.threadId,
+            principal,
+            sourceSubmissionId: child.submissionId,
+          })
+          .pipe(Effect.flip)).reason,
+      ).toBe("denied");
+    }),
+  );
+
   // Regression: https://github.com/danieljvdm/effect-agent/commit/43882d187248665eaf7fd46950b3bc617edcb73d
   it.effect(
     "serializes source-aware active slots across raced starts, steering and idle reactivation",


### PR DESCRIPTION
After a deployment admits a new root Agent ID to an existing conversation, worker creation can still compare that input to the original `ThreadCreated` Agent and reject it. Resolve worker authority from the explicit owner’s exact retained Agent/digest binding. Keep the original thread record and existing workers’ lineage unchanged.

```text
Admitted root Submission → exact retained Agent binding → new worker origin → report to that binding
Existing worker follow-up → original worker origin and reporting binding
No explicit Submission → original thread Agent
```

Unregistered bindings, mismatched source threads, and attempts to replace a child Agent remain rejected. No records are rewritten.

The SQLite certification verdict matrix now gives each full sweep its own timeout; four sweeps previously shared one five-minute budget and timed out in CI.

This library fix is separate from travel demo PR #427 so it can be released independently. Existing conversations in that demo need this fix before its npm-based deployment.
