### PR TITLE
perf(ci): isolate slow suites and preserve task caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,11 @@ jobs:
             vite-task-checks-${{ runner.os }}-
 
       - name: Format, lint, and type checks
+        id: checks
         run: ./node_modules/.bin/vp run check
 
       - name: Save Vite Task cache
-        if: success()
+        if: ${{ !cancelled() && (steps.checks.outcome == 'success' || steps.checks.outcome == 'failure') }}
         uses: actions/cache/save@v4
         with:
           path: node_modules/.vite/task-cache
@@ -86,6 +87,18 @@ jobs:
               -F '!@effect-agent/testing'
               -F '!@effect-agent/platform-cloudflare'
               -F '!@effect-agent/storage-cloudflare'
+              -F '!@effect-agent/example-travel-planner'
+              -F '!@effect-agent/example-context-continuity-eval'
+              -F '!@effect-agent/example-runtime-benchmark'
+          - suite: travel-planner
+            filters: -F @effect-agent/example-travel-planner
+            cache-seed: workspace
+          - suite: context-continuity
+            filters: -F @effect-agent/example-context-continuity-eval
+            cache-seed: workspace
+          - suite: runtime-benchmark
+            filters: -F @effect-agent/example-runtime-benchmark
+            cache-seed: workspace
           - suite: platform-node
             filters: -F @effect-agent/platform-node
           - suite: testing
