### PR TITLE
fix(cloudflare): isolate alarm writes from SQL transactions

### DIFF
--- a/.changeset/tidy-alarm-isolation.md
+++ b/.changeset/tidy-alarm-isolation.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Keep alarm updates independent of concurrent SQLite transactions, and retain the earliest requested recovery deadline atomically. Provide the owner's SqlClient when building standalone alarm or maintenance layers.

--- a/packages/platform-cloudflare/src/Alarm.ts
+++ b/packages/platform-cloudflare/src/Alarm.ts
@@ -28,6 +28,7 @@ import {
   Semaphore,
   Stream,
 } from "effect";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
 
 import { DurableObjectContext } from "./CloudflareBindings.ts";
 import { CloudflareDurableRuntimeConfig } from "./CloudflareConfig.ts";
@@ -64,6 +65,25 @@ const alarmFailure =
       cause,
     });
 
+// SQL and raw KV/alarm operations share one physical SQLite transaction. Reserve its
+// connection for each short storage operation, never around a mutation or snapshot body.
+const makeStorageOperation = Effect.map(
+  SqlClient,
+  (sql) =>
+    <A>(operation: string, execute: () => Promise<A>) =>
+      Effect.flatMap(Effect.serviceOption(sql.transactionService), (current) => {
+        const body = Effect.uninterruptible(
+          Effect.tryPromise({ try: execute, catch: alarmFailure(operation) }),
+        );
+
+        return current._tag === "Some"
+          ? body
+          : Effect.scoped(
+              Effect.andThen(sql.reserve.pipe(Effect.mapError(alarmFailure(operation))), body),
+            );
+      }),
+);
+
 /** `ctx.storage` alarm slot as an Effect service; storage is truth, never a memory field. */
 export class DurableAlarmService extends Context.Service<
   DurableAlarmService,
