### PR TITLE
fix(travel-planner): keep login progress stable through sign-in

### DIFF
--- a/examples/travel-planner/README.md
+++ b/examples/travel-planner/README.md
@@ -225,6 +225,10 @@ starts a fresh authorization to establish its session. Denied or failed exchange
 an explicit new attempt. Email and GitHub are separate credentials/accounts even if their
 profile emails match. There is no automatic linking, admin bootstrap or invitation gate.
 
+GitHub authorization and callback completion show a dedicated loading screen until the
+session is ready. A successful sign-in never appears as an error while account state is
+replaced; actual failures offer a fresh attempt without automatically repeating an exchange.
+
 GitHub accounts display the authenticated profile name, falling back to the GitHub username.
 Registration saves that name, and each fresh GitHub sign-in refreshes the session's display
 name without changing the local account or its stored data. After upgrading an existing

--- a/examples/travel-planner/src/auth/client.ts
+++ b/examples/travel-planner/src/auth/client.ts
@@ -2,7 +2,7 @@ import * as AuthAtom from "@yielded/auth/Atom";
 import * as Client from "@yielded/auth/Client";
 import type { ProofReference } from "@yielded/auth/Proofs";
 import { Cause, Effect, Option, Redacted, Schema } from "effect";
-import { Atom, AsyncResult } from "effect/unstable/reactivity";
+import { Atom, AtomRegistry, AsyncResult } from "effect/unstable/reactivity";
 
 import { LoginApi } from "./contract";
 
@@ -73,14 +73,15 @@ const browser = <A>(run: () => A) =>
 const id = () => browser(() => crypto.randomUUID());
 const PendingGithub = Schema.fromJsonString(Schema.Struct({ flowId: Schema.NonEmptyString }));
 
-const startGithub = Effect.fn("Login.startGithub")(function* (get: Atom.FnContext) {
+const startGithub = Effect.gen(function* () {
+  const registry = yield* AtomRegistry.AtomRegistry;
   const flowId = yield* id();
 
   yield* browser(() =>
     sessionStorage.setItem("elsewhere:github", Schema.encodeSync(PendingGithub)({ flowId })),
   );
 
-  const started = yield* get.setResult(auth.signIn, {
+  registry.set(auth.signIn, {
     flowId,
     commandId: yield* id(),
     provider: "github",
@@ -88,10 +89,14 @@ const startGithub = Effect.fn("Login.startGithub")(function* (get: Atom.FnContex
     returnTarget: "/",
   });
 
-  yield* browser(() => location.assign(Redacted.value(started.authorizationUrl)));
-});
+  const started = yield* AtomRegistry.getResult(registry, auth.signIn, { suspendOnWaiting: true });
 
-export const githubLogin = Atom.fn<void>()((_, get) => startGithub(get)).pipe(Atom.setIdleTTL(0));
+  yield* browser(() => location.assign(Redacted.value(started.authorizationUrl)));
+}).pipe(Effect.withSpan("Login.startGithub"));
+
+export const githubLogin = Atom.fn<void>()((_, get) =>
+  startGithub.pipe(Effect.provideService(AtomRegistry.AtomRegistry, get.registry)),
+).pipe(Atom.setIdleTTL(0));
 
 // The Worker captures callback credentials in memory before loading page resources.
 // Only public flow correlation survives navigation.
@@ -160,11 +165,11 @@ export const completeGithub = Atom.fn<void>()((_, get) =>
 
       if (registered._tag !== "RegistrationAccepted") return yield* new BrowserFlowUnavailable();
       // Accepted registration creates an account, not a session. Start a NEW authorized flow.
-      yield* startGithub(get);
+      yield* startGithub;
     }
 
     return result;
-  }),
+  }).pipe(Effect.provideService(AtomRegistry.AtomRegistry, get.registry)),
 ).pipe(Atom.setIdleTTL(0));
 
 const callbackStarted = Atom.make(false).pipe(Atom.keepAlive);
@@ -182,20 +187,23 @@ export type EmailPending = {
   readonly reference: typeof ProofReference.Encoded;
 };
 
