### PR TITLE
test: gate durable runtime work deterministically

### DIFF
--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -41,7 +41,7 @@ jobs:
                 !/^effect-agent@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(report.baselineTag) ||
                 report.activeBatch !== null || report.failure !== null ||
                 report.settings?.batches !== 3 || report.settings?.warmupsPerBatch !== 2 || report.settings?.samplesPerBatch !== 3 ||
-                report.settings?.production !== true || report.settings?.execution !== 'unbundled published ESM' ||
+                report.settings?.production !== true || report.settings?.execution !== 'unbundled published ESM' || report.settings?.timingGate !== 'informational' ||
                 report.environment?.node !== 'v24.20.0' ||
                 !/^[a-f0-9]{64}$/.test(report.fixtureSha256) ||
                 !Array.isArray(report.revisions) || report.revisions.length !== 2 ||
@@ -120,19 +120,21 @@ jobs:
               const values = role => samples.filter(s => s.name === name && s.role === role).map(s => s.ms);
               const base = summarize(values('base')), head = summarize(values('head'));
               const format = value => `${value.median.toFixed(2)} [${value.q1.toFixed(2)}–${value.q3.toFixed(2)}]`;
-              const change = identical || base.median === 0 ? 'n/a' : `${((head.median / base.median - 1) * 100).toFixed(1)}%`;
-              return `| ${name} | ${format(base)} | ${format(head)} | ${change} |`;
+              return `| ${name} | ${format(base)} | ${format(head)} |`;
             });
             const marker = '<!-- effect-agent:runtime-performance -->';
             const repoUrl = `https://github.com/${repository}`;
-            const body = `${marker}\n### Runtime performance: latest release → main\n\n` +
+            const body = `${marker}\n### Runtime timing diagnostics: latest release → main\n\n` +
+              `**Informational timings.** [Deterministic performance gates](${repoUrl}/blob/${revision('head').revision}/docs/TOOLCHAIN.md#deterministic-performance-checks) run in ordinary CI and bound algorithmic work. This timing run does not establish a latency regression or a merge threshold.\n\n` +
               `Release: [\`${report.baselineTag}\`](${repoUrl}/releases/tag/${encodeURIComponent(report.baselineTag)}) (\`${revision('base').revision.slice(0,12)}\`). ` +
               `Main: [\`${revision('head').revision.slice(0,12)}\`](${repoUrl}/commit/${revision('head').revision}).\n\n` +
+              '<details>\n<summary>Observed operation timings</summary>\n\n' +
               'Operation median [Q1–Q3] in milliseconds; nine samples per workload and revision across three worker processes. Same fixture bytes and Node runtime; separate lockfiles and public builds.\n\n' +
-              (identical ? '**Identical built JavaScript and lockfiles. Timing differences do not establish a code regression; percentage changes are suppressed.**\n\n' : '') +
-              '| Workload | Latest release | Main | Change |\n| --- | ---: | ---: | ---: |\n' + rows.join('\n') +
-              `\n\n[Raw samples, cold process totals, failures, environment, and exact revisions](${run.html_url}). ` +
-              'Sample spread is not a confidence interval. Timing deltas are observations, not established regressions or a merge threshold; runner and process variability have not been calibrated.';
+              (identical ? '**Identical built JavaScript and lockfiles. Timing differences do not establish a code regression.**\n\n' : '') +
+              '| Workload | Latest release | Main |\n| --- | ---: | ---: |\n' + rows.join('\n') +
+              '\n\n</details>\n\n' +
+              `[Full timing report, raw samples, cold process totals, failures, environment, and exact revisions](${run.html_url}). ` +
+              'Shared-runner wall-clock measurements vary. Sample spread is not a confidence interval; percentage deltas remain in the diagnostic artifact rather than this automatic comment.';
             const pulls = await github.paginate(github.rest.pulls.list, {
               ...context.repo, state: 'open', base: 'main', head: `${context.repo.owner}:changeset-release/main`, per_page: 100,
             });

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -46,7 +46,7 @@ See the [package map](reference/packages.md) for public packages and capabilitie
 | ----------------------------------- | ----------------------------------------------------- |
 | `packages/*`                        | Framework and private PR-review integration packages  |
 | `examples/demo`                     | Local browser app                                     |
-| `examples/runtime-benchmark`        | Deterministic public-package runtime comparisons      |
+| `examples/runtime-benchmark`        | Scripted public-package timing diagnostics            |
 | `examples/context-continuity-eval`  | Continuity gates and opt-in deployed performance      |
 | `examples/cloudflare-memory`        | Opt-in deployed Thread-to-Memory latency benchmark    |
 | `examples/providers`                | Provider bindings, persistent history, Workflow host  |
