### PR TITLE
feat(travel-planner): add conversation URL routing

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -27,7 +27,14 @@ ID and model settings without clearing a new draft. Accepted queued messages sur
 messages that have not reached the server remain local to the current tab.
 
 **Plan a new trip** starts a separate conversation with fresh model history. Returning
-to a trip restores that conversation's messages. The first message reserves a private
+to a trip restores that conversation's messages. Each conversation has a private
+`/conversations/<conversationId>` URL, including conversations without a saved itinerary.
+Opening `/` or **Plan a new trip** redirects to a fresh conversation URL before the first
+message; it does not create a stored conversation until you send one. Refresh, bookmarks,
+and browser Back/Forward restore the conversation selected by that URL. Sidebar links can
+also open in another tab. Links still require sign-in to the owning account; they do not
+publish conversation history. Malformed conversation IDs show the not-found page.
+The first message reserves a private
 sidebar entry before agent admission, independently of whether the model saves trip details.
 Unfinished and failed conversations remain reachable after reload or restart. Entries initially
 use the first message as their title; saved trip details replace that label without a duplicate.

--- a/examples/travel-planner/src/planner.tsx
+++ b/examples/travel-planner/src/planner.tsx
@@ -1,9 +1,10 @@
 import { Dialog } from "@base-ui/react/dialog";