-const sendSignInCode = Effect.fn("Login.sendSignInCode")(function* (
-  email: string,
-  get: Atom.FnContext,
-) {
+const sendSignInCode = Effect.fn("Login.sendSignInCode")(function* (email: string) {
+  const registry = yield* AtomRegistry.AtomRegistry;
   const flowId = yield* id();
 
-  yield* get.setResult(auth.beginEmailSignIn, { flowId });
+  registry.set(auth.beginEmailSignIn, { flowId });
+  yield* AtomRegistry.getResult(registry, auth.beginEmailSignIn, { suspendOnWaiting: true });
 
-  const receipt = yield* get.setResult(auth.requestEmailCode, {
+  registry.set(auth.requestEmailCode, {
     flowId,
     email,
     requestId: yield* id(),
     returnTarget: "/",
     locale: "en",
+  });
+
+  const receipt = yield* AtomRegistry.getResult(registry, auth.requestEmailCode, {
+    suspendOnWaiting: true,
   });
 
   return { mode: "signin", flowId, email, reference: receipt.reference } satisfies EmailPending;
@@ -208,7 +216,7 @@ export const requestEmailCode = Atom.fn<{
   Effect.gen(function* () {
     const email = input.email.trim().toLowerCase();
 
-    if (input.mode === "signin") return yield* sendSignInCode(email, get);
+    if (input.mode === "signin") return yield* sendSignInCode(email);
     const flowId = yield* id();
 
     yield* get.setResult(auth.beginEmailRegistration, { flowId });
@@ -222,7 +230,7 @@ export const requestEmailCode = Atom.fn<{
     });
 
     return { mode: "register", flowId, email, reference: receipt.reference } satisfies EmailPending;
-  }),
+  }).pipe(Effect.provideService(AtomRegistry.AtomRegistry, get.registry)),
 ).pipe(Atom.setIdleTTL(0));
 
 export const verifyEmailCode = Atom.fn<{
@@ -249,7 +257,7 @@ export const verifyEmailCode = Atom.fn<{
 
       if (result._tag !== "RegistrationAccepted") return yield* new BrowserFlowUnavailable();
 
-      return yield* sendSignInCode(email, get);
+      return yield* sendSignInCode(email);
     }
     const base = { flowId, email, returnTarget: "/" };
 
@@ -264,7 +272,7 @@ export const verifyEmailCode = Atom.fn<{
       continuationId: verified.continuation.continuationId,
     });
     // auth.session remains the rendering authority after credential settlement.
-  }),
+  }).pipe(Effect.provideService(AtomRegistry.AtomRegistry, get.registry)),
 ).pipe(Atom.setIdleTTL(0));
 
 export type LoginLoadingStep = "session" | "github" | "callback";

--- a/examples/travel-planner/src/auth/client.ts
+++ b/examples/travel-planner/src/auth/client.ts
@@ -1,7 +1,7 @@
 import * as AuthAtom from "@yielded/auth/Atom";
 import * as Client from "@yielded/auth/Client";
 import type { ProofReference } from "@yielded/auth/Proofs";
-import { Effect, Redacted, Schema } from "effect";
+import { Cause, Effect, Option, Redacted, Schema } from "effect";
 import { Atom, AsyncResult } from "effect/unstable/reactivity";
 
 import { LoginApi } from "./contract";
@@ -73,15 +73,14 @@ const browser = <A>(run: () => A) =>
 const id = () => browser(() => crypto.randomUUID());
 const PendingGithub = Schema.fromJsonString(Schema.Struct({ flowId: Schema.NonEmptyString }));
 
