### PR TITLE
fix(travel-planner): clear OAuth query before resource links

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -450,7 +450,8 @@ provider-side revocation is needed to invalidate copies in historical database b
   already admitted work with their original tool schemas and output formats.
 - Auth HTTP middleware supplies request context; `auth.requireSession()` explicitly authorizes
   private planner pages, published snapshots, RPC, voice and progress. `/login`, callback GET
-  and required static assets are public. Callback GET only renders: an inline script removes
+  and required static assets are public. Callback GET only renders: the Worker prepends an
+  inline script to the rendered head, ahead of React's hoisted resource links. It removes
   secret query values before assets/hydration, then typed Auth actions submit the callback
   through a same-origin CSRF-protected POST. Codes/state/tokens are never logged or persisted
   in browser storage. Only the public GitHub flow ID survives the round trip in session storage.

--- a/examples/travel-planner/src/auth/callback.ts
+++ b/examples/travel-planner/src/auth/callback.ts
@@ -1,0 +1,3 @@
+/** Inject into the rendered head at the Worker boundary: React hoists resources
+ * ahead of ordinary script elements, even when they appear first in JSX. */
+export const captureCallbackScript = `if(location.pathname==='/auth/github/callback'){const q=location.search;history.replaceState(null,'',location.pathname);window.__elsewhereCallback=q;}`;

--- a/examples/travel-planner/src/auth/client.ts
+++ b/examples/travel-planner/src/auth/client.ts
@@ -94,9 +94,8 @@ const startGithub = Effect.gen(function* () {
 
 export const githubLogin = auth.runtime.fn<void>()(() => startGithub);
 
-// This static script runs before styles, hydration, analytics or other page scripts.
-// Only public flow correlation survives navigation; callback credentials stay in memory.
-export const captureCallbackScript = `if(location.pathname==='/auth/github/callback'){const q=location.search;history.replaceState(null,'',location.pathname);window.__elsewhereCallback=q;}`;
+// The Worker captures callback credentials in memory before loading page resources.
+// Only public flow correlation survives navigation.
 declare global {
   interface Window {
     __elsewhereCallback?: string;

--- a/examples/travel-planner/src/routes/__root.tsx
+++ b/examples/travel-planner/src/routes/__root.tsx
@@ -1,7 +1,7 @@
 import { RegistryProvider, useAtomMount } from "@effect/atom-react";
 import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
 
-import { captureCallbackScript, sessionObservation } from "../auth/client";
+import { sessionObservation } from "../auth/client";
 
 import appCss from "../styles.css?url";
 
@@ -35,7 +35,6 @@ function Document({ children }: { readonly children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <script dangerouslySetInnerHTML={{ __html: captureCallbackScript }} />
         <meta name="referrer" content="no-referrer" />
         <HeadContent />
       </head>

--- a/examples/travel-planner/src/worker.ts
+++ b/examples/travel-planner/src/worker.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, Schema } from "effect";
 import { Worker, WorkerEnvironment } from "effect-cf";
 
 import { artifactsLayer } from "./artifacts";
+import { captureCallbackScript } from "./auth/callback";
 import type { AuthConfiguration } from "./auth/server";
 import { authenticate, type PlannerAuth } from "./auth/worker";
 import { Trip, TripId, TripSiteStore, type AppBuildRequest } from "./domain";
@@ -148,7 +149,17 @@ export const handleRequest = (verify = authenticate) =>
       headers.set("cache-control", "no-store");
       headers.set("referrer-policy", "no-referrer");
 
-      return new Response(response.body, { status: response.status, headers });
+      const page = new Response(response.body, { status: response.status, headers });
+
+      return url.pathname === "/auth/github/callback"
+        ? new HTMLRewriter()
+            .on("head", {
+              element: (head) => {
+                head.prepend(`<script>${captureCallbackScript}</script>`, { html: true });
+              },
+            })
+            .transform(page)
+        : page;
     }
     if (url.pathname.startsWith("/auth/")) {
       return yield* Effect.tryPromise({

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -492,6 +492,26 @@ it("keeps callback GET inert, exposes only login assets, and rejects unauthentic
 
   expect(home.status).toBe(303);
   expect(home.headers.get("location")).toBe("/login");
+
+  const callback = await client.request(
+    "/auth/github/callback?code=PRIVATE_CODE&state=PRIVATE_STATE",
+  );
+
+  const callbackHtml = await callback.text();
+
+  // The browser must clear the query before React's hoisted resource links.
+  expect(callbackHtml).toMatch(/<head><script>.*history\.replaceState/);
+  expect(callbackHtml.indexOf("history.replaceState")).toBeLessThan(
+    callbackHtml.indexOf('<link rel="stylesheet"'),
+  );
+  expect(callbackHtml.indexOf("history.replaceState")).toBeLessThan(
+    callbackHtml.indexOf('<link rel="modulepreload"'),
+  );
+  expect(callbackHtml.match(/window\.__elsewhereCallback=q/g)).toHaveLength(1);
+  expect(callbackHtml).not.toMatch(/PRIVATE_CODE|PRIVATE_STATE/);
+  expect(callback.headers.get("referrer-policy")).toBe("no-referrer");
+  expect(callback.headers.get("cache-control")).toBe("no-store");
+  expect(callback.headers.has("set-cookie")).toBe(false);
   for (const path of [
     "/login",
     "/auth/github/callback?code=PRIVATE_CODE&state=PRIVATE_STATE",

--- a/examples/travel-planner/test/fixtures/start.ts
+++ b/examples/travel-planner/test/fixtures/start.ts
@@ -4,9 +4,10 @@ export default {
     new Response(
       new URL(request.url).pathname === "/login" ||
         new URL(request.url).pathname === "/auth/github/callback"
-        ? "Login fixture"
+        ? '<!doctype html><html><head><link rel="stylesheet" href="/assets/login.css"><link rel="modulepreload" href="/assets/login.js"></head><body>Login fixture<script type="module" src="/assets/login.js"></script></body></html>'
         : "SSR fixture",
       {
+        headers: { "content-type": "text/html" },
         status: ["/login", "/auth/github/callback"].includes(new URL(request.url).pathname)
           ? 200
           : 404,


### PR DESCRIPTION
React hoists stylesheet and module-preload links ahead of the callback capture script, so placing that script first in JSX does not clear the OAuth query before resource loading. Prepend it to the rendered callback head in the Worker, capture the query only in memory, and remove it from the address bar before those links. Callback GET remains inert with no-store and no-referrer headers.

This fixes callback HTML ordering; the live GitHub `OAuthRejected` failure remains under investigation. No dependency or production configuration changes.