@@ -115,9 +128,13 @@ jobs:
         with:
           path: node_modules/.vite/task-cache
           key: vite-task-test-v2-${{ matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          # New suites can reuse results from before the split. Vite Task
+          # still fingerprints every task before replaying any restored entry.
           restore-keys: |
             vite-task-test-v2-${{ matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}-
             vite-task-test-v2-${{ matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-
+            vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}-
+            vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run workspace test suites
         id: tests
@@ -164,6 +181,7 @@ jobs:
             vite-task-build-${{ runner.os }}-
 
       - name: Build packages, examples, and docs
+        id: build
         run: ./node_modules/.bin/vp run -v build
 
       - name: Upload the Action bundle
@@ -176,7 +194,7 @@ jobs:
           retention-days: 7
 
       - name: Save Vite Task cache
-        if: success()
+        if: ${{ !cancelled() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         uses: actions/cache/save@v4
         with:
           path: node_modules/.vite/task-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
             vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}-
             vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-
 
+      # Temporary measurement: remove after the cold CI sample completes.
+      - name: Measure cold test execution
+        run: ./node_modules/.bin/vp cache clean
+
       - name: Run workspace test suites
         id: tests
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,6 @@ jobs:
             vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}-
             vite-task-test-v2-${{ matrix.cache-seed || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-
 
-      # Temporary measurement: remove after the cold CI sample completes.
-      - name: Measure cold test execution
-        run: ./node_modules/.bin/vp cache clean
-
       - name: Run workspace test suites
         id: tests
         run: >-

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -109,8 +109,8 @@ the ordinary test command.
 
 Vite Task caches successful results against their inputs. Vitest's mutable result cache is
 disabled so it does not invalidate task caching. CI transfers `node_modules/.vite/task-cache`.
-Direct Vitest tasks and the Node platform test task exclude generated Vite files and dependency
-directory listings, but track imported dependency files and the lockfile. Failed tasks are never
+Direct Vitest tasks and the Node platform and travel-planner test tasks exclude generated Vite files
+and dependency directory listings, but track imported dependency files and the lockfile. Failed tasks are never
 cached. Vite Task fingerprints whole files, including package manifests: a version-only change
 can invalidate tests even when their source is unchanged. Keep manifests tracked because exports,
 module type, and dependency declarations also affect execution.

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -99,7 +99,11 @@ Use `vp run <task>` for other scripts. Do not use `bun run`, `npm run`, `pnpm ru
 `yarn run`, or invoke the wrapped compiler, formatter, linter, or test runner directly.
 Include `vp env doctor` output when asking for toolchain help.
 
-Tests run with at most four workspace tasks at once and without dependency ordering.
+Local tests run with at most four workspace tasks at once and without dependency ordering.
+CI gives the travel planner, context-continuity evaluation, runtime benchmark, Node platform,
+testing package, and both Cloudflare packages separate runners. The remaining workspace suites
+share one runner and run sequentially. Each suite keeps its own Vitest/workerd worker limits;
+running more heavy suites on one runner can starve ownership-lease renewals in crash tests.
 Builds follow dependency order. Process-kill, soak, and adapter contract suites are part of
 the ordinary test command.
 
@@ -448,8 +452,10 @@ existing maintainer authorization and do not require a second approval. Never ch
 out, install dependencies from, or execute the PR head in this secret-bearing workflow;
 the reviewer reads untrusted source through GitHub's API instead.
 
-Each test-matrix job has its own task-cache key. Successful task results are saved even when
-another task fails. Main pushes run static checks, tests, and builds to populate shared caches
+Each test-matrix job has its own task-cache key. The three suites split from the workspace job
+also fall back to its earlier cache, so splitting the matrix does not discard reusable results.
+Static checks, tests, and builds save successful task results even when another task fails.
+Main pushes run static checks, tests, and builds to populate shared caches
 and validate Action releases. The `ready` fan-in runs only on PRs. Main runs are not cancelled
 by newer pushes. GitHub scopes PR caches to each PR's merge ref, so another PR cannot reuse them.
 A new release PR can restore the latest main results only after those jobs finish saving their

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -109,9 +109,11 @@ the ordinary test command.
 
 Vite Task caches successful results against their inputs. Vitest's mutable result cache is
 disabled so it does not invalidate task caching. CI transfers `node_modules/.vite/task-cache`.
-Direct Vitest tasks and the Node platform and travel-planner test tasks exclude generated Vite files
-and dependency directory listings, but track imported dependency files and the lockfile. Failed tasks are never
-cached. Vite Task fingerprints whole files, including package manifests: a version-only change
+Direct Vitest tasks, Node platform and Cloudflare-memory tests, and travel-planner tests and builds
+exclude generated Vite files and dependency directory listings, but track imported dependency files
+and the lockfile. Wrangler dry-run builds exclude their temporary `.wrangler` bundles; the Action
+build excludes its generated bundle from inputs and restores `action/dist/index.mjs` on a cache hit.
+Failed tasks are never cached. Vite Task fingerprints whole files, including package manifests: a version-only change
 can invalidate tests even when their source is unchanged. Keep manifests tracked because exports,
 module type, and dependency declarations also affect execution.
 

--- a/examples/travel-planner/package.json
+++ b/examples/travel-planner/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "scripts": {
     "dev": "vp exec alchemy dev alchemy.run.ts",
-    "build": "vp build",
     "deploy": "vp exec alchemy deploy alchemy.run.ts --stage production"
   },
   "dependencies": {

--- a/examples/travel-planner/package.json
+++ b/examples/travel-planner/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "vp exec alchemy dev alchemy.run.ts",
     "build": "vp build",
-    "test": "vp test",
     "deploy": "vp exec alchemy deploy alchemy.run.ts --stage production"
   },
   "dependencies": {

--- a/examples/travel-planner/vite.config.ts
+++ b/examples/travel-planner/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
         command: "vp build",
         input: [
           { auto: true },
+          // Track root inputs individually so a missing generated dist
+          // directory does not invalidate the package directory listing.
+          "*",
+          { pattern: "!examples/travel-planner", base: "workspace" },
+          "!dist",
+          "!dist/**",
           { pattern: "bun.lock", base: "workspace" },
           { pattern: "!**/node_modules", base: "workspace" },
           { pattern: "!**/node_modules/.vite*", base: "workspace" },

--- a/examples/travel-planner/vite.config.ts
+++ b/examples/travel-planner/vite.config.ts
@@ -23,6 +23,19 @@ export default defineConfig({
   test: { cache: false, silent: "passed-only" },
   run: {
     tasks: {
+      test: {
+        command: "vp test",
+        // Fresh runners do not have Vite's generated directories. Keep
+        // dependency file hashes and the lockfile, but ignore directory listings.
+        input: [
+          { auto: true },
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
+        output: [],
+      },
       check: {
         command: "tsc --noEmit",
         input: [

--- a/examples/travel-planner/vite.config.ts
+++ b/examples/travel-planner/vite.config.ts
@@ -23,6 +23,16 @@ export default defineConfig({
   test: { cache: false, silent: "passed-only" },
   run: {
     tasks: {
+      build: {
+        command: "vp build",
+        input: [
+          { auto: true },
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
+      },
       test: {
         command: "vp test",
         // Fresh runners do not have Vite's generated directories. Keep

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "action:build": "bun scripts/build-action.ts",
     "check": "vp check && vp run -r --concurrency-limit 1 check && tsc --noEmit -p scripts/tsconfig.json && vp run check:exports && bun scripts/verify-package-purity.ts",
     "check:exports": "bun scripts/verify-package-exports.ts",
     "test": "vp run -r --parallel --concurrency-limit 4 test",

--- a/tooling/browser-run-worker-proof/package.json
+++ b/tooling/browser-run-worker-proof/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "wrangler deploy --dry-run",
     "check": "tsc --noEmit -p tsconfig.json",
     "prove:live": "node --experimental-transform-types src/live-main.ts",
     "test": "vp test --passWithNoTests"

--- a/tooling/browser-run-worker-proof/vite.config.ts
+++ b/tooling/browser-run-worker-proof/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  run: {
+    tasks: {
+      build: {
+        command: "wrangler deploy --dry-run",
+        // Wrangler reads its own temporary bundle during validation.
+        input: [{ auto: true }, "!.wrangler", "!.wrangler/**"],
+        output: [],
+      },
+    },
+  },
+  test: { cache: false, silent: "passed-only" },
+});

--- a/tooling/browser-run-worker-proof/vite.config.ts
+++ b/tooling/browser-run-worker-proof/vite.config.ts
@@ -6,7 +6,15 @@ export default defineConfig({
       build: {
         command: "wrangler deploy --dry-run",
         // Wrangler reads its own temporary bundle during validation.
-        input: [{ auto: true }, "!.wrangler", "!.wrangler/**"],
+        input: [
+          { auto: true },
+          "!.wrangler",
+          "!.wrangler/**",
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
         output: [],
       },
     },

--- a/tooling/cloudflare-memory/package.json
+++ b/tooling/cloudflare-memory/package.json
@@ -4,11 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "wrangler deploy --dry-run",
     "check": "tsc --noEmit -p tsconfig.json",
     "measure": "node --experimental-transform-types src/measure-main.ts",
-    "measure:heap": "node --experimental-transform-types src/heap-main.ts",
-    "test": "vp test --passWithNoTests"
+    "measure:heap": "node --experimental-transform-types src/heap-main.ts"
   },
   "dependencies": {
     "@effect-agent/capabilities": "workspace:*",

--- a/tooling/cloudflare-memory/vite.config.ts
+++ b/tooling/cloudflare-memory/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  run: {
+    tasks: {
+      build: {
+        command: "wrangler deploy --dry-run",
+        // Wrangler reads its own temporary bundle during validation.
+        input: [{ auto: true }, "!.wrangler", "!.wrangler/**"],
+        output: [],
+      },
+      test: {
+        command: "vp test --passWithNoTests",
+        input: [
+          { auto: true },
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
+        output: [],
+      },
+    },
+  },
+  test: { cache: false, silent: "passed-only" },
+});

--- a/tooling/cloudflare-memory/vite.config.ts
+++ b/tooling/cloudflare-memory/vite.config.ts
@@ -6,7 +6,15 @@ export default defineConfig({
       build: {
         command: "wrangler deploy --dry-run",
         // Wrangler reads its own temporary bundle during validation.
-        input: [{ auto: true }, "!.wrangler", "!.wrangler/**"],
+        input: [
+          { auto: true },
+          "!.wrangler",
+          "!.wrangler/**",
+          { pattern: "bun.lock", base: "workspace" },
+          { pattern: "!**/node_modules", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*", base: "workspace" },
+          { pattern: "!**/node_modules/.vite*/**", base: "workspace" },
+        ],
         output: [],
       },
       test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,6 +166,11 @@ export default defineConfig({
       scripts: true,
     },
     tasks: {
+      "action:build": {
+        command: "bun scripts/build-action.ts",
+        input: [{ auto: true }, "!action/dist", "!action/dist/**"],
+        output: ["action/dist/index.mjs"],
+      },
       "perf:compare": {
         cache: false,
         command: "bun scripts/runtime-benchmark.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -168,7 +168,15 @@ export default defineConfig({
     tasks: {
       "action:build": {
         command: "bun scripts/build-action.ts",
-        input: [{ auto: true }, "!action/dist", "!action/dist/**"],
+        input: [
+          { auto: true },
+          "!action/dist",
+          "!action/dist/**",
+          "bun.lock",
+          "!**/node_modules",
+          "!**/node_modules/.vite*",
+          "!**/node_modules/.vite*/**",
+        ],
         output: ["action/dist/index.mjs"],
       },
       "perf:compare": {


### PR DESCRIPTION
The workspace test job serialized the travel planner, context-continuity evaluation, and runtime benchmark alongside the other workspaces. Give those three suites separate runners while preserving every test and each suite's worker limits. New jobs can restore the previous workspace cache; checks, tests, and builds retain successful task results when a sibling fails.

Exclude generated Vite/Wrangler directories and build outputs from the affected task inputs. Restore the Action bundle explicitly on cache hits. Keep source files, manifests, dependency files, and lockfiles tracked: version-only manifests still invalidate results, and increasing workers on one runner would risk starving crash-test ownership leases.

Measured on fresh GitHub Ubuntu x64 runners with Bun 1.4.0. Test durations include job setup, cache transfers, and cleanup; the underlying test sources are unchanged.

| Run | Longest test job | Test task cache hits |
| --- | ---: | ---: |
| [Original release PR](https://github.com/danieljvdm/effect-agent/actions/runs/34672983997) | 6m04s | 0/19 in workspace |
| [Target main `4641b20f`](https://github.com/danieljvdm/effect-agent/actions/runs/34673264255) | 4m55s | 1/19 in workspace |
| [Candidate `2b1fb840`, cold](https://github.com/danieljvdm/effect-agent/actions/runs/34673906073/attempts/1) | 3m09s | 0/23 across all suites |
| [Final `dda5f330`, unchanged rerun](https://github.com/danieljvdm/effect-agent/actions/runs/34674265567/attempts/2) | 31s | 23/23 across all suites |

Two cold candidate samples took 3m09s–3m10s. The final cached run reached `ready` 37s after its first runner started. Cold CI remains build-bound at about five minutes. The final rerun reused 17/20 cacheable build tasks; three short builds still rerun for generated-directory or environment changes, and the checkout-identity build stays intentionally uncached. Missing Action and travel-planner output was also restored byte-for-byte in local cache probes.
