### PR TITLE
ci(travel-planner): add Alchemy production deployment

### DIFF
--- a/.github/workflows/deploy-travel-planner.yml
+++ b/.github/workflows/deploy-travel-planner.yml
@@ -1,0 +1,76 @@
+name: Deploy travel planner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/travel-planner/**"
+      - ".github/workflows/deploy-travel-planner.yml"
+      - "bun.lock"
+      - "package.json"
+      - "bunfig.toml"
+      - "tsconfig.base.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-travel-planner-production
+  cancel-in-progress: false
+
+env:
+  CI: "true"
+  VP_GIT_HOOKS: "0"
+
+jobs:
+  deploy:
+    # Automatic releases start after the initial, explicitly dispatched cutover.
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || vars.TRAVEL_PLANNER_DEPLOY_ENABLED == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
+        with:
+          version: "0.3.0"
+          node-version: "24"
+          run-install: false
+          cache: true
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile --ignore-scripts
+
+      - name: Check application
+        run: vp run -F @effect-agent/example-travel-planner check
+
+      - name: Test application
+        working-directory: examples/travel-planner
+        run: vp test
+
+      - name: Deploy with Alchemy
+        env:
+          # Same account and remote Alchemy state credentials as Deploy docs.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AUTH_ORIGIN: https://travel.effect-agent.com
+          AUTH_EMAIL_FROM: auth@effect-agent.com
+          AUTH_GITHUB_CLIENT_ID: ${{ secrets.TRAVEL_PLANNER_GITHUB_CLIENT_ID }}
+          AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.TRAVEL_PLANNER_GITHUB_CLIENT_SECRET }}
+          AUTH_BINDING_KEY: ${{ secrets.TRAVEL_PLANNER_AUTH_BINDING_KEY }}
+          AUTH_PROOF_KEY: ${{ secrets.TRAVEL_PLANNER_AUTH_PROOF_KEY }}
+          AUTH_TRANSACTION_KEY: ${{ secrets.TRAVEL_PLANNER_AUTH_TRANSACTION_KEY }}
+          BYOK_ENCRYPTION_KEY: ${{ secrets.TRAVEL_PLANNER_BYOK_ENCRYPTION_KEY }}
+        run: |
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET AUTH_BINDING_KEY AUTH_PROOF_KEY AUTH_TRANSACTION_KEY BYOK_ENCRYPTION_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing deployment configuration: $name"
+              exit 1
+            fi
+          done
+          vp run -F @effect-agent/example-travel-planner deploy --yes

--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -292,6 +292,19 @@ the Alchemy container build; its image and SDK use the same pinned version.
 It uses Cloudflare's remote Alchemy state store. `ALCHEMY_LOCAL_STATE=true` selects local
 state for isolated experiments; do not switch state stores for an existing deployment.
 The root docs stack is independent. Deployment credentials are never bound into the Worker.
+The `Deploy travel planner` GitHub Actions workflow deploys changes on `main` to this
+production stack and also supports manual dispatch from `main`. It reuses the docs workflow's
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, including the account-wide Alchemy state
+store; it does not need a second Alchemy key. Application checks and tests run before deployment.
+Set repository Actions secrets `TRAVEL_PLANNER_GITHUB_CLIENT_ID`,
+`TRAVEL_PLANNER_GITHUB_CLIENT_SECRET`, `TRAVEL_PLANNER_AUTH_BINDING_KEY`,
+`TRAVEL_PLANNER_AUTH_PROOF_KEY`, `TRAVEL_PLANNER_AUTH_TRANSACTION_KEY` and
+`TRAVEL_PLANNER_BYOK_ENCRYPTION_KEY`. The workflow fixes the origin to
+`https://travel.effect-agent.com` and the sender to `auth@effect-agent.com`.
+Use manual dispatch for the initial cutover only after the maintenance and reset prerequisites
+below are complete. After the cutover and live login checks, set repository variable
+`TRAVEL_PLANNER_DEPLOY_ENABLED=true` to enable automatic deployments. Until then push-triggered
+jobs are skipped. Normal deployments never run the one-time cleanup.
 Alchemy owns the custom domain; workers.dev and preview URLs are disabled. Generated app
 hosts remain public. The planner uses a single canonical origin and 30-day Auth sessions.
 The obsolete Access application, policy, membership APIs and demo-funding controls are removed.
@@ -304,6 +317,7 @@ The obsolete Access application, policy, membership APIs and demo-funding contro
   `AUTH_EMAIL_FROM` to the verified sender. `AUTH_EMAIL` is a structured Workers send binding
   restricted to that sender, with unrestricted recipients for public signup. It needs no
   email API key. The template and bounded acceptance adapter are in `src/auth/email-delivery.ts`.
+  Disable the sending domain's activity-log message previews so login codes do not appear there.
 - Create a GitHub **OAuth App**, with homepage `https://travel.effect-agent.com` and exact
   callback `https://travel.effect-agent.com/auth/github/callback`. Supply
   `AUTH_GITHUB_CLIENT_ID` and secret `AUTH_GITHUB_CLIENT_SECRET`. This requests identity


### PR DESCRIPTION
Deploy travel-planner from main with Alchemy using the same Cloudflare account token and remote state store as the docs workflow. Pin the setup actions, run application checks and tests, and fail before deployment when an app secret is missing.

Manual dispatch supports the initial approved clean-start cutover. Automatic deployments remain disabled until that cutover and live login checks pass and `TRAVEL_PLANNER_DEPLOY_ENABLED` is set to `true`; subsequent app changes on main then deploy automatically. The workflow never repeats the one-time data cleanup.

Document the six app-specific Actions secrets, `auth@effect-agent.com` sender, and the release activation step in the existing README. The first release still requires the documented planner-only maintenance protection and reset procedure before dispatch.