-const startGithub = Effect.gen(function* () {
-  const client = yield* AppClient;
+const startGithub = Effect.fn("Login.startGithub")(function* (get: Atom.FnContext) {
   const flowId = yield* id();
 
   yield* browser(() =>
     sessionStorage.setItem("elsewhere:github", Schema.encodeSync(PendingGithub)({ flowId })),
   );
 
-  const started = yield* client.auth.signIn({
+  const started = yield* get.setResult(auth.signIn, {
     flowId,
     commandId: yield* id(),
     provider: "github",
@@ -92,7 +91,7 @@ const startGithub = Effect.gen(function* () {
   yield* browser(() => location.assign(Redacted.value(started.authorizationUrl)));
 });
 
-export const githubLogin = auth.runtime.fn<void>()(() => startGithub);
+export const githubLogin = Atom.fn<void>()((_, get) => startGithub(get)).pipe(Atom.setIdleTTL(0));
 
 // The Worker captures callback credentials in memory before loading page resources.
 // Only public flow correlation survives navigation.
@@ -144,14 +143,15 @@ export const callbackInput = Effect.gen(function* () {
   };
 });
 
-export const completeGithub = auth.runtime.fn<void>()(() =>
+// Public login workflows compose named mutations in the host registry. Those mutations
+// retain their own success or rejection while Auth replaces the private account registry.
+export const completeGithub = Atom.fn<void>()((_, get) =>
   Effect.gen(function* () {
-    const client = yield* AppClient;
     const input = yield* callbackInput;
-    const result = yield* client.auth.completeSignIn(input);
+    const result = yield* get.setResult(auth.completeSignIn, input);
 
     if ("_tag" in result && result._tag === "RegistrationRequired") {
-      const registered = yield* client.auth.register({
+      const registered = yield* get.setResult(auth.register, {
         flowId: input.flowId,
         commandId: yield* id(),
         reference: result.reference,
@@ -160,12 +160,12 @@ export const completeGithub = auth.runtime.fn<void>()(() =>
 
       if (registered._tag !== "RegistrationAccepted") return yield* new BrowserFlowUnavailable();
       // Accepted registration creates an account, not a session. Start a NEW authorized flow.
-      yield* startGithub;
+      yield* startGithub(get);
     }
 
     return result;
   }),
-);
+).pipe(Atom.setIdleTTL(0));
 
 const callbackStarted = Atom.make(false).pipe(Atom.keepAlive);
 
@@ -182,13 +182,15 @@ export type EmailPending = {
   readonly reference: typeof ProofReference.Encoded;
 };
 
-const sendSignInCode = Effect.fn("Login.sendSignInCode")(function* (email: string) {
-  const client = yield* AppClient;
+const sendSignInCode = Effect.fn("Login.sendSignInCode")(function* (
+  email: string,
+  get: Atom.FnContext,
+) {
   const flowId = yield* id();
 
-  yield* client.auth.beginEmailSignIn({ flowId });
+  yield* get.setResult(auth.beginEmailSignIn, { flowId });
 
-  const receipt = yield* client.auth.requestEmailCode({
+  const receipt = yield* get.setResult(auth.requestEmailCode, {
     flowId,
     email,
     requestId: yield* id(),
@@ -199,20 +201,19 @@ const sendSignInCode = Effect.fn("Login.sendSignInCode")(function* (email: strin
   return { mode: "signin", flowId, email, reference: receipt.reference } satisfies EmailPending;
 });
 
-export const requestEmailCode = auth.runtime.fn<{
+export const requestEmailCode = Atom.fn<{
   readonly mode: "register" | "signin";
   readonly email: string;
-}>()((input) =>
+}>()((input, get) =>
   Effect.gen(function* () {
     const email = input.email.trim().toLowerCase();
 
-    if (input.mode === "signin") return yield* sendSignInCode(email);
-    const client = yield* AppClient;
+    if (input.mode === "signin") return yield* sendSignInCode(email, get);
     const flowId = yield* id();
 
-    yield* client.auth.beginEmailRegistration({ flowId });
+    yield* get.setResult(auth.beginEmailRegistration, { flowId });
 
-    const receipt = yield* client.auth.registerEmail({
+    const receipt = yield* get.setResult(auth.registerEmail, {
       flowId,
       email,
       registration: { displayName: "Traveler" },
@@ -222,26 +223,25 @@ export const requestEmailCode = auth.runtime.fn<{
 
     return { mode: "register", flowId, email, reference: receipt.reference } satisfies EmailPending;
   }),
-);
+).pipe(Atom.setIdleTTL(0));
 
-export const verifyEmailCode = auth.runtime.fn<{
+export const verifyEmailCode = Atom.fn<{
   readonly pending: EmailPending;
   readonly code: string;
-}>()((input) =>
+}>()((input, get) =>
   Effect.gen(function* () {
-    const client = yield* AppClient;
     const { flowId, email, reference, mode } = input.pending;
 
     if (mode === "register") {
       const base = { flowId, email, registration: { displayName: "Traveler" } };
 
-      const verified = yield* client.auth.verifyEmailRegistration({
+      const verified = yield* get.setResult(auth.verifyEmailRegistration, {
         ...base,
         reference,
         secret: input.code,
       });
 
-      const result = yield* client.auth.completeEmailRegistration({
+      const result = yield* get.setResult(auth.completeEmailRegistration, {
         ...base,
         continuationId: verified.continuation.continuationId,
         commandId: yield* id(),
@@ -249,15 +249,98 @@ export const verifyEmailCode = auth.runtime.fn<{
 
       if (result._tag !== "RegistrationAccepted") return yield* new BrowserFlowUnavailable();
 
-      return yield* sendSignInCode(email);
+      return yield* sendSignInCode(email, get);
     }
     const base = { flowId, email, returnTarget: "/" };
-    const verified = yield* client.auth.verifyEmailCode({ ...base, reference, secret: input.code });
 
-    yield* client.auth.completeEmailSignIn({
+    const verified = yield* get.setResult(auth.verifyEmailCode, {
+      ...base,
+      reference,
+      secret: input.code,
+    });
+
+    yield* get.setResult(auth.completeEmailSignIn, {
       ...base,
       continuationId: verified.continuation.continuationId,
     });
-    // Session rendering owns the transition: this custom workflow may retire here.
+    // auth.session remains the rendering authority after credential settlement.
   }),
+).pipe(Atom.setIdleTTL(0));
+
+export type LoginLoadingStep = "session" | "github" | "callback";
+
+type LoginView =
+  | { readonly _tag: "Authenticated" }
+  | { readonly _tag: "Loading"; readonly step: LoginLoadingStep }
+  | {
+      readonly _tag: "Form";
+      readonly pending: EmailPending | undefined;
+      readonly registered: boolean;
+      readonly busy: boolean;
+      readonly error: "github" | "email" | "session" | undefined;
+      readonly cancelled: boolean;
+    };
+
+const interrupted = <A, E>(result: AsyncResult.AsyncResult<A, E>) =>
+  AsyncResult.isFailure(result) && Cause.hasInterruptsOnly(result.cause);
+
+const failed = <A, E>(result: AsyncResult.AsyncResult<A, E>) =>
+  AsyncResult.isFailure(result) && !result.waiting && !interrupted(result);
+
+/** Session publication owns success; public login results live only as long as this screen. */
+export const loginView = Atom.family((callback: boolean) =>
+  Atom.make((get): LoginView => {
+    const session = get(auth.session);
+    const github = get(githubLogin);
+    const completed = get(completeGithub);
+    const requested = get(requestEmailCode);
+    const verified = get(verifyEmailCode);
+
+    if (AsyncResult.isSuccess(session) && session.value !== null) return { _tag: "Authenticated" };
+
+    if (github.waiting || AsyncResult.isSuccess(github)) return { _tag: "Loading", step: "github" };
+    if (
+      callback &&
+      (completed._tag === "Initial" ||
+        completed.waiting ||
+        (AsyncResult.isSuccess(completed) &&
+          "_tag" in completed.value &&
+          completed.value._tag === "RegistrationRequired"))
+    )
+      return { _tag: "Loading", step: "callback" };
+
+    const registered = Option.getOrUndefined(AsyncResult.value(verified));
+    const busy = requested.waiting || verified.waiting;
+
+    const authenticated =
+      (AsyncResult.isSuccess(completed) &&
+        "completion" in completed.value &&
+        completed.value.completion._tag === "Authenticated") ||
+      (AsyncResult.isSuccess(verified) && verified.value === undefined);
+
+    if (session.waiting && authenticated) return { _tag: "Loading", step: "callback" };
+    if (session._tag === "Initial" && !busy)
+      return { _tag: "Loading", step: callback ? "callback" : "session" };
+
+    return {
+      _tag: "Form",
+      pending: registered ?? Option.getOrUndefined(AsyncResult.value(requested)),
+      registered: registered !== undefined,
+      busy,
+      error: busy
+        ? undefined
+        : failed(github) || (callback && failed(completed))
+          ? "github"
+          : failed(requested) || failed(verified)
+            ? "email"
+            : failed(session)
+              ? "session"
+              : undefined,
+      cancelled:
+        callback &&
+        AsyncResult.isSuccess(completed) &&
+        "_tag" in completed.value &&
+        completed.value._tag === "Cancelled",
+    };
+  }).pipe(Atom.setIdleTTL(0)),
 );

--- a/examples/travel-planner/src/auth/login.tsx
+++ b/examples/travel-planner/src/auth/login.tsx
@@ -1,24 +1,23 @@
-import { useAtom, useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { Navigate } from "@tanstack/react-router";
-import { Atom, AsyncResult } from "effect/unstable/reactivity";
+import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useState } from "react";
 
 import {
-  auth,
-  completeGithub,
   consumeCallback,
   githubLogin,
+  loginView,
   requestEmailCode,
   verifyEmailCode,
+  type LoginLoadingStep,
 } from "./client";
 
 export function Login({ callback = false }: { readonly callback?: boolean }) {
-  const session = useAtomValue(auth.session);
-  const [github, startGithub] = useAtom(githubLogin);
-  const completed = useAtomValue(completeGithub);
+  const view = useAtomValue(loginView(callback));
+  const startGithub = useAtomSet(githubLogin);
   const consume = useAtomSet(consumeCallback);
-  const [requested, requestCode] = useAtom(requestEmailCode);
-  const [verified, verifyCode] = useAtom(verifyEmailCode);
+  const requestCode = useAtomSet(requestEmailCode);
+  const verifyCode = useAtomSet(verifyEmailCode);
   const [mode, setMode] = useState<"register" | "signin">("signin");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
@@ -26,26 +25,10 @@ export function Login({ callback = false }: { readonly callback?: boolean }) {
   useEffect(() => {
     if (callback) consume();
   }, [callback, consume]);
-  if (AsyncResult.isSuccess(session) && session.value !== null) return <Navigate to="/" replace />;
+  if (view._tag === "Authenticated") return <Navigate to="/" replace />;
+  if (view._tag === "Loading") return <LoginLoading step={view.step} />;
 
-  const pending =
-    AsyncResult.isSuccess(verified) && verified.value
-      ? verified.value
-      : AsyncResult.isSuccess(requested)
-        ? requested.value
-        : undefined;
-
-  const busy =
-    requested.waiting || verified.waiting || github.waiting || (callback && completed.waiting);
-
-  const failed = [requested, verified, github, ...(callback ? [completed] : [])].some(
-    (result) => result._tag === "Failure",
-  );
-
-  const cancelled =
-    AsyncResult.isSuccess(completed) &&
-    "_tag" in completed.value &&
-    completed.value._tag === "Cancelled";
+  const { pending, busy } = view;
 
   return (
     <main className="login-page">
@@ -110,7 +93,7 @@ export function Login({ callback = false }: { readonly callback?: boolean }) {
             }}
           >
             <p role="status">
-              {AsyncResult.isSuccess(verified) && verified.value
+              {view.registered
                 ? "Your account is ready. We sent a new code to finish signing in."
                 : pending.mode === "register"
                   ? "Enter the code to create your account. Then we’ll send a fresh sign-in code."
@@ -154,18 +137,52 @@ export function Login({ callback = false }: { readonly callback?: boolean }) {
             </p>
           </form>
         )}
-        {failed && (
+        {view.error && (
           <p className="error" role="alert">
-            We couldn’t complete that step. Check your code or start a new sign-in attempt. If you
-            just created an account, choose Sign in.
+            {view.error === "github"
+              ? "We couldn’t finish signing in with GitHub. Please start a new attempt."
+              : view.error === "email"
+                ? "We couldn’t complete that step. Check your code or request a new one."
+                : "We couldn’t check your sign-in. Please try again."}
           </p>
         )}
-        {cancelled && (
+        {view.cancelled && (
           <p role="status">GitHub sign-in was cancelled. You can start again when you’re ready.</p>
         )}
         <p className="login-note">
           Email and GitHub create separate accounts. Use the same method when you return.
         </p>
+      </section>
+    </main>
+  );
+}
+
+export function LoginLoading({ step }: { readonly step: LoginLoadingStep }) {
+  return (
+    <main className="login-page">
+      <section className="login-card login-loading" aria-labelledby="login-loading-title">
+        <a className="wordmark" href="/login">
+          elsewhere<span>↗</span>
+        </a>
+        <div className="login-loading-content" role="status" aria-live="polite">
+          <div className="login-loader" aria-hidden="true">
+            <span>↗</span>
+          </div>
+          <h1 id="login-loading-title">
+            {step === "github"
+              ? "Connecting to GitHub"
+              : step === "callback"
+                ? "Signing you in"
+                : "Getting things ready"}
+          </h1>
+          <p>
+            {step === "github"
+              ? "Taking you to GitHub to continue."
+              : step === "callback"
+                ? "Finishing up. Your planner will open shortly."
+                : "One moment while we check your sign-in."}
+          </p>
+        </div>
       </section>
     </main>
   );

--- a/examples/travel-planner/src/routes/auth.github.callback.tsx
+++ b/examples/travel-planner/src/routes/auth.github.callback.tsx
@@ -1,10 +1,10 @@
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 
-import { Login } from "../auth/login";
+import { Login, LoginLoading } from "../auth/login";
 
 export const Route = createFileRoute("/auth/github/callback")({
   component: () => (
-    <ClientOnly>
+    <ClientOnly fallback={<LoginLoading step="callback" />}>
       <Login callback />
     </ClientOnly>
   ),

--- a/examples/travel-planner/src/routes/login.tsx
+++ b/examples/travel-planner/src/routes/login.tsx
@@ -1,10 +1,10 @@
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 
-import { Login } from "../auth/login";
+import { Login, LoginLoading } from "../auth/login";
 
 export const Route = createFileRoute("/login")({
   component: () => (
-    <ClientOnly>
+    <ClientOnly fallback={<LoginLoading step="session" />}>
       <Login />
     </ClientOnly>
   ),

--- a/examples/travel-planner/src/styles.css
+++ b/examples/travel-planner/src/styles.css
@@ -2596,3 +2596,51 @@
   padding: 12px;
   background: #fff4f1;
 }
+.login-loading {
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+}
+.login-loading-content {
+  flex: 1;
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+  padding: 20px 0 40px;
+}
+.login-loading-content h1 {
+  font-size: 26px;
+  margin-bottom: 8px;
+}
+.login-loading-content p {
+  max-width: 260px;
+  margin: 0;
+  font-size: 14px;
+}
+.login-loader {
+  width: 76px;
+  height: 76px;
+  display: grid;
+  place-items: center;
+  position: relative;
+  margin-bottom: 32px;
+  border-radius: 50%;
+  background: #f1f5e9;
+  color: #587047;
+  font-size: 36px;
+}
+.login-loader::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+  border: 2px solid #e3e9d9;
+  border-top-color: #789064;
+  border-radius: 50%;
+  animation: app-spin 1.4s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .login-loader::after {
+    animation: none;
+  }
+}

--- a/examples/travel-planner/test/login-state.test.ts
+++ b/examples/travel-planner/test/login-state.test.ts
@@ -1,0 +1,319 @@
+import { Schema } from "effect";
+import { AtomRegistry, AsyncResult } from "effect/unstable/reactivity";
+import { expect, it, vi } from "vite-plus/test";
+
+import {
+  auth,
+  completeGithub,
+  consumeCallback,
+  githubLogin,
+  loginView,
+  requestEmailCode,
+  verifyEmailCode,
+} from "../src/auth/client";
+
+const session = {
+  sessionId: "fixture-session",
+  subjectId: "00000000-0000-0000-0000-000000000001",
+  securityRevision: "revision",
+  assurance: { method: "oauth", factors: ["possession"], authenticatedAt: 1_800_000_000_000 },
+  issuedAt: 1_800_000_000_000,
+  expiresAt: 1_900_000_000_000,
+  absoluteExpiresAt: 1_900_000_000_000,
+  claims: { displayName: "River Traveler" },
+};
+
+const envelope = Schema.fromJsonString(
+  Schema.Struct({ payload: Schema.Record(Schema.String, Schema.Unknown) }),
+);
+
+const fixture = () => {
+  const storage = new Map([["elsewhere:github", JSON.stringify({ flowId: "fixture-flow" })]]);
+  const assign = vi.fn<(url: string) => void>();
+  const settledBegin = vi.fn<() => void>();
+  const requests: string[] = [];
+  const pendingSessions: Array<() => void> = [];
+  const pendingBegins: Array<() => void> = [];
+
+  const state = {
+    authenticated: false,
+    holdSession: true,
+    outcome: "authenticated" as "authenticated" | "registration" | "cancelled" | "rejected",
+    rejectCode: false,
+    holdBegin: false,
+  };
+
+  vi.stubGlobal("location", { origin: "https://fixture.test", assign });
+  vi.stubGlobal("window", {
+    __elsewhereCallback:
+      "?code=fixture-code&state=fixture-state&iss=https%3A%2F%2Fgithub.com%2Flogin%2Foauth",
+  });
+  vi.stubGlobal("sessionStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  });
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const name = new URL(request.url).pathname.split("/").at(-1) ?? "";
+
+    requests.push(name);
+    const success = (value: unknown) => Response.json({ _tag: "Success", value });
+
+    const rejected = (tag: string) =>
+      Response.json({ _tag: "Failure", error: { _tag: tag } }, { status: 400 });
+
+    if (name === "getSession") {
+      if (state.authenticated && state.holdSession)
+        return new Promise<Response>((resolve) => {
+          pendingSessions.push(() => resolve(success(session)));
+        });
+
+      return success(state.authenticated ? session : null);
+    }
+    const { payload } = Schema.decodeUnknownSync(envelope)(await request.text());
+
+    if (name === "signIn")
+      return success({
+        flowId: payload.flowId,
+        authorizationUrl: "https://github.com/login/oauth/authorize?state=fixture-state",
+        expiresAtMillis: 1_900_000_000_000,
+      });
+    if (name === "completeSignIn") {
+      if (state.outcome === "rejected") return rejected("OAuthRejected");
+      if (state.outcome === "cancelled") return success({ _tag: "Cancelled", returnTarget: "/" });
+      if (state.outcome === "registration")
+        return success({
+          _tag: "RegistrationRequired",
+          reference: "r".repeat(43),
+          expiresAtMillis: 1_900_000_000_000,
+          returnTarget: "/",
+        });
+    }
+    if (name === "completeSignIn" || name === "completeEmailSignIn") {
+      state.authenticated = true;
+
+      return success({ completion: { _tag: "Authenticated", session }, returnTarget: "/" });
+    }
+    if (name === "register" || name === "completeEmailRegistration")
+      return success({ _tag: "RegistrationAccepted" });
+    if (name === "beginEmailRegistration" || name === "beginEmailSignIn") {
+      if (state.holdBegin) await new Promise<void>((resolve) => pendingBegins.push(resolve));
+
+      settledBegin();
+
+      return success({ flowId: payload.flowId, expiresAtMillis: 1_900_000_000_000 });
+    }
+    if (name === "requestEmailCode" || name === "registerEmail")
+      return success({
+        requestId: payload.requestId,
+        reference: {
+          proofId: `fixture-${name}`,
+          purpose: name === "registerEmail" ? "email-code-registration" : "email-code-sign-in",
+          keyId: "v1",
+        },
+      });
+    if (name === "verifyEmailCode" || name === "verifyEmailRegistration") {
+      if (state.rejectCode) return rejected("EmailRejected");
+
+      return success({
+        continuation: {
+          continuationId: "fixture-continuation",
+          purpose: "email-code-sign-in",
+          expiresAtMillis: 1_900_000_000_000,
+        },
+      });
+    }
+    throw new Error(`Unexpected fixture action: ${name}`);
+  });
+
+  const host = AtomRegistry.make();
+
+  const releaseSession = () => {
+    state.holdSession = false;
+    for (const release of pendingSessions.splice(0)) release();
+  };
+
+  const releaseBegin = () => {
+    for (const release of pendingBegins.splice(0)) release();
+  };
+
+  host.mount(auth.session);
+
+  return {
+    host,
+    state,
+    assign,
+    settledBegin,
+    requests,
+    releaseSession,
+    releaseBegin,
+    beginPending: () => pendingBegins.length > 0,
+    ready: () =>
+      vi.waitFor(() => expect(AsyncResult.getOrThrow(host.get(auth.session))).toBeNull()),
+    dispose: () => {
+      releaseSession();
+      host.dispose();
+      releaseBegin();
+      vi.unstubAllGlobals();
+    },
+  };
+};
+
+it.each(["github", "email"] as const)(
+  "keeps %s sign-in pending through account replacement until the session is published",
+  async (method) => {
+    const f = fixture();
+    const view = loginView(method === "github");
+    const observedFailures: boolean[] = [];
+
+    const unsubscribe = f.host.subscribe(
+      view,
+      (value) => observedFailures.push(value._tag === "Form" && value.error !== undefined),
+      { immediate: true },
+    );
+
+    try {
+      await f.ready();
+      expect(f.host.get(view)._tag).toBe(method === "github" ? "Loading" : "Form");
+      if (method === "github") {
+        f.host.set(consumeCallback, undefined);
+      } else {
+        f.host.set(requestEmailCode, { mode: "signin", email: "fixture@example.com" });
+        await vi.waitUntil(() => AsyncResult.isSuccess(f.host.get(requestEmailCode)));
+        const pending = AsyncResult.getOrThrow(f.host.get(requestEmailCode));
+
+        f.host.set(verifyEmailCode, { pending, code: "123456" });
+      }
+      await vi.waitFor(() => {
+        const result =
+          method === "github" ? f.host.get(completeGithub) : f.host.get(verifyEmailCode);
+
+        expect(result._tag).toBe("Success");
+      });
+      expect(f.host.get(view)).toEqual({ _tag: "Loading", step: "callback" });
+      expect(observedFailures).not.toContain(true);
+      f.releaseSession();
+      await vi.waitFor(() => expect(f.host.get(view)).toEqual({ _tag: "Authenticated" }));
+      expect(f.requests.filter((name) => name === "completeSignIn")).toHaveLength(
+        method === "github" ? 1 : 0,
+      );
+    } finally {
+      unsubscribe();
+      f.dispose();
+    }
+  },
+);
+
+it("keeps GitHub registration in the loading screen while redirecting to its fresh sign-in", async () => {
+  const f = fixture();
+
+  f.state.outcome = "registration";
+  f.host.mount(loginView(true));
+  try {
+    await f.ready();
+    f.host.set(consumeCallback, undefined);
+    f.host.set(consumeCallback, undefined);
+    await vi.waitFor(() => expect(f.assign).toHaveBeenCalledTimes(1));
+    expect(f.host.get(loginView(true))).toEqual({ _tag: "Loading", step: "callback" });
+    expect(f.requests.filter((name) => name === "completeSignIn")).toHaveLength(1);
+    expect(f.requests.filter((name) => name === "register")).toHaveLength(1);
+    expect(f.requests.filter((name) => name === "signIn")).toHaveLength(1);
+  } finally {
+    f.dispose();
+  }
+});
+
+it("releases email input and challenge state when the login screen is left", async () => {
+  const f = fixture();
+  const unmount = f.host.mount(loginView(false));
+
+  try {
+    await f.ready();
+    f.host.set(requestEmailCode, { mode: "signin", email: "fixture@example.com" });
+    await vi.waitFor(() => expect(f.host.get(requestEmailCode)._tag).toBe("Success"));
+    unmount();
+    await vi.waitFor(() => expect(f.host.get(requestEmailCode)._tag).toBe("Initial"));
+    expect(f.host.get(loginView(false))).toMatchObject({ _tag: "Form", pending: undefined });
+  } finally {
+    f.dispose();
+  }
+});
+
+it("stops the email workflow on disposal while an admitted credential response settles", async () => {
+  const f = fixture();
+
+  f.state.holdBegin = true;
+  f.host.mount(loginView(false));
+  try {
+    await f.ready();
+    f.host.set(requestEmailCode, { mode: "signin", email: "fixture@example.com" });
+    await vi.waitFor(() => expect(f.beginPending()).toBe(true));
+    f.host.dispose();
+    // Auth settles admitted Set-Cookie responses uninterruptibly. The disposed
+    // application workflow must not proceed to issue a code afterward.
+    f.releaseBegin();
+    await vi.waitFor(() => expect(f.settledBegin).toHaveBeenCalledTimes(1));
+    expect(f.requests).not.toContain("requestEmailCode");
+  } finally {
+    f.dispose();
+  }
+});
+
+it.each(["cancelled", "rejected"] as const)(
+  "offers a fresh GitHub attempt after a %s callback without repeating the exchange",
+  async (outcome) => {
+    const f = fixture();
+
+    f.state.outcome = outcome;
+    f.host.mount(loginView(true));
+    try {
+      await f.ready();
+      f.host.set(consumeCallback, undefined);
+      await vi.waitFor(() => expect(f.host.get(loginView(true))._tag).toBe("Form"));
+      expect(f.host.get(loginView(true))).toMatchObject({
+        cancelled: outcome === "cancelled",
+        error: outcome === "rejected" ? "github" : undefined,
+      });
+      expect(f.requests.filter((name) => name === "completeSignIn")).toHaveLength(1);
+      f.host.set(githubLogin, undefined);
+      expect(f.host.get(loginView(true))).toEqual({ _tag: "Loading", step: "github" });
+      await vi.waitFor(() => expect(f.assign).toHaveBeenCalledTimes(1));
+      expect(f.host.get(loginView(true))).toEqual({ _tag: "Loading", step: "github" });
+    } finally {
+      f.dispose();
+    }
+  },
+);
+
+it("retains the new email sign-in challenge after a registration succeeds and a sign-in code fails", async () => {
+  const f = fixture();
+
+  f.host.mount(loginView(false));
+  try {
+    await f.ready();
+    f.host.set(requestEmailCode, { mode: "register", email: "fixture@example.com" });
+    await vi.waitFor(() => expect(AsyncResult.isSuccess(f.host.get(requestEmailCode))).toBe(true));
+    f.host.set(verifyEmailCode, {
+      pending: AsyncResult.getOrThrow(f.host.get(requestEmailCode)),
+      code: "123456",
+    });
+    await vi.waitFor(() => expect(AsyncResult.isSuccess(f.host.get(verifyEmailCode))).toBe(true));
+    const pending = AsyncResult.getOrThrow(f.host.get(verifyEmailCode));
+
+    if (!pending) throw new Error("Expected the fresh sign-in challenge");
+    expect(pending.mode).toBe("signin");
+    f.state.rejectCode = true;
+    f.host.set(verifyEmailCode, { pending, code: "000000" });
+    await vi.waitFor(() => expect(f.host.get(verifyEmailCode)._tag).toBe("Failure"));
+    expect(f.host.get(loginView(false))).toMatchObject({
+      _tag: "Form",
+      pending,
+      registered: true,
+      busy: false,
+      error: "email",
+    });
+  } finally {
+    f.dispose();
+  }
+});


### PR DESCRIPTION
Successful GitHub sign-in briefly showed a failure because replacing the account registry interrupted the login workflow before the refreshed session rendered. GitHub also reused the email form’s “Sending…” state.

Compose login workflows from Yielded’s named Auth atoms and render a dedicated loading screen through authorization, registration and session refresh. `auth.session` still owns navigation; genuine rejection and cancellation remain visible, and callback exchanges are never automatically repeated. Email registration retains its fresh sign-in challenge after an incorrect code. Login inputs and results are released when the screen is left.

The loading screen includes a polite status announcement, reduced-motion support and an initial server-rendered fallback. No dependency, provider configuration or stored-data changes are required.

![Sign-in progress on mobile](https://github.com/user-attachments/assets/cd48077d-5b39-49ff-90c3-4ddb5e0fe220)