### PR TITLE
fix(travel-planner): wait for Airbnb amenity content

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -145,6 +145,27 @@ local hostnames, embedded credentials, and custom ports, and also apply to brows
 and subresources. These are URL checks, not a DNS-resolution firewall. Page-size limits,
 timeouts, and access-challenge handling still apply.
 
+Airbnb listing URLs on `airbnb.com` and `www.airbnb.com` use a 10-second
+`domcontentloaded` navigation limit followed by a 10-second wait for
+`[data-section-id="AMENITIES_DEFAULT"]`. This waits for listing details without depending
+on network quiet. Other sites retain their existing navigation policy. A navigation shell,
+a title/gallery alone, or a heading without a text section is a typed `WebCapturePageUnready`
+failure. A successful result still contains selected source excerpts, not a complete amenity
+inventory: missing amenities remain unverified, and titles or photos alone do not prove them.
+
+Each inspection makes one capture request with a 25-second outer timeout, a 512 KiB capture
+limit, and a 12 KiB result limit. There is no automatic retry or fallback capture. Selector
+changes, incomplete content, access challenges, and provider timeouts can still fail. Browser
+Run API HTTP 422 is not a destination status or proof that Airbnb blocked the request.
+The provider's detailed cause stays in private diagnostics; the published beta.78 adapter
+reports only the generic API status for these navigation timeouts to the model.
+
+Local interruption stops waiting and finalizes an acquired response reader; it does not
+confirm remote browser termination because the native Quick Action binding provides no
+abort signal or session handle. REST captures informed the readiness policy. Local tests
+exercise the published adapter with scripted binding responses, not the hosted provider's
+lifecycle.
+
 ## Deploy with Alchemy
 
 The app pins published `0.1.0-beta.78` packages, including JSON persistence,

--- a/examples/travel-planner/src/research.ts
+++ b/examples/travel-planner/src/research.ts
@@ -7,6 +7,7 @@ import {
   PageCaptureRequest,
   PageNavigationOptions,
   PageResourcePolicy,
+  PageSelectorWait,
   PageUrlTarget,
   type PageCaptureError,
 } from "@effect-agent/sandbox/PageCapture";
