### PR TITLE
perf(thread): leave ready input to its first worker claim

### DIFF
--- a/.changeset/ready-input-worker-claim.md
+++ b/.changeset/ready-input-worker-claim.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Leave untouched ready inputs for their normal worker claim while preserving interrupted input and marker repair. BEHAVIOR CHANGE: `runRecovery` and `recoverSubmission` report these inputs as `ApplyInput/deferred` until a worker runs them.

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -137,6 +137,7 @@ classifies the last committed boundary:
 | Last committed boundary                          | Recovery                                                        |
 | ------------------------------------------------ | --------------------------------------------------------------- |
 | admission without readiness                      | finish materialization and readiness                            |
+| ready input with no attempted execution          | leave input application to the normal worker claim              |
 | input appended without its ledger marker         | repair the marker without applying input twice                  |
 | `RunStarted`                                     | preserve the original deadline                                  |
 | incomplete model response                        | retry inference when policy allows; provider charges may repeat |

--- a/packages/platform-cloudflare/test/travel-planner-dc.test.ts
+++ b/packages/platform-cloudflare/test/travel-planner-dc.test.ts
@@ -242,9 +242,13 @@ describe("DC Travel Planner — baseline settlement", () => {
 
     const records = await readCanonical(thread);
 
-    // Repair audit records (DUR-013) are host evidence, not scenario semantics: on DC even a
-    // clean run carries `recovery:ApplyInput`, because every pass reconciles before it claims
-    // (plan §1.4) and the ready lane's input is applied through the recovery path.
+    // A ready input belongs to its first worker claim; an untouched run needs no input repair.
+    expect(
+      records.filter(
+        ({ record: { payload } }) =>
+          payload._tag === "RepairAnnotated" && payload.reason === "recovery:ApplyInput",
+      ),
+    ).toEqual([]);
     expect(canonicalTags(records)).toEqual([
       "ThreadCreated",
       "UserInputRecorded",

--- a/packages/platform-node/test/crash/crash.test.ts
+++ b/packages/platform-node/test/crash/crash.test.ts
@@ -320,7 +320,7 @@ layer(NodeFileSystem.layer, { excludeTestServices: true })(
                 );
 
                 expect(report?.decision._tag).toBe("ApplyInput");
-                expect(report?.disposition).toBe("repaired");
+                expect(report?.disposition).toBe("deferred");
                 const settlements = yield* drainPlanner(thread, CHILD_ANSWER);
 
                 expect(settlements[0]?.outcome).toBe("completed");

--- a/packages/platform-node/test/layers.test.ts
+++ b/packages/platform-node/test/layers.test.ts
@@ -1541,7 +1541,7 @@ describe("NodeDurableAgentRuntime", () => {
             );
 
             expect(report?.decision._tag).toBe("ApplyInput");
-            expect(report?.disposition).toBe("repaired");
+            expect(report?.disposition).toBe("deferred");
 
             const reclaimed = yield* nextLedger.claim(
               ClaimRequest.make({

--- a/packages/storage-memory/test/recovery-history.test.ts
+++ b/packages/storage-memory/test/recovery-history.test.ts
@@ -18,8 +18,10 @@ import {
   ProducerEpoch,
   ProducerId,
   RepairAnnotated,
+  UserInputRecorded,
 } from "@effect-agent/thread/Records";
 import { type RecoveryDecision } from "@effect-agent/thread/Recovery";
+import { runIdForSubmission } from "@effect-agent/thread/RunJournal";
 import {
   AbortCommand,
   AdmissionRequest,
@@ -27,12 +29,15 @@ import {
   MarkReadyRequest,
   Principal,
   SubmissionLedger,
+  submissionInputBatchId,
+  submissionInputRecordId,
 } from "@effect-agent/thread/SubmissionLedger";
 import { type ThreadRead } from "@effect-agent/thread/ThreadStore";
 import {
   ThreadMaterialization,
   ThreadNotMaterialized,
   ThreadStore,
+  ThreadTailRequest,
   FencedAppendRequest,
 } from "@effect-agent/thread/ThreadStore";
 import { ToolReconciler } from "@effect-agent/thread/ToolReconciler";
@@ -272,6 +277,8 @@ describe("DurableAgentRuntime recovery history", () => {
       const ledger = yield* SubmissionLedger;
       const runtime = yield* DurableAgentRuntime;
       const probe = yield* RecoveryReadProbe;
+      const store = yield* ThreadStore;
+      let prefixTail = HISTORY_TAIL;
 
       for (let index = 0; index < 2; index++) {
         const input = { work: `suffix-race-${index}` };
@@ -299,11 +306,44 @@ describe("DurableAgentRuntime recovery history", () => {
               reason: "exercise suffix refresh after a repaired predecessor",
             }),
           );
+        } else {
+          // A lost input marker requires suffix repair; untouched ready input does not.
+          const tail = yield* store.inspectTail(ThreadTailRequest.make({ threadId: THREAD_ID }));
+
+          const appended = yield* store.append(
+            FencedAppendRequest.make({
+              threadId: THREAD_ID,
+              expectedTailSequence: tail.tailSequence,
+              expectedTailDigest: tail.tailDigest,
+              producerEpoch: tail.producerEpoch,
+              batch: CanonicalBatch.make({
+                batchId: submissionInputBatchId(admitted.submissionId),
+                producerId: PRODUCER_ID,
+                records: [
+                  CanonicalRecord.make({
+                    recordId: submissionInputRecordId(admitted.submissionId),
+                    family: "thread",
+                    schemaVersion: 1,
+                    createdAt: DateTime.toUtc(DateTime.makeUnsafe(HISTORY_RECORDS + 1)),
+                    deploymentId: DEPLOYMENT_ID,
+                    payload: UserInputRecorded.make({
+                      submissionId: admitted.submissionId,
+                      kind: "user",
+                      runId: runIdForSubmission(admitted.submissionId),
+                      input,
+                    }),
+                  }),
+                ],
+              }),
+            }),
+          );
+
+          prefixTail = appended.lastSequence;
         }
       }
 
       yield* probe.reset;
-      yield* probe.failReadAfter(HISTORY_TAIL);
+      yield* probe.failReadAfter(prefixTail);
       const failure = yield* runtime.runRecovery.pipe(Effect.flip);
 
       expect(failure).toMatchObject({
@@ -319,10 +359,10 @@ describe("DurableAgentRuntime recovery history", () => {
       expect(requests.slice(0, 3)).toEqual([
         { afterSequence: undefined, limit: 1_024 },
         { afterSequence: 1_024, limit: 1_024 },
-        { afterSequence: 2_048, limit: 2 },
+        { afterSequence: 2_048, limit: 3 },
       ]);
       expect(requests.at(-1)).toMatchObject({
-        afterSequence: HISTORY_TAIL,
+        afterSequence: prefixTail,
       });
     }).pipe(Effect.provide(runtimeLayer)),
   );

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -8845,9 +8845,14 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
 
     const decision = classifyRecovery(snapshot, evidence);
 
-    const disposition = yield* Effect.scoped(
-      executeRecoveryDecision(snapshot, evidence, decision, history.records, history),
-    );
+    // Untouched ready input belongs to the worker's first claim. Running attempts and
+    // canonical appends with a missing marker still take their classified repair path.
+    const disposition =
+      decision._tag === "ApplyInput" && snapshot.submission.state === "ready"
+        ? "deferred"
+        : yield* Effect.scoped(
+            executeRecoveryDecision(snapshot, evidence, decision, history.records, history),
+          );
 
     if (disposition === "repaired") {
       yield* annotateRepair(submission.threadId, submission.submissionId, decision);
@@ -9929,7 +9934,8 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
  *   unresolvable root surfaces the typed refusal after releasing the claim.
  * - `runRecovery()` — classify every nonterminal Submission with the pure `classifyRecovery` and
  *   execute the repair decisions, appending a `RepairAnnotated` audit record per executed decision
- *   (DUR-013). Model-resuming work is reported `deferred` for a worker claim; lanes blocked on
+ *   (DUR-013). Untouched ready input and model-resuming work are reported `deferred` for a
+ *   worker claim; lanes blocked on
  *   Unknown Outcomes are reported `unknown`. The S2 binding-free Subagent executors (admission
  *   completion, start-link repair, waiting restoration, wake replay, canonical join accounting,
  *   abort propagation, orphan reservation release) run here; the settlement join itself is
@@ -10170,7 +10176,7 @@ export class DurableAgentRuntime extends Context.Service<
     >;
     readonly runResolvedWorker: Effect.Effect<void, DurableWorkerFailure | DurableBindingFailure>;
     readonly runRecovery: Effect.Effect<ReadonlyArray<RecoveryReport>, DurableWorkerFailure>;
-    /** Apply one recovery decision for this Submission. */
+    /** Apply one recovery decision; untouched ready input is deferred to its worker claim. */
     readonly recoverSubmission: (
       submissionId: SubmissionId,
     ) => Effect.Effect<RecoveryReport, DurableWorkerFailure>;


### PR DESCRIPTION
A fresh ready submission currently takes an extra recovery claim to append its input, releases that claim, then takes the normal worker claim. Leave classified `ApplyInput` work in `ready` for that first worker claim, which already applies the canonical input idempotently. This removes the extra claim, history refresh, release, and repair annotation from clean startup. Hosted latency is not yet measured for this change.

```text
Before: ready → recovery claim → apply input → release → worker claim → attempt
After:  ready → worker claim → apply input → attempt
```

The recovery sweep still reads current ledger and canonical evidence before this decision. Interrupted running input, missing input markers, aborts, child obligations, unknown outcomes, and reserved settlements retain their classified repair paths. There is no stored-format change.

`runRecovery` and `recoverSubmission` now return `ApplyInput` with `disposition: "deferred"` for untouched ready input; an explicit operator retry still executes its selected repair. The existing clean travel-planner scenario checks that it emits no `recovery:ApplyInput` annotation. The existing issue96 suffix-read regression now injects its failure during missing-marker repair, preserving that recovery coverage.