-import { useAtom, useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtom, useAtomInitialValues, useAtomSet, useAtomValue } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import { Option } from "effect";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { ArrowUp, ArrowUpRight, Clock3, Map, Menu, Plus, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { ActivityPanel } from "./components/activity-panel";
 import { AgentProgress } from "./components/agent-progress.tsx";
@@ -25,7 +26,6 @@ import {
   draftAtom,
   plannerAtom,
   changeTripAppAtom,
-  newTripAtom,
   selectTripAtom,
   selectionAtom,
   sendMessageAtom,
@@ -53,7 +53,20 @@ function failure(result: AsyncResult.AsyncResult<unknown, unknown>): string | nu
     : "Couldn't connect. Reload the page to sign in again.";
 }
 
-export function Planner() {
+export function Planner({ conversationId }: { readonly conversationId: string }) {
+  // Seed before any authenticated query mounts on a direct link. Later route
+  // changes update the existing registry, retaining its account-scoped cache.
+  useAtomInitialValues([[selectionAtom, { conversationId, tripId: null }]]);
+  const selectTrip = useAtomSet(selectTripAtom);
+
+  useLayoutEffect(() => {
+    selectTrip({ conversationId, id: null });
+  }, [conversationId, selectTrip]);
+
+  return <PlannerContent />;
+}
+
+function PlannerContent() {
   const connectionResult = useAtomValue(openAiConnectionAtom);
   const connected = AsyncResult.isSuccess(connectionResult) && connectionResult.value.connected;
   const openSettings = useAtomSet(modelSettingsOpenAtom);
@@ -62,8 +75,6 @@ export function Planner() {
   const [manageAccess, setManageAccess] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const selectTrip = useAtomSet(selectTripAtom);
-  const newTrip = useAtomSet(newTripAtom);
   const selection = useAtomValue(selectionAtom);
   const [draft, setDraft] = useAtom(draftAtom);
   const result = useAtomValue(plannerAtom);
@@ -136,29 +147,31 @@ export function Planner() {
 
   const navigation = (
     <>
-      <a className="wordmark" href="/">
+      <Link className="wordmark" to="/" preload={false}>
         elsewhere
         <ArrowUpRight size={34} aria-hidden="true" />
-      </a>
-      <button
+      </Link>
+      <Link
         className="new-trip"
+        to="/"
+        preload={false}
         onClick={() => {
-          newTrip();
           setMenuOpen(false);
         }}
       >
         <Plus size={21} aria-hidden="true" /> Plan a new trip
-      </button>
+      </Link>
       <div className="sidebar-heading">
         YOUR TRIPS <span>{savedTrips.length}</span>
       </div>
       <nav aria-label="Saved trips" className="trip-list">
         {savedTrips.map((saved) => (
-          <button
+          <Link
             className={`trip-link ${selection.conversationId === saved.conversationId ? "selected" : ""}`}
             key={saved.conversationId}
+            to="/conversations/$conversationId"
+            params={{ conversationId: saved.conversationId }}
             onClick={() => {
-              selectTrip(saved);
               setMenuOpen(false);
             }}
           >
@@ -169,7 +182,7 @@ export function Planner() {
               <strong>{saved.title}</strong>
               <small>{saved.destination}</small>
             </span>
-          </button>
+          </Link>
         ))}
         {!savedTrips.length && conversationStatus === "ready" && (
           <p className="sidebar-empty">
@@ -226,7 +239,9 @@ export function Planner() {
         ) : (
           <p className="session-status" role="status">
             {failure(sessionResult) ?? "Checking your session…"}
-            {AsyncResult.isFailure(sessionResult) && <a href="/">Reload / sign in</a>}
+            {AsyncResult.isFailure(sessionResult) && (
+              <a href={window.location.href}>Reload / sign in</a>
+            )}
           </p>
         )}
         <p className="powered">A travel companion built with Effect Agent</p>

--- a/examples/travel-planner/src/routeTree.gen.ts
+++ b/examples/travel-planner/src/routeTree.gen.ts
@@ -10,33 +10,44 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ConversationsConversationIdRouteImport } from './routes/conversations.$conversationId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ConversationsConversationIdRoute =
+  ConversationsConversationIdRouteImport.update({
+    id: '/conversations/$conversationId',
+    path: '/conversations/$conversationId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/conversations/$conversationId': typeof ConversationsConversationIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/conversations/$conversationId': typeof ConversationsConversationIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/conversations/$conversationId': typeof ConversationsConversationIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/conversations/$conversationId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/conversations/$conversationId'
+  id: '__root__' | '/' | '/conversations/$conversationId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ConversationsConversationIdRoute: typeof ConversationsConversationIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,11 +59,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/conversations/$conversationId': {
+      id: '/conversations/$conversationId'
+      path: '/conversations/$conversationId'
+      fullPath: '/conversations/$conversationId'
+      preLoaderRoute: typeof ConversationsConversationIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ConversationsConversationIdRoute: ConversationsConversationIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/examples/travel-planner/src/routes/conversations.$conversationId.tsx
+++ b/examples/travel-planner/src/routes/conversations.$conversationId.tsx
@@ -1,0 +1,32 @@
+import { ClientOnly, createFileRoute, notFound } from "@tanstack/react-router";
+import { Schema } from "effect";
+
+import { ConversationId } from "../domain";
+import { Planner } from "../planner";
+
+export const Route = createFileRoute("/conversations/$conversationId")({
+  beforeLoad: ({ params }) => {
+    if (!Schema.is(ConversationId)(params.conversationId)) throw notFound();
+  },
+  component: Conversation,
+});
+
+function Conversation() {
+  const { conversationId } = Route.useParams();
+
+  return (
+    <ClientOnly
+      fallback={
+        <main className="empty">
+          <span className="wordmark">
+            elsewhere<span>↗</span>
+          </span>
+          <h1>Your next trip awaits.</h1>
+          <p>Loading your conversation…</p>
+        </main>
+      }
+    >
+      <Planner conversationId={conversationId} />
+    </ClientOnly>
+  );
+}

--- a/examples/travel-planner/src/routes/index.tsx
+++ b/examples/travel-planner/src/routes/index.tsx
@@ -1,21 +1,11 @@
-import { ClientOnly, createFileRoute } from "@tanstack/react-router";
-
-import { Planner } from "../planner";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
-  component: () => (
-    <ClientOnly
-      fallback={
-        <main className="empty">
-          <span className="wordmark">
-            elsewhere<span>↗</span>
-          </span>
-          <h1>Where do you want to go?</h1>
-          <p>Your next trip starts with a conversation.</p>
-        </main>
-      }
-    >
-      <Planner />
-    </ClientOnly>
-  ),
+  beforeLoad: () => {
+    throw redirect({
+      to: "/conversations/$conversationId",
+      params: { conversationId: crypto.randomUUID() },
+      replace: true,
+    });
+  },
 });

--- a/examples/travel-planner/src/state.ts
+++ b/examples/travel-planner/src/state.ts
@@ -630,15 +630,11 @@ export const activeTripAtom = Atom.make((get) => {
   );
 });
 
-export const newTripAtom = Atom.fnSync<void>()((_, get) => {
-  get.set(selectionAtom, { conversationId: crypto.randomUUID(), tripId: null });
-  get.set(draftAtom, "");
-});
-
 export const selectTripAtom = Atom.fnSync<{
   readonly conversationId: string;
   readonly id: string | null;
 }>()((trip, get) => {
+  if (get(selectionAtom).conversationId === trip.conversationId) return;
   get.set(selectionAtom, { conversationId: trip.conversationId, tripId: trip.id });
   get.set(draftAtom, "");
 });

--- a/examples/travel-planner/test/conversation.test.ts
+++ b/examples/travel-planner/test/conversation.test.ts
@@ -5,7 +5,7 @@ import { expect, it } from "vite-plus/test";
 
 import { SavedTrip, Trip } from "../src/domain.ts";
 import { legacyTripMessages } from "../src/server/conversation.ts";
-import { draftAtom, newTripAtom, selectionAtom, selectTripAtom } from "../src/state.ts";
+import { draftAtom, selectionAtom, selectTripAtom } from "../src/state.ts";
 
 const trip = Schema.decodeUnknownSync(Trip)({
   id: "tahoe-trip",
@@ -99,18 +99,17 @@ it("retains only the selected trip's historical conversation without changing it
   expect(JSON.stringify(source)).toBe(before);
 });
 
-it("starts distinct new conversations and returns to the saved trip's conversation", () => {
+it("clears the draft when switching conversations and preserves it when reselecting the same one", () => {
   const registry = AtomRegistry.make();
 
   try {
     registry.set(draftAtom, "Draft from another trip");
-    registry.set(newTripAtom, undefined);
-    const first = registry.get(selectionAtom);
-
-    expect(first.conversationId).toBeTruthy();
+    registry.set(selectTripAtom, { conversationId: "new-conversation", id: null });
+    expect(registry.get(selectionAtom).conversationId).toBe("new-conversation");
     expect(registry.get(draftAtom)).toBe("");
-    registry.set(newTripAtom, undefined);
-    expect(registry.get(selectionAtom).conversationId).not.toBe(first.conversationId);
+    registry.set(draftAtom, "Still writing");
+    registry.set(selectTripAtom, { conversationId: "new-conversation", id: null });
+    expect(registry.get(draftAtom)).toBe("Still writing");
 
     const saved = Schema.decodeUnknownSync(SavedTrip)({
       ...trip,
@@ -118,6 +117,7 @@ it("starts distinct new conversations and returns to the saved trip's conversati
     });
 
     registry.set(selectTripAtom, saved);
+    expect(registry.get(draftAtom)).toBe("");
     expect(registry.get(selectionAtom)).toEqual({
       conversationId: "saved-conversation",
       tripId: trip.id,

--- a/examples/travel-planner/test/routing.test.ts
+++ b/examples/travel-planner/test/routing.test.ts
@@ -1,0 +1,59 @@
+import { createMemoryHistory, createRouter } from "@tanstack/react-router";
+import { expect, it } from "vite-plus/test";
+
+import { routeTree } from "../src/routeTree.gen";
+
+const setup = (path: string) => {
+  const history = createMemoryHistory({ initialEntries: [path] });
+
+  const router = createRouter({
+    routeTree,
+    history,
+    isServer: false,
+    origin: "https://planner.test",
+  });
+
+  return { router, history };
+};
+
+it("keeps conversation addresses across direct loads, new trips, and browser history", async () => {
+  const { router, history } = setup("/conversations/saved-conversation");
+
+  await router.load();
+  expect(router.state.matches.at(-1)?.params).toEqual({ conversationId: "saved-conversation" });
+  await router.navigate({ to: "/" });
+  const freshPath = history.location.pathname;
+
+  expect(freshPath).toMatch(/^\/conversations\/[a-f0-9-]{36}$/);
+  history.back();
+  await router.load();
+  expect(history.location.pathname).toBe("/conversations/saved-conversation");
+  history.forward();
+  await router.load();
+  expect(history.location.pathname).toBe(freshPath);
+
+  const reloaded = setup(freshPath).router;
+
+  await reloaded.load();
+  expect(reloaded.state.location.pathname).toBe(freshPath);
+  expect(reloaded.state.matches.at(-1)?.params).toEqual({
+    conversationId: freshPath.split("/").at(-1),
+  });
+  await router.navigate({ to: "/" });
+  expect(history.location.pathname).not.toBe(freshPath);
+});
+
+it("rejects malformed conversation URLs and leaves valid unsaved conversations addressable", async () => {
+  for (const id of ["bad%20id", "bad%2Fid", "x".repeat(241)]) {
+    const { router } = setup(`/conversations/${id}`);
+
+    await router.load();
+    expect(router.state.matches.some((match) => match.status === "notFound")).toBe(true);
+  }
+
+  const { router } = setup("/conversations/unfinished");
+
+  await router.load();
+  expect(router.state.matches.at(-1)?.status).toBe("success");
+  expect(router.state.matches.at(-1)?.params).toEqual({ conversationId: "unfinished" });
+});


### PR DESCRIPTION
The travel planner already uses TanStack Start, but selecting a conversation leaves the browser at `/`. Give each conversation a `/conversations/<id>` address so refresh, bookmarks, new tabs, and Back/Forward restore the selected conversation, including plans without a saved itinerary.

Opening `/` starts a fresh conversation URL before the first message. The route seeds and updates the existing Effect Atom selection while preserving its account-scoped cache; malformed IDs show the not-found page. Conversation links remain private to the signed-in account.

```mermaid
flowchart LR
  URL["Conversation URL"] --> Route["TanStack conversation route"]
  Route --> Planner["Planner"]
  Planner --> Selection["Effect Atom selection"]
  Selection --> Query["Existing account/conversation query"]
```

Final UI with local fixture data:

![Travel planner conversation route with fixture trips](https://github.com/user-attachments/assets/99ecc529-4803-4c9c-9e1f-3cd66a51ff83)