### PR TITLE
docs: split subagent guides by execution lifecycle

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,69 +104,93 @@ export default defineConfig({
     logo: { src: "/mark.svg", alt: "Effect Agent" },
     siteTitle: "Effect Agent",
     nav: [
-      { text: "Guide", link: "/guide/getting-started", activeMatch: "/guide/" },
+      { text: "Guide", link: "/guide/", activeMatch: "/guide/" },
       { text: "Platforms", link: "/platforms/", activeMatch: "/platforms/" },
-      { text: "Architecture", link: "/concepts/effect-native", activeMatch: "/concepts/" },
-      { text: "Reference", link: "/reference/packages", activeMatch: "/reference/" },
+      { text: "Architecture", link: "/concepts/", activeMatch: "/concepts/" },
+      { text: "Reference", link: "/reference/", activeMatch: "/reference/" },
     ],
-    sidebar: [
-      {
-        text: "Start",
-        items: [
-          { text: "Getting started", link: "/guide/getting-started" },
-          { text: "What is Effect Agent?", link: "/guide/introduction" },
-        ],
-      },
-      {
-        text: "Build agents",
-        items: [
-          { text: "Agent definitions", link: "/guide/agents" },
-          { text: "Tools & layers", link: "/guide/tools" },
-          { text: "Run & stream", link: "/guide/run-agents" },
-          { text: "Threads", link: "/guide/threads" },
-          { text: "Context management", link: "/guide/context-management" },
-        ],
-      },
-      {
-        text: "Extensions",
-        items: [
-          { text: "Subagents", link: "/guide/subagents" },
-          { text: "Effect Workflows", link: "/guide/workflows" },
-          { text: "Sandbox execution", link: "/guide/sandbox" },
-          { text: "Code Mode", link: "/guide/code-mode" },
-          { text: "Browser tools", link: "/guide/browser" },
-        ],
-      },
-      {
-        text: "Platforms",
-        items: [
-          { text: "Overview", link: "/platforms/" },
-          { text: "Node.js", link: "/platforms/node" },
-          { text: "Cloudflare", link: "/platforms/cloudflare" },
-        ],
-      },
-      {
-        text: "Test & operate",
-        items: [
-          { text: "Deterministic testing", link: "/guide/testing" },
-          { text: "Operations", link: "/guide/operations" },
-          { text: "Certify storage adapters", link: "/guide/certify-adapters" },
-        ],
-      },
-      {
-        text: "Architecture",
-        items: [
-          { text: "Built on Effect", link: "/concepts/effect-native" },
-          { text: "The runtime model", link: "/concepts/runtime-model" },
-          { text: "Budgets & bounded autonomy", link: "/concepts/budgets" },
-          { text: "Persistence & durability", link: "/concepts/durability" },
-        ],
-      },
-      {
-        text: "Reference",
-        items: [{ text: "Package map", link: "/reference/packages" }],
-      },
-    ],
+    sidebar: {
+      "/guide/": [
+        {
+          text: "Start",
+          items: [
+            { text: "Overview", link: "/guide/" },
+            { text: "Getting started", link: "/guide/getting-started" },
+            { text: "What is Effect Agent?", link: "/guide/introduction" },
+          ],
+        },
+        {
+          text: "Build agents",
+          items: [
+            { text: "Agent definitions", link: "/guide/agents" },
+            { text: "Tools & layers", link: "/guide/tools" },
+            { text: "Run & stream", link: "/guide/run-agents" },
+            { text: "Threads", link: "/guide/threads" },
+            { text: "Context management", link: "/guide/context-management" },
+          ],
+        },
+        {
+          text: "Extensions",
+          items: [
+            {
+              text: "Subagents",
+              link: "/guide/subagents",
+              collapsed: false,
+              items: [
+                { text: "Ephemeral attached", link: "/guide/subagents/ephemeral-attached" },
+                { text: "Durable attached", link: "/guide/subagents/durable-attached" },
+                { text: "Durable background", link: "/guide/subagents/background" },
+              ],
+            },
+            { text: "Agent messaging", link: "/guide/messaging" },
+            { text: "Effect Workflows", link: "/guide/workflows" },
+            { text: "Sandbox execution", link: "/guide/sandbox" },
+            { text: "Code Mode", link: "/guide/code-mode" },
+            { text: "Browser tools", link: "/guide/browser" },
+          ],
+        },
+        {
+          text: "Test & operate",
+          items: [
+            { text: "Deterministic testing", link: "/guide/testing" },
+            { text: "Operations", link: "/guide/operations" },
+            { text: "Certify storage adapters", link: "/guide/certify-adapters" },
+          ],
+        },
+      ],
+      "/platforms/": [
+        {
+          text: "Platforms",
+          items: [
+            { text: "Overview", link: "/platforms/" },
+            { text: "Node.js", link: "/platforms/node" },
+            { text: "Cloudflare", link: "/platforms/cloudflare" },
+          ],
+        },
+      ],
+      "/concepts/": [
+        {
+          text: "Architecture",
+          items: [
+            { text: "Overview", link: "/concepts/" },
+            { text: "Built on Effect", link: "/concepts/effect-native" },
+            { text: "The runtime model", link: "/concepts/runtime-model" },
+            { text: "Budgets & bounded autonomy", link: "/concepts/budgets" },
+            { text: "Persistence & durability", link: "/concepts/durability" },
+          ],
+        },
+      ],
+      "/reference/": [
+        {
+          text: "Reference",
+          items: [
+            { text: "Overview", link: "/reference/" },
+            { text: "Package map", link: "/reference/packages" },
+            { text: "Subagent policies & recovery", link: "/reference/subagents" },
+          ],
+        },
+      ],
+    },
     search: {
       provider: "local",
       options: {

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -122,6 +122,11 @@ report. Set `PRINT_REPORT` in the Cloudflare test file to print its workerd repo
 
 ## Documentation examples
 
+Lead implementation guides with a short, concrete code example after at most one introductory
+sentence. Explain behavior after the code it describes. Keep complete setup available and
+type-check examples through their runnable entry points; move advanced contracts and recovery
+details into linked reference pages instead of front-loading them in walkthroughs.
+
 The homepage imports `docs/snippets/travel-planner/*.ts`.
 Edit those files to change its examples. A `twoslash` fence enables type hovers and compiler
 validation during `vp run docs:build`. Relative imports resolve from that snippet directory.

--- a/docs/concepts/budgets.md
+++ b/docs/concepts/budgets.md
@@ -136,7 +136,7 @@ lineage still controls Tool grants and depth; accounting belongs to the worker's
 New Runs reuse the configured allowance, while joined input and every recovery Attempt share the
 existing Run's usage. No cumulative token or cost cap is invented when that dimension is omitted.
 Attached descendants remain bounded by the immediate worker Run's reserved subtree. See the
-[subagent guide](../guide/subagents#independently-fund-background-runs) for host configuration.
+[subagent reference](../reference/subagents#independently-fund-background-runs) for host configuration.
 
 ### Request a larger child budget {#containment-and-the-extension-flow}
 

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -155,7 +155,7 @@ See [Operations](../guide/operations).
 
 ## Attached subagents
 
-Use [`Subagent.make`](../guide/subagents#define-a-delegation) to expose a child agent as a tool.
+Use [`Subagent.make`](../guide/subagents/durable-attached#define-the-delegation) to expose a child agent as a tool.
 A durable child owns a separate thread and attempt. While waiting for it, the parent releases
 its worker permit.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,32 @@
+---
+title: Architecture
+description: Understand Effect Agent's execution model, resource boundaries, budgets, and durable recovery.
+---
+
+# Architecture
+
+Understand how Effect Agent runs work, bounds its resources, and recovers recorded progress.
+These pages explain the contracts behind the [implementation guides](../guide/).
+
+## Effect foundations
+
+[Built on Effect](./effect-native) explains typed errors, Schema-defined data, dependency
+Layers, and scoped resource ownership.
+
+## Agent execution
+
+[The runtime model](./runtime-model) follows a run through context preparation, model calls,
+tool batches, subagents, and input delivered between turns.
+
+## Budgets and limits
+
+[Budgets and bounded autonomy](./budgets) explains execution ceilings, shared delegation
+allowances, token limits, and cost accounting.
+
+## Durability and recovery
+
+[Persistence and durability](./durability) explains accepted work, recorded results,
+ownership loss, child recovery, and uncertain external effects.
+
+For host-specific setup, see [Platforms](../platforms/). For package boundaries and
+advanced configuration, see [Reference](../reference/).

--- a/docs/concepts/runtime-model.md
+++ b/docs/concepts/runtime-model.md
@@ -74,14 +74,18 @@ Agent, tenant, and platform limits may further reduce concurrency.
 
 ## Subagents {#subagents}
 
-Delegation starts a child run in a fresh thread through a tool in the parent's toolkit. The
-child repeats the same model/tool loop under its own policy and a reserved allowance. Its projected
-result returns to the parent as the delegation tool result; its raw transcript stays private.
+Delegation gives a child its own model/tool loop, explicit toolkit, and reserved allowance.
+The parent supplies task input; the child's raw transcript stays in its own thread.
 
-The parent joins the child outcome before settling that tool call. Durable recovery preserves the
-child's identity, allowance, and committed usage across attempts. See the
-[Subagents guide](../guide/subagents) for setup, input and result projections, budgets, authority,
-and child lifecycle.
+Attached children return a projected result through the parent's waiting tool call. Ephemeral
+attached children share the parent's Scope. Durable attached children have persisted threads;
+the parent releases its worker permit while waiting, and recovery preserves the child identity,
+allowance, and committed usage.
+
+Background workers return a reference immediately and keep running independently of the parent
+run. Follow-ups target the same child thread. Configured completion reports deliver the projected
+outcome as new parent input. See the [Subagents overview](../guide/subagents) to choose between
+the three execution forms and follow their setup guides.
 
 <a id="safe-seam-input"></a>
 <a id="when-queued-input-is-applied"></a>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,35 @@
+---
+title: Guide
+description: Build, run, and operate Effect agents with step-by-step guides and working examples.
+---
+
+# Guide
+
+Build an agent, give it tools, and run it in your application. Start with
+[Getting started](./getting-started) for a working example, or read
+[What is Effect Agent?](./introduction) for an introduction.
+
+## Build your agent
+
+- [Agent definitions](./agents): define inputs, outputs, instructions, and execution limits.
+- [Tools and layers](./tools): connect models to your application services.
+- [Run and stream](./run-agents): execute an agent and observe its progress.
+- [Threads](./threads): keep conversation history across runs.
+- [Context management](./context-management): manage long conversations and retrieved context.
+
+## Add capabilities
+
+- [Subagents](./subagents): delegate work and choose whether the parent waits or continues.
+- [Agent messaging](./messaging): exchange input between independent agents.
+- [Effect Workflows](./workflows): drive durable execution through a workflow engine.
+- [Sandbox execution](./sandbox): run commands in a controlled environment.
+- [Code Mode](./code-mode): let agents compose authorized tools with generated JavaScript.
+- [Browser tools](./browser): capture pages, crawl sites, and interact with browsers.
+
+## Test and operate
+
+Use [deterministic testing](./testing) to exercise behavior without live model calls.
+The [operations guide](./operations) covers authorization, recovery, and scheduled work.
+Storage adapter authors can [run the certification contracts](./certify-adapters).
+
+When you are ready to host durable work, choose a [platform](../platforms/).

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -1,0 +1,62 @@
+---
+title: Agent messaging
+description: Send durable messages between independent agent threads through fixed, authorized routes.
+---
+
+# Agent messaging
+
+Use peer messaging when independent agents need to exchange input. For a parent that launches and
+steers a child worker, use [background subagents](./subagents/background) instead.
+
+## Send messages through fixed peer routes
+
+Peers are independent Agent Threads. Their input Schema belongs to the receiving Definition:
+
+```ts
+const Advisor = Messaging.peer("advisor", { target: advisor });
+const send = Messaging.sendTool(Advisor);
+// Programmatic: Messaging.send(Advisor, input, { idempotencyKey })
+```
+
+Provide the caller-bound `MessagingHost` returned by
+`durableRuntime.messagingHost({ sourceThreadId, principal })` for programmatic operations.
+The interpreter provides native tools with the actual caller facet. `sendTool`, `replyTool`,
+`inboxTool`, `inspectTool`, and `retryTool` each derive a native Tool, Toolkit, and handler Layer;
+install only the operations the host wants to expose.
+The runtime provides `MessagingHost.forTool` through Effect context with the same per-Run
+identity check and unavailable default as worker tools.
+
+`PeerRoutes` maps a source, fixed peer name, and registered target to a destination Thread.
+`PeerAuthorizer` separately authorizes context, read, send, and control and returns a stable
+delivery principal. Both deny by default. Reply authorization receives the recorded sender
+address and the original `reply` operation. Incoming messages confer no reverse send grant or
+worker management grant. Use `Subagent.followUp` for worker input; a peer route cannot bypass
+worker admission and budget ownership.
+
+The runtime retains authenticated sender and return-address metadata separately from application
+input, backed by a canonical source proof. `Messaging.inbox` returns bounded provenance from
+authorized sender Threads. `Messaging.reply` requires one of those actual inbound references
+and checks its sender against the declared peer. A send's optional `inReplyTo` is correlation
+only. Models cannot choose arbitrary destination Threads, principals, or return addresses.
+
+`Messaging.send` and `reply` return a retained message status. `pending` means outbound work is
+stored; `accepted` includes the destination Receipt; `processed` includes its Settlement. Use
+`Messaging.inspect` to read status. Automatic delivery retries preserve the exact destination,
+input, principal, code version, and admission identity, including after a lost admission reply.
+`Messaging.retry` renews a parked delivery's finite retry budget after control authorization;
+conclusively refused and processed deliveries cannot be rewound.
+
+Default delivery limits are eight automatic attempts, a 30-second attempt timeout, exponential
+backoff from 1 to 60 seconds, and a 24-hour peer deadline. Exhaustion parks work; rejection remains
+inspectable. `PeerMessageCapacity` bounds canonical send intents across all peers and principals
+in a source Thread (default 256, maximum 1,000), including preparations whose insertion failed.
+The delivery store separately bounds pending and retained rows. Neither history nor deduplication
+evidence is automatically deleted. Effect spans identify preparation, admission, and driver
+operations; persisted failures contain bounded codes rather than raw application errors.
+
+Node's scoped delivery pump and Cloudflare's persisted alarms rediscover stored obligations even
+after both Runs settle and wake hints are lost. During an active Cloudflare maintenance pass,
+message delivery continues alongside source execution, so a message can reach its destination
+before the source Run finishes. Progress still needs a functioning host and
+available capacity. The [canonical Cloudflare application](https://github.com/danieljvdm/effect-agent/tree/main/examples/travel-planner)
+provides the runnable application entrypoint.

--- a/docs/guide/subagents.md
+++ b/docs/guide/subagents.md
@@ -1,593 +1,88 @@
 ---
 title: Subagents
-description: Build a parent that delegates to a child agent, with runnable code for tools, model bindings, budgets, and results.
+description: Declare a child agent, give its tool to a parent, and choose attached or background execution.
 ---
 
 # Subagents
 
-A parent calls a child agent through a declared tool. Here, a trip coordinator asks a researcher
-for activities, then turns its shortlist into an itinerary.
+Give a parent agent a specialist it can call:
 
-```text
-Coordinator
-  delegate_research_activities
-    prepareInput
-    Researcher
-      search_activities
-    projectResult
-  return itinerary
-```
+<<< @/snippets/travel-planner/subagent-basics.ts{ts twoslash}
 
-The parent sees the shortlist. The child's tool history and research notes stay in its thread.
+The parent calls `summarize` like any other tool. The child gets that call's input, runs with its
+own instructions and conversation, and returns `{ output, budgetExhausted }`. Its intermediate
+history stays out of the parent's context. Each agent can use its own model and toolkit.
 
-## Start with the child contract
+This defines the agents. Choose how to run them below.
 
-Ordinary delegation needs only a target. Its toolkit remains explicit; parent tools are never
-inherited.
+## Choose an execution kind
 
-```ts
-const Research = Subagent.make("research", {
-  target: Agent.make("researcher", {
-    input: ResearchRequest,
-    output: ResearchFindings,
-    instructions: "Check opening hours. Cite URLs.",
-    toolkit: ResearchTools,
-  }),
-});
+| Kind                                                 | Parent behavior                                                        | Use it when                                                    |
+| ---------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [Ephemeral attached](./subagents/ephemeral-attached) | Waits for a tool result; child shares its Scope                        | Restarting the task after a process crash is acceptable        |
+| [Durable attached](./subagents/durable-attached)     | Suspends, then resumes with the child's result                         | The parent needs the answer and progress must survive restarts |
+| [Durable background](./subagents/background)         | Continues; receives findings through inspection or a completion report | The user should keep chatting while work runs                  |
 
-const ResearchLive = SubagentRuntime.layer(Research, ResearchModel).pipe(
-  Layer.provide(ResearchToolsLive),
-);
-```
+Both attached forms use `Summarize.tool`. Durable execution comes from the host you run them on.
+For background work, expose start and follow-up tools instead:
 
-The tool parameters use the child's input Schema. The default result is
-`{ output: ResearchFindings, budgetExhausted: boolean }`. Identity input mapping works on decoded
-values, including transformed Schemas. Expected child failures become a bounded
-`SubagentExecutionFailure` with the error tag, without exposing the raw child error.
-
-Set `parameters` and `prepareInput` when the parent's request differs from the child's input.
-Set `success` and `projectResult` when only part of the child output should be exposed.
-Set `failure` and `mapChildFailure` for application-specific errors. These customization points
-are independent. Missing mappings validate the default value against the selected Schema and
-fail with `SubagentProjectionFailure` if it does not fit.
-
-Child terminal events and the `projectResult` context expose `usage` and `delegatedUsage`.
-Durable joins preserve verified totals across recovery; see [usage accounting](run-agents.md#provider-usage-and-cost-evidence).
-For live child deltas or pricing, pass `child.budget` or `child.estimateCostMicrousd` to
-`SubagentRuntime.layer`.
-
-## Define the child
-
-The child is an ordinary agent. Give it a narrow task and the tools that task needs.
-Save these files in the same directory. `tools.ts` uses sample data so the only external service
-needed for this example is the model provider.
-
-::: code-group
-
-<<< @/snippets/travel-planner/researcher.ts{ts twoslash}
-
-<<< @/snippets/travel-planner/tools.ts{ts twoslash}
-
-:::
-
-`Researcher` can call `search_activities`. The parent will receive a different toolkit containing
-only the delegation tool.
-
-## Expose the child as a tool {#define-a-delegation}
-
-In `delegation.ts`, `Subagent.make` connects what the parent requests, what the child receives,
-and what the parent gets back. Use an application name such as `research`. The definition's
-tool annotation determines delegation behavior; names never confer authority or authorize replay.
-
-Replace `Subagent.define(name, options)` with `Subagent.make(name, options)`. The deprecated
-constructor remains an alias. Keep existing names, including `delegate_` names, when upgrading:
-the constructor migration preserves their durable identities.
-
-<<< @/snippets/travel-planner/delegation.ts{ts twoslash}
-
-This example inherits parameters and input mapping from `Researcher`. A custom `prepareInput`
-also receives bounded parent metadata, but never the parent's transcript.
-`projectResult` drops `researchNotes` and exposes
-whether the child finished because its budget ran out.
-
-For a successful call, the parent receives a tool result shaped like this:
-
-```json
-{
-  "activities": ["Riverside walk", "Food market"],
-  "partial": false
-}
-```
-
-The returned activities depend on the model's selection. Both projections return Effects, so they
-can use services and retain typed failures.
-
-## Give the parent the delegation tool
-
-Save the parent as `coordinator.ts`. Add `Research.tool` to its toolkit. The parent model decides
-when to invoke it, just as it decides when to call any other tool.
-
-<<< @/snippets/travel-planner/coordinator.ts{ts twoslash}
-
-One delegation counts as one parent tool call. The child's calls to `search_activities` consume its
-own allowance. The parent waits for the projected result before continuing its model loop.
-
-## Bind models and run
-
-`SubagentRuntime.layer` receives the child's model Layer directly and implements the delegation
-tool. Supply the child's tool handlers through `Layer.provide`.
-
-::: code-group
-
-<<< @/snippets/travel-planner/delegation-live.ts{ts twoslash}
-
-<<< @/snippets/travel-planner/delegation-main.ts{ts twoslash}
-
-:::
-
-The model Layer on `AgentRuntime.run` supplies the parent. The model passed to
-`SubagentRuntime.layer` supplies the child. They use the same model here; change either independently.
-
-`SubagentReservationsMemoryLive` tracks the parent's child reservations. `ThreadHistory.layerTransient`
-keeps this example ephemeral. `RunContextPreparationPassthrough` disables additional context
-loading. Children inherit the parent's history and context services. The provider client and
-HTTP Layer serve both model bindings.
-
-## Start and manage a background worker
-
-An authorized durable host can run a declaration in the background. A worker identifies its
-reusable child Thread; a Receipt identifies one accepted input in that Thread. Programmatic
-starts and follow-ups require an explicit `IdempotencyKey`:
-
-```ts
-const { worker, receipt } =
-  yield *
-  Subagent.start(Research, request, {
-    idempotencyKey: Schema.decodeSync(IdempotencyKey)("research:first-request"),
-  });
-const status = yield * Subagent.inspect(Research, worker, receipt);
-const settled = yield * Subagent.await(Research, worker, receipt);
-const next =
-  yield *
-  Subagent.followUp(Research, worker, nextRequest, {
-    idempotencyKey: Schema.decodeSync(IdempotencyKey)("research:follow-up"),
-  });
-```
-
-Import `IdempotencyKey` from `@effect-agent/core/Receipt`. These operations require the host's
-authorized `SubagentHost` facet. The host resolves the declaration's exact registered target;
-worker values carry identity, not permission. An unavailable host fails closed.
-
-`inspect` returns `Pending` or a `Settled` result for the requested Receipt. Successful settlement
-decodes that input's saved parameters and child output before applying `projectResult`.
-Interrupting or timing out `await` stops only the waiter. Use `Subagent.cancel(Research, worker,
-receipt)` to request cancellation of that input. A `JoinedToHost` conflict remains explicit and
-never redirects cancellation to the host input. `Subagent.list(Research, { limit: 20 })` returns a
-bounded page of visible workers.
-
-Opt in to native model tools separately:
-
-```ts
-const ResearchBackground = Subagent.background(Research, {
+```ts twoslash
+import * as Subagent from "@effect-agent/capabilities/Subagent";
+import { Summarize } from "./subagent-basics.ts";
+// ---cut---
+const background = Subagent.background(Summarize, {
   start: true,
   followUp: true,
   inspect: true,
-  summary: true,
-  list: true,
   cancel: true,
 });
 ```
 
-Use `ResearchBackground.toolkit` and provide `ResearchBackground.layer` for its handlers. The
-selected names are `research_start`, `research_follow_up`, `research_inspect`, `research_summary`,
-`research_list`, and `research_cancel`; `Research.tool` remains the attached delegation. There is no model wait
-tool. Start and follow-up tools derive stable keys from the host-bound Tool Call identity and
-require the platform Crypto service. Projection services are supplied to the handler Layer.
-
-Custom `prepareInput` receives `context.source` as `"tool"` or `"programmatic"`. Only the tool
-variant contains `context.toolCallId` and `context.parent.runId`.
-
-## Independently fund background Runs
-
-Background workers normally reserve against their source's subtree. A host may separately
-fund a root's reusable worker by supplying `WorkerBudgetAuthorizer` from
-`@effect-agent/thread/WorkerHost` and allowing the exact source, destination, and allowance.
-The default denies this permission. Request it from author-owned code:
-
-```ts
-const start = Subagent.start(Research, request, {
-  idempotencyKey,
-  budgetScope: "worker-run",
-});
-const tools = Subagent.background(Research, { start: true, budgetScope: "worker-run" });
-```
-
-The model cannot select the funding scope. The host checks it before every native input admission.
-This mode resolves the worker's own Definition policy without inheriting its source's execution
-ceiling. Declared delegation allocations bound the worker's own work and its descendants. Tokens
-and cost have no cumulative ceiling unless explicitly configured. Keep finite turn, tool-call,
-duration, concurrency, and result bounds, and authorize the exact allocation at the host.
-
-The first admission freezes the scope with the worker's immutable source, grant, and depth.
-A later native logical Run receives the same configured allowance. Input joining an active Run
-shares that Run's usage and deadline; a Receipt does not create budget credit. Retried delivery,
-replacement Attempts, owner eviction, and compaction retain the same Run journal. Changing history
-or application task identifiers never resets an active allowance.
-
-Independent funding is available only to root-created workers. Root, worker, and attached scout
-still have depths zero, one, and two. Set the worker grant's `childLifetimes` to `["attached"]`
-and `maxDepth` to `2` to allow scouts without another background generation. Reserve enough
-`descendantInvocations` and allocation beyond the worker's own full ceiling for those scouts.
-Scouts share the immediate worker Run's remaining allocation. Host worker-count, pending-input,
-input-retention, concurrency, and lifetime limits still apply across the source Thread.
-Set `WorkerHostConfig.maxActiveWorkersPerSource` to bound concurrent background workers separately
-from the root's Tool execution concurrency; omission retains the prior concurrency ceiling.
-
-When each source has an authorized concurrency preference, provide `WorkerConcurrencyResolver`
-from `@effect-agent/thread/WorkerHost` through an Effect Layer. It receives the immutable source,
-worker, principal, and explicitly selected canonical owner submission. Return `Option.some({
-maxActiveWorkersPerSource })` to narrow the fixed host ceiling, or `Option.none()` to retain it.
-The runtime resolves this limit inside the source reservation CAS loop, including retries after
-competing appends. Counted workers have at least one input awaiting canonical completion; queued
-inputs count, and steering an active worker needs no additional slot. An idle worker must acquire
-a slot before a later input. Lowering the ceiling, including to zero, does not cancel incumbents
-or reject replay of an established reservation. Temporarily unavailable authority must return
-`WorkerError` with reason `unavailable`; it must not silently choose a fallback. This operational
-limit never changes an established worker policy, delegation depth, retained-worker limit, or
-Run allowance.
-
-### Resolve policies from captured input
-
-Supply `WorkerPolicyResolver` from `@effect-agent/thread/WorkerHost` when immutable application
-input captures an execution policy separately from a finite, versioned Agent Definition. Provide
-its implementation through an Effect Layer and retain the Layer's construction dependencies.
-The default returns `Option.none()`, preserving registered policy inheritance and overrides.
-Returning `Option.some(policy)` selects a complete policy without reapplying static overrides.
-Missing authority for an opted-in definition must fail explicitly, rather than returning the
-legacy fallback or loading mutable settings. Use `WorkerError` with reason `unavailable` when
-the same captured evidence can become available on retry.
-
-`Subagent.start` prepares and encodes input before the caller-bound host resolves its target
-policy. Both source start and destination admission validate that exact initial input; destination
-validation also runs before replay returns an existing reservation. Explicit declaration limits
-still narrow the resolved policy. Construct a declaration per invocation from the same immutable
-capture when its allocation includes the worker's own ceiling plus fixed attached-scout reserves.
-Reuse the exact registered target Definition, grant, and reporting projection; this does not
-require a dynamic registration graph or another compiled model Tool.
-
-The initial admission stores the effective policy in the existing immutable worker origin.
-For `RetainedWorker`, a resolver may affirm `origin.policy`; returning a different policy fails.
-Later inputs, joined receipts, retries, and replacement Attempts never select a new worker policy.
-Application follow-up preparation must retain the original authorized capture and change only
-the intended task input. Receiving a new payload does not authorize changing its capture.
-
-Root source resolution receives the exact explicitly selected owner Submission and its registered
-binding, when retained. It never selects the latest input. Programmatic callers can pass
-`sourceSubmissionId` to `durableRuntime.workerHost`; `WorkerHostAuthorizer` receives that locator
-for authorization. Worker and attached source policies continue to come from stored lineage.
-Inspection, listing, observation, and cancellation do not require resolving a source policy.
-Keep retained binding versions available; a policy resolver cannot repair ambiguous historical
-definition identities or reconstruct a missing capture.
-
-A root conversation can admit a new registered Agent ID after an application upgrade. When
-an explicit owner Submission selects that Agent, worker creation and reporting use its exact
-retained binding, while the original `ThreadCreated` record stays unchanged. An unregistered
-Agent/digest pair is rejected. Existing workers retain their original lineage and reporting
-binding when the upgraded root sends follow-ups; worker and attached child Agent IDs cannot
-be replaced this way. Without an explicit owner Submission, programmatic hosts continue to
-use the thread's original Agent.
-
-Captured source reporting uses the initial owner binding and stores its existing reporting intent
-in the worker origin. A later input from another source revision does not replace that projection;
-terminal preparation validates the original owner retained by the first worker input reservation.
-
-## Bound child work
-
-Children inherit omitted policy fields from their parent's resolved policy. Explicit child fields
-override those defaults, then delegation ceilings clamp turns, calls, duration, tokens, and cost.
-Use a partial `policy` object for selective overrides. A complete `AgentPolicy.make(...)` value
-already includes its defaults, so those fields count as explicit.
-
-When delegation `policy` is omitted, the parent's limits also set a shared delegation pool.
-Children reserve slices of that pool, not a fresh copy per invocation. Explicit `SubagentPolicy`
-retains the per-child limits below and derives aggregate caps by multiplying by `maxChildren`.
-Use `parentCaps` to set another aggregate pool, and share identical caps across all delegations
-in the parent Run. This pool accounts for child work; it is separate from the parent's own
-model and tool-call counters. A global spending quota still needs a host-owned usage budget.
-
-Ephemeral settlement refunds reported unused allocation. Durable settlement conservatively
-charges the reservation when usage is unavailable. Durable admission rejects a reservation
-that exceeds the shared pool, including its child-count and concurrency limits.
-
-Parent, delegation, and child limits apply at different points:
-
-| Setting in this example            | Meaning                                                      |
-| ---------------------------------- | ------------------------------------------------------------ |
-| Parent `maxToolCalls: 2`           | At most two ordinary delegation calls before finalization    |
-| Delegation `maxChildren: 2`        | At most two child invocations in this parent run             |
-| Delegation `maxConcurrency: 2`     | At most two children executing at once                       |
-| Delegation `maxToolCalls: 4`       | Four tool calls reserved for each child                      |
-| Child `maxToolCalls: 8`            | The child's definition ceiling; a delegation cannot raise it |
-| Delegation `maxResultBytes: 4_096` | Maximum encoded result returned to the parent                |
-
-To let the parent request a smaller allowance, change `delegation.ts`:
-
-```diff
-+parameters: Schema.Struct({
-+  city: Schema.String,
-+  focus: Schema.String,
-+  maxCalls: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
-+}),
-+prepareInput: ({ city, focus }) => Effect.succeed({ city, focus }),
-+toolCallAllowance: {
-+  default: 1,
-+  fromParameters: ({ maxCalls }) => maxCalls,
-+},
-```
-
-A request for two calls gets two. A request for twenty gets four, the reservation ceiling in this
-example. If the child returns `partial: true`, the parent can delegate again with a larger request
-and forward its findings through the input. That starts a new child thread; it does not top
-up the first child. See [delegation budgets](../concepts/budgets#delegation-budgets).
-
-## Let the parent handle a failed child {#handle-failures}
-
-The example fails the parent tool batch if the child fails. To make expected failures available to
-the parent model as result data, change one option in `delegation.ts`:
-
-```diff
--failureMode: "error",
-+failureMode: "return",
-```
-
-The optional `mapChildFailure` maps a child run failure to the declared `ResearchFailed` Schema. With return
-mode, the parent can receive this result and choose another approach:
-
-```json
-{ "_tag": "ResearchFailed", "reason": "AgentPolicyError" }
-```
-
-Expected delegation failures, such as denied admission or an invalid result projection, also
-become result data. Suspension and durability failures stay in the error channel. Defects and
-interruption retain their Effect meaning.
-
-## Limit the child's authority {#limit-authority}
-
-The example gives the child `TravelTools` and gives the parent only `Research.tool`. Adding a tool
-to the parent does not add it to the child.
-
-To require approval before establishing the child, add this to `Subagent.make`:
-
-```diff
- failureMode: "error",
-+needsApproval: true,
-```
-
-Supply an [approval handler](./tools#approval) for the request. This approves starting the child;
-its individual actions still need their own authorization. A narrower grant hides child tools
-outside its allowlist and rejects attempts to invoke them, including through the programmatic
-broker. It does not reject the whole child Toolkit.
-
-## Keep the child attached {#keep-children-attached}
-
-```text
-parent invokes child → reserve allowance → run child → project result → settle parent tool
-```
-
-Ephemeral children share the parent's Scope. Durable children have separate threads and
-attempts; a waiting parent releases its worker permit.
-
-For durable execution, register the exact target Definition with its model and version declarations.
-The handler resolves its digests from that registration. Missing, ambiguous, or different
-Definitions fail before child admission; an explicit `durable.targetDigests` override must
-match the registration. Use the
-[Node](../platforms/node) or [Cloudflare](../platforms/cloudflare) runtime setup to supply durable
-storage and registrations instead of the ephemeral assembly above.
-
-Registration accepts the same Definition and model Layer without `Agent.withModel`:
-
-```ts
-{ agent: Research.target, model: ResearchModel, definitions: childVersions }
-```
-
-Existing bindings still work, but `SubagentRuntime.layer` rejects one whose Definition is not
-the delegation's exact target. Durable workers continue to require matching identity and version
-digests. Change the declared versions when changing a definition, model, or tool contract.
-
-Recovery rejoins the same child and restores its resolved policy, allowance, shared reservation,
-and committed usage. These values are recorded before child admission. Uncertain admission
-never starts a replacement child. Parent abort joins the child's terminal outcome before settling
-the parent; it cannot undo external effects. See [child recovery](../concepts/durability#attached-subagents).
-
-## Bound nested delegation
-
-Nested declarations are allowed. The default `maxDepth: 1` keeps further launch tools hidden.
-Set a root-relative `maxDepth` such as `2` on the participating declarations to permit a child
-and grandchild, and include the permitted tool names across that subtree in the grant. Each Run
-still exposes only tools from its own Toolkit. Effective names, depth, and child lifetimes
-intersect at every level; a descendant cannot restore removed authority.
-
-`grant.childLifetimes` controls children that the resulting worker may launch. For example,
-a root may start a background builder whose grant permits only `["attached"]`; the builder can
-then attach scouts but cannot start background grandchildren. Omitting the field permits both
-lifetimes, subject to depth and budget. Inspection and cancellation tools remain usable at the
-depth ceiling when their names are allowed.
-
-Reserve descendant slots explicitly with `SubagentPolicy.descendantInvocations`; omission
-reserves zero. The allocation covers the child's own execution plus its descendants. Its own
-resolved policy for nested and background launches remains bounded by the parent and child
-policies, while the allocation may be larger to leave a remainder. Descendants reserve only that remainder after the child's full
-own ceiling is deducted, across turns, calls, duration, tokens, cost, and result bytes.
-`maxChildren` includes the held descendant slots. Ephemeral subtrees also hold their possible
-concurrent child slots up front and charge the whole started subtree allocation at settlement.
-
-A top-level attached delegation's explicit pool remains separate from its parent's own Run
-counters. At inherited depth one and deeper, attached and background descendants share the
-reserved subtree allowance. Background roots remain bounded by the source Thread's host policy.
-A declaration with sufficient depth but no remaining slots or allocation fails before starting
-another child. Handoff remains unsupported.
-
-## Continue work in the background
-
-`Subagent.start` returns a continuing worker identity and the Receipt for its first accepted
-input. `Subagent.followUp` submits more declared parameters to that same Thread. Both are
-Effects; acceptance does not wait for the child to finish. Programmatic calls require an
-explicit, stable `IdempotencyKey`. A model tool derives its key from its actual invocation.
-
-If another delivery attempt owns the claim, `start` and `followUp` can fail with
-`WorkerError` reason `delivery-pending`. This confirms that the exact input is durably retained;
-it does not confirm destination acceptance or that the child started. The host's existing
-delivery recovery owns progress. Preserve the same parameters and idempotency key when
-reconciling instead of launching replacement work. Conclusive refusal retains its specific
-reason, while a recorded retry failure or a storage exception still reports `storage`.
-These operations add no waiting or polling for a competing claim.
-
-```ts
-const Research = Subagent.make("research", { target: researcher });
-const tools = Subagent.background(Research, {
-  start: true,
-  followUp: true,
-  inspect: true,
-  list: true,
-  cancel: true,
-});
-// Add tools.toolkit to the parent Definition and tools.layer to its services.
-```
-
-The host chooses which native tools to expose. Each retains this declaration's parameter and
-result Schemas. Programmatic code acquires a separately authorized facet with
-`durableRuntime.workerHost({ sourceThreadId, principal })` and provides it as `SubagentHost`.
-The source Thread must already exist. No fabricated Run or Tool Call ID is needed.
-
-For native tools, the durable runtime provides `SubagentHost.forTool` through Effect context.
-The interpreter supplies the actual Agent, Thread, Run, and Tool Call identity; the runtime
-refuses a binding from another Run. The reference defaults to an unavailable host and is not
-a `RunOptions` callback.
-
-Keep the two references distinct: a worker identifies its continuing Thread, while a Receipt
-identifies one input. Neither grants access. Encode/decode worker references with
-`Subagent.Worker(Research)`. `inspect(Research, worker)` returns the same summary as discovery;
-passing a third Receipt argument inspects that exact input. `await` takes the declaration,
-worker, and exact Receipt and can be interrupted without cancelling work. `cancel` targets only that
-Receipt and preserves `JoinedToHost` if it joined another input's Run. Cancellation does not
-close the worker or cancel an entire work tree.
-
-Inputs can join an active Run at a safe boundary or start a later Run. Callers use the same
-operation for both. Parent completion or abort leaves background work running; attached
-children retain their existing cancellation and join semantics. Worker provenance, authority,
-and reservations survive later coordinator Runs and host reconstruction. The admission ledger
-atomically prevents replacing an ordinary Thread lane with a worker lane or changing its origin.
-
-`Subagent.list(Research, { limit, after })` returns a bounded page. Read canonical history with
-`Subagent.observe(Research, worker, { after })`: this is a finite Stream through the tail captured
-at acquisition, using bounded storage pages. Pass its last `sequence` as the next cursor.
-Observation acquires no execution permit and does not cancel work when interrupted.
-
-`WorkerHostAuthorizer` separates context, read, send, and control access and denies by default.
-`WorkerHostConfig` bounds retained workers, inputs per worker, pending inputs, and lifetime across
-coordinator Runs (defaults: 32 workers, 64 inputs, 8 pending, 24 hours). Started allocations are
-not refunded. Execution concurrency is a separate host setting; waiting attached parents release
-their permits. Configure sufficient host capacity for conversational work and the chosen child
-concurrency. Idle workers own no execution resources.
-
-## Deliver completion reports
-
-Declare the conversion from the child's projected outcome to coordinator input on the existing
-coordinator registration:
-
-```ts
-const report = Subagent.reporting(Research, {
-  input: CoordinatorInput,
-  prepare: (outcome) =>
-    Effect.succeed({
-      _tag: "ResearchFinished",
-      runId: outcome.runId,
-      summary: outcome.outcome === "completed" ? outcome.result : outcome.failure.classification,
-    }),
-});
-
-const registration = {
-  agent: coordinator,
-  definitions: coordinatorVersions,
-  reporting: [report],
-};
-```
-
-The Schema must be the coordinator Definition's exact input Schema. Registration captures the
-projection's required services separately from per-Attempt services. Declare an expected mapper
-failure with the optional `failure` Schema. Change the existing registration versions when changing
-report behavior; recovery never substitutes another source binding or target Definition.
-
-Launch intent pins reporting before acceptance. Each actual child Run has one logical report,
-even when several steering Receipts join it; an input cancelled before any Run starts has no Run
-report. The declaration's result projection and mapper produce a frozen `PreparedInput` before
-delivery insertion. They should be deterministic and free of external side effects: a crash before
-the canonical preparation decision commits can rerun them. Delivery retries never reproject a
-committed decision. Expected failure, defect, invalid output, or preparation timeout records a
-bounded refusal without replacing the child's outcome. Preparation has its own Scope and a
-5-second default timeout, configurable up to 30 seconds in `WorkerHostConfig`.
-
-For a receiving coordinator that is itself a background worker, express the report in its incoming
-declaration's Parameters Schema and wrap it with
-`Subagent.reportingToWorker(report, receivingDeclaration)`. This explicitly maps parameters into
-Agent input and charges the additional input to the original ancestor allocation. It cannot reuse
-old parameters or obtain a fresh budget. An attached destination has no independent continuing
-input lifetime; delivery to it is refused. An attached scout returns directly through its waiting
-parent's tool result.
-
-Report preparation decisions appear in authorized canonical worker history. Retained delivery
-records expose pending, accepted, processed, parked, and refused states through the host-owned
-`MessageDeliveryStore`. A child's completion and its report's processing remain separate facts.
-
-## Send messages through fixed peer routes
-
-Peers are independent Agent Threads. Their input Schema belongs to the receiving Definition:
-
-```ts
-const Advisor = Messaging.peer("advisor", { target: advisor });
-const send = Messaging.sendTool(Advisor);
-// Programmatic: Messaging.send(Advisor, input, { idempotencyKey })
-```
-
-Provide the caller-bound `MessagingHost` returned by
-`durableRuntime.messagingHost({ sourceThreadId, principal })` for programmatic operations.
-The interpreter provides native tools with the actual caller facet. `sendTool`, `replyTool`,
-`inboxTool`, `inspectTool`, and `retryTool` each derive a native Tool, Toolkit, and handler Layer;
-install only the operations the host wants to expose.
-The runtime provides `MessagingHost.forTool` through Effect context with the same per-Run
-identity check and unavailable default as worker tools.
-
-`PeerRoutes` maps a source, fixed peer name, and registered target to a destination Thread.
-`PeerAuthorizer` separately authorizes context, read, send, and control and returns a stable
-delivery principal. Both deny by default. Reply authorization receives the recorded sender
-address and the original `reply` operation. Incoming messages confer no reverse send grant or
-worker management grant. Use `Subagent.followUp` for worker input; a peer route cannot bypass
-worker admission and budget ownership.
-
-The runtime retains authenticated sender and return-address metadata separately from application
-input, backed by a canonical source proof. `Messaging.inbox` returns bounded provenance from
-authorized sender Threads. `Messaging.reply` requires one of those actual inbound references
-and checks its sender against the declared peer. A send's optional `inReplyTo` is correlation
-only. Models cannot choose arbitrary destination Threads, principals, or return addresses.
-
-`Messaging.send` and `reply` return a retained message status. `pending` means outbound work is
-stored; `accepted` includes the destination Receipt; `processed` includes its Settlement. Use
-`Messaging.inspect` to read status. Automatic delivery retries preserve the exact destination,
-input, principal, code version, and admission identity, including after a lost admission reply.
-`Messaging.retry` renews a parked delivery's finite retry budget after control authorization;
-conclusively refused and processed deliveries cannot be rewound.
-
-Default delivery limits are eight automatic attempts, a 30-second attempt timeout, exponential
-backoff from 1 to 60 seconds, and a 24-hour peer deadline. Exhaustion parks work; rejection remains
-inspectable. `PeerMessageCapacity` bounds canonical send intents across all peers and principals
-in a source Thread (default 256, maximum 1,000), including preparations whose insertion failed.
-The delivery store separately bounds pending and retained rows. Neither history nor deduplication
-evidence is automatically deleted. Effect spans identify preparation, admission, and driver
-operations; persisted failures contain bounded codes rather than raw application errors.
-
-Node's scoped delivery pump and Cloudflare's persisted alarms rediscover stored obligations even
-after both Runs settle and wake hints are lost. During an active Cloudflare maintenance pass,
-message delivery continues alongside source execution, so a message can reach its destination
-before the source Run finishes. Progress still needs a functioning host and
-available capacity. The [canonical Cloudflare application](https://github.com/danieljvdm/effect-agent/tree/main/examples/travel-planner)
-provides the runnable application entrypoint.
+Give the parent `background.toolkit` and provide `background.layer` for its handlers. The
+[background guide](./subagents/background) shows how findings become new input to the parent.
+
+## Lifecycle and limits
+
+Attached children can run concurrently, but the parent's next model call waits for the batch to
+settle. A durable parent releases its execution slot while waiting and recovers the same child
+after a restart. Aborting the parent propagates cancellation to attached children.
+
+Background workers keep running after the parent finishes or aborts. Follow-ups continue the
+same child thread. Durable hosts recover their accepted work and pending report delivery.
+
+All three forms enforce permissions and budgets. Parent tools are not inherited. See the
+[subagent reference](../reference/subagents) for projections, nested delegation, and limits, or
+[durability](../concepts/durability) for recovery of uncertain external actions.
+
+<!-- Keep previously published section links useful after the guide split. -->
+<details>
+<summary>Looking for a section from the previous guide?</summary>
+
+<a id="start-with-the-child-contract"></a>
+<a id="define-the-child"></a>
+<a id="define-a-delegation"></a>
+<a id="give-the-parent-the-delegation-tool"></a>
+<a id="bind-models-and-run"></a>
+Child definitions, delegation tools, and model bindings now live in the
+[ephemeral attached walkthrough](./subagents/ephemeral-attached).
+
+<a id="keep-children-attached"></a>
+Durable registration and recovery now live in the [durable attached guide](./subagents/durable-attached).
+
+<a id="start-and-manage-a-background-worker"></a>
+<a id="continue-work-in-the-background"></a>
+<a id="deliver-completion-reports"></a>
+Starting workers, follow-ups, and replies now live in the [background guide](./subagents/background).
+
+<a id="bound-child-work"></a>
+<a id="handle-failures"></a>
+<a id="limit-authority"></a>
+<a id="bound-nested-delegation"></a>
+<a id="independently-fund-background-runs"></a>
+<a id="resolve-policies-from-captured-input"></a>
+Advanced policies now live in the [subagent reference](../reference/subagents).
+
+<a id="send-messages-through-fixed-peer-routes"></a>
+Peer routes now live in [Agent messaging](./messaging).
+
+</details>

--- a/docs/guide/subagents/background.md
+++ b/docs/guide/subagents/background.md
@@ -1,0 +1,82 @@
+---
+title: Durable background subagents
+description: Give the parent background tools and send worker findings back as new input.
+---
+
+# Durable background subagents
+
+Give the parent tools to start and steer a researcher while it keeps chatting:
+
+<<< @/snippets/travel-planner/background-coordinator.ts{ts twoslash}
+
+`ResearchBackground.toolkit` exposes start, follow-up, inspection, listing, and cancellation.
+A start returns a worker reference immediately; follow-ups go to that worker's existing thread.
+Finishing or aborting the parent run leaves the worker running.
+
+This uses the [activity researcher](./ephemeral-attached#define-the-child) and its `Research`
+declaration. Save the code as `background-coordinator.ts`.
+
+## Send findings back {#turn-the-findings-into-parent-input}
+
+<<< @/snippets/travel-planner/background-report.ts{ts twoslash}
+
+Save this as `background-report.ts`. `Subagent.reporting` turns the child's result into **new input
+for the parent**. A finished search sends `ResearchFinished`; failure or cancellation sends
+`ResearchFailed`. The parent can then explain the findings to the user.
+
+Reports can join an active parent run at an input boundary or start a later run in the same
+thread. Report delivery is configured on the host below.
+
+### Define the parent's inputs
+
+<<< @/snippets/travel-planner/background-input.ts{ts twoslash}
+
+Save as `background-input.ts`. User messages and worker reports share this input Schema;
+the `_tag` distinguishes them. The child returns `{ activities, partial }` through its result
+projection, so the report does not copy private research notes.
+
+## Connect the host {#connect-both-agents-to-a-durable-host}
+
+<<< @/snippets/travel-planner/background-host.ts{ts twoslash}
+
+Save as `background-host.ts`. Each entry registers an agent and its code versions with the host.
+`reporting: [researchReport]` connects completed research to the coordinator that started it.
+The Layers supply tool handlers, provider credentials, and worker access.
+
+The host recovers accepted work and pending reports after restarts. Keep report preparation
+free of external side effects: recovery may repeat it before its decision is recorded.
+
+### Authorize the conversation
+
+<<< @/snippets/travel-planner/background-access.ts{ts twoslash}
+
+Save as `background-access.ts`. Worker access denies by default; this local example permits
+one user and conversation. In an application, check authenticated identity and thread ownership.
+
+## Run it
+
+<<< @/snippets/travel-planner/background-main.ts{ts twoslash}
+
+Save as `background-main.ts` and run with `node --experimental-transform-types background-main.ts`.
+Use the [Node.js setup](../../platforms/node#start-the-host) to submit
+`BackgroundCoordinator` with the exported `principal`, `threadId`, and this input:
+
+```json
+{ "_tag": "Message", "text": "Find food and walking activities in Lisbon." }
+```
+
+Keep the host running so research and report delivery can progress. The
+[Cloudflare runtime](../../platforms/cloudflare) supports the same contracts.
+
+## Follow up and cancel {#steer-inspect-and-cancel}
+
+A follow-up joins an active worker run at a safe input boundary or starts a later run.
+Inspection reads progress or a saved result. Cancellation targets one input's receipt;
+it does not close the worker. Several inputs joining one run produce one logical report.
+
+Workers share a bounded allocation from their source by default. Host lifetime and concurrency
+limits still apply. See [independent budgets](../../reference/subagents#independently-fund-background-runs)
+for separately funded work.
+
+For application-driven starts, see the [programmatic API](../../reference/subagents#start-workers-from-application-code).
+For delivery failures and recovery, see [report guarantees](../../reference/subagents#completion-report-guarantees).

--- a/docs/guide/subagents/durable-attached.md
+++ b/docs/guide/subagents/durable-attached.md
@@ -1,0 +1,54 @@
+---
+title: Durable attached subagents
+description: Run attached children on a durable host and recover the same child after a restart.
+---
+
+# Durable attached subagents
+
+Run the parent and its child on a durable host:
+
+<<< @/snippets/travel-planner/durable-delegation-host.ts{ts twoslash}
+
+Each `{ agent, model, definitions }` entry registers an agent with the host. Register both the
+coordinator and the exact child used by `Research`, so recovery can find them after a restart.
+`definitions` contains the code versions; SQLite stores accepted work and recorded results.
+
+Save this as `durable-delegation-host.ts`. It reuses the
+[attached example files](./ephemeral-attached) and the provider setup from
+[`node-agent.ts`](../../platforms/node#create-an-agent).
+
+## Define the delegation
+
+<<< @/snippets/travel-planner/delegation.ts{ts twoslash}
+
+The declaration is the same for ephemeral and durable attached execution. Put `Research.tool`
+in the parent's toolkit. The host supplies durability; no different subagent constructor is needed.
+
+## Start the host
+
+```ts twoslash
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
+import { HostLive } from "./durable-delegation-host.ts";
+
+NodeRuntime.runMain(NodeDurableHost.run.pipe(Effect.provide(HostLive)));
+```
+
+Use the [Node.js setup](../../platforms/node) to submit `Coordinator` with `{ city: "Lisbon" }`.
+The [Cloudflare host](../../platforms/cloudflare) supports the same attached lifecycle.
+
+## Waiting and recovery
+
+The parent's next model call waits until its current tool batch settles. Children can run
+concurrently; the waiting parent releases its execution slot for other work.
+
+After a restart, recovery reconnects to the same child and restores recorded results, policy,
+and budget reservations. Uncertain admission does not launch a replacement child. Keep the
+registered code versions needed by pending work available.
+
+Aborting the parent propagates cancellation to its children and joins their terminal outcomes.
+Cancellation cannot undo external effects. See [recovery details](../../concepts/durability#attached-subagents)
+and [failure handling](../../reference/subagents#handle-failures).
+
+To keep the parent responding while its child runs, use [durable background subagents](./background).

--- a/docs/guide/subagents/ephemeral-attached.md
+++ b/docs/guide/subagents/ephemeral-attached.md
@@ -1,0 +1,73 @@
+---
+title: Ephemeral attached subagents
+description: Run a parent and child in one process, and return the child's findings as a tool result.
+---
+
+# Ephemeral attached subagents
+
+Bind a model to the child, then run the parent:
+
+<<< @/snippets/travel-planner/delegation-live.ts{ts twoslash}
+
+`Coordinator` calls the `Research` tool, waits for its findings, and builds an itinerary.
+`SubagentRuntime.layer` supplies the child's model and tool handlers. The parent and child can
+use different models.
+
+The files below define `Research`, `Coordinator`, and the sample activity tools. Save them beside
+`delegation-live.ts`.
+
+## Define the child
+
+::: code-group
+
+<<< @/snippets/travel-planner/researcher.ts{ts twoslash}
+
+<<< @/snippets/travel-planner/tools.ts{ts twoslash}
+
+:::
+
+`Researcher` receives a city and focus. Its `search_activities` tool uses sample data, so only
+the model needs an API key. The child's tool calls stay in its own conversation.
+
+## Expose the child as a tool {#define-a-delegation}
+
+<<< @/snippets/travel-planner/delegation.ts{ts twoslash}
+
+`Subagent.make` uses the child's input Schema as its tool parameters. This example customizes
+the result: `projectResult` returns the activities and a `partial` flag, leaving research notes
+in the child's thread. The policy bounds each research task.
+
+For default input and output mapping, only `name` and `{ target: Researcher }` are needed.
+See the [minimal declaration](../subagents) or [mapping reference](../../reference/subagents#input-and-result-mappings).
+
+## Give the parent the delegation tool
+
+<<< @/snippets/travel-planner/coordinator.ts{ts twoslash}
+
+The parent sees the projected result as the tool's answer:
+
+```json
+{ "activities": ["Riverside walk", "Food market"], "partial": false }
+```
+
+## Run it {#bind-models-and-run}
+
+<<< @/snippets/travel-planner/delegation-main.ts{ts twoslash}
+
+```sh
+export OPENAI_API_KEY="your-api-key"
+node --experimental-transform-types delegation-main.ts
+```
+
+The child shares the parent's Scope. Interruption stops both; a process restart loses active
+execution. Use [durable attached](./durable-attached) when that work needs recovery. Stored history
+alone does not make execution durable.
+
+## Failure and limits
+
+One delegation counts as one parent tool call. The child consumes its own reserved allowance.
+Set `failureMode: "return"` to give expected child failures to the parent model as data; defects
+and interruption retain their Effect meaning.
+
+See [budgets and permissions](../../reference/subagents), or switch to
+[background workers](./background) so the parent can continue while children work.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,22 @@
+---
+title: Reference
+description: Find package boundaries, public imports, and detailed subagent configuration contracts.
+---
+
+# Reference
+
+Look up package ownership and detailed configuration after following the
+[guides](../guide/).
+
+## Packages and public imports
+
+The [package map](./packages) covers public imports, available capabilities, dependencies,
+and the responsibilities of each framework package.
+
+## Subagent policies and recovery
+
+The [subagent reference](./subagents) covers input and result mappings, failure handling,
+budgets, permission grants, nested delegation, and background delivery guarantees.
+
+To choose a subagent lifecycle and build your first delegation, start with the
+[subagent overview](../guide/subagents).

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -113,8 +113,10 @@ implementations.
 `connectMcp` bounds discovery and returns dynamic tools. Server-initiated sampling, elicitation,
 resources, and prompts are not served.
 
-Nested delegation, subagent handoff, detached subagents, runtime Skills, a framework-owned memory
-extraction or sharing policy, arbitrary Thread metadata, and dynamic Turn Plans have no public APIs.
+[Background subagents](../guide/subagents/background) and
+[bounded nested delegation](./subagents#bound-nested-delegation) have public APIs.
+Subagent handoff, runtime Skills, a framework-owned memory extraction or sharing policy,
+arbitrary Thread metadata, and dynamic Turn Plans have no public APIs.
 Applications own domain state. `Memory.recall` reads bounded passages from sources they select; it
 does not store them. Thread history and compaction summaries do not replace application state.
 

--- a/docs/reference/subagents.md
+++ b/docs/reference/subagents.md
@@ -1,0 +1,381 @@
+---
+title: Subagent policies and recovery
+description: Configure subagent projections, budgets, authority, nested delegation, and durable worker recovery.
+---
+
+# Subagent policies and recovery
+
+Start with the [subagent overview](../guide/subagents) to choose a lifecycle, then follow the
+[ephemeral attached](../guide/subagents/ephemeral-attached),
+[durable attached](../guide/subagents/durable-attached), or
+[background worker](../guide/subagents/background) guide. This reference covers advanced configuration
+shared by those guides.
+
+## Input and result mappings
+
+`Subagent.make("research", { target: researcher })` is enough to declare delegation.
+`researcher` is an ordinary Agent Definition with input and output Schemas and an explicit toolkit.
+
+The tool parameters use the child's input Schema. The default result is
+`{ output: ChildOutput, budgetExhausted: boolean }`. Identity input mapping works on decoded
+values, including transformed Schemas. Expected child failures become a bounded
+`SubagentExecutionFailure` with the error tag, without exposing the raw child error.
+
+Set `parameters` and `prepareInput` when the parent's request differs from the child's input.
+Set `success` and `projectResult` when only part of the child output should be exposed.
+Set `failure` and `mapChildFailure` for application-specific errors. These customization points
+are independent. Missing mappings validate the default value against the selected Schema and
+fail with `SubagentProjectionFailure` if it does not fit.
+
+Child terminal events and the `projectResult` context expose `usage` and `delegatedUsage`.
+Durable joins preserve verified totals across recovery; see [usage accounting](../guide/run-agents.md#provider-usage-and-cost-evidence).
+For live child deltas or pricing, pass `child.budget` or `child.estimateCostMicrousd` to
+`SubagentRuntime.layer`.
+
+Custom `prepareInput` receives `context.source` as `"tool"` or `"programmatic"`.
+Only the tool variant contains `context.toolCallId` and `context.parent.runId`.
+A custom mapper receives bounded parent metadata, never the parent's transcript.
+
+## Upgrade the constructor
+
+Replace `Subagent.define(name, options)` with `Subagent.make(name, options)`. The deprecated
+constructor remains an alias. Keep existing names, including `delegate_` names, when upgrading:
+the constructor migration preserves their durable identities.
+
+## Bound child work
+
+Children inherit omitted policy fields from their parent's resolved policy. Explicit child fields
+override those defaults, then delegation ceilings clamp turns, calls, duration, tokens, and cost.
+Use a partial `policy` object for selective overrides. A complete `AgentPolicy.make(...)` value
+already includes its defaults, so those fields count as explicit.
+
+When delegation `policy` is omitted, the parent's limits also set a shared delegation pool.
+Children reserve slices of that pool, not a fresh copy per invocation. Explicit `SubagentPolicy`
+retains the per-child limits below and derives aggregate caps by multiplying by `maxChildren`.
+Use `parentCaps` to set another aggregate pool, and share identical caps across all delegations
+in the parent Run. This pool accounts for child work; it is separate from the parent's own
+model and tool-call counters. A global spending quota still needs a host-owned usage budget.
+
+Ephemeral settlement refunds reported unused allocation. Durable settlement conservatively
+charges the reservation when usage is unavailable. Durable admission rejects a reservation
+that exceeds the shared pool, including its child-count and concurrency limits.
+
+In the [attached walkthrough](../guide/subagents/ephemeral-attached), parent, delegation, and child limits apply at different points:
+
+| Setting in this example            | Meaning                                                      |
+| ---------------------------------- | ------------------------------------------------------------ |
+| Parent `maxToolCalls: 2`           | At most two ordinary delegation calls before finalization    |
+| Delegation `maxChildren: 2`        | At most two child invocations in this parent run             |
+| Delegation `maxConcurrency: 2`     | At most two children executing at once                       |
+| Delegation `maxToolCalls: 4`       | Four tool calls reserved for each child                      |
+| Child `maxToolCalls: 8`            | The child's definition ceiling; a delegation cannot raise it |
+| Delegation `maxResultBytes: 4_096` | Maximum encoded result returned to the parent                |
+
+In the [attached example](../guide/subagents/ephemeral-attached), change `delegation.ts` to let the parent request a smaller allowance:
+
+```diff
++parameters: Schema.Struct({
++  city: Schema.String,
++  focus: Schema.String,
++  maxCalls: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
++}),
++prepareInput: ({ city, focus }) => Effect.succeed({ city, focus }),
++toolCallAllowance: {
++  default: 1,
++  fromParameters: ({ maxCalls }) => maxCalls,
++},
+```
+
+A request for two calls gets two. A request for twenty gets four, the reservation ceiling in this
+example. If the child returns `partial: true`, the parent can delegate again with a larger request
+and forward its findings through the input. That starts a new child thread; it does not top
+up the first child. See [delegation budgets](../concepts/budgets#delegation-budgets).
+
+## Let the parent handle a failed child {#handle-failures}
+
+The [attached example](../guide/subagents/ephemeral-attached) fails the parent tool batch if the child fails. To make expected failures available to
+the parent model as result data, change one option in `delegation.ts`:
+
+```diff
+-failureMode: "error",
++failureMode: "return",
+```
+
+The optional `mapChildFailure` maps a child run failure to the declared `ResearchFailed` Schema. With return
+mode, the parent can receive this result and choose another approach:
+
+```json
+{ "_tag": "ResearchFailed", "reason": "AgentPolicyError" }
+```
+
+Expected delegation failures, such as denied admission or an invalid result projection, also
+become result data. Suspension and durability failures stay in the error channel. Defects and
+interruption retain their Effect meaning.
+
+## Limit the child's authority {#limit-authority}
+
+The [attached example](../guide/subagents/ephemeral-attached) gives the child `TravelTools` and gives the parent only `Research.tool`. Adding a tool
+to the parent does not add it to the child.
+
+To require approval before establishing the child, add this to `Subagent.make`:
+
+```diff
+ failureMode: "error",
++needsApproval: true,
+```
+
+Supply an [approval handler](../guide/tools#approval) for the request. This approves starting the child;
+its individual actions still need their own authorization. A narrower grant hides child tools
+outside its allowlist and rejects attempts to invoke them, including through the programmatic
+broker. It does not reject the whole child Toolkit.
+
+## Bound nested delegation
+
+Nested declarations are allowed. The default `maxDepth: 1` keeps further launch tools hidden.
+Set a root-relative `maxDepth` such as `2` on the participating declarations to permit a child
+and grandchild, and include the permitted tool names across that subtree in the grant. Each Run
+still exposes only tools from its own Toolkit. Effective names, depth, and child lifetimes
+intersect at every level; a descendant cannot restore removed authority.
+
+`grant.childLifetimes` controls children that the resulting worker may launch. For example,
+a root may start a background builder whose grant permits only `["attached"]`; the builder can
+then attach scouts but cannot start background grandchildren. Omitting the field permits both
+lifetimes, subject to depth and budget. Inspection and cancellation tools remain usable at the
+depth ceiling when their names are allowed.
+
+Reserve descendant slots explicitly with `SubagentPolicy.descendantInvocations`; omission
+reserves zero. The allocation covers the child's own execution plus its descendants. Its own
+resolved policy for nested and background launches remains bounded by the parent and child
+policies, while the allocation may be larger to leave a remainder. Descendants reserve only that remainder after the child's full
+own ceiling is deducted, across turns, calls, duration, tokens, cost, and result bytes.
+`maxChildren` includes the held descendant slots. Ephemeral subtrees also hold their possible
+concurrent child slots up front and charge the whole started subtree allocation at settlement.
+
+A top-level attached delegation's explicit pool remains separate from its parent's own Run
+counters. At inherited depth one and deeper, attached and background descendants share the
+reserved subtree allowance. Background roots remain bounded by the source Thread's host policy.
+A declaration with sufficient depth but no remaining slots or allocation fails before starting
+another child. Handoff remains unsupported.
+
+## Independently fund background Runs
+
+Background workers normally reserve against their source's subtree. A host may separately
+fund a root's reusable worker by supplying `WorkerBudgetAuthorizer` from
+`@effect-agent/thread/WorkerHost` and allowing the exact source, destination, and allowance.
+The default denies this permission. Request it from author-owned code:
+
+```ts
+const start = Subagent.start(Research, request, {
+  idempotencyKey,
+  budgetScope: "worker-run",
+});
+const tools = Subagent.background(Research, { start: true, budgetScope: "worker-run" });
+```
+
+The model cannot select the funding scope. The host checks it before every native input admission.
+This mode resolves the worker's own Definition policy without inheriting its source's execution
+ceiling. Declared delegation allocations bound the worker's own work and its descendants. Tokens
+and cost have no cumulative ceiling unless explicitly configured. Keep finite turn, tool-call,
+duration, concurrency, and result bounds, and authorize the exact allocation at the host.
+
+The first admission freezes the scope with the worker's immutable source, grant, and depth.
+A later native logical Run receives the same configured allowance. Input joining an active Run
+shares that Run's usage and deadline; a Receipt does not create budget credit. Retried delivery,
+replacement Attempts, owner eviction, and compaction retain the same Run journal. Changing history
+or application task identifiers never resets an active allowance.
+
+Independent funding is available only to root-created workers. Root, worker, and attached scout
+still have depths zero, one, and two. Set the worker grant's `childLifetimes` to `["attached"]`
+and `maxDepth` to `2` to allow scouts without another background generation. Reserve enough
+`descendantInvocations` and allocation beyond the worker's own full ceiling for those scouts.
+Scouts share the immediate worker Run's remaining allocation. Host worker-count, pending-input,
+input-retention, concurrency, and lifetime limits still apply across the source Thread.
+Set `WorkerHostConfig.maxActiveWorkersPerSource` to bound concurrent background workers separately
+from the root's Tool execution concurrency; omission retains the prior concurrency ceiling.
+
+When each source has an authorized concurrency preference, provide `WorkerConcurrencyResolver`
+from `@effect-agent/thread/WorkerHost` through an Effect Layer. It receives the immutable source,
+worker, principal, and explicitly selected canonical owner submission. Return `Option.some({
+maxActiveWorkersPerSource })` to narrow the fixed host ceiling, or `Option.none()` to retain it.
+The runtime resolves this limit inside the source reservation CAS loop, including retries after
+competing appends. Counted workers have at least one input awaiting canonical completion; queued
+inputs count, and steering an active worker needs no additional slot. An idle worker must acquire
+a slot before a later input. Lowering the ceiling, including to zero, does not cancel incumbents
+or reject replay of an established reservation. Temporarily unavailable authority must return
+`WorkerError` with reason `unavailable`; it must not silently choose a fallback. This operational
+limit never changes an established worker policy, delegation depth, retained-worker limit, or
+Run allowance.
+
+### Resolve policies from captured input
+
+Supply `WorkerPolicyResolver` from `@effect-agent/thread/WorkerHost` when immutable application
+input captures an execution policy separately from a finite, versioned Agent Definition. Provide
+its implementation through an Effect Layer and retain the Layer's construction dependencies.
+The default returns `Option.none()`, preserving registered policy inheritance and overrides.
+Returning `Option.some(policy)` selects a complete policy without reapplying static overrides.
+Missing authority for an opted-in definition must fail explicitly, rather than returning the
+legacy fallback or loading mutable settings. Use `WorkerError` with reason `unavailable` when
+the same captured evidence can become available on retry.
+
+`Subagent.start` prepares and encodes input before the caller-bound host resolves its target
+policy. Both source start and destination admission validate that exact initial input; destination
+validation also runs before replay returns an existing reservation. Explicit declaration limits
+still narrow the resolved policy. Construct a declaration per invocation from the same immutable
+capture when its allocation includes the worker's own ceiling plus fixed attached-scout reserves.
+Reuse the exact registered target Definition, grant, and reporting projection; this does not
+require a dynamic registration graph or another compiled model Tool.
+
+The initial admission stores the effective policy in the existing immutable worker origin.
+For `RetainedWorker`, a resolver may affirm `origin.policy`; returning a different policy fails.
+Later inputs, joined receipts, retries, and replacement Attempts never select a new worker policy.
+Application follow-up preparation must retain the original authorized capture and change only
+the intended task input. Receiving a new payload does not authorize changing its capture.
+
+Root source resolution receives the exact explicitly selected owner Submission and its registered
+binding, when retained. It never selects the latest input. Programmatic callers can pass
+`sourceSubmissionId` to `durableRuntime.workerHost`; `WorkerHostAuthorizer` receives that locator
+for authorization. Worker and attached source policies continue to come from stored lineage.
+Inspection, listing, observation, and cancellation do not require resolving a source policy.
+Keep retained binding versions available; a policy resolver cannot repair ambiguous historical
+definition identities or reconstruct a missing capture.
+
+A root conversation can admit a new registered Agent ID after an application upgrade. When
+an explicit owner Submission selects that Agent, worker creation and reporting use its exact
+retained binding, while the original `ThreadCreated` record stays unchanged. An unregistered
+Agent/digest pair is rejected. Existing workers retain their original lineage and reporting
+binding when the upgraded root sends follow-ups; worker and attached child Agent IDs cannot
+be replaced this way. Without an explicit owner Submission, programmatic hosts continue to
+use the thread's original Agent.
+
+Captured source reporting uses the initial owner binding and stores its existing reporting intent
+in the worker origin. A later input from another source revision does not replace that projection;
+terminal preparation validates the original owner retained by the first worker input reservation.
+
+## Start workers from application code
+
+The [background guide](../guide/subagents/background) shows model-facing tools. Application code can also call
+`Subagent.start`, `followUp`, `inspect`, `await`, and `cancel` with an authorized `SubagentHost`.
+
+A programmatic start needs an **idempotency key**: a stable identifier for one intended input.
+If delivery is retried, reuse the same key and parameters so the host can recognize that input.
+Use a new key for a new input. Native model tools derive their keys automatically.
+
+```ts twoslash
+import * as Subagent from "@effect-agent/capabilities/Subagent";
+import { IdempotencyKey } from "@effect-agent/core/Receipt";
+import { Effect, Schema } from "effect";
+
+import { Research } from "./delegation.ts";
+
+const program = Effect.gen(function* () {
+  const { worker, receipt } = yield* Subagent.start(
+    Research,
+    { city: "Lisbon", focus: "food and walking" },
+    { idempotencyKey: Schema.decodeSync(IdempotencyKey)("lisbon-research-1") },
+  );
+  return yield* Subagent.inspect(Research, worker, receipt);
+});
+```
+
+Provide the facet obtained from
+`durableRuntime.workerHost({ sourceThreadId, principal })` as `SubagentHost`. The source thread
+must already exist. Programmatic `Subagent.await` waits for an exact receipt; interruption or
+timeout stops only that waiter, leaving the worker running.
+
+## Background delivery and recovery
+
+`Subagent.start` returns a continuing worker identity and the Receipt for its first accepted
+input. `Subagent.followUp` submits more declared parameters to that same Thread. Both are
+Effects; acceptance does not wait for the child to finish. Programmatic calls require an
+explicit, stable `IdempotencyKey`. A model tool derives its key from its actual invocation.
+
+If another delivery attempt owns the claim, `start` and `followUp` can fail with
+`WorkerError` reason `delivery-pending`. This confirms that the exact input is durably retained;
+it does not confirm destination acceptance or that the child started. The host's existing
+delivery recovery owns progress. Preserve the same parameters and idempotency key when
+reconciling instead of launching replacement work. Conclusive refusal retains its specific
+reason, while a recorded retry failure or a storage exception still reports `storage`.
+These operations add no waiting or polling for a competing claim.
+
+```ts
+const Research = Subagent.make("research", { target: researcher });
+const tools = Subagent.background(Research, {
+  start: true,
+  followUp: true,
+  inspect: true,
+  list: true,
+  cancel: true,
+});
+// Add tools.toolkit to the parent Definition and tools.layer to its services.
+```
+
+The host chooses which native tools to expose. Each retains this declaration's parameter and
+result Schemas. Programmatic code acquires a separately authorized facet with
+`durableRuntime.workerHost({ sourceThreadId, principal })` and provides it as `SubagentHost`.
+The source Thread must already exist. No fabricated Run or Tool Call ID is needed.
+Successful receipt inspection decodes that input's saved parameters and child output before
+applying `projectResult`. The optional `summary: true` background tool exposes a worker summary;
+projection services must be supplied to the handler Layer. Native start and follow-up tools
+require the platform Crypto service.
+
+For native tools, the durable runtime provides `SubagentHost.forTool` through Effect context.
+The interpreter supplies the actual Agent, Thread, Run, and Tool Call identity; the runtime
+refuses a binding from another Run. The reference defaults to an unavailable host and is not
+a `RunOptions` callback.
+
+Keep the two references distinct: a worker identifies its continuing Thread, while a Receipt
+identifies one input. Neither grants access. Encode/decode worker references with
+`Subagent.Worker(Research)`. `inspect(Research, worker)` returns the same summary as discovery;
+passing a third Receipt argument inspects that exact input. `await` takes the declaration,
+worker, and exact Receipt and can be interrupted without cancelling work. `cancel` targets only that
+Receipt and preserves `JoinedToHost` if it joined another input's Run. Cancellation does not
+close the worker or cancel an entire work tree.
+
+Inputs can join an active Run at a safe boundary or start a later Run. Callers use the same
+operation for both. Parent completion or abort leaves background work running; attached
+children retain their existing cancellation and join semantics. Worker provenance, authority,
+and reservations survive later coordinator Runs and host reconstruction. The admission ledger
+atomically prevents replacing an ordinary Thread lane with a worker lane or changing its origin.
+
+`Subagent.list(Research, { limit, after })` returns a bounded page. Read canonical history with
+`Subagent.observe(Research, worker, { after })`: this is a finite Stream through the tail captured
+at acquisition, using bounded storage pages. Pass its last `sequence` as the next cursor.
+Observation acquires no execution permit and does not cancel work when interrupted.
+
+`WorkerHostAuthorizer` separates context, read, send, and control access and denies by default.
+`WorkerHostConfig` bounds retained workers, inputs per worker, pending inputs, and lifetime across
+coordinator Runs (defaults: 32 workers, 64 inputs, 8 pending, 24 hours). Started allocations are
+not refunded. Execution concurrency is a separate host setting; waiting attached parents release
+their permits. Configure sufficient host capacity for conversational work and the chosen child
+concurrency. Idle workers own no execution resources.
+
+## Completion report guarantees
+
+Configure the mapping with `Subagent.reporting` as shown in the
+[background walkthrough](../guide/subagents/background#turn-the-findings-into-parent-input).
+
+The Schema must be the coordinator Definition's exact input Schema. Registration captures the
+projection's required services separately from per-Attempt services. Declare an expected mapper
+failure with the optional `failure` Schema. Change the existing registration versions when changing
+report behavior; recovery never substitutes another source binding or target Definition.
+
+Launch intent pins reporting before acceptance. Each actual child Run has one logical report,
+even when several steering Receipts join it; an input cancelled before any Run starts has no Run
+report. The declaration's result projection and mapper produce a frozen `PreparedInput` before
+delivery insertion. They should be deterministic and free of external side effects: a crash before
+the canonical preparation decision commits can rerun them. Delivery retries never reproject a
+committed decision. Expected failure, defect, invalid output, or preparation timeout records a
+bounded refusal without replacing the child's outcome. Preparation has its own Scope and a
+5-second default timeout, configurable up to 30 seconds in `WorkerHostConfig`.
+
+For a receiving coordinator that is itself a background worker, express the report in its incoming
+declaration's Parameters Schema and wrap it with
+`Subagent.reportingToWorker(report, receivingDeclaration)`. This explicitly maps parameters into
+Agent input and charges the additional input to the original ancestor allocation. It cannot reuse
+old parameters or obtain a fresh budget. An attached destination has no independent continuing
+input lifetime; delivery to it is refused. An attached scout returns directly through its waiting
+parent's tool result.
+
+Report preparation decisions appear in authorized canonical worker history. Retained delivery
+records expose pending, accepted, processed, parked, and refused states through the host-owned
+`MessageDeliveryStore`. A child's completion and its report's processing remain separate facts.

--- a/docs/snippets/travel-planner/background-access.ts
+++ b/docs/snippets/travel-planner/background-access.ts
@@ -1,0 +1,16 @@
+import { ThreadId } from "@effect-agent/core/Identifiers";
+import { WorkerError } from "@effect-agent/core/Worker";
+import { Principal } from "@effect-agent/thread/SubmissionLedger";
+import { WorkerHostAuthorizer } from "@effect-agent/thread/WorkerHost";
+import { Effect, Layer, Schema } from "effect";
+
+// This local example permits one user to manage workers from one conversation.
+export const principal = Schema.decodeSync(Principal)("travel-user");
+export const threadId = Schema.decodeSync(ThreadId)("travel-chat");
+
+export const WorkerAccessLive = Layer.succeed(WorkerHostAuthorizer)({
+  authorize: (request) =>
+    request.principal === principal && request.sourceThreadId === threadId
+      ? Effect.succeed(principal)
+      : WorkerError.make({ operation: request.operation, reason: "denied" }),
+});

--- a/docs/snippets/travel-planner/background-coordinator.ts
+++ b/docs/snippets/travel-planner/background-coordinator.ts
@@ -1,0 +1,27 @@
+import * as Subagent from "@effect-agent/capabilities/Subagent";
+import * as Agent from "@effect-agent/core/Agent";
+import { Schema } from "effect";
+
+import { CoordinatorInput } from "./background-input.ts";
+import { Research } from "./delegation.ts";
+
+export const ResearchBackground = Subagent.background(Research, {
+  start: true,
+  followUp: true,
+  inspect: true,
+  list: true,
+  cancel: true,
+});
+
+export const BackgroundCoordinator = Agent.make("background-trip-coordinator", {
+  input: CoordinatorInput,
+  output: Schema.String,
+  toolkit: ResearchBackground.toolkit,
+  instructions:
+    "Help the user plan a trip. Start activity research in the background when needed. " +
+    "Keep discussing their preferences while research runs. Send changed preferences " +
+    "to the existing worker with follow_up. When ResearchFinished arrives, explain " +
+    "the findings and flag partial results. On ResearchFailed, help choose a next step. " +
+    "Do not start another search just because a research report arrived.",
+  policy: { maxTurns: 6, maxToolCalls: 4, maxDuration: "2 minutes", toolConcurrency: 2 },
+});

--- a/docs/snippets/travel-planner/background-host.ts
+++ b/docs/snippets/travel-planner/background-host.ts
@@ -1,0 +1,32 @@
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { Layer } from "effect";
+
+import { WorkerAccessLive } from "./background-access.ts";
+import { BackgroundCoordinator, ResearchBackground } from "./background-coordinator.ts";
+import { researchReport } from "./background-report.ts";
+import { Research } from "./delegation.ts";
+import { definitions, ModelLive, OpenAiLive } from "./node-agent.ts";
+import { TravelToolsLive } from "./tools.ts";
+
+export const HostLive = NodeDurableHost.layer(
+  [
+    {
+      agent: BackgroundCoordinator,
+      model: ModelLive,
+      definitions,
+      reporting: [researchReport],
+    },
+    { agent: Research.target, model: ModelLive, definitions },
+  ],
+  {
+    filename: "./agents.sqlite",
+    deploymentId: "background-research",
+    producerId: "worker-start-001",
+    workerConcurrency: 4,
+  },
+).pipe(
+  Layer.provide(ResearchBackground.layer),
+  Layer.provide(TravelToolsLive),
+  Layer.provide(WorkerAccessLive),
+  Layer.provide(OpenAiLive),
+);

--- a/docs/snippets/travel-planner/background-input.ts
+++ b/docs/snippets/travel-planner/background-input.ts
@@ -1,0 +1,11 @@
+import { Schema } from "effect";
+
+export const CoordinatorInput = Schema.Union([
+  Schema.Struct({ _tag: Schema.Literal("Message"), text: Schema.String }),
+  Schema.Struct({
+    _tag: Schema.Literal("ResearchFinished"),
+    activities: Schema.Array(Schema.String),
+    partial: Schema.Boolean,
+  }),
+  Schema.Struct({ _tag: Schema.Literal("ResearchFailed"), reason: Schema.String }),
+]);

--- a/docs/snippets/travel-planner/background-main.ts
+++ b/docs/snippets/travel-planner/background-main.ts
@@ -1,0 +1,7 @@
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
+
+import { HostLive } from "./background-host.ts";
+
+NodeRuntime.runMain(NodeDurableHost.run.pipe(Effect.provide(HostLive)));

--- a/docs/snippets/travel-planner/background-report.ts
+++ b/docs/snippets/travel-planner/background-report.ts
@@ -1,0 +1,19 @@
+import * as Subagent from "@effect-agent/capabilities/Subagent";
+import { Effect } from "effect";
+
+import { CoordinatorInput } from "./background-input.ts";
+import { Research } from "./delegation.ts";
+
+export const researchReport = Subagent.reporting(Research, {
+  input: CoordinatorInput,
+  prepare: (report) =>
+    Effect.succeed(
+      report.outcome === "completed"
+        ? {
+            _tag: "ResearchFinished",
+            activities: report.result.activities,
+            partial: report.result.partial,
+          }
+        : { _tag: "ResearchFailed", reason: report.failure.classification },
+    ),
+});

--- a/docs/snippets/travel-planner/durable-delegation-host.ts
+++ b/docs/snippets/travel-planner/durable-delegation-host.ts
@@ -1,0 +1,33 @@
+import { SubagentRuntime } from "@effect-agent/capabilities/Subagent";
+import { SubagentReservationsMemoryLive } from "@effect-agent/capabilities/SubagentReservations";
+import { IdGenerator } from "@effect-agent/core/IdGenerator";
+import { NodeDurableHost } from "@effect-agent/platform-node";
+import { Layer } from "effect";
+
+import { Coordinator } from "./coordinator.ts";
+import { Research, ResearchFailed } from "./delegation.ts";
+import { definitions, ModelLive, OpenAiLive } from "./node-agent.ts";
+import { TravelToolsLive } from "./tools.ts";
+
+const ResearchLive = SubagentRuntime.layer(Research, ModelLive, {
+  mapChildFailure: (error) => ResearchFailed.make({ reason: error._tag }),
+}).pipe(Layer.provide(TravelToolsLive));
+
+export const HostLive = NodeDurableHost.layer(
+  [
+    { agent: Coordinator, model: ModelLive, definitions },
+    { agent: Research.target, model: ModelLive, definitions },
+  ],
+  {
+    filename: "./agents.sqlite",
+    deploymentId: "attached-research",
+    producerId: "worker-start-001",
+    workerConcurrency: 4,
+  },
+).pipe(
+  Layer.provide(ResearchLive),
+  Layer.provide(SubagentReservationsMemoryLive),
+  Layer.provide(IdGenerator.layer),
+  Layer.provide(TravelToolsLive),
+  Layer.provide(OpenAiLive),
+);

--- a/docs/snippets/travel-planner/subagent-basics.ts
+++ b/docs/snippets/travel-planner/subagent-basics.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect";
+import { Agent, Subagent } from "effect-agent";
+import { Toolkit } from "effect/unstable/ai";
+
+export const Summarize = Subagent.make("summarize", {
+  description: "Summarize a support case in three sentences.",
+  target: Agent.make("summarizer", {
+    input: Schema.String,
+    output: Schema.String,
+    instructions: "Summarize the case. Include the issue and next action.",
+    toolkit: Toolkit.empty,
+  }),
+});
+
+export const Support = Agent.make("support", {
+  input: Schema.String,
+  output: Schema.String,
+  instructions: "Use summarize to prepare a concise case summary, then answer the user.",
+  toolkit: Toolkit.make(Summarize.tool),
+});


### PR DESCRIPTION
The subagent guide mixes initial setup with detailed recovery and policy contracts. Split it into an overview and focused ephemeral attached, durable attached, and background walkthroughs, with type-checked examples for host setup, worker authorization, and completion reports.

Move advanced contracts into a subagent reference and peer messaging into its own guide. Add section landing pages and scoped sidebars, correct the capability inventory, and preserve existing subagent section anchors so published links remain useful.

![Subagent overview with the new guide navigation](https://github.com/user-attachments/assets/6ebcabb4-e219-4021-84fa-a89d96b69e6f)
