### PR TITLE
fix(travel-planner): display authenticated GitHub names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
         "@streamparser/json": "catalog:",
         "@tanstack/react-router": "catalog:",
         "@tanstack/react-start": "catalog:",
-        "@yielded/auth": "0.1.0-beta.4",
+        "@yielded/auth": "0.1.0-beta.5",
         "class-variance-authority": "catalog:",
         "clsx": "catalog:",
         "drizzle-orm": "1.0.0-rc.5-ab785fc",
@@ -100,7 +100,7 @@
     },
     "packages/capabilities": {
       "name": "@effect-agent/capabilities",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/core": {
       "name": "@effect-agent/core",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -131,7 +131,7 @@
     },
     "packages/effect-agent": {
       "name": "effect-agent",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -148,7 +148,7 @@
     },
     "packages/engine": {
       "name": "@effect-agent/engine",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
       },
@@ -164,7 +164,7 @@
     },
     "packages/platform-cloudflare": {
       "name": "@effect-agent/platform-cloudflare",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -202,7 +202,7 @@
     },
     "packages/platform-node": {
       "name": "@effect-agent/platform-node",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "packages/pr-review": {
       "name": "@effect-agent/pr-review",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -260,7 +260,7 @@
     },
     "packages/sandbox": {
       "name": "@effect-agent/sandbox",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -272,7 +272,7 @@
     },
     "packages/sandbox-local": {
       "name": "@effect-agent/sandbox-local",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/sandbox": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -290,7 +290,7 @@
     },
     "packages/storage-cloudflare": {
       "name": "@effect-agent/storage-cloudflare",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/storage-memory": {
       "name": "@effect-agent/storage-memory",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -332,7 +332,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@effect-agent/storage-sqlite",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -351,7 +351,7 @@
     },
     "packages/testing": {
       "name": "@effect-agent/testing",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -376,7 +376,7 @@
     },
     "packages/thread": {
       "name": "@effect-agent/thread",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -394,7 +394,7 @@
     },
     "packages/workflow": {
       "name": "@effect-agent/workflow",
-      "version": "0.1.0-beta.81",
+      "version": "0.1.0-beta.82",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -1743,7 +1743,7 @@
 
     "@vueuse/shared": ["@vueuse/shared@14.4.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g=="],
 
-    "@yielded/auth": ["@yielded/auth@0.1.0-beta.4", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/hashes": "2.3.0" }, "peerDependencies": { "@effect/sql-d1": ">=4.0.0-rc.112", "@effect/sql-libsql": ">=4.0.0-rc.112", "@effect/sql-mysql2": ">=4.0.0-rc.112", "@effect/sql-pg": ">=4.0.0-rc.112", "@effect/sql-pglite": ">=4.0.0-rc.112", "@effect/sql-sqlite-bun": ">=4.0.0-rc.112", "@effect/sql-sqlite-do": ">=4.0.0-rc.112", "@effect/sql-sqlite-node": ">=4.0.0-rc.112", "@effect/sql-sqlite-wasm": ">=4.0.0-rc.112", "@simplewebauthn/browser": ">=14.0.0 <15", "@simplewebauthn/server": ">=14.0.1 <15", "drizzle-orm": ">=1.0.0-rc.5-ab785fc", "effect": "^4.0.0-rc.112", "effect-cf": "^0.40.0", "openid-client": ">=6.8.8 <7", "tldts": ">=7.4.11 <8" }, "optionalPeers": ["@effect/sql-d1", "@effect/sql-libsql", "@effect/sql-mysql2", "@effect/sql-pg", "@effect/sql-pglite", "@effect/sql-sqlite-bun", "@effect/sql-sqlite-do", "@effect/sql-sqlite-node", "@effect/sql-sqlite-wasm", "@simplewebauthn/browser", "@simplewebauthn/server", "drizzle-orm", "effect-cf", "openid-client", "tldts"] }, "sha512-EYJrNY8+gb2EECfw1GURL28sWP5d9Q6LFlMZTj3YQKeh8AxBz/tG7xKSU6d6lxcbk1KpAKx//B8KbRwa19aasw=="],
+    "@yielded/auth": ["@yielded/auth@0.1.0-beta.5", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/hashes": "2.3.0" }, "peerDependencies": { "@effect/sql-d1": ">=4.0.0-rc.112", "@effect/sql-libsql": ">=4.0.0-rc.112", "@effect/sql-mysql2": ">=4.0.0-rc.112", "@effect/sql-pg": ">=4.0.0-rc.112", "@effect/sql-pglite": ">=4.0.0-rc.112", "@effect/sql-sqlite-bun": ">=4.0.0-rc.112", "@effect/sql-sqlite-do": ">=4.0.0-rc.112", "@effect/sql-sqlite-node": ">=4.0.0-rc.112", "@effect/sql-sqlite-wasm": ">=4.0.0-rc.112", "@simplewebauthn/browser": ">=14.0.0 <15", "@simplewebauthn/server": ">=14.0.1 <15", "drizzle-orm": ">=1.0.0-rc.5-ab785fc", "effect": "^4.0.0-rc.112", "effect-cf": "^0.40.0", "openid-client": ">=6.8.8 <7", "tldts": ">=7.4.11 <8" }, "optionalPeers": ["@effect/sql-d1", "@effect/sql-libsql", "@effect/sql-mysql2", "@effect/sql-pg", "@effect/sql-pglite", "@effect/sql-sqlite-bun", "@effect/sql-sqlite-do", "@effect/sql-sqlite-node", "@effect/sql-sqlite-wasm", "@simplewebauthn/browser", "@simplewebauthn/server", "drizzle-orm", "effect-cf", "openid-client", "tldts"] }, "sha512-SlT07mV9Ef8oAaFGi/em2WIKG9Xkgk4oncYg6epls1ny0DI2rFQpqNrak65FuRG5YxQnJ6w1gWeGYK9JJQVhMg=="],
 
     "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.5.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg=="],
 

--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -208,7 +208,7 @@ vp install
 cp examples/travel-planner/.env.example examples/travel-planner/.env
 ```
 
-Fill the ignored `.env` using `.env.example`. The app pins `@yielded/auth@0.1.0-beta.4`
+Fill the ignored `.env` using `.env.example`. The app pins `@yielded/auth@0.1.0-beta.5`
 and the existing Effect `4.0.0-rc.112` catalog. It uses one `Auth.make` service for
 email codes and GitHub, with the published SQLite Durable Object adapters. Auth owns
 proofs, request binding, credential/session authority and OAuth exchanges; application
@@ -224,6 +224,13 @@ GitHub automatically provisions a new local account when registration is require
 starts a fresh authorization to establish its session. Denied or failed exchanges offer
 an explicit new attempt. Email and GitHub are separate credentials/accounts even if their
 profile emails match. There is no automatic linking, admin bootstrap or invitation gate.
+
+GitHub accounts display the authenticated profile name, falling back to the GitHub username.
+Registration saves that name, and each fresh GitHub sign-in refreshes the session's display
+name without changing the local account or its stored data. After upgrading an existing
+session that shows **GitHub traveler**, sign out and sign in again. The app exposes only the
+display name in session claims; provider profile fields do not grant local authority or link
+accounts. No new GitHub scopes, provider configuration or data reset are needed for this update.
 
 GitHub callbacks must retain the provider's `iss` value as `response.issuer`. The
 provider requires `https://github.com/login/oauth` and rejects missing or mismatched

--- a/examples/travel-planner/package.json
+++ b/examples/travel-planner/package.json
@@ -25,7 +25,7 @@
     "@streamparser/json": "catalog:",
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "catalog:",
-    "@yielded/auth": "0.1.0-beta.4",
+    "@yielded/auth": "0.1.0-beta.5",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "drizzle-orm": "1.0.0-rc.5-ab785fc",

--- a/examples/travel-planner/src/auth/oauth-schema.ts
+++ b/examples/travel-planner/src/auth/oauth-schema.ts
@@ -317,10 +317,10 @@ export const oauthRegistrationMapping: OAuthRegistrationMapping<
   allocateCredentialId: Effect.sync(() => crypto.randomUUID()),
   allocateRevision: Effect.sync(() => SecurityRevision.make(crypto.randomUUID())),
   retentionMillis: 3_600_000,
-  encodeSubjectInsert: ({ registration }, ids) => ({
+  encodeSubjectInsert: ({ intent, registration }, ids) => ({
     id: ids.subjectId,
     revision: ids.securityRevision,
     active: true,
-    displayName: registration.displayName,
+    displayName: intent.profile?.displayName ?? registration.displayName,
   }),
 };

--- a/examples/travel-planner/src/auth/persistence.ts
+++ b/examples/travel-planner/src/auth/persistence.ts
@@ -81,8 +81,12 @@ export const persistenceLayer = (AppAuth: AppAuth) =>
             ),
         }),
         Layer.succeed(AppAuth.strategies.github.ClaimsForOAuth, {
-          resolve: (credential) =>
+          resolve: (credential, verified) =>
             claims(credential.revision.subjectId).pipe(
+              Effect.map((local) => ({
+                ...local,
+                displayName: verified.profile?.displayName ?? local.displayName,
+              })),
               Effect.mapError(() => OAuthUnavailable.make({})),
             ),
         }),

--- a/examples/travel-planner/test/auth.test.ts
+++ b/examples/travel-planner/test/auth.test.ts
@@ -19,6 +19,7 @@ import { defaultPlannerSettings } from "../src/domain";
 let mf: Miniflare;
 let directory: string;
 let githubExchanges = 0;
+let githubName: string | null = "River Traveler";
 const githubIssuer = "https://github.com/login/oauth";
 
 beforeAll(async () => {
@@ -71,7 +72,9 @@ beforeAll(async () => {
           return Response.json({
             id: 424242,
             login: "fixture-traveler",
+            name: githubName,
             email: "reader@example.com",
+            site_admin: true,
           });
 
         return new Response("Unexpected provider request", { status: 500 });
@@ -312,19 +315,48 @@ it("registers and signs in new and returning email and GitHub accounts through d
   ).toMatchObject({ _tag: "RegistrationAccepted" });
   expect(await call("getSession")).toBeNull();
   expect(await call("completeSignIn", await githubStart("github-signin"))).toMatchObject({
-    completion: { _tag: "Authenticated", session: { claims: { displayName: "GitHub traveler" } } },
+    completion: { _tag: "Authenticated", session: { claims: { displayName: "River Traveler" } } },
   });
-  expect(await call("getSession")).toMatchObject({ claims: { displayName: "GitHub traveler" } });
+  expect(await call("getSession")).toMatchObject({ claims: { displayName: "River Traveler" } });
 
   const githubAccount = Schema.decodeUnknownSync(Schema.Struct({ subjectId: Schema.String }))(
     await call("getSession"),
   );
 
   expect(githubAccount.subjectId).not.toBe(emailAccount.subjectId);
+  expect(
+    await (await mf.dispatchFetch("https://planner.test/_fixture/subjects")).json(),
+  ).toContainEqual({ id: githubAccount.subjectId, displayName: "River Traveler" });
   expect(await privateRpc(githubAccount.subjectId, "GetPlannerSettings")).toEqual(
     defaultPlannerSettings,
   );
-  await call("signOut", {});
+  expect(await privateRpc(githubAccount.subjectId, "SavePlannerSettings", preferences)).toEqual(
+    preferences,
+  );
+
+  try {
+    for (const [name, displayName] of [
+      ["River Explorer", "River Explorer"],
+      [null, "fixture-traveler"],
+    ] as const) {
+      await call("signOut", {});
+      expect(await call("getSession")).toBeNull();
+      githubName = name;
+      expect(await call("completeSignIn", await githubStart(crypto.randomUUID()))).toMatchObject({
+        completion: { _tag: "Authenticated" },
+      });
+
+      const session = Schema.decodeUnknownSync(
+        Schema.Struct({ subjectId: Schema.String, claims: Schema.Unknown }),
+      )(await call("getSession"));
+
+      expect(session).toEqual({ subjectId: githubAccount.subjectId, claims: { displayName } });
+      expect(await privateRpc(githubAccount.subjectId, "GetPlannerSettings")).toEqual(preferences);
+    }
+  } finally {
+    githubName = "River Traveler";
+    await call("signOut", {});
+  }
   expect(await call("getSession")).toBeNull();
 }, 30_000);
 

--- a/examples/travel-planner/test/fixtures/auth-worker.ts
+++ b/examples/travel-planner/test/fixtures/auth-worker.ts
@@ -37,6 +37,10 @@ export class AuthFixture extends DurableObject {
     const url = new URL(request.url);
 
     if (url.pathname === "/_fixture/rejections") return Response.json(this.rejections);
+    if (url.pathname === "/_fixture/subjects")
+      return Response.json(
+        this.ctx.storage.sql.exec("select id, displayName from auth_subject").toArray(),
+      );
     if (url.pathname === "/_fixture/reporter") {
       this.reporterMode = url.searchParams.get("mode");
 


### PR DESCRIPTION
GitHub accounts now show their authenticated profile name, with the GitHub username as fallback, instead of **GitHub traveler**. Consume the published `@yielded/auth@0.1.0-beta.5` profile APIs from [Yielded Auth #17](https://github.com/yielded-dev/auth/pull/17) during registration and each fresh sign-in. Only the display name enters public session claims.

Existing users keep the same local account and stored trips, settings and keys; sign out and back in after deployment to refresh the name. This update requires no provider configuration, additional scopes or data reset. The Effect `4.0.0-rc.112` catalog and app's Effect Agent `0.1.0-beta.78` pins remain unchanged.

Full `vp run ready` passed. Durable Auth HTTP tests cover saved registration names, refreshed names, username fallback, account isolation and retained settings. The screenshot uses local Auth/RPC fixtures, with external requests blocked; browser sign-out also clears the name.

![Authenticated profile name in the existing sidebar, using local fixtures](https://github.com/user-attachments/assets/e1dc431b-b822-48a5-b14a-d047ed37397c)
