### PR TITLE
fix(travel-planner): consume GitHub issuer fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
         "@streamparser/json": "catalog:",
         "@tanstack/react-router": "catalog:",
         "@tanstack/react-start": "catalog:",
-        "@yielded/auth": "0.1.0-beta.2",
+        "@yielded/auth": "0.1.0-beta.4",
         "class-variance-authority": "catalog:",
         "clsx": "catalog:",
         "drizzle-orm": "1.0.0-rc.5-ab785fc",
@@ -1743,7 +1743,7 @@
 
     "@vueuse/shared": ["@vueuse/shared@14.4.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g=="],
 
-    "@yielded/auth": ["@yielded/auth@0.1.0-beta.2", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/hashes": "2.3.0" }, "peerDependencies": { "@effect/sql-d1": ">=4.0.0-rc.112", "@effect/sql-libsql": ">=4.0.0-rc.112", "@effect/sql-mysql2": ">=4.0.0-rc.112", "@effect/sql-pg": ">=4.0.0-rc.112", "@effect/sql-pglite": ">=4.0.0-rc.112", "@effect/sql-sqlite-bun": ">=4.0.0-rc.112", "@effect/sql-sqlite-do": ">=4.0.0-rc.112", "@effect/sql-sqlite-node": ">=4.0.0-rc.112", "@effect/sql-sqlite-wasm": ">=4.0.0-rc.112", "@simplewebauthn/browser": ">=14.0.0 <15", "@simplewebauthn/server": ">=14.0.1 <15", "drizzle-orm": ">=1.0.0-rc.5-ab785fc", "effect": "^4.0.0-rc.112", "effect-cf": "^0.40.0", "openid-client": ">=6.8.8 <7", "tldts": ">=7.4.11 <8" }, "optionalPeers": ["@effect/sql-d1", "@effect/sql-libsql", "@effect/sql-mysql2", "@effect/sql-pg", "@effect/sql-pglite", "@effect/sql-sqlite-bun", "@effect/sql-sqlite-do", "@effect/sql-sqlite-node", "@effect/sql-sqlite-wasm", "@simplewebauthn/browser", "@simplewebauthn/server", "drizzle-orm", "effect-cf", "openid-client", "tldts"] }, "sha512-u8YYKaB5TQBeIDXG/hcE4ZSphZBnUMbfEqi3gLyBE7ZW1E1V8jc5NH/hXQO7JTPhSQ8KAJTIbAODezksU1T/qw=="],
+    "@yielded/auth": ["@yielded/auth@0.1.0-beta.4", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/hashes": "2.3.0" }, "peerDependencies": { "@effect/sql-d1": ">=4.0.0-rc.112", "@effect/sql-libsql": ">=4.0.0-rc.112", "@effect/sql-mysql2": ">=4.0.0-rc.112", "@effect/sql-pg": ">=4.0.0-rc.112", "@effect/sql-pglite": ">=4.0.0-rc.112", "@effect/sql-sqlite-bun": ">=4.0.0-rc.112", "@effect/sql-sqlite-do": ">=4.0.0-rc.112", "@effect/sql-sqlite-node": ">=4.0.0-rc.112", "@effect/sql-sqlite-wasm": ">=4.0.0-rc.112", "@simplewebauthn/browser": ">=14.0.0 <15", "@simplewebauthn/server": ">=14.0.1 <15", "drizzle-orm": ">=1.0.0-rc.5-ab785fc", "effect": "^4.0.0-rc.112", "effect-cf": "^0.40.0", "openid-client": ">=6.8.8 <7", "tldts": ">=7.4.11 <8" }, "optionalPeers": ["@effect/sql-d1", "@effect/sql-libsql", "@effect/sql-mysql2", "@effect/sql-pg", "@effect/sql-pglite", "@effect/sql-sqlite-bun", "@effect/sql-sqlite-do", "@effect/sql-sqlite-node", "@effect/sql-sqlite-wasm", "@simplewebauthn/browser", "@simplewebauthn/server", "drizzle-orm", "effect-cf", "openid-client", "tldts"] }, "sha512-EYJrNY8+gb2EECfw1GURL28sWP5d9Q6LFlMZTj3YQKeh8AxBz/tG7xKSU6d6lxcbk1KpAKx//B8KbRwa19aasw=="],
 
     "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.5.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg=="],
 

--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -208,7 +208,7 @@ vp install
 cp examples/travel-planner/.env.example examples/travel-planner/.env
 ```
 
-Fill the ignored `.env` using `.env.example`. The app pins `@yielded/auth@0.1.0-beta.2`
+Fill the ignored `.env` using `.env.example`. The app pins `@yielded/auth@0.1.0-beta.4`
 and the existing Effect `4.0.0-rc.112` catalog. It uses one `Auth.make` service for
 email codes and GitHub, with the published SQLite Durable Object adapters. Auth owns
 proofs, request binding, credential/session authority and OAuth exchanges; application
@@ -224,6 +224,13 @@ GitHub automatically provisions a new local account when registration is require
 starts a fresh authorization to establish its session. Denied or failed exchanges offer
 an explicit new attempt. Email and GitHub are separate credentials/accounts even if their
 profile emails match. There is no automatic linking, admin bootstrap or invitation gate.
+
+GitHub callbacks must retain the provider's `iss` value as `response.issuer`. The
+provider requires `https://github.com/login/oauth` and rejects missing or mismatched
+issuers before exchanging a code. The corrected provider uses configuration generation
+2; start a fresh GitHub attempt after upgrading from beta.2. This does not reset Auth or
+planner storage. Existing GitHub bindings under the previous `https://github.com` issuer
+are not linked automatically; email accounts and existing account data remain intact.
 
 ```sh
 vp run -F @effect-agent/example-travel-planner dev

--- a/examples/travel-planner/package.json
+++ b/examples/travel-planner/package.json
@@ -25,7 +25,7 @@
     "@streamparser/json": "catalog:",
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "catalog:",
-    "@yielded/auth": "0.1.0-beta.2",
+    "@yielded/auth": "0.1.0-beta.4",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "drizzle-orm": "1.0.0-rc.5-ab785fc",

--- a/examples/travel-planner/src/auth/server.ts
+++ b/examples/travel-planner/src/auth/server.ts
@@ -106,7 +106,7 @@ export const makeAuth = (config: AuthConfiguration) => {
   const github = gitHubOAuthAppProtocolLayer({
     registrations: [
       {
-        configurationGeneration: 1,
+        configurationGeneration: 2,
         issuance: "active",
         clientId: config.AUTH_GITHUB_CLIENT_ID,
         clientSecret: Redacted.make(config.AUTH_GITHUB_CLIENT_SECRET),

--- a/examples/travel-planner/test/auth-state.test.ts
+++ b/examples/travel-planner/test/auth-state.test.ts
@@ -207,6 +207,7 @@ it("consumes callback credentials once and rejects ambiguous callback shapes bef
       "?state=s&code=one&error=access_denied",
       "?code=one",
       "?state=s&error=x&error=y",
+      "?state=s&code=one&iss=https://github.com/login/oauth&iss=https://other.test",
     ]) {
       const captured = { __elsewhereCallback: query };
       let removed = false;
@@ -223,6 +224,36 @@ it("consumes callback credentials once and rejects ambiguous callback shapes bef
       expect(exit._tag).toBe("Failure");
       expect(captured.__elsewhereCallback).toBeUndefined();
       expect(removed).toBe(true);
+    }
+
+    for (const response of [
+      { _tag: "Code", code: "fixture-code" },
+      { _tag: "Error", error: "access-denied" },
+    ]) {
+      const issuer = "https://github.com/login/oauth";
+      const query = new URLSearchParams({ state: "fixture-state", iss: issuer });
+
+      if (response.code) query.set("code", response.code);
+      else query.set("error", "access_denied");
+      const captured = { __elsewhereCallback: `?${query}` };
+      let removed = false;
+
+      vi.stubGlobal("window", captured);
+      vi.stubGlobal("sessionStorage", {
+        getItem: () => JSON.stringify({ flowId: "public-flow" }),
+        removeItem: () => {
+          removed = true;
+        },
+      });
+      expect(await Effect.runPromise(callbackInput)).toEqual({
+        flowId: "public-flow",
+        provider: "github",
+        callbackId: "github",
+        response: { ...response, state: "fixture-state", issuer },
+      });
+      expect(captured.__elsewhereCallback).toBeUndefined();
+      expect(removed).toBe(true);
+      expect((await Effect.runPromiseExit(callbackInput))._tag).toBe("Failure");
     }
   } finally {
     vi.unstubAllGlobals();

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -19,6 +19,7 @@ import { defaultPlannerSettings } from "../src/domain";
 let mf: Miniflare;
 let directory: string;
 let githubExchanges = 0;
+const githubIssuer = "https://github.com/login/oauth";
 
 beforeAll(async () => {
   const bundle = await build({
@@ -290,6 +291,7 @@ it("registers and signs in new and returning email and GitHub accounts through d
         _tag: "Code",
         state: authorization.searchParams.get("state"),
         code: "fixture-code",
+        issuer: githubIssuer,
       },
     };
   };
@@ -435,7 +437,12 @@ const githubStart = async (client: ReturnType<typeof makeClient>) => {
     flowId,
     provider: "github",
     callbackId: "github",
-    response: { _tag: "Code", state: url.searchParams.get("state"), code: "fixture-code" },
+    response: {
+      _tag: "Code",
+      state: url.searchParams.get("state"),
+      code: "fixture-code",
+      issuer: githubIssuer,
+    },
   };
 };
 
@@ -459,7 +466,12 @@ it("rejects invalid and replayed GitHub callbacks, and handles denial without ex
   expect(
     await client.call("completeSignIn", {
       ...denied,
-      response: { _tag: "Error", state: denied.response.state, error: "access-denied" },
+      response: {
+        _tag: "Error",
+        state: denied.response.state,
+        error: "access-denied",
+        issuer: githubIssuer,
+      },
     }),
   ).toMatchObject({ _tag: "Cancelled" });
   expect(githubExchanges).toBe(count);
@@ -504,10 +516,8 @@ it("reports only fixed callback rejection reasons without changing authorization
   await rejected(superseded);
   await rejected({ ...input, response: { ...input.response, state: "malformed-private-state" } });
   await rejected({ ...input, response: { ...input.response, state: "A".repeat(43) } });
-  await rejected({
-    ...input,
-    response: { ...input.response, issuer: "https://github.com/login/oauth" },
-  });
+  for (const issuer of [undefined, "https://github.com"])
+    await rejected({ ...input, response: { ...input.response, issuer } });
   expect(githubExchanges).toBe(exchanges);
   await rejected({ ...input, response: { ...input.response, code: "fixture-rejected-code" } });
   expect(githubExchanges).toBe(exchanges + 1);
@@ -515,7 +525,8 @@ it("reports only fixed callback rejection reasons without changing authorization
     "request-binding-invalid",
     "state-invalid",
     "state-mismatch",
-    "issuer-unexpected",
+    "issuer-mismatch",
+    "issuer-mismatch",
     "after-claim",
   ]);
   // Missing/invalid private values never appear in the diagnostic sink.
@@ -534,7 +545,7 @@ it("reports only fixed callback rejection reasons without changing authorization
     }
   }
   expect(githubExchanges).toBe(exchanges + 1);
-  expect((await read()).length).toBe(before + 5);
+  expect((await read()).length).toBe(before + 6);
 });
 
 it("keeps callback GET inert, exposes only login assets, and rejects unauthenticated private APIs", async () => {


### PR DESCRIPTION
GitHub login failed with `OAuthRejected` because the previous Yielded Auth adapter rejected GitHub's `iss` callback field. Consume the published `@yielded/auth@0.1.0-beta.4` fix from [yielded-dev/auth#15](https://github.com/yielded-dev/auth/pull/15), which validates `https://github.com/login/oauth` before exchanging the code. The npm artifact was verified against release commit [`2dd530a`](https://github.com/yielded-dev/auth/commit/2dd530a61b8e2244a795eb6fe3f488ae1433975d). Effect remains at catalog `4.0.0-rc.112`; Effect Agent packages remain at `0.1.0-beta.78`.

Use provider configuration generation 2 and retain the issuer in the existing signup, returning-signin, denial and browser callback fixtures. Pending GitHub attempts must restart from `/login` after deployment. This requires no provider-console changes, key rotation or further data wipe: existing Auth/planner storage and email accounts remain intact. GitHub bindings using the previous issuer are not linked automatically. Live GitHub verification remains pending deployment.
