### PR TITLE
fix(travel-planner): replace planner binding for clean start

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -295,7 +295,13 @@ The root docs stack is independent. Deployment credentials are never bound into 
 The `Deploy travel planner` GitHub Actions workflow deploys changes on `main` to this
 production stack and also supports manual dispatch from `main`. It reuses the docs workflow's
 `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, including the account-wide Alchemy state
-store; it does not need a second Alchemy key. Application checks and tests run before deployment.
+store; it does not need a second Alchemy key. The shared token must cover this app's zone,
+not only the docs zone: Zone Read, DNS Read/Write and Workers Routes Read/Write for
+`effect-agent.com`; account permissions include Workers Scripts, Workers Containers and
+Workers R2 Storage Read/Write, plus the existing Alchemy state-store access. The initial
+cutover also needs temporary Access Apps and Policies Write to remove this app's old
+resources; remove that permission once reconciliation completes. Cloudflare scopes these
+account permissions beyond a single Worker. Application checks and tests run before deployment.
 Set repository Actions secrets `TRAVEL_PLANNER_GITHUB_CLIENT_ID`,
 `TRAVEL_PLANNER_GITHUB_CLIENT_SECRET`, `TRAVEL_PLANNER_AUTH_BINDING_KEY`,
 `TRAVEL_PLANNER_AUTH_PROOF_KEY`, `TRAVEL_PLANNER_AUTH_TRANSACTION_KEY` and
@@ -343,13 +349,13 @@ again and re-enters their OpenAI key. There is no identity migration or recovery
 The following is a release procedure for the owner to approve and execute; PR preparation
 must not deploy, change provider consoles/secrets or delete live data.
 
-| State                       | Exact reset scope                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Old account/agent data      | This stack's `PlannerThread` SQLite Durable Object namespace, including original `travel-planner-owner-v1`, `member-*` owners, their conversation Objects and child workers. This removes trips/revisions, conversation history, admitted work, journals/checkpoints, diagnostics, model settings, encrypted BYOK rows, app/editor records and the old `travel_demo_access` funding row. No other Worker/stack namespace is included. |
-| New auth and planner state  | New logical binding `AuthThreadsV1` / class `AuthPlannerThread`, and `AuthV1` / class `PlannerAuth` (Object name `auth-v1`). The latter begins empty: local subjects, identifiers/provider bindings, credentials, proof/abuse/continuation records, OAuth flow/registration records and sessions. Existing CF Access auth/proofs are external; no shared IdP or Cloudflare account-wide user store is deleted.                        |
-| Source and snapshots        | Old Artifacts namespace exactly `effect-agent-travel-planner`, including trip repositories, published snapshot branches, generated-app forks and old template. New writes use `effect-agent-travel-planner-auth-v1`. No other Artifacts namespace is included.                                                                                                                                                                        |
-| Builds and public addresses | In this stack's `TripAppBuilds` R2 bucket only, old object prefixes `apps/` and `app-addresses/v1/`. New writes use `auth-apps/v1/` and `app-addresses/auth-v1/`. Old generated URLs return not found; there is no legacy admin lookup or automatic directory repair.                                                                                                                                                                 |
-| Browser state               | Close planner tabs; clear site data only for the planner origin, including old Access/Auth cookies, local/session storage, HTTP cache and retained voice admission IDs. New account runtimes discard drafts, history, settings, key metadata, progress and media on sign-out/account change.                                                                                                                                          |
+| State                       | Exact reset scope                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Old account/agent data      | This stack's `PlannerThread` SQLite Durable Object namespace, including original `travel-planner-owner-v1`, `member-*` owners, their conversation Objects and child workers. This removes trips/revisions, conversation history, admitted work, journals/checkpoints, diagnostics, model settings, encrypted BYOK rows, app/editor records and the old `travel_demo_access` funding row. No other Worker/stack namespace is included.            |
+| New auth and planner state  | New env binding `ACCOUNT_THREADS` / declaration `AccountThreadsV1` / class `AccountPlannerThread`, and `AuthV1` / class `PlannerAuth` (Object name `auth-v1`). The latter begins empty: local subjects, identifiers/provider bindings, credentials, proof/abuse/continuation records, OAuth flow/registration records and sessions. Existing CF Access auth/proofs are external; no shared IdP or Cloudflare account-wide user store is deleted. |
+| Source and snapshots        | Old Artifacts namespace exactly `effect-agent-travel-planner`, including trip repositories, published snapshot branches, generated-app forks and old template. New writes use `effect-agent-travel-planner-auth-v1`. No other Artifacts namespace is included.                                                                                                                                                                                   |
+| Builds and public addresses | In this stack's `TripAppBuilds` R2 bucket only, old object prefixes `apps/` and `app-addresses/v1/`. New writes use `auth-apps/v1/` and `app-addresses/auth-v1/`. Old generated URLs return not found; there is no legacy admin lookup or automatic directory repair.                                                                                                                                                                            |
+| Browser state               | Close planner tabs; clear site data only for the planner origin, including old Access/Auth cookies, local/session storage, HTTP cache and retained voice admission IDs. New account runtimes discard drafts, history, settings, key metadata, progress and media on sign-out/account change.                                                                                                                                                     |
 
 1. Inventory the actual deployed Worker, Durable Object namespace ID, `TripAppBuilds`
    bucket name, Artifacts namespace and `SiteBuild` Workflow from **this stack's existing
@@ -368,9 +374,14 @@ must not deploy, change provider consoles/secrets or delete live data.
    from republishing obsolete addresses during cutover. These are app resources, not other
    applications' Workflow or container instances.
 4. Review the Alchemy dry-run against the existing state. Require deletion of only the old
-   `PlannerThread` class and creation of SQLite classes `AuthPlannerThread` and `PlannerAuth`;
-   the new logical ID must not be interpreted as a class rename/transfer. This is an
-   irreversible application namespace deletion on deployment. Require removal of only
+   planner class (`PlannerThread`, or `AuthPlannerThread` if the initial cutover renamed it)
+   and creation of SQLite class `AccountPlannerThread`. Create `PlannerAuth` only if absent;
+   retain an existing Auth database. The old `THREADS` env binding must disappear and
+   `ACCOUNT_THREADS` must be new: Alchemy keys env-bound Objects by binding name, overriding
+   the declaration ID. Changing the declaration ID alone preserves the namespace through a
+   class rename. Require no class rename/transfer and verify that the new planner namespace ID
+   differs from the inventoried old ID. Keep the binding and class stable after this reset.
+   This is an irreversible application namespace deletion on deployment. Require removal of only
    `TravelAccess` and `TravelInvitedUsers`, the new Email binding/auth configuration, fresh
    Artifacts namespace and disabled workers.dev/previews. Preserve the bucket and unrelated
    stack resources. Only then execute the deployment commands above as the release decision.
@@ -379,7 +390,8 @@ must not deploy, change provider consoles/secrets or delete live data.
    then delete those keys and verify both listings are empty. Do not empty the whole bucket
    or touch the new prefixes. Purge CDN cache entries only for the retired generated hostnames
    from step 1; old open tabs/browser caches can retain already public assets until cleared
-   or expired. Verify the old DO namespace is gone. Remove obsolete app-only
+   or expired. Verify the old DO namespace ID is absent from the account listing, even if
+   its class was renamed. Remove obsolete app-only
    `ACCESS_*`, `OPENAI_API_KEY` and `DEMO_OPENAI_API_KEY` Worker bindings if still present:
    Alchemy has previously left a removed secret bound after deployment. Never delete shared
    IdPs, Access groups, other apps' secrets or provider credentials as part of this reset.

--- a/examples/travel-planner/alchemy.run.ts
+++ b/examples/travel-planner/alchemy.run.ts
@@ -49,9 +49,12 @@ export default Alchemy.Stack(
       compatibility: { date: "2026-07-01", flags: ["nodejs_compat"] },
       assets: { runWorkerFirst: true },
       env: {
-        // New logical ID AND class: the reviewed clean-start deploy deletes only
-        // this app's old PlannerThread namespace instead of renaming/migrating it.
-        THREADS: Cloudflare.DurableObject("AuthThreadsV1", { className: "AuthPlannerThread" }),
+        // Alchemy keys env-bound Objects by the binding name, overriding the
+        // declaration ID. Change both binding and class for this clean start.
+        // Keep both stable after release; changing them deletes account data.
+        ACCOUNT_THREADS: Cloudflare.DurableObject("AccountThreadsV1", {
+          className: "AccountPlannerThread",
+        }),
         AUTH: Cloudflare.DurableObject("AuthV1", { className: "PlannerAuth" }),
         AUTH_EMAIL: Cloudflare.Email.SendEmail("AuthEmail", {
           allowedSenderAddresses: [yield* Config.nonEmptyString("AUTH_EMAIL_FROM")],

--- a/examples/travel-planner/src/research/state.ts
+++ b/examples/travel-planner/src/research/state.ts
@@ -89,7 +89,7 @@ export const researchSnapshot = Effect.fn("researchSnapshot")(function* (
         const env = yield* WorkerEnvironment;
 
         const progress = yield* Effect.tryPromise({
-          try: () => env.THREADS.getByName(worker.threadId).plannerProgress(),
+          try: () => env.ACCOUNT_THREADS.getByName(worker.threadId).plannerProgress(),
           catch: () => "unavailable" as const,
         }).pipe(
           Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(PlannerProgress))),
@@ -97,7 +97,7 @@ export const researchSnapshot = Effect.fn("researchSnapshot")(function* (
         );
 
         const diagnostics = yield* Effect.tryPromise({
-          try: () => env.THREADS.getByName(worker.threadId).plannerDiagnostics(),
+          try: () => env.ACCOUNT_THREADS.getByName(worker.threadId).plannerDiagnostics(),
           catch: () => "unavailable" as const,
         }).pipe(
           Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(RecordedDiagnostics))),

--- a/examples/travel-planner/src/server/cloudflare.ts
+++ b/examples/travel-planner/src/server/cloudflare.ts
@@ -185,7 +185,7 @@ export const plannerHandlers = PlannerRpcs.toLayer({
         const env = yield* WorkerEnvironment;
 
         const reply = yield* Effect.tryPromise({
-          try: () => env.THREADS.getByName(privateId).plannerState(),
+          try: () => env.ACCOUNT_THREADS.getByName(privateId).plannerState(),
           catch: () =>
             new PlannerError({
               code: "unavailable",
@@ -626,7 +626,7 @@ export const makeTravelPlannerThread = <E>(
   application = PlannerLive,
 ) => {
   return class extends ThreadObject.make(application.pipe(Layer.provideMerge(sites)), {
-    namespaceBinding: "THREADS",
+    namespaceBinding: "ACCOUNT_THREADS",
     deploymentId: "travel-planner-v1",
     producerPrefix: "travel-planner",
     wakeScanInterval: 250,

--- a/examples/travel-planner/src/server/credentials.ts
+++ b/examples/travel-planner/src/server/credentials.ts
@@ -11,7 +11,7 @@ export interface CredentialEnvironment {
 }
 
 export interface CredentialBindings extends CredentialEnvironment {
-  readonly THREADS: {
+  readonly ACCOUNT_THREADS: {
     readonly getByName: (owner: string) => {
       readonly modelCredential: () => Promise<string>;
     };
@@ -57,7 +57,7 @@ export const credentialSourceLayer = (env: CredentialBindings) =>
     },
     stored: (owner) =>
       Effect.tryPromise({
-        try: () => env.THREADS.getByName(owner).modelCredential(),
+        try: () => env.ACCOUNT_THREADS.getByName(owner).modelCredential(),
         catch: unavailable,
       }).pipe(
         Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(StoredCredential))),

--- a/examples/travel-planner/src/server/progress-http.ts
+++ b/examples/travel-planner/src/server/progress-http.ts
@@ -7,7 +7,7 @@ import { PlannerError, PlannerProgress, ProgressRpcs } from "../domain.ts";
 import { plannerOwner, privateConversation } from "./tenancy.ts";
 
 export interface ProgressEnvironment {
-  readonly THREADS: {
+  readonly ACCOUNT_THREADS: {
     readonly getByName: (name: string) => { readonly plannerProgress: () => Promise<string> };
   };
 }
@@ -81,7 +81,7 @@ export const serveProgress = Effect.fn("serveProgress")(
               const id = yield* privateConversation(owner, conversationId);
 
               const read = Effect.tryPromise({
-                try: () => env.THREADS.getByName(id).plannerProgress(),
+                try: () => env.ACCOUNT_THREADS.getByName(id).plannerProgress(),
                 catch: unavailable,
               }).pipe(
                 Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(PlannerProgress))),

--- a/examples/travel-planner/src/server/trip-rpc.ts
+++ b/examples/travel-planner/src/server/trip-rpc.ts
@@ -118,7 +118,7 @@ export const tripRepositoryForOwner = (
       const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(Request))(request);
 
       const reply = yield* Effect.tryPromise({
-        try: () => env.THREADS.getByName(storageOwner).tripRepository(encoded),
+        try: () => env.ACCOUNT_THREADS.getByName(storageOwner).tripRepository(encoded),
         catch: unavailable,
       });
 

--- a/examples/travel-planner/src/trip-app/editor-state.ts
+++ b/examples/travel-planner/src/trip-app/editor-state.ts
@@ -74,7 +74,7 @@ export const editorSnapshot = Effect.fn("editorSnapshot")(function* (
     const env = yield* WorkerEnvironment;
 
     const progress = yield* Effect.tryPromise({
-      try: () => env.THREADS.getByName(worker.threadId).plannerProgress(),
+      try: () => env.ACCOUNT_THREADS.getByName(worker.threadId).plannerProgress(),
       catch: () => "unavailable" as const,
     }).pipe(
       Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(PlannerProgress))),
@@ -82,7 +82,7 @@ export const editorSnapshot = Effect.fn("editorSnapshot")(function* (
     );
 
     const diagnostics = yield* Effect.tryPromise({
-      try: () => env.THREADS.getByName(worker.threadId).plannerDiagnostics(),
+      try: () => env.ACCOUNT_THREADS.getByName(worker.threadId).plannerDiagnostics(),
       catch: () => "unavailable" as const,
     }).pipe(
       Effect.flatMap(Schema.decodeUnknownEffect(Schema.fromJsonString(RecordedDiagnostics))),

--- a/examples/travel-planner/src/trip-app/remote.ts
+++ b/examples/travel-planner/src/trip-app/remote.ts
@@ -91,7 +91,7 @@ export const callAppRepository = <A, I>(
     const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(AppCommand))(request);
 
     const response = yield* Effect.tryPromise({
-      try: () => env.THREADS.getByName(owner).tripApp(encoded),
+      try: () => env.ACCOUNT_THREADS.getByName(owner).tripApp(encoded),
       catch: unavailable,
     });
 

--- a/examples/travel-planner/src/worker.ts
+++ b/examples/travel-planner/src/worker.ts
@@ -21,7 +21,7 @@ export { Sandbox } from "@cloudflare/sandbox";
 export { SiteBuild } from "./trip-app/build.ts";
 export { TripData } from "./trip-app/gateway.ts";
 
-export class AuthPlannerThread extends makeTravelPlannerThread(
+export class AccountPlannerThread extends makeTravelPlannerThread(
   Layer.unwrap(
     Effect.map(WorkerEnvironment, (env) => artifactsLayer(env.ARTIFACTS, env.ARTIFACTS_GIT_BASE)),
   ),
@@ -32,7 +32,7 @@ declare global {
     interface Env extends AuthConfiguration, CredentialEnvironment {
       AUTH: DurableObjectNamespace<PlannerAuth>;
       AUTH_EMAIL: SendEmail;
-      THREADS: DurableObjectNamespace<AuthPlannerThread>;
+      ACCOUNT_THREADS: DurableObjectNamespace<AccountPlannerThread>;
       ARTIFACTS: Artifacts;
       ARTIFACTS_GIT_BASE: string;
       ASSETS?: Fetcher;
@@ -251,7 +251,7 @@ export const handleRequest = (verify = authenticate) =>
           const owner = yield* plannerOwner(identity.session.subjectId);
 
           return yield* Effect.promise(async () => {
-            using response = await env.THREADS.getByName(owner).plannerFetch(bounded);
+            using response = await env.ACCOUNT_THREADS.getByName(owner).plannerFetch(bounded);
             const headers = new Headers(response.headers);
 
             headers.set("cache-control", "no-store");

--- a/examples/travel-planner/test/auth-state.test.ts
+++ b/examples/travel-planner/test/auth-state.test.ts
@@ -74,7 +74,12 @@ it("retires app registries and pending requests on signout/account switch while 
           (await request.text()).trim(),
         );
 
-        request.signal.addEventListener(
+        // Observe the signal given to fetch. A copied Request's dependent signal
+        // can be garbage-collected while this fixture keeps its response pending.
+        const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+
+        if (!signal) throw new Error("Expected an abortable account request");
+        signal.addEventListener(
           "abort",
           () => {
             cancelled = true;

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -47,7 +47,7 @@ beforeAll(async () => {
       r2Buckets: ["APP_BUILDS"],
       serviceBindings: { ASSETS: () => new Response("Fixture asset") },
       durableObjects: {
-        THREADS: { className: "TravelPlannerThread", useSQLite: true },
+        ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true },
         AUTH: { className: "AuthFixture", useSQLite: true },
         STORAGE: { className: "AuthStorageFixture", useSQLite: true },
       },

--- a/examples/travel-planner/test/credentials.test.ts
+++ b/examples/travel-planner/test/credentials.test.ts
@@ -43,7 +43,7 @@ const makeRuntime = () =>
         BYOK_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
       },
       r2Buckets: ["APP_BUILDS"],
-      durableObjects: { THREADS: { className: "TravelPlannerThread", useSQLite: true } },
+      durableObjects: { ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true } },
       resourcePersistencePath: directory,
       outboundService: async (request) => {
         expect(request.url).toBe("https://api.openai.com/v1/models");

--- a/examples/travel-planner/test/editor-worker.test.ts
+++ b/examples/travel-planner/test/editor-worker.test.ts
@@ -36,7 +36,7 @@ const makeRuntime = () =>
       compatibilityDate: "2026-07-01",
       compatibilityFlags: ["nodejs_compat"],
       bindings: { PLANNER_TOKEN: token, APP_DOMAIN: "effect-agent.com" },
-      durableObjects: { THREADS: { className: "TravelPlannerThread", useSQLite: true } },
+      durableObjects: { ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true } },
       r2Buckets: ["APP_BUILDS"],
       workflows: { SITE_BUILD: { name: "editor-build", className: "FixtureBuild" } },
       resourcePersistencePath: directory,

--- a/examples/travel-planner/test/fixtures/credentials-worker.ts
+++ b/examples/travel-planner/test/fixtures/credentials-worker.ts
@@ -102,7 +102,7 @@ export default {
 
         return Response.json(resolved);
       }
-      const response = await env.THREADS.getByName(owner).fetch(request);
+      const response = await env.ACCOUNT_THREADS.getByName(owner).fetch(request);
 
       return new Response(await response.arrayBuffer(), {
         status: response.status,

--- a/examples/travel-planner/test/fixtures/editor-worker.ts
+++ b/examples/travel-planner/test/fixtures/editor-worker.ts
@@ -390,9 +390,9 @@ export default {
         return Response.json({ entered: (await bucket.head(`${key}/entered`)) !== null });
       }
       if (url.pathname === "/__editor/journal") {
-        const response = await env.THREADS.getByName(url.searchParams.get("thread") ?? "").fetch(
-          request,
-        );
+        const response = await env.ACCOUNT_THREADS.getByName(
+          url.searchParams.get("thread") ?? "",
+        ).fetch(request);
 
         return new Response(await response.arrayBuffer(), response);
       }

--- a/examples/travel-planner/test/fixtures/research-worker.ts
+++ b/examples/travel-planner/test/fixtures/research-worker.ts
@@ -576,13 +576,13 @@ export default {
         url.pathname === "/__research/seed-research" ||
         url.pathname === "/__research/seed-progress"
       )
-        return env.THREADS.getByName(ownerOfThread(url.searchParams.get("thread") ?? "")).fetch(
-          request,
-        );
+        return env.ACCOUNT_THREADS.getByName(
+          ownerOfThread(url.searchParams.get("thread") ?? ""),
+        ).fetch(request);
       if (url.pathname === "/__research/journal") {
         const threadId = url.searchParams.get("thread") ?? "";
 
-        return env.THREADS.getByName(
+        return env.ACCOUNT_THREADS.getByName(
           threadId.startsWith("worker:") ? threadId : ownerOfThread(threadId),
         ).fetch(request);
       }

--- a/examples/travel-planner/test/fixtures/settings-worker.ts
+++ b/examples/travel-planner/test/fixtures/settings-worker.ts
@@ -85,7 +85,7 @@ export default {
         plannerOwner(fixtureSubject(request.headers.get("x-test-email") ?? ownerEmail)),
       );
 
-      const response = await env.THREADS.getByName(owner).fetch(request);
+      const response = await env.ACCOUNT_THREADS.getByName(owner).fetch(request);
 
       return new Response(await response.arrayBuffer(), {
         status: response.status,

--- a/examples/travel-planner/test/models.test.ts
+++ b/examples/travel-planner/test/models.test.ts
@@ -793,7 +793,7 @@ it.effect(
 
       const credentials = credentialSourceLayer({
         BYOK_ENCRYPTION_KEY: btoa(String.fromCharCode(...encryption)),
-        THREADS: {
+        ACCOUNT_THREADS: {
           getByName: (owner) => ({
             demoAccessAllowed: async () => false,
             modelCredential: async () => {

--- a/examples/travel-planner/test/planner.test.ts
+++ b/examples/travel-planner/test/planner.test.ts
@@ -69,7 +69,7 @@ it("isolates conversations while retaining owner trips, native mutations, public
         },
         outboundService: () => new Response("Unexpected outbound request", { status: 500 }),
         r2Buckets: ["APP_BUILDS"],
-        durableObjects: { THREADS: { className: "TravelPlannerThread", useSQLite: true } },
+        durableObjects: { ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true } },
         resourcePersistencePath: directory,
       }),
     );

--- a/examples/travel-planner/test/progress.test.ts
+++ b/examples/travel-planner/test/progress.test.ts
@@ -286,7 +286,7 @@ it("streams HTTP before completion and cancellation disposes the request without
           }) + "\n",
       }),
       {
-        THREADS: {
+        ACCOUNT_THREADS: {
           getByName: (name) => {
             addresses.push(name);
 
@@ -329,7 +329,7 @@ it("streams HTTP before completion and cancellation disposes the request without
           }) + "\n",
       }),
       {
-        THREADS: {
+        ACCOUNT_THREADS: {
           getByName: (name) => {
             deniedAddresses.push(name);
 

--- a/examples/travel-planner/test/research-worker.test.ts
+++ b/examples/travel-planner/test/research-worker.test.ts
@@ -44,7 +44,7 @@ const makeRuntime = () =>
       compatibilityDate: "2026-07-01",
       compatibilityFlags: ["nodejs_compat"],
       bindings: { PLANNER_TOKEN: token },
-      durableObjects: { THREADS: { className: "TravelPlannerThread", useSQLite: true } },
+      durableObjects: { ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true } },
       r2Buckets: ["APP_BUILDS"],
       resourcePersistencePath: directory,
     }),

--- a/examples/travel-planner/test/settings.test.ts
+++ b/examples/travel-planner/test/settings.test.ts
@@ -39,7 +39,7 @@ const makeRuntime = () =>
       compatibilityFlags: ["nodejs_compat"],
       bindings: { PLANNER_TOKEN: token },
       r2Buckets: ["APP_BUILDS"],
-      durableObjects: { THREADS: { className: "TravelPlannerThread", useSQLite: true } },
+      durableObjects: { ACCOUNT_THREADS: { className: "TravelPlannerThread", useSQLite: true } },
       resourcePersistencePath: directory,
     }),
   );

--- a/examples/travel-planner/test/trip-app-gateway.test.ts
+++ b/examples/travel-planner/test/trip-app-gateway.test.ts
@@ -81,7 +81,7 @@ export class OwnerFixture extends DurableObject {
 export default {async fetch(request,env,ctx){
  const url=new URL(request.url);
  if(url.pathname==="/__seed"){
-   const input=await request.json();await env.THREADS.getByName(input.owner).seed(input.app,input.data);
+   const input=await request.json();await env.ACCOUNT_THREADS.getByName(input.owner).seed(input.app,input.data);
    if(input.register!==false)await Effect.runPromise(publishTripAppAddress(input.owner,input.app,"effect-agent.com").pipe(Effect.provide(AppBuildBucketLive),Effect.provideService(WorkerEnvironment,env)));
    if(input.app.activeCommit!==null){
      const prefix=buildPrefix(input.app.id,input.app.activeCommit);
@@ -136,7 +136,7 @@ export default {async fetch(request,env,ctx){
       modulesRoot: "/",
       compatibilityDate: "2026-07-01",
       compatibilityFlags: ["nodejs_compat"],
-      durableObjects: { THREADS: { className: "OwnerFixture", useSQLite: true } },
+      durableObjects: { ACCOUNT_THREADS: { className: "OwnerFixture", useSQLite: true } },
       r2Buckets: ["APP_BUILDS"],
       workerLoaders: { APP_LOADER: {} },
       bindings: {

--- a/examples/travel-planner/test/voice-http.test.ts
+++ b/examples/travel-planner/test/voice-http.test.ts
@@ -35,7 +35,7 @@ const environment = Effect.gen(function* () {
 
   return {
     BYOK_ENCRYPTION_KEY: btoa(String.fromCharCode(...bytes)),
-    THREADS: {
+    ACCOUNT_THREADS: {
       getByName: (owner: string) => ({
         modelCredential: async () => {
           expect(owner).toBe(ownerThread);
@@ -135,7 +135,7 @@ it.effect("refuses voice without BYOK even when an obsolete host key exists", ()
   Effect.gen(function* () {
     const env = {
       DEMO_OPENAI_API_KEY: "sk-obsolete-host-key",
-      THREADS: { getByName: () => ({ modelCredential: async () => "null" }) },
+      ACCOUNT_THREADS: { getByName: () => ({ modelCredential: async () => "null" }) },
     };
 
     let calls = 0;


### PR DESCRIPTION
The clean-start auth cutover must create a fresh planner Durable Object namespace. Alchemy `2.0.0-beta.72` tracks env-bound Objects by the environment binding name, overriding the declaration ID; keeping `THREADS` caused a class rename that retained the old namespace.

Replace that binding with `ACCOUNT_THREADS` and class `AccountPlannerThread`, and update planner, BYOK, progress and fixture references. This deletes only the old planner namespace while preserving `PlannerAuth` and the build Sandbox. The README now requires comparing actual namespace IDs, explains the binding-name constraint, and documents the shared deployment token's additional zone/account permissions.

The cancellation fixture also observes the original fetch signal. A Node garbage-collection reproduction showed that the copied Request signal could disappear while the mock response remained pending, causing CI to miss a real abort.

The explicit clean-start decision still applies: old accounts' trips, history, settings and encrypted keys are discarded. Keep maintenance active until the scoped reset and live login checks pass. Dependencies remain unchanged, including `@yielded/auth@0.1.0-beta.2` and Effect `4.0.0-rc.112`.