@@ -359,9 +359,47 @@ in [esbuild's analyzer](https://esbuild.github.io/analyze/). CI attaches these a
 and `bundle-analysis` artifacts and updates one PR comment through a separate trusted workflow.
 The comment workflow becomes active after it is merged into the default branch.
 
+## Deterministic performance checks
+
+Ordinary PR CI, `vp run test`, and `vp run ready` gate algorithmic work, not elapsed time.
+The gates reuse the engine tests, adapter read contracts, and retained-history fixture. They
+use local scripted models, real SQLite files where storage matters, and test clocks for the new
+runtime checks. No provider request or separate benchmark job is needed.
+
+| Public operation         | Work budget and evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Fresh durable submission | The shared [history fixture](../test/fixtures/runtime-history-cost.ts) counts canonical records delivered by `ThreadStore.read`. The memory suite and [Node/SQLite suite](../packages/platform-node/test/runtime-work-budget.test.ts) allow at most `2H + 6` records from admission through a one-answer settlement for an uncompacted `H`-record history. The provider must receive every retained input, make one call, and finalize its stream; read scopes and ownership must close. SQLite reopens histories of 1, 1,025, and 8,193 records. Each extra 1,024-record history page permits four SQL statements: two passes, each with a Thread existence read and a range read. Actual query plans must seek by canonical sequence and page queries must be bounded. |
+| Nonterminal ledger scan  | The shared [ledger read contracts](../test/fixtures/ledger-read-contracts.ts), run by SQLite and Durable Object SQLite, cross 0/2,048/8,192 settled rows with 0/16/768 unfinished rows. They require every unfinished row in order, at most `floor(U / 256) + 1` statements for `U` unfinished rows, a partial unfinished-row index, cursor seeks on later pages, and no temporary sort. This permits linear work in unfinished rows, including an empty end page, while excluding scans of retained settlements and offset pagination. The existing interleaved-settlement cases also check cursor correctness.                                                                                                                                                         |
+| Checkpoint recovery      | The Node suite saves a native rollover checkpoint through the public runtime, faults after save, closes the runtime, and reopens the same file. `runRecovery` followed by `processThread` may load at most two checkpoints and read at most `2S` canonical records for the fixture's eligible `S`-record suffix. No canonical record through the checkpoint may be reread. Retired histories grow from 1 to 8,193 records independently of 0/1,025-record suffixes; only suffix pages may add SQL statements. One resumed model call, no repeated completed tool, finalizers, released ownership, exact canonical output, and an unchanged archive remain required.                                                                                                      |
+
+These are workload-specific bounds, not exact SQL snapshots or universal constant-time claims.
+Statement counts are paired with record counts and actual query plans: one statement can still
+scan an entire table. Checkpoint digest validation currently searches a Thread's batch metadata
+by Thread identity and then filters its ending sequence. The gate allows at most two such
+searches; their database work can grow linearly with that Thread's batch count. It does not claim
+constant SQLite VM work, checkpoint byte decoding, or latency independent of retained history.
+
+The existing [history fault tests](../packages/storage-memory/test/runtime-history-cost.test.ts)
+cover gaps, short reads, typed failure, defects, interruption, racing appends, and compaction
+fallback. [Recovery tests](../packages/storage-memory/test/recovery-history.test.ts) retain one
+captured prefix across mixed decisions; [checkpoint tests](../packages/storage-memory/test/recovery-checkpoint.test.ts)
+and the [Node crash suite](../packages/platform-node/test/crash/recovery-checkpoint.test.ts) cover
+missing/incompatible caches and process loss. The [engine suite](../packages/engine/test/agent-runtime.test.ts)
+already gates model/tool calls, bounded concurrency, declaration order, resource finalization,
+and tracing under response fragmentation. The runtime diagnostic policy and fairness suites
+also check call counts, worker/tool bounds, and cleanup. Those guards remain in their owning suites.
+
+Run `vp run -F @effect-agent/platform-node test` and
+`vp run -F @effect-agent/storage-sqlite test` for the SQLite gates; the corresponding memory and
+Cloudflare suites run through ordinary CI as well. Test timeouts detect hangs, not performance
+regressions. Compacted or checkpoint-ineligible fresh histories retain their existing validation
+passes. Checkpoint-only bounds do not establish constant-time fresh admission, and these checks
+do not measure CPU, allocations, disk/scheduler/GC costs, lock contention, or all supported sizes.
+
 ## Runtime performance comparisons
 
-Pull requests run the **Runtime performance** workflow against the exact base and head commits.
+Pushes to `main` run the **Runtime performance** workflow against the latest published release
+and the exact triggering `main` commit.
 The [scripted benchmark](../examples/runtime-benchmark/README.md) runs identical
 fixture bytes against production builds and each revision's own lockfile on the same Node runtime.
 Run `vp run perf:compare --help` for local reproduction. Timing tasks bypass the task cache; keep
@@ -375,11 +413,12 @@ provider callback. A separate subprocess measurement includes startup and fixtur
 Retain raw samples, failures, environment metadata, fixture and artifact hashes, and exact SHAs.
 The trusted comment workflow becomes active after it reaches the default branch.
 
-Latency reports are informational until repeated CI runs establish variance and useful absolute
-and relative thresholds. Deterministic call, concurrency, ownership, tracing, and history-work
-budgets remain correctness gates. The fresh-submission history guard permits two linear scans plus
-fixed work for histories without compaction. Compacted and checkpoint-seeded views keep their
-existing validation passes. Checkpoint recovery bounds do not establish constant-time fresh admission.
+Latency reports remain informational. The automatic release PR comment links the deterministic
+gates and keeps observed medians and spread in a collapsed table without percentage deltas.
+Full diagnostic artifacts retain all samples and percentage comparisons (suppressed for identical
+builds and lockfiles). This makes individual timing changes less prominent in review while
+preserving the evidence needed for a controlled investigation. The timing workflow does not
+report the result of the ordinary CI work-budget gates or establish a latency regression.
 Fairness, lock contention, optional
 memory/MCP publication, and large settled-ledger indexing require their own controlled evidence
 before changing those paths.

--- a/examples/runtime-benchmark/README.md
+++ b/examples/runtime-benchmark/README.md
@@ -1,8 +1,10 @@
 # Scripted runtime benchmark
 
 This leaf consumer measures public production packages with deterministic Effect AI responses.
-It makes no provider requests. Correctness assertions fail the command; latency changes are
-informational until CI variance supports workload-specific relative and absolute thresholds.
+It makes no provider requests. Correctness assertions fail the command; latency changes remain
+informational. [Deterministic performance gates](../../docs/TOOLCHAIN.md#deterministic-performance-checks)
+run in ordinary CI and bound records, SQL statements and query plans, calls, concurrency, and
+resource ownership. Shared-runner timings do not provide deterministic regression signals.
 
 Run from the repository root with Node 24 and the repository's Bun/Vite+ toolchain. Prepare two
 checkouts, install each checkout's own lockfile, and build before measuring:
@@ -133,8 +135,10 @@ interquartile range, and process failures. The artifact includes the exact trans
 
 The `runtime-v3` artifact contract contains only Base and Head, with `baselineTag` naming
 the release (null for an unlabeled local comparison). The trusted publisher rejects
-older three-revision reports. Release PR tables name Latest release, Main, and Change and
-link the exact tag and commits. Both the comment and artifact show medians and Q1–Q3 spread.
+older three-revision reports. The automatic release PR comment links the ordinary CI work-budget
+gates and labels timing as informational. Its collapsed table names Latest release and Main,
+links the exact tag and commits, and omits percentage deltas. Both the comment and artifact show
+medians and Q1–Q3 spread; percentage comparisons remain available in the full diagnostic artifact.
 The nine samples share three worker processes per revision; that spread is not a confidence
 interval, and runner/process variability has not been calibrated. Timing differences alone
 do not establish a regression. When built JavaScript and lockfile hashes match, reports
@@ -158,9 +162,10 @@ with another matched cohort. Small-sample p95, local source timings, or differin
 do not establish an SLO, Cloudflare CPU billing, or a competitive ranking. Deterministic engine
 and adapter work-budget tests remain the PR regression gates; timing evidence complements them.
 The manual diagnostics below separate fairness and lock contention from isolated run latency.
-Keep timing informational until repeated matched cohorts establish a workload-specific relative
-and absolute regression threshold. Current hosted runs show substantial machine and storage
-variance; one small-sample tail estimate or percentage alone is not a release gate. Confirm a
+Keep timing informational. Making deltas less prominent in automatic comments trades quick
+percentage scanning for a clearer distinction between measured latency and enforced work budgets;
+all raw diagnostic evidence remains available. Current hosted runs show substantial variance;
+one small-sample tail estimate or percentage alone is not a release gate. Confirm a
 suspected regression in a fresh matched run and retain both results before changing a baseline.
 
 ## Manual diagnostics
@@ -173,8 +178,8 @@ Run this command from the candidate checkout, with no concurrent builds, tests, 
 vp run perf:diagnose --base-dir /tmp/effect-agent-base --require-clean --out-dir /tmp/diagnostic-001
 ```
 
-The manual workflow's `diagnostic` choice runs the same command. Ordinary PRs run the
-`runtime-v3` matrix and trusted report validator.
+The manual workflow's `diagnostic` choice runs the same command. Main pushes run the
+`runtime-v3` matrix; ordinary PR CI runs the work-budget gates and trusted report validator.
 Diagnostics run base/head followed by head/base, with two warmups and five measured samples per
 cohort: ten measured samples per case and revision. They use the same production-package staging,
 published manifests, own-lockfile dependencies, built-artifact identities, and identical unbundled

--- a/examples/runtime-benchmark/test/trusted-report.test.ts
+++ b/examples/runtime-benchmark/test/trusted-report.test.ts
@@ -222,12 +222,8 @@ it("publishes release versus main even though the release PR head is a version-o
   );
   expect(comments[0]).toContain(baselineTag);
   expect(comments[0]).toContain(`/commit/${head}`);
-  expect(comments[0]).toContain(
-    "| Workload | Latest release | Main | Change |\n| --- | ---: | ---: | ---: |\n",
-  );
-  expect(comments[0]).toContain(
-    "| settled-ledger-2048 | 2.00 [2.00–2.00] | 2.00 [2.00–2.00] | 0.0% |",
-  );
+  expect(comments[0]).toContain("| Workload | Latest release | Main |\n| --- | ---: | ---: |\n");
+  expect(comments[0]).toContain("| settled-ledger-2048 | 2.00 [2.00–2.00] | 2.00 [2.00–2.00] |");
   expect(comments[0]).not.toMatch(/reference/i);
   expect(await publish(makeReport(), { annotatedTag: true })).toHaveLength(1);
 });
@@ -243,7 +239,7 @@ it.each([
   expect(await publish(makeReport(), options)).toEqual([]);
 });
 
-it("computes Head/base from measured warm samples only", async () => {
+it("shows measured warm samples without automatic percentage regression signals", async () => {
   const report = makeReport();
 
   for (const batch of report.batches) {
@@ -261,10 +257,13 @@ it("computes Head/base from measured warm samples only", async () => {
 
   const comments = await publish(report);
 
-  expect(comments[0]).toContain("| small-run | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] | -50.0% |");
-  expect(comments[0]).toContain(
-    "| settled-ledger-2048 | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] | -50.0% |",
-  );
+  expect(comments[0]).toContain("| small-run | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] |");
+  expect(comments[0]).toContain("| settled-ledger-2048 | 4.00 [4.00–4.00] | 2.00 [2.00–2.00] |");
+  expect(comments[0]).toContain("**Informational timings.**");
+  expect(comments[0]).toContain("#deterministic-performance-checks");
+  expect(comments[0]).toContain("<summary>Observed operation timings</summary>");
+  expect(comments[0]).not.toMatch(/[+-]?\d+(?:\.\d+)?%/);
+  expect(renderPerformanceReport(report)).toContain("| -50.0% |");
 });
 
 it("preserves slow samples and spread without claiming identical builds regressed", async () => {
@@ -287,16 +286,21 @@ it("preserves slow samples and spread without claiming identical builds regresse
 
   for (const output of [comments[0]!, renderPerformanceReport(report)]) {
     expect(output).toContain("Identical built JavaScript and lockfiles");
-    expect(output).toContain("| small-run | 2.00 [2.00–2.00] | 4.00 [3.00–100.00] | n/a |");
+    expect(output).toContain("| small-run | 2.00 [2.00–2.00] | 4.00 [3.00–100.00] |");
     expect(output).not.toContain("100.0%");
   }
+  expect(renderPerformanceReport(report)).toContain("| n/a |");
   report.revisions[1]!.lockfileSha256 = "a".repeat(64);
-  expect((await publish(report))[0]).toContain("| 100.0% |");
+  expect((await publish(report))[0]).not.toContain("100.0%");
+  expect(renderPerformanceReport(report)).toContain("| 100.0% |");
 });
 
 it("rejects historical contracts and reference roles before commenting", async () => {
   const report = makeReport();
 
+  await expect(
+    publish({ ...report, settings: { ...report.settings, timingGate: "threshold" } }),
+  ).rejects.toThrow("Invalid report contract");
   await expect(publish({ ...report, fixture: "runtime-v2" })).rejects.toThrow(
     "Invalid report contract",
   );

--- a/packages/platform-node/test/runtime-work-budget.test.ts
+++ b/packages/platform-node/test/runtime-work-budget.test.ts
@@ -1,0 +1,524 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { ContextCompactor } from "@effect-agent/engine/ContextCompactor";
+import { RunContextPreparation, RunToolAuthorization } from "@effect-agent/engine/RunOptions";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import {
+  DurableRuntimeFailpoint,
+  DurableRuntimeFailpointError,
+} from "@effect-agent/thread/DurableFailpoint";
+import {
+  BatchId,
+  CanonicalBatch,
+  DeploymentId,
+  ProducerId,
+  RecordEnvelope,
+  RecordId,
+  RepairAnnotated,
+} from "@effect-agent/thread/Records";
+import {
+  IdempotencyKey,
+  Principal,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
+} from "@effect-agent/thread/SubmissionLedger";
+import {
+  FencedAppendRequest,
+  LoadCheckpointRequest,
+  ThreadExportRequest,
+  ThreadStore,
+  ThreadTailRequest,
+  type ThreadRead,
+} from "@effect-agent/thread/ThreadStore";
+import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
+import { NodeCrypto, NodeFileSystem } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+import { expect, it } from "@effect/vitest";
+import {
+  Array as EffectArray,
+  Cause,
+  DateTime,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  Schema,
+  Stream,
+} from "effect";
+import {
+  LanguageModel,
+  Model,
+  Tool,
+  Toolkit,
+  type Prompt,
+  type Response,
+} from "effect/unstable/ai";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type { Statement } from "effect/unstable/sql/Statement";
+
+import { observeQueries } from "../../../test/fixtures/ledger-read-contracts.ts";
+import {
+  historyDefinition,
+  historyDefinitions,
+  historyResponse,
+  measureHistory,
+  seedHistory,
+} from "../../../test/fixtures/runtime-history-cost.ts";
+import { NodeDurableAgentRuntime } from "../src/NodeDurableAgentRuntime.ts";
+
+type CompiledQuery = ReturnType<Statement<unknown>["compile"]>;
+
+const host = (filename: string) =>
+  NodeDurableAgentRuntime.layer({
+    filename,
+    deploymentId: "history-cost",
+    producerId: "history-cost",
+  });
+
+// Rebuild the coordinator over the Node assembly's observed ports. The SQLite connection,
+// durability settings, scheduler, ownership drain, and runtime configuration are unchanged.
+const coordinatorServices = Layer.mergeAll(
+  DurableRuntimeFailpoint.layer,
+  ToolReconciler.uncertain,
+  RunToolAuthorization.allowAll,
+  NodeCrypto.layer,
+);
+
+const handoff = "Continue the checkpoint work-budget request.";
+
+const checkpointContext = Layer.succeed(RunContextPreparation, {
+  hook: {
+    prepare: (request) =>
+      Effect.succeed({
+        prompt: request.source,
+        ...(request.turn === 2 && !JSON.stringify(request.source).includes(handoff)
+          ? { rollover: { handoff, through: request.source.content.length } }
+          : {}),
+      }),
+  },
+});
+
+const measureCheckpoint = Effect.fn("WorkBudget.checkpoint")(function* (
+  historySize: number,
+  suffixSize: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "checkpoint-work-budget-" });
+  const filename = `${directory}/thread.sqlite`;
+  const prompts: Array<Prompt.Prompt> = [];
+  let modelFinalizers = 0;
+  let toolCalls = 0;
+  let toolFinalizers = 0;
+
+  const tools = Toolkit.make(
+    Tool.make("recorded_work", { parameters: Tool.EmptyParams, success: Schema.String }),
+  );
+
+  const handlers = tools.toLayer({
+    recorded_work: () =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => {
+          toolCalls++;
+        }),
+        () => Effect.succeed("recorded"),
+        () =>
+          Effect.sync(() => {
+            toolFinalizers++;
+          }),
+      ),
+  });
+
+  const model = Model.make(
+    "scripted",
+    "checkpoint-work-budget",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.die("Unexpected non-streaming model call"),
+        streamText: (request) => {
+          prompts.push(request.prompt);
+
+          const parts: ReadonlyArray<Response.StreamPartEncoded> =
+            prompts.length === 1
+              ? [
+                  { type: "tool-call", id: "recorded-call", name: "recorded_work", params: {} },
+                  {
+                    type: "finish",
+                    reason: "tool-calls",
+                    usage: { inputTokens: {}, outputTokens: {} },
+                  },
+                ]
+              : historyResponse;
+
+          return Stream.fromIterable(parts).pipe(
+            Stream.ensuring(
+              Effect.sync(() => {
+                modelFinalizers++;
+              }),
+            ),
+          );
+        },
+      }),
+    ),
+  );
+
+  const agent = Agent.withModel(
+    Agent.make(historyDefinition.id, {
+      input: Schema.String,
+      output: Schema.String,
+      instructions: "Keep the checkpoint work-budget instructions.",
+      toolkit: tools,
+      policy: { maxTurns: 2, maxToolCalls: 1, maxDuration: "30 seconds", toolConcurrency: 1 },
+    }),
+    model,
+  );
+
+  const checkpointHost = (crash: boolean) =>
+    NodeDurableAgentRuntime.layer({
+      filename,
+      deploymentId: "history-cost",
+      producerId: "history-cost",
+      runContext: checkpointContext,
+      runtimeFailpoint: (location) =>
+        crash && location === "checkpoint:after-save"
+          ? DurableRuntimeFailpointError.make({ location })
+          : Effect.void,
+    }).pipe(Layer.provide(ContextCompactor.layerRollover));
+
+  const prepared = yield* Effect.gen(function* () {
+    const seed = yield* seedHistory(historySize);
+    const runtime = yield* DurableAgentRuntime;
+    const store = yield* ThreadStore;
+    const ledger = yield* SubmissionLedger;
+
+    const receipt = yield* runtime.submit(agent, "checkpoint work", {
+      threadId: seed.threadId,
+      principal: Principal.make("work-budget"),
+      idempotencyKey: IdempotencyKey.make("work-budget"),
+      definitions: historyDefinitions,
+    });
+
+    const stopped = yield* runtime.processThread(agent, seed.threadId).pipe(Effect.exit);
+
+    expect(Exit.isFailure(stopped)).toBe(true);
+    if (Exit.isFailure(stopped))
+      expect(Cause.findErrorOption(stopped.cause)).toMatchObject({
+        _tag: "Some",
+        value: { _tag: "DurableRuntimeFailpointError", location: "checkpoint:after-save" },
+      });
+    expect(prompts).toHaveLength(1);
+    expect(modelFinalizers).toBe(1);
+    expect(toolCalls).toBe(1);
+    expect(toolFinalizers).toBe(1);
+    expect(
+      (yield* ledger.loadRecoverySnapshot(
+        RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+      )).ownership,
+    ).toBeUndefined();
+
+    const checkpoint = yield* store.recoveryCheckpoints!.load(
+      LoadCheckpointRequest.make({ threadId: seed.threadId }),
+    );
+
+    if (Option.isNone(checkpoint))
+      return yield* Effect.die("The real runtime did not save a recovery checkpoint");
+
+    for (let start = 0; start < suffixSize; start += 256) {
+      const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId: seed.threadId }));
+
+      yield* store.append(
+        FencedAppendRequest.make({
+          threadId: seed.threadId,
+          producerEpoch: tail.producerEpoch,
+          expectedTailSequence: tail.tailSequence,
+          expectedTailDigest: tail.tailDigest,
+          batch: CanonicalBatch.make({
+            batchId: BatchId.make(`suffix-${start}`),
+            producerId: ProducerId.make("history-cost"),
+            records: EffectArray.makeBy(Math.min(256, suffixSize - start), (offset) =>
+              RecordEnvelope.make({
+                recordId: RecordId.make(`suffix-${start + offset}`),
+                family: "thread",
+                schemaVersion: 1,
+                deploymentId: DeploymentId.make("history-cost"),
+                createdAt: DateTime.makeUnsafe(0),
+                payload: RepairAnnotated.make({
+                  reason: "work-budget suffix",
+                  details: { position: start + offset },
+                }),
+              }),
+            ),
+          }),
+        }),
+      );
+    }
+    const before = yield* store.export(ThreadExportRequest.make({ threadId: seed.threadId }));
+
+    expect(before.tailSequence - checkpoint.value.throughSequence).toBe(suffixSize);
+
+    return { receipt, checkpoint: checkpoint.value, before };
+  }).pipe(Effect.provide(Layer.merge(checkpointHost(true), handlers)));
+
+  let returnedRecords = 0;
+  let retiredRecords = 0;
+  let closedPages = 0;
+  let checkpointLoads = 0;
+  let checkpointHits = 0;
+  const requests: Array<ThreadRead> = [];
+
+  const { result, queries } = yield* observeQueries(
+    Effect.gen(function* () {
+      const store = yield* ThreadStore;
+      const cache = store.recoveryCheckpoints!;
+
+      const counted = ThreadStore.of({
+        ...store,
+        recoveryCheckpoints: {
+          ...cache,
+          load: (request) =>
+            cache.load(request).pipe(
+              Effect.tap((value) =>
+                Effect.sync(() => {
+                  checkpointLoads++;
+                  if (Option.isSome(value)) checkpointHits++;
+                }),
+              ),
+            ),
+        },
+        read: (request) =>
+          Stream.suspend(() => {
+            requests.push(request);
+
+            return store.read(request);
+          }).pipe(
+            Stream.tap((record) =>
+              Effect.sync(() => {
+                returnedRecords++;
+                if (record.sequence <= prepared.checkpoint.throughSequence) retiredRecords++;
+              }),
+            ),
+            Stream.ensuring(
+              Effect.sync(() => {
+                closedPages++;
+              }),
+            ),
+          ),
+      });
+
+      const runtime = yield* DurableAgentRuntime.pipe(
+        Effect.provide(
+          Layer.fresh(DurableAgentRuntime.layer).pipe(
+            Layer.provide(
+              Layer.mergeAll(
+                coordinatorServices,
+                checkpointContext,
+                ContextCompactor.layerRollover,
+              ),
+            ),
+          ),
+        ),
+        Effect.provideService(ThreadStore, counted),
+      );
+
+      const recovery = yield* runtime.runRecovery;
+
+      expect(recovery.map(({ decision }) => decision._tag)).toEqual(["ResumeFromTurnBoundary"]);
+      expect(prompts).toHaveLength(1);
+      const settlements = yield* runtime.processThread(agent, prepared.receipt.threadId);
+      const settled = yield* runtime.awaitSettlement(prepared.receipt);
+
+      expect(settlements).toEqual([settled]);
+      expect(settled.outcome).toBe("completed");
+      const ledger = yield* SubmissionLedger;
+
+      expect(
+        (yield* ledger.loadRecoverySnapshot(
+          RecoverySnapshotRequest.make({ submissionId: prepared.receipt.submissionId }),
+        )).ownership,
+      ).toBeUndefined();
+
+      return settled;
+    }).pipe(Effect.provide(Layer.merge(checkpointHost(false), handlers))),
+  );
+
+  expect(prompts).toHaveLength(2);
+  expect(modelFinalizers).toBe(2);
+  expect(toolCalls).toBe(1);
+  expect(toolFinalizers).toBe(1);
+  expect(result.usageSummary?.modelCalls).toBe(2);
+  expect(JSON.stringify(prompts[1])).toContain(handoff);
+  expect(JSON.stringify(prompts[1])).toContain("checkpoint work-budget instructions");
+  expect(JSON.stringify(prompts[1])).toContain("checkpoint work");
+  expect(JSON.stringify(prompts[1])).not.toContain("retained input");
+  expect(retiredRecords).toBe(0);
+  expect(checkpointHits).toBeGreaterThan(0);
+  expect(checkpointHits).toBe(checkpointLoads);
+  expect(closedPages).toBe(requests.length);
+
+  const { batchDigestQueries } = yield* assertCanonicalReadPlans(queries).pipe(
+    Effect.provide(SqliteClient.layer({ filename, readonly: true })),
+  );
+
+  // Each public operation may load one checkpoint and replay one active suffix. Completed
+  // tools and the retired prefix must not be read/replayed again for this eligible checkpoint.
+  expect(checkpointLoads).toBeLessThanOrEqual(2);
+  // SQLite currently seeks these digests by Thread, then filters its batch metadata.
+  // That is up to two linear batch searches, not constant-time SQLite/VM work.
+  expect(batchDigestQueries).toBeLessThanOrEqual(2);
+  expect(returnedRecords).toBeGreaterThanOrEqual(suffixSize);
+  expect(returnedRecords, "Checkpoint canonical-record work budget").toBeLessThanOrEqual(
+    2 * suffixSize,
+  );
+  expect(requests.length).toBeLessThanOrEqual(2 * Math.ceil(suffixSize / 1_024));
+
+  const after = yield* Effect.gen(function* () {
+    const store = yield* ThreadStore;
+
+    return yield* store.export(ThreadExportRequest.make({ threadId: prepared.receipt.threadId }));
+  }).pipe(Effect.provide(checkpointHost(false)));
+
+  expect(after.records.slice(0, prepared.before.records.length)).toEqual(prepared.before.records);
+  expect(
+    after.records.flatMap(({ record }) =>
+      record.payload._tag === "RunCompleted" ? [record.payload.output] : [],
+    ),
+  ).toEqual(["done"]);
+  expect(
+    after.records.filter(({ record }) => record.payload._tag === "SubmissionSettled"),
+  ).toHaveLength(1);
+
+  return { statements: queries.length };
+}, Effect.provide(NodeFileSystem.layer));
+
+// Retired history and active suffix grow independently. The baseline uses the same
+// public operation, with one retired record and no suffix; no machine timing is involved.
+it.effect.each([
+  { historySize: 1_025, suffixSize: 0 },
+  { historySize: 8_193, suffixSize: 0 },
+  { historySize: 8_193, suffixSize: 1_025 },
+])(
+  "bounds checkpoint recovery after reopening SQLite with $historySize retired and $suffixSize suffix records",
+  ({ historySize, suffixSize }) =>
+    Effect.gen(function* () {
+      const baseline = yield* measureCheckpoint(1, 0);
+      const measured = yield* measureCheckpoint(historySize, suffixSize);
+
+      // One recovery snapshot and one Attempt snapshot; each page has a Thread existence
+      // read and a canonical range read. Retired history must add no statements or pages.
+      expect(measured.statements).toBeLessThanOrEqual(
+        baseline.statements + 4 * Math.ceil(suffixSize / 1_024),
+      );
+    }),
+  30_000,
+);
+
+const assertCanonicalReadPlans = Effect.fn("WorkBudget.assertCanonicalReadPlans")(function* (
+  queries: ReadonlyArray<CompiledQuery>,
+) {
+  const sql = yield* SqlClient.SqlClient;
+
+  const reads = queries.filter(
+    ([query]) =>
+      /^\s*SELECT\b/i.test(query) && /\bFROM effect_agent_canonical_records\b/.test(query),
+  );
+
+  for (const [query, parameters] of reads) {
+    const plan = yield* sql.unsafe<{ detail: string }>(`EXPLAIN QUERY PLAN ${query}`, parameters);
+    const identityProbe = /\brecord_id IN\b/.test(query);
+
+    // Identity probes are bounded by the append batch; history pages must seek by sequence.
+    // Checking SEARCH alone is insufficient: a thread_id-only search scans that Thread.
+    const accesses = plan.filter(({ detail }) => /\b(?:SCAN|SEARCH)\b/.test(detail));
+
+    expect(accesses.length).toBeGreaterThan(0);
+    for (const { detail } of accesses)
+      expect(detail, "Canonical read must use its identity/range index").toMatch(
+        identityProbe
+          ? /SEARCH .*\(thread_id=\? AND record_id=\?\)/
+          : /SEARCH .*\(thread_id=\? AND sequence>\?\)/,
+      );
+    if (!identityProbe) {
+      expect(plan.some(({ detail }) => detail.includes("TEMP B-TREE"))).toBe(false);
+      expect(query).toMatch(/\bLIMIT \?\s*$/);
+      expect(parameters.at(-1)).toBeGreaterThan(0);
+      expect(parameters.at(-1)).toBeLessThanOrEqual(1_024);
+    }
+  }
+  let batchDigestQueries = 0;
+
+  for (const [query, parameters] of queries.filter(
+    ([query]) =>
+      /^\s*SELECT\b/i.test(query) && /\bFROM effect_agent_canonical_batches\b/.test(query),
+  )) {
+    const digestProbe = /\bAND last_sequence\s*=/.test(query);
+
+    if (digestProbe) batchDigestQueries++;
+    const plan = yield* sql.unsafe<{ detail: string }>(`EXPLAIN QUERY PLAN ${query}`, parameters);
+    const accesses = plan.filter(({ detail }) => /\b(?:SCAN|SEARCH)\b/.test(detail));
+
+    expect(accesses.length).toBeGreaterThan(0);
+    for (const { detail } of accesses)
+      expect(detail, "Batch reads must stay within their Thread or exact batch identity").toMatch(
+        digestProbe
+          ? /SEARCH .*\(thread_id=\?(?: AND last_sequence=\?)?\)/
+          : /SEARCH .*\(thread_id=\? AND batch_id=\?\)/,
+      );
+  }
+
+  return { canonicalQueries: reads.length, batchDigestQueries };
+});
+
+const measureFresh = Effect.fn("WorkBudget.fresh")(function* (historySize: number) {
+  const fs = yield* FileSystem.FileSystem;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-work-budget-" });
+  const filename = `${directory}/thread.sqlite`;
+  const seed = yield* seedHistory(historySize).pipe(Effect.provide(host(filename)));
+
+  const { result, queries } = yield* observeQueries(
+    measureHistory(seed).pipe(Effect.provide(Layer.merge(host(filename), coordinatorServices))),
+  );
+
+  expect(Exit.isSuccess(result.exit)).toBe(true);
+  if (Exit.isSuccess(result.exit))
+    expect(result.exit.value.map(({ outcome }) => outcome)).toEqual(["completed"]);
+  expect(result.measured).toBe(true);
+  expect(result.modelCalls).toBe(1);
+  expect(result.modelFinalizers).toBe(1);
+  expect(result.openedPages).toBe(result.closedPages);
+  expect(result.snapshot.ownership).toBeUndefined();
+  expect(result.returnedRecords).toBeGreaterThanOrEqual(historySize);
+  // The control/journal prefix and prompt fold each visit history once. The fixed six
+  // permits new input/Run control records; it does not grow with retained history.
+  expect(result.returnedRecords).toBeLessThanOrEqual(2 * historySize + 6);
+
+  const { canonicalQueries } = yield* assertCanonicalReadPlans(queries).pipe(
+    Effect.provide(SqliteClient.layer({ filename, readonly: true })),
+  );
+
+  expect(
+    result.totalReturnedRecords,
+    "Fresh submission canonical-record work budget",
+  ).toBeLessThanOrEqual(2 * historySize + 6);
+
+  return { statements: queries.length, canonicalQueries };
+}, Effect.provide(NodeFileSystem.layer));
+
+// Cross the 1,024-record page boundary, then grow the prefix eightfold. Each comparison
+// owns its baseline and files, so test ordering and parallel workers cannot affect it.
+it.effect.each([1_025, 8_193])(
+  "bounds fresh submission work after reopening SQLite with %i retained records",
+  (historySize) =>
+    Effect.gen(function* () {
+      const baseline = yield* measureFresh(1);
+      const measured = yield* measureFresh(historySize);
+      const extraPages = Math.ceil(historySize / 1_024) - 1;
+
+      // Two history passes, each with one Thread existence query and one range query per
+      // page. Fixed admission/settlement work is compared, not snapshotted as an exact count.
+      expect(measured.statements).toBeLessThanOrEqual(baseline.statements + 4 * extraPages);
+      expect(measured.canonicalQueries).toBeLessThanOrEqual(
+        baseline.canonicalQueries + 2 * extraPages,
+      );
+    }),
+  30_000,
+);

--- a/packages/storage-memory/test/runtime-history-cost.test.ts
+++ b/packages/storage-memory/test/runtime-history-cost.test.ts
@@ -1,75 +1,21 @@
-import * as Agent from "@effect-agent/core/Agent";
-import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
-import { RunId, ThreadId } from "@effect-agent/core/Identifiers";
 import { RunToolAuthorization } from "@effect-agent/engine/RunOptions";
 import { MemorySubmissionLedgerLive } from "@effect-agent/storage-memory/MemorySubmissionLedger";
 import { MemoryThreadStoreLive } from "@effect-agent/storage-memory/MemoryThreadStore";
-import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
-import {
-  DurableAgentRuntime,
-  DurableRuntimeConfig,
-} from "@effect-agent/thread/DurableAgentRuntime";
+import { DurableRuntimeConfig } from "@effect-agent/thread/DurableAgentRuntime";
 import { DurableRuntimeFailpoint } from "@effect-agent/thread/DurableFailpoint";
-import {
-  BatchId,
-  CanonicalBatch,
-  CanonicalSequence,
-  CompactionCreated,
-  DefinitionDigests,
-  DeploymentId,
-  Digest,
-  ModelCompleted,
-  PersistedJson,
-  ProducerEpoch,
-  ProducerId,
-  RecordEnvelope,
-  RecordId,
-  RepairAnnotated,
-  ThreadCreated,
-} from "@effect-agent/thread/Records";
-import {
-  IdempotencyKey,
-  Principal,
-  RecoverySnapshotRequest,
-  SubmissionLedger,
-} from "@effect-agent/thread/SubmissionLedger";
-import {
-  FencedAppendRequest,
-  ThreadMaterialization,
-  ThreadStore,
-  ThreadStoreError,
-  ThreadTailRequest,
-  type ThreadRead,
-} from "@effect-agent/thread/ThreadStore";
+import { DeploymentId, ProducerId } from "@effect-agent/thread/Records";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { NodeCrypto } from "@effect/platform-node";
 import { expect, it } from "@effect/vitest";
-import { Array, Cause, DateTime, Effect, Exit, Layer, Schema, Stream } from "effect";
-import { LanguageModel, Model, Prompt, Toolkit, type Response } from "effect/unstable/ai";
+import { Cause, Effect, Exit, Layer, Schema } from "effect";
 
-const digest = Schema.decodeSync(Digest)("a".repeat(64));
-const definitions = DefinitionDigests.make({ agent: digest, model: digest, tools: digest });
-
-const definition = Agent.make("history-cost", {
-  input: Schema.String,
-  output: Schema.String,
-  instructions: "Answer as JSON.",
-  toolkit: Toolkit.empty,
-  policy: AgentPolicy.make({
-    maxTurns: 1,
-    maxToolCalls: 1,
-    maxDuration: "30 seconds",
-    toolConcurrency: 1,
-  }),
-});
-
-const response: ReadonlyArray<Response.StreamPartEncoded> = [
-  { type: "text-start", id: "answer" },
-  { type: "text-delta", id: "answer", delta: '"done"' },
-  { type: "text-end", id: "answer" },
-  { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
-];
+import {
+  measureHistory,
+  seedHistory,
+  type ReadFault,
+  type ReadPhase,
+} from "../../../test/fixtures/runtime-history-cost.ts";
 
 const base = Layer.mergeAll(
   MemoryThreadStoreLive,
@@ -84,272 +30,33 @@ const base = Layer.mergeAll(
   }),
 ).pipe(Layer.provideMerge(NodeCrypto.layer));
 
-type ReadFault = "gap" | "short" | "failure" | "defect" | "interruption";
-type ReadPhase = "prefix" | "suffix" | "fold";
-
-const measure = Effect.fn("RuntimeHistoryCost.measure")(function* (
+const measure = Effect.fn("RuntimeHistoryCost.memory")(function* (
   historySize: number,
   fault?: { readonly kind: ReadFault; readonly phase: ReadPhase },
   raceAppend = false,
   withCompaction = false,
 ) {
-  const store = yield* ThreadStore;
-  const threadId = Schema.decodeSync(ThreadId)(`history-cost-${historySize}`);
-  const producerEpoch = Schema.decodeSync(ProducerEpoch)(0);
-  const createdAt = yield* DateTime.now;
-  let tailSequence = Schema.decodeSync(CanonicalSequence)(0);
-  let tailDigest = EMPTY_TAIL_DIGEST;
-  const retainedInputs: Array<string> = [];
-
-  yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch }));
-  for (let start = 0; start < historySize; start += 256) {
-    const records = Array.makeBy(Math.min(256, historySize - start), (offset) => {
-      const position = start + offset;
-      const input = `retained input ${position}`;
-      const compaction = withCompaction && position === 128;
-      const retained = position > 0 && position % 4 === 0 && !compaction;
-
-      if (retained) retainedInputs.push(input);
-
-      return RecordEnvelope.make({
-        recordId: Schema.decodeSync(RecordId)(`history-seed:${start + offset}`),
-        family: "thread",
-        schemaVersion: 1,
-        deploymentId: Schema.decodeSync(DeploymentId)("history-cost"),
-        createdAt,
-        payload:
-          start + offset === 0
-            ? ThreadCreated.make({ agentId: definition.id, definitions })
-            : compaction
-              ? CompactionCreated.make({
-                  runId: RunId.make("prior-compaction"),
-                  turn: 1,
-                  kind: "summarize",
-                  coversThrough: Schema.decodeSync(CanonicalSequence)(0),
-                  summary: "Invalid zero coverage must not hide retained input",
-                })
-              : retained
-                ? ModelCompleted.make({
-                    runId: RunId.make(`retained:${position}`),
-                    output: "retained answer",
-                    messages: Schema.decodeUnknownSync(PersistedJson)(
-                      Schema.encodeSync(Prompt.Prompt)(
-                        Prompt.make([
-                          { role: "user", content: input },
-                          { role: "assistant", content: "retained answer" },
-                        ]),
-                      ),
-                    ),
-                  })
-                : RepairAnnotated.make({
-                    reason: "history-cost",
-                    details: { text: "x".repeat(128) },
-                  }),
-      });
-    });
-
-    const appended = yield* store.append(
-      FencedAppendRequest.make({
-        threadId,
-        producerEpoch,
-        expectedTailSequence: tailSequence,
-        expectedTailDigest: tailDigest,
-        batch: CanonicalBatch.make({
-          batchId: Schema.decodeSync(BatchId)(`history-seed:${start}`),
-          producerId: Schema.decodeSync(ProducerId)("history-cost"),
-          records,
-        }),
-      }),
-    );
-
-    tailSequence = appended.lastSequence;
-    tailDigest = appended.tailDigest;
-  }
-  let returnedRecords = 0;
-  let measured = false;
-
-  let openedPages = 0;
-  let closedPages = 0;
-  let prefixTraversals = 0;
-  let injected = false;
-  let raced = false;
-  const requests: Array<ThreadRead> = [];
-
-  const counted = ThreadStore.of({
-    ...store,
-    read: (request) =>
-      Stream.suspend(() => {
-        openedPages++;
-        requests.push(request);
-        if (request.afterSequence === undefined) prefixTraversals++;
-
-        const inject =
-          !injected &&
-          fault !== undefined &&
-          (fault.phase === "suffix"
-            ? request.afterSequence === historySize
-            : request.afterSequence === 1_024 &&
-              prefixTraversals === (fault.phase === "prefix" ? 1 : 2));
-
-        if (inject) {
-          injected = true;
-          switch (fault.kind) {
-            case "gap":
-              return store.read(request).pipe(Stream.drop(1));
-            case "short":
-              return Stream.empty;
-            case "failure":
-              return Stream.fail(
-                ThreadStoreError.make({ operation: "history test", message: "read unavailable" }),
-              );
-            case "defect":
-              return Stream.die("read defect");
-            case "interruption":
-              return Stream.fromEffect(Effect.interrupt);
-          }
-        }
-
-        if (raceAppend && !raced && request.afterSequence === 1_024) {
-          raced = true;
-
-          return Stream.unwrap(
-            Effect.gen(function* () {
-              const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
-              const input = "retained input racing append";
-
-              retainedInputs.push(input);
-              yield* store
-                .append(
-                  FencedAppendRequest.make({
-                    threadId,
-                    producerEpoch: tail.producerEpoch,
-                    expectedTailSequence: tail.tailSequence,
-                    expectedTailDigest: tail.tailDigest,
-                    batch: CanonicalBatch.make({
-                      batchId: BatchId.make("racing-history"),
-                      producerId: ProducerId.make("history-cost"),
-                      records: [
-                        RecordEnvelope.make({
-                          recordId: RecordId.make("racing-history"),
-                          family: "thread",
-                          schemaVersion: 1,
-                          createdAt,
-                          deploymentId: DeploymentId.make("history-cost"),
-                          payload: ModelCompleted.make({
-                            runId: RunId.make("racing-history"),
-                            output: "racing answer",
-                            messages: Schema.decodeUnknownSync(PersistedJson)(
-                              Schema.encodeSync(Prompt.Prompt)(
-                                Prompt.make([
-                                  { role: "user", content: input },
-                                  { role: "assistant", content: "racing answer" },
-                                ]),
-                              ),
-                            ),
-                          }),
-                        }),
-                      ],
-                    }),
-                  }),
-                )
-                .pipe(Effect.orDie);
-
-              return store.read(request);
-            }),
-          );
-        }
-
-        return store.read(request);
-      }).pipe(
-        Stream.tap(() =>
-          Effect.sync(() => {
-            if (!measured) returnedRecords++;
-          }),
-        ),
-        Stream.ensuring(
-          Effect.sync(() => {
-            closedPages++;
-          }),
-        ),
-      ),
-  });
-
-  const model = Model.make(
-    "scripted",
-    "history-cost",
-    Layer.effect(
-      LanguageModel.LanguageModel,
-      LanguageModel.make({
-        generateText: () => Effect.succeed([]),
-        streamText: (request) =>
-          Stream.fromEffect(
-            Effect.sync(() => {
-              measured = true;
-
-              const userTexts = request.prompt.content.flatMap((message) =>
-                message.role === "user"
-                  ? message.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
-                  : [],
-              );
-
-              expect(userTexts.filter((text) => text.startsWith("retained input "))).toEqual(
-                retainedInputs,
-              );
-            }),
-          ).pipe(Stream.flatMap(() => Stream.fromIterable(response))),
-      }),
-    ),
-  );
-
-  const agent = Agent.withModel(definition, model);
-
-  const runtime = yield* DurableAgentRuntime.pipe(
-    Effect.provide(DurableAgentRuntime.layer),
-    Effect.provideService(ThreadStore, counted),
-  );
-
-  const receipt = yield* runtime.submit(agent, "measure", {
-    threadId,
-    principal: Schema.decodeSync(Principal)("history-cost"),
-    idempotencyKey: Schema.decodeSync(IdempotencyKey)("history-cost"),
-    definitions,
-  });
-
-  const exit = yield* runtime.processThread(agent, threadId).pipe(Effect.exit);
-  const ledger = yield* SubmissionLedger;
-
-  const snapshot = yield* ledger.loadRecoverySnapshot(
-    RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
-  );
-
-  return {
-    returnedRecords,
-    measured,
-    exit,
-    openedPages,
-    closedPages,
-    requests,
-    injected,
-    raced,
-    snapshot,
-  };
+  return yield* measureHistory(yield* seedHistory(historySize, withCompaction), fault, raceAppend);
 });
 
-it.live("bounds startup history reads while retaining the complete fixed prefix", () =>
+it.effect("bounds startup history reads while retaining the complete fixed prefix", () =>
   Effect.gen(function* () {
     for (const historySize of [1, 11, 2051]) {
       const measurement = yield* measure(historySize).pipe(Effect.provide(base));
 
       expect(Exit.isSuccess(measurement.exit)).toBe(true);
       expect(measurement.measured).toBe(true);
+      expect(measurement.modelCalls).toBe(1);
+      expect(measurement.modelFinalizers).toBe(1);
       expect(measurement.openedPages).toBe(measurement.closedPages);
       expect(measurement.snapshot.ownership).toBeUndefined();
       expect(measurement.returnedRecords).toBeLessThanOrEqual(2 * historySize + 6);
+      expect(measurement.totalReturnedRecords).toBeLessThanOrEqual(2 * historySize + 6);
     }
   }),
 );
 
-it.live.each([
+it.effect.each([
   { kind: "gap", phase: "prefix" },
   { kind: "short", phase: "prefix" },
   { kind: "failure", phase: "prefix" },
@@ -378,7 +85,7 @@ it.live.each([
     }),
 );
 
-it.live("captures the initial tail and incorporates racing appends through a later suffix", () =>
+it.effect("captures the initial tail and incorporates racing appends through a later suffix", () =>
   Effect.gen(function* () {
     const result = yield* measure(1_025, undefined, true).pipe(Effect.provide(base));
 
@@ -397,7 +104,7 @@ it.live("captures the initial tail and incorporates racing appends through a lat
   }),
 );
 
-it.live("falls back to ordinary journal scans when any compaction metadata is present", () =>
+it.effect("falls back to ordinary journal scans when any compaction metadata is present", () =>
   Effect.gen(function* () {
     const result = yield* measure(1_025, undefined, false, true).pipe(Effect.provide(base));
 

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -254,7 +254,8 @@ export const renderPerformanceReport = (report: PerformanceReport): string => {
           "",
         ]),
     "Timing is informational. Operation median [Q1–Q3] in milliseconds; every measured sample and outlier is retained. Model-entry timings remain in raw samples.",
-    "Samples share three worker processes per revision in the pr profile; their spread is not a confidence interval or a calibrated regression threshold.",
+    "Deterministic performance gates run in ordinary CI and bound algorithmic work. Wall-clock changes here are diagnostic observations, never pass/fail thresholds.",
+    "Samples share three worker processes per revision in the pr profile; their spread is not a confidence interval and does not establish a latency regression.",
     ...(identical
       ? [
           "Identical built JavaScript and lockfiles. Timing differences do not establish a code regression; percentage changes are suppressed.",

--- a/test/fixtures/ledger-read-contracts.ts
+++ b/test/fixtures/ledger-read-contracts.ts
@@ -195,18 +195,27 @@ const assertIndexedScan = Effect.fn("LedgerReadFixture.assertIndexedScan")(funct
 
   for (const [index, [query, parameters]] of queries.entries()) {
     const plan = yield* sql.unsafe<{ detail: string }>(`EXPLAIN QUERY PLAN ${query}`, parameters);
+    const accesses = plan.filter(({ detail }) => /\b(?:SCAN|SEARCH)\b/.test(detail));
 
-    expect(plan.some(({ detail }) => detail.includes("effect_agent_submissions_nonterminal"))).toBe(
-      true,
-    );
+    // A constant statement count can still hide a full-ledger scan or a correlated scan.
+    // Each page walks only the outstanding-obligation index, and later pages seek past
+    // the cursor rather than revisiting earlier rows through OFFSET pagination.
+    expect(accesses.length).toBeGreaterThan(0);
+    for (const { detail } of accesses) {
+      expect(detail, "Nonterminal scans must exclude settled rows at the index").toContain(
+        "effect_agent_submissions_nonterminal",
+      );
+      if (index > 0) {
+        expect(detail, "Later ledger pages must seek from their cursor").toContain("SEARCH");
+        expect(detail, "A Thread-only seek can rescan its earlier queue pages").toContain(
+          "queue_sequence",
+        );
+      }
+    }
     expect(plan.some(({ detail }) => detail.includes("TEMP B-TREE"))).toBe(false);
-    if (index > 0)
-      expect(
-        plan.some(
-          ({ detail }) =>
-            detail.includes("SEARCH") && detail.includes("effect_agent_submissions_nonterminal"),
-        ),
-      ).toBe(true);
+    expect(query).toMatch(/\bLIMIT \?\s*$/);
+    expect(parameters.at(-1)).toBeGreaterThan(0);
+    expect(parameters.at(-1)).toBeLessThanOrEqual(256);
   }
 });
 
@@ -228,21 +237,30 @@ export const ledgerReadCases = [
       yield* assertIndexedScan(queries);
     }),
   },
-  {
-    name: "skips a large settled prefix with one indexed page",
-    run: Effect.gen(function* () {
-      const ledger = yield* SubmissionLedger;
+  // Empty, short, and exact multiple-page scans distinguish fixed/indexed work from
+  // the allowed linear work in *unfinished* rows. Retained settlements add no pages.
+  ...[0, 2_048, 8_192].flatMap((settled) =>
+    [0, 16, 768].map((unfinished) => ({
+      name: `bounds the scan to ${unfinished} unfinished rows with ${settled} settled rows`,
+      run: Effect.gen(function* () {
+        const ledger = yield* SubmissionLedger;
 
-      yield* seedScan(2064, 2048);
-      const { result, queries } = yield* observeQueries(Stream.runCollect(ledger.scanNonterminal));
+        if (settled + unfinished > 0) yield* seedScan(settled + unfinished, settled);
 
-      expect(result.map(({ submissionId }) => submissionId)).toEqual(
-        Array.from({ length: 16 }, (_, n) => `scan-${2048 + n}`),
-      );
-      expect(queries).toHaveLength(1);
-      yield* assertIndexedScan(queries);
-    }),
-  },
+        const { result, queries } = yield* observeQueries(
+          Stream.runCollect(ledger.scanNonterminal),
+        );
+
+        expect(result.map(({ submissionId }) => submissionId)).toEqual(
+          Array.from({ length: unfinished }, (_, n) => `scan-${settled + n}`),
+        );
+        // A full final page may need one empty read to discover the end of the stream.
+        expect(queries.length).toBeLessThanOrEqual(Math.floor(unfinished / 256) + 1);
+        expect(queries.length).toBeGreaterThan(0);
+        yield* assertIndexedScan(queries);
+      }),
+    })),
+  ),
   {
     name: "keeps cursor order during settlement and observes earlier admissions on the next scan",
     run: Effect.gen(function* () {

--- a/test/fixtures/runtime-history-cost.ts
+++ b/test/fixtures/runtime-history-cost.ts
@@ -1,0 +1,351 @@
+import * as Agent from "@effect-agent/core/Agent";
+import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
+import { RunId, ThreadId } from "@effect-agent/core/Identifiers";
+import { EMPTY_TAIL_DIGEST } from "@effect-agent/thread/Digest";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import {
+  BatchId,
+  CanonicalBatch,
+  CanonicalSequence,
+  CompactionCreated,
+  DefinitionDigests,
+  DeploymentId,
+  Digest,
+  ModelCompleted,
+  PersistedJson,
+  ProducerEpoch,
+  ProducerId,
+  RecordEnvelope,
+  RecordId,
+  RepairAnnotated,
+  ThreadCreated,
+} from "@effect-agent/thread/Records";
+import {
+  IdempotencyKey,
+  Principal,
+  RecoverySnapshotRequest,
+  SubmissionLedger,
+} from "@effect-agent/thread/SubmissionLedger";
+import {
+  FencedAppendRequest,
+  ThreadMaterialization,
+  ThreadStore,
+  ThreadStoreError,
+  ThreadTailRequest,
+  type ThreadRead,
+} from "@effect-agent/thread/ThreadStore";
+import { Array, DateTime, Effect, Exit, Layer, Schema, Stream } from "effect";
+import { LanguageModel, Model, Prompt, Toolkit, type Response } from "effect/unstable/ai";
+import { expect } from "vite-plus/test";
+
+const digest = Schema.decodeSync(Digest)("a".repeat(64));
+
+export const historyDefinitions = DefinitionDigests.make({
+  agent: digest,
+  model: digest,
+  tools: digest,
+});
+
+export const historyDefinition = Agent.make("history-cost", {
+  input: Schema.String,
+  output: Schema.String,
+  instructions: "Answer as JSON.",
+  toolkit: Toolkit.empty,
+  policy: AgentPolicy.make({
+    maxTurns: 1,
+    maxToolCalls: 1,
+    maxDuration: "30 seconds",
+    toolConcurrency: 1,
+  }),
+});
+
+export const historyResponse: ReadonlyArray<Response.StreamPartEncoded> = [
+  { type: "text-start", id: "answer" },
+  { type: "text-delta", id: "answer", delta: '"done"' },
+  { type: "text-end", id: "answer" },
+  { type: "finish", reason: "stop", usage: { inputTokens: {}, outputTokens: {} } },
+];
+
+export type ReadFault = "gap" | "short" | "failure" | "defect" | "interruption";
+export type ReadPhase = "prefix" | "suffix" | "fold";
+
+/** The same retained-history fixture serves the memory and real SQLite work-budget gates. */
+export const seedHistory = Effect.fn("RuntimeHistoryCost.seed")(function* (
+  historySize: number,
+  withCompaction = false,
+) {
+  const store = yield* ThreadStore;
+  const threadId = Schema.decodeSync(ThreadId)(`history-cost-${historySize}`);
+  const producerEpoch = Schema.decodeSync(ProducerEpoch)(0);
+  const createdAt = yield* DateTime.now;
+  let tailSequence = Schema.decodeSync(CanonicalSequence)(0);
+  let tailDigest = EMPTY_TAIL_DIGEST;
+  const retainedInputs: Array<string> = [];
+
+  yield* store.materialize(ThreadMaterialization.make({ threadId, producerEpoch }));
+  for (let start = 0; start < historySize; start += 256) {
+    const records = Array.makeBy(Math.min(256, historySize - start), (offset) => {
+      const position = start + offset;
+      const input = `retained input ${position}`;
+      const compaction = withCompaction && position === 128;
+      const retained = position > 0 && position % 4 === 0 && !compaction;
+
+      if (retained) retainedInputs.push(input);
+
+      return RecordEnvelope.make({
+        recordId: Schema.decodeSync(RecordId)(`history-seed:${start + offset}`),
+        family: "thread",
+        schemaVersion: 1,
+        deploymentId: Schema.decodeSync(DeploymentId)("history-cost"),
+        createdAt,
+        payload:
+          start + offset === 0
+            ? ThreadCreated.make({ agentId: historyDefinition.id, definitions: historyDefinitions })
+            : compaction
+              ? CompactionCreated.make({
+                  runId: RunId.make("prior-compaction"),
+                  turn: 1,
+                  kind: "summarize",
+                  coversThrough: Schema.decodeSync(CanonicalSequence)(0),
+                  summary: "Invalid zero coverage must not hide retained input",
+                })
+              : retained
+                ? ModelCompleted.make({
+                    runId: RunId.make(`retained:${position}`),
+                    output: "retained answer",
+                    messages: Schema.decodeUnknownSync(PersistedJson)(
+                      Schema.encodeSync(Prompt.Prompt)(
+                        Prompt.make([
+                          { role: "user", content: input },
+                          { role: "assistant", content: "retained answer" },
+                        ]),
+                      ),
+                    ),
+                  })
+                : RepairAnnotated.make({
+                    reason: "history-cost",
+                    details: { text: "x".repeat(128) },
+                  }),
+      });
+    });
+
+    const appended = yield* store.append(
+      FencedAppendRequest.make({
+        threadId,
+        producerEpoch,
+        expectedTailSequence: tailSequence,
+        expectedTailDigest: tailDigest,
+        batch: CanonicalBatch.make({
+          batchId: Schema.decodeSync(BatchId)(`history-seed:${start}`),
+          producerId: Schema.decodeSync(ProducerId)("history-cost"),
+          records,
+        }),
+      }),
+    );
+
+    tailSequence = appended.lastSequence;
+    tailDigest = appended.tailDigest;
+  }
+
+  return { historySize, threadId, createdAt, retainedInputs };
+});
+
+export const measureHistory = Effect.fn("RuntimeHistoryCost.measure")(function* (
+  seed: Effect.Success<ReturnType<typeof seedHistory>>,
+  fault?: { readonly kind: ReadFault; readonly phase: ReadPhase },
+  raceAppend = false,
+) {
+  const store = yield* ThreadStore;
+  const { historySize, threadId, createdAt, retainedInputs } = seed;
+  let returnedRecords = 0;
+  let totalReturnedRecords = 0;
+  let modelCalls = 0;
+  let modelFinalizers = 0;
+  let measured = false;
+
+  let openedPages = 0;
+  let closedPages = 0;
+  let prefixTraversals = 0;
+  let injected = false;
+  let raced = false;
+  const requests: Array<ThreadRead> = [];
+
+  const counted = ThreadStore.of({
+    ...store,
+    read: (request) =>
+      Stream.suspend(() => {
+        openedPages++;
+        requests.push(request);
+        if (request.afterSequence === undefined) prefixTraversals++;
+
+        const inject =
+          !injected &&
+          fault !== undefined &&
+          (fault.phase === "suffix"
+            ? request.afterSequence === historySize
+            : request.afterSequence === 1_024 &&
+              prefixTraversals === (fault.phase === "prefix" ? 1 : 2));
+
+        if (inject) {
+          injected = true;
+          switch (fault.kind) {
+            case "gap":
+              return store.read(request).pipe(Stream.drop(1));
+            case "short":
+              return Stream.empty;
+            case "failure":
+              return Stream.fail(
+                ThreadStoreError.make({ operation: "history test", message: "read unavailable" }),
+              );
+            case "defect":
+              return Stream.die("read defect");
+            case "interruption":
+              return Stream.fromEffect(Effect.interrupt);
+          }
+        }
+
+        if (raceAppend && !raced && request.afterSequence === 1_024) {
+          raced = true;
+
+          return Stream.unwrap(
+            Effect.gen(function* () {
+              const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId }));
+              const input = "retained input racing append";
+
+              retainedInputs.push(input);
+              yield* store
+                .append(
+                  FencedAppendRequest.make({
+                    threadId,
+                    producerEpoch: tail.producerEpoch,
+                    expectedTailSequence: tail.tailSequence,
+                    expectedTailDigest: tail.tailDigest,
+                    batch: CanonicalBatch.make({
+                      batchId: BatchId.make("racing-history"),
+                      producerId: ProducerId.make("history-cost"),
+                      records: [
+                        RecordEnvelope.make({
+                          recordId: RecordId.make("racing-history"),
+                          family: "thread",
+                          schemaVersion: 1,
+                          createdAt,
+                          deploymentId: DeploymentId.make("history-cost"),
+                          payload: ModelCompleted.make({
+                            runId: RunId.make("racing-history"),
+                            output: "racing answer",
+                            messages: Schema.decodeUnknownSync(PersistedJson)(
+                              Schema.encodeSync(Prompt.Prompt)(
+                                Prompt.make([
+                                  { role: "user", content: input },
+                                  { role: "assistant", content: "racing answer" },
+                                ]),
+                              ),
+                            ),
+                          }),
+                        }),
+                      ],
+                    }),
+                  }),
+                )
+                .pipe(Effect.orDie);
+
+              return store.read(request);
+            }),
+          );
+        }
+
+        return store.read(request);
+      }).pipe(
+        Stream.tap(() =>
+          Effect.sync(() => {
+            totalReturnedRecords++;
+            if (!measured) returnedRecords++;
+          }),
+        ),
+        Stream.ensuring(
+          Effect.sync(() => {
+            closedPages++;
+          }),
+        ),
+      ),
+  });
+
+  const model = Model.make(
+    "scripted",
+    "history-cost",
+    Layer.effect(
+      LanguageModel.LanguageModel,
+      LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: (request) =>
+          Stream.fromEffect(
+            Effect.sync(() => {
+              measured = true;
+              modelCalls++;
+
+              const userTexts = request.prompt.content.flatMap((message) =>
+                message.role === "user"
+                  ? message.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
+                  : [],
+              );
+
+              expect(userTexts.filter((text) => text.startsWith("retained input "))).toEqual(
+                retainedInputs,
+              );
+            }),
+          ).pipe(
+            Stream.flatMap(() => Stream.fromIterable(historyResponse)),
+            Stream.ensuring(
+              Effect.sync(() => {
+                modelFinalizers++;
+              }),
+            ),
+          ),
+      }),
+    ),
+  );
+
+  const agent = Agent.withModel(historyDefinition, model);
+
+  const runtime = yield* DurableAgentRuntime.pipe(
+    // A Node host may already have acquired this Layer. Its memoized coordinator would
+    // retain the unobserved store, so construct a fresh one over the counting decorator.
+    Effect.provide(Layer.fresh(DurableAgentRuntime.layer)),
+    Effect.provideService(ThreadStore, counted),
+  );
+
+  const receipt = yield* runtime.submit(agent, "measure", {
+    threadId,
+    principal: Schema.decodeSync(Principal)("history-cost"),
+    idempotencyKey: Schema.decodeSync(IdempotencyKey)("history-cost"),
+    definitions: historyDefinitions,
+  });
+
+  const exit = yield* runtime.processThread(agent, threadId).pipe(Effect.exit);
+
+  if (Exit.isSuccess(exit)) {
+    const settled = yield* runtime.awaitSettlement(receipt);
+
+    expect(exit.value).toEqual([settled]);
+  }
+  const ledger = yield* SubmissionLedger;
+
+  const snapshot = yield* ledger.loadRecoverySnapshot(
+    RecoverySnapshotRequest.make({ submissionId: receipt.submissionId }),
+  );
+
+  return {
+    returnedRecords,
+    totalReturnedRecords,
+    modelCalls,
+    modelFinalizers,
+    measured,
+    exit,
+    openedPages,
+    closedPages,
+    requests,
+    injected,
+    raced,
+    snapshot,
+  };
+});


### PR DESCRIPTION
Shared-runner timing deltas can make unchanged runtime work look like a regression. Extend the existing work-budget fixtures in ordinary CI with deterministic guards for durable operations:

- Fresh submission through settlement on reopened SQLite permits two linear history passes plus fixed work (`2H + 6` canonical records). Record counts, bounded range queries, and actual sequence-index plans constrain history growth together.
- Nonterminal ledger scans cross independently growing settled and unfinished populations. Their partial-index plans, cursor seeks, and page budgets exclude scanning retained settlements and revisiting earlier pages.
- Recovery from a real rollover checkpoint permits at most two checkpoint loads and two reads of the active suffix, with no retired canonical records reread or completed tool repeated. Model calls, finalizers, ownership release, output, and retained canonical history remain checked.

Reuse the memory history/fault fixture and shared SQLite/Durable Object ledger contracts rather than adding a separate benchmark framework. Document these bounds alongside the existing concurrency, recovery, and resource guards. Statement counts alone cannot establish a bounded scan, so the SQLite checks also inspect the executed queries' plans and count records delivered by the real adapter.

The automatic release PR comment now labels timing as informational and puts medians and spread in a collapsed table without percentage deltas. Full diagnostic artifacts retain the percentages and raw samples; this trades quick percentage scanning for a clearer distinction between latency observations and enforced work budgets.

The checkpoint bound applies to eligible canonical replay. Digest validation still searches a Thread's batch metadata linearly; these checks do not bound SQLite VM instructions, in-memory CPU work, byte decoding, or wall-clock latency. Runtime behavior, durability settings, and public APIs are unchanged.
