### PR TITLE
fix(cloudflare): report browser navigation timeouts accurately

### DIFF
--- a/.changeset/calm-browsers-report.md
+++ b/.changeset/calm-browsers-report.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Report recognized Browser Run navigation timeouts with their provider limit and distinguish Quick Action API statuses from destination page statuses.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -541,6 +541,24 @@ Browser Run API response, not necessarily the destination page. Applications can
 redact and retain these causes for operator diagnostics; they are not automatically exposed to
 models or logged.
 
+Recognized Browser Run navigation timeouts report the provider's elapsed limit in the public
+`PageCaptureNavigationError` message. An API HTTP 422 is not the destination's status and does
+not establish that the destination blocked the request. Unknown provider text stays private.
+
+For JavaScript-rendered pages, choose a content-specific `waitForSelector` with a finite timeout
+alongside the navigation timeout. `domcontentloaded` alone can capture a navigation shell, and
+a heading alone may precede the content being researched. Inspect the returned evidence before
+treating the pass as useful; missing amenities are not evidence of their absence. See Cloudflare's
+[Markdown endpoint](https://developers.cloudflare.com/browser-run/quick-actions/markdown-endpoint/)
+and [independent timeout controls](https://developers.cloudflare.com/browser-run/reference/timeouts/).
+
+Quick Action response readers are canceled and unlocked on local interruption, including an
+outer Effect timeout. The native `quickAction()` binding exposes neither an abort signal nor a
+session handle: interrupting an unresolved RPC stops local waiting but does not confirm remote
+browser termination. Provider navigation/readiness limits remain important. The adapter does not
+retry that RPC. Tests with a scripted binding establish local waiting and reader cleanup only;
+hosted provider lifecycle behavior requires separate live evidence.
+
 The protected Cloudflare binding requests at most ten minutes of provider idle keep-alive,
 independently of the total pass deadline. A longer policy permits active work; it does not promise
 that an idle browser will remain available for the whole hour or reconnect an expired session.

--- a/packages/platform-cloudflare/src/internal/browser-quick-action.ts
+++ b/packages/platform-cloudflare/src/internal/browser-quick-action.ts
@@ -175,6 +175,28 @@ const QuickActionErrorEnvelope = Schema.Struct({
 const QuickActionEnvelope = Schema.Union([QuickActionSuccessEnvelope, QuickActionErrorEnvelope]);
 const decodeEnvelope = Schema.decodeUnknownOption(Schema.fromJsonString(QuickActionEnvelope));
 
+/** Recognize only the provider's exact timeout grammar; never forward arbitrary error text. */
+const navigationFailureMessage = (bodyText: string, response: Response): string => {
+  const fallback = `The Browser Run Quick Action API answered HTTP ${response.status}; the destination status is unknown`;
+
+  if (!isJsonResponse(response)) return fallback;
+  const envelope = decodeEnvelope(bodyText);
+
+  if (Option.isNone(envelope) || envelope.value.success) return fallback;
+  for (const error of envelope.value.errors) {
+    if (error.code !== 6002) continue;
+
+    const timeout = /^Navigation timeout of ([1-9][0-9]{0,5}) ms exceeded$/.exec(
+      error.detail ?? "",
+    );
+
+    if (timeout !== null)
+      return `Browser Run navigation timed out after ${timeout[1]} ms (Quick Action API HTTP ${response.status}); the destination status is unknown`;
+  }
+
+  return fallback;
+};
+
 /** Project the schema-validated request onto Cloudflare's native common options. */
 const quickActionCommonOptions = (request: PageCaptureRequest): BrowserRunCommonOptions => {
   const options: BrowserRunBaseOptions = {};
@@ -419,7 +441,7 @@ const parseOutput = (
   }
   if (!envelope.value.success) {
     return navigationError(
-      "The Quick Action reported a navigation failure",
+      navigationFailureMessage(bodyText, response),
       privateResponseCause(bodyText, response),
     );
   }
@@ -536,7 +558,7 @@ const makeCapture = (
       });
     }
     if (!response.ok) {
-      const message = `The Quick Action answered HTTP ${response.status}`;
+      const message = navigationFailureMessage(bodyText, response);
       const cause = privateResponseCause(bodyText, response);
 
       if (response.status >= 500) {

--- a/packages/platform-cloudflare/test/browser-quick-action.test.ts
+++ b/packages/platform-cloudflare/test/browser-quick-action.test.ts
@@ -25,7 +25,19 @@ import {
   type PageCaptureError,
   type PageCaptureResult,
 } from "@effect-agent/sandbox/PageCapture";
-import { Context, Deferred, Effect, Fiber, Layer, Schema, SchemaGetter, Stream } from "effect";
+import { it as effectIt } from "@effect/vitest";
+import {
+  Context,
+  Deferred,
+  Effect,
+  Fiber,
+  Layer,
+  Option,
+  Schema,
+  SchemaGetter,
+  Stream,
+} from "effect";
+import { TestClock } from "effect/testing";
 import type { Tool } from "effect/unstable/ai";
 import { Toolkit } from "effect/unstable/ai";
 import { describe, expect, expectTypeOf, it } from "vite-plus/test";
@@ -586,7 +598,8 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
 
     expect(navigation).toMatchObject({
       _tag: "PageCaptureNavigationError",
-      message: "The Quick Action answered HTTP 400",
+      message:
+        "The Browser Run Quick Action API answered HTTP 400; the destination status is unknown",
     });
     expect(navigation.message).not.toContain(privateDiagnostic);
     expect(navigation._tag === "PageCaptureNavigationError" && navigation.cause).toMatchObject({
@@ -597,7 +610,8 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
 
     expect(protocol).toMatchObject({
       _tag: "PageCaptureProtocolError",
-      message: "The Quick Action answered HTTP 500",
+      message:
+        "The Browser Run Quick Action API answered HTTP 500; the destination status is unknown",
     });
     expect(protocol.message).not.toContain(privateDiagnostic);
     expect(protocol._tag === "PageCaptureProtocolError" && protocol.cause).toMatchObject({
@@ -608,7 +622,8 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
 
     expect(envelope).toMatchObject({
       _tag: "PageCaptureNavigationError",
-      message: "The Quick Action reported a navigation failure",
+      message:
+        "The Browser Run Quick Action API answered HTTP 200; the destination status is unknown",
     });
     expect(envelope.message).not.toContain(privateDiagnostic);
     expect(envelope._tag === "PageCaptureNavigationError" && envelope.cause).toMatchObject({
@@ -619,6 +634,115 @@ describe("Browser Run Quick Action PageCapture adapter", () => {
       message: expect.stringContaining("valid response envelope"),
     });
   });
+
+  it("reports recognized provider navigation timeouts without exposing arbitrary diagnostics", async () => {
+    for (const status of [200, 422]) {
+      const { binding, calls } = makeBinding([
+        jsonResponse(
+          {
+            success: false,
+            errors: [
+              {
+                code: 6002,
+                message: "private provider detail",
+                detail: "Navigation timeout of 20000 ms exceeded",
+              },
+            ],
+          },
+          { status },
+        ),
+      ]);
+
+      const error = await captureError(binding, request(CapturePageMarkdown.make({})));
+
+      expect(error).toMatchObject({
+        _tag: "PageCaptureNavigationError",
+        message: `Browser Run navigation timed out after 20000 ms (Quick Action API HTTP ${status}); the destination status is unknown`,
+      });
+      expect(error.message).not.toContain("private provider detail");
+      expect(calls).toHaveLength(1);
+    }
+    for (const [code, detail] of [
+      [6002, "Navigation timeout of 20000 ms exceeded; token=private"],
+      [6002, "Navigation timeout of secret ms exceeded"],
+      [1, "Navigation timeout of 20000 ms exceeded"],
+    ] as const) {
+      const { binding } = makeBinding([
+        jsonResponse(
+          { success: false, errors: [{ code, message: "private", detail }] },
+          { status: 422 },
+        ),
+      ]);
+
+      const error = await captureError(binding, request(CapturePageMarkdown.make({})));
+
+      expect(error).toMatchObject({
+        _tag: "PageCaptureNavigationError",
+        message:
+          "The Browser Run Quick Action API answered HTTP 422; the destination status is unknown",
+      });
+    }
+  });
+
+  effectIt.effect(
+    "bounds waiting at the native RPC boundary and releases an acquired response on timeout",
+    () =>
+      Effect.gen(function* () {
+        for (const mode of ["rpc", "response"] as const) {
+          const entered = yield* Deferred.make<void>();
+          let calls = 0;
+          let canceled = false;
+
+          const stream = new ReadableStream<Uint8Array>(
+            {
+              pull() {
+                Effect.runSync(Deferred.succeed(entered, undefined));
+
+                return new Promise<void>(() => {});
+              },
+              cancel() {
+                canceled = true;
+              },
+            },
+            { highWaterMark: 0 },
+          );
+
+          const browser: BrowserRun = {
+            fetch: () => Promise.reject(new Error("Unexpected fetch")),
+            quickAction: () => {
+              calls += 1;
+              if (mode === "response") return Promise.resolve(new Response(stream));
+              Effect.runSync(Deferred.succeed(entered, undefined));
+
+              return new Promise<Response>(() => {});
+            },
+          };
+
+          const fiber = yield* Effect.gen(function* () {
+            const port = yield* PageCapture;
+
+            return yield* port.capture(request(CapturePageMarkdown.make({})));
+          }).pipe(
+            Effect.provide(
+              browserQuickActionCaptureLayer().pipe(
+                Layer.provide(BrowserQuickActionBrowserBinding.layer({ browser })),
+              ),
+            ),
+            Effect.timeoutOption("25 seconds"),
+            Effect.forkChild,
+          );
+
+          yield* Deferred.await(entered);
+          yield* TestClock.adjust("25 seconds");
+          expect(Option.isNone(yield* Fiber.join(fiber))).toBe(true);
+          expect(calls).toBe(1);
+          expect(canceled).toBe(mode === "response");
+          expect(stream.locked).toBe(false);
+          // The pending RPC has no cancellation handle. This establishes local
+          // waiting/reader behavior, not provider browser-session termination.
+        }
+      }),
+  );
 
   it("enforces the output byte budget on the encoded response", async () => {
     const { binding } = makeBinding([jsonResponse({ success: true, result: "x".repeat(4_096) })]);


### PR DESCRIPTION
Browser Run Quick Actions could return a navigation timeout as only “HTTP 422,” hiding the timeout reason and leaving the status ambiguous. Recognize the provider’s exact navigation-timeout format, report its millisecond limit, and identify HTTP statuses as Browser Run API responses. Keep arbitrary provider diagnostics private and preserve typed failures.

Document content-specific readiness waits and the native binding’s cleanup boundary: local interruption stops waiting and releases an acquired response reader, but the binding exposes no abort signal or session handle to confirm remote browser termination. No automatic replay is added.
