### PR TITLE
feat(cloudflare): host threads in an application Durable Object

### DIFF
--- a/.changeset/shared-application-owner.md
+++ b/.changeset/shared-application-owner.md
@@ -1,0 +1,6 @@
+---
+"@effect-agent/platform-cloudflare": patch
+"@effect-agent/storage-cloudflare": patch
+---
+
+Host multiple logical Threads inside an application Durable Object using its existing SQL client and one shared alarm, with addressed controls, recovery across local lanes, and isolated native migration history. **BEHAVIOR CHANGE:** Define custom `ThreadObjectNamespace` services with `get(threadId)` to resolve each logical endpoint.

--- a/docs/platforms/cloudflare.md
+++ b/docs/platforms/cloudflare.md
@@ -229,6 +229,45 @@ They are captured when the Object acquires the runtime, not on each worker call.
 Use `options.eventLayer` for per-event observability and resources. Use
 `options.toolFailureObserver` for [recovered tool failures](../guide/run-agents#observe-recovered-tool-failures).
 
+### Share an application Object
+
+Use `ThreadObject.layerInHost(application)` when an existing SQLite Durable Object owns related
+logical Threads. The application Layer receives the existing `SqlClient`, native stores,
+`ThreadMutationGate`, wake scheduler, and `PreparedInputAdmission`. Build its Bindings from those
+services and return `DurableAgentRuntime` plus the application's services. The platform then
+constructs one maintenance coordinator from that runtime. Do not construct a second runtime or
+require `ThreadMaintenance` while building the application.
+
+Supply `ThreadObject.layerHostConfig(options, ownsThread)`, `DurableObjectContext`, and
+`ThreadObjectNamespace`. The namespace's `get(threadId)` returns a bound logical endpoint;
+its methods call the application's RPC with the selected Thread ID and native encoded payload.
+The receiver dispatches with `ThreadObject.handleRpc(threadId, operation, encoded)`. Direct local
+admission uses `ThreadObject.submit(threadId, decodedRequest)` and the same validation and prearm.
+The [shared-owner example](https://github.com/danieljvdm/effect-agent/blob/main/packages/platform-cloudflare/examples/shared-owner.ts) composes
+an existing SQL client, application services and an optional projection without external requirements.
+
+Placement must be deterministic and stable across reconstruction. It grants no access: authenticate
+callers and validate membership at the application's boundary. Encoded controls additionally check
+the addressed Thread against the local receipt or submission before routed runtime access. No
+logical `ThreadObjectIdentity` is installed globally; addressed dispatch binds it per invocation.
+The producer identity belongs to the physical Object. Native Thread and receipt identities remain
+unchanged. Moving existing Threads between physical Objects requires a host-owned fenced transfer;
+changing the resolver alone does not move their durable records.
+
+Own one `SqlClient`, `ThreadMutationGate` and alarm slot per physical Object. Native migrations use
+their own migration history, leaving the application's migration rows intact. Call
+`ThreadMaintenance.ensureAlarm` in the local constructor gate and one bounded
+`ThreadMaintenance.pass` from `alarm()`. A pass recovers all local lanes and serves one eligible
+FIFO head, with a durable cursor rotating between Threads. Later work retains the alarm.
+
+Application outboxes can supply `ThreadHostMaintenance` from the application Layer. Its
+`pendingDeadline` is a bounded, local, read-only earliest deadline. `drainUntil(finished)` runs
+beside native work, completes one initial bounded wave even if already signalled, stops starting
+new waves after the signal, and finishes the current wave before returning. Native maintenance
+joins it before acknowledging a generation. Every accepted host mutation must use the shared
+`ThreadMutationGate`; hooks must not write the raw alarm slot. Typed failures and defects retain
+the prearmed generation; event interruption closes scoped work and leaves durable recovery pending.
+
 ### Publish durable host activity
 
 Use the optional publication Layer to deliver canonical records or durable approval, abort, and

--- a/packages/platform-cloudflare/examples/scheduling.ts
+++ b/packages/platform-cloudflare/examples/scheduling.ts
@@ -22,7 +22,11 @@ export const makeSchedulingOwner = <E>(
       authorizer,
       Layer.effect(
         ThreadObjectNamespace,
-        Effect.map(WorkerEnvironment, (env) => ({ namespace: env.THREADS })),
+        Effect.map(WorkerEnvironment, (env) =>
+          ThreadObjectNamespace.of({
+            get: (threadId) => env.THREADS.get(env.THREADS.idFromName(threadId)),
+          }),
+        ),
       ),
     ),
   );

--- a/packages/platform-cloudflare/examples/shared-owner.ts
+++ b/packages/platform-cloudflare/examples/shared-owner.ts
@@ -1,0 +1,62 @@
+import { type ThreadId } from "@effect-agent/core/Identifiers";
+import { type ResolvedBinding } from "@effect-agent/thread/AgentRegistration";
+import { DurableAgentRuntime } from "@effect-agent/thread/DurableAgentRuntime";
+import { PreparedInputAdmission } from "@effect-agent/thread/PreparedInputAdmission";
+import { ThreadProjectionMaintenance } from "@effect-agent/thread/ThreadProjectionMaintenance";
+import { ThreadStore } from "@effect-agent/thread/ThreadStore";
+import { SqliteClient } from "@effect/sql-sqlite-do";
+import { Context, Effect, Layer, ManagedRuntime } from "effect";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+
+import { ThreadMutationGate } from "../src/Alarm.ts";
+import { DurableObjectContext, ThreadObjectNamespace } from "../src/CloudflareBindings.ts";
+import * as ThreadObject from "../src/ThreadObject.ts";
+
+/** An application service acquired from the same ports its Bindings use. */
+class LocalReads extends Context.Service<LocalReads, { readonly store: ThreadStore["Service"] }>()(
+  "shared-owner/LocalReads",
+) {}
+
+/**
+ * Build once per physical incarnation. The host routes each logical Thread deterministically,
+ * calls handleRpc with that identity, and owns one bounded ThreadMaintenance.pass per alarm.
+ */
+export const sharedOwnerRuntime = (
+  state: DurableObjectState,
+  environment: unknown,
+  namespace: ThreadObjectNamespace["Service"],
+  ownsThread: (threadId: ThreadId) => boolean,
+  bindings: ReadonlyArray<ResolvedBinding>,
+) => {
+  const localReads = Layer.effect(LocalReads)(Effect.map(ThreadStore, (store) => ({ store })));
+  const projection = Layer.merge(ThreadProjectionMaintenance.layer, localReads);
+
+  const application = Layer.unwrap(
+    Effect.gen(function* () {
+      // Each service is supplied by layerInHost before the application is constructed.
+      yield* SqlClient;
+      yield* PreparedInputAdmission;
+      yield* ThreadMutationGate;
+      yield* LocalReads;
+
+      return DurableAgentRuntime.layerWithBindings(bindings);
+    }),
+  );
+
+  const platform = Layer.merge(
+    DurableObjectContext.layer(state, environment),
+    Layer.succeed(ThreadObjectNamespace, namespace),
+  );
+
+  return ManagedRuntime.make(
+    ThreadObject.layerInHost(application, { projection }).pipe(
+      Layer.provideMerge(SqliteClient.layer({ storage: state.storage })),
+      Layer.provideMerge(
+        ThreadObject.layerHostConfig(
+          { deploymentId: "application", producerPrefix: "application" },
+          ownsThread,
+        ).pipe(Layer.provideMerge(platform)),
+      ),
+    ),
+  );
+};

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -1,3 +1,4 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
 import { type DurableBindingFailure } from "@effect-agent/thread/AgentRegistration";
 import {
   DurableAgentRuntime,
@@ -28,7 +29,7 @@ import {
   Stream,
 } from "effect";
 
-import { ThreadObjectIdentity, DurableObjectContext } from "./CloudflareBindings.ts";
+import { DurableObjectContext } from "./CloudflareBindings.ts";
 import { CloudflareDurableRuntimeConfig } from "./CloudflareConfig.ts";
 import { safeCauseMessage } from "./internal/boundary.ts";
 
@@ -188,6 +189,8 @@ export type ThreadMaintenanceFailpointLocation =
   | "maintenance:ensure:after"
   | "maintenance:begin:before"
   | "maintenance:begin:after"
+  | "maintenance:select:before"
+  | "maintenance:select:after"
   | "maintenance:finish:before"
   | "maintenance:finish:after";
 
@@ -255,6 +258,26 @@ export const ThreadMessageDelivery = Context.Reference<{
   defaultValue: () => ({ drain: Effect.void, pendingDeadline: Effect.succeed(Option.none()) }),
 });
 
+/**
+ * Application obligations sharing this Object's alarm. The deadline read is local and
+ * read-only. Drain beside the native Attempt and always finish one initial bounded wave,
+ * even when `finished` was already signalled. Then stop starting new waves on that signal
+ * and finish the bounded current wave before returning. Native maintenance joins that work
+ * before acknowledging a generation. Mutations use the same ThreadMutationGate; hooks never
+ * write the raw alarm slot. Pending host work does not defer a ready model Attempt.
+ */
+export const ThreadHostMaintenance = Context.Reference<{
+  readonly pendingDeadline: Effect.Effect<Option.Option<number>, DurableAlarmError>;
+  readonly drainUntil: (
+    finished: Deferred.Deferred<void>,
+  ) => Effect.Effect<void, DurableAlarmError>;
+}>("@effect-agent/platform-cloudflare/ThreadHostMaintenance", {
+  defaultValue: () => ({
+    pendingDeadline: Effect.succeed(Option.none()),
+    drainUntil: () => Effect.void,
+  }),
+});
+
 const earliestDeadline = (
   left: Option.Option<number>,
   right: Option.Option<number>,
@@ -290,6 +313,8 @@ class ThreadMaintenanceState extends Schema.Class<ThreadMaintenanceState>(
   dirty: MaintenanceGeneration,
   processed: MaintenanceGeneration,
   nonterminal: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  /** One physical-owner cursor; old single-lane records need no conversion. */
+  lastServedThreadId: Schema.optionalKey(ThreadId),
 }) {}
 
 const MAINTENANCE_STATE_KEY = "effect-agent:thread-maintenance:v1";
@@ -482,7 +507,6 @@ export class ThreadMaintenance extends Context.Service<
     | DurableAlarmService
     | ThreadMaintenanceFailpoint
     | CloudflareDurableRuntimeConfig
-    | ThreadObjectIdentity
     | DurableObjectContext
   > = Layer.effect(ThreadMaintenance)(
     Effect.gen(function* () {
@@ -490,7 +514,6 @@ export class ThreadMaintenance extends Context.Service<
       const ledger = yield* SubmissionLedger;
       const alarm = yield* DurableAlarmService;
       const config = yield* CloudflareDurableRuntimeConfig;
-      const identity = yield* ThreadObjectIdentity;
       const { ctx } = yield* DurableObjectContext;
       const failpoint = yield* ThreadMaintenanceFailpoint;
 
@@ -503,6 +526,7 @@ export class ThreadMaintenance extends Context.Service<
       const publication = yield* ThreadPublication;
       const projection = yield* ThreadProjectionMaintenance;
       const messages = yield* ThreadMessageDelivery;
+      const host = yield* ThreadHostMaintenance;
 
       // A broken disposable index still needs a retry alarm and must not prevent startup.
       const projectionDeadline = projection.pendingDeadline.pipe(
@@ -518,7 +542,7 @@ export class ThreadMaintenance extends Context.Service<
       const pendingDeadline = Effect.gen(function* () {
         return earliestDeadline(
           earliestDeadline(yield* publication.pendingDeadline, yield* messages.pendingDeadline),
-          yield* projectionDeadline,
+          earliestDeadline(yield* projectionDeadline, yield* host.pendingDeadline),
         );
       });
 
@@ -643,8 +667,13 @@ export class ThreadMaintenance extends Context.Service<
           messages.drainUntil?.(deliveryFinished) ?? messages.drain,
         );
 
+        const hostWork = yield* Effect.forkChild(host.drainUntil(deliveryFinished));
+
         const finishDelivery = Deferred.succeed(deliveryFinished, undefined).pipe(
-          Effect.andThen(Fiber.join(delivery)),
+          Effect.andThen(Fiber.awaitAll([delivery, hostWork])),
+          Effect.flatMap((outcomes) =>
+            Effect.forEach(outcomes, (outcome) => outcome, { discard: true }),
+          ),
         );
 
         // Capture derived-index failures until canonical work has had its turn. Interruption
@@ -717,24 +746,72 @@ export class ThreadMaintenance extends Context.Service<
         }
         // Step 2 — reconciliation strictly precedes new work in this pass (exit gate).
         const recovered: ReadonlyArray<RecoveryReport> = yield* runtime.runRecovery;
-        // One head Attempt per event. The runtime yields after a committed turn when the
-        // soft deadline is reached; queued followers belong to a subsequent alarm.
-        const settlement = yield* runtime.processThreadHead(identity.threadId, { yieldAfter });
+        const reports = new Map(recovered.map((report) => [report.submissionId, report]));
+        const current = yield* Stream.runCollect(ledger.scanNonterminal);
+        const heads = new Map<ThreadId, SubmissionSnapshot>();
+
+        for (const row of current) {
+          if (!heads.has(row.threadId)) heads.set(row.threadId, row);
+        }
+
+        const eligible = [...heads.values()]
+          .filter((head) => !stableExternalWait(head, reports))
+          .map((head) => head.threadId)
+          .sort();
+
+        let selected = eligible[0];
+
+        if (heads.size > 1 && selected !== undefined) {
+          yield* failpoint.hit("maintenance:select:before");
+          selected = yield* runTransaction("select maintenance lane", () =>
+            ctx.storage.transaction(async (transaction) => {
+              const { state } = await readMaintenanceState(transaction);
+
+              const next =
+                eligible.find(
+                  (threadId) =>
+                    state.lastServedThreadId === undefined || threadId > state.lastServedThreadId,
+                ) ?? eligible[0];
+
+              if (next !== undefined) {
+                // Persist before the Attempt so an eviction or repeated yield cannot
+                // monopolize the first lane. The generation and prearmed alarm survive.
+                await transaction.put(
+                  MAINTENANCE_STATE_KEY,
+                  encodeMaintenanceState(
+                    ThreadMaintenanceState.make({ ...state, lastServedThreadId: next }),
+                  ),
+                );
+              }
+
+              return next;
+            }),
+          );
+          yield* failpoint.hit("maintenance:select:after");
+        }
+
+        // One FIFO head per event, across all local lanes. The runtime keeps its normal
+        // bounded Attempt and recovery contracts; followers belong to another alarm.
+        const settlement =
+          selected === undefined
+            ? Option.none()
+            : yield* runtime.processThreadHead(selected, { yieldAfter });
 
         yield* finishDelivery;
         if (Exit.isFailure(projected)) return yield* Effect.failCause(projected.cause);
         // Observe residual state before acknowledging this exact pass-start generation.
         const remaining = yield* Stream.runCollect(ledger.scanNonterminal);
-        const reports = new Map(recovered.map((report) => [report.submissionId, report]));
-        const head = remaining[0];
-        const headWaiting = head !== undefined && stableExternalWait(head, reports);
+        const waitingHeads = new Map<ThreadId, boolean>();
 
-        const autonomous = remaining.some((snapshot, index) => {
+        const autonomous = remaining.some((snapshot) => {
+          const headWaiting = waitingHeads.get(snapshot.threadId);
+
+          if (headWaiting === undefined)
+            waitingHeads.set(snapshot.threadId, stableExternalWait(snapshot, reports));
           // FIFO followers cannot execute through a stable external wait. Only plain queued
           // input is dormant here; admission repairs and accepted aborts still need a pass.
           if (
-            index > 0 &&
-            headWaiting &&
+            headWaiting === true &&
             snapshot.state === "ready" &&
             reports.get(snapshot.submissionId)?.decision._tag === "ApplyInput"
           )

--- a/packages/platform-cloudflare/src/CloudflareBindings.ts
+++ b/packages/platform-cloudflare/src/CloudflareBindings.ts
@@ -52,15 +52,18 @@ export interface ThreadObjectRpc extends Rpc.DurableObjectBranded {
   wake(): Promise<void>;
 }
 
+/** A logical Thread endpoint may be bound to an application Object without forging its brand. */
+export type ThreadObjectClient = Omit<ThreadObjectRpc, keyof Rpc.DurableObjectBranded>;
+
 /**
- * The `DurableObjectNamespace` binding that addresses Thread Objects. The Object
- * identity rule is `namespace.idFromName(threadId)` (plan §1.2): Thread IDs are
- * globally unique, so the mapping is total and deterministic and no directory service exists.
+ * Deterministic logical Thread placement. The native adapter uses `idFromName(threadId)`;
+ * a shared application owner can bind that logical identity into its RPC adapter instead.
+ * Lookup performs no I/O and grants no authority. Every call resolves its target afresh.
  */
 export class ThreadObjectNamespace extends Context.Service<
   ThreadObjectNamespace,
   {
-    readonly namespace: DurableObjectNamespace<ThreadObjectRpc>;
+    readonly get: (threadId: ThreadId) => ThreadObjectClient;
     /** Stable binding name for opted-in native RPC tracing; absent by default. */
     readonly rpcTracing?: string;
   }
@@ -70,7 +73,7 @@ export class ThreadObjectNamespace extends Context.Service<
     options: { readonly rpcTracing?: string } = {},
   ): Layer.Layer<ThreadObjectNamespace> {
     return Layer.succeed(ThreadObjectNamespace)({
-      namespace,
+      get: (threadId) => namespace.get(namespace.idFromName(threadId)),
       ...(options.rpcTracing === undefined ? {} : { rpcTracing: options.rpcTracing }),
     });
   }
@@ -135,7 +138,7 @@ export const threadNamespaceLayer = (
 ): Layer.Layer<ThreadObjectNamespace, CloudflareBindingError> =>
   Layer.effect(ThreadObjectNamespace)(
     Effect.map(threadNamespaceFromEnv(env, binding), (namespace) => ({
-      namespace,
+      get: (threadId) => namespace.get(namespace.idFromName(threadId)),
       ...(options.rpcTracing === true ? { rpcTracing: binding } : {}),
     })),
   );
@@ -169,3 +172,9 @@ export class ThreadObjectIdentity extends Context.Service<
     readonly producerId: ProducerId;
   }
 >()("@effect-agent/platform-cloudflare/ThreadObjectIdentity") {}
+
+/** Logical Threads whose canonical stores and admission ledger live in this physical Object. */
+export class ThreadObjectPlacement extends Context.Service<
+  ThreadObjectPlacement,
+  { readonly ownsThread: (threadId: ThreadId) => boolean }
+>()("@effect-agent/platform-cloudflare/ThreadObjectPlacement") {}

--- a/packages/platform-cloudflare/src/CloudflareThreadClient.ts
+++ b/packages/platform-cloudflare/src/CloudflareThreadClient.ts
@@ -445,12 +445,12 @@ export class CloudflareThreadClient extends Context.Service<
     ThreadObjectNamespace | Crypto.Crypto
   > = Layer.effect(CloudflareThreadClient)(
     Effect.gen(function* () {
-      const { namespace, rpcTracing } = yield* ThreadObjectNamespace;
+      const { get, rpcTracing } = yield* ThreadObjectNamespace;
       const crypto = yield* Crypto.Crypto;
 
       const call = Effect.fn(
         function* (
-          threadId: string,
+          threadId: ThreadId,
           operation: keyof typeof hostRpcMethods,
           encoded: unknown,
         ): Effect.fn.Return<HostResponse, ThreadClientError | HostProtocolError> {
@@ -460,7 +460,7 @@ export class CloudflareThreadClient extends Context.Service<
 
           const raw = yield* Effect.tryPromise({
             try: () => {
-              const stub = namespace.get(namespace.idFromName(threadId));
+              const stub = get(threadId);
 
               return stub[hostRpcMethods[operation]](encoded, ...traceArgs);
             },

--- a/packages/platform-cloudflare/src/ThreadObject.ts
+++ b/packages/platform-cloudflare/src/ThreadObject.ts
@@ -1,9 +1,14 @@
-import { type AgentId } from "@effect-agent/core/Identifiers";
+import { type AgentId, type ThreadId } from "@effect-agent/core/Identifiers";
 import { SubmissionId } from "@effect-agent/core/Identifiers";
 import {
   decodePortRequest,
   encodePortResponse,
+  LedgerLookupResult,
+  PortFailed,
+  PortProtocolError,
+  PortSucceeded,
   type PortRequest,
+  type PortResponse,
 } from "@effect-agent/storage-cloudflare/PortProtocol";
 import {
   IntegrityReport,
@@ -16,6 +21,7 @@ import {
 import { DigestError } from "@effect-agent/thread/Digest";
 import {
   DurableAgentRuntime,
+  DurableRuntimeConfig,
   RecoveryReport,
   type DurableSubmitAgent,
 } from "@effect-agent/thread/DurableAgentRuntime";
@@ -55,10 +61,13 @@ import {
   ThreadMaintenance,
   DurableAlarmError,
   DurableAlarmService,
+  ThreadMutationGate,
+  publishCommitted,
   type MaintenancePassFailure,
 } from "./Alarm.ts";
 import {
   ThreadObjectIdentity,
+  ThreadObjectPlacement,
   DurableObjectContext,
   ThreadObjectNamespace,
   threadNamespaceFromEnv,
@@ -89,6 +98,7 @@ import {
   encodeHostResponse,
   type HostFailure,
   type HostResponse,
+  type SubmitRequest,
 } from "./CloudflareThreadClient.ts";
 import {
   layerConfig,
@@ -103,6 +113,9 @@ import { ProgressWaitRegistry } from "./internal/progress-wait.ts";
 export {
   layer,
   layerConfig,
+  layerHostConfig,
+  layerInHost,
+  ThreadObjectPorts,
   type ThreadPublicationOptions as PublicationOptions,
   type CloudflareDurableRuntimeOptions as RuntimeOptions,
   type CloudflareDurableRuntimeServices as Services,
@@ -231,19 +244,21 @@ const utf8Bytes = (value: PersistedJson): number =>
  * exempt: its accepted-work obligation already exists, and returning the original Receipt
  * consumes no new quota. Refusals are typed `AdmissionLimitExceeded` and nothing is written.
  */
-const gateAdmissionLimits = Effect.fn("ThreadObject.gateAdmissionLimits")(function* (request: {
-  readonly principal: SubmissionLookupByKey["principal"];
-  readonly idempotencyKey: SubmissionLookupByKey["idempotencyKey"];
-  readonly inputPayload: PersistedJson;
-}) {
-  const identity = yield* ThreadObjectIdentity;
+const gateAdmissionLimits = Effect.fn("ThreadObject.gateAdmissionLimits")(function* (
+  threadId: ThreadId,
+  request: {
+    readonly principal: SubmissionLookupByKey["principal"];
+    readonly idempotencyKey: SubmissionLookupByKey["idempotencyKey"];
+    readonly inputPayload: PersistedJson;
+  },
+) {
   const config = yield* CloudflareDurableRuntimeConfig;
   const ledger = yield* SubmissionLedger;
   const { ctx } = yield* DurableObjectContext;
 
   const existing = yield* ledger.lookup(
     SubmissionLookupByKey.make({
-      threadId: identity.threadId,
+      threadId,
       principal: request.principal,
       idempotencyKey: request.idempotencyKey,
     }),
@@ -261,8 +276,10 @@ const gateAdmissionLimits = Effect.fn("ThreadObject.gateAdmissionLimits")(functi
     });
   }
 
-  // One Thread per Object (durability §5): the local scan IS this lane's queue.
-  const nonterminal = yield* Stream.runCollect(ledger.scanNonterminal);
+  const nonterminal = yield* ledger.scanNonterminal.pipe(
+    Stream.filter((submission) => submission.threadId === threadId),
+    Stream.runCollect,
+  );
 
   if (nonterminal.length >= config.limits.maxQueueDepthPerLane) {
     return yield* AdmissionLimitExceeded.make({
@@ -296,39 +313,110 @@ const passthroughSubmitAgent = (agentId: AgentId): DurableSubmitAgent<typeof Per
   },
 });
 
+/** A physical owner may hold other Threads; an addressed request cannot act on their IDs. */
+const lookupAddressedSubmission = Effect.fn("ThreadObject.lookupAddressedSubmission")(function* (
+  submissionId: SubmissionId,
+) {
+  const { threadId } = yield* ThreadObjectIdentity;
+  const ports = yield* ThreadObjectPorts;
+  const submission = yield* ports.lookupSubmission(submissionId);
+
+  if (Option.isSome(submission) && submission.value.threadId !== threadId)
+    return yield* HostProtocolError.make({ message: "The Submission belongs to another Thread" });
+
+  return submission;
+});
+
+const requireSubmissionThread = Effect.fn("ThreadObject.requireSubmissionThread")(function* (
+  submissionId: SubmissionId,
+) {
+  const submission = yield* lookupAddressedSubmission(submissionId);
+
+  if (Option.isNone(submission))
+    return yield* LedgerError.make({
+      operation: "addressed Submission lookup",
+      message: "The addressed Thread has no such Submission",
+    });
+});
+
+const requireReceiptThread = Effect.fn("ThreadObject.requireReceiptThread")(function* (
+  threadId: ThreadId,
+) {
+  const identity = yield* ThreadObjectIdentity;
+
+  if (threadId !== identity.threadId)
+    return yield* HostProtocolError.make({ message: "The Receipt belongs to another Thread" });
+});
+
+const requirePortThread = (request: PortRequest) => {
+  switch (request._tag) {
+    case "LedgerLookup":
+      return request.request._tag === "SubmissionLookupById"
+        ? lookupAddressedSubmission(request.request.submissionId).pipe(Effect.asVoid)
+        : requireReceiptThread(request.request.threadId);
+    case "LedgerMarkReady":
+    case "LedgerRequestAbort":
+      return requireSubmissionThread(request.request.submissionId);
+    case "LedgerRecordChildSettled":
+      return requireSubmissionThread(request.request.parentSubmissionId);
+    case "LedgerAdmit":
+    case "LedgerResolveAdmission":
+    case "StoreMaterialize":
+    case "StoreAppend":
+    case "StoreReadPage":
+    case "StoreInspectTail":
+    case "StoreExport":
+      return requireReceiptThread(request.request.threadId);
+  }
+  request satisfies never;
+};
+
+/**
+ * Admit an already Schema-decoded request to a logical Thread in this physical owner.
+ * Custom hosts validate local placement before calling this Effect and provide their same
+ * runtime/maintenance instances. The native endpoint uses this path too: queue limits,
+ * idempotent receipts and the pre-admission generation/alarm commit have one owner.
+ */
+export const submit = Effect.fn("ThreadObject.submit")(function* (
+  threadId: ThreadId,
+  request: SubmitRequest,
+) {
+  const placement = yield* ThreadObjectPlacement;
+
+  if (!placement.ownsThread(threadId))
+    return yield* HostProtocolError.make({ message: "The Thread belongs to another Object" });
+  const mutations = yield* ThreadMutationGate;
+  const runtime = yield* DurableAgentRuntime;
+
+  yield* gateAdmissionLimits(threadId, request);
+
+  return yield* mutations.withMutation(
+    runtime
+      .submit(passthroughSubmitAgent(request.agentId), request.inputPayload, {
+        threadId,
+        principal: request.principal,
+        idempotencyKey: request.idempotencyKey,
+        ...(request.admissionGroup === undefined ? {} : { admissionGroup: request.admissionGroup }),
+        ...(request.admissionFence === undefined ? {} : { admissionFence: request.admissionFence }),
+        ...(request.workerAdmission === undefined
+          ? {}
+          : { workerAdmission: request.workerAdmission }),
+        ...(request.messageAdmission === undefined
+          ? {}
+          : { messageAdmission: request.messageAdmission }),
+        definitions: request.definitions,
+      })
+      .pipe(Effect.tap(() => publishCommitted)),
+  );
+});
+
 const submitEndpoint = (encoded: unknown): Effect.Effect<unknown, never, EndpointServices> =>
   decodeSubmitRequest(encoded).pipe(
     Effect.mapError(protocolFailure("The submit request could not be decoded")),
     Effect.flatMap((request) =>
       Effect.gen(function* () {
         const identity = yield* ThreadObjectIdentity;
-        const maintenance = yield* ThreadMaintenance;
-        const runtime = yield* DurableAgentRuntime;
-
-        yield* gateAdmissionLimits(request);
-
-        // Alarm invariant: the generation + alarm commit BEFORE the admission, and maintenance
-        // cannot acknowledge that generation until this mutation leaves its public RPC seam.
-        const receipt = yield* maintenance.withMutation(
-          runtime.submit(passthroughSubmitAgent(request.agentId), request.inputPayload, {
-            threadId: identity.threadId,
-            principal: request.principal,
-            idempotencyKey: request.idempotencyKey,
-            ...(request.admissionGroup === undefined
-              ? {}
-              : { admissionGroup: request.admissionGroup }),
-            ...(request.admissionFence === undefined
-              ? {}
-              : { admissionFence: request.admissionFence }),
-            ...(request.workerAdmission === undefined
-              ? {}
-              : { workerAdmission: request.workerAdmission }),
-            ...(request.messageAdmission === undefined
-              ? {}
-              : { messageAdmission: request.messageAdmission }),
-            definitions: request.definitions,
-          }),
-        );
+        const receipt = yield* submit(identity.threadId, request);
 
         return SubmitSucceeded.make({ receipt });
       }),
@@ -344,6 +432,17 @@ const submissionStatusEndpoint = (
     Effect.mapError(protocolFailure("The receipt could not be decoded")),
     Effect.flatMap((receipt) =>
       Effect.gen(function* () {
+        const authorizer = yield* OperationAuthorizer;
+
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "awaitSettlement",
+            threadId: receipt.threadId,
+            submissionId: receipt.submissionId,
+          }),
+        );
+        yield* requireReceiptThread(receipt.threadId);
+        yield* requireSubmissionThread(receipt.submissionId);
         const runtime = yield* DurableAgentRuntime;
 
         return SubmissionStatusResponse.make({ status: yield* runtime.submissionStatus(receipt) });
@@ -360,6 +459,17 @@ const awaitSettlementEndpoint = (
     Effect.mapError(protocolFailure("The receipt could not be decoded")),
     Effect.flatMap((receipt) =>
       Effect.gen(function* () {
+        const authorizer = yield* OperationAuthorizer;
+
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "awaitSettlement",
+            threadId: receipt.threadId,
+            submissionId: receipt.submissionId,
+          }),
+        );
+        yield* requireReceiptThread(receipt.threadId);
+        yield* requireSubmissionThread(receipt.submissionId);
         const runtime = yield* DurableAgentRuntime;
         const settlement = yield* runtime.awaitSettlement(receipt);
 
@@ -381,7 +491,9 @@ const awaitProgressEndpoint = (encoded: unknown): Effect.Effect<unknown, never, 
 
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const cancelled = yield* registry.subscribe(request.waiterId);
+            const cancelled = yield* registry.subscribe(
+              JSON.stringify([identity.threadId, request.waiterId]),
+            );
 
             yield* Effect.raceFirst(
               runtime.awaitProgress(identity.threadId, request.afterSequence),
@@ -404,9 +516,10 @@ const cancelProgressEndpoint = (
     Effect.mapError(protocolFailure("The progress cancellation could not be decoded")),
     Effect.flatMap((request) =>
       Effect.gen(function* () {
+        const identity = yield* ThreadObjectIdentity;
         const registry = yield* ProgressWaitRegistry;
 
-        yield* registry.cancel(request.waiterId);
+        yield* registry.cancel(JSON.stringify([identity.threadId, request.waiterId]));
 
         return ProgressCancelled.make();
       }),
@@ -457,6 +570,15 @@ const abortEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpoint
     Effect.mapError(protocolFailure("The abort command could not be decoded")),
     Effect.flatMap((command) =>
       Effect.gen(function* () {
+        const authorizer = yield* OperationAuthorizer;
+
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "abort",
+            submissionId: command.submissionId,
+          }),
+        );
+        yield* requireSubmissionThread(command.submissionId);
         const maintenance = yield* ThreadMaintenance;
         const runtime = yield* DurableAgentRuntime;
         const intent = yield* maintenance.withMutation(runtime.abort(command));
@@ -475,6 +597,15 @@ const resolveApprovalEndpoint = (
     Effect.mapError(protocolFailure("The approval command could not be decoded")),
     Effect.flatMap((command) =>
       Effect.gen(function* () {
+        const authorizer = yield* OperationAuthorizer;
+
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "resolveApproval",
+            submissionId: command.submissionId,
+          }),
+        );
+        yield* requireSubmissionThread(command.submissionId);
         const maintenance = yield* ThreadMaintenance;
         const runtime = yield* DurableAgentRuntime;
         const intent = yield* maintenance.withMutation(runtime.resolveApproval(command));
@@ -493,6 +624,15 @@ const resolveUnknownEndpoint = (
     Effect.mapError(protocolFailure("The resolution command could not be decoded")),
     Effect.flatMap((command) =>
       Effect.gen(function* () {
+        const authorizer = yield* OperationAuthorizer;
+
+        yield* authorizer.authorize(
+          OperationAuthorizationRequest.make({
+            operation: "resolveUnknown",
+            submissionId: command.submissionId,
+          }),
+        );
+        yield* requireSubmissionThread(command.submissionId);
         const maintenance = yield* ThreadMaintenance;
         const runtime = yield* DurableAgentRuntime;
         const intent = yield* maintenance.withMutation(runtime.resolveUnknown(command));
@@ -692,7 +832,30 @@ const obligationsEndpoint = (encoded: unknown): Effect.Effect<unknown, never, En
  * alarm so the mutated lane is processed promptly. Protocol anomalies answer
  * `PortFailed(PortProtocolError)`.
  */
-const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, EndpointServices> =>
+const encodePortResponseTotal = (response: PortResponse) =>
+  encodePortResponse(response).pipe(
+    Effect.catch((error) =>
+      Effect.succeed(
+        encodedPortProtocolFailure(`The port response could not be encoded: ${error.message}`),
+      ),
+    ),
+  );
+
+const portGuardFailure = (failure: LedgerError | HostProtocolError): PortFailed =>
+  PortFailed.make({
+    failure:
+      failure._tag === "LedgerError"
+        ? failure
+        : PortProtocolError.make({ message: "The port request is not for the addressed Thread" }),
+  });
+
+export const portCall = (
+  encoded: unknown,
+): Effect.Effect<
+  unknown,
+  never,
+  ThreadObjectPorts | ThreadMaintenance | DurableAlarmService | ThreadObjectIdentity
+> =>
   Effect.gen(function* () {
     const ports = yield* ThreadObjectPorts;
     const maintenance = yield* ThreadMaintenance;
@@ -708,6 +871,27 @@ const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpo
         `The port request could not be decoded: ${decoded.message}`,
       );
     }
+    if (
+      decoded.request._tag === "LedgerLookup" &&
+      decoded.request.request._tag === "SubmissionLookupById"
+    ) {
+      const response = yield* lookupAddressedSubmission(decoded.request.request.submissionId).pipe(
+        Effect.map((submission) =>
+          PortSucceeded.make({
+            result: LedgerLookupResult.make(
+              Option.isSome(submission) ? { submission: submission.value } : {},
+            ),
+          }),
+        ),
+        Effect.catch((failure) => Effect.succeed(portGuardFailure(failure))),
+      );
+
+      return yield* encodePortResponseTotal(response);
+    }
+    const identityCheck = yield* requirePortThread(decoded.request).pipe(Effect.result);
+
+    if (identityCheck._tag === "Failure")
+      return yield* encodePortResponseTotal(portGuardFailure(identityCheck.failure));
     const mutating = isMutatingPortRequest(decoded.request);
 
     const handled = yield* (
@@ -724,13 +908,7 @@ const portCallEndpoint = (encoded: unknown): Effect.Effect<unknown, never, Endpo
       );
     }
 
-    const response = yield* encodePortResponse(handled.value).pipe(
-      Effect.catch((error) =>
-        Effect.succeed(
-          encodedPortProtocolFailure(`The port response could not be encoded: ${error.message}`),
-        ),
-      ),
-    );
+    const response = yield* encodePortResponseTotal(handled.value);
 
     if (mutating) {
       // Prompt processing hint; the pre-armed alarm already guarantees convergence.
@@ -751,6 +929,63 @@ const wakeEndpoint: Effect.Effect<void, never, EndpointServices> = Effect.gen(fu
   // Route the remote hint through this incarnation's scheduler so scoped progress waiters and
   // the alarm receive the same hint. Delivery remains droppable; canonical storage is authority.
   yield* wake.notify(identity.threadId);
+});
+
+/** The per-Thread wire operations supported by native and application-owned endpoints. */
+export const ThreadRpcOperation = Schema.Literals([
+  "submitEncoded",
+  "submissionStatusEncoded",
+  "awaitSettlementEncoded",
+  "awaitProgressEncoded",
+  "cancelProgressEncoded",
+  "observePage",
+  "abortEncoded",
+  "resolveApprovalEncoded",
+  "resolveUnknownEncoded",
+  "portCall",
+  "wake",
+]);
+
+export type ThreadRpcOperation = typeof ThreadRpcOperation.Type;
+
+const threadRpc = {
+  submitEncoded: submitEndpoint,
+  submissionStatusEncoded: submissionStatusEndpoint,
+  awaitSettlementEncoded: awaitSettlementEndpoint,
+  awaitProgressEncoded: awaitProgressEndpoint,
+  cancelProgressEncoded: cancelProgressEndpoint,
+  observePage: observePageEndpoint,
+  abortEncoded: abortEndpoint,
+  resolveApprovalEncoded: resolveApprovalEndpoint,
+  resolveUnknownEncoded: resolveUnknownEndpoint,
+  portCall,
+  wake: () => wakeEndpoint,
+} satisfies Record<
+  ThreadRpcOperation,
+  (encoded: unknown) => Effect.Effect<unknown, never, EndpointServices>
+>;
+
+/**
+ * Bind an addressed request to its logical Thread while sharing one physical runtime. This
+ * validates local placement before invoking the same native handlers. Receipts, Submission
+ * commands and port envelopes must match this identity; progress cancellation is Thread-scoped.
+ * The producer comes from the actual runtime configuration, never from caller input. These
+ * guards supplement the existing current model/Tool and operation authorization policies.
+ */
+export const handleRpc = Effect.fn("ThreadObject.handleRpc")(function* (
+  threadId: ThreadId,
+  operation: ThreadRpcOperation,
+  encoded: unknown,
+) {
+  const placement = yield* ThreadObjectPlacement;
+
+  if (!placement.ownsThread(threadId))
+    return yield* HostProtocolError.make({ message: "The Thread belongs to another Object" });
+  const { producerId } = yield* DurableRuntimeConfig;
+
+  return yield* threadRpc[operation](encoded).pipe(
+    Effect.provideService(ThreadObjectIdentity, { threadId, producerId }),
+  );
 });
 
 const alarmEndpoint: Effect.Effect<void, MaintenancePassFailure, EndpointServices> = Effect.gen(
@@ -802,7 +1037,7 @@ const effectCfPlatformLayer = (
       const binding = yield* threadNamespaceFromEnv(env, namespaceBinding);
 
       return ThreadObjectNamespace.of({
-        namespace: binding,
+        get: (threadId) => binding.get(binding.idFromName(threadId)),
         ...(rpcTracing === true ? { rpcTracing: namespaceBinding } : {}),
       });
     }),
@@ -896,21 +1131,11 @@ export const make = <
   );
 
   const rpc = {
-    submitEncoded: (encoded: unknown) => submitEndpoint(encoded),
-    submissionStatusEncoded: (encoded: unknown) => submissionStatusEndpoint(encoded),
-    awaitSettlementEncoded: (encoded: unknown) => awaitSettlementEndpoint(encoded),
-    awaitProgressEncoded: (encoded: unknown) => awaitProgressEndpoint(encoded),
-    cancelProgressEncoded: (encoded: unknown) => cancelProgressEndpoint(encoded),
-    observePage: (encoded: unknown) => observePageEndpoint(encoded),
-    abortEncoded: (encoded: unknown) => abortEndpoint(encoded),
-    resolveApprovalEncoded: (encoded: unknown) => resolveApprovalEndpoint(encoded),
-    resolveUnknownEncoded: (encoded: unknown) => resolveUnknownEndpoint(encoded),
+    ...threadRpc,
     explainEncoded: (encoded: unknown) => explainEndpoint(encoded),
     verifyEncoded: (encoded: unknown) => verifyEndpoint(encoded),
     retryEncoded: (encoded: unknown) => retryEndpoint(encoded),
     obligationsEncoded: (encoded: unknown) => obligationsEndpoint(encoded),
-    portCall: (encoded: unknown) => portCallEndpoint(encoded),
-    wake: () => wakeEndpoint,
   } satisfies EffectCfDurableObject.DurableObjectRpc<
     RuntimeServices | ApplicationServices | EventServices
   >;

--- a/packages/platform-cloudflare/src/WakeScheduler.ts
+++ b/packages/platform-cloudflare/src/WakeScheduler.ts
@@ -3,7 +3,7 @@ import { makeWakeSubscriptionHub, WakeScheduler } from "@effect-agent/thread/Wak
 import { Effect, Layer, PubSub, Schema, Stream } from "effect";
 
 import { DurableAlarmService } from "./Alarm.ts";
-import { ThreadObjectIdentity, ThreadObjectNamespace } from "./CloudflareBindings.ts";
+import { ThreadObjectPlacement, ThreadObjectNamespace } from "./CloudflareBindings.ts";
 import { safeCauseMessage } from "./internal/boundary.ts";
 
 /**
@@ -36,12 +36,12 @@ class RemoteWakeDropped extends Schema.TaggedError<RemoteWakeDropped>()("RemoteW
 export const cloudflareWakeSchedulerLayer: Layer.Layer<
   WakeScheduler,
   never,
-  DurableAlarmService | ThreadObjectIdentity | ThreadObjectNamespace
+  DurableAlarmService | ThreadObjectPlacement | ThreadObjectNamespace
 > = Layer.effect(WakeScheduler)(
   Effect.gen(function* () {
     const alarm = yield* DurableAlarmService;
-    const identity = yield* ThreadObjectIdentity;
-    const { namespace } = yield* ThreadObjectNamespace;
+    const placement = yield* ThreadObjectPlacement;
+    const { get } = yield* ThreadObjectNamespace;
     const hints = yield* PubSub.sliding<ThreadId>(WAKE_BUFFER_CAPACITY);
     const progress = yield* makeWakeSubscriptionHub;
 
@@ -61,7 +61,7 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
 
     const notifyRemote = (threadId: ThreadId) =>
       Effect.tryPromise({
-        try: () => namespace.get(namespace.idFromName(threadId)).wake(),
+        try: () => get(threadId).wake(),
         catch: (cause) =>
           RemoteWakeDropped.make({
             threadId,
@@ -77,7 +77,7 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
 
     return WakeScheduler.of({
       notify: (threadId) =>
-        threadId === identity.threadId ? notifyLocal(threadId) : notifyRemote(threadId),
+        placement.ownsThread(threadId) ? notifyLocal(threadId) : notifyRemote(threadId),
       subscribe: progress.subscribe,
       wakes: Stream.fromPubSub(hints),
     });

--- a/packages/platform-cloudflare/src/internal/layers.ts
+++ b/packages/platform-cloudflare/src/internal/layers.ts
@@ -1,4 +1,4 @@
-import { ThreadId } from "@effect-agent/core/Identifiers";
+import { ThreadId, type SubmissionId } from "@effect-agent/core/Identifiers";
 import {
   type RunContextPreparation,
   type RunCostEstimator,
@@ -52,16 +52,31 @@ import {
   operationAuthorizerLayer,
   type OperationAuthorizerService,
 } from "@effect-agent/thread/OperationAuthorizer";
+import { type PreparedInputAdmission } from "@effect-agent/thread/PreparedInputAdmission";
 import { ProducerId } from "@effect-agent/thread/Records";
-import { LedgerError, SubmissionLedger } from "@effect-agent/thread/SubmissionLedger";
+import {
+  LedgerError,
+  SubmissionLedger,
+  SubmissionLookupById,
+  type SubmissionSnapshot,
+} from "@effect-agent/thread/SubmissionLedger";
 import { ThreadProjectionMaintenance } from "@effect-agent/thread/ThreadProjectionMaintenance";
 import { ThreadStoreError, ThreadStore } from "@effect-agent/thread/ThreadStore";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
 import { type WakeScheduler } from "@effect-agent/thread/WakeScheduler";
 import { BrowserCrypto } from "@effect/platform-browser";
 import { SqliteClient } from "@effect/sql-sqlite-do";
-import type { Crypto } from "effect";
-import { Cause, Context, Duration, Effect, Layer, Schema, Semaphore } from "effect";
+import {
+  type Crypto,
+  Cause,
+  Context,
+  Duration,
+  Effect,
+  Layer,
+  Schema,
+  Semaphore,
+  type Option,
+} from "effect";
 import { SqlClient } from "effect/unstable/sql/SqlClient";
 
 import {
@@ -75,6 +90,7 @@ import {
 } from "../Alarm.ts";
 import {
   ThreadObjectIdentity,
+  ThreadObjectPlacement,
   DurableObjectContext,
   type ThreadObjectNamespace,
 } from "../CloudflareBindings.ts";
@@ -162,6 +178,7 @@ export interface CloudflareDurableRuntimeOptions {
 export type CloudflareBootstrapServices =
   | CloudflareDurableRuntimeConfig
   | ThreadObjectIdentity
+  | ThreadObjectPlacement
   | DurableRuntimeConfig
   | Crypto.Crypto
   | DoStorageFailpoint
@@ -208,6 +225,10 @@ export class ThreadObjectPorts extends Context.Service<
   ThreadObjectPorts,
   {
     readonly handle: (request: PortRequest) => Effect.Effect<PortResponse>;
+    /** Local-only identity check before a bound RPC can read or mutate a Submission. */
+    readonly lookupSubmission: (
+      submissionId: SubmissionId,
+    ) => Effect.Effect<Option.Option<SubmissionSnapshot>, LedgerError>;
   }
 >()("@effect-agent/platform-cloudflare/ThreadObjectPorts") {}
 
@@ -284,27 +305,21 @@ const threadIdFromState = (
  * The native class factory builds this Layer inside its constructor gate. Custom Effect hosts
  * can provide it around the complete application Layer with the native context already supplied.
  */
-export const layerConfig = (
+const runtimeConfigLayer = (
   options: CloudflareDurableRuntimeOptions,
-): Layer.Layer<CloudflareBootstrapServices, CloudflarePlatformConfigError, DurableObjectContext> =>
+  producerId: ProducerId,
+): Layer.Layer<
+  Exclude<CloudflareBootstrapServices, ThreadObjectIdentity | ThreadObjectPlacement>,
+  CloudflarePlatformConfigError,
+  DurableObjectContext
+> =>
   Layer.unwrap(
     Effect.gen(function* () {
       const { ctx } = yield* DurableObjectContext;
       const config = yield* configFromOptions(options);
-      const threadId = yield* threadIdFromState(ctx);
-
-      const producerId = yield* decodeProducerId(`${config.producerPrefix}:${threadId}`).pipe(
-        Effect.mapError((error) =>
-          CloudflarePlatformConfigError.make({
-            message: `The minted producer identity is invalid: ${error.message}`,
-            cause: error,
-          }),
-        ),
-      );
 
       return Layer.mergeAll(
         Layer.succeed(CloudflareDurableRuntimeConfig, config),
-        Layer.succeed(ThreadObjectIdentity, { threadId, producerId }),
         DurableRuntimeConfig.layer({
           deploymentId: config.deploymentId,
           producerId,
@@ -334,6 +349,59 @@ export const layerConfig = (
           : toolFailureObserverLayer(options.toolFailureObserver),
         RunContextPreparationPassthrough,
         RunToolAuthorization.allowAll,
+      );
+    }),
+  );
+
+const producerIdentity = (prefix: string, owner: string) =>
+  decodeProducerId(`${prefix}:${owner}`).pipe(
+    Effect.mapError((error) =>
+      CloudflarePlatformConfigError.make({
+        message: `The minted producer identity is invalid: ${error.message}`,
+        cause: error,
+      }),
+    ),
+  );
+
+/** Native one-Thread configuration; retains its existing producer and logical identities. */
+export const layerConfig = (
+  options: CloudflareDurableRuntimeOptions,
+): Layer.Layer<CloudflareBootstrapServices, CloudflarePlatformConfigError, DurableObjectContext> =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const { ctx } = yield* DurableObjectContext;
+      const threadId = yield* threadIdFromState(ctx);
+      const producerId = yield* producerIdentity(options.producerPrefix, threadId);
+
+      return Layer.mergeAll(
+        runtimeConfigLayer(options, producerId),
+        Layer.succeed(ThreadObjectIdentity, { threadId, producerId }),
+        Layer.succeed(ThreadObjectPlacement, { ownsThread: (target) => target === threadId }),
+      );
+    }),
+  );
+
+/**
+ * Configuration for an application Object owning several logical Threads. The producer is
+ * the stable physical Object. No logical identity is installed globally: handleRpc binds and
+ * validates it per request using the placement guard and this actual runtime producer.
+ */
+export const layerHostConfig = (
+  options: CloudflareDurableRuntimeOptions,
+  ownsThread: (threadId: ThreadId) => boolean,
+): Layer.Layer<
+  Exclude<CloudflareBootstrapServices, ThreadObjectIdentity>,
+  CloudflarePlatformConfigError,
+  DurableObjectContext
+> =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const { ctx } = yield* DurableObjectContext;
+      const producerId = yield* producerIdentity(options.producerPrefix, ctx.id.toString());
+
+      return Layer.merge(
+        runtimeConfigLayer(options, producerId),
+        Layer.succeed(ThreadObjectPlacement, { ownsThread }),
       );
     }),
   );
@@ -452,10 +520,66 @@ const boundLayer = <E = never, R = never>(
   | Exclude<R, ThreadStore | SubmissionLedger | SqlClient>
 > =>
   Layer.unwrap(
+    Effect.map(DurableObjectContext, ({ ctx }) =>
+      sharedLayer(DurableAgentRuntime.layerWithBindings(bindings), options).pipe(
+        Layer.provideMerge(SqliteClient.layer({ storage: ctx.storage })),
+      ),
+    ),
+  );
+
+/**
+ * Build the application runtime over the existing owner SqlClient and native ports, then
+ * assemble its one maintenance coordinator. The application may acquire its Bindings from
+ * those ports and expose extra services, including ThreadHostMaintenance. It must not acquire
+ * another runtime stack or require ThreadMaintenance while constructing this Layer.
+ * Supply layerHostConfig and deterministic placement; dispatch addressed ingress with handleRpc.
+ */
+export function layerInHost<A, E, R, P = never, PE = never, PR = never>(
+  application: Layer.Layer<DurableAgentRuntime | A, E, R>,
+  options: Omit<ThreadPublicationOptions<PE, PR>, "projection"> & {
+    readonly projection: Layer.Layer<ThreadProjectionMaintenance | P, PE, PR>;
+  },
+): Layer.Layer<
+  CloudflareDurableRuntimeServices | A | P,
+  Layer.Error<ReturnType<typeof sharedLayer<A, E, R, PE, PR>>>,
+  Layer.Services<ReturnType<typeof sharedLayer<A, E, Exclude<R, P>, PE, PR>>>
+>;
+
+export function layerInHost<A, E, R, PE = never, PR = never>(
+  application: Layer.Layer<DurableAgentRuntime | A, E, R>,
+  options?: ThreadPublicationOptions<PE, PR>,
+): ReturnType<typeof sharedLayer<A, E, R, PE, PR>>;
+
+export function layerInHost<A, E, R, PE = never, PR = never>(
+  application: Layer.Layer<DurableAgentRuntime | A, E, R>,
+  options: ThreadPublicationOptions<PE, PR> = {},
+) {
+  return sharedLayer(application, options);
+}
+
+type HostRuntimeServices = Exclude<
+  CloudflareDurableRuntimeServices,
+  DurableAgentRuntime | ThreadMaintenance
+>;
+
+const sharedLayer = <A, E, R, PE = never, PR = never>(
+  application: Layer.Layer<DurableAgentRuntime | A, E, R>,
+  options: ThreadPublicationOptions<PE, PR> = {},
+): Layer.Layer<
+  CloudflareDurableRuntimeServices | A,
+  DoStorageInitializationError | MessageDeliveryError | E | PE,
+  | DurableObjectContext
+  | ThreadObjectNamespace
+  | Exclude<CloudflareBootstrapServices, ThreadObjectIdentity>
+  | SqlClient
+  | Exclude<R, HostRuntimeServices | PreparedInputAdmission>
+  | Exclude<PR, ThreadStore | SubmissionLedger | SqlClient>
+> =>
+  Layer.unwrap(
     Effect.gen(function* () {
       const { ctx } = yield* DurableObjectContext;
       const config = yield* CloudflareDurableRuntimeConfig;
-      const { threadId } = yield* ThreadObjectIdentity;
+      const { ownsThread } = yield* ThreadObjectPlacement;
 
       const storageOptions: DoStorageOptions = {
         storage: ctx.storage,
@@ -467,7 +591,7 @@ const boundLayer = <E = never, R = never>(
 
       const infrastructure = Layer.mergeAll(
         storageConfigLayer(storageOptions),
-        SqliteClient.layer({ storage: ctx.storage }),
+        Layer.effect(SqlClient)(SqlClient),
       );
 
       // The same local ports serve routed decorators and owner-side RPC execution.
@@ -585,19 +709,22 @@ const boundLayer = <E = never, R = never>(
       const portsEndpointLayer = Layer.effect(ThreadObjectPorts)(
         Effect.gen(function* () {
           const local = yield* Effect.context<SubmissionLedger | ThreadStore>();
+          const ledger = Context.get(local, SubmissionLedger);
 
           return ThreadObjectPorts.of({
             handle: (request) => executePortRequest(request).pipe(Effect.provide(local)),
+            lookupSubmission: (submissionId) =>
+              ledger.lookup(SubmissionLookupById.make({ submissionId })),
           });
         }),
       ).pipe(Layer.provide(localPorts));
 
       const routedPorts = Layer.mergeAll(
-        routedSubmissionLedgerLayer({ localThreadId: threadId }),
-        routedThreadStoreLayer({ localThreadId: threadId }),
+        routedSubmissionLedgerLayer({ ownsThread }),
+        routedThreadStoreLayer({ ownsThread }),
       ).pipe(Layer.provide(localPorts), Layer.provide(threadPortTransportLayer));
 
-      const runtimeStack = DurableAgentRuntime.layerWithBindings(bindings).pipe(
+      const runtimeStack = application.pipe(
         Layer.provide(
           cloudflarePreparedInputAdmissionLayer.pipe(Layer.provide(CloudflareThreadClient.layer)),
         ),
@@ -605,6 +732,7 @@ const boundLayer = <E = never, R = never>(
         Layer.provideMerge(routedPorts),
         Layer.provideMerge(wakes),
         Layer.provideMerge(base),
+        Layer.provideMerge(portsEndpointLayer),
       );
 
       return Layer.mergeAll(

--- a/packages/platform-cloudflare/src/internal/message-delivery.ts
+++ b/packages/platform-cloudflare/src/internal/message-delivery.ts
@@ -1,13 +1,14 @@
+import { type ThreadId } from "@effect-agent/core/Identifiers";
 import {
   MessageDeliveryDriver,
   MessageDeliveryError,
   MessageDeliveryStore,
 } from "@effect-agent/thread/MessageDelivery";
 import { WakeScheduler } from "@effect-agent/thread/WakeScheduler";
-import { Clock, Context, Deferred, Effect, Layer, Option, Ref, Semaphore } from "effect";
+import { Clock, Context, Deferred, Effect, Layer, Option, Ref, Semaphore, Stream } from "effect";
 
 import { DurableAlarmError, ThreadMessageDelivery, ThreadMutationGate } from "../Alarm.ts";
-import { ThreadObjectIdentity } from "../CloudflareBindings.ts";
+import { ThreadObjectPlacement } from "../CloudflareBindings.ts";
 import { CloudflareDurableRuntimeConfig } from "../CloudflareConfig.ts";
 
 /** Every externally requested write prearms the owning Object's maintenance generation. */
@@ -17,14 +18,17 @@ export const guardedMessageDeliveryStoreLayer = Layer.effect(
     const store = yield* MessageDeliveryStore;
     const mutations = yield* ThreadMutationGate;
     const wakes = yield* WakeScheduler;
-    const { threadId } = yield* ThreadObjectIdentity;
+    const { ownsThread } = yield* ThreadObjectPlacement;
     // Reconstructed as unknown on every incarnation. The gate prevents a racing read from
     // caching an empty deadline across a write; SQL remains the recovery authority.
     const deadline = yield* Ref.make<number | null | undefined>(undefined);
     const cacheGate = yield* Semaphore.make(1);
 
-    const local = <A, E>(owner: string, body: Effect.Effect<A, E>) =>
-      owner === threadId
+    const local = <A, E>(
+      owner: ThreadId | undefined,
+      body: Effect.Effect<A, E>,
+    ): Effect.Effect<A, E | MessageDeliveryError> =>
+      owner === undefined || ownsThread(owner)
         ? body
         : Effect.fail(
             MessageDeliveryError.make({ reason: "validation", operation: "message owner" }),
@@ -44,7 +48,7 @@ export const guardedMessageDeliveryStoreLayer = Layer.effect(
         const cached = yield* Ref.get(deadline);
 
         if (cached !== undefined) return cached;
-        const current = yield* store.nextDeadline(threadId);
+        const current = yield* store.nextDeadline();
 
         yield* Ref.set(deadline, current);
 
@@ -56,14 +60,27 @@ export const guardedMessageDeliveryStoreLayer = Layer.effect(
       insert: (record) =>
         local(
           record.key.ownerThreadId,
-          mutate(store.insert(record)).pipe(Effect.tap(() => wakes.notify(threadId))),
+          mutate(store.insert(record)).pipe(
+            Effect.tap(() => wakes.notify(record.key.ownerThreadId)),
+          ),
         ),
       get: (key) => local(key.ownerThreadId, store.get(key)),
       list: (request) => local(request.ownerThreadId, store.list(request)),
       change: (key, change) => local(key.ownerThreadId, mutate(store.change(key, change))),
-      due: (nowMillis, limit, owner = threadId) =>
-        local(owner, store.due(nowMillis, limit, threadId)),
-      nextDeadline: (owner = threadId) => local(owner, nextDeadline),
+      // Only the trusted physical-owner pump omits an owner. All returned keys still
+      // pass placement validation before the driver may dispatch any of the wave.
+      due: (nowMillis, limit, owner) =>
+        local(owner, store.due(nowMillis, limit, owner)).pipe(
+          Effect.flatMap((keys) =>
+            keys.every((key) => ownsThread(key.ownerThreadId))
+              ? Effect.succeed(keys)
+              : Effect.fail(
+                  MessageDeliveryError.make({ reason: "validation", operation: "message owner" }),
+                ),
+          ),
+        ),
+      nextDeadline: (owner) =>
+        local(owner, owner === undefined ? nextDeadline : store.nextDeadline(owner)),
     });
   }),
 );
@@ -75,7 +92,6 @@ export const threadMessageDeliveryLayer = Layer.effectContext(
     const store = yield* MessageDeliveryStore;
     const wakes = yield* WakeScheduler;
     const config = yield* CloudflareDurableRuntimeConfig;
-    const { threadId } = yield* ThreadObjectIdentity;
 
     const failure = (operation: string) => () =>
       DurableAlarmError.make({
@@ -84,10 +100,10 @@ export const threadMessageDeliveryLayer = Layer.effectContext(
       });
 
     const drain = Effect.gen(function* () {
-      const deadline = yield* store.nextDeadline(threadId);
+      const deadline = yield* store.nextDeadline();
 
       if (deadline !== null && deadline <= (yield* Clock.currentTimeMillis)) {
-        yield* driver.runDue(threadId);
+        yield* driver.runDue();
       }
     }).pipe(Effect.mapError(failure("drain message delivery")));
 
@@ -96,16 +112,16 @@ export const threadMessageDeliveryLayer = Layer.effectContext(
       drainUntil: Effect.fn("ThreadMessageDelivery.drainUntil")(function* (
         finished: Deferred.Deferred<void>,
       ) {
+        // One scoped subscription covers every logical lane in this physical owner.
+        // Acquire it before reading durable deadlines; hints remain droppable.
+        const notified = (yield* Stream.toPull(wakes.wakes)).pipe(Effect.catch(() => Effect.never));
+
         // Always finish one wave; source completion prevents starting subsequent waves.
         yield* Effect.gen(function* () {
-          // Subscribe before the durable read so an insertion during a wave is retained
-          // as a hint for the next one. The scan interval covers dropped notifications.
-          const notified = yield* wakes.subscribe(threadId);
-
           yield* drain;
 
           const deadline = yield* store
-            .nextDeadline(threadId)
+            .nextDeadline()
             .pipe(Effect.mapError(failure("read message deadline")));
 
           // The index includes unfinished waves, lease expiry, retry and settlement polls.
@@ -122,10 +138,10 @@ export const threadMessageDeliveryLayer = Layer.effectContext(
             Deferred.await(finished),
             Effect.raceFirst(notified, Effect.sleep(delay)),
           );
-        }).pipe(Effect.scoped, Effect.repeat({ until: () => Deferred.isDone(finished) }));
-      }),
+        }).pipe(Effect.repeat({ until: () => Deferred.isDone(finished) }));
+      }, Effect.scoped),
       pendingDeadline: store
-        .nextDeadline(threadId)
+        .nextDeadline()
         .pipe(Effect.map(Option.fromNullishOr), Effect.mapError(failure("read message deadline"))),
     });
   }),

--- a/packages/platform-cloudflare/src/internal/transport.ts
+++ b/packages/platform-cloudflare/src/internal/transport.ts
@@ -25,12 +25,12 @@ export const threadPortTransportLayer: Layer.Layer<
   ThreadObjectNamespace
 > = Layer.effect(ThreadPortTransport)(
   Effect.gen(function* () {
-    const { namespace } = yield* ThreadObjectNamespace;
+    const { get } = yield* ThreadObjectNamespace;
 
     return ThreadPortTransport.of({
       call: (threadId, request) =>
         Effect.tryPromise({
-          try: () => namespace.get(namespace.idFromName(threadId)).portCall(request),
+          try: () => get(threadId).portCall(request),
           catch: (cause) => portTransportFailure(threadId, cause),
         }).pipe(
           Effect.withSpan("CloudflarePortTransport.call", {

--- a/packages/platform-cloudflare/test/restart/scheduling-restart-worker.ts
+++ b/packages/platform-cloudflare/test/restart/scheduling-restart-worker.ts
@@ -72,7 +72,11 @@ let admissionReplyFailures = 0;
 const scheduleHostLayer = Layer.mergeAll(
   Layer.effect(
     ThreadObjectNamespace,
-    Effect.map(WorkerEnvironment, (env) => ({ namespace: env.RESTART_THREADS })),
+    Effect.map(WorkerEnvironment, (env) =>
+      ThreadObjectNamespace.of({
+        get: (threadId) => env.RESTART_THREADS.get(env.RESTART_THREADS.idFromName(threadId)),
+      }),
+    ),
   ),
   Layer.succeed(ScheduleAuthorizer)({
     manage: () => Effect.void,

--- a/packages/platform-cloudflare/test/worker.ts
+++ b/packages/platform-cloudflare/test/worker.ts
@@ -133,7 +133,11 @@ const scheduleHostLayer = Layer.mergeAll(
   ),
   Layer.effect(
     ThreadObjectNamespace,
-    Effect.map(WorkerEnvironment, (env) => ({ namespace: env.THREADS })),
+    Effect.map(WorkerEnvironment, (env) =>
+      ThreadObjectNamespace.of({
+        get: (threadId) => env.THREADS.get(env.THREADS.idFromName(threadId)),
+      }),
+    ),
   ),
 );
 
@@ -162,7 +166,11 @@ const subscriptionHostLayer = Layer.mergeAll(
   subscriptionFailpointLayer,
   Layer.effect(
     ThreadObjectNamespace,
-    Effect.map(WorkerEnvironment, (env) => ({ namespace: env.THREADS })),
+    Effect.map(WorkerEnvironment, (env) =>
+      ThreadObjectNamespace.of({
+        get: (threadId) => env.THREADS.get(env.THREADS.idFromName(threadId)),
+      }),
+    ),
   ),
 );
 

--- a/packages/storage-cloudflare/src/PortRouting.ts
+++ b/packages/storage-cloudflare/src/PortRouting.ts
@@ -151,11 +151,11 @@ export class ThreadPortTransport extends Context.Service<
 /** Construction options shared by both routed port Layers. */
 export interface RoutedPortOptions {
   /**
-   * The Thread this Durable Object owns (the Object identity rule is
-   * `namespace.idFromName(threadId)`). Requests addressed here execute on the local
-   * facet; requests addressed anywhere else route through the transport or fail fast typed.
+   * Decide whether this physical owner stores the addressed logical Thread. Local
+   * requests use the same SQLite facets; foreign requests use the transport or fail
+   * fast typed. The predicate determines placement, never caller authorization.
    */
-  readonly localThreadId: ThreadId;
+  readonly ownsThread: (threadId: ThreadId) => boolean;
 }
 
 /** Where one port request must execute. */
@@ -175,7 +175,7 @@ const LOCAL: RouteTarget = { _tag: "local" };
  * refused them at admission, so they cannot name any stored row anywhere.
  */
 const routableSubmissionTarget = (
-  localThreadId: ThreadId,
+  ownsThread: RoutedPortOptions["ownsThread"],
 ): ((operation: string, submissionId: string) => Effect.Effect<RouteTarget, LedgerError>) =>
   Effect.fn("DoPortRouting.routableSubmissionTarget")(function* (
     operation: string,
@@ -196,10 +196,10 @@ const routableSubmissionTarget = (
     if (!UUID_HEAD_PATTERN.test(submissionId.slice(0, separator))) return LOCAL;
     const tail = submissionId.slice(separator + 1);
 
-    if (tail === localThreadId) return LOCAL;
-
     return yield* decodeThreadId(tail).pipe(
-      Effect.map((threadId): RouteTarget => ({ _tag: "foreign", threadId })),
+      Effect.map((threadId): RouteTarget =>
+        ownsThread(threadId) ? LOCAL : { _tag: "foreign", threadId },
+      ),
       Effect.orElseSucceed(() => LOCAL),
     );
   });
@@ -261,7 +261,7 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
   const local = yield* SubmissionLedger;
   const transport = yield* ThreadPortTransport;
   const transportCall: TransportCall = makeTransportCall(transport);
-  const submissionTarget = routableSubmissionTarget(options.localThreadId);
+  const submissionTarget = routableSubmissionTarget(options.ownsThread);
 
   const routeFailure =
     (operation: string, target: string) =>
@@ -476,7 +476,7 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
     capabilities: local.capabilities,
 
     admit: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.admit(request)
         : foreignLedgerCall(
             "ledger admit",
@@ -510,7 +510,7 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
                 : foreignLookupById("ledger lookup", target.threadId, request.submissionId),
             ),
           )
-        : request.threadId === options.localThreadId
+        : options.ownsThread(request.threadId)
           ? local.lookup(request)
           : foreignLedgerCall(
               "ledger lookup",
@@ -525,7 +525,7 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
             ),
 
     resolveAdmission: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.resolveAdmission(request)
         : resolveForeignAdmission(request.threadId, request),
 
@@ -562,12 +562,12 @@ const makeRoutedLedgerServices = Effect.fn("DoPortRouting.makeRoutedLedgerServic
     // Every operation below is lane-local by construction (plan §1.3): a foreign address is
     // an out-of-contract call and fails fast typed instead of being quietly distributed.
     claim: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.claim(request)
         : Effect.fail(crossThreadLedgerError("ledger claim", request.threadId)),
 
     claimJoining: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.claimJoining(request)
         : Effect.fail(crossThreadLedgerError("ledger claim joining", request.threadId)),
 
@@ -793,7 +793,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
 
   const routed = ThreadStore.of({
     materialize: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.materialize(request)
         : foreignStoreCall(
             "thread materialize",
@@ -804,7 +804,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
           ).pipe(Effect.asVoid),
 
     append: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.append(request)
         : foreignStoreCall(
             "thread append",
@@ -815,7 +815,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
           ).pipe(Effect.map((reply) => reply.result)),
 
     read: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.read(request)
         : Stream.unwrap(
             foreignStoreCall(
@@ -828,7 +828,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
           ),
 
     inspectTail: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.inspectTail(request)
         : foreignStoreCall(
             "thread inspect tail",
@@ -839,7 +839,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
           ).pipe(Effect.map((reply) => reply.tail)),
 
     export: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.export(request)
         : foreignStoreCall(
             "thread export",
@@ -853,7 +853,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
     // is materialize/append/read/inspectTail/export. Recovery cache misses can fall back
     // to those canonical reads, including when the cache belongs to a foreign Object.
     observe: (request) =>
-      request.threadId === options.localThreadId
+      options.ownsThread(request.threadId)
         ? local.observe(request)
         : Stream.unwrap(Effect.fail(crossThreadStoreError("thread observe", request.threadId))),
 
@@ -862,7 +862,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
       : {
           recoveryCheckpoints: {
             save: (request) =>
-              request.checkpoint.threadId === options.localThreadId
+              options.ownsThread(request.checkpoint.threadId)
                 ? recoveryCheckpoints.save(request)
                 : Effect.fail(
                     crossThreadStoreError(
@@ -871,7 +871,7 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
                     ),
                   ),
             load: (request) =>
-              request.threadId === options.localThreadId
+              options.ownsThread(request.threadId)
                 ? recoveryCheckpoints.load(request)
                 : Effect.succeed(Option.none()),
           },
@@ -881,13 +881,13 @@ const makeRoutedStoreServices = Effect.fn("DoPortRouting.makeRoutedStoreServices
       : {
           checkpoints: {
             save: (request) =>
-              request.checkpoint.threadId === options.localThreadId
+              options.ownsThread(request.checkpoint.threadId)
                 ? checkpoints.save(request)
                 : Effect.fail(
                     crossThreadStoreError("thread save checkpoint", request.checkpoint.threadId),
                   ),
             load: (request) =>
-              request.threadId === options.localThreadId
+              options.ownsThread(request.threadId)
                 ? checkpoints.load(request)
                 : Effect.fail(crossThreadStoreError("thread load checkpoint", request.threadId)),
           },

--- a/packages/storage-cloudflare/src/internal/do-journal.ts
+++ b/packages/storage-cloudflare/src/internal/do-journal.ts
@@ -474,7 +474,13 @@ const ensureCurrentStorage = Effect.fn("DoJournal.ensureCurrentStorage")(functio
       });
     }
 
-    yield* SqliteMigrator.run({ loader: doMigrations }).pipe(
+    yield* SqliteMigrator.run({
+      loader: doMigrations,
+      // An application can share this SQL client and own its own migration history.
+      // Keep bookkeeping outside effect_agent_% so interrupted unversioned schemas
+      // still fail the ambiguity check above.
+      table: "effect_sql_migrations_agent_threads",
+    }).pipe(
       // SqliteMigrator depends on the generic client supplied by this adapter. The concrete
       // Durable Object client is kept at the outer Layer boundary.
       Effect.provideService(SqlClient.SqlClient, sql),

--- a/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
+++ b/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
@@ -170,8 +170,9 @@ describe("unpatched v2 native storage upgrade", () => {
 
           return yield* ledger.admit(request);
         }).pipe(
-          Effect.provide(submissionLedgerLayer),
-          Effect.provide(services(storage, () => undefined)),
+          Effect.provide(
+            submissionLedgerLayer.pipe(Layer.provideMerge(services(storage, () => undefined))),
+          ),
         );
 
         const first = yield* submit;

--- a/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
+++ b/packages/storage-cloudflare/test/do-storage-upgrade.test.ts
@@ -32,7 +32,7 @@ import { DoStorageFailpoint } from "../src/DoStorageFailpoint.ts";
 import { submissionLedgerLayer } from "../src/DoSubmissionLedger.ts";
 import { DoSubscriptionTransaction, doSubscriptionStoreLayer } from "../src/DoSubscriptionStore.ts";
 import { storageConfigLayer, type DoStorageInitializationError } from "../src/DoThreadStore.ts";
-import { withScheduleStorage } from "./harness.ts";
+import { admission, withScheduleStorage } from "./harness.ts";
 
 let counter = 0;
 
@@ -149,6 +149,45 @@ const services = (
 };
 
 describe("unpatched v2 native storage upgrade", () => {
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/78d05490ac4f3512b57ec37be37cab4a454a03a3
+  it("initializes beside an application's migration history and preserves admission receipts", () =>
+    withScheduleStorage(`shared-sql-migrations-${counter++}`, (storage) =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClientService.SqlClient;
+
+        yield* sql`CREATE TABLE effect_sql_migrations (
+          migration_id INTEGER PRIMARY KEY,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          name VARCHAR(255) NOT NULL
+        )`;
+        yield* sql`INSERT INTO effect_sql_migrations (migration_id, name) VALUES (100, 'application')`;
+        yield* sql`CREATE TABLE application_messages (id TEXT PRIMARY KEY, body TEXT NOT NULL)`;
+        yield* sql`INSERT INTO application_messages VALUES ('human', 'hey')`;
+
+        const submit = Effect.gen(function* () {
+          const ledger = yield* SubmissionLedger;
+          const request = yield* admission("shared-sql-thread", "human", { text: "hey" });
+
+          return yield* ledger.admit(request);
+        }).pipe(
+          Effect.provide(submissionLedgerLayer),
+          Effect.provide(services(storage, () => undefined)),
+        );
+
+        const first = yield* submit;
+        const replay = yield* submit;
+
+        expect(first.replayed).toBe(false);
+        expect(replay).toEqual({ ...first, replayed: true });
+        expect(yield* sql`SELECT migration_id, name FROM effect_sql_migrations`).toEqual([
+          { migration_id: 100, name: "application" },
+        ]);
+        expect(yield* sql`SELECT id, body FROM application_messages`).toEqual([
+          { id: "human", body: "hey" },
+        ]);
+      }).pipe(Effect.provide(SqliteClient.layer({ storage }))),
+    ));
+
   for (const point of [
     "upgrade:before-mutation",
     "upgrade:after-mutation",

--- a/packages/storage-cloudflare/test/routing.test.ts
+++ b/packages/storage-cloudflare/test/routing.test.ts
@@ -143,12 +143,14 @@ const withRoutedPorts = <A, E>(
       build.pipe(
         Effect.provide(
           Layer.mergeAll(
-            routedSubmissionLedgerLayer({ localThreadId: thread(objectName) }).pipe(
+            routedSubmissionLedgerLayer({
+              ownsThread: (target) => target === thread(objectName),
+            }).pipe(
               Layer.provide(
                 Layer.mergeAll(ledgerLayer({ storage: doState.storage }), transportLayer(state)),
               ),
             ),
-            routedThreadStoreLayer({ localThreadId: thread(objectName) }).pipe(
+            routedThreadStoreLayer({ ownsThread: (target) => target === thread(objectName) }).pipe(
               Layer.updateService(ThreadStore, (store) =>
                 includeCheckpoints
                   ? store


### PR DESCRIPTION
An application Durable Object can now own related logical Threads without a second Object, SQL client, runtime, or alarm. `ThreadObject.layerInHost(application)` supplies the native ports before constructing the application's real runtime, then builds its single maintenance coordinator.

```mermaid
flowchart LR
  RPC[Addressed host RPC] --> Owner[Application Durable Object]
  Owner --> SQL[Shared SQL client]
  Owner --> Runtime[One durable runtime]
  Runtime --> A[Logical Thread A]
  Runtime --> B[Logical Thread B]
  Alarm[One alarm and mutation gate] --> Runtime
  Alarm --> Host[Bounded host outboxes]
```

`layerHostConfig` establishes deterministic placement and a physical producer identity; `handleRpc(threadId, operation, encoded)` binds the logical identity per request. Addressed receipt, control and port operations verify their local submission before routed access. Host authentication and current model/tool authorization remain required. Existing Threads require a fenced transfer before changing physical placement.

Maintenance recovers all local lanes, rotates eligible FIFO heads using a durable cursor, and drains aggregate message delivery plus bounded host work beside an Attempt. It joins the current host wave before acknowledgement; failures and interruption retain the prearmed generation. Native migrations now use their own migration table, preserving the application's migration history and data.

The [compiling shared-owner example](https://github.com/danieljvdm/effect-agent/blob/dan/kom-180-embedded-thread-host/packages/platform-cloudflare/examples/shared-owner.ts) demonstrates shared SQL, application requirements and projection-provided services. Custom `ThreadObjectNamespace` services now implement `get(threadId)`.

Validation: `vp run ready` passed, including 521 Cloudflare tests (3 existing skips). Private Workerd acceptance also passed two-thread identity isolation and nine checks covering reconstruction, both cursor crash points, two-source message recovery, host work during a held model stream, typed/defect failure, and 14-minute event interruption with finalizers and alarm-only recovery. The committed migration regression reproduces an existing missing-native-table failure when a host already owns `effect_sql_migrations`, then proves admission/replay and unchanged host rows.

The application-Layer seam avoids constructing an empty runtime and replacing it later: that would capture the wrong runtime in maintenance. One shared SQL client also avoids independently locked clients over the same physical SQLite storage.