@@ -74,7 +75,7 @@ export const ReadTravelPageResult = Schema.Struct({
 );
 
 export const ReadTravelPage = Tool.make("read_travel_page", {
-  description: `${PreviousReadTravelPage.description} Includes up to four image references from the inspected page when available. These are untrusted source photo candidates, not proof of amenities; use only images relevant to this listing.`,
+  description: `${PreviousReadTravelPage.description} Includes up to four image references from the inspected page when available. These are untrusted source photo candidates, not proof of amenities; use only images relevant to this listing. A successful read contains excerpts, not a complete amenity inventory. Missing amenities remain unverified, and titles or photos alone do not establish them.`,
   parameters: ReadTravelPageParameters,
   success: ReadTravelPageResult,
   failure: WebCaptureFailure,
@@ -215,11 +216,38 @@ const excerptsFor = (markdown: string, focus: string) => {
   return selected;
 };
 
+// A selector wait can still return incomplete content. Require a listing heading
+// and a text section beyond the gallery; this does not certify every amenity.
+const AirbnbListingContent = Schema.String.check(
+  Schema.isPattern(/^#[ \t]+\S[^\n]*\n[\s\S]*^##[ \t]+\S[^\n]*\n+(?![#\s!]|\[)\S/m),
+);
+
 const inspect = Effect.fn("TravelResearch.inspect")(function* (
   parameters: typeof ReadTravelPageParameters.Type,
   toolCallId?: string,
 ) {
   const started = yield* Clock.currentTimeMillis;
+  const decoded = decodeUrl(parameters.url);
+
+  const airbnbListing =
+    Option.isSome(decoded) &&
+    ["airbnb.com", "www.airbnb.com"].includes(decoded.value.hostname) &&
+    /^\/rooms\/[0-9]+\/?$/.test(decoded.value.pathname);
+
+  // Network quiet and the listing title can precede useful amenity content.
+  // Keep this site-specific readiness policy out of the general capture adapter.
+  const navigation = PageNavigationOptions.make(
+    airbnbListing
+      ? {
+          waitUntil: "domcontentloaded",
+          timeoutMillis: 10_000,
+          waitForSelector: PageSelectorWait.make({
+            selector: '[data-section-id="AMENITIES_DEFAULT"]',
+            timeoutMillis: 10_000,
+          }),
+        }
+      : { waitUntil: "networkidle2", timeoutMillis: 20_000 },
+  );
 
   const report = (category: string, data: unknown) =>
     Effect.flatMap(Clock.currentTimeMillis, (now) =>
@@ -232,8 +260,9 @@ const inspect = Effect.fn("TravelResearch.inspect")(function* (
             provider: "cloudflare-browser-run",
             action: "markdown",
             engine: "chromium",
-            waitUntil: "networkidle2",
-            navigationTimeoutMs: 20_000,
+            waitUntil: navigation.waitUntil,
+            navigationTimeoutMs: navigation.timeoutMillis,
+            waitForSelector: navigation.waitForSelector,
             overallTimeoutMs: 25_000,
             maxOutputBytes: 512 * 1_024,
           },
@@ -245,8 +274,6 @@ const inspect = Effect.fn("TravelResearch.inspect")(function* (
         },
       ),
     );
-
-  const decoded = decodeUrl(parameters.url);
 
   if (Option.isNone(decoded)) {
     yield* report("url-policy", {
@@ -271,10 +298,7 @@ const inspect = Effect.fn("TravelResearch.inspect")(function* (
         action: CapturePageMarkdown.make({}),
         engine: "chromium",
         limits: PageCaptureLimits.make({ maxOutputBytes: 512 * 1_024 }),
-        navigation: PageNavigationOptions.make({
-          waitUntil: "networkidle2",
-          timeoutMillis: 20_000,
-        }),
+        navigation,
         resourcePolicy,
       }),
     )
@@ -287,7 +311,10 @@ const inspect = Effect.fn("TravelResearch.inspect")(function* (
           report("timeout", { timeoutMs: 25_000 }).pipe(
             Effect.andThen(
               Effect.fail(
-                failure("WebCaptureTimeout", "Page inspection timed out. Try another source."),
+                failure(
+                  "WebCaptureTimeout",
+                  "Page inspection exceeded its 25-second overall limit. The destination status is unknown; use another source.",
+                ),
               ),
             ),
           ),
@@ -318,6 +345,21 @@ const inspect = Effect.fn("TravelResearch.inspect")(function* (
     return yield* failure(
       "WebCapturePageUnavailable",
       `The page ${category === "empty-page" ? "returned no text" : category === "page-not-found" ? "shows a not-found message" : "shows an access challenge"}. It was not inspected; use another source.`,
+    );
+  }
+
+  if (airbnbListing && !Schema.is(AirbnbListingContent)(markdown)) {
+    yield* report("unready-page", {
+      evidence: "rendered-page-text",
+      destinationHttpStatus: null,
+      pageText: markdown,
+      resourceUse: result.resourceUse,
+      implementation: result.implementation,
+    });
+
+    return yield* failure(
+      "WebCapturePageUnready",
+      "The listing content did not finish loading. Its title or photos alone do not verify amenities; use another source.",
     );
   }
 

--- a/examples/travel-planner/test/research.test.ts
+++ b/examples/travel-planner/test/research.test.ts
@@ -1,5 +1,6 @@
 import { WebCaptureFailure } from "@effect-agent/capabilities/WebCapture";
 import { ToolExecutionClass } from "@effect-agent/engine/DurableStep";
+import { CloudflareBrowser } from "@effect-agent/platform-cloudflare/CloudflareBrowser";
 import {
   PageCapture,
   PageCaptureNavigationError,
@@ -107,6 +108,96 @@ it.effect("keeps deep amenity evidence from a large page within the encoded resu
     expect(second.result).toEqual(first.result);
     expect(yield* Ref.get(calls)).toBe(2);
   }),
+);
+
+it.effect("waits for Airbnb amenity content through the published Browser Run adapter", () =>
+  Effect.gen(function* () {
+    for (const [id, title] of [
+      ["11960125", "Coastal Cabin, with king bed, big deck, hot tub"],
+      ["12269624", "Romantic Retreat with hot tub near the beach!"],
+    ]) {
+      const url = `https://www.airbnb.com/rooms/${id}`;
+      const markdown = `# ${title}\n\n![](https://a0.muscache.com/pictures/cabin.jpg)\n\n## What this place offers\n\nKitchen\n\nPrivate hot tub\n\nWifi`;
+      let calls = 0;
+
+      const browser: BrowserRun = {
+        fetch: () => Promise.reject(new Error("Unexpected fetch")),
+        quickAction: (action, options) => {
+          calls += 1;
+          expect(action).toBe("markdown");
+          expect(options).toMatchObject({
+            url,
+            gotoOptions: { waitUntil: "domcontentloaded", timeout: 10_000 },
+            waitForSelector: {
+              selector: '[data-section-id="AMENITIES_DEFAULT"]',
+              timeout: 10_000,
+            },
+            rejectResourceTypes: ["image", "media", "font"],
+          });
+
+          return Promise.resolve(Response.json({ success: true, result: markdown }));
+        },
+      };
+
+      const result = yield* read({ ...parameters, url }).pipe(
+        Effect.provide(CloudflareBrowser.layer({ handlers: ReadTravelPageLive }, { browser })),
+      );
+
+      expect(result.isFailure).toBe(false);
+      const inspected = yield* Schema.decodeUnknownEffect(ReadTravelPageResult)(result.result);
+
+      expect(inspected.title).toBe(title);
+      expect(inspected.photos).toHaveLength(1);
+      expect(inspected.excerpts.join("\n")).toContain("Private hot tub");
+      expect(new TextEncoder().encode(JSON.stringify(inspected)).byteLength).toBeLessThanOrEqual(
+        12 * 1_024,
+      );
+      expect(calls).toBe(1);
+    }
+  }),
+);
+
+it.effect(
+  "rejects Airbnb navigation shells and title galleries without replaying the capture",
+  () =>
+    Effect.gen(function* () {
+      const captured = yield* Ref.make<FailureDiagnostic[]>([]);
+
+      const diagnostics = Layer.succeed(FailureDiagnostics, {
+        append: (value) => Ref.update(captured, (values) => [...values, value]),
+        list: Effect.succeed([]),
+      });
+
+      for (const markdown of [
+        "[Airbnb homepage](/)\n\nHomesHomesExperiencesExperiencesServicesServices\n\nStart your search\n\nAnywhere Anytime Add guests\n\n[Log in or sign up](https://www.airbnb.com/signup_login)",
+        "# Coastal Cabin, with king bed, big deck, hot tub\n\nShare\n\nSave\n\n![](https://a0.muscache.com/pictures/cabin.jpg)\n\nShow all photos\n\n# Help us improve your experience\n\nWe use cookies and other technologies.",
+        "# Cabin\n\n## What this place offers\n\n",
+      ]) {
+        const calls = yield* Ref.make(0);
+
+        const result = yield* read({
+          ...parameters,
+          url: "https://www.airbnb.com/rooms/11960125",
+        }).pipe(
+          provideCapture(() =>
+            Ref.update(calls, (count) => count + 1).pipe(Effect.as(page(markdown))),
+          ),
+          Effect.provide(diagnostics),
+        );
+
+        expect(result).toMatchObject({
+          isFailure: true,
+          result: { errorTag: "WebCapturePageUnready" },
+        });
+        expect(yield* Ref.get(calls)).toBe(1);
+        const diagnostic = (yield* Ref.get(captured)).at(-1);
+
+        expect(diagnostic?.operation).toBe("read_travel_page: unready-page");
+        expect(diagnostic?.text).toContain("domcontentloaded");
+        expect(diagnostic?.text).toContain("AMENITIES_DEFAULT");
+        expect(diagnostic?.text).toContain('"destinationHttpStatus": null');
+      }
+    }),
 );
 
 it.effect("inspects newly discovered sites and CDNs without a travel-site allowlist", () =>
@@ -292,7 +383,10 @@ it.effect("times out a stalled capture and completes its finalizer", () =>
     yield* TestClock.adjust("26 seconds");
     expect(yield* Fiber.join(fiber)).toMatchObject({
       isFailure: true,
-      result: { errorTag: "WebCaptureTimeout" },
+      result: {
+        errorTag: "WebCaptureTimeout",
+        message: expect.stringContaining("25-second overall limit"),
+      },
     });
     expect(yield* Ref.get(closed)).toBe(true);
   }),


### PR DESCRIPTION
Airbnb listing reads could time out while waiting for network quiet, while an early DOM/title capture could return only navigation or a photo gallery. For Airbnb room URLs, use a bounded DOM-content navigation followed by a wait for the amenity section. Reject navigation-only and title/gallery-only content with a typed unready failure, retain bounded source excerpts and photos, and leave missing amenities unverified.

Keep the existing public-HTTPS resource policy, output budgets, 25-second outer timeout, and single capture with no automatic replay. This policy is based on REST captures; site changes and provider timeouts can still fail, and local response cleanup does not confirm remote browser termination. A title-only selector was rejected because it omitted amenity evidence.

The demo continues to consume exact published beta.78 packages. The separate library improvement in #436 exposes sanitized navigation-timeout details; adopting that improvement requires a later published release and a separate dependency upgrade. No deployment or package publication is included.
