### PR TITLE
fix(cloudflare): retain browser failure diagnostics

### DIFF
--- a/.changeset/quiet-browsers-explain.md
+++ b/.changeset/quiet-browsers-explain.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Retain Browser Run response status, request identifiers, and body truncation metadata in host-only failure causes.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -535,6 +535,12 @@ Browser APIs use finite requests and typed expected failures:
 - An interactive policy fixes network mode, at most 1,000 actions, at most 60 minutes, and at most
   8 MiB from one result. Handles expire at policy limits or explicit close.
 
+Quick Action failures retain bounded response text and Browser Run API status, selected request
+identifiers, and body truncation metadata in their host-only `cause`. That status describes the
+Browser Run API response, not necessarily the destination page. Applications can explicitly
+redact and retain these causes for operator diagnostics; they are not automatically exposed to
+models or logged.
+
 The protected Cloudflare binding requests at most ten minutes of provider idle keep-alive,
 independently of the total pass deadline. A longer policy permits active work; it does not promise
 that an idle browser will remain available for the whole hour or reconnect an expired session.

--- a/packages/platform-cloudflare/src/internal/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/internal/browser-quick-action.ts
@@ -268,8 +268,25 @@ const navigationError = (message: string, cause?: unknown): PageCaptureNavigatio
   });
 
 /** Preserve bounded remote diagnostics for the host without exposing their text to a model. */
-const privateResponseCause = (bodyText: string): Error | undefined =>
-  bodyText.length === 0 ? undefined : new Error(boundedDiagnostic(bodyText));
+const privateResponseCause = (bodyText: string, response: Response): Error =>
+  new Error(boundedDiagnostic(bodyText), {
+    cause: {
+      provider: "cloudflare-browser-run",
+      httpStatus: response.status,
+      httpStatusSource: "browser-api",
+      headers: Object.fromEntries(
+        ["content-type", "cf-ray", "x-request-id", "retry-after", "x-browser-ms-used"].flatMap(
+          (name) => {
+            const value = response.headers.get(name);
+
+            return value === null ? [] : [[name, boundedDiagnostic(value)]];
+          },
+        ),
+      ),
+      bodyCharacters: bodyText.length,
+      bodyTruncated: bodyText.length > MAX_DIAGNOSTIC_LENGTH,
+    },
+  });
 
 /** Foreign cancellation must not keep a response Scope open indefinitely. */
 const cancelResponse = (cancel: () => Promise<void>, warning: string): Effect.Effect<void> =>
@@ -389,7 +406,7 @@ const parseOutput = (
   if (!isJsonResponse(response)) {
     return protocolError(
       "The Quick Action success response was not a JSON response envelope",
-      privateResponseCause(bodyText),
+      privateResponseCause(bodyText, response),
     );
   }
   const envelope = decodeEnvelope(bodyText);
@@ -397,13 +414,13 @@ const parseOutput = (
   if (Option.isNone(envelope)) {
     return protocolError(
       "The JSON Quick Action response did not carry a valid response envelope",
-      privateResponseCause(bodyText),
+      privateResponseCause(bodyText, response),
     );
   }
   if (!envelope.value.success) {
     return navigationError(
       "The Quick Action reported a navigation failure",
-      privateResponseCause(bodyText),
+      privateResponseCause(bodyText, response),
     );
   }
   switch (action._tag) {
@@ -505,7 +522,7 @@ const makeCapture = (
     if (response.status === 429) {
       const retryAfter = retryAfterMillis(response);
       const reason = isQuotaMessage(bodyText) ? "quota" : "rate";
-      const cause = privateResponseCause(bodyText);
+      const cause = privateResponseCause(bodyText, response);
 
       return yield* PageCaptureRateLimitedError.make({
         implementation: browserQuickActionImplementation,
@@ -520,7 +537,7 @@ const makeCapture = (
     }
     if (!response.ok) {
       const message = `The Quick Action answered HTTP ${response.status}`;
-      const cause = privateResponseCause(bodyText);
+      const cause = privateResponseCause(bodyText, response);
 
       if (response.status >= 500) {
         return yield* protocolError(message, cause);

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -516,7 +516,7 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     const { binding } = makeBinding([
       new Response(`Too many requests; ${privateDiagnostic}`, {
         status: 429,
-        headers: { "Retry-After": "12" },
+        headers: { "Retry-After": "12", "CF-Ray": "ray-test", "Set-Cookie": "private-cookie" },
       }),
       new Response(`Browser time limit exceeded for today; ${privateDiagnostic}`, { status: 429 }),
     ]);
@@ -532,7 +532,16 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
     expect(rate.message).not.toContain(privateDiagnostic);
     expect(rate._tag === "PageCaptureRateLimitedError" && rate.cause).toMatchObject({
       message: expect.stringContaining(privateDiagnostic),
+      cause: {
+        httpStatus: 429,
+        httpStatusSource: "browser-api",
+        headers: { "cf-ray": "ray-test", "retry-after": "12" },
+        bodyTruncated: false,
+      },
     });
+    expect(JSON.stringify(rate._tag === "PageCaptureRateLimitedError" && rate.cause)).not.toContain(
+      "private-cookie",
+    );
     const quota = await captureError(binding, request(CapturePageMarkdown.make({})));
 
     expect(quota).toMatchObject({


### PR DESCRIPTION
Quick Action failures retain remote response text but lose the API status and request identifiers needed to diagnose them. Preserve the Browser Run API status, selected response headers, and body truncation metadata in the existing host-only error cause. The status is explicitly identified as the Browser Run API response, not the destination site's status.

The regression verifies retained status/request metadata and exclusion of `Set-Cookie`; model-facing errors remain sanitized. The browser guide describes the diagnostic boundary.

Extracted from the travel demo PR #427 so the library change can be reviewed and released independently.

Validation: `VITEST_MAX_WORKERS=2 vp run ready` passed, including static checks, workspace tests, package builds, and documentation validation. The focused Quick Action suite also passed all 17 tests.
