### PR TITLE
fix(travel-planner): add safe GitHub callback diagnostics

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -340,6 +340,12 @@ The obsolete Access application, policy, membership APIs and demo-funding contro
 - Automatic invocation URL logs, request traces and Worker Logpush are disabled to keep
   callback codes/state out of telemetry. Keep that setting; review any independently managed
   edge Logpush/analytics pipeline to exclude callback query strings before enabling it.
+- Rejected GitHub callbacks emit `auth.github.callback-rejected` in Workers Logs with a fixed
+  `reason` label for the observed binding, state, issuer, flow or post-claim failure stage.
+  These records contain no account/flow IDs, codes, state values, cookies, digests or provider
+  response bodies. Flow inspection happens only after rejection, is read-only and bounded,
+  and cannot authorize a request or trigger another exchange. Logging failure leaves the
+  original public `OAuthRejected` response intact.
   Auth diagnostics contain only safe stage names, never request bodies or provider errors.
 
 ### Clean-start cutover and reset

--- a/examples/travel-planner/src/auth/host.ts
+++ b/examples/travel-planner/src/auth/host.ts
@@ -7,8 +7,8 @@ import * as Drizzle from "drizzle-orm/effect-sqlite-do";
 import { Effect, Layer, Option, Schema } from "effect";
 import { HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http";
 
-import { makeGithubDiagnostics, type GithubRejectionReporter } from "./oauth-diagnostics";
-import { persistenceLayer } from "./persistence";
+import { makeGithubDiagnostics } from "./oauth-diagnostics";
+import { AuthDatabase, persistenceLayer } from "./persistence";
 import { makeAuth, type AuthConfiguration } from "./server";
 import { initializeAuthStorage } from "./storage";
 
@@ -28,23 +28,24 @@ export const serveAuth = Effect.fn("Auth.fetch")(function* (
   config: AuthConfiguration,
   delivery: Layer.Layer<EmailProofDelivery>,
   protocol?: Layer.Layer<OAuthProtocol>,
-  onGithubRejection?: GithubRejectionReporter,
 ) {
   yield* initializeAuthStorage(storage);
   const { AppAuth, http, security, github } = makeAuth(config);
-  const diagnostics = yield* makeGithubDiagnostics(AppAuth, onGithubRejection);
+  const diagnostics = yield* makeGithubDiagnostics(AppAuth);
 
   const database = Layer.effectContext(
     Effect.gen(function* () {
       const db = yield* Drizzle.makeWithDefaults({ storage });
 
-      return yield* Layer.build(persistenceLayer(AppAuth, db, diagnostics));
+      return yield* Layer.build(
+        persistenceLayer(AppAuth).pipe(Layer.provideMerge(Layer.succeed(AuthDatabase, db))),
+      );
     }),
   ).pipe(Layer.provide(SqliteClient.layer({ storage })), Layer.provide(LifecycleHooks.empty));
 
   const live = AppAuth.layer.pipe(
     Layer.provide([
-      database,
+      diagnostics.persistenceLayer.pipe(Layer.provideMerge(database)),
       security,
       protocol ?? github,
       delivery,

--- a/examples/travel-planner/src/auth/host.ts
+++ b/examples/travel-planner/src/auth/host.ts
@@ -4,12 +4,22 @@ import type { OAuthProtocol } from "@yielded/auth/OAuth";
 import type { EmailProofDelivery } from "@yielded/auth/Proofs";
 import { layerWebCrypto } from "@yielded/auth/WebCrypto";
 import * as Drizzle from "drizzle-orm/effect-sqlite-do";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option, Schema } from "effect";
 import { HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http";
 
+import { makeGithubDiagnostics, type GithubRejectionReporter } from "./oauth-diagnostics";
 import { persistenceLayer } from "./persistence";
 import { makeAuth, type AuthConfiguration } from "./server";
 import { initializeAuthStorage } from "./storage";
+
+const rejectedCallback = Schema.decodeOption(
+  Schema.fromJsonString(
+    Schema.Struct({
+      _tag: Schema.Literal("Failure"),
+      error: Schema.Struct({ _tag: Schema.Literal("OAuthRejected") }),
+    }),
+  ),
+);
 
 /** The Auth object owns only auth state; planner data never passes through it. */
 export const serveAuth = Effect.fn("Auth.fetch")(function* (
@@ -18,20 +28,28 @@ export const serveAuth = Effect.fn("Auth.fetch")(function* (
   config: AuthConfiguration,
   delivery: Layer.Layer<EmailProofDelivery>,
   protocol?: Layer.Layer<OAuthProtocol>,
+  onGithubRejection?: GithubRejectionReporter,
 ) {
   yield* initializeAuthStorage(storage);
   const { AppAuth, http, security, github } = makeAuth(config);
+  const diagnostics = yield* makeGithubDiagnostics(AppAuth, onGithubRejection);
 
   const database = Layer.effectContext(
     Effect.gen(function* () {
       const db = yield* Drizzle.makeWithDefaults({ storage });
 
-      return yield* Layer.build(persistenceLayer(AppAuth, db));
+      return yield* Layer.build(persistenceLayer(AppAuth, db, diagnostics));
     }),
   ).pipe(Layer.provide(SqliteClient.layer({ storage })), Layer.provide(LifecycleHooks.empty));
 
   const live = AppAuth.layer.pipe(
-    Layer.provide([database, security, protocol ?? github, delivery]),
+    Layer.provide([
+      database,
+      security,
+      protocol ?? github,
+      delivery,
+      diagnostics.bindingLayer.pipe(Layer.provide(security)),
+    ]),
     Layer.provide(layerWebCrypto),
   );
 
@@ -66,6 +84,16 @@ export const serveAuth = Effect.fn("Auth.fetch")(function* (
 
   const response = yield* Effect.promise(() => web.handler(request));
   const body = yield* Effect.promise(() => response.arrayBuffer());
+
+  if (
+    new URL(request.url).pathname === "/auth/completeSignIn" &&
+    response.status === 400 &&
+    Option.isSome(rejectedCallback(new TextDecoder().decode(body)))
+  )
+    yield* diagnostics.report.pipe(
+      Effect.timeout("100 millis"),
+      Effect.catchCause(() => Effect.void),
+    );
 
   return new Response(body, { status: response.status, headers: response.headers });
 }, Effect.scoped);

--- a/examples/travel-planner/src/auth/oauth-diagnostics.ts
+++ b/examples/travel-planner/src/auth/oauth-diagnostics.ts
@@ -1,0 +1,134 @@
+import { OAuthPendingFlow, OAuthSignInPersistence } from "@yielded/auth/OAuth";
+import { and, eq } from "drizzle-orm";
+import type { EffectSQLiteDoDatabase } from "drizzle-orm/effect-sqlite-do";
+import { Effect, Layer, Ref, Schema } from "effect";
+
+import { oauthFlow } from "./oauth-schema";
+import type { AppAuth } from "./server";
+
+export const GithubRejectionReason = Schema.Literals([
+  "callback-invalid",
+  "request-binding-invalid",
+  "state-invalid",
+  "flow-missing",
+  "flow-not-pending",
+  "flow-expired",
+  "flow-not-yet-valid",
+  "flow-configuration-mismatch",
+  "state-mismatch",
+  "request-binding-mismatch",
+  "issuer-unexpected",
+  "issuer-mismatch",
+  "flow-rejected",
+  "after-claim",
+]);
+
+export type GithubRejectionReason = typeof GithubRejectionReason.Type;
+export type GithubRejectionReporter = (reason: GithubRejectionReason) => Effect.Effect<void>;
+
+export const reportGithubRejection: GithubRejectionReporter = (reason) =>
+  Effect.logWarning("auth.github.callback-rejected").pipe(Effect.annotateLogs({ reason }));
+
+const pending = Schema.fromJsonString(OAuthPendingFlow);
+
+type ClaimInput = Parameters<OAuthSignInPersistence["Service"]["claim"]>[0];
+
+/** Read only after a rejected claim has finished. These observations are diagnostic;
+ * the adapter remains the sole authority for authorization and durable mutation. */
+const describeRejectedClaim = Effect.fn("Auth.describeRejectedClaim")(function* (
+  database: EffectSQLiteDoDatabase,
+  input: ClaimInput,
+): Effect.fn.Return<GithubRejectionReason> {
+  return yield* Effect.gen(function* () {
+    const rows = yield* database
+      .select({ state: oauthFlow.state, snapshot: oauthFlow.snapshot })
+      .from(oauthFlow)
+      .where(and(eq(oauthFlow.moduleId, input.moduleId), eq(oauthFlow.flowId, input.flowId)));
+
+    const row = rows[0];
+
+    if (!row) return "flow-missing" as const;
+    if (row.state !== "Pending" || row.snapshot === null) return "flow-not-pending" as const;
+    const flow = yield* Schema.decodeEffect(pending)(row.snapshot);
+    const context = flow.context;
+
+    if (context.responseIssuerMode === "unsupported" && input.responseIssuer !== undefined)
+      return "issuer-unexpected" as const;
+    if (context.responseIssuerMode === "required" && input.responseIssuer !== context.issuer)
+      return "issuer-mismatch" as const;
+    if (
+      context.generation !== input.generation ||
+      context.provider !== input.provider ||
+      context.callbackId !== input.callbackId
+    )
+      return "flow-configuration-mismatch" as const;
+    if (context.stateDigest !== input.stateDigest) return "state-mismatch" as const;
+    if (
+      context.requestBindingVerifier !== input.requestBindingVerifier ||
+      context.requestBindingExpiresAtMillis !== input.requestBindingExpiresAtMillis
+    )
+      return "request-binding-mismatch" as const;
+    if (input.nowMillis < context.issuedAtMillis) return "flow-not-yet-valid" as const;
+    if (input.nowMillis >= context.expiresAtMillis) return "flow-expired" as const;
+
+    return "flow-rejected" as const;
+  }).pipe(
+    // Telemetry cannot replace the original rejection, including when its read fails.
+    Effect.timeout("100 millis"),
+    Effect.catchCause(() => Effect.succeed("flow-rejected" as const)),
+  );
+});
+
+/** Request-local observations contain only fixed reason labels, never identifiers,
+ * raw callback values, credential values, digests, or provider response bodies. */
+export const makeGithubDiagnostics = Effect.fn("Auth.makeGithubDiagnostics")(function* (
+  AppAuth: AppAuth,
+  report: GithubRejectionReporter = reportGithubRejection,
+) {
+  const reason = yield* Ref.make<GithubRejectionReason>("callback-invalid");
+  const binding = AppAuth.strategies.github.binding;
+
+  const bindingLayer = Layer.effect(
+    binding.RequestBinding,
+    Effect.gen(function* () {
+      const original = yield* binding.RequestBinding;
+
+      return binding.RequestBinding.of({
+        ...original,
+        verify: (flowId, credential) =>
+          original.verify(flowId, credential).pipe(
+            Effect.tap(() => Ref.set(reason, "state-invalid")),
+            Effect.tapError(() => Ref.set(reason, "request-binding-invalid")),
+          ),
+      });
+    }),
+  ).pipe(Layer.provide(binding.layer));
+
+  return {
+    bindingLayer,
+    persistence: (original: OAuthSignInPersistence["Service"], database: EffectSQLiteDoDatabase) =>
+      OAuthSignInPersistence.of({
+        ...original,
+        claim: (input, prepare) =>
+          Effect.gen(function* () {
+            let rejected = false;
+
+            const receipt = yield* original.claim(input, (decision, journal) => {
+              rejected = decision._tag !== "Claimed";
+
+              return prepare(decision, journal);
+            });
+
+            yield* Ref.set(
+              reason,
+              rejected ? yield* describeRejectedClaim(database, input) : "after-claim",
+            );
+
+            return receipt;
+          }),
+      }),
+    report: Effect.flatMap(Ref.get(reason), report),
+  };
+});
+
+export type GithubDiagnostics = Effect.Success<ReturnType<typeof makeGithubDiagnostics>>;

--- a/examples/travel-planner/src/auth/oauth-diagnostics.ts
+++ b/examples/travel-planner/src/auth/oauth-diagnostics.ts
@@ -1,9 +1,9 @@
 import { OAuthPendingFlow, OAuthSignInPersistence } from "@yielded/auth/OAuth";
 import { and, eq } from "drizzle-orm";
-import type { EffectSQLiteDoDatabase } from "drizzle-orm/effect-sqlite-do";
 import { Effect, Layer, Ref, Schema } from "effect";
 
 import { oauthFlow } from "./oauth-schema";
+import { AuthDatabase } from "./persistence";
 import type { AppAuth } from "./server";
 
 export const GithubRejectionReason = Schema.Literals([
@@ -24,11 +24,6 @@ export const GithubRejectionReason = Schema.Literals([
 ]);
 
 export type GithubRejectionReason = typeof GithubRejectionReason.Type;
-export type GithubRejectionReporter = (reason: GithubRejectionReason) => Effect.Effect<void>;
-
-export const reportGithubRejection: GithubRejectionReporter = (reason) =>
-  Effect.logWarning("auth.github.callback-rejected").pipe(Effect.annotateLogs({ reason }));
-
 const pending = Schema.fromJsonString(OAuthPendingFlow);
 
 type ClaimInput = Parameters<OAuthSignInPersistence["Service"]["claim"]>[0];
@@ -36,9 +31,10 @@ type ClaimInput = Parameters<OAuthSignInPersistence["Service"]["claim"]>[0];
 /** Read only after a rejected claim has finished. These observations are diagnostic;
  * the adapter remains the sole authority for authorization and durable mutation. */
 const describeRejectedClaim = Effect.fn("Auth.describeRejectedClaim")(function* (
-  database: EffectSQLiteDoDatabase,
   input: ClaimInput,
-): Effect.fn.Return<GithubRejectionReason> {
+): Effect.fn.Return<GithubRejectionReason, never, AuthDatabase> {
+  const database = yield* AuthDatabase;
+
   return yield* Effect.gen(function* () {
     const rows = yield* database
       .select({ state: oauthFlow.state, snapshot: oauthFlow.snapshot })
@@ -83,7 +79,6 @@ const describeRejectedClaim = Effect.fn("Auth.describeRejectedClaim")(function* 
  * raw callback values, credential values, digests, or provider response bodies. */
 export const makeGithubDiagnostics = Effect.fn("Auth.makeGithubDiagnostics")(function* (
   AppAuth: AppAuth,
-  report: GithubRejectionReporter = reportGithubRejection,
 ) {
   const reason = yield* Ref.make<GithubRejectionReason>("callback-invalid");
   const binding = AppAuth.strategies.github.binding;
@@ -106,29 +101,40 @@ export const makeGithubDiagnostics = Effect.fn("Auth.makeGithubDiagnostics")(fun
 
   return {
     bindingLayer,
-    persistence: (original: OAuthSignInPersistence["Service"], database: EffectSQLiteDoDatabase) =>
-      OAuthSignInPersistence.of({
-        ...original,
-        claim: (input, prepare) =>
-          Effect.gen(function* () {
-            let rejected = false;
+    persistenceLayer: Layer.effect(
+      OAuthSignInPersistence,
+      Effect.gen(function* () {
+        const original = yield* OAuthSignInPersistence;
+        const database = yield* AuthDatabase;
 
-            const receipt = yield* original.claim(input, (decision, journal) => {
-              rejected = decision._tag !== "Claimed";
+        return OAuthSignInPersistence.of({
+          ...original,
+          claim: (input, prepare) =>
+            Effect.gen(function* () {
+              let rejected = false;
 
-              return prepare(decision, journal);
-            });
+              const receipt = yield* original.claim(input, (decision, journal) => {
+                rejected = decision._tag !== "Claimed";
 
-            yield* Ref.set(
-              reason,
-              rejected ? yield* describeRejectedClaim(database, input) : "after-claim",
-            );
+                return prepare(decision, journal);
+              });
 
-            return receipt;
-          }),
+              yield* Ref.set(
+                reason,
+                rejected
+                  ? yield* describeRejectedClaim(input).pipe(
+                      Effect.provideService(AuthDatabase, database),
+                    )
+                  : "after-claim",
+              );
+
+              return receipt;
+            }),
+        });
       }),
-    report: Effect.flatMap(Ref.get(reason), report),
+    ),
+    report: Effect.flatMap(Ref.get(reason), (reason) =>
+      Effect.logWarning("auth.github.callback-rejected").pipe(Effect.annotateLogs({ reason })),
+    ),
   };
 });
-
-export type GithubDiagnostics = Effect.Success<ReturnType<typeof makeGithubDiagnostics>>;

--- a/examples/travel-planner/src/auth/persistence.ts
+++ b/examples/travel-planner/src/auth/persistence.ts
@@ -9,23 +9,23 @@ import { ProofPersistence } from "@yielded/auth/Proofs";
 import { AuthenticationAuthority } from "@yielded/auth/Sessions";
 import { eq } from "drizzle-orm";
 import type { EffectSQLiteDoDatabase } from "drizzle-orm/effect-sqlite-do";
-import { Effect, Layer } from "effect";
+import { Context, Effect, Layer } from "effect";
 
 import { emailSignInMapping, emailRegistrationMapping } from "./email-schema";
-import type { GithubDiagnostics } from "./oauth-diagnostics";
 import { oauthSignInMapping, oauthIntentMapping, oauthRegistrationMapping } from "./oauth-schema";
 import { proofs } from "./proof-schema";
 import { subject, subjectMapping, subjectId, credentialMapping } from "./schema";
 import type { AppAuth } from "./server";
 import { sessionsMapping } from "./session-schema";
 
-export const persistenceLayer = (
-  AppAuth: AppAuth,
-  database: EffectSQLiteDoDatabase,
-  diagnostics: GithubDiagnostics,
-) =>
+export class AuthDatabase extends Context.Service<AuthDatabase, EffectSQLiteDoDatabase>()(
+  "travel-planner/AuthDatabase",
+) {}
+
+export const persistenceLayer = (AppAuth: AppAuth) =>
   Layer.unwrap(
     Effect.gen(function* () {
+      const database = yield* AuthDatabase;
       const proof = yield* Drizzle.makeProofPersistenceServices(database, proofs);
       const email = yield* Drizzle.makeEmailSignInServices(database, emailSignInMapping);
 
@@ -86,10 +86,7 @@ export const persistenceLayer = (
               Effect.mapError(() => OAuthUnavailable.make({})),
             ),
         }),
-        Layer.succeed(
-          OAuthSignInPersistence,
-          diagnostics.persistence(oauth.oauthSignInPersistence, database),
-        ),
+        Layer.succeed(OAuthSignInPersistence, oauth.oauthSignInPersistence),
         Layer.succeed(OAuthRegistrationIntents, intents.oauthRegistrationIntents),
         Layer.succeed(
           AppAuth.strategies.github.registration.RegistrationAuthority,

--- a/examples/travel-planner/src/auth/persistence.ts
+++ b/examples/travel-planner/src/auth/persistence.ts
@@ -12,13 +12,18 @@ import type { EffectSQLiteDoDatabase } from "drizzle-orm/effect-sqlite-do";
 import { Effect, Layer } from "effect";
 
 import { emailSignInMapping, emailRegistrationMapping } from "./email-schema";
+import type { GithubDiagnostics } from "./oauth-diagnostics";
 import { oauthSignInMapping, oauthIntentMapping, oauthRegistrationMapping } from "./oauth-schema";
 import { proofs } from "./proof-schema";
 import { subject, subjectMapping, subjectId, credentialMapping } from "./schema";
 import type { AppAuth } from "./server";
 import { sessionsMapping } from "./session-schema";
 
-export const persistenceLayer = (AppAuth: AppAuth, database: EffectSQLiteDoDatabase) =>
+export const persistenceLayer = (
+  AppAuth: AppAuth,
+  database: EffectSQLiteDoDatabase,
+  diagnostics: GithubDiagnostics,
+) =>
   Layer.unwrap(
     Effect.gen(function* () {
       const proof = yield* Drizzle.makeProofPersistenceServices(database, proofs);
@@ -81,7 +86,10 @@ export const persistenceLayer = (AppAuth: AppAuth, database: EffectSQLiteDoDatab
               Effect.mapError(() => OAuthUnavailable.make({})),
             ),
         }),
-        Layer.succeed(OAuthSignInPersistence, oauth.oauthSignInPersistence),
+        Layer.succeed(
+          OAuthSignInPersistence,
+          diagnostics.persistence(oauth.oauthSignInPersistence, database),
+        ),
         Layer.succeed(OAuthRegistrationIntents, intents.oauthRegistrationIntents),
         Layer.succeed(
           AppAuth.strategies.github.registration.RegistrationAuthority,

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -11,6 +11,7 @@ import { convertV4MiniflareOptions, Miniflare } from "miniflare";
 import { afterAll, beforeAll, expect, expectTypeOf, it } from "vite-plus/test";
 
 import type { AccountError } from "../src/auth/account";
+import { GithubRejectionReason } from "../src/auth/oauth-diagnostics";
 import type { authenticate } from "../src/auth/worker";
 import type { PlannerSettings } from "../src/domain";
 import { defaultPlannerSettings } from "../src/domain";
@@ -55,6 +56,9 @@ beforeAll(async () => {
       outboundService: async (request) => {
         if (request.url === "https://github.com/login/oauth/access_token") {
           githubExchanges++;
+
+          if (new URLSearchParams(await request.text()).get("code") === "fixture-rejected-code")
+            return Response.json({ error: "bad_verification_code" });
 
           return Response.json({
             access_token: "fixture-token",
@@ -476,6 +480,61 @@ it("rejects invalid and replayed GitHub callbacks, and handles denial without ex
       })
     ).status,
   ).toBe(400);
+});
+
+it("reports only fixed callback rejection reasons without changing authorization or retrying an exchange", async () => {
+  const read = async () =>
+    Schema.decodeUnknownSync(Schema.Array(GithubRejectionReason))(
+      await (await mf.dispatchFetch("https://planner.test/_fixture/rejections")).json(),
+    );
+
+  const before = (await read()).length;
+  const exchanges = githubExchanges;
+  const client = makeClient();
+  const superseded = await githubStart(client);
+  const input = await githubStart(client);
+
+  const rejected = async (payload: object) => {
+    expect(await client.raw("completeSignIn", payload)).toEqual({
+      status: 400,
+      body: { _tag: "Failure", error: { _tag: "OAuthRejected" } },
+    });
+  };
+
+  await rejected(superseded);
+  await rejected({ ...input, response: { ...input.response, state: "malformed-private-state" } });
+  await rejected({ ...input, response: { ...input.response, state: "A".repeat(43) } });
+  await rejected({
+    ...input,
+    response: { ...input.response, issuer: "https://github.com/login/oauth" },
+  });
+  expect(githubExchanges).toBe(exchanges);
+  await rejected({ ...input, response: { ...input.response, code: "fixture-rejected-code" } });
+  expect(githubExchanges).toBe(exchanges + 1);
+  expect((await read()).slice(before)).toEqual([
+    "request-binding-invalid",
+    "state-invalid",
+    "state-mismatch",
+    "issuer-unexpected",
+    "after-claim",
+  ]);
+  // Missing/invalid private values never appear in the diagnostic sink.
+  expect(JSON.stringify(await read())).not.toMatch(
+    /malformed-private-state|fixture-rejected-code|https:|eyJ/,
+  );
+
+  for (const mode of ["defect", "interrupt", "timeout"]) {
+    const started = await githubStart(client);
+
+    await mf.dispatchFetch(`https://planner.test/_fixture/reporter?mode=${mode}`);
+    try {
+      await rejected({ ...started, response: { ...started.response, state: "malformed" } });
+    } finally {
+      await mf.dispatchFetch("https://planner.test/_fixture/reporter");
+    }
+  }
+  expect(githubExchanges).toBe(exchanges + 1);
+  expect((await read()).length).toBe(before + 5);
 });
 
 it("keeps callback GET inert, exposes only login assets, and rejects unauthenticated private APIs", async () => {

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -523,10 +523,10 @@ it("reports only fixed callback rejection reasons without changing authorization
     /malformed-private-state|fixture-rejected-code|https:|eyJ/,
   );
 
-  for (const mode of ["defect", "interrupt", "timeout"]) {
+  {
     const started = await githubStart(client);
 
-    await mf.dispatchFetch(`https://planner.test/_fixture/reporter?mode=${mode}`);
+    await mf.dispatchFetch("https://planner.test/_fixture/reporter?mode=defect");
     try {
       await rejected({ ...started, response: { ...started.response, state: "malformed" } });
     } finally {

--- a/examples/travel-planner/test/fixtures/auth-worker.ts
+++ b/examples/travel-planner/test/fixtures/auth-worker.ts
@@ -6,6 +6,7 @@ import { WorkerEnvironment } from "effect-cf";
 import { handleRequest } from "../../src/worker";
 export { TravelPlannerThread } from "./worker";
 import { serveAuth } from "../../src/auth/host";
+import type { GithubRejectionReason } from "../../src/auth/oauth-diagnostics";
 import {
   initializeAuthStorage,
   AuthStorageFailpoint,
@@ -30,8 +31,17 @@ export const fixtureAuthConfig = {
 export class AuthFixture extends DurableObject {
   private deliveries: Array<{ code: string; email: string }> = [];
   private deliveryFailure = false;
+  private rejections: GithubRejectionReason[] = [];
+  private reporterMode: string | null = null;
   async fetch(request: Request) {
     const url = new URL(request.url);
+
+    if (url.pathname === "/_fixture/rejections") return Response.json(this.rejections);
+    if (url.pathname === "/_fixture/reporter") {
+      this.reporterMode = url.searchParams.get("mode");
+
+      return new Response(null);
+    }
 
     if (url.pathname === "/_fixture/delivery")
       return Response.json({ ...this.deliveries.at(-1), count: this.deliveries.length });
@@ -61,7 +71,17 @@ export class AuthFixture extends DurableObject {
     ).pipe(Layer.orDie);
 
     return Effect.runPromise(
-      serveAuth(request, this.ctx.storage, fixtureAuthConfig, delivery).pipe(
+      serveAuth(request, this.ctx.storage, fixtureAuthConfig, delivery, undefined, (reason) =>
+        Effect.suspend(() => {
+          if (this.reporterMode === "defect") return Effect.die("Fixture logger defect");
+          if (this.reporterMode === "interrupt") return Effect.interrupt;
+          if (this.reporterMode === "timeout") return Effect.never;
+
+          return Effect.sync(() => {
+            this.rejections.push(reason);
+          });
+        }),
+      ).pipe(
         Effect.catchTag("AuthStorageError", (error) =>
           Effect.succeed(Response.json({ error: String(error.cause) }, { status: 500 })),
         ),

--- a/examples/travel-planner/test/fixtures/auth-worker.ts
+++ b/examples/travel-planner/test/fixtures/auth-worker.ts
@@ -1,12 +1,12 @@
 import { EmailProofDelivery } from "@yielded/auth/Proofs";
 import { DurableObject } from "cloudflare:workers";
-import { Effect, Layer, Redacted } from "effect";
+import { Effect, Layer, Logger, Redacted, Schema } from "effect";
 import { WorkerEnvironment } from "effect-cf";
 
 import { handleRequest } from "../../src/worker";
 export { TravelPlannerThread } from "./worker";
 import { serveAuth } from "../../src/auth/host";
-import type { GithubRejectionReason } from "../../src/auth/oauth-diagnostics";
+import { GithubRejectionReason } from "../../src/auth/oauth-diagnostics";
 import {
   initializeAuthStorage,
   AuthStorageFailpoint,
@@ -71,17 +71,18 @@ export class AuthFixture extends DurableObject {
     ).pipe(Layer.orDie);
 
     return Effect.runPromise(
-      serveAuth(request, this.ctx.storage, fixtureAuthConfig, delivery, undefined, (reason) =>
-        Effect.suspend(() => {
-          if (this.reporterMode === "defect") return Effect.die("Fixture logger defect");
-          if (this.reporterMode === "interrupt") return Effect.interrupt;
-          if (this.reporterMode === "timeout") return Effect.never;
-
-          return Effect.sync(() => {
-            this.rejections.push(reason);
-          });
-        }),
-      ).pipe(
+      serveAuth(request, this.ctx.storage, fixtureAuthConfig, delivery).pipe(
+        Effect.provide(
+          Logger.layer([
+            Logger.map(Logger.formatStructured, ({ message, annotations }) => {
+              if (message !== "auth.github.callback-rejected") return;
+              if (this.reporterMode === "defect") throw new Error("Fixture logger defect");
+              this.rejections.push(
+                Schema.decodeUnknownSync(GithubRejectionReason)(annotations.reason),
+              );
+            }),
+          ]),
+        ),
         Effect.catchTag("AuthStorageError", (error) =>
           Effect.succeed(Response.json({ error: String(error.cause) }, { status: 500 })),
         ),


### PR DESCRIPTION
GitHub callback failures currently collapse to `OAuthRejected`, leaving production failures indistinguishable without browser debugging. Observe the existing request-binding and durable-claim boundaries and emit a fixed reason label in Workers Logs after rejection. Read-only flow inspection and reporting are bounded; neither can authorize a request, replay an exchange, or replace the public error.

The diagnostic records exclude account/flow IDs, callback values, cookies, digests and provider response bodies. This enables investigation of the unresolved live login failure; it does not claim to fix its cause. The published `@yielded/auth@0.1.0-beta.2` dependency and production configuration are unchanged.
