### PR TITLE
fix(thread): report terminal durable run failures with causes

### DIFF
--- a/.changeset/clear-durable-run-failures.md
+++ b/.changeset/clear-durable-run-failures.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/thread": patch
+---
+
+Report terminal durable Agent failures with their original cause and execution identity before storing the bounded settlement diagnostic.

--- a/packages/storage-memory/test/durable-thread-head.test.ts
+++ b/packages/storage-memory/test/durable-thread-head.test.ts
@@ -55,14 +55,17 @@ import { NodeCrypto } from "@effect/platform-node";
 import { expect, layer } from "@effect/vitest";
 import {
   DateTime,
+  Cause,
   Deferred,
   Duration,
   Effect,
   Exit,
   Fiber,
   Layer,
+  Logger,
   Option,
   Ref,
+  References,
   Schema,
   Stream,
 } from "effect";
@@ -153,6 +156,86 @@ const snapshot = Effect.fn(function* (receipt: Receipt) {
 });
 
 layer(baseLayer)("bounded durable Thread processing", (it) => {
+  // Regression: https://github.com/reve-ai/kommunikasie/commit/b98ab37b8976c536e766bea8e51572d73fcb23f4
+  // A failed context preparation settled durably without reporting its live cause.
+  it.effect("reports a terminal preparation failure once with its cause and durable identity", () =>
+    Effect.gen(function* () {
+      const original = new Error("Tool schema cannot be estimated");
+
+      const failure = CompactionError.make({
+        message: "Could not prepare context",
+        cause: original,
+      });
+
+      const events: Array<{
+        cause: Cause.Cause<unknown>;
+        annotations: Readonly<Record<string, unknown>>;
+      }> = [];
+
+      const logger = Logger.make(({ logLevel, cause, fiber }) => {
+        if (logLevel === "Error")
+          events.push({ cause, annotations: fiber.getRef(References.CurrentLogAnnotations) });
+      });
+
+      const agent = Agent.withModel(definition, makeModel(Stream.die("provider must not start")));
+      const binding = yield* DurableWorkerBinding.make(agent, digests);
+
+      const runtime = yield* makeRuntime([binding]).pipe(
+        Effect.provideService(RunContextPreparation, {
+          hook: { prepare: () => Effect.fail(failure) },
+        }),
+      );
+
+      const receipt = yield* runtime.submit(
+        agent,
+        "private request",
+        options("failed-preparation", "first"),
+      );
+
+      yield* runtime
+        .processThreadHead(receipt.threadId)
+        .pipe(Effect.provide(Logger.layer([logger])));
+      expect((yield* runtime.submissionStatus(receipt))._tag).toBe("settled");
+      expect(events).toHaveLength(1);
+      expect(Cause.squash(events[0]!.cause)).toBe(failure);
+      expect(Cause.pretty(events[0]!.cause)).toContain(original.message);
+      expect(events[0]!.annotations).toMatchObject({
+        threadId: receipt.threadId,
+        submissionId: receipt.submissionId,
+        agentId: definition.id,
+      });
+
+      const duplicate = yield* runtime.submit(
+        agent,
+        "private request",
+        options("failed-preparation", "first"),
+      );
+
+      expect(duplicate).toEqual(receipt);
+      expect(
+        yield* runtime
+          .processThreadHead(receipt.threadId)
+          .pipe(Effect.provide(Logger.layer([logger]))),
+      ).toEqual(Option.none());
+      expect(events).toHaveLength(1);
+
+      const records = yield* (yield* ThreadStore).export(
+        ThreadExportRequest.make({ threadId: receipt.threadId }),
+      );
+
+      const settlements = records.records.filter(
+        ({ record }) => record.payload._tag === "SubmissionSettled",
+      );
+
+      expect(settlements).toHaveLength(1);
+      expect(settlements[0]!.record.payload).toMatchObject({
+        outcome: "failed",
+        result: { errorTag: "CompactionError", message: failure.message },
+      });
+      expect(JSON.stringify(settlements)).not.toContain(original.message);
+    }),
+  );
+
   it.effect.each(["new-failure", "provider-failure", "retained-incomplete"] as const)(
     "rolls over after terminal Tool failure without rewriting evidence: %s",
     (scenario) =>

--- a/packages/storage-memory/test/durable-thread-head.test.ts
+++ b/packages/storage-memory/test/durable-thread-head.test.ts
@@ -233,7 +233,7 @@ layer(baseLayer)("bounded durable Thread processing", (it) => {
         result: { errorTag: "CompactionError", message: failure.message },
       });
       expect(JSON.stringify(settlements)).not.toContain(original.message);
-    }),
+    }).pipe(Effect.annotateLogs({ hostContext: "captured registration" })),
   );
 
   it.effect.each(["new-failure", "provider-failure", "retained-incomplete"] as const)(

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -82,6 +82,7 @@ import { ThreadHistory } from "@effect-agent/engine/ThreadHistory";
 import { RunToolVisibility } from "@effect-agent/engine/ToolExposure";
 import type { Scope } from "effect";
 import {
+  Cause,
   Clock,
   Context,
   Crypto,
@@ -7014,6 +7015,13 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               if (halted !== undefined) {
                 return yield* halted;
               }
+
+              // Settlement keeps only a bounded diagnostic. Report the live failure here,
+              // after excluding suspensions, so hosts retain its cause and stack exactly
+              // once per failed Run; reading or retrying its receipt never reports again.
+              yield* Effect.logError("Agent run failed", Cause.fail(error)).pipe(
+                Effect.annotateLogs({ agentId: agent.definition.id, runId }),
+              );
 
               return {
                 _tag: "failedRun" as const,

--- a/packages/thread/src/DurableAgentRuntime.ts
+++ b/packages/thread/src/DurableAgentRuntime.ts
@@ -1,6 +1,12 @@
 import type * as Agent from "@effect-agent/core/Agent";
 import { type RunDispositionDeclaration, type InputPromptSource } from "@effect-agent/core/Agent";
-import { AgentApprovalPending, AgentInputError, PolicyLimit } from "@effect-agent/core/AgentError";
+import {
+  AgentApprovalDenied,
+  AgentApprovalPending,
+  AgentInputError,
+  AgentToolAuthorizationDenied,
+  PolicyLimit,
+} from "@effect-agent/core/AgentError";
 import { AgentPolicy } from "@effect-agent/core/AgentPolicy";
 import {
   type ReceiptId,
@@ -7019,9 +7025,19 @@ const make = Effect.fn("DurableAgentRuntime.make")(function* (
               // Settlement keeps only a bounded diagnostic. Report the live failure here,
               // after excluding suspensions, so hosts retain its cause and stack exactly
               // once per failed Run; reading or retrying its receipt never reports again.
-              yield* Effect.logError("Agent run failed", Cause.fail(error)).pipe(
-                Effect.annotateLogs({ agentId: agent.definition.id, runId }),
-              );
+              if (
+                !(error instanceof AgentApprovalDenied) &&
+                !(error instanceof AgentToolAuthorizationDenied)
+              )
+                yield* Effect.logError("Agent run failed", Cause.fail(error)).pipe(
+                  Effect.annotateLogs({
+                    agentId: agent.definition.id,
+                    runId,
+                    threadId: ctx.threadId,
+                    submissionId,
+                    attemptId: lineage.attemptId,
+                  }),
+                );
 
               return {
                 _tag: "failedRun" as const,


### PR DESCRIPTION
Terminal durable runs could fail before any tool started and settle with only a bounded message, leaving host error reporting silent. Report the original failure cause at the durable runtime's terminal failure boundary, with agent, run, thread, submission and attempt identity. Hosts with a cause-aware logger can capture the failure with its stack, including when captured registration context replaces the processing fiber's annotations.

Approval and child suspension, explicit approval or tool-authorization denial, and coordinator recovery stay outside this capture. Reading a failed settlement or retrying its admission receipt does not report or execute it again. The persisted diagnostic remains bounded and does not acquire stacks or provider payloads.

Discovered during the Kommunikasie September 11 delegated-document incident. Publication is required before the consumer can use this fix.
