### PR TITLE
fix: reuse invocation RPC targets in Cloudflare adapters

### DIFF
--- a/.changeset/stable-cloudflare-rpc-targets.md
+++ b/.changeset/stable-cloudflare-rpc-targets.md
@@ -1,0 +1,5 @@
+---
+"@effect-agent/platform-cloudflare": patch
+---
+
+Reuse native RPC targets within each Cloudflare invocation so delegated work, progress observation, memory and scheduling callbacks do not exhaust subrequest depth. Replace failed channels and start fresh target scopes for incoming requests and durable retries.

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "packages/capabilities": {
       "name": "@effect-agent/capabilities",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/core": {
       "name": "@effect-agent/core",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -131,7 +131,7 @@
     },
     "packages/effect-agent": {
       "name": "effect-agent",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -148,7 +148,7 @@
     },
     "packages/engine": {
       "name": "@effect-agent/engine",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
       },
@@ -164,7 +164,7 @@
     },
     "packages/platform-cloudflare": {
       "name": "@effect-agent/platform-cloudflare",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -194,7 +194,7 @@
       "peerDependencies": {
         "@cloudflare/puppeteer": "^1.1.0",
         "effect": "^4.0.0-rc.112",
-        "effect-cf": "^0.40.0",
+        "effect-cf": "^0.41.0",
       },
       "optionalPeers": [
         "@cloudflare/puppeteer",
@@ -202,7 +202,7 @@
     },
     "packages/platform-node": {
       "name": "@effect-agent/platform-node",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "packages/pr-review": {
       "name": "@effect-agent/pr-review",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -260,7 +260,7 @@
     },
     "packages/sandbox": {
       "name": "@effect-agent/sandbox",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "devDependencies": {
         "effect": "catalog:",
         "typescript": "catalog:",
@@ -272,7 +272,7 @@
     },
     "packages/sandbox-local": {
       "name": "@effect-agent/sandbox-local",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/sandbox": "workspace:*",
         "@effect/platform-node": "catalog:",
@@ -290,7 +290,7 @@
     },
     "packages/storage-cloudflare": {
       "name": "@effect-agent/storage-cloudflare",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/storage-memory": {
       "name": "@effect-agent/storage-memory",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -332,7 +332,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@effect-agent/storage-sqlite",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -351,7 +351,7 @@
     },
     "packages/testing": {
       "name": "@effect-agent/testing",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/capabilities": "workspace:*",
         "@effect-agent/core": "workspace:*",
@@ -376,7 +376,7 @@
     },
     "packages/thread": {
       "name": "@effect-agent/thread",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/engine": "workspace:*",
@@ -394,7 +394,7 @@
     },
     "packages/workflow": {
       "name": "@effect-agent/workflow",
-      "version": "0.1.0-beta.82",
+      "version": "0.1.0-beta.83",
       "dependencies": {
         "@effect-agent/core": "workspace:*",
         "@effect-agent/thread": "workspace:*",
@@ -583,7 +583,7 @@
     "clsx": "2.1.1",
     "diff": "8.0.4",
     "effect": "4.0.0-rc.112",
-    "effect-cf": "0.40.0",
+    "effect-cf": "0.41.0",
     "esbuild": "0.28.1",
     "isomorphic-git": "1.41.9",
     "jose": "6.2.12",
@@ -2089,7 +2089,7 @@
 
     "effect-agent": ["effect-agent@workspace:packages/effect-agent"],
 
-    "effect-cf": ["effect-cf@0.40.0", "", { "peerDependencies": { "@cloudflare/computer": "^0.2.0", "@cloudflare/sandbox": "^0.13.0-next.738.2", "@cloudflare/vitest-plugin": "^1.0.0", "@cloudflare/workers-types": "^5.20260825.1", "@effect/sql-d1": "^4.0.0-rc.112", "@effect/sql-pg": "^4.0.0-rc.112", "@effect/sql-sqlite-do": "^4.0.0-rc.112", "@modelcontextprotocol/server": "^2.0.0", "effect": "^4.0.0-rc.112" }, "optionalPeers": ["@cloudflare/computer", "@cloudflare/sandbox", "@cloudflare/vitest-plugin", "@cloudflare/workers-types", "@effect/sql-pg", "@modelcontextprotocol/server"] }, "sha512-aCsnokqMK/4V8K4SeW6YMr5o4x3Bdglxv9rAm9MHjwyb5MXnBmt1/pgRj70SqrfmpJ6HrwLOHZCC0nPHjeMRcw=="],
+    "effect-cf": ["effect-cf@0.41.0", "", { "peerDependencies": { "@cloudflare/computer": "^0.2.0", "@cloudflare/sandbox": "^0.13.0-next.738.2", "@cloudflare/vitest-plugin": "^1.0.0", "@cloudflare/workers-types": "^5.20260825.1", "@effect/sql-d1": "^4.0.0-rc.112", "@effect/sql-pg": "^4.0.0-rc.112", "@effect/sql-sqlite-do": "^4.0.0-rc.112", "@modelcontextprotocol/server": "^2.0.0", "effect": "^4.0.0-rc.112" }, "optionalPeers": ["@cloudflare/computer", "@cloudflare/sandbox", "@cloudflare/vitest-plugin", "@cloudflare/workers-types", "@effect/sql-pg", "@modelcontextprotocol/server"] }, "sha512-xj/xsr3exy+bV6hkXuj3wtPii4NRhKmqMfeZhAC17KPioe/wY47/D3m76TrrO3q4hameTIdj26ix8SkASs6eRw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.398", "", {}, "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ=="],
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -17,7 +17,7 @@ Commit the Bun lockfile; CI installs with `--frozen-lockfile`.
 | Bun                                                     | `1.4.0`              |
 | Vite+                                                   | `0.3.0`              |
 | Effect and its provider/platform/SQL/Atom/test packages | `4.0.0-rc.112`       |
-| `effect-cf`                                             | `0.40.0`             |
+| `effect-cf`                                             | `0.41.0`             |
 | TypeScript                                              | `7.0.2`              |
 | `@effect/tsgo`                                          | `0.33.0`             |
 | Node.js                                                 | `22.18+` or `24.11+` |
@@ -27,7 +27,7 @@ development version. Raise the peer minimum when code needs a newer API.
 Private examples declare Effect as a regular dependency. Adapters depend on the platform and
 SQL implementations they use.
 
-`platform-cloudflare` requires `effect-cf@^0.40.0` and `effect@^4.0.0-rc.112` as host peers
+`platform-cloudflare` requires `effect-cf@^0.41.0` and `effect@^4.0.0-rc.112` as host peers
 and uses the exact catalog versions for development. Supply Effect SQL packages compatible with
 rc.112 for `effect-cf`. Consumers provide the shared runtime.
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "clsx": "2.1.1",
     "diff": "8.0.4",
     "effect": "4.0.0-rc.112",
-    "effect-cf": "0.40.0",
+    "effect-cf": "0.41.0",
     "esbuild": "0.28.1",
     "lucide-react": "1.27.0",
     "miniflare": "5.20260811.1-alpha",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "@cloudflare/puppeteer": "^1.1.0",
     "effect": "^4.0.0-rc.112",
-    "effect-cf": "^0.40.0"
+    "effect-cf": "^0.41.0"
   },
   "peerDependenciesMeta": {
     "@cloudflare/puppeteer": {

--- a/packages/platform-cloudflare/src/CloudflareBindings.ts
+++ b/packages/platform-cloudflare/src/CloudflareBindings.ts
@@ -1,6 +1,7 @@
 import { type ThreadId } from "@effect-agent/core/Identifiers";
 import { type ProducerId } from "@effect-agent/thread/Records";
 import { Context, Effect, Layer, Predicate, Schema } from "effect";
+import { RpcTargets } from "effect-cf";
 
 /**
  * Cloudflare platform bindings as Effect services (DEPLOY-010: "Cloudflare platform bindings
@@ -58,7 +59,8 @@ export type ThreadObjectClient = Omit<ThreadObjectRpc, keyof Rpc.DurableObjectBr
 /**
  * Deterministic logical Thread placement. The native adapter uses `idFromName(threadId)`;
  * a shared application owner can bind that logical identity into its RPC adapter instead.
- * Lookup performs no I/O and grants no authority. Every call resolves its target afresh.
+ * Lookup performs no I/O and grants no authority. Calls reuse a native target within
+ * one invocation; incoming requests and durable retries acquire their own targets.
  */
 export class ThreadObjectNamespace extends Context.Service<
   ThreadObjectNamespace,
@@ -78,6 +80,22 @@ export class ThreadObjectNamespace extends Context.Service<
     });
   }
 }
+
+/** Invoke a placed Thread using the current invocation's native RPC channel. */
+export const callThreadObject = <A, E>(
+  namespace: ThreadObjectNamespace["Service"],
+  threadId: ThreadId,
+  invoke: (target: ThreadObjectClient) => Promise<A>,
+  onError: (cause: unknown) => E,
+): Effect.Effect<A, E> =>
+  RpcTargets.get(namespace, threadId, () => namespace.get(threadId)).pipe(
+    Effect.mapError(onError),
+    Effect.flatMap((target) =>
+      Effect.tryPromise({ try: () => invoke(target), catch: onError }).pipe(
+        Effect.tapCause(() => RpcTargets.invalidate(target)),
+      ),
+    ),
+  );
 
 /**
  * Narrow one `env` member to a `DurableObjectNamespace`. `env` is an untyped platform value,

--- a/packages/platform-cloudflare/src/CloudflareBindings.ts
+++ b/packages/platform-cloudflare/src/CloudflareBindings.ts
@@ -82,20 +82,21 @@ export class ThreadObjectNamespace extends Context.Service<
 }
 
 /** Invoke a placed Thread using the current invocation's native RPC channel. */
-export const callThreadObject = <A, E>(
-  namespace: ThreadObjectNamespace["Service"],
+export const callThreadObject = Effect.fn("callThreadObject")(function* <A, E>(
   threadId: ThreadId,
   invoke: (target: ThreadObjectClient) => Promise<A>,
   onError: (cause: unknown) => E,
-): Effect.Effect<A, E> =>
-  RpcTargets.get(namespace, threadId, () => namespace.get(threadId)).pipe(
+): Effect.fn.Return<A, E, ThreadObjectNamespace> {
+  const namespace = yield* ThreadObjectNamespace;
+
+  const target = yield* RpcTargets.get(namespace, threadId, () => namespace.get(threadId)).pipe(
     Effect.mapError(onError),
-    Effect.flatMap((target) =>
-      Effect.tryPromise({ try: () => invoke(target), catch: onError }).pipe(
-        Effect.tapCause(() => RpcTargets.invalidate(target)),
-      ),
-    ),
   );
+
+  return yield* Effect.tryPromise({ try: () => invoke(target), catch: onError }).pipe(
+    Effect.tapCause(() => RpcTargets.invalidate(target)),
+  );
+});
 
 /**
  * Narrow one `env` member to a `DurableObjectNamespace`. `env` is an untyped platform value,

--- a/packages/platform-cloudflare/src/CloudflareMemory.ts
+++ b/packages/platform-cloudflare/src/CloudflareMemory.ts
@@ -40,6 +40,7 @@ import { Clock, Context, Effect, Layer, Schema } from "effect";
 import {
   DurableObject as EffectCfDurableObject,
   DurableObjectState,
+  RpcTargets,
   type WorkerEnvironment,
 } from "effect-cf";
 
@@ -90,11 +91,24 @@ const makeMemoryClient = Effect.fn("CloudflareMemoryClient.make")(function* <
 
     const encoded = yield* encodeMemoryWire(MemoryOwnerRequest, decoded, validated.maxRequestBytes);
 
+    const unavailable = (cause: unknown) => {
+      const error = MemoryRpcError.make({ reason: "unavailable" });
+
+      error.cause = cause;
+
+      return error;
+    };
+
+    const address = memoryObjectName(bound.namespace);
+
+    const target = yield* RpcTargets.get(namespace, address, () =>
+      namespace.get(namespace.idFromName(address)),
+    ).pipe(Effect.mapError(unavailable));
+
     const raw = yield* Effect.tryPromise({
-      try: () =>
-        namespace.get(namespace.idFromName(memoryObjectName(bound.namespace))).memory(encoded),
-      catch: () => MemoryRpcError.make({ reason: "unavailable" }),
-    });
+      try: () => target.memory(encoded),
+      catch: unavailable,
+    }).pipe(Effect.tapCause(() => RpcTargets.invalidate(target)));
 
     const response = yield* decodeMemoryWire(MemoryOwnerResponse, raw, validated.maxResponseBytes);
 

--- a/packages/platform-cloudflare/src/CloudflareScheduling.ts
+++ b/packages/platform-cloudflare/src/CloudflareScheduling.ts
@@ -40,6 +40,7 @@ import { Clock, Context, DateTime, Effect, Layer, Schema } from "effect";
 import {
   DurableObject as EffectCfDurableObject,
   DurableObjectAlarm,
+  RpcTargets,
   DurableObjectState as EffectCfDurableObjectState,
   type WorkerEnvironment,
 } from "effect-cf";
@@ -198,14 +199,27 @@ export class CloudflareSchedulingClient {
           ),
         );
 
+        const unavailable = (cause: unknown) => {
+          const error = ScheduleStorageError.make({
+            operation: "call Schedule Owner",
+            reason: "unavailable",
+          });
+
+          error.cause = cause;
+
+          return error;
+        };
+
+        const address = scheduleOwnerKey(owner);
+
+        const target = yield* RpcTargets.get(namespace, address, () =>
+          namespace.get(namespace.idFromName(address)),
+        ).pipe(Effect.mapError(unavailable));
+
         const raw = yield* Effect.tryPromise({
-          try: () => namespace.get(namespace.idFromName(scheduleOwnerKey(owner))).schedule(encoded),
-          catch: () =>
-            ScheduleStorageError.make({
-              operation: "call Schedule Owner",
-              reason: "unavailable",
-            }),
-        });
+          try: () => target.schedule(encoded),
+          catch: unavailable,
+        }).pipe(Effect.tapCause(() => RpcTargets.invalidate(target)));
 
         const response = yield* decodeScheduleOwnerResponse(raw).pipe(
           Effect.mapError(() =>

--- a/packages/platform-cloudflare/src/CloudflareThreadClient.ts
+++ b/packages/platform-cloudflare/src/CloudflareThreadClient.ts
@@ -464,7 +464,6 @@ export class CloudflareThreadClient extends Context.Service<
             rpcTracing === undefined ? [] : yield* RpcTracing.withRpcTraceContext([]);
 
           const raw = yield* callThreadObject(
-            namespace,
             threadId,
             (stub) => stub[hostRpcMethods[operation]](encoded, ...traceArgs),
             (cause) =>
@@ -479,7 +478,7 @@ export class CloudflareThreadClient extends Context.Service<
                 cause,
                 ...cloudflareFailureSignals(cause),
               }),
-          );
+          ).pipe(Effect.provideService(ThreadObjectNamespace, namespace));
 
           return yield* decodeHostResponse(raw).pipe(
             Effect.mapError((error): HostProtocolError =>

--- a/packages/platform-cloudflare/src/CloudflareThreadClient.ts
+++ b/packages/platform-cloudflare/src/CloudflareThreadClient.ts
@@ -48,7 +48,11 @@ import { Context, Crypto, Duration, Effect, Layer, Schema } from "effect";
 import { RpcTracing } from "effect-cf";
 
 import { DurableAlarmError } from "./Alarm.ts";
-import { ThreadObjectNamespace, type ThreadObjectRpc } from "./CloudflareBindings.ts";
+import {
+  callThreadObject,
+  ThreadObjectNamespace,
+  type ThreadObjectRpc,
+} from "./CloudflareBindings.ts";
 import { AdmissionLimitExceeded } from "./CloudflareConfig.ts";
 import { cloudflareFailureSignals, safeCauseMessage } from "./internal/boundary.ts";
 
@@ -445,7 +449,8 @@ export class CloudflareThreadClient extends Context.Service<
     ThreadObjectNamespace | Crypto.Crypto
   > = Layer.effect(CloudflareThreadClient)(
     Effect.gen(function* () {
-      const { get, rpcTracing } = yield* ThreadObjectNamespace;
+      const namespace = yield* ThreadObjectNamespace;
+      const { rpcTracing } = namespace;
       const crypto = yield* Crypto.Crypto;
 
       const call = Effect.fn(
@@ -458,13 +463,11 @@ export class CloudflareThreadClient extends Context.Service<
           const traceArgs =
             rpcTracing === undefined ? [] : yield* RpcTracing.withRpcTraceContext([]);
 
-          const raw = yield* Effect.tryPromise({
-            try: () => {
-              const stub = get(threadId);
-
-              return stub[hostRpcMethods[operation]](encoded, ...traceArgs);
-            },
-            catch: (cause) =>
+          const raw = yield* callThreadObject(
+            namespace,
+            threadId,
+            (stub) => stub[hostRpcMethods[operation]](encoded, ...traceArgs),
+            (cause) =>
               ThreadClientError.make({
                 threadId,
                 message: boundHostDiagnostic(
@@ -476,7 +479,7 @@ export class CloudflareThreadClient extends Context.Service<
                 cause,
                 ...cloudflareFailureSignals(cause),
               }),
-          });
+          );
 
           return yield* decodeHostResponse(raw).pipe(
             Effect.mapError((error): HostProtocolError =>

--- a/packages/platform-cloudflare/src/WakeScheduler.ts
+++ b/packages/platform-cloudflare/src/WakeScheduler.ts
@@ -3,7 +3,11 @@ import { makeWakeSubscriptionHub, WakeScheduler } from "@effect-agent/thread/Wak
 import { Effect, Layer, PubSub, Schema, Stream } from "effect";
 
 import { DurableAlarmService } from "./Alarm.ts";
-import { ThreadObjectPlacement, ThreadObjectNamespace } from "./CloudflareBindings.ts";
+import {
+  callThreadObject,
+  ThreadObjectPlacement,
+  ThreadObjectNamespace,
+} from "./CloudflareBindings.ts";
 import { safeCauseMessage } from "./internal/boundary.ts";
 
 /**
@@ -41,7 +45,7 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
   Effect.gen(function* () {
     const alarm = yield* DurableAlarmService;
     const placement = yield* ThreadObjectPlacement;
-    const { get } = yield* ThreadObjectNamespace;
+    const namespace = yield* ThreadObjectNamespace;
     const hints = yield* PubSub.sliding<ThreadId>(WAKE_BUFFER_CAPACITY);
     const progress = yield* makeWakeSubscriptionHub;
 
@@ -60,15 +64,17 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
       );
 
     const notifyRemote = (threadId: ThreadId) =>
-      Effect.tryPromise({
-        try: () => get(threadId).wake(),
-        catch: (cause) =>
+      callThreadObject(
+        namespace,
+        threadId,
+        (target) => target.wake(),
+        (cause) =>
           RemoteWakeDropped.make({
             threadId,
             message: safeCauseMessage(cause, "The remote wake failed without a diagnostic"),
             cause,
           }),
-      }).pipe(
+      ).pipe(
         Effect.catch((error) =>
           Effect.logWarning(`CloudflareWakeScheduler: remote wake of ${threadId} dropped`, error),
         ),

--- a/packages/platform-cloudflare/src/WakeScheduler.ts
+++ b/packages/platform-cloudflare/src/WakeScheduler.ts
@@ -65,7 +65,6 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
 
     const notifyRemote = (threadId: ThreadId) =>
       callThreadObject(
-        namespace,
         threadId,
         (target) => target.wake(),
         (cause) =>
@@ -75,6 +74,7 @@ export const cloudflareWakeSchedulerLayer: Layer.Layer<
             cause,
           }),
       ).pipe(
+        Effect.provideService(ThreadObjectNamespace, namespace),
         Effect.catch((error) =>
           Effect.logWarning(`CloudflareWakeScheduler: remote wake of ${threadId} dropped`, error),
         ),

--- a/packages/platform-cloudflare/src/internal/transport.ts
+++ b/packages/platform-cloudflare/src/internal/transport.ts
@@ -30,11 +30,11 @@ export const threadPortTransportLayer: Layer.Layer<
     return ThreadPortTransport.of({
       call: (threadId, request) =>
         callThreadObject(
-          namespace,
           threadId,
           (target) => target.portCall(request),
           (cause) => portTransportFailure(threadId, cause),
         ).pipe(
+          Effect.provideService(ThreadObjectNamespace, namespace),
           Effect.withSpan("CloudflarePortTransport.call", {
             attributes: { threadId },
           }),

--- a/packages/platform-cloudflare/src/internal/transport.ts
+++ b/packages/platform-cloudflare/src/internal/transport.ts
@@ -4,7 +4,7 @@ import {
 } from "@effect-agent/storage-cloudflare/PortRouting";
 import { Effect, Layer } from "effect";
 
-import { ThreadObjectNamespace } from "../CloudflareBindings.ts";
+import { callThreadObject, ThreadObjectNamespace } from "../CloudflareBindings.ts";
 
 /**
  * `ThreadPortTransport` over native Durable Object JS RPC (decision D-P6-3): one
@@ -25,14 +25,16 @@ export const threadPortTransportLayer: Layer.Layer<
   ThreadObjectNamespace
 > = Layer.effect(ThreadPortTransport)(
   Effect.gen(function* () {
-    const { get } = yield* ThreadObjectNamespace;
+    const namespace = yield* ThreadObjectNamespace;
 
     return ThreadPortTransport.of({
       call: (threadId, request) =>
-        Effect.tryPromise({
-          try: () => get(threadId).portCall(request),
-          catch: (cause) => portTransportFailure(threadId, cause),
-        }).pipe(
+        callThreadObject(
+          namespace,
+          threadId,
+          (target) => target.portCall(request),
+          (cause) => portTransportFailure(threadId, cause),
+        ).pipe(
           Effect.withSpan("CloudflarePortTransport.call", {
             attributes: { threadId },
           }),


### PR DESCRIPTION
Cloudflare thread, memory and scheduling adapters recreated native RPC targets for each call. After a cross-Worker callback, those new targets can extend the current native request chain until the subrequest depth limit is reached, even during alarm-owned execution.

Require published `effect-cf@^0.41.0` and use its invocation boundary for host calls, peer ports, remote wake hints, memory and scheduling. Reuse targets only within that boundary, discard failed channels, and retain transport causes for the existing owning reporter. Wire payloads, authorization checks and durable receipt identities are unchanged.

The shared target lifetime and its regression are owned by https://github.com/danieljvdm/effect-cf/pull/159.