@@ -97,7 +117,7 @@ export class DurableAlarmService extends Context.Service<
     readonly cancel: Effect.Effect<void, DurableAlarmError>;
   }
 >()("@effect-agent/platform-cloudflare/DurableAlarmService") {
-  static readonly layer: Layer.Layer<DurableAlarmService, never, DurableObjectContext> =
+  static readonly layer: Layer.Layer<DurableAlarmService, never, DurableObjectContext | SqlClient> =
     Layer.effect(DurableAlarmService)(
       Effect.gen(function* () {
         const { ctx } = yield* DurableObjectContext;
@@ -108,28 +128,26 @@ export class DurableAlarmService extends Context.Service<
          */
         const runningPasses = yield* Ref.make(0);
 
-        const scheduled = Effect.tryPromise({
-          try: () => ctx.storage.getAlarm(),
-          catch: alarmFailure("get alarm"),
-        }).pipe(
+        const storageOperation = yield* makeStorageOperation;
+
+        const scheduled = storageOperation("get alarm", () => ctx.storage.getAlarm()).pipe(
           Effect.map((deadline) =>
             deadline === null ? Option.none<number>() : Option.some(deadline),
           ),
         );
 
         const scheduleAt = (epochMillis: number) =>
-          Effect.tryPromise({
-            try: () => ctx.storage.setAlarm(epochMillis),
-            catch: alarmFailure("set alarm"),
-          });
+          storageOperation("set alarm", () => ctx.storage.setAlarm(epochMillis));
 
         const ensureScheduledBy = (epochMillis: number) =>
-          scheduled.pipe(
-            Effect.flatMap((existing) =>
-              Option.isSome(existing) && existing.value <= epochMillis
-                ? Effect.void
-                : scheduleAt(epochMillis),
-            ),
+          storageOperation("ensure alarm", () =>
+            ctx.storage.transaction(async (transaction) => {
+              const existing = await transaction.getAlarm();
+
+              if (existing === null || existing > epochMillis) {
+                await transaction.setAlarm(epochMillis);
+              }
+            }),
           );
 
         const armNow = Clock.currentTimeMillis.pipe(
@@ -146,10 +164,7 @@ export class DurableAlarmService extends Context.Service<
             Effect.ensuring(Ref.update(runningPasses, (passes) => passes - 1)),
           );
 
-        const cancel = Effect.tryPromise({
-          try: () => ctx.storage.deleteAlarm(),
-          catch: alarmFailure("delete alarm"),
-        });
+        const cancel = storageOperation("delete alarm", () => ctx.storage.deleteAlarm());
 
         return DurableAlarmService.of({
           scheduled,
@@ -404,8 +419,7 @@ export class ThreadMutationGate extends Context.Service<
       const generationGate = yield* Semaphore.make(1);
       const minimumAlarmDelay = Math.max(1, Math.ceil(config.alarmBackoffBase / 2));
 
-      const runTransaction = <A>(operation: string, transaction: () => Promise<A>) =>
-        Effect.tryPromise({ try: transaction, catch: alarmFailure(operation) });
+      const runTransaction = yield* makeStorageOperation;
 
       const beginMutation = Effect.fn("ThreadMaintenance.beginMutation")(function* () {
         yield* failpoint.hit("maintenance:dirty:before");
@@ -508,6 +522,7 @@ export class ThreadMaintenance extends Context.Service<
     | ThreadMaintenanceFailpoint
     | CloudflareDurableRuntimeConfig
     | DurableObjectContext
+    | SqlClient
   > = Layer.effect(ThreadMaintenance)(
     Effect.gen(function* () {
       const runtime = yield* DurableAgentRuntime;
@@ -549,8 +564,7 @@ export class ThreadMaintenance extends Context.Service<
       const maintenancePassGate = yield* Semaphore.make(1);
       const minimumAlarmDelay = Math.max(1, Math.ceil(config.alarmBackoffBase / 2));
 
-      const runTransaction = <A>(operation: string, transaction: () => Promise<A>) =>
-        Effect.tryPromise({ try: transaction, catch: alarmFailure(operation) });
+      const runTransaction = yield* makeStorageOperation;
 
       const ensureAlarm = Effect.fn("ThreadMaintenance.ensureAlarm")(function* () {
         yield* failpoint.hit("maintenance:ensure:before");

--- a/packages/platform-cloudflare/test/alarm.test.ts
+++ b/packages/platform-cloudflare/test/alarm.test.ts
@@ -1,3 +1,4 @@
+import { DurableAlarmService, ThreadMutationGate } from "@effect-agent/platform-cloudflare/Alarm";
 import { CloudflareThreadClient } from "@effect-agent/platform-cloudflare/CloudflareThreadClient";
 import {
   AbortCommand,
@@ -11,6 +12,7 @@ import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { Cause, Clock, Deferred, Effect, Exit, Fiber, Schema } from "effect";
 import { DurableObject } from "effect-cf";
 import { TestClock } from "effect/testing";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -99,6 +101,66 @@ const maintenanceGeneration = (thread: string) =>
   );
 
 describe("DC alarm semantics", () => {
+  // Regression: https://github.com/danieljvdm/effect-agent/commit/78d05490a
+  it("keeps alarm changes independent of an interrupted concurrent SQL transaction", async () => {
+    const thread = lane("sql-alarm-isolation");
+
+    await runInDurableObject(stubFor(thread), (instance, state) =>
+      instance[DurableObject.RunSymbol](
+        Effect.gen(function* () {
+          const sql = yield* SqlClient;
+          const alarm = yield* DurableAlarmService;
+
+          yield* sql`CREATE TABLE alarm_isolation_probe (value INTEGER)`;
+
+          const raceRollback = <A, E>(operation: Effect.Effect<A, E>) =>
+            Effect.gen(function* () {
+              const entered = yield* Deferred.make<void>();
+
+              const transaction = yield* sql
+                .withTransaction(
+                  Effect.gen(function* () {
+                    yield* sql`INSERT INTO alarm_isolation_probe VALUES (1)`;
+                    yield* Deferred.succeed(entered, undefined);
+
+                    return yield* Effect.never;
+                  }),
+                )
+                .pipe(Effect.forkChild);
+
+              yield* Deferred.await(entered);
+              const update = yield* operation.pipe(Effect.forkChild);
+
+              for (let index = 0; index < 20; index++) yield* Effect.yieldNow;
+              yield* Fiber.interrupt(transaction);
+
+              return yield* Fiber.join(update);
+            });
+
+          const later = Date.now() + 172_800_000;
+          const earlier = later - 86_400_000;
+
+          yield* raceRollback(alarm.scheduleAt(later));
+          expect(yield* alarm.scheduled).toMatchObject({ _tag: "Some", value: later });
+          yield* raceRollback(alarm.ensureScheduledBy(earlier));
+          expect(yield* alarm.scheduled).toMatchObject({ _tag: "Some", value: earlier });
+          yield* raceRollback(alarm.cancel);
+          expect(yield* alarm.scheduled).toMatchObject({ _tag: "None" });
+
+          const generations = Effect.promise(() =>
+            state.storage.get<unknown>("effect-agent:thread-maintenance:v1"),
+          ).pipe(Effect.flatMap(Schema.decodeUnknownEffect(MaintenanceGenerationProbe)));
+
+          const before = yield* generations;
+
+          yield* raceRollback((yield* ThreadMutationGate).withMutation(Effect.void));
+          expect((yield* generations).dirty).toBe(before.dirty + 1n);
+          expect(yield* sql`SELECT * FROM alarm_isolation_probe`).toEqual([]);
+        }),
+      ),
+    );
+  });
+
   // Regression: https://github.com/danieljvdm/effect-agent/commit/e6407479ae233527685928bead040dbfe5153a22
   it("returns after one head Attempt and leaves later FIFO work armed for another event", () =>
     Effect.runPromise(


### PR DESCRIPTION
A concurrent SQLite transaction can roll back a successful alarm update from another Effect fiber. Reserve the owning SQL connection for each short alarm or maintenance-storage operation, and update the earliest alarm in one transaction. Mutation and snapshot bodies retain their existing lock order and run outside the reservation.

`ThreadObject` composition already supplies the shared client. Standalone alarm, mutation-gate and maintenance layers now require that same `SqlClient`; stored generations and alarm contracts are unchanged.

The Workerd regression reproduces the lost alarm on the released implementation and verifies scheduling, earlier deadlines, cancellation and maintenance generations across an interrupted SQL transaction. This correction is required by Kommunikasie's conversation-hosted agent integration ([#1273](https://github.com/reve-ai/kommunikasie/pull/1273)).
