### PR TITLE
fix(release): keep demo outside library versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -34,5 +34,6 @@
     "tag": false
   },
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []
 }

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,6 @@
     },
     "examples/travel-planner": {
       "name": "@effect-agent/example-travel-planner",
-      "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "catalog:",
         "@cloudflare/sandbox": "catalog:",

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -160,6 +160,9 @@ retain a cached preview after a deployment.
 
 All fifteen public packages share one Changesets fixed group and publish to `beta`
 as `X.Y.Z-beta.N`. Keep the group in `.changeset/config.json` aligned with public workspaces.
+The travel planner is a private application with no package version. It does not receive
+changesets, version bumps, changelogs, package tags, or npm releases. Private-package versioning
+and tagging remain disabled in the Changesets configuration.
 Changesets updates internal dependency ranges only when they use `workspace:`. Exact registry
 pins, including the travel planner's published Effect Agent dependencies, stay unchanged during
 versioning. Upgrade those consumers separately after publication; otherwise the version task's

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -160,6 +160,10 @@ retain a cached preview after a deployment.
 
 All fifteen public packages share one Changesets fixed group and publish to `beta`
 as `X.Y.Z-beta.N`. Keep the group in `.changeset/config.json` aligned with public workspaces.
+Changesets updates internal dependency ranges only when they use `workspace:`. Exact registry
+pins, including the travel planner's published Effect Agent dependencies, stay unchanged during
+versioning. Upgrade those consumers separately after publication; otherwise the version task's
+install would request packages that have not been published yet.
 The project is in prerelease mode. Leaving it requires an explicit release decision and
 `vp run changeset pre exit`.
 

--- a/examples/travel-planner/package.json
+++ b/examples/travel-planner/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@effect-agent/example-travel-planner",
-  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Library versioning rewrote the travel planner’s exact npm dependencies to an unpublished prerelease, causing the version task’s install to fail. Keep the private demo versionless and restrict Changesets dependency updates to explicit `workspace:` references so library release preparation leaves the demo unchanged.

The demo has no changesets, version bumps, changelogs, package tags, or npm releases. Its dependency upgrades happen separately after the libraries are published.
